### PR TITLE
fix(core): correct the interface for `initTestEnvironment` options

### DIFF
--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -79,9 +79,9 @@ export interface ModuleTeardownOptions {
 export interface TestBedStatic {
   new(...args: any[]): TestBed;
 
-  initTestEnvironment(ngModule: Type<any>|Type<any>[], platform: PlatformRef, options?: {
-    teardown?: ModuleTeardownOptions
-  }): TestBed;
+  initTestEnvironment(
+      ngModule: Type<any>|Type<any>[], platform: PlatformRef,
+      options?: TestEnvironmentOptions): TestBed;
   initTestEnvironment(
       ngModule: Type<any>|Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
 


### PR DESCRIPTION
This commit switches the interface used for the options object of
`TestBed.initTestEnvironment` to include `aotSummaries`, where previously
it did not. This was a copy/paste error in the original implementation.