### PR TITLE
fix(docs-infra): convert button-like elements to actual buttons

### DIFF
--- a/aio/src/app/custom-elements/contributor/contributor-list.component.ts
+++ b/aio/src/app/custom-elements/contributor/contributor-list.component.ts
@@ -7,16 +7,15 @@ import { LocationService } from 'app/shared/location.service';
   selector: 'aio-contributor-list',
   template: `
     <div class="flex-center group-buttons">
-      <a *ngFor="let name of groupNames"
+      <button *ngFor="let name of groupNames"
           class="button mat-button filter-button"
           [class.selected]="name === selectedGroup.name"
-          tabindex="0"
-          (click)="selectGroup(name)"
-          (keyup.enter)="selectGroup(name)">{{name}}</a>
+          (click)="selectGroup(name)">{{name}}</button>
     </div>
     <section *ngIf="selectedGroup" class="grid-fluid">
       <div class="contributor-group">
-        <aio-contributor *ngFor="let person of selectedGroup.contributors" [person]="person"></aio-contributor>
+        <aio-contributor *ngFor="let person of selectedGroup.contributors"
+            [person]="person"></aio-contributor>
       </div>
     </section>
   `,

--- a/aio/src/app/custom-elements/contributor/contributor.component.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.component.ts
@@ -8,7 +8,8 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
   template: `
     <div [ngClass]="{ 'flipped': person.isFlipped }" class="contributor-card">
 
-        <button class="card-front" (click)="flipCard(person)">
+         <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
+        <div class="card-front" (click)="flipCard(person)">
             <h3>{{person.name}}</h3>
 
             <div class="contributor-image"
@@ -30,7 +31,7 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
                      </a>
                  </div>
             </div>
-        </button>
+        </div>
 
         <button class="card-back" *ngIf="person.isFlipped" (click)="flipCard(person)">
             <h3>{{person.name}}</h3>

--- a/aio/src/app/custom-elements/contributor/contributor.component.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.component.ts
@@ -8,15 +8,17 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
   template: `
     <div [ngClass]="{ 'flipped': person.isFlipped }" class="contributor-card">
 
-        <div class="card-front" (click)="flipCard(person)" (keyup.enter)="flipCard(person)">
+        <button class="card-front" (click)="flipCard(person)">
             <h3>{{person.name}}</h3>
 
             <div class="contributor-image"
                  [style.background-image]="'url('+pictureBase+(person.picture || noPicture)+')'">
                  <div class="contributor-info">
-                     <a *ngIf="person.bio" mat-button class="info-item" tabindex="0">
-                         View Bio
-                     </a>
+                     <div *ngIf="person.bio" mat-button class="info-item">
+                         <button mat-button>
+                             View Bio
+                         </button>
+                     </div>
                      <a *ngIf="person.twitter" mat-icon-button class="info-item icon"
                          href="https://twitter.com/{{person.twitter}}"
                          target="_blank" (click)="$event.stopPropagation()">
@@ -28,13 +30,12 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
                      </a>
                  </div>
             </div>
-        </div>
+        </button>
 
-        <div class="card-back" *ngIf="person.isFlipped" (click)="flipCard(person)" (keyup.enter)="flipCard(person)"
-             tabindex="0">
+        <button class="card-back" *ngIf="person.isFlipped" (click)="flipCard(person)">
             <h3>{{person.name}}</h3>
             <p class="contributor-bio">{{person.bio}}</p>
-        </div>
+        </button>
     </div>
   `
 })

--- a/aio/src/app/custom-elements/contributor/contributor.component.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.component.ts
@@ -14,7 +14,7 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
             <div class="contributor-image"
                  [style.background-image]="'url('+pictureBase+(person.picture || noPicture)+')'">
                  <div class="contributor-info">
-                     <div *ngIf="person.bio" mat-button class="info-item">
+                     <div *ngIf="person.bio" class="info-item">
                          <button mat-button>
                              View Bio
                          </button>

--- a/aio/src/app/custom-elements/contributor/contributor.component.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.component.ts
@@ -8,7 +8,7 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
   template: `
     <div [ngClass]="{ 'flipped': person.isFlipped }" class="contributor-card">
 
-         <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
+        <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
         <div class="card-front" (click)="flipCard(person)">
             <h3>{{person.name}}</h3>
 

--- a/aio/src/app/custom-elements/contributor/contributor.component.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.component.ts
@@ -15,11 +15,9 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
             <div class="contributor-image"
                  [style.background-image]="'url('+pictureBase+(person.picture || noPicture)+')'">
                  <div class="contributor-info">
