### PR TITLE
fix(docs-infra): improve cancel icon in top-menu search

### DIFF
--- a/aio/src/app/search/search-box/search-box.component.ts
+++ b/aio/src/app/search/search-box/search-box.component.ts
@@ -15,7 +15,8 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
  */
 @Component({
   selector: 'aio-search-box',
-  template: `<input #searchBox
+  template: `
+  <input #searchBox
     type="search"
     aria-label="search"
     placeholder="Search"
@@ -23,10 +24,12 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
     (keyup)="doSearch()"
     (focus)="doFocus()"
     (click)="doSearch()">
-    <mat-icon
-      *ngIf="searchBox.value"
-      (click)="searchBox.value = ''"
-    >close</mat-icon>`
+  <mat-icon
+    *ngIf="searchBox.value"
+    (click)="searchBox.value = ''">
+    close
+  </mat-icon>
+  `
 })
 export class SearchBoxComponent implements AfterViewInit {
 

--- a/aio/src/app/search/search-box/search-box.component.ts
+++ b/aio/src/app/search/search-box/search-box.component.ts
@@ -22,7 +22,11 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
     (input)="doSearch()"
     (keyup)="doSearch()"
     (focus)="doFocus()"
-    (click)="doSearch()">`
+    (click)="doSearch()">
+    <mat-icon
+      *ngIf="searchBox.value"
+      (click)="searchBox.value = ''"
+    >close</mat-icon>`
 })
 export class SearchBoxComponent implements AfterViewInit {
 

--- a/aio/src/app/search/search-box/search-box.component.ts
+++ b/aio/src/app/search/search-box/search-box.component.ts
@@ -26,7 +26,7 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
     (click)="doSearch()">
   <mat-icon
     *ngIf="searchBox.value"
-    (click)="searchBox.value = ''">
+    (click)="searchBox.value = ''; searchBox.focus()">
     close
   </mat-icon>
   `

--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -196,7 +196,7 @@ mat-toolbar.app-toolbar {
         display: none;
       }
 
-      &:not(:focus-within,:hover) + mat-icon:not(:hover,:focus) {
+      &:not(:focus):not(:hover) + mat-icon:not(:hover):not(:focus) {
         display: none;
       }
     }

--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -1,4 +1,5 @@
 @use '../../mixins';
+@use '../../constants';
 
 // VARIABLES
 $showTopMenuWidth: 1150px;
@@ -159,6 +160,7 @@ mat-toolbar.app-toolbar {
     min-width: 150px;
     height: 100%;
     margin-right: 16px;
+    position: relative;
 
     input {
       border: none;
@@ -189,6 +191,25 @@ mat-toolbar.app-toolbar {
       @media (max-width: 515px) {
         width: 150px;
       }
+
+      &::-webkit-search-cancel-button {
+        display: none;
+      }
+
+      &:not(:focus-within,:hover) + mat-icon:not(:hover,:focus) {
+        display: none;
+      }
+    }
+
+    mat-icon {
+      position: absolute;
+      color: constants.$blue;
+      right: 0.7rem;
+      font-size: 2rem;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
   }
 

--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -165,7 +165,7 @@ mat-toolbar.app-toolbar {
     input {
       border: none;
       border-radius: 100px;
-      padding: 5px 16px;
+      padding: 5px 3rem 5px 16px;
       margin-left: 8px;
       width: 180px;
       max-width: 240px;
@@ -193,6 +193,10 @@ mat-toolbar.app-toolbar {
       }
 
       &::-webkit-search-cancel-button {
+        display: none;
+      }
+
+      &::-ms-clear {
         display: none;
       }
 

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -5,7 +5,7 @@
         "runtime": 4454,
         "main": 463521,
         "polyfills": 55658,
-        "styles": 69791,
+        "styles": 70486,
         "light-theme": 77646,
         "dark-theme": 77764
       }
@@ -15,9 +15,9 @@
     "master": {
       "uncompressed": {
         "runtime": 4454,
-        "main": 462288,
+        "main": 462958,
         "polyfills": 55807,
-        "styles": 69791,
+        "styles": 70486,
         "light-theme": 77646,
         "dark-theme": 77764
       }


### PR DESCRIPTION
webkit browsers show a cancel X icon in the input search on focus/hover
which allows to clear the content of the input, such icon has small
glitches/imperfections so use a mat-icon instead

(this also adds such icon to non-webkit browsers)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

This related to the cancel icon in the top-menu search input (present in webkit browsers):
![Screenshot at 2021-09-26 13-08-05](https://user-images.githubusercontent.com/61631103/134807334-eb546f84-5c89-4ce6-8516-11c551a493b4.png)

I often see quirky behaviors, like it being partially "cut" (this may need changing the browser's font-size to reproduce): 
![Screenshot at 2021-09-26 13-07-00](https://user-images.githubusercontent.com/61631103/134807367-031427e8-397c-49de-ae26-68f4cd2b3531.png)

Or very often, leaving "marks" after disappearing:
![Screenshot at 2021-09-26 13-05-46](https://user-images.githubusercontent.com/61631103/134807399-3c3c8256-5ac1-49e1-9428-1185bebaca82.png)


## What is the new behavior?

The icon has been hidden and it's been replaced with the cancel mat-icon:
![Screenshot at 2021-09-26 13-07-50](https://user-images.githubusercontent.com/61631103/134807418-00ac5661-9f56-498a-98a7-9d04449b86af.png)
(to me it even looks more slick/modern :slightly_smiling_face: )

This gives us more control on the icon allowing us to fix the aforementioned quirks:

![Screenshot at 2021-09-26 13-07-23](https://user-images.githubusercontent.com/61631103/134807485-80f8ea5f-4f4f-4d1a-9bcd-0d4e55bf20b1.png)

![Screenshot at 2021-09-26 13-12-28](https://user-images.githubusercontent.com/61631103/134807491-c9a7169c-67df-437f-aa61-3632c1a49e81.png)




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
 - I appreciated that the quirks mentioned above may have happened only for me.... if that's the case please let me know :sweat: 
 (My browser is: Chormium Version 93.0.4577.82 (Official Build) snap (64-bit))
 - this change also adds the icon to non webkit browsers (like firefox), not sure if this is ok or not, please let me know :slightly_smiling_face: 
 - I could only test this changes in Chromium and Firefox, hopefully they look ok on other browsers too :sweat: 
 - this is a pretty minor thing so it may not even be worth adding a new mat-icon and css/logic for it, but I just wanted to open this PR as the marks left behind have been a bit of an eye sore for me for a while :sweat_smile: 