### PR TITLE
feat(service-worker): SwUpdate#activeUpdate and `SwUpdate#checkForUpdate` should have a meaningful outcome

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -61,6 +61,7 @@ v12 - v15
 | `@angular/core/testing` | [`aotSummaries` field of the `TestModuleMetadata` type](#testing)                                                                           | <!--v13--> v14         |
 | `@angular/forms`        | [`FormBuilder.group` legacy options parameter](api/forms/FormBuilder#group)                   | <!--v11--> v14        |
 | `@angular/service-worker`| [`SwUpdate.activated`](api/service-worker/SwUpdate#activated)                                | <!--v13--> unspecified |
+| `@angular/service-worker`| [`SwUpdate.available`](api/service-worker/SwUpdate#available)                                | <!--v13--> unspecified |
 | `@angular/router`       | [`ActivatedRoute` params and `queryParams` properties](#activatedroute-props)                 | unspecified           |
 | template syntax         | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector)                            | <!--v7--> unspecified |
 
@@ -138,6 +139,7 @@ This section contains a complete list all of the currently-deprecated APIs, with
 | API                                                            | Replacement                                                                            | Deprecation announced    | Notes
 |:---                                                            |:---                                                                                    |:---                      |:---
 | [`SwUpdate.activated`](api/service-worker/SwUpdate#activated)  | [`SwUpdate.activateUpdate` return value](api/service-worker/SwUpdate#activateUpdate)   | v13                      | [`SwUpdate.activateUpdate`](api/service-worker/SwUpdate#activateUpdate)  return value indicates if an update was successfully activated |
+| [`SwUpdate.available`](api/service-worker/SwUpdate#available)  | [`SwUpdate.versionUpdates`](api/service-worker/SwUpdate#versionUpdates)                | v13                      | Behavior of [`SwUpdate.available`](api/service-worker/SwUpdate#available) can be rebuild by filtering for the  [`VersionReadyEvent`](api/service-worker/VersionReadyEvent) |
 
 {@a service-worker}
 

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -60,6 +60,7 @@ v12 - v15
 | `@angular/core/testing` | [`aotSummaries` argument in `TestBed.initTestEnvironment`](#testing)                                                                           | <!--v13--> v14         |
 | `@angular/core/testing` | [`aotSummaries` field of the `TestModuleMetadata` type](#testing)                                                                           | <!--v13--> v14         |
 | `@angular/forms`        | [`FormBuilder.group` legacy options parameter](api/forms/FormBuilder#group)                   | <!--v11--> v14        |
+| `@angular/service-worker`| [`SwUpdate.activated`](api/service-worker/SwUpdate#activated)                                | <!--v13--> unspecified |
 | `@angular/router`       | [`ActivatedRoute` params and `queryParams` properties](#activatedroute-props)                 | unspecified           |
 | template syntax         | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector)                            | <!--v7--> unspecified |
 
@@ -131,6 +132,14 @@ This section contains a complete list all of the currently-deprecated APIs, with
 | [`FormBuilder.group` legacy options parameter](api/forms/FormBuilder#group) | [`AbstractControlOptions` parameter value](api/forms/AbstractControlOptions) | v11                   | none  |
 
 {@a upgrade}
+
+### @angular/service-worker
+
+| API                                                            | Replacement                                                                            | Deprecation announced    | Notes
+|:---                                                            |:---                                                                                    |:---                      |:---
+| [`SwUpdate.activated`](api/service-worker/SwUpdate#activated)  | [`SwUpdate.activateUpdate` return value](api/service-worker/SwUpdate#activateUpdate)   | v13                      | [`SwUpdate.activateUpdate`](api/service-worker/SwUpdate#activateUpdate)  return value indicates if an update was successfully activated |
+
+{@a service-worker}
 
 ### @angular/upgrade
 

--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -37,7 +37,8 @@ Do this with the `checkForUpdate()` method:
 
 <code-example path="service-worker-getting-started/src/app/check-for-update.service.ts" header="check-for-update.service.ts"></code-example>
 
-This method returns a `Promise` which indicates that the update check completed successfully, though it does not indicate whether an update was discovered as a result of the check. Even if one is found, the service worker must still successfully download the changed files, which can fail. If successful, the `available` event indicates availability of a new version of the application.
+This method returns a `Promise<boolean>` which indicates if an update is available for activation. The check might fail
+which will cause a rejection of the `Promise`.
 
 <div class="alert is-important">
 

--- a/goldens/public-api/service-worker/service-worker.md
+++ b/goldens/public-api/service-worker/service-worker.md
@@ -44,11 +44,13 @@ export class SwUpdate {
     readonly activated: Observable<UpdateActivatedEvent>;
     // (undocumented)
     activateUpdate(): Promise<boolean>;
+    // @deprecated
     readonly available: Observable<UpdateAvailableEvent>;
     // (undocumented)
     checkForUpdate(): Promise<boolean>;
     get isEnabled(): boolean;
     readonly unrecoverable: Observable<UnrecoverableStateEvent>;
+    readonly versionUpdates: Observable<VersionEvent>;
 }
 
 // @public
@@ -75,7 +77,7 @@ export interface UpdateActivatedEvent {
     type: 'UPDATE_ACTIVATED';
 }
 
-// @public
+// @public @deprecated
 export interface UpdateAvailableEvent {
     // (undocumented)
     available: {

--- a/goldens/public-api/service-worker/service-worker.md
+++ b/goldens/public-api/service-worker/service-worker.md
@@ -42,11 +42,9 @@ export class SwUpdate {
     constructor(sw: ɵangular_packages_service_worker_service_worker_a);
     // @deprecated
     readonly activated: Observable<UpdateActivatedEvent>;
-    // (undocumented)
     activateUpdate(): Promise<boolean>;
     // @deprecated
     readonly available: Observable<UpdateAvailableEvent>;
-    // (undocumented)
     checkForUpdate(): Promise<boolean>;
     get isEnabled(): boolean;
     readonly unrecoverable: Observable<UnrecoverableStateEvent>;

--- a/goldens/public-api/service-worker/service-worker.md
+++ b/goldens/public-api/service-worker/service-worker.md
@@ -59,7 +59,7 @@ export interface UnrecoverableStateEvent {
     type: 'UNRECOVERABLE_STATE';
 }
 
-// @public
+// @public @deprecated
 export interface UpdateActivatedEvent {
     // (undocumented)
     current: {

--- a/goldens/public-api/service-worker/service-worker.md
+++ b/goldens/public-api/service-worker/service-worker.md
@@ -40,12 +40,13 @@ export abstract class SwRegistrationOptions {
 // @public
 export class SwUpdate {
     constructor(sw: ɵangular_packages_service_worker_service_worker_a);
+    // @deprecated
     readonly activated: Observable<UpdateActivatedEvent>;
     // (undocumented)
-    activateUpdate(): Promise<void>;
+    activateUpdate(): Promise<boolean>;
     readonly available: Observable<UpdateAvailableEvent>;
     // (undocumented)
-    checkForUpdate(): Promise<void>;
+    checkForUpdate(): Promise<boolean>;
     get isEnabled(): boolean;
     readonly unrecoverable: Observable<UnrecoverableStateEvent>;
 }
@@ -89,7 +90,6 @@ export interface UpdateAvailableEvent {
     // (undocumented)
     type: 'UPDATE_AVAILABLE';
 }
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/goldens/public-api/service-worker/service-worker.md
+++ b/goldens/public-api/service-worker/service-worker.md
@@ -91,6 +91,49 @@ export interface UpdateAvailableEvent {
     type: 'UPDATE_AVAILABLE';
 }
 
+// @public
+export interface VersionDetectedEvent {
+    // (undocumented)
+    type: 'VERSION_DETECTED';
+    // (undocumented)
+    version: {
+        hash: string;
+        appData?: object;
+    };
+}
+
+// @public (undocumented)
+export type VersionEvent = VersionDetectedEvent | VersionInstallationFailedEvent | VersionReadyEvent;
+
+// @public
+export interface VersionInstallationFailedEvent {
+    // (undocumented)
+    error: string;
+    // (undocumented)
+    type: 'VERSION_INSTALLATION_FAILED';
+    // (undocumented)
+    version: {
+        hash: string;
+        appData?: object;
+    };
+}
+
+// @public
+export interface VersionReadyEvent {
+    // (undocumented)
+    currentVersion: {
+        hash: string;
+        appData?: object;
+    };
+    // (undocumented)
+    latestVersion: {
+        hash: string;
+        appData?: object;
+    };
+    // (undocumented)
+    type: 'VERSION_READY';
+}
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2017": 4841,
-        "main-es2017": 462372,
+        "main-es2017": 463358,
         "polyfills-es2017": 55373,
         "styles": 69772,
         "light-theme": 79025,

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2017": 4841,
-        "main-es2017": 463358,
+        "main-es2017": 462347,
         "polyfills-es2017": 55373,
         "styles": 69772,
         "light-theme": 79025,

--- a/packages/service-worker/src/index.ts
+++ b/packages/service-worker/src/index.ts
@@ -14,7 +14,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent} from './low_level';
+export {UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent, VersionDetectedEvent, VersionEvent, VersionInstallationFailedEvent, VersionReadyEvent,} from './low_level';
 export {ServiceWorkerModule, SwRegistrationOptions} from './module';
 export {SwPush} from './push';
 export {SwUpdate} from './update';

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -17,8 +17,8 @@ export const ERR_SW_NOT_SUPPORTED = 'Service workers are disabled or not support
  * @see {@link guide/service-worker-communications Service worker communication guide}
  *
  * @deprecated
- * This event was only emitted by the deprecated {@link SwUpdate#available}.
- * Use the `VersionEvent` instead which is emitted by {@link SwUpdate#versionUpdates}.
+ * This event is only emitted by the deprecated {@link SwUpdate#available}.
+ * Use the {@link VersionReadyEvent} instead, which is emitted by {@link SwUpdate#versionUpdates}.
  * See {@link SwUpdate#available} docs for an example.
  *
  * @publicApi

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -113,13 +113,6 @@ export interface TypedEvent {
   type: string;
 }
 
-interface StatusEvent {
-  type: 'STATUS';
-  nonce: number;
-  status: boolean;
-  error?: string;
-}
-
 interface OperationCompletedEvent {
   type: 'OPERATION_COMPLETED';
   nonce: number;
@@ -201,17 +194,6 @@ export class NgswCommChannel {
 
   nextEventOfType<T extends TypedEvent>(type: T['type']): Observable<T> {
     return this.eventsOfType(type).pipe(take(1));
-  }
-
-  waitForStatus(nonce: number): Promise<void> {
-    return this.eventsOfType<StatusEvent>('STATUS')
-        .pipe(filter(event => event.nonce === nonce), take(1), map(event => {
-                if (event.status) {
-                  return undefined;
-                }
-                throw new Error(event.error!);
-              }))
-        .toPromise();
   }
 
   waitForOperationCompleted(nonce: number): Promise<boolean> {

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -178,14 +178,11 @@ export class NgswCommChannel {
         .then(() => undefined);
   }
 
-  postMessageWithStatus(type: string, payload: Object, nonce: number, operationNonce: number):
+  postMessageWithOperation(type: string, payload: Object, operationNonce: number):
       Promise<boolean> {
-    const waitForStatus = this.waitForStatus(nonce);
     const waitForOperationCompleted = this.waitForOperationCompleted(operationNonce);
     const postMessage = this.postMessage(type, payload);
-    return Promise.all([waitForStatus, postMessage, waitForOperationCompleted]).then(([
-                                                                                       , , result
-                                                                                     ]) => result);
+    return Promise.all([postMessage, waitForOperationCompleted]).then(([, result]) => result);
   }
 
   generateNonce(): number {

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -113,12 +113,14 @@ export interface TypedEvent {
   type: string;
 }
 
-interface OperationCompletedEvent {
+type OperationCompletedEvent = {
+  type: 'OPERATION_COMPLETED'; nonce: number; result: boolean;
+}|{
   type: 'OPERATION_COMPLETED';
   nonce: number;
-  result: boolean;
-  error?: string;
-}
+  result?: undefined;
+  error: string;
+};
 
 
 function errorObservable(message: string): Observable<any> {

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -17,6 +17,9 @@ export const ERR_SW_NOT_SUPPORTED = 'Service workers are disabled or not support
  * @see {@link guide/service-worker-communications Service worker communication guide}
  *
  * @deprecated
+ * This event was only emitted by the deprecated {@link SwUpdate#available}.
+ * Use the {@link VersionEvent} instead which is emitted by {@link SwUpdate#versionUpdates}.
+ * See {@link SwUpdate#available} docs for an example.
  *
  * @publicApi
  */
@@ -44,7 +47,8 @@ export interface UpdateActivatedEvent {
 }
 
 /**
- * An event emitted when a new version of the app has been detected but downloaded yet.
+ * An event emitted when the service worker has detected a new version of the app on the server and
+ * is about to start downloading it.
  *
  * @see {@link guide/service-worker-communications Service worker communication guide}
  *
@@ -57,6 +61,7 @@ export interface VersionDetectedEvent {
 
 /**
  * An event emitted when the installation of a new version failed.
+ * It may be used for logging/monitoring purposes.
  *
  * @see {@link guide/service-worker-communications Service worker communication guide}
  *

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -32,6 +32,8 @@ export interface UpdateAvailableEvent {
  * @see {@link guide/service-worker-communications Service worker communication guide}
  *
  * @deprecated
+ * This event was only emitted by the deprecated {@link SwUpdate#activated}.
+ * Use the return value of {@link SwUpdate#activateUpdate} instead.
  *
  * @publicApi
  */

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -18,7 +18,7 @@ export const ERR_SW_NOT_SUPPORTED = 'Service workers are disabled or not support
  *
  * @deprecated
  * This event was only emitted by the deprecated {@link SwUpdate#available}.
- * Use the {@link VersionEvent} instead which is emitted by {@link SwUpdate#versionUpdates}.
+ * Use the `VersionEvent` instead which is emitted by {@link SwUpdate#versionUpdates}.
  * See {@link SwUpdate#available} docs for an example.
  *
  * @publicApi

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -87,6 +87,14 @@ export class SwUpdate {
     this.unrecoverable = this.sw.eventsOfType<UnrecoverableStateEvent>('UNRECOVERABLE_STATE');
   }
 
+  /**
+   * Checks for an update and waits until the new version is ready for activation.
+   *
+   * @returns a promise that
+   * - resolves to `true` if a new version was found and is ready to be activated.
+   * - resolves to `false` if no new version was found
+   * - rejects if any error occurs
+   */
   checkForUpdate(): Promise<boolean> {
     if (!this.sw.isEnabled) {
       return Promise.reject(new Error(ERR_SW_NOT_SUPPORTED));
@@ -95,6 +103,14 @@ export class SwUpdate {
     return this.sw.postMessageWithOperation('CHECK_FOR_UPDATES', {nonce}, nonce);
   }
 
+  /**
+   * Activates an update that is ready for activation.
+   *
+   * @returns a promise that
+   *  - resolves to `true` if an update was activated successfully
+   *  - resolves to `false` if no updated was ready for activation
+   *  - rejects if any error occurs
+   */
   activateUpdate(): Promise<boolean> {
     if (!this.sw.isEnabled) {
       return Promise.reject(new Error(ERR_SW_NOT_SUPPORTED));

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -8,8 +8,9 @@
 
 import {Injectable} from '@angular/core';
 import {NEVER, Observable} from 'rxjs';
+import {filter, map} from 'rxjs/operators';
 
-import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent} from './low_level';
+import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent, VersionEvent, VersionReadyEvent,} from './low_level';
 
 
 
@@ -24,7 +25,20 @@ import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, UnrecoverableStateEvent, UpdateAc
 @Injectable()
 export class SwUpdate {
   /**
+   * Emits an `VersionDetectedEvent` event whenever a new version was detected.
+   *
+   * Emits an `VersionInstallationFailedEvent` event whenever an installation of version fails.
+   *
+   * Emits an `VersionReadyEvent` event whenever a new version is ready for activation.
+   *
+   */
+  readonly versionUpdates: Observable<VersionEvent>;
+
+  /**
    * Emits an `UpdateAvailableEvent` event whenever a new app version is available.
+   *
+   * @deprecated use {@link versionUpdates} instead.
+   *
    */
   readonly available: Observable<UpdateAvailableEvent>;
 
@@ -53,12 +67,21 @@ export class SwUpdate {
 
   constructor(private sw: NgswCommChannel) {
     if (!sw.isEnabled) {
+      this.versionUpdates = NEVER;
       this.available = NEVER;
       this.activated = NEVER;
       this.unrecoverable = NEVER;
       return;
     }
-    this.available = this.sw.eventsOfType<UpdateAvailableEvent>('UPDATE_AVAILABLE');
+    this.versionUpdates = this.sw.eventsOfType<VersionEvent>(
+        ['VERSION_DETECTED', 'VERSION_INSTALLATION_FAILED', 'VERSION_READY']);
+    this.available = this.versionUpdates.pipe(
+        filter((evt: VersionEvent): evt is VersionReadyEvent => evt.type === 'VERSION_READY'),
+        map(evt => ({
+              type: 'UPDATE_AVAILABLE',
+              current: evt.currentVersion,
+              available: evt.latestVersion,
+            })));
     this.activated = this.sw.eventsOfType<UpdateActivatedEvent>('UPDATE_ACTIVATED');
     this.unrecoverable = this.sw.eventsOfType<UnrecoverableStateEvent>('UNRECOVERABLE_STATE');
   }

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -30,6 +30,9 @@ export class SwUpdate {
 
   /**
    * Emits an `UpdateActivatedEvent` event whenever the app has been updated to a new version.
+   *
+   * @deprecated Use the return value of {@link activateUpdate} instead.
+   *
    */
   readonly activated: Observable<UpdateActivatedEvent>;
 
@@ -60,19 +63,23 @@ export class SwUpdate {
     this.unrecoverable = this.sw.eventsOfType<UnrecoverableStateEvent>('UNRECOVERABLE_STATE');
   }
 
-  checkForUpdate(): Promise<void> {
+  checkForUpdate(): Promise<boolean> {
     if (!this.sw.isEnabled) {
       return Promise.reject(new Error(ERR_SW_NOT_SUPPORTED));
     }
     const statusNonce = this.sw.generateNonce();
-    return this.sw.postMessageWithStatus('CHECK_FOR_UPDATES', {statusNonce}, statusNonce);
+    const operationNonce = this.sw.generateNonce();
+    return this.sw.postMessageWithStatus(
+        'CHECK_FOR_UPDATES', {statusNonce, operationNonce}, statusNonce, operationNonce);
   }
 
-  activateUpdate(): Promise<void> {
+  activateUpdate(): Promise<boolean> {
     if (!this.sw.isEnabled) {
       return Promise.reject(new Error(ERR_SW_NOT_SUPPORTED));
     }
     const statusNonce = this.sw.generateNonce();
-    return this.sw.postMessageWithStatus('ACTIVATE_UPDATE', {statusNonce}, statusNonce);
+    const operationNonce = this.sw.generateNonce();
+    return this.sw.postMessageWithStatus(
+        'ACTIVATE_UPDATE', {statusNonce, operationNonce}, statusNonce, operationNonce);
   }
 }

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -90,19 +90,15 @@ export class SwUpdate {
     if (!this.sw.isEnabled) {
       return Promise.reject(new Error(ERR_SW_NOT_SUPPORTED));
     }
-    const statusNonce = this.sw.generateNonce();
-    const operationNonce = this.sw.generateNonce();
-    return this.sw.postMessageWithStatus(
-        'CHECK_FOR_UPDATES', {statusNonce, operationNonce}, statusNonce, operationNonce);
+    const nonce = this.sw.generateNonce();
+    return this.sw.postMessageWithOperation('CHECK_FOR_UPDATES', {nonce}, nonce);
   }
 
   activateUpdate(): Promise<boolean> {
     if (!this.sw.isEnabled) {
       return Promise.reject(new Error(ERR_SW_NOT_SUPPORTED));
     }
-    const statusNonce = this.sw.generateNonce();
-    const operationNonce = this.sw.generateNonce();
-    return this.sw.postMessageWithStatus(
-        'ACTIVATE_UPDATE', {statusNonce, operationNonce}, statusNonce, operationNonce);
+    const nonce = this.sw.generateNonce();
+    return this.sw.postMessageWithOperation('ACTIVATE_UPDATE', {nonce}, nonce);
   }
 }

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -42,9 +42,15 @@ export class SwUpdate {
    *
    * The of behavior `available` can be rebuild by filtering for the `VersionReadyEvent`:
    * ```
-   * this.versionUpdates.pipe(
-   *   filter((evt: VersionEvent): evt is VersionReadyEvent => evt.type === 'VERSION_READY'),
-   * ).subscribe(...)
+   * import {filter, map} from 'rxjs/operators';
+   * // ...
+   * const updatesAvailable = swUpdate.versionUpdates.pipe(
+   *   filter((evt): evt is VersionReadyEvent => evt.type === 'VERSION_READY'),
+   *   map(evt => ({
+   *     type: 'UPDATE_AVAILABLE',
+   *     current: evt.currentVersion,
+   *     available: evt.latestVersion,
+   *   })));
    * ```
    */
   readonly available: Observable<UpdateAvailableEvent>;

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -94,7 +94,8 @@ export class SwUpdate {
   }
 
   /**
-   * Checks for an update and waits until the new version is ready for activation.
+   * Checks for an update and waits until the new version is downloaded from the server and ready
+   * for activation.
    *
    * @returns a promise that
    * - resolves to `true` if a new version was found and is ready to be activated.
@@ -110,11 +111,13 @@ export class SwUpdate {
   }
 
   /**
-   * Activates an update that is ready for activation.
+   * Updates the current client (i.e. browser tab) to the latest version that is ready for
+   * activation.
    *
    * @returns a promise that
    *  - resolves to `true` if an update was activated successfully
-   *  - resolves to `false` if no updated was ready for activation
+   *  - resolves to `false` if no update was available (for example, the client was already on the
+   * latest version).
    *  - rejects if any error occurs
    */
   activateUpdate(): Promise<boolean> {

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -38,7 +38,13 @@ export class SwUpdate {
   /**
    * Emits an `UpdateAvailableEvent` event whenever a new app version is available.
    *
-   * @deprecated use {@link versionUpdates} instead.
+   * @deprecated Use {@link versionUpdates} instead.
+   *
+   * The of behavior `available` can be rebuild by filtering for the `VersionReadyEvent`:
+   * @example
+   * this.versionUpdates.pipe(
+   *   filter((evt: VersionEvent): evt is VersionReadyEvent => evt.type === 'VERSION_READY'),
+   * ).subscribe(...)
    *
    */
   readonly available: Observable<UpdateAvailableEvent>;

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -41,11 +41,11 @@ export class SwUpdate {
    * @deprecated Use {@link versionUpdates} instead.
    *
    * The of behavior `available` can be rebuild by filtering for the `VersionReadyEvent`:
-   * @example
+   * ```
    * this.versionUpdates.pipe(
    *   filter((evt: VersionEvent): evt is VersionReadyEvent => evt.type === 'VERSION_READY'),
    * ).subscribe(...)
-   *
+   * ```
    */
   readonly available: Observable<UpdateAvailableEvent>;
 

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -52,7 +52,7 @@ export class SwUpdate {
   /**
    * Emits an `UpdateActivatedEvent` event whenever the app has been updated to a new version.
    *
-   * @deprecated Use the return value of {@link activateUpdate} instead.
+   * @deprecated Use the return value of {@link SwUpdate#activateUpdate} instead.
    *
    */
   readonly activated: Observable<UpdateActivatedEvent>;

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -10,7 +10,7 @@ import {Injectable} from '@angular/core';
 import {NEVER, Observable} from 'rxjs';
 import {filter, map} from 'rxjs/operators';
 
-import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent, VersionEvent, VersionReadyEvent,} from './low_level';
+import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent, VersionEvent, VersionReadyEvent} from './low_level';
 
 
 
@@ -25,12 +25,13 @@ import {ERR_SW_NOT_SUPPORTED, NgswCommChannel, UnrecoverableStateEvent, UpdateAc
 @Injectable()
 export class SwUpdate {
   /**
-   * Emits an `VersionDetectedEvent` event whenever a new version was detected.
+   * Emits a `VersionDetectedEvent` event whenever a new version is detected on the server.
    *
-   * Emits an `VersionInstallationFailedEvent` event whenever an installation of version fails.
+   * Emits a `VersionInstallationFailedEvent` event whenever checking for or downloading a new
+   * version fails.
    *
-   * Emits an `VersionReadyEvent` event whenever a new version is ready for activation.
-   *
+   * Emits a `VersionReadyEvent` event whenever a new version has been downloaded and is ready for
+   * activation.
    */
   readonly versionUpdates: Observable<VersionEvent>;
 

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -516,6 +516,7 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
           update.available.toPromise().catch(err => fail(err));
           update.activated.toPromise().catch(err => fail(err));
           update.unrecoverable.toPromise().catch(err => fail(err));
+          update.versionUpdates.toPromise().catch(err => fail(err));
         });
         it('gives an error when checking for updates', done => {
           update = new SwUpdate(comm);

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -474,38 +474,25 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
         });
       });
       it('activates updates when requested', async () => {
-        mock.messages.subscribe(
-            (msg: {action: string, statusNonce: number, operationNonce: number}) => {
-              expect(msg.action).toEqual('ACTIVATE_UPDATE');
-              mock.sendMessage({
-                type: 'STATUS',
-                nonce: msg.statusNonce,
-                status: true,
-              });
-              mock.sendMessage({
-                type: 'OPERATION_COMPLETED',
-                nonce: msg.operationNonce,
-                result: true,
-              });
-            });
+        mock.messages.subscribe((msg: {action: string, nonce: number}) => {
+          expect(msg.action).toEqual('ACTIVATE_UPDATE');
+          mock.sendMessage({
+            type: 'OPERATION_COMPLETED',
+            nonce: msg.nonce,
+            result: true,
+          });
+        });
         expect(await update.activateUpdate()).toBeTruthy();
       });
       it('reports activation failure when requested', async () => {
-        mock.messages.subscribe(
-            (msg: {action: string, statusNonce: number, operationNonce: number}) => {
-              expect(msg.action).toEqual('ACTIVATE_UPDATE');
-              mock.sendMessage({
-                type: 'STATUS',
-                nonce: msg.statusNonce,
-                status: false,
-                error: 'Failed to activate',
-              });
-              mock.sendMessage({
-                type: 'OPERATION_COMPLETED',
-                nonce: msg.operationNonce,
-                error: 'Failed to activate',
-              });
-            });
+        mock.messages.subscribe((msg: {action: string, nonce: number}) => {
+          expect(msg.action).toEqual('ACTIVATE_UPDATE');
+          mock.sendMessage({
+            type: 'OPERATION_COMPLETED',
+            nonce: msg.nonce,
+            error: 'Failed to activate',
+          });
+        });
         await expectAsync(update.activateUpdate()).toBeRejectedWithError('Failed to activate');
       });
       it('is injectable', () => {

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -8,7 +8,7 @@
 
 import {PLATFORM_ID} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {NgswCommChannel} from '@angular/service-worker/src/low_level';
+import {NgswCommChannel, VersionDetectedEvent} from '@angular/service-worker/src/low_level';
 import {ngswCommChannelFactory, SwRegistrationOptions} from '@angular/service-worker/src/module';
 import {SwPush} from '@angular/service-worker/src/push';
 import {SwUpdate} from '@angular/service-worker/src/update';
@@ -426,11 +426,11 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
           done();
         });
         mock.sendMessage({
-          type: 'UPDATE_AVAILABLE',
-          current: {
+          type: 'VERSION_READY',
+          currentVersion: {
             hash: 'A',
           },
-          available: {
+          latestVersion: {
             hash: 'B',
           },
         });
@@ -457,6 +457,19 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
           },
           current: {
             hash: 'B',
+          },
+        });
+      });
+      it('process any version update event when sent', done => {
+        update.versionUpdates.subscribe(event => {
+          expect(event.type).toEqual('VERSION_DETECTED');
+          expect((event as VersionDetectedEvent).version).toEqual({hash: 'A'});
+          done();
+        });
+        mock.sendMessage({
+          type: 'VERSION_DETECTED',
+          version: {
+            hash: 'A',
           },
         });
       });

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -320,12 +320,10 @@ export class Driver implements Debuggable, UpdateSource {
   private async handleMessage(msg: MsgAny&{action: string}, from: Client): Promise<void> {
     if (isMsgCheckForUpdates(msg)) {
       const action = this.checkForUpdate();
-      await this.reportStatus(from, action.then(() => undefined), msg.statusNonce);
-      await this.completeOperation(from, action, msg.operationNonce);
+      await this.completeOperation(from, action, msg.nonce);
     } else if (isMsgActivateUpdate(msg)) {
       const action = this.updateClient(from);
-      await this.reportStatus(from, action.then(() => undefined), msg.statusNonce);
-      await this.completeOperation(from, action, msg.operationNonce);
+      await this.completeOperation(from, action, msg.nonce);
     }
   }
 
@@ -398,19 +396,6 @@ export class Driver implements Debuggable, UpdateSource {
 
     // As per the spec windowClients are `sorted in the most recently focused order`
     return windowClients[0];
-  }
-  private async reportStatus(client: Client, promise: Promise<void>, nonce: number): Promise<void> {
-    const response = {type: 'STATUS', nonce, status: true};
-    try {
-      await promise;
-      client.postMessage(response);
-    } catch (e) {
-      client.postMessage({
-        ...response,
-        status: false,
-        error: e.toString(),
-      });
-    }
   }
 
   private async completeOperation(client: Client, promise: Promise<boolean>, nonce: number):

--- a/packages/service-worker/worker/src/msg.ts
+++ b/packages/service-worker/worker/src/msg.ts
@@ -12,8 +12,7 @@ export interface MsgAny {
 
 export interface MsgCheckForUpdates {
   action: 'CHECK_FOR_UPDATES';
-  statusNonce: number;
-  operationNonce: number;
+  nonce: number;
 }
 
 export function isMsgCheckForUpdates(msg: MsgAny): msg is MsgCheckForUpdates {
@@ -22,8 +21,7 @@ export function isMsgCheckForUpdates(msg: MsgAny): msg is MsgCheckForUpdates {
 
 export interface MsgActivateUpdate {
   action: 'ACTIVATE_UPDATE';
-  statusNonce: number;
-  operationNonce: number;
+  nonce: number;
 }
 
 export function isMsgActivateUpdate(msg: MsgAny): msg is MsgActivateUpdate {

--- a/packages/service-worker/worker/src/msg.ts
+++ b/packages/service-worker/worker/src/msg.ts
@@ -13,6 +13,7 @@ export interface MsgAny {
 export interface MsgCheckForUpdates {
   action: 'CHECK_FOR_UPDATES';
   statusNonce: number;
+  operationNonce: number;
 }
 
 export function isMsgCheckForUpdates(msg: MsgAny): msg is MsgCheckForUpdates {
@@ -22,6 +23,7 @@ export function isMsgCheckForUpdates(msg: MsgAny): msg is MsgCheckForUpdates {
 export interface MsgActivateUpdate {
   action: 'ACTIVATE_UPDATE';
   statusNonce: number;
+  operationNonce: number;
 }
 
 export function isMsgActivateUpdate(msg: MsgAny): msg is MsgActivateUpdate {

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -14,7 +14,7 @@ import {sha1} from '../src/sha1';
 import {clearAllCaches, MockCache} from '../testing/cache';
 import {MockWindowClient} from '../testing/clients';
 import {MockRequest, MockResponse} from '../testing/fetch';
-import {MockFileSystem, MockFileSystemBuilder, MockServerState, MockServerStateBuilder, tmpHashTableForFs,} from '../testing/mock';
+import {MockFileSystem, MockFileSystemBuilder, MockServerState, MockServerStateBuilder, tmpHashTableForFs} from '../testing/mock';
 import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
 import {envIsSupported} from '../testing/utils';
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -14,7 +14,7 @@ import {sha1} from '../src/sha1';
 import {clearAllCaches, MockCache} from '../testing/cache';
 import {MockWindowClient} from '../testing/clients';
 import {MockRequest, MockResponse} from '../testing/fetch';
-import {MockFileSystem, MockFileSystemBuilder, MockServerState, MockServerStateBuilder, tmpHashTableForFs} from '../testing/mock';
+import {MockFileSystem, MockFileSystemBuilder, MockServerState, MockServerStateBuilder, tmpHashTableForFs,} from '../testing/mock';
 import {SwTestHarness, SwTestHarnessBuilder} from '../testing/scope';
 import {envIsSupported} from '../testing/utils';
 
@@ -478,11 +478,17 @@ describe('Driver', () => {
     serverUpdate.assertSawRequestFor('/redirected.txt');
     serverUpdate.assertNoOtherRequests();
 
-    expect(client.messages).toEqual([{
-      type: 'UPDATE_AVAILABLE',
-      current: {hash: manifestHash, appData: {version: 'original'}},
-      available: {hash: manifestUpdateHash, appData: {version: 'update'}},
-    }]);
+    expect(client.messages).toEqual([
+      {
+        type: 'VERSION_DETECTED',
+        version: {hash: manifestUpdateHash, appData: {version: 'update'}},
+      },
+      {
+        type: 'VERSION_READY',
+        currentVersion: {hash: manifestHash, appData: {version: 'original'}},
+        latestVersion: {hash: manifestUpdateHash, appData: {version: 'update'}},
+      },
+    ]);
 
     // Default client is still on the old version of the app.
     expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
@@ -523,10 +529,11 @@ describe('Driver', () => {
     await driver.updateClient(client as any as Client);
 
     expect(client.messages).toEqual([
+      {type: 'VERSION_DETECTED', version: {hash: manifestUpdateHash, appData: {version: 'update'}}},
       {
-        type: 'UPDATE_AVAILABLE',
-        current: {hash: manifestHash, appData: {version: 'original'}},
-        available: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        type: 'VERSION_READY',
+        currentVersion: {hash: manifestHash, appData: {version: 'original'}},
+        latestVersion: {hash: manifestUpdateHash, appData: {version: 'update'}},
       },
       {
         type: 'UPDATE_ACTIVATED',
@@ -636,9 +643,13 @@ describe('Driver', () => {
 
     expect(client.messages).toEqual([
       {
-        type: 'UPDATE_AVAILABLE',
-        current: {hash: manifestHash, appData: {version: 'original'}},
-        available: {hash: manifestUpdateHash, appData: {version: 'update'}},
+        type: 'VERSION_DETECTED',
+        version: {hash: manifestUpdateHash, appData: {version: 'update'}},
+      },
+      {
+        type: 'VERSION_READY',
+        currentVersion: {hash: manifestHash, appData: {version: 'original'}},
+        latestVersion: {hash: manifestUpdateHash, appData: {version: 'update'}},
       },
       {
         type: 'UPDATE_ACTIVATED',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #39840 


## What is the new behavior?

Exposing a versionUpdate Event and adding a meaningful return value for `SwUpdate#activateUpdate` and ´SwUpdate#checkForUpdate´. Basically implementing what is suggested [here](https://github.com/angular/angular/issues/39840#issuecomment-901157285):

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The return type of `SwUpdate#activateUpdate` and `SwUpdate#checkForUpdate` changed to `Promise<boolean>`. Variable declaration adjustments might be necessary.

## Other information
@gkalpak as promised here is the PR. I did not update the docs completly yet. I guess waiting for the other changes to be ready makes sense.