### PR TITLE
docs: remove http example dependency on 3rd party service

### DIFF
--- a/aio/content/examples/http/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/http/e2e/src/app.e2e-spec.ts
@@ -138,11 +138,11 @@ describe('Http Tests', () => {
   });
 
   describe('PackageSearch', () => {
-    it('can search for npm package and find in cache', async () => {
+    it('can search for package and find in cache', async () => {
       const packageName = 'angular';
       await page.searchInput.sendKeys(packageName);
       await checkLogForMessage(
-        'Caching response from "https://npmsearch.com/query?q=angular"');
+        'Caching response from "/packages/query?name=angular".');
       expect(await page.searchListItems.count()).toBeGreaterThan(1, 'angular items');
 
       await page.searchInput.clear();
@@ -152,7 +152,7 @@ describe('Http Tests', () => {
       await page.searchInput.clear();
       await page.searchInput.sendKeys(packageName);
       await checkLogForMessage(
-        'Found cached response for "https://npmsearch.com/query?q=angular"');
+        'Found cached response for "/packages/query?name=angular"');
     });
   });
 });

--- a/aio/content/examples/http/src/app/http-interceptors/caching-interceptor.ts
+++ b/aio/content/examples/http/src/app/http-interceptors/caching-interceptor.ts
@@ -68,11 +68,7 @@ function sendRequest(
   req: HttpRequest<any>,
   next: HttpHandler,
   cache: RequestCache): Observable<HttpEvent<any>> {
-
-  // No headers allowed in npm search request
-  const noHeaderReq = req.clone({ headers: new HttpHeaders() });
-
-  return next.handle(noHeaderReq).pipe(
+  return next.handle(req).pipe(
     tap(event => {
       // There may be other events besides the response.
       if (event instanceof HttpResponse) {

--- a/aio/content/examples/http/src/app/in-memory-data.service.ts
+++ b/aio/content/examples/http/src/app/in-memory-data.service.ts
@@ -8,6 +8,11 @@ export class InMemoryDataService implements InMemoryDbService {
       { id: 13, name: 'Bombasto' },
       { id: 14, name: 'Celeritas' },
     ];
-    return {heroes};
+    const query = [
+      { name: '@angular/core', version: '20.1.0', description: 'angular core package' },
+      { name: '@angular/common', version: '20.1.0', description: 'angular common package' },
+      { name: '@angular/material', version: '20.1.5', description: 'angular material package' },
+    ];
+    return {heroes, query};
   }
 }

--- a/aio/content/examples/http/src/app/package-search/package-search.service.ts
+++ b/aio/content/examples/http/src/app/package-search/package-search.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 
 import { Observable, of } from 'rxjs';
-import { catchError, map } from 'rxjs/operators';
+import { catchError } from 'rxjs/operators';
 
 import { HttpErrorHandler, HandleError } from '../http-error-handler.service';
 
@@ -12,12 +12,12 @@ export interface NpmPackageInfo {
   description: string;
 }
 
-export const searchUrl = 'https://npmsearch.com/query';
+export const searchUrl = '/packages/query';
 
 function createHttpOptions(packageName: string, refresh = false) {
-    // npm package name search api
-    // e.g., http://npmsearch.com/query?q=dom'
-    const params = new HttpParams({ fromObject: { q: packageName } });
+    // package name search api
+    // e.g., /packages/query?name=dom'
+    const params = new HttpParams({ fromObject: { name: packageName } });
     const headerMap: Record<string, string> = refresh ? {'x-refresh': 'true'} : {};
     const headers = new HttpHeaders(headerMap) ;
     return { headers, params };
@@ -39,16 +39,7 @@ export class PackageSearchService {
 
     const options = createHttpOptions(packageName, refresh);
 
-    // TODO: Add error handling
-    return this.http.get(searchUrl, options).pipe(
-      map((data: any) => {
-        return data.results.map((entry: any) => ({
-            name: entry.name[0],
-            version: entry.version[0],
-            description: entry.description[0]
-          } as NpmPackageInfo )
-        );
-      }),
+    return this.http.get<NpmPackageInfo[]>(searchUrl, options).pipe(
       catchError(this.handleError('search', []))
     );
   }

--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -856,7 +856,7 @@ The `CachingInterceptor` in the following example demonstrates this approach.
 </code-example>
 
 * The `isCacheable()` function determines if the request is cacheable.
-In this sample, only GET requests to the npm package search API are cacheable.
+In this sample, only GET requests to the package search API are cacheable.
 
 * If the request is not cacheable, the interceptor forwards the request
 to the next handler in the chain.
@@ -865,8 +865,7 @@ to the next handler in the chain.
 the cached response, by-passing the `next` handler (and all other interceptors downstream).
 
 * If a cacheable request is not in cache, the code calls `sendRequest()`.
-This function creates a [request clone](#immutability) without headers, because the npm API forbids them.
-The function then forwards the clone of the request to `next.handle()` which ultimately calls the server and returns the server's response.
+This function forwards the request to `next.handle()` which ultimately calls the server and returns the server's response.
 
 {@a send-request}
 <code-example
@@ -890,7 +889,7 @@ The `HttpClient.get()` method normally returns an observable that emits a single
 An interceptor can change this to an observable that emits [multiple values](guide/observables).
 
 The following revised version of the `CachingInterceptor` optionally returns an observable that
-immediately emits the cached response, sends the request on to the npm web API,
+immediately emits the cached response, sends the request on to the package search API,
 and emits again later with the updated search results.
 
 <code-example
@@ -980,9 +979,9 @@ If you need to make an HTTP request in response to user input, it's not efficien
 It's better to wait until the user stops typing and then send a request.
 This technique is known as debouncing.
 
-Consider the following template, which lets a user enter a search term to find an npm package by name.
+Consider the following template, which lets a user enter a search term to find a package by name.
 When the user enters a name in a search-box, the `PackageSearchComponent` sends
-a search request for a package with that name to the npm web API.
+a search request for a package with that name to the package search API.
 
 <code-example
   path="http/src/app/package-search/package-search.component.html"


### PR DESCRIPTION
Previously the `http` example did look ups a the npmsearch.com website to demonstrate response caching.
But if this service became unavailable then the example (and its e2e tests) would fail.

This commit changes the example to use the in-memory-web-api for this lookup,
which will not be affected by 3rd party outages.

The guide that references this example has been updated to avoid references to the original npm search service.
