### PR TITLE
docs(router): `params` or `queryParams` are not advised against

### DIFF
--- a/aio/content/guide/router-reference.md
+++ b/aio/content/guide/router-reference.md
@@ -157,6 +157,17 @@ It has a great deal of useful information including:
 
   <tr>
     <td>
+      <code>params</code>
+    </td>
+    <td>
+
+    An `Observable` that contains the required and [optional parameters](guide/router-tutorial-toh#optional-route-parameters) specific to the route.
+
+    </td>
+  </tr>
+
+  <tr>
+    <td>
       <code>paramMap</code>
     </td>
     <td>
@@ -175,6 +186,17 @@ It has a great deal of useful information including:
 
     An `Observable` that contains a [map](api/router/ParamMap) of the [query parameters](guide/router-tutorial-toh#query-parameters) available to all routes.
     The map supports retrieving single and multiple values from the query parameter.
+
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <code>queryParams</code>
+    </td>
+    <td>
+
+    An `Observable` that contains the [query parameters](guide/router-tutorial-toh#query-parameters) available to all routes.
 
     </td>
   </tr>
@@ -246,17 +268,6 @@ It has a great deal of useful information including:
     </td>
   </tr>
 </table>
-
-<div class="alert is-helpful">
-
-Two older properties are still available; however, their replacements are preferable as they might be deprecated in a future Angular version.
-
-* `params`: An `Observable` that contains the required and [optional parameters](guide/router-tutorial-toh#optional-route-parameters) specific to the route. Use `paramMap` instead.
-
-* `queryParams`: An `Observable` that contains the [query parameters](guide/router-tutorial-toh#query-parameters) available to all routes.
-Use `queryParamMap` instead.
-
-</div>
 
 ### Router events
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

This supersede #43529.

According to @atscott:

> We no longer speculate about future deprecations. There are no current plans to remove
> `params` or `queryParams` and there's no benefit to advising against their use.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
