### PR TITLE
fix(core): add undefined type to QueryList's first and last

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1124,11 +1124,11 @@ export class QueryList<T> implements Iterable<T> {
     filter(fn: (item: T, index: number, array: T[]) => boolean): T[];
     find(fn: (item: T, index: number, array: T[]) => boolean): T | undefined;
     // (undocumented)
-    readonly first: T;
+    readonly first?: T;
     forEach(fn: (item: T, index: number, array: T[]) => void): void;
     get(index: number): T | undefined;
     // (undocumented)
-    readonly last: T;
+    readonly last?: T;
     // (undocumented)
     readonly length: number;
     map<U>(fn: (item: T, index: number, array: T[]) => U): U[];

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -138,7 +138,7 @@ describe('insert/remove', () => {
        fixture.componentInstance.currentComponent = InjectedComponent;
        fixture.componentInstance.projectables =
            [fixture.componentInstance.vcRef
-                .createEmbeddedView(fixture.componentInstance.tplRefs.first)
+                .createEmbeddedView(fixture.componentInstance.tplRefs.first!)
                 .rootNodes];
 
 

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -15,6 +15,7 @@ pkg_npm(
     deps = [
         "//packages/core/schematics/migrations/entry-components",
         "//packages/core/schematics/migrations/path-match-type",
+        "//packages/core/schematics/migrations/query-list-first-last",
         "//packages/core/schematics/migrations/typed-forms",
     ],
 )

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -14,6 +14,11 @@
       "version": "14.0.0-beta",
       "description": "In Angular version 14, the `pathMatch` property of `Routes` was updated to be a strict union of the two valid options: `'full'|'prefix'`. `Routes` and `Route` variables need an explicit type so TypeScript does not infer the property as the looser `string`.",
       "factory": "./migrations/path-match-type/index"
+    },
+    "query-list-first-last": {
+      "version": "14.0.0-beta",
+      "description": "As of Angular version 14, `QueryList`'s `first` and `last` types can be `undefined`.",
+      "factory": "./migrations/query-list-first-last/index"
     }
   }
 }

--- a/packages/core/schematics/migrations/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/google3/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
         "//packages/core/schematics/migrations/entry-components",
         "//packages/core/schematics/migrations/path-match-type",
         "//packages/core/schematics/migrations/path-match-type/google3",
+        "//packages/core/schematics/migrations/query-list-first-last",
         "//packages/core/schematics/migrations/typed-forms",
         "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tslint",

--- a/packages/core/schematics/migrations/google3/queryListFirstLastRule.ts
+++ b/packages/core/schematics/migrations/google3/queryListFirstLastRule.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Replacement, RuleFailure, Rules} from 'tslint';
+import ts from 'typescript';
+
+import {migrateFile} from '../query-list-first-last/util';
+
+/** TSLint rule for accesses of `QueryList`'s `first` and `last` (which need to be null-checked). */
+export class Rule extends Rules.TypedRule {
+  override applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[] {
+    const typeChecker = program.getTypeChecker();
+
+    const failures: RuleFailure[] = [];
+
+    const rewriter =
+        (sourceFile: ts.SourceFile, startPos: number, origLength: number, text: string) => {
+          const failure = new RuleFailure(
+              sourceFile, startPos, startPos + origLength,
+              `QueryList's first and last can be undefined so they need to be accessed safely`,
+              this.ruleName, new Replacement(startPos, origLength, text));
+          failures.push(failure);
+        };
+
+    migrateFile(sourceFile, '', typeChecker, rewriter);
+
+    return failures;
+  }
+}

