### PR TITLE
fix(core): incorrect signature for initTestEnvironment

### DIFF
--- a/goldens/public-api/core/testing/testing.md
+++ b/goldens/public-api/core/testing/testing.md
@@ -76,7 +76,7 @@ export class InjectSetupWrapper {
     constructor(_moduleDef: () => TestModuleMetadata);
     // (undocumented)
     inject(tokens: any[], fn: Function): () => any;
-    }
+}
 
 // @public
 export type MetadataOverride<T> = {
@@ -173,9 +173,7 @@ export interface TestBedStatic {
     // @deprecated (undocumented)
     get(token: any, notFoundValue?: any): any;
     // (undocumented)
-    initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: {
-        teardown?: ModuleTeardownOptions;
-    }): TestBed;
+    initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: TestEnvironmentOptions): TestBed;
     // (undocumented)
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     // (undocumented)
@@ -251,7 +249,6 @@ export function withModule(moduleDef: TestModuleMetadata): InjectSetupWrapper;
 
 // @public (undocumented)
 export function withModule(moduleDef: TestModuleMetadata, fn: Function): () => any;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -227,9 +227,9 @@ export class TestBedRender3 implements TestBed {
    *
    * @publicApi
    */
-  initTestEnvironment(ngModule: Type<any>|Type<any>[], platform: PlatformRef, summariesOrOptions?: {
-    teardown?: ModuleTeardownOptions
-  }|(() => any[])): void {
+  initTestEnvironment(
+      ngModule: Type<any>|Type<any>[], platform: PlatformRef,
+      summariesOrOptions?: TestEnvironmentOptions|(() => any[])): void {
     if (this.platform || this.ngModule) {
       throw new Error('Cannot set base providers because it has already been called');
     }

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -79,9 +79,9 @@ export interface ModuleTeardownOptions {
 export interface TestBedStatic {
   new(...args: any[]): TestBed;
 
-  initTestEnvironment(ngModule: Type<any>|Type<any>[], platform: PlatformRef, options?: {
-    teardown?: ModuleTeardownOptions
-  }): TestBed;
+  initTestEnvironment(
+      ngModule: Type<any>|Type<any>[], platform: PlatformRef,
+      options?: TestEnvironmentOptions): TestBed;
   initTestEnvironment(
       ngModule: Type<any>|Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
 


### PR DESCRIPTION
Fixes that one of the signatures of `initTestEnvironment` wasn't using the correct type.