### PR TITLE
refactor(compiler): reduce number of reexports of ParseTreeResult

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -70,6 +70,7 @@ export * from './expression_parser/ast';
 export * from './expression_parser/lexer';
 export * from './expression_parser/parser';
 export * from './metadata_resolver';
+export {ParseTreeResult} from './ml_parser/parser';
 export * from './ml_parser/ast';
 export * from './ml_parser/html_parser';
 export * from './ml_parser/html_tags';

--- a/packages/compiler/src/ml_parser/html_parser.ts
+++ b/packages/compiler/src/ml_parser/html_parser.ts
@@ -10,8 +10,6 @@ import {getHtmlTagDefinition} from './html_tags';
 import {TokenizeOptions} from './lexer';
 import {Parser, ParseTreeResult} from './parser';
 
-export {ParseTreeResult, TreeError} from './parser';
-
 export class HtmlParser extends Parser {
   constructor() {
     super(getHtmlTagDefinition);

--- a/packages/compiler/src/ml_parser/xml_parser.ts
+++ b/packages/compiler/src/ml_parser/xml_parser.ts
@@ -10,8 +10,6 @@ import {TokenizeOptions} from './lexer';
 import {Parser, ParseTreeResult} from './parser';
 import {getXmlTagDefinition} from './xml_tags';
 
-export {ParseTreeResult, TreeError} from './parser';
-
 export class XmlParser extends Parser {
   constructor() {
     super(getXmlTagDefinition);

--- a/packages/compiler/src/template_parser/template_parser.ts
+++ b/packages/compiler/src/template_parser/template_parser.ts
@@ -14,10 +14,11 @@ import {AST, ASTWithSource, EmptyExpr, ParsedEvent, ParsedProperty, ParsedVariab
 import {Parser} from '../expression_parser/parser';
 import {createTokenForExternalReference, createTokenForReference, Identifiers} from '../identifiers';
 import * as html from '../ml_parser/ast';
-import {HtmlParser, ParseTreeResult} from '../ml_parser/html_parser';
+import {HtmlParser} from '../ml_parser/html_parser';
 import {removeWhitespaces, replaceNgsp} from '../ml_parser/html_whitespaces';
 import {expandNodes} from '../ml_parser/icu_ast_expander';
 import {InterpolationConfig} from '../ml_parser/interpolation_config';
+import {ParseTreeResult} from '../ml_parser/parser';
 import {isNgTemplate, splitNsName} from '../ml_parser/tags';
 import {identifierName, ParseError, ParseErrorLevel, ParseSourceSpan, syntaxError} from '../parse_util';
 import {ProviderElementContext, ProviderViewContext} from '../provider_analyzer';

--- a/packages/compiler/test/ml_parser/ast_spec_utils.ts
+++ b/packages/compiler/test/ml_parser/ast_spec_utils.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ParseTreeResult} from '../../src/compiler';
 import * as html from '../../src/ml_parser/ast';
-import {ParseTreeResult} from '../../src/ml_parser/html_parser';
 import {ParseLocation} from '../../src/parse_util';
 
 export function humanizeDom(parseResult: ParseTreeResult, addSourceSpan: boolean = false): any[] {

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TreeError} from '../..//src/ml_parser/parser';
+import {TreeError} from '../../src/ml_parser/parser';
 import {ParseTreeResult} from '../../src/compiler';
 import * as html from '../../src/ml_parser/ast';
 import {HtmlParser} from '../../src/ml_parser/html_parser';

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {TreeError} from '../..//src/ml_parser/parser';
+import {ParseTreeResult} from '../../src/compiler';
 import * as html from '../../src/ml_parser/ast';
-import {HtmlParser, ParseTreeResult, TreeError} from '../../src/ml_parser/html_parser';
+import {HtmlParser} from '../../src/ml_parser/html_parser';
 import {TokenType} from '../../src/ml_parser/tokens';
 import {ParseError} from '../../src/parse_util';
 

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TreeError} from '../../src/ml_parser/parser';
 import {ParseTreeResult} from '../../src/compiler';
 import * as html from '../../src/ml_parser/ast';
 import {HtmlParser} from '../../src/ml_parser/html_parser';
+import {TreeError} from '../../src/ml_parser/parser';
 import {TokenType} from '../../src/ml_parser/tokens';
 import {ParseError} from '../../src/parse_util';
 

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ParseTreeResult} from '../../../src/compiler';
 import * as e from '../../../src/expression_parser/ast';
 import {Lexer} from '../../../src/expression_parser/lexer';
 import {Parser} from '../../../src/expression_parser/parser';
 import * as html from '../../../src/ml_parser/ast';
-import {HtmlParser, ParseTreeResult} from '../../../src/ml_parser/html_parser';
+import {HtmlParser} from '../../../src/ml_parser/html_parser';
 import {WhitespaceVisitor} from '../../../src/ml_parser/html_whitespaces';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../src/ml_parser/interpolation_config';
 import * as a from '../../../src/render3/r3_ast';


### PR DESCRIPTION
With an upcoming update of the rollup optimizer that is used during bundling, a circular reexport
of ParseTreeResult is discovered.  Instead of expressing reexports of the Symbol within the xml
and html parser files, the ParseTreeResult symbol is explicitly exported in the root
`src/compiler.ts` file.
