### PR TITLE
fix(migrations): Ensure routerLink migration works for CRLF line endings

### DIFF
--- a/packages/core/schematics/migrations/router-link-empty-expression/index.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/index.ts
@@ -136,7 +136,7 @@ function getFixesByFile(templates: ResolvedTemplate[]): Map<string, FixedTemplat
 function fixEmptyRouterlinksInTemplate(template: ResolvedTemplate): FixedTemplate|null {
   const emptyRouterlinkExpressions = analyzeResolvedTemplate(template);
 
-  if (!emptyRouterlinkExpressions) {
+  if (!emptyRouterlinkExpressions || emptyRouterlinkExpressions.length === 0) {
     return null;
   }
 

--- a/packages/core/schematics/test/routerlink_empty_expr_migration_spec.ts
+++ b/packages/core/schematics/test/routerlink_empty_expr_migration_spec.ts
@@ -200,4 +200,24 @@ describe('routerlink emptyExpr assignment migration', () => {
 
        expect(content).toEqual(contents);
      });
+
+  it('should work for files that use CRLF line endings', async () => {
+    writeFile(
+        '/index.ts',
+        `
+      import {Component} from '@angular/core';
+
+      @Component({` +
+            'template: `<div [routerLink]=\'\'>\r\n{{1}}\r\n</div>`' +
+            `})
+      export class MyComp {}
+    `);
+
+    await runMigration();
+    expect(warnOutput.length).toBe(1);
+    expect(warnOutput[0]).toMatch(/^⮑ {3}index.ts@4:35/);
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`<div [routerLink]='[]'>\r\n{{1}}\r\n</div>`);
+  });
 });


### PR DESCRIPTION
The previous replacement logic would not account for the CRLF line
endings when applying replacements because it would replace the whole
template with `template.content.length` which would not account for
CRLF. This update applies individual expression edits at each location
in the template rather than attempting to replace the whole template
contents with a new string that contains the migrations.

fixes #43416