### PR TITLE
fix(service-worker): do not unassign clients from a broken version

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -800,36 +800,32 @@ export class Driver implements Debuggable, UpdateSource {
     }
 
     const brokenHash = broken[0];
-    const affectedClients = Array.from(this.clientVersionMap.entries())
-                                .filter(([clientId, hash]) => hash === brokenHash)
-                                .map(([clientId]) => clientId);
+
+    // The specified version is broken and new clients should not be served from it. However, it is
+    // deemed even riskier to switch the existing clients to a different version or to the network.
+    // Therefore, we keep clients on their current version (even if broken) and ensure that no new
+    // clients will be assigned to it.
 
     // TODO: notify affected apps.
 
     // The action taken depends on whether the broken manifest is the active (latest) or not.
-    // If so, the SW cannot accept new clients, but can continue to service old ones.
+    // - If the broken version is not the latest, no further action is necessary, since new clients
+    //   will be assigned to the latest version anyway.
+    // - If the broken version is the latest, the SW cannot accept new clients (but can continue to
+    //   service old ones).
     if (this.latestHash === brokenHash) {
-      // The latest manifest is broken. This means that new clients are at the mercy of the
-      // network, but caches continue to be valid for previous versions. This is
-      // unfortunate but unavoidable.
+      // The latest manifest is broken. This means that new clients are at the mercy of the network,
+      // but caches continue to be valid for previous versions. This is unfortunate but unavoidable.
       this.state = DriverReadyState.EXISTING_CLIENTS_ONLY;
       this.stateMessage = `Degraded due to: ${errorToString(err)}`;
 
-      // Cancel the binding for the affected clients.
-      affectedClients.forEach(clientId => this.clientVersionMap.delete(clientId));
-    } else {
-      // The latest version is viable, but this older version isn't. The only
-      // possible remedy is to stop serving the older version and go to the network.
-      // Put the affected clients on the latest version.
-      affectedClients.forEach(clientId => this.clientVersionMap.set(clientId, this.latestHash!));
-    }
-
-    try {
-      await this.sync();
-    } catch (err2) {
-      // We are already in a bad state. No need to make things worse.
-      // Just log the error and move on.
-      this.debugger.log(err2, `Driver.versionFailed(${err.message || err})`);
+      try {
+        await this.sync();
+      } catch (err2) {
+        // We are already in a bad state. No need to make things worse.
+        // Just log the error and move on.
+        this.debugger.log(err2, `Driver.versionFailed(${err.message || err})`);
+      }
     }
   }
 

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -481,7 +481,8 @@ export class Driver implements Debuggable, UpdateSource {
             await this.notifyClientsAboutUnrecoverableState(appVersion, err.message);
           }
           if (err.isCritical) {
-            // Something went wrong with the activation of this version.
+            // Something went wrong with handling the request from this version.
+            this.debugger.log(err, `Driver.handleFetch(version: ${appVersion.manifestHash})`);
             await this.versionFailed(appVersion, err);
             return this.safeFetch(event.request);
           }

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -2045,12 +2045,12 @@ describe('Driver', () => {
       // `client1`).
       expect(await makeRequest(scope, '/bar.txt', 'client1')).toBe('this is bar (broken)');
       expect(driver.state).toBe(DriverReadyState.EXISTING_CLIENTS_ONLY);
-      brokenLazyServer.sawRequestFor('/bar.txt');
+      brokenLazyServer.assertSawRequestFor('/bar.txt');
       brokenLazyServer.clearRequests();
 
-      // `client1` should not be served from the network.
+      // `client1` should now be served from the network.
       expect(await makeRequest(scope, '/foo.txt', 'client1')).toBe('this is foo (broken)');
-      brokenLazyServer.sawRequestFor('/foo.txt');
+      brokenLazyServer.assertSawRequestFor('/foo.txt');
 
       // `client2` should still be served from the old version (since it never updated).
       expect(await makeRequest(scope, '/foo.txt', 'client2')).toBe('this is foo');


### PR DESCRIPTION
Previously, when a version was found to be broken, any clients assigned to that version were unassigned (and either assigned to the latest version or to none if the latest version was the broken one). A version could be considered broken for several reasons, but most often it is a response for a hashed asset that eiher does not exist or contains different content than the SW expects. See https://github.com/angular/angular/issues/28114#issuecomment-923122967 for more details.

However, assigning a client to a different version (or the network) in the middle of a session, turned out to be more risky than keeping it on the same version. For angular.io, for example, it has led to #28114.

This commit avoids making things worse when identifying a broken version by keeping existing clients to their assigned version (but ensuring that no new clients are assigned to the broken version).

NOTE:
Reloading the page generates a new client ID, so it is like a new client for the SW, even if the tab and URL are the same.