### PR TITLE
fix(core): do not use Function constructors in development mode to avoid CSP violations

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -14,8 +14,6 @@ import {validateAgainstEventAttributes, validateAgainstEventProperties} from '..
 import {Sanitizer} from '../../sanitization/sanitizer';
 import {assertDefined, assertDomNode, assertEqual, assertGreaterThanOrEqual, assertIndexInRange, assertNotEqual, assertNotSame, assertSame, assertString} from '../../util/assert';
 import {escapeCommentText} from '../../util/dom';
-import {createNamedArrayType} from '../../util/named_array_type';
-import {initNgDevMode} from '../../util/ng_dev_mode';
 import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../../util/ng_reflect';
 import {stringify} from '../../util/stringify';
 import {assertFirstCreatePass, assertFirstUpdatePass, assertLContainer, assertLView, assertTNodeForLView, assertTNodeForTView} from '../assert';
@@ -1623,8 +1621,7 @@ function generateInitialInputs(inputs: {[key: string]: string}, attrs: TAttribut
 //////////////////////////
 
 // Not sure why I need to do `any` here but TS complains later.
-const LContainerArray: any = ((typeof ngDevMode === 'undefined' || ngDevMode) && initNgDevMode()) &&
-    createNamedArrayType('LContainer');
+const LContainerArray: any = class LContainer extends Array {};
 
 /**
  * Creates a LContainer, either from a container instruction, or for a ViewContainerRef.

--- a/packages/core/test/acceptance/ngdevmode_debug_spec.ts
+++ b/packages/core/test/acceptance/ngdevmode_debug_spec.ts
@@ -11,15 +11,28 @@ import {Component} from '@angular/core';
 import {getLContext} from '@angular/core/src/render3/context_discovery';
 import {getComponentLView} from '@angular/core/src/render3/util/discovery_utils';
 import {createNamedArrayType} from '@angular/core/src/util/named_array_type';
+import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
 import {TestBed} from '@angular/core/testing';
 import {onlyInIvy} from '@angular/private/testing';
 
-const supportsArraySubclassing =
-    createNamedArrayType('SupportsArraySubclassing').name === 'SupportsArraySubclassing';
+class SupportsArraySubclassing extends Array {}
+
+// If this is being compiled to ES5 then the array subclass has `Array` as constructor
+// instead of `SupportsArraySubclassing`.
+const targetSupportsArraySubclassing =
+    (new SupportsArraySubclassing()).constructor.name === 'SupportsArraySubclassing';
+
+// Creation of a named array types dynamically may succeed even in ES5 targets, as the named array
+// is created using the Function constructor.
+const runtimeSupportsArraySubclassing =
+    (new (createNamedArrayType('SupportsArraySubclassing'))).constructor.name ===
+    'SupportsArraySubclassing';
 
 onlyInIvy('Debug information exist in ivy only').describe('ngDevMode debug', () => {
   describe('LViewDebug', () => {
-    supportsArraySubclassing && it('should name LView based on type', () => {
+    beforeEach(ngDevModeResetPerfCounters);
+
+    runtimeSupportsArraySubclassing && it('should not name LView based on type by default', () => {
       @Component({
         template: `
         <ul>
@@ -33,16 +46,49 @@ onlyInIvy('Debug information exist in ivy only').describe('ngDevMode debug', () 
       TestBed.configureTestingModule({declarations: [MyApp], imports: [CommonModule]});
       const fixture = TestBed.createComponent(MyApp);
       const rootLView = getLContext(fixture.nativeElement)!.lView;
-      expect(rootLView.constructor.name).toEqual('LRootView');
+      expect(rootLView.constructor.name)
+          .toEqual(targetSupportsArraySubclassing ? 'LRootView' : 'Array');
 
       const componentLView = getComponentLView(fixture.componentInstance);
-      expect(componentLView.constructor.name).toEqual('LComponentView_MyApp');
+      expect(componentLView.constructor.name)
+          .toEqual(targetSupportsArraySubclassing ? 'LComponentView' : 'Array');
 
       const element: HTMLElement = fixture.nativeElement;
       fixture.detectChanges();
       const li = element.querySelector('li')!;
       const embeddedLView = getLContext(li)!.lView;
-      expect(embeddedLView.constructor.name).toEqual('LEmbeddedView_MyApp_li_1');
+      expect(embeddedLView.constructor.name)
+          .toEqual(targetSupportsArraySubclassing ? 'LEmbeddedView' : 'Array');
     });
+
+    runtimeSupportsArraySubclassing &&
+        it('should name LView based on type when namedConstructors is true', () => {
+          ngDevMode!.namedConstructors = true;
+
+          @Component({
+            template: `
+            <ul>
+              <li *ngIf="true">item</li>
+            </ul>
+            `
+          })
+          class MyApp {
+          }
+
+          TestBed.configureTestingModule({declarations: [MyApp], imports: [CommonModule]});
+          const fixture = TestBed.createComponent(MyApp);
+          const rootLView = getLContext(fixture.nativeElement)!.lView;
+          expect(rootLView.constructor.name)
+              .toEqual(targetSupportsArraySubclassing ? 'LRootView' : 'Array');
+
+          const componentLView = getComponentLView(fixture.componentInstance);
+          expect(componentLView.constructor.name).toEqual('LComponentView_MyApp');
+
+          const element: HTMLElement = fixture.nativeElement;
+          fixture.detectChanges();
+          const li = element.querySelector('li')!;
+          const embeddedLView = getLContext(li)!.lView;
+          expect(embeddedLView.constructor.name).toEqual('LEmbeddedView_MyApp_li_1');
+        });
   });
 });


### PR DESCRIPTION
This commit removes the dynamic creation of named arrays for internal
runtime storage arrays as they may cause CSP violations in development
mode,  when an application's CSP configuration does not include
`unsafe-eval`.

Named arrays for view data can still be enabled in development mode
using the `ngDevMode=namedConstructors` query parameter when loading the
application.

The usage of native class syntax for named arrays does not have the
desired effect when the code is downleveled to ES5. Since ES5 targets
are becoming increasingly more rare this is considered less of a problem
than the CSP violation.

Fixes #43494