### PR TITLE
fix(router): Prevent URL flicker when new navigations cancel ongoing …

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -921,27 +921,7 @@ export class Router {
                        if (!completed && !errored) {
                          const cancelationReason = `Navigation ID ${
                              t.id} is not equal to the current navigation id ${this.navigationId}`;
-                         if (this.canceledNavigationResolution === 'replace') {
-                           // Must reset to current URL tree here to ensure history.state is set. On
-                           // a fresh page load, if a new navigation comes in before a successful
-                           // navigation completes, there will be nothing in
-                           // history.state.navigationId. This can cause sync problems with
-                           // AngularJS sync code which looks for a value here in order to determine
-                           // whether or not to handle a given popstate event or to leave it to the
-                           // Angular router.
-                           this.restoreHistory(t);
-                           this.cancelNavigationTransition(t, cancelationReason);
-                         } else {
-                           // We cannot trigger a `location.historyGo` if the
-                           // cancellation was due to a new navigation before the previous could
-                           // complete. This is because `location.historyGo` triggers a `popstate`
-                           // which would also trigger another navigation. Instead, treat this as a
-                           // redirect and do not reset the state.
-                           this.cancelNavigationTransition(t, cancelationReason);
-                           // TODO(atscott): The same problem happens here with a fresh page load
-                           // and a new navigation before that completes where we won't set a page
-                           // id.
-                         }
+                         this.cancelNavigationTransition(t, cancelationReason);
                        }
                        // currentNavigation should always be reset to null here. If navigation was
                        // successful, lastSuccessfulTransition will have already been set. Therefore


### PR DESCRIPTION
…ones

This bit of code is problematic for several reasons:
1. AngularJS-specific handling should not exist in core router code if it can be avoided.
It's not something that should complicated the code long-term
2. It causes URL flickering (the `replace: /` really does happen and can be observed)
3. The original intent was likely for the URL to not actually change;
since the Router only initially supported 'deferred' navigations, this would _usually_ be the case.
4. It actually causes observers of URL changes more problems in handling changes
because the router is already about to process another navigation request.
Notice that when using `'computed'` restoration logic, we do not reset the URL
because it would cause another location change event and conflict with the new navigation.
5. It only resets the browser URL but does nothing to sync the rest of the internal state of the router.
6. It makes guards which call `router.navigate()` behave _slightly_ differently
than guard which return `UrlTree`. Guards which return `UrlTree` do not reset the
URL, but instead just trigger a new navigation.
7. It resets the entire URL rather than just the portion that the
   `UrlHandlingStrategy` is configured to handle. Theoretically, the
   Router could be configured to only handle a part of the URL so failed
   navigations should not reset parts it is not configured to touch.
   Note that this is actually a problem in other places in the router as
   well where `resetState` is not called before
   `resetUrlToCurrentUrlTree`.

As a nice benefit, when `urlUpdateStrategy` is set to `'eager'`, this
makes #17004 possible.

BREAKING CHANGE:
The router will no longer replace the browser URL when a new navigation
cancels an ongoing navigation. This often causes URL flicker and was
only in place to support some AngularJS hybrid applications. Hybrid
applications which rely on the `navigationId` being present on initial
navigations that were handled by the Angular router should instead
subscribe to `NavigationCancel` events and perform the
`location.replaceState` themselves to add `navigationId` to the Router
state.
In addition, tests which assert `urlChanges` on the `SpyLocation` may
need to be adjusted to account for the `replaceState` which is no longer
triggered.

[TGP](https://test.corp.google.com/ui#id=OCL:397147633:BASE:397365371:1631903912824:7dcb3c0d) - The one failure is being addressed in the test. It relates to the "assert `urlChanges` on the `SpyLocation`" note in the breaking change.