### PR TITLE
fix(compiler-cli): avoid broken references in .d.ts files due to @internal markers

### DIFF
--- a/packages/compiler-cli/src/ngtsc/diagnostics/index.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/index.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+export {COMPILER_ERRORS_WITH_GUIDES, ERROR_DETAILS_PAGE_BASE_URL} from './src/docs';
 export {FatalDiagnosticError, isFatalDiagnosticError, makeDiagnostic, makeRelatedInformation} from './src/error';
-export {COMPILER_ERRORS_WITH_GUIDES, ERROR_DETAILS_PAGE_BASE_URL, ErrorCode, ngErrorCode} from './src/error_code';
-export {replaceTsWithNgInErrors} from './src/util';
+export {ErrorCode} from './src/error_code';
+export {ngErrorCode, replaceTsWithNgInErrors} from './src/util';

--- a/packages/compiler-cli/src/ngtsc/diagnostics/index.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/index.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {COMPILER_ERRORS_WITH_GUIDES, ERROR_DETAILS_PAGE_BASE_URL} from './src/docs';
+export {COMPILER_ERRORS_WITH_GUIDES} from './src/docs';
 export {FatalDiagnosticError, isFatalDiagnosticError, makeDiagnostic, makeRelatedInformation} from './src/error';
 export {ErrorCode} from './src/error_code';
+export {ERROR_DETAILS_PAGE_BASE_URL} from './src/error_details_base_url';
 export {ngErrorCode, replaceTsWithNgInErrors} from './src/util';

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/docs.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/docs.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ErrorCode} from './error_code';
+
+/**
+ * Base URL for the error details page.
+ * Keep this value in sync with a similar const in
+ * `packages/core/src/render3/error_code.ts`.
+ */
+export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';
+
+/**
+ * Contains a set of error messages that have detailed guides at angular.io.
+ * Full list of available error guides can be found at https://angular.io/errors
+ */
+export const COMPILER_ERRORS_WITH_GUIDES = new Set([
+  ErrorCode.DECORATOR_ARG_NOT_LITERAL,
+  ErrorCode.IMPORT_CYCLE_DETECTED,
+  ErrorCode.PARAM_MISSING_TOKEN,
+  ErrorCode.SCHEMA_INVALID_ELEMENT,
+  ErrorCode.SCHEMA_INVALID_ATTRIBUTE,
+  ErrorCode.MISSING_REFERENCE_TARGET,
+  ErrorCode.COMPONENT_INVALID_SHADOW_DOM_SELECTOR,
+]);

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/docs.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/docs.ts
@@ -9,13 +9,6 @@
 import {ErrorCode} from './error_code';
 
 /**
- * Base URL for the error details page.
- * Keep this value in sync with a similar const in
- * `packages/core/src/render3/error_code.ts`.
- */
-export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';
-
-/**
  * Contains a set of error messages that have detailed guides at angular.io.
  * Full list of available error guides can be found at https://angular.io/errors
  */

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
@@ -8,7 +8,8 @@
 
 import ts from 'typescript';
 
