### PR TITLE
fix(forms): not picking up disabled state if group is swapped out and disabled

### DIFF
--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -123,9 +123,6 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
         cleanUpControl(previousForm, this, /* validateControlPresenceOnChange */ false);
       }
       setUpControl(this.form, this);
-      if (this.control.disabled && this.valueAccessor!.setDisabledState) {
-        this.valueAccessor!.setDisabledState!(true);
-      }
       this.form.updateValueAndValidity({emitEvent: false});
     }
     if (isPropertyUpdated(changes, this.viewModel)) {

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -205,9 +205,6 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
   private _setUpControl() {
     this._checkParentType();
     (this as {control: FormControl}).control = this.formDirective.addControl(this);
-    if (this.control.disabled && this.valueAccessor!.setDisabledState) {
-      this.valueAccessor!.setDisabledState!(true);
-    }
     this._added = true;
   }
 }

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -41,6 +41,10 @@ export function setUpControl(control: FormControl, dir: NgControl): void {
 
   dir.valueAccessor!.writeValue(control.value);
 
+  if (control.disabled) {
+    dir.valueAccessor!.setDisabledState?.(true);
+  }
+
   setUpViewChangePipeline(control, dir);
   setUpModelChangePipeline(control, dir);
 

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -9,7 +9,7 @@
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {Component, Directive, forwardRef, Input, NgModule, OnDestroy, Type} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {AbstractControl, AsyncValidator, AsyncValidatorFn, COMPOSITION_BUFFER_MODE, ControlValueAccessor, DefaultValueAccessor, FormArray, FormControl, FormControlDirective, FormControlName, FormGroup, FormGroupDirective, FormsModule, MaxValidator, MinLengthValidator, MinValidator, NG_ASYNC_VALIDATORS, NG_VALIDATORS, NG_VALUE_ACCESSOR, ReactiveFormsModule, Validator, Validators} from '@angular/forms';
+import {AbstractControl, AsyncValidator, AsyncValidatorFn, COMPOSITION_BUFFER_MODE, ControlValueAccessor, DefaultValueAccessor, FormArray, FormBuilder, FormControl, FormControlDirective, FormControlName, FormGroup, FormGroupDirective, FormsModule, MaxValidator, MinLengthValidator, MinValidator, NG_ASYNC_VALIDATORS, NG_VALIDATORS, NG_VALUE_ACCESSOR, ReactiveFormsModule, Validator, Validators} from '@angular/forms';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {dispatchEvent, sortedClassList} from '@angular/platform-browser/testing/src/browser_util';
 import {merge, NEVER, of, Subscription, timer} from 'rxjs';
@@ -307,6 +307,42 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
         inputs = fixture.debugElement.queryAll(By.css('input'));
         expect(inputs[2]).not.toBeDefined();
+      });
+
+      it('should sync the disabled state if it changes right after a group is re-bound', () => {
+        @Component({
+          template: `
+            <form [formGroup]="form">
+              <input formControlName="input">
+            </form>
+          `
+        })
+        class App {
+          form: FormGroup;
+
+          constructor(private _fb: FormBuilder) {
+            this.form = this._getForm();
+          }
+
+          private _getForm() {
+            return this._fb.group({'input': 'value'});
+          }
+
+          recreateAndDisable() {
+            this.form = this._getForm();
+            this.form.disable();
+          }
+        }
+
+        const fixture = initTest(App);
+        fixture.detectChanges();
+
+        const input = fixture.nativeElement.querySelector('input');
+        expect(input.disabled).toBe(false);
+
+        fixture.componentInstance.recreateAndDisable();
+        fixture.detectChanges();
+        expect(input.disabled).toBe(true);
       });
 
       describe('nested control rebinding', () => {


### PR DESCRIPTION
Fixes a long-standing issue where swapping out the `FormGroup` and calling `disable` immediately afterwards doesn't actually disable the `ControlValueAccessor`.

Fixes #22556.