### PR TITLE
ci(*): correctly handle commit message with carriage returns in `payload-size.sh`

### DIFF
--- a/scripts/ci/payload-size.sh
+++ b/scripts/ci/payload-size.sh
@@ -96,7 +96,7 @@ addMessage() {
   # because $CI_COMMIT_RANGE may contain the previous SHA which will not be in the
   # force push or commit, hence we default to last commit.
   message=$(git --git-dir ${PROJECT_ROOT}/.git log --oneline $commitRange -- || git --git-dir ${PROJECT_ROOT}/.git log --oneline -n1)
-  message=$(echo $message | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+  message=$(echo $message | sed 's/\r//g' | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
   payloadData="$payloadData\"message\": \"$message\", "
 }
 


### PR DESCRIPTION
Previously, if a commit message contained a carriage return in its header, the `payload-size.sh` script would fail to upload the payload size data to Firebase, because the JSON payload would be messed up when trying to concatenate the commit message headers. See an example [here][1].

This commit avoids this problem by replacing carriage returns before concatenating the commit message headers with the JSON payload string.

[1]: https://app.circleci.com/pipelines/github/angular/angular/37437/workflows/d0fa4adf-43bb-464e-a2fd-d87da15226dd