-                     <div *ngIf="person.bio" class="info-item">
-                         <button mat-button>
-                             View Bio
-                         </button>
-                     </div>
+                     <button *ngIf="person.bio" mat-button class="info-item">
+                         View Bio
+                     </button>
                      <a *ngIf="person.twitter" mat-icon-button class="info-item icon"
                          href="https://twitter.com/{{person.twitter}}"
                          target="_blank" (click)="$event.stopPropagation()">

--- a/aio/src/app/custom-elements/resource/resource-list.component.html
+++ b/aio/src/app/custom-elements/resource/resource-list.component.html
@@ -1,11 +1,9 @@
 <div class="center-layout">
   <div class="flex-center group-buttons">
-    <a *ngFor="let category of categories"
+    <button *ngFor="let category of categories"
       class="button mat-button filter-button"
       [class.selected]="category.id == selectedCategory.id"
-      tabindex="0"
-      (click)="selectCategory(category.id)"
-      (keyup.enter)="selectCategory(category.id)">{{category.title}}</a>
+      (click)="selectCategory(category.id)">{{category.title}}</button>
   </div>
   <div class="showcase">
     <div *ngFor="let subCategory of selectedCategory?.subCategories">

--- a/aio/src/styles/2-modules/buttons/_buttons-theme.scss
+++ b/aio/src/styles/2-modules/buttons/_buttons-theme.scss
@@ -53,7 +53,7 @@
   .group-buttons {
     // This rule overrides some Angular Material styles defined for `.mat-button`
     // (hence we include `.mat-button` in the selector).
-    a.button.mat-button.filter-button {
+    button.button.mat-button.filter-button {
       background-color: rgba(constants.$blue, 0.2);
 
       &.selected {

--- a/aio/src/styles/2-modules/buttons/_buttons.scss
+++ b/aio/src/styles/2-modules/buttons/_buttons.scss
@@ -62,7 +62,7 @@ a.button.mat-button,
 
   // This rule overrides some Angular Material styles defined for `.mat-button`
   // (hence we include `.mat-button` in the selector).
-  a.button.mat-button.filter-button {
+  button.button.mat-button.filter-button {
     border-radius: 4px;
     @include mixins.font-size(16);
     @include mixins.line-height(48);

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -1,4 +1,5 @@
 @use '../../mixins';
+@use '../../constants';
 
 aio-contributor-list {
   .contributor-group {
@@ -20,7 +21,6 @@ aio-contributor-list {
 
 aio-contributor {
   margin: 8px;
-  cursor: pointer;
   border-radius: 4px;
   box-shadow: 0 2px 2px rgba(10, 16, 20, 0.24), 0 0 2px rgba(10, 16, 20, 0.12);
   transition: all .3s;
@@ -87,6 +87,17 @@ aio-contributor {
           }
         }
       }
+
+      button {
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        color: constants.$white;
+
+        &:hover {
+          color: constants.$lightgray;
+        }
+      }
     }
   }
 
@@ -103,13 +114,16 @@ aio-contributor {
     }
 
     .card-front, .card-back {
+      cursor: pointer;
       width: 100%;
       height: 100%;
-      text-align: center;
       display: flex;
       flex-direction: column;
       box-sizing: border-box;
       justify-content: center;
+      align-items: center;
+      border: none;
+      background: transparent;
     }
 
     .card-back {

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -57,6 +57,7 @@ aio-contributor {
       font-size: clamp(10px, 1.4rem, 30px);
       font-weight: 500;
       margin: 0.8rem;
+      padding: 0.5rem;
       width: 100%;
       justify-content: center;
 

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -1,5 +1,4 @@
 @use '../../mixins';
-@use '../../constants';
 
 aio-contributor-list {
   .contributor-group {
@@ -87,17 +86,12 @@ aio-contributor {
           }
         }
       }
+    }
 
-      button {
-        background: transparent;
-        border: none;
-        cursor: pointer;
-        color: constants.$white;
-
-        &:hover {
-          color: constants.$lightgray;
-        }
-      }
+    button {
+      background: transparent;
+      border: none;
+      cursor: pointer;
     }
   }
 


### PR DESCRIPTION
some elements in the aio application are anchors or divs but behave
like buttons, it is semantically (and a11y) more correct to convert
them to actual button elements instead

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

divs and anchors are coded to behave like buttons

## What is the new behavior?

divs and anchors behaving like buttons are converted to actual buttons

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
As discussed here: https://github.com/angular/angular/pull/43460/files#r711713181
@gkalpak @jelbourn :slightly_smiling_face::+1: 
