### PR TITLE
fix(compiler-cli): not evaluating new signature for __spreadArray

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/ts_helpers.ts
@@ -39,7 +39,7 @@ export class SpreadHelperFn extends KnownFn {
 // Used for `__spreadArray` TypeScript helper function.
 export class SpreadArrayHelperFn extends KnownFn {
   override evaluate(node: ts.Node, args: ResolvedValueArray): ResolvedValue {
-    if (args.length !== 2) {
+    if (args.length !== 2 && args.length !== 3) {
       return DynamicValue.fromUnknown(node);
     }
 

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -760,7 +760,7 @@ runInEachFileSystem(() => {
               export declare function __assign(t: any, ...sources: any[]): any;
               export declare function __spread(...args: any[][]): any[];
               export declare function __spreadArrays(...args: any[][]): any[];
-              export declare function __spreadArray(to: any[], from: any[]): any[];
+              export declare function __spreadArray(to: any[], from: any[], pack?: boolean): any[];
               export declare function __read(o: any, n?: number): any[];
             `,
           },
@@ -870,6 +870,18 @@ runInEachFileSystem(() => {
               const b = [5, 6];
             `,
             'tslib.__spreadArray(a, b)');
+
+        expect(arr).toEqual([4, 5, 6]);
+      });
+
+      it('should evaluate `__spreadArray()` with three arguments', () => {
+        const arr: number[] = evaluateExpression(
+            `
+              import {__spreadArray} from 'tslib';
+              const a = [4];
+              const b = [5, 6];
+            `,
+            '__spreadArray(a, b, false)');
 
         expect(arr).toEqual([4, 5, 6]);
       });


### PR DESCRIPTION
In TypeScript 4.4 the `__spreadArray` function has three parameters, however we only allowed two which can result in an error.