### PR TITLE
fix(docs-infra): amend color of code links inside a tags

### DIFF
--- a/aio/src/styles/2-modules/code/_code-theme.scss
+++ b/aio/src/styles/2-modules/code/_code-theme.scss
@@ -87,16 +87,21 @@
   }
 
   .sidenav-content {
+    $link-color: if($is-dark-theme, constants.$cyan, constants.$darkblue);
     code {
       a {
-        color: if($is-dark-theme, constants.$cyan, constants.$darkblue);
+        color: $link-color;
       }
     }
 
     :not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(pre) {
-      > code {
+      & > code {
         background-color: if($is-dark-theme, constants.$darkgray, rgba(constants.$lightgray, 0.3));
         color: if($is-dark-theme, constants.$white, constants.$darkgray);
+      }
+
+      &:is(a) > code {
+        color: $link-color;
       }
     }
   }

--- a/aio/src/styles/2-modules/code/_code-theme.scss
+++ b/aio/src/styles/2-modules/code/_code-theme.scss
@@ -93,9 +93,10 @@
     }
 
     :not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(pre) {
-      & > code {
+      > code {
         background-color: if($is-dark-theme, constants.$darkgray, rgba(constants.$lightgray, 0.3));
       }
+
       &:not(a) > code {
         color: if($is-dark-theme, constants.$white, constants.$darkgray);
       }

--- a/aio/src/styles/2-modules/code/_code-theme.scss
+++ b/aio/src/styles/2-modules/code/_code-theme.scss
@@ -87,21 +87,17 @@
   }
 
   .sidenav-content {
-    $link-color: if($is-dark-theme, constants.$cyan, constants.$darkblue);
-    code {
-      a {
-        color: $link-color;
-      }
+    code a,
+    a > code {
+      color: if($is-dark-theme, constants.$cyan, constants.$darkblue);
     }
 
     :not(h1):not(h2):not(h3):not(h4):not(h5):not(h6):not(pre) {
       & > code {
         background-color: if($is-dark-theme, constants.$darkgray, rgba(constants.$lightgray, 0.3));
-        color: if($is-dark-theme, constants.$white, constants.$darkgray);
       }
-
-      &:is(a) > code {
-        color: $link-color;
+      &:not(a) > code {
+        color: if($is-dark-theme, constants.$white, constants.$darkgray);
       }
     }
   }


### PR DESCRIPTION
when some auto code links fail to happen they are added manually
with the md ``[`code text`](link)``, these generate anchor elements which
contain a code element, such code element does not get the correct text
color, this commit fixes such issue

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] docs style change


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Code links automatically generated by the docs pre-processor get a light blue color, but those added manually in md files don't

For example:
![Screenshot at 2021-09-25 13-12-39](https://user-images.githubusercontent.com/61631103/134771182-9e5f2e0e-7424-4627-ac05-3f0d2e4d7008.png)


## What is the new behavior?

Code links manually added in md files get the blue color as the other auto-generated links:

For example:
![Screenshot at 2021-09-25 13-13-02](https://user-images.githubusercontent.com/61631103/134771229-57141aa4-297a-4e4d-9ec4-e8081f68988a.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