--- a/packages/core/schematics/migrations/query-list-first-last/BUILD.bazel
+++ b/packages/core/schematics/migrations/query-list-first-last/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//tools:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "query-list-first-last",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/core/schematics/migrations/query-list-first-last/README.md
+++ b/packages/core/schematics/migrations/query-list-first-last/README.md
@@ -1,0 +1,48 @@
+## entryComponents migration
+In Angular version 14, the types of the `QueryList`'s `first` and `last` fields have been extended with `undefined` (that is how they always behaved but their types did not reflect that). This migration automatically identifies usages and adds non-null assertions.
+
+#### Before
+```ts
+import { Component, QueryList, ViewChildren } from '@angular/core';
+import { NotificationComponent } from './notification/notification.component';
+
+@Component({
+  selector: 'my-comp',
+  templateUrl: './my-comp.component.html',
+  styleUrls: ['./my-comp.component.scss']
+})
+export class MyComponent {
+  @ViewChildren(NotificationComponent) notifications!: QueryList<NotificationComponent>;
+
+  getFirstNotificationMessage() {
+    return this.notifications.first.message;
+  }
+
+  getLastNotificationMessage() {
+    return this.notifications.last.message;
+  }
+}
+```
+
+#### After
+```ts
+import { Component, QueryList, ViewChildren } from '@angular/core';
+import { NotificationComponent } from './notification/notification.component';
+
+@Component({
+  selector: 'my-comp',
+  templateUrl: './my-comp.component.html',
+  styleUrls: ['./my-comp.component.scss']
+})
+export class MyComponent {
+  @ViewChildren(NotificationComponent) notifications!: QueryList<NotificationComponent>;
+
+  getFirstNotificationMessage() {
+    return this.notifications.first!.message;
+  }
+
+  getLastNotificationMessage() {
+    return this.notifications.last!.message;
+  }
+}
+```

--- a/packages/core/schematics/migrations/query-list-first-last/index.ts
+++ b/packages/core/schematics/migrations/query-list-first-last/index.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {relative} from 'path';
+import ts from 'typescript';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
+
+import {migrateFile} from './util';
+
+/** Migration that marks accesses of `QueryList`'s `first` and `last` as non-null. */
+export default function(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot add non null assertions to QueryList first and last accesses.');
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runQueryListFirstLastMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+function runQueryListFirstLastMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const {program} = createMigrationProgram(tree, tsconfigPath, basePath);
+  const typeChecker = program.getTypeChecker();
+  const sourceFiles =
+      program.getSourceFiles().filter(sourceFile => canMigrateFile(basePath, sourceFile, program));
+
+  const updateFn =
+      (sourceFile: ts.SourceFile, start: number, length: number, content: string,
+       basePath?: string) => {
+        const update = tree.beginUpdate(relative(basePath!, sourceFile.fileName));
+        update.insertRight(start + length, content);
+        tree.commitUpdate(update);
+      };
+
+  sourceFiles.forEach(sourceFile => migrateFile(sourceFile, basePath, typeChecker, updateFn));
+}

