### PR TITLE
Adds support for `ng_module()` to support compilations with warnings

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -351,7 +351,8 @@ export function compile({
   });
   const tsickleEmitResult = emitResult as tsickle.EmitResult;
   let externs = '/** @externs */\n';
-  if (!diagnostics.length) {
+  const hasError = diagnostics.some((diag) => diag.category === ts.DiagnosticCategory.Error);
+  if (!hasError) {
     if (bazelOpts.tsickleGenerateExterns) {
       externs += tsickle.getGeneratedExterns(tsickleEmitResult.externs);
     }

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/BUILD.bazel
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 load("//tools:defaults.bzl", "jasmine_node_test", "ng_module", "ts_library")
 
 ts_library(
@@ -43,4 +44,19 @@ jasmine_node_test(
         ":test_module_partial_compilation",
     ],
     tags = ["ivy-only"],
+)
+
+ng_module(
+    name = "test_module_warnings_lib",
+    srcs = ["test_module_warnings.ts"],
+    experimental_extended_template_diagnostics = True,
+    strict_templates = True,
+    tags = ["ivy-only"],
+    deps = ["//packages/core"],
+)
+
+build_test(
+    name = "test_module_warnings",
+    tags = ["ivy-only"],
+    targets = [":test_module_warnings_lib"],
 )

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_warnings.ts
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/test_module_warnings.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+
+/** Test component which contains an invalid banana in box warning. Should build successfully. */
+@Component({
+  template: `
+    <div ([foo])="bar"></div>
+  `,
+})
+export class TestCmp {
+  bar: string = 'test';
+}


### PR DESCRIPTION
`ngc_wrapped` currently fails when given a compilation that emits only warnings. It doesn't generate the output `.es5.MF` file which Bazel interprets as a hard failure. This PR updates `ngc_wrapped` to emit the manifest as long as none of the diagnostics are errors. This allows it to support a compilation that emits some warnings but no errors and pass the build.

I added `strict_templates` to `ng_module()`, mostly in line with how we do this internally. I also added a new `experimental_extended_template_diagnostics` attribute which enables `_extendedTemplateDiagnostics` as well which gives a warning we can test with. For now, there is one target which enables this and contains an invalid banana in box, which is shown as a warning but most importantly does **not** fail the build. I wanted to add a second `ng_module()` target with `expected_diagnostics` to confirm that the banana in box warning is _actually_ emitted, but it doesn't seem to have any effect and may not be supported. I left out that test for now.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [X] Bugfix (`ngc_wrapped` no longer fails on compilations with warnings).
- [X] Feature (`ng_module()` now supports `strict_templates`)

## What is the current behavior?

`ngc_wrapped` does not generate an `.es5.MF` file when the compilation returns warnings and no errors. This fails `ng_module()` because Bazel requires that all output files are generated.

Issue Number: [b/199443160](http://b/199443160)

## What is the new behavior?

`ngc_wrapped` now generates the `.es5.MF` file as long as no errors are emitted. `ng_module()` now builds successfully when warnings are emitted.

## Does this PR introduce a breaking change?

- [X] No

## Other information

This PR is slightly awkward for versioning because it's really a bugfix for `ngc_wrapped` but also happens to implement a feature for `ng_module()` in order to test it. `ng_module()` is publicly exported, so `strict_templates` is usable. Extended template diagnostics have the `experimental` prefix to be more clear that this is intended as an internal option and not publicly supported yet.

/cc @atscott