### PR TITLE
fix(docs-infra): display deprecation notes for properties

### DIFF
--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -235,9 +235,7 @@
           {$ (property.description or property.constructorParamDoc.description) | marked $}
 
           {%- if property.deprecated !== undefined %}
-          <p class="deprecated">
-            {$ ('**Deprecated** ' + property.deprecated) | marked | trim $}
-          </p>
+          {$ ('**Deprecated** ' + property.deprecated) | marked | trim $}
           {%- endif %}
 
           {%- if property.see.length %}

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -234,6 +234,12 @@
           {$ property.shortDescription | marked | trim $}{% endif %}
           {$ (property.description or property.constructorParamDoc.description) | marked $}
 
+          {%- if property.deprecated !== undefined %}
+          <p class="deprecated">
+            {$ ('**Deprecated** ' + property.deprecated) | marked | trim $}
+          </p>
+          {%- endif %}
+
           {%- if property.see.length %}
           <p>See also:</p>
           <ul>


### PR DESCRIPTION
Previously, deprecation notes for deprecated class/interface properties were not shown in the API docs. This commit fixes it by ensuring that deprecation notes are shown for properties (similar to how it works for methods).

##
You can see an example at `/api/core/WrappedValue#wrapped`: [Before][1] / [After][2]

[1]: https://v11.angular.io/api/core/WrappedValue?mode=stable#wrapped
[2]: https://pr43566-e1d831b.ngbuilds.io/api/core/WrappedValue#wrapped 