### PR TITLE
docs: update CSP section to mention Angular's minimum requirements

### DIFF
--- a/aio/content/guide/security.md
+++ b/aio/content/guide/security.md
@@ -167,9 +167,23 @@ Angular to let binding into `<iframe src>`:
 
 Content Security Policy (CSP) is a defense-in-depth
 technique to prevent XSS. To enable CSP, configure your web server to return an appropriate
-`Content-Security-Policy` HTTP header. Read more about content security policy at the 
+`Content-Security-Policy` HTTP header. Read more about content security policy at the
 [Web Fundamentals guide](https://developers.google.com/web/fundamentals/security/csp) on the
 Google Developers website.
+
+The minimal policy required for brand new Angular is:
+
+```
+default-src 'self'; style-src 'self' 'unsafe-inline';
+```
+
+* The `default-src 'self';` section allows the page to load all its required resources from the same
+  origin.
+* `style-src 'self' 'unsafe-inline';` allows the page to load global styles from the same origin
+  (`'self'`) and enables components to load their styles (`'unsafe-inline'` - see
+  [`angular/angular#6361`](https://github.com/angular/angular/issues/6361)).
+
+Angular itself requires only these settings to function correctly. As your project grows, however, you may need to expand your CSP settings beyond this minimum to accommodate additional features specific to your application.
 
 {@a trusted-types}
 ### Enforcing Trusted Types


### PR DESCRIPTION
Closes angular/angular-cli#21711.
Refs #6361.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Documentation content changes

## What is the current behavior?

Issue Number: angular/angular-cli#21711

CSP documentation does not state anything meaningful about Angular's requirements. In particular about `style-src unsafe-inline;`.

## What is the new behavior?

CSP section now states Angular's minimal requirements (`default-src self; style-src unsafe-inline;`) and links to the relevant issue for style-src because users are likely to ask why that is necessary and if/when it can be removed.

## Does this PR introduce a breaking change?

- [X] No

## Other information

I'm assuming that `style-src unsafe-inline;` is always necessary. Adding @jelbourn, to keep me honest here in case it only applies to certain view encapsulation strategies.