-import {ErrorCode, ngErrorCode} from './error_code';
+import {ErrorCode} from './error_code';
+import {ngErrorCode} from './util';
 
 export class FatalDiagnosticError {
   constructor(

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts
@@ -226,33 +226,3 @@ export enum ErrorCode {
    */
   SUGGEST_SUBOPTIMAL_TYPE_INFERENCE = 10002,
 }
-
-/**
- * @internal
- * Base URL for the error details page.
- * Keep this value in sync with a similar const in
- * `packages/core/src/render3/error_code.ts`.
- */
-export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';
-
-/**
- * @internal
- * Contains a set of error messages that have detailed guides at angular.io.
- * Full list of available error guides can be found at https://angular.io/errors
- */
-export const COMPILER_ERRORS_WITH_GUIDES = new Set([
-  ErrorCode.DECORATOR_ARG_NOT_LITERAL,
-  ErrorCode.IMPORT_CYCLE_DETECTED,
-  ErrorCode.PARAM_MISSING_TOKEN,
-  ErrorCode.SCHEMA_INVALID_ELEMENT,
-  ErrorCode.SCHEMA_INVALID_ATTRIBUTE,
-  ErrorCode.MISSING_REFERENCE_TARGET,
-  ErrorCode.COMPONENT_INVALID_SHADOW_DOM_SELECTOR,
-]);
-
-/**
- * @internal
- */
-export function ngErrorCode(code: ErrorCode): number {
-  return parseInt('-99' + code);
-}

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// IMPORTANT: this file is patched when it's synced into g3.
-// Changing this file may cause conflicts, please update only when it's unavoidable.
-
 /**
  * Base URL for the error details page.
  *

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// IMPORTANT: this file is patched when it's synced into g3.
+// Changing this file may cause conflicts, please update only when it's unavoidable.
+
+/**
+ * Base URL for the error details page.
+ *
+ * Keep the files below in full sync:
+ *  - packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
+ *  - packages/core/src/render3/error_details_base_url.ts
+ */
+export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/util.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ErrorCode} from './error_code';
+
 const ERROR_CODE_MATCHER = /(\u001b\[\d+m ?)TS-99(\d+: ?\u001b\[\d+m)/g;
 
 /**
@@ -19,4 +21,8 @@ const ERROR_CODE_MATCHER = /(\u001b\[\d+m ?)TS-99(\d+: ?\u001b\[\d+m)/g;
  */
 export function replaceTsWithNgInErrors(errors: string): string {
   return errors.replace(ERROR_CODE_MATCHER, '$1NG$2');
+}
+
+export function ngErrorCode(code: ErrorCode): number {
+  return parseInt('-99' + code);
 }

--- a/packages/core/src/render3/error_code.ts
+++ b/packages/core/src/render3/error_code.ts
@@ -6,10 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Base URL for the error details page.
-// Keep this value in sync with a similar const in
-// `packages/compiler-cli/src/ngtsc/diagnostics/src/docs.ts`.
-const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';
+import {ERROR_DETAILS_PAGE_BASE_URL} from './error_details_base_url';
 
 export const enum RuntimeErrorCode {
   // Internal Errors

--- a/packages/core/src/render3/error_code.ts
+++ b/packages/core/src/render3/error_code.ts
@@ -8,7 +8,7 @@
 
 // Base URL for the error details page.
 // Keep this value in sync with a similar const in
-// `packages/compiler-cli/src/ngtsc/diagnostics/src/error_code.ts`.
+// `packages/compiler-cli/src/ngtsc/diagnostics/src/docs.ts`.
 const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';
 
 export const enum RuntimeErrorCode {

--- a/packages/core/src/render3/error_details_base_url.ts
+++ b/packages/core/src/render3/error_details_base_url.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// IMPORTANT: this file is patched when it's synced into g3.
-// Changing this file may cause conflicts, please update only when it's unavoidable.
-
 /**
  * Base URL for the error details page.
  *

--- a/packages/core/src/render3/error_details_base_url.ts
+++ b/packages/core/src/render3/error_details_base_url.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// IMPORTANT: this file is patched when it's synced into g3.
+// Changing this file may cause conflicts, please update only when it's unavoidable.
+
+/**
+ * Base URL for the error details page.
+ *
+ * Keep the files below in full sync:
+ *  - packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
+ *  - packages/core/src/render3/error_details_base_url.ts
+ */
+export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';


### PR DESCRIPTION
The `ErrorCode` enum in the `error_code.ts` file is governed by public
api guards but the other top-level exports from that file are exempt
from public api documentation and are therefore marked as `@internal`.
However, TypeScript is configured with the `stripInternal` compiler
option such that declarations with `@internal` markers are not emitted
into the `.d.ts` files, but this means that the reexports in the barrel
file end up referring to missing declarations.

The `stripInternal` option is considered internal and its documentation
states to use at your own risk (as per https://github.com/microsoft/TypeScript/issues/45307).
Having the option enabled is desirable for us as it works well for
hiding class fields that are marked `@internal`, which is an effective
way to hide members from the .d.ts file. As a workaround for the issue
with top-level symbols, the declarations with `@internal` markers are
moved to dedicated files for which no public api guard is setup,
therefore allowing their `@internal` markers to be dropped.

Fixes #43097