--- a/packages/core/schematics/migrations/query-list-first-last/util.ts
+++ b/packages/core/schematics/migrations/query-list-first-last/util.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {normalize} from 'path';
+import ts from 'typescript';
+
+import {isNullCheck, isSafeAccess} from '../../utils/typescript/nodes';
+import {hasOneOfTypes, isNullableType} from '../../utils/typescript/symbol';
+
+type UpdateFn =
+    (sourceFile: ts.SourceFile, start: number, length: number, content: string,
+     basePath?: string) => void;
+
+export function migrateFile(
+    sourceFile: ts.SourceFile, basePath: string, typeChecker: ts.TypeChecker, updateFn: UpdateFn) {
+  // We sort the nodes based on their position in the file and we offset the positions by one
+  // for each non-null assertion that we've added. We have to do it this way, rather than
+  // creating and printing a new AST node like in other migrations, because property access
+  // expressions can be nested (e.g. `control.parent.parent.value`), but the node positions
+  // aren't being updated as we're inserting new code. If we were to go through the AST,
+  // we'd have to update the `SourceFile` and start over after each operation.
+  findFirstLastAccesses(typeChecker, sourceFile)
+      .sort((a, b) => a.getStart() - b.getStart())
+      .forEach(
+          (node, index) =>
+              updateFn(sourceFile, node.getStart(), node.getWidth() + index, '!', basePath));
+}
+
+/**
+ * Finds the `PropertyAccessExpression`-s that are accessing the `first` or `last` property of
+ * a QueryList.
+ */
+function findFirstLastAccesses(
+    typeChecker: ts.TypeChecker, sourceFile: ts.SourceFile): ts.PropertyAccessExpression[] {
+  const results: ts.PropertyAccessExpression[] = [];
+
+  sourceFile.forEachChild(function walk(node: ts.Node) {
+    if (ts.isPropertyAccessExpression(node) &&
+        (node.name.text === 'first' || node.name.text === 'last') && !isNullCheck(node) &&
+        !isSafeAccess(node) && results.indexOf(node) === -1 &&
+        isQueryListReference(typeChecker, node) && isNullableType(typeChecker, node)) {
+      results.unshift(node);
+    }
+
+    node.forEachChild(walk);
+  });
+
+  return results;
+}
+
+/** Checks whether a property access is on an `QueryList` coming from `@angular/core`. */
+function isQueryListReference(
+    typeChecker: ts.TypeChecker, node: ts.PropertyAccessExpression): boolean {
+  let current: ts.Expression = node;
+  const corePattern = /node_modules\/?.*\/@angular\/core/;
+  // Walks up the property access chain and tries to find a symbol tied to a `SourceFile`.
+  // If such a node is found, we check whether the type is the QueryList symbol
+  // and whether it comes from the `@angular/core` directory in the `node_modules`.
+  while (ts.isPropertyAccessExpression(current)) {
+    const symbol = typeChecker.getTypeAtLocation(current.expression)?.getSymbol();
+    if (symbol) {
+      const sourceFile = symbol.valueDeclaration?.getSourceFile();
+      return sourceFile != null &&
+          corePattern.test(normalize(sourceFile.fileName).replace(/\\/g, '/')) &&
+          hasOneOfTypes(typeChecker, current.expression, ['QueryList']);
+    }
+    current = current.expression;
+  }
+  return false;
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
     deps = [
         "//packages/core/schematics/migrations/entry-components",
         "//packages/core/schematics/migrations/path-match-type",
+        "//packages/core/schematics/migrations/query-list-first-last",
         "//packages/core/schematics/migrations/typed-forms",
         "//packages/core/schematics/utils",
         "@npm//@angular-devkit/core",

--- a/packages/core/schematics/test/google3/BUILD.bazel
+++ b/packages/core/schematics/test/google3/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     srcs = glob(["**/*.ts"]),
     deps = [
         "//packages/core/schematics/migrations/google3",
+        "@npm//@angular-devkit/core",
         "@npm//@types/shelljs",
         "@npm//tslint",
     ],

--- a/packages/core/schematics/test/google3/query_list_first_last_spec.ts
+++ b/packages/core/schematics/test/google3/query_list_first_last_spec.ts
@@ -1,0 +1,215 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {dirname, join} from 'path';
+import * as shx from 'shelljs';
+import {Configuration, Linter} from 'tslint';
+
+describe('QueryList first and last access migration', () => {
+  const rulesDirectory =
+      dirname(require.resolve('../../migrations/google3/queryListFirstLastRule'));
+  let host: TempScopedNodeJsSyncHost;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  beforeEach(() => {
+    host = new TempScopedNodeJsSyncHost();
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+        strictNullChecks: true,
+      },
+    }));
+    writeFile('/angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('/node_modules/@angular/core/index.d.ts', `
+      export declare class QueryList<T> {
+        readonly first?: T;
+        readonly last?: T;
+      }
+    `);
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  const testFileLinting = (fileContent: string, numOfFailures: number) => {
+    writeFile('/index.ts', fileContent);
+    const linter = runTSLint(false);
+    const failures = linter.getResult().failures.map(failure => failure.getFailure());
+
+    expect(failures.length).toBe(numOfFailures);
+    failures.forEach(
+        failure => expect(failure).toMatch(
+            /QueryList's first and last can be undefined so they need to be accessed safely/));
+  };
+
+  it('should add ! to accesses to a QueryList\'s first field', async () => {
+    const fileContent = `
+      import { Component, QueryList, ViewChildren, OnInit } from '@angular/core';
+
+      @Component({
+        selector: 'comp-test',
+        template: ''
+      })
+      export class CompTest {
+        value = 'test';
+      }
+
+      @Component({selector: 'my-comp', template: ''})
+      export class MyComp implements OnInit {
+        @ViewChildren(CompTest) testElements!: QueryList<CompTest>;
+
+        ngOnInit() {
+          console.log(this.testElements.first.value);
+        }
+      }
+    `;
+    const expectedFailures = 1;
+    testFileLinting(fileContent, expectedFailures);
+  });
+
+  it('should add ! to accesses to a QueryList\'s last field', () => {
+    const fileContent = `
+      import { Component, QueryList, ViewChildren, OnInit } from '@angular/core';
+
+      @Component({
+        selector: 'comp-test',
+        template: ''
+      })
+      export class CompTest {
+        value = 'test';
+      }
+
+      @Component({selector: 'my-comp', template: ''})
+      export class MyComp implements OnInit {
+        @ViewChildren(CompTest) testElements!: QueryList<CompTest>;
+
+        ngOnInit() {
+          console.log(this.testElements.last.value);
+        }
+      }
+    `;
+    const expectedFailures = 1;
+    testFileLinting(fileContent, expectedFailures);
+  });
+
+  it('should add ! to accesses to both QueryList\'s first and last fields', () => {
+    const fileContent = `
+      import { Component, QueryList, ViewChildren, Input } from '@angular/core';
+
+      @Component({
+        selector: 'comp-test',
+        template: ''
+      })
+      export class CompTest {
+        @Input() id: string!;
+      }
+
+      @Component({selector: 'my-comp', template: ''})
+      export class MyComp {
+        @ViewChildren(CompTest) testElements!: QueryList<CompTest>;
+
+        checkFirstAndLastIdsEquality() {
+          return this.testElements.first.id === this.testElements.last.id;
+        }
+      }
+    `;
+    const expectedFailures = 2;
+    testFileLinting(fileContent, expectedFailures);
+  });
+
+  it('should not add ! to accesses to the QueryList\'s fist/last fields if they are null checked',
+     () => {
+       const fileContent = `
+      import { Component, QueryList, ViewChildren, OnInit } from '@angular/core';
+
+      @Component({
+        selector: 'comp-test',
+        template: ''
+      })
+      export class CompTest {
+        value = 'test';
+      }
+
+      @Component({selector: 'my-comp', template: ''})
+      export class MyComp implements OnInit {
+        @ViewChildren(CompTest) testElements!: QueryList<CompTest>;
+
+        ngOnInit() {
+          this.testElements.first && console.log(this.testElements.first.value);
+          this.testElements.last && console.log(this.testElements.last.value);
+        }
+      }
+    `;
+       const expectedFailures = 0;
+       testFileLinting(fileContent, expectedFailures);
+     });
+
+  it('should add ! to accesses to QueryList\'s first and last fields even after reassignment',
+     () => {
+       const fileContent = `
+      import { Component, QueryList, ViewChildren, Input } from '@angular/core';
+
+      @Component({
+        selector: 'comp-test',
+        template: ''
+      })
+      export class CompTest {
+        execLogic() {}
+      }
+
+      @Component({selector: 'my-comp', template: ''})
+      export class MyComp {
+        @ViewChildren(CompTest) testElements!: QueryList<CompTest>;
+
+        onClick() {
+          const allCompTests = this.testElements;
+          if(allCompTests.first) {
+            allCompTests.first.execLogic();
+          } else {
+            allCompTests.last.execLogic();
+          }
+        }
+      }
+    `;
+       const expectedFailures = 1;
+       testFileLinting(fileContent, expectedFailures);
+     });
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runTSLint(fix: boolean) {
+    const program = Linter.createProgram(join(tmpDirPath, 'tsconfig.json'));
+    const linter = new Linter({fix, rulesDirectory: [rulesDirectory]}, program);
+    const config = Configuration.parseConfigFile({rules: {'queryListFirstLast': true}});
+
+    program.getRootFileNames().forEach(fileName => {
+      linter.lint(fileName, program.getSourceFile(fileName)!.getFullText(), config);
+    });
+
+    return linter;
+  }
+});

--- a/packages/core/schematics/test/query_list_first_last_spec.ts
+++ b/packages/core/schematics/test/query_list_first_last_spec.ts
@@ -1,0 +1,227 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import * as shx from 'shelljs';
+
+
+describe('QueryList first and last access migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+        strictNullChecks: true,
+      },
+    }));
+    writeFile('/angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('/node_modules/@angular/core/index.d.ts', `
+      export declare class QueryList<T> {
+        readonly first?: T;
+        readonly last?: T;
+      }
+    `);
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  const testFileMigration = async (fileContent: string, expectedPartAfterMigration: string) => {
+    writeFile('/index.ts', fileContent);
+    await runMigration();
+    expect(stripWhitespace(tree.readContent('/index.ts')))
+        .toContain(stripWhitespace(expectedPartAfterMigration));
+  };
+
+  it('should add ! to accesses to a QueryList\'s first field', async () => {
+    await testFileMigration(
+        `
+      import { Component, QueryList, ViewChildren, OnInit } from '@angular/core';
+
+      @Component({
+        selector: 'comp-test',
+        template: ''
+      })
+      export class CompTest {
+        value = 'test';
+      }
+
+      @Component({selector: 'my-comp', template: ''})
+      export class MyComp implements OnInit {
+        @ViewChildren(CompTest) testElements!: QueryList<CompTest>;
+
+        ngOnInit() {
+          console.log(this.testElements.first.value);
+        }
+      }
+    `,
+        `ngOnInit() {
+        console.log(this.testElements.first!.value);
+     }`);
+  });
+
+  it('should add ! to accesses to a QueryList\'s last field', async () => {
+    await testFileMigration(
+        `
+      import { Component, QueryList, ViewChildren, OnInit } from '@angular/core';
+
+      @Component({
+        selector: 'comp-test',
+        template: ''
+      })
+      export class CompTest {
+        value = 'test';
+      }
+
+      @Component({selector: 'my-comp', template: ''})
+      export class MyComp implements OnInit {
+        @ViewChildren(CompTest) testElements!: QueryList<CompTest>;
+
+        ngOnInit() {
+          console.log(this.testElements.last.value);
+        }
+      }
+    `,
+        `ngOnInit() {
+       console.log(this.testElements.last!.value);
+     }`);
+  });
+
+  it('should add ! to accesses to both QueryList\'s first and last fields', async () => {
+    await testFileMigration(
+        `
+      import { Component, QueryList, ViewChildren, Input } from '@angular/core';
+
+      @Component({
+        selector: 'comp-test',
+        template: ''
+      })
+      export class CompTest {
+        @Input() id: string!;
+      }
+
+      @Component({selector: 'my-comp', template: ''})
+      export class MyComp {
+        @ViewChildren(CompTest) testElements!: QueryList<CompTest>;
+
+        checkFirstAndLastIdsEquality() {
+          return this.testElements.first.id === this.testElements.last.id;
+        }
+      }
+    `,
+        `checkFirstAndLastIdsEquality() {
+      return this.testElements.first!.id === this.testElements.last!.id;
+    }`);
+  });
+
+  it('should not add ! to accesses to the QueryList\'s fist/last fields if they are null checked',
+     async () => {
+       await testFileMigration(
+           `
+      import { Component, QueryList, ViewChildren, OnInit } from '@angular/core';
+
+      @Component({
+        selector: 'comp-test',
+        template: ''
+      })
+      export class CompTest {
+        value = 'test';
+      }
+
+      @Component({selector: 'my-comp', template: ''})
+      export class MyComp implements OnInit {
+        @ViewChildren(CompTest) testElements!: QueryList<CompTest>;
+
+        ngOnInit() {
+          this.testElements.first && console.log(this.testElements.first.value);
+          this.testElements.last && console.log(this.testElements.last.value);
+        }
+      }
+    `,
+           `ngOnInit() {
+          this.testElements.first && console.log(this.testElements.first.value);
+          this.testElements.last && console.log(this.testElements.last.value);
+     }`);
+     });
+
+  it('should add ! to accesses to QueryList\'s first and last fields even after reassignment',
+     async () => {
+       await testFileMigration(
+           `
+      import { Component, QueryList, ViewChildren, Input } from '@angular/core';
+
+      @Component({
+        selector: 'comp-test',
+        template: ''
+      })
+      export class CompTest {
+        execLogic() {}
+      }
+
+      @Component({selector: 'my-comp', template: ''})
+      export class MyComp {
+        @ViewChildren(CompTest) testElements!: QueryList<CompTest>;
+
+        onClick() {
+          const allCompTests = this.testElements;
+          if(allCompTests.first) {
+            allCompTests.first.execLogic();
+          } else {
+            allCompTests.last.execLogic();
+          }
+        }
+      }
+    `,
+           `
+        onClick() {
+          const allCompTests = this.testElements;
+          if(allCompTests.first) {
+            allCompTests.first.execLogic();
+          } else {
+            allCompTests.last!.execLogic();
+          }
+        }`);
+     });
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematicAsync('query-list-first-last', {}, tree).toPromise();
+  }
+
+  function stripWhitespace(contents: string) {
+    return contents.replace(/\s/g, '');
+  }
+});

--- a/packages/core/schematics/utils/typescript/nodes.ts
+++ b/packages/core/schematics/utils/typescript/nodes.ts
@@ -37,13 +37,16 @@ export function isNullCheck(node: ts.Node): boolean {
   }
 
   // `foo.bar && foo.bar.value` where `node` is `foo.bar`.
-  if (ts.isBinaryExpression(node.parent) && node.parent.left === node) {
+  if (ts.isBinaryExpression(node.parent) &&
+      node.parent.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken &&
+      node.parent.left === node) {
     return true;
   }
 
   // `foo.bar && foo.bar.parent && foo.bar.parent.value`
   // where `node` is `foo.bar`.
   if (node.parent.parent && ts.isBinaryExpression(node.parent.parent) &&
+      node.parent.parent.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken &&
       node.parent.parent.left === node.parent) {
     return true;
   }

--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -49,8 +49,8 @@ export class QueryList<T> implements Iterable<T> {
   private _changes: EventEmitter<QueryList<T>>|null = null;
 
   readonly length: number = 0;
-  readonly first: T = undefined!;
-  readonly last: T = undefined!;
+  readonly first?: T;
+  readonly last?: T;
 
   /**
    * Returns `Observable` of `QueryList` notifying the subscriber of changes.
@@ -200,6 +200,6 @@ interface QueryListInternal<T> extends QueryList<T> {
   reset(a: any[]): void;
   notifyOnChanges(): void;
   length: number;
-  last: T;
-  first: T;
+  last?: T;
+  first?: T;
 }

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -316,7 +316,7 @@ describe('ViewContainerRef', () => {
 
       const template0 = fixture.componentInstance.vcrComp.templates.first;
       const viewContainerRef = fixture.componentInstance.vcrComp.vcr;
-      const ref0 = viewContainerRef.createEmbeddedView(template0);
+      const ref0 = viewContainerRef.createEmbeddedView(template0!);
 
       // Insert the view again at the same index
       viewContainerRef.insert(ref0, 0);
@@ -685,7 +685,7 @@ describe('ViewContainerRef', () => {
       fixture.detectChanges();
 
       const cmpt = fixture.componentInstance;
-      const viewRef = cmpt.templates.first.createEmbeddedView({});
+      const viewRef = cmpt.templates.first!.createEmbeddedView({});
 
       // ViewContainerRef is empty and we've got a reference to a view that was not attached
       // anywhere

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -237,8 +237,9 @@ describe('Query API', () => {
       const view = createTestCmpAndDetectChanges(MyComp0, template);
       const needsTpl: NeedsTpl = view.debugElement.children[0].injector.get(NeedsTpl);
 
-      expect(needsTpl.vc.createEmbeddedView(needsTpl.query.first).rootNodes[0]).toHaveText('light');
-      expect(needsTpl.vc.createEmbeddedView(needsTpl.viewQuery.first).rootNodes[0])
+      expect(needsTpl.vc.createEmbeddedView(needsTpl.query.first!).rootNodes[0])
+          .toHaveText('light');
+      expect(needsTpl.vc.createEmbeddedView(needsTpl.viewQuery.first!).rootNodes[0])
           .toHaveText('shadow');
     });
 
@@ -534,7 +535,7 @@ describe('Query API', () => {
       q.show = true;
       view.detectChanges();
       expect(q.query.length).toBe(1);
-      expect(q.query.first.text).toEqual('1');
+      expect(q.query.first!.text).toEqual('1');
     });
 
     it('should not be affected by other changes in the component', () => {
@@ -543,12 +544,12 @@ describe('Query API', () => {
       const q: NeedsViewQueryNestedIf = view.debugElement.children[0].references!['q'];
 
       expect(q.query.length).toEqual(1);
-      expect(q.query.first.text).toEqual('1');
+      expect(q.query.first!.text).toEqual('1');
 
       q.show = false;
       view.detectChanges();
       expect(q.query.length).toEqual(1);
-      expect(q.query.first.text).toEqual('1');
+      expect(q.query.first!.text).toEqual('1');
     });
 
     it('should maintain directives in pre-order depth-first DOM order after dynamic insertion',


### PR DESCRIPTION
A QueryList's first and last could be undefined in case the query
did not succeed in finding any target element, add such missing
type so that this can be recognized by the compiler and related tooling
    
Since this is a breaking change also add an automated migration for
angular 14 so that non-null operators are added on accesses to nullable
first and last fields of QueryLists
    
resolves #42563

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/42563

The QueryList's first and last are not recognized as possibly undefined

## What is the new behavior?

The QueryList's first and last are recognized as possibly undefined

![Screenshot at 2021-09-26 22-19-00](https://user-images.githubusercontent.com/61631103/134825243-39c39f75-3b51-442f-a1d6-1889bc91a4ab.png)
![Screenshot at 2021-09-26 22-42-35](https://user-images.githubusercontent.com/61631103/134825246-a45d00ee-3364-471a-8800-873ec6a363cb.png)

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No
