### PR TITLE
fix(core): handle invalid constructor parameters in partial factory d…

### DIFF
--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -241,7 +241,7 @@ export interface R3FactoryDefMetadataFacade {
 
 export interface R3DeclareFactoryFacade {
   type: Type;
-  deps: R3DeclareDependencyMetadataFacade[]|null;
+  deps: R3DeclareDependencyMetadataFacade[]|'invalid'|null;
   target: FactoryTarget;
 }
 

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -241,7 +241,8 @@ export class CompilerFacadeImpl implements CompilerFacade {
       type: wrapReference(meta.type),
       internalType: new WrappedNodeExpr(meta.type),
       typeArgumentCount: 0,
-      deps: meta.deps && meta.deps.map(convertR3DeclareDependencyMetadata),
+      deps: Array.isArray(meta.deps) ? meta.deps.map(convertR3DeclareDependencyMetadata) :
+                                       meta.deps,
       target: meta.target,
     });
     return this.jitExpression(

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -241,7 +241,7 @@ export interface R3FactoryDefMetadataFacade {
 
 export interface R3DeclareFactoryFacade {
   type: Type;
-  deps: R3DeclareDependencyMetadataFacade[]|null;
+  deps: R3DeclareDependencyMetadataFacade[]|'invalid'|null;
   target: FactoryTarget;
 }
 

--- a/packages/core/test/render3/jit/declare_factory_spec.ts
+++ b/packages/core/test/render3/jit/declare_factory_spec.ts
@@ -36,6 +36,11 @@ describe('Factory declaration jit compilation', () => {
     expect(instance).toBeInstanceOf(ChildClass);
     expect(instance.testClass).toBeInstanceOf(TestClass);
   });
+
+  it('should compile a factory declaration with an invalid dependency', () => {
+    const factory = InvalidDepsClass.ɵfac as Function;
+    expect(() => factory()).toThrowError(/not compatible/);
+  });
 });
 
 class TestClass {
@@ -54,6 +59,11 @@ class DependingClass {
 class ChildClass extends DependingClass {
   static override ɵfac =
       ɵɵngDeclareFactory({type: ChildClass, deps: null, target: ɵɵFactoryTarget.Injectable});
+}
+
+class InvalidDepsClass {
+  static ɵfac = ɵɵngDeclareFactory(
+      {type: InvalidDepsClass, deps: 'invalid', target: ɵɵFactoryTarget.Injectable});
 }
 
 class TestInjector {


### PR DESCRIPTION
…eclarations

This commit fixes an oversight in the JIT compilation of partial factory
declarations, where the literal `'invalid'` was not accounted for
(unlike the AOT linker).

Fixes #43609