### PR TITLE
feat(common): add injection token for default date pipe timezone

### DIFF
--- a/goldens/public-api/common/common.md
+++ b/goldens/public-api/common/common.md
@@ -74,8 +74,11 @@ export class CurrencyPipe implements PipeTransform {
 }
 
 // @public
+export const DATE_PIPE_DEFAULT_TIMEZONE: InjectionToken<string>;
+
+// @public
 export class DatePipe implements PipeTransform {
-    constructor(locale: string);
+    constructor(locale: string, defaultTimezone?: string | null | undefined);
     // (undocumented)
     transform(value: Date | string | number, format?: string, timezone?: string, locale?: string): string | null;
     // (undocumented)
@@ -83,7 +86,7 @@ export class DatePipe implements PipeTransform {
     // (undocumented)
     transform(value: Date | string | number | null | undefined, format?: string, timezone?: string, locale?: string): string | null;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<DatePipe, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<DatePipe, [null, { optional: true; }]>;
     // (undocumented)
     static ɵpipe: i0.ɵɵPipeDeclaration<DatePipe, "date">;
 }

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -22,7 +22,7 @@ export {parseCookieValue as ɵparseCookieValue} from './cookie';
 export {CommonModule} from './common_module';
 export {NgClass, NgForOf, NgForOfContext, NgIf, NgIfContext, NgPlural, NgPluralCase, NgStyle, NgSwitch, NgSwitchCase, NgSwitchDefault, NgTemplateOutlet, NgComponentOutlet} from './directives/index';
 export {DOCUMENT} from './dom_tokens';
-export {AsyncPipe, DatePipe, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCasePipe, CurrencyPipe, DecimalPipe, PercentPipe, SlicePipe, UpperCasePipe, TitleCasePipe, KeyValuePipe, KeyValue} from './pipes/index';
+export {AsyncPipe, DatePipe, DATE_PIPE_DEFAULT_TIMEZONE, I18nPluralPipe, I18nSelectPipe, JsonPipe, LowerCasePipe, CurrencyPipe, DecimalPipe, PercentPipe, SlicePipe, UpperCasePipe, TitleCasePipe, KeyValuePipe, KeyValue} from './pipes/index';
 export {PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID, PLATFORM_SERVER_ID as ɵPLATFORM_SERVER_ID, PLATFORM_WORKER_APP_ID as ɵPLATFORM_WORKER_APP_ID, PLATFORM_WORKER_UI_ID as ɵPLATFORM_WORKER_UI_ID, isPlatformBrowser, isPlatformServer, isPlatformWorkerApp, isPlatformWorkerUi} from './platform_id';
 export {VERSION} from './version';
 export {ViewportScroller, NullViewportScroller as ɵNullViewportScroller} from './viewport_scroller';

--- a/packages/common/src/pipes/index.ts
+++ b/packages/common/src/pipes/index.ts
@@ -13,7 +13,7 @@
  */
 import {AsyncPipe} from './async_pipe';
 import {LowerCasePipe, TitleCasePipe, UpperCasePipe} from './case_conversion_pipes';
-import {DatePipe} from './date_pipe';
+import {DATE_PIPE_DEFAULT_TIMEZONE, DatePipe} from './date_pipe';
 import {I18nPluralPipe} from './i18n_plural_pipe';
 import {I18nSelectPipe} from './i18n_select_pipe';
 import {JsonPipe} from './json_pipe';
@@ -24,6 +24,7 @@ import {SlicePipe} from './slice_pipe';
 export {
   AsyncPipe,
   CurrencyPipe,
+  DATE_PIPE_DEFAULT_TIMEZONE,
   DatePipe,
   DecimalPipe,
   I18nPluralPipe,

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -14,17 +14,17 @@ import {ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
 import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_reflector';
 
 {
-  let date: Date;
   describe('DatePipe', () => {
     const isoStringWithoutTime = '2015-01-01';
     let pipe: DatePipe;
+    let date: Date;
 
     beforeAll(() => ɵregisterLocaleData(localeEn, localeEnExtra));
     afterAll(() => ɵunregisterLocaleData());
 
     beforeEach(() => {
       date = new Date(2015, 5, 15, 9, 3, 1, 550);
-      pipe = new DatePipe('en-US');
+      pipe = new DatePipe('en-US', null);
     });
 
     it('should be marked as pure', () => {
@@ -99,6 +99,22 @@ import {JitReflector} from '@angular/platform-browser-dynamic/src/compiler_refle
         expect(pipe.transform('2020-08-01T23:59:59.999', 'yyyy-MM-dd')).toEqual('2020-08-01');
         expect(pipe.transform('2020-08-01T23:59:59.9999', 'yyyy-MM-dd, h:mm:ss SSS'))
             .toEqual('2020-08-01, 11:59:59 999');
+      });
+
+      it('should take timezone into account', () => {
+        expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '-1200'))
+            .toEqual('Jan 10, 2017');
+      });
+
+      it('should take the default timezone into account when no timezone is passed in', () => {
+        pipe = new DatePipe('en-US', '-1200');
+        expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate')).toEqual('Jan 10, 2017');
+      });
+
+      it('should give precedence to the passed in timezone over the default one', () => {
+        pipe = new DatePipe('en-US', '-1200');
+        expect(pipe.transform('2017-01-11T00:00:00', 'mediumDate', '+0100'))
+            .toEqual('Jan 11, 2017');
       });
     });
   });


### PR DESCRIPTION
Adds a new injection token called `DATE_PIPE_DEFAULT_TIMEZONE` that allows for the default timezone for all `DatePipe` instances to be specified.

Fixes #43031.