### PR TITLE
fix(compiler-cli): handle directives that refer to a namespaced class in a type parameter bound

### DIFF
--- a/packages/compiler-cli/ngcc/src/host/delegating_host.ts
+++ b/packages/compiler-cli/ngcc/src/host/delegating_host.ts
@@ -162,7 +162,7 @@ export class DelegatingReflectionHost implements NgccReflectionHost {
     return this.ngccHost.detectKnownDeclaration(decl);
   }
 
-  isStaticallyExported(clazz: ClassDeclaration): boolean {
-    return this.ngccHost.isStaticallyExported(clazz);
+  isStaticallyExported(decl: ts.Node): boolean {
+    return this.ngccHost.isStaticallyExported(decl);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -858,12 +858,12 @@ export interface ReflectionHost {
   getAdjacentNameOfClass(clazz: ClassDeclaration): ts.Identifier;
 
   /**
-   * Returns `true` if a class is exported from the module in which it's defined.
+   * Returns `true` if a declaration is exported from the module in which it's defined.
    *
-   * Not all mechanisms by which a class is exported can be statically detected, especially when
-   * processing already compiled JavaScript. A `false` result does not indicate that the class is
-   * never visible outside its module, only that it was not exported via one of the export
-   * mechanisms that the `ReflectionHost` is capable of statically checking.
+   * Not all mechanisms by which a declaration is exported can be statically detected, especially
+   * when processing already compiled JavaScript. A `false` result does not indicate that the
+   * declaration is never visible outside its module, only that it was not exported via one of the
+   * export mechanisms that the `ReflectionHost` is capable of statically checking.
    */
-  isStaticallyExported(clazz: ClassDeclaration): boolean;
+  isStaticallyExported(decl: ts.Node): boolean;
 }


### PR DESCRIPTION
The template type-checker has to emit type constructors for the
directives that are used in a template, where a type constructor's
declaration has to mirror the type parameter constraints as they were
originally declared. Therefore, the compiler analyzes whether a type
parameter constraint can be recreated, e.g. by generating imports for
any type references. Some type references cannot be recreated, in which
case the compiler has to fall back to a strategy where the type
constructor is created inline in the original source file (which comes
with a performance penalty).

There used to be an issue for type references to namespaced declarations.
The compiler is unable to emit such references such that an inline
type constructor should be used as fallback, but this did not happen.
This caused the attempt to emit the type reference to fail, as the
namespaced declaration cannot be located by the reference emitters.

This commit fixes the issue by using a stricter check to determine if a
type parameter requires an inline type constructor. The TypeScript
reflection host's `isStaticallyExported` logic was expanded to work for
any declaration instead of just classes, as e.g. type declarations can
also be referenced in a type parameter constraint.

Closes #43383