### PR TITLE
build(docs-infra): ensure all overloads are shown interfaces

### DIFF
--- a/aio/tests/e2e/src/api-pages.e2e-spec.ts
+++ b/aio/tests/e2e/src/api-pages.e2e-spec.ts
@@ -76,4 +76,9 @@ describe('Api pages', () => {
       .toMatch(/https:\/\/github\.com\/angular\/angular\/tree\/[^/]+\/packages\/core\/src\/event_emitter\.ts#L\d+-L\d+/);
     /* eslint-enable max-len */
   });
+
+  it('should show all overloads of interface methods', async () => {
+    await page.navigateTo('api/core/testing/TestBedStatic');
+    expect(await (await page.getInstanceMethodOverloads('initTestEnvironment')).length).toEqual(2);
+  });
 });

--- a/aio/tests/e2e/src/api.po.ts
+++ b/aio/tests/e2e/src/api.po.ts
@@ -34,4 +34,10 @@ export class ApiPage extends SitePage {
   getBadge(cls: string) {
     return element(by.css('.api-status-label.' +  cls));
   }
+
+  getInstanceMethodOverloads(name: string) {
+    return element.all(by.css('.instance-method'))
+        .filter(async e => (await e.element(by.css('h3')).getText()).includes(name))
+        .all(by.css('.overload-info'));
+  }
 }

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -123,7 +123,7 @@
       </td>
     </tr>
   {%- elseif method.overloads.length < 3 -%}
-    {%- if method.isAbstract %}
+    {%- if method.isAbstract or method.containerDoc.docType === 'interface' %}
     <tr>
       <td>
         {$ renderOverloadInfo(method, cssClass + '-overload', method) $}


### PR DESCRIPTION
In the API docs, concrete classes do not list the "implementation" overload on a method, since this is not strictly part of its API.
There is already a special case for abstract methods that do not have such an implementation overload.

But we were missing the case where the method was part of an interface. In interfaces none of the methods have implementation overloads.

Fixes #43001
