### PR TITLE
docs: remove web-animations from required polyfills (since IE11 is deprecated)

### DIFF
--- a/aio/content/guide/browser-support.md
+++ b/aio/content/guide/browser-support.md
@@ -47,7 +47,7 @@ using [Sauce Labs](https://saucelabs.com/) and
 Angular is built on the latest standards of the web platform.
 Targeting such a wide range of browsers is challenging because they do not support all features of modern browsers.
 You compensate by loading polyfill scripts ("polyfills") for the browsers that you must support.
-The [following table](#polyfill-libs) identifies most of the polyfills you might need.
+See instructions on how to include polyfills into your project below.
 
 <div class="alert is-important">
 
@@ -69,87 +69,6 @@ This file incorporates the mandatory and many of the optional polyfills as JavaS
 
 * If you need an _optional_ polyfill, you must install its npm package, then uncomment or create the corresponding import statement in the `src/polyfills.ts` configuration file.
 
-For example, if you need the optional [web animations polyfill](https://caniuse.com/web-animation), you could install it with `npm`, using the following command (or the `yarn` equivalent):
-
-<code-example language="sh">
-  # install the optional web animations polyfill
-  npm install --save web-animations-js
-</code-example>
-
-Then add the import statement in the `src/polyfills.ts` file.
-For many polyfills, you can un-comment the corresponding `import` statement in the file, as in the following example.
-
-<code-example header="src/polyfills.ts">
-  /**
-  * Required to support Web Animations `@angular/platform-browser/animations`.
-  * Needed for: All but Chrome, Firefox and Opera. https://caniuse.com/web-animation
-  **/
-  import 'web-animations-js';  // Run `npm install --save web-animations-js`.
-</code-example>
-
-If the polyfill you want is not already in `polyfills.ts` file, add the `import` statement by hand.
-
-
-{@a polyfill-libs}
-
-### Optional browser features to polyfill
-
-Some features of Angular might require additional polyfills.
-
-<table>
-  <tr style="vertical-align: top">
-    <th>Feature</th>
-    <th>Polyfill</th>
-    <th style="width: 50%">Browsers (Desktop & Mobile)</th>
-  </tr>
-  <tr style="vertical-align: top">
-    <td>
-      <a href="api/animations/AnimationBuilder">AnimationBuilder</a>
-      (Standard animation support does not require polyfills.)
-    </td>
-    <td>
-      <a href="guide/browser-support#web-animations">Web Animations</a>
-    </td>
-    <td>
-      <p>If AnimationBuilder is used, enables scrubbing
-      support for Edge and Safari.
-      (Chrome and Firefox support this natively).</p>
-    </td>
-  </tr>
-</table>
-
-### Suggested polyfills
-
-The following polyfills are used to test the framework itself. They are a good starting point for an application.
-
-<table>
-  <tr>
-    <th>
-      Polyfill
-    </th>
-    <th>
-      License
-    </th>
-    <th>
-      Size*
-    </th>
-  </tr>
-  <tr>
-    <td>
-       <a id='web-animations' href="https://github.com/web-animations/web-animations-js">Web Animations</a>
-    </td>
-    <td>
-      Apache
-    </td>
-    <td>
-      14.8KB
-    </td>
-  </tr>
-</table>
-
-
-\* Figures are for minified and gzipped code,
-computed with the [closure compiler](https://closure-compiler.appspot.com/home).
 
 {@a non-cli}
 
@@ -162,7 +81,6 @@ For example:
 <code-example header="src/index.html" language="html">
   &lt;!-- pre-zone polyfills -->
   &lt;script src="node_modules/core-js/client/shim.min.js">&lt;/script>
-  &lt;script src="node_modules/web-animations-js/web-animations.min.js">&lt;/script>
   &lt;script>
     /**
      * you can configure some zone flags which can disable zone interception for some


### PR DESCRIPTION
Based on the https://caniuse.com/web-animation the only unsupported feature (in supported browsers) of Web Animations is [the "composite" option](https://css-tricks.com/additive-animation-web-animations-api/#a-new-option) (unsupported in Safari). However it looks like this option is [unused in WebAnimations inside `@angular/animations`](https://github.com/angular/angular/blob/master/packages/animations/browser/src/render/web_animations/web_animations_driver.ts#L56-L61). So the Web Animations polyfill should not be required anymore, so this commit removes it from the browser support page.

Closes #43035.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No