### PR TITLE
docs(http): get rid of not needed space at the end of the sentence

### DIFF
--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -36,7 +36,7 @@ import {HttpEvent} from './response';
  * @usageNotes
  *
  * To use the same instance of `HttpInterceptors` for the entire app, import the `HttpClientModule`
- * only in your `AppModule`, and add the interceptors to the root application injector .
+ * only in your `AppModule`, and add the interceptors to the root application injector.
  * If you import `HttpClientModule` multiple times across different modules (for example, in lazy
  * loading modules), each import creates a new copy of the `HttpClientModule`, which overwrites the
  * interceptors provided in the root module.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is a space at the end of the sentence when describing the usage of the HttpInterceptor. 

Issue Number: N/A


## What is the new behavior?
There is not a space at the end of the sentence when describing the usage of the HttpInterceptor anymore. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
