### PR TITLE
Support use of an ESM `@angular/compiler` package in `@angular/core` migrations

### DIFF
--- a/packages/core/schematics/migrations/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/google3/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = ["//packages/core/schematics/test/google3:__pkg__"],
     deps = [
+        "//packages/compiler",
         "//packages/core/schematics/migrations/activated-route-snapshot-fragment",
         "//packages/core/schematics/migrations/can-activate-with-redirect-to",
         "//packages/core/schematics/migrations/dynamic-queries",

--- a/packages/core/schematics/migrations/google3/explicitQueryTimingRule.ts
+++ b/packages/core/schematics/migrations/google3/explicitQueryTimingRule.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as compiler from '@angular/compiler';
 import {Replacement, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
 
@@ -49,7 +50,7 @@ export class Rule extends Rules.TypedRule {
     });
 
     const queries = resolvedQueries.get(sourceFile);
-    const usageStrategy = new QueryUsageStrategy(classMetadata, typeChecker);
+    const usageStrategy = new QueryUsageStrategy(classMetadata, typeChecker, compiler);
 
     // No queries detected for the given source file.
     if (!queries) {

--- a/packages/core/schematics/migrations/google3/noTemplateVariableAssignmentRule.ts
+++ b/packages/core/schematics/migrations/google3/noTemplateVariableAssignmentRule.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as compiler from '@angular/compiler';
 import {RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
 
@@ -34,7 +35,7 @@ export class Rule extends Rules.TypedRule {
     // template variables.
     resolvedTemplates.forEach(template => {
       const filePath = template.filePath;
-      const nodes = analyzeResolvedTemplate(template);
+      const nodes = analyzeResolvedTemplate(template, compiler);
       const templateFile =
           template.inline ? sourceFile : createHtmlSourceFile(filePath, template.content);
 

--- a/packages/core/schematics/migrations/router-link-empty-expression/analyze_template.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/analyze_template.ts
@@ -6,14 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {BoundAttribute, visitAll} from '@angular/compiler/src/render3/r3_ast';
+import {TmplAstBoundAttribute} from '@angular/compiler';
+import {visitAll} from '@angular/compiler/src/render3/r3_ast';
 
 import {ResolvedTemplate} from '../../utils/ng_component_template';
 import {parseHtmlGracefully} from '../../utils/parse_html';
 
 import {RouterLinkEmptyExprVisitor} from './angular/html_routerlink_empty_expr_visitor';
 
-export function analyzeResolvedTemplate(template: ResolvedTemplate): BoundAttribute[]|null {
+export function analyzeResolvedTemplate(template: ResolvedTemplate): TmplAstBoundAttribute[]|null {
   const templateNodes = parseHtmlGracefully(template.content, template.filePath);
 
   if (!templateNodes) {

--- a/packages/core/schematics/migrations/router-link-empty-expression/analyze_template.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/analyze_template.ts
@@ -6,21 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TmplAstBoundAttribute} from '@angular/compiler';
+import type {TmplAstBoundAttribute} from '@angular/compiler';
 
 import {ResolvedTemplate} from '../../utils/ng_component_template';
 import {parseHtmlGracefully} from '../../utils/parse_html';
 
 import {RouterLinkEmptyExprVisitor} from './angular/html_routerlink_empty_expr_visitor';
 
-export function analyzeResolvedTemplate(template: ResolvedTemplate): TmplAstBoundAttribute[]|null {
-  const templateNodes = parseHtmlGracefully(template.content, template.filePath);
+export function analyzeResolvedTemplate(
+    template: ResolvedTemplate,
+    compilerModule: typeof import('@angular/compiler')): TmplAstBoundAttribute[]|null {
+  const templateNodes = parseHtmlGracefully(template.content, template.filePath, compilerModule);
 
   if (!templateNodes) {
     return null;
   }
 
-  const visitor = new RouterLinkEmptyExprVisitor();
+  const visitor = new RouterLinkEmptyExprVisitor(compilerModule);
 
   // Analyze the Angular Render3 HTML AST and collect all template variable assignments.
   visitor.visitAll(templateNodes);

--- a/packages/core/schematics/migrations/router-link-empty-expression/analyze_template.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/analyze_template.ts
@@ -7,7 +7,6 @@
  */
 
 import {TmplAstBoundAttribute} from '@angular/compiler';
-import {visitAll} from '@angular/compiler/src/render3/r3_ast';
 
 import {ResolvedTemplate} from '../../utils/ng_component_template';
 import {parseHtmlGracefully} from '../../utils/parse_html';
@@ -24,7 +23,7 @@ export function analyzeResolvedTemplate(template: ResolvedTemplate): TmplAstBoun
   const visitor = new RouterLinkEmptyExprVisitor();
 
   // Analyze the Angular Render3 HTML AST and collect all template variable assignments.
-  visitAll(visitor, templateNodes);
+  visitor.visitAll(templateNodes);
 
   return visitor.emptyRouterLinkExpressions;
 }

--- a/packages/core/schematics/migrations/router-link-empty-expression/angular/html_routerlink_empty_expr_visitor.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/angular/html_routerlink_empty_expr_visitor.ts
@@ -7,23 +7,23 @@
  */
 
 import {ASTWithSource, EmptyExpr, TmplAstBoundAttribute, TmplAstElement, TmplAstTemplate} from '@angular/compiler';
-import {NullVisitor, visitAll} from '@angular/compiler/src/render3/r3_ast';
+import {TemplateAstVisitor} from '../../../utils/template_ast_visitor';
 
 /**
  * HTML AST visitor that traverses the Render3 HTML AST in order to find all
  * undefined routerLink asssignment ([routerLink]="").
  */
-export class RouterLinkEmptyExprVisitor extends NullVisitor {
+export class RouterLinkEmptyExprVisitor extends TemplateAstVisitor {
   readonly emptyRouterLinkExpressions: TmplAstBoundAttribute[] = [];
 
   override visitElement(element: TmplAstElement): void {
-    visitAll(this, element.inputs);
-    visitAll(this, element.children);
+    this.visitAll(element.inputs);
+    this.visitAll(element.children);
   }
 
   override visitTemplate(t: TmplAstTemplate): void {
-    visitAll(this, t.inputs);
-    visitAll(this, t.children);
+    this.visitAll(t.inputs);
+    this.visitAll(t.children);
   }
 
   override visitBoundAttribute(node: TmplAstBoundAttribute) {

--- a/packages/core/schematics/migrations/router-link-empty-expression/angular/html_routerlink_empty_expr_visitor.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/angular/html_routerlink_empty_expr_visitor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ASTWithSource, EmptyExpr, TmplAstBoundAttribute, TmplAstElement, TmplAstTemplate} from '@angular/compiler';
+import type {TmplAstBoundAttribute, TmplAstElement, TmplAstTemplate} from '@angular/compiler';
 import {TemplateAstVisitor} from '../../../utils/template_ast_visitor';
 
 /**
@@ -27,8 +27,8 @@ export class RouterLinkEmptyExprVisitor extends TemplateAstVisitor {
   }
 
   override visitBoundAttribute(node: TmplAstBoundAttribute) {
-    if (node.name === 'routerLink' && node.value instanceof ASTWithSource &&
-        node.value.ast instanceof EmptyExpr) {
+    if (node.name === 'routerLink' && node.value instanceof this.compilerModule.ASTWithSource &&
+        node.value.ast instanceof this.compilerModule.EmptyExpr) {
       this.emptyRouterLinkExpressions.push(node);
     }
   }

--- a/packages/core/schematics/migrations/router-link-empty-expression/angular/html_routerlink_empty_expr_visitor.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/angular/html_routerlink_empty_expr_visitor.ts
@@ -6,27 +6,27 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ASTWithSource, EmptyExpr} from '@angular/compiler';
-import {BoundAttribute, Element, NullVisitor, Template, visitAll} from '@angular/compiler/src/render3/r3_ast';
+import {ASTWithSource, EmptyExpr, TmplAstBoundAttribute, TmplAstElement, TmplAstTemplate} from '@angular/compiler';
+import {NullVisitor, visitAll} from '@angular/compiler/src/render3/r3_ast';
 
 /**
  * HTML AST visitor that traverses the Render3 HTML AST in order to find all
  * undefined routerLink asssignment ([routerLink]="").
  */
 export class RouterLinkEmptyExprVisitor extends NullVisitor {
-  readonly emptyRouterLinkExpressions: BoundAttribute[] = [];
+  readonly emptyRouterLinkExpressions: TmplAstBoundAttribute[] = [];
 
-  override visitElement(element: Element): void {
+  override visitElement(element: TmplAstElement): void {
     visitAll(this, element.inputs);
     visitAll(this, element.children);
   }
 
-  override visitTemplate(t: Template): void {
+  override visitTemplate(t: TmplAstTemplate): void {
     visitAll(this, t.inputs);
     visitAll(this, t.children);
   }
 
-  override visitBoundAttribute(node: BoundAttribute) {
+  override visitBoundAttribute(node: TmplAstBoundAttribute) {
     if (node.name === 'routerLink' && node.value instanceof ASTWithSource &&
         node.value.ast instanceof EmptyExpr) {
       this.emptyRouterLinkExpressions.push(node);

--- a/packages/core/schematics/migrations/static-queries/index.ts
+++ b/packages/core/schematics/migrations/static-queries/index.ts
@@ -11,6 +11,7 @@ import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit
 import {relative} from 'path';
 import * as ts from 'typescript';
 
+import {loadEsmModule} from '../../utils/load_esm';
 import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
 import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
 import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
@@ -69,9 +70,21 @@ async function runMigration(tree: Tree, context: SchematicContext) {
     }
   }
 
+  let compilerModule;
+  try {
+    // Load ESM `@angular/compiler` using the TypeScript dynamic import workaround.
+    // Once TypeScript provides support for keeping the dynamic import this workaround can be
+    // changed to a direct dynamic import.
+    compilerModule = await loadEsmModule<typeof import('@angular/compiler')>('@angular/compiler');
+  } catch (e) {
+    throw new SchematicsException(
+        `Unable to load the '@angular/compiler' package. Details: ${e.message}`);
+  }
+
   if (buildProjects.size) {
     for (let project of Array.from(buildProjects.values())) {
-      failures.push(...await runStaticQueryMigration(tree, project, strategy, logger));
+      failures.push(
+          ...await runStaticQueryMigration(tree, project, strategy, logger, compilerModule));
     }
   }
 
@@ -80,8 +93,8 @@ async function runMigration(tree: Tree, context: SchematicContext) {
   for (const tsconfigPath of testPaths) {
     const project = await analyzeProject(tree, tsconfigPath, basePath, analyzedFiles, logger);
     if (project) {
-      failures.push(
-          ...await runStaticQueryMigration(tree, project, SELECTED_STRATEGY.TESTS, logger));
+      failures.push(...await runStaticQueryMigration(
+          tree, project, SELECTED_STRATEGY.TESTS, logger, compilerModule));
     }
   }
 
@@ -150,7 +163,8 @@ function analyzeProject(
  */
 async function runStaticQueryMigration(
     tree: Tree, project: AnalyzedProject, selectedStrategy: SELECTED_STRATEGY,
-    logger: logging.LoggerApi): Promise<string[]> {
+    logger: logging.LoggerApi,
+    compilerModule: typeof import('@angular/compiler')): Promise<string[]> {
   const {sourceFiles, typeChecker, host, queryVisitor, tsconfigPath, basePath} = project;
   const printer = ts.createPrinter();
   const failureMessages: string[] = [];
@@ -177,11 +191,11 @@ async function runStaticQueryMigration(
 
   let strategy: TimingStrategy;
   if (selectedStrategy === SELECTED_STRATEGY.USAGE) {
-    strategy = new QueryUsageStrategy(classMetadata, typeChecker);
+    strategy = new QueryUsageStrategy(classMetadata, typeChecker, compilerModule);
   } else if (selectedStrategy === SELECTED_STRATEGY.TESTS) {
     strategy = new QueryTestStrategy();
   } else {
-    strategy = new QueryTemplateStrategy(tsconfigPath, classMetadata, host);
+    strategy = new QueryTemplateStrategy(tsconfigPath, classMetadata, host, compilerModule);
   }
 
   try {

--- a/packages/core/schematics/migrations/static-queries/strategies/template_strategy/template_strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/template_strategy/template_strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompiler, CompileDirectiveMetadata, CompileMetadataResolver, CompileNgModuleMetadata, CompileStylesheetMetadata, ElementAst, EmbeddedTemplateAst, NgAnalyzedModules, QueryMatch, StaticSymbol, TemplateAst} from '@angular/compiler';
+import type {AotCompiler, CompileDirectiveMetadata, CompileMetadataResolver, CompileNgModuleMetadata, CompileStylesheetMetadata, ElementAst, EmbeddedTemplateAst, NgAnalyzedModules, QueryMatch, StaticSymbol, TemplateAst} from '@angular/compiler';
 import {createProgram, Diagnostic, readConfiguration} from '@angular/compiler-cli';
 import {resolve} from 'path';
 import * as ts from 'typescript';
@@ -25,7 +25,7 @@ export class QueryTemplateStrategy implements TimingStrategy {
 
   constructor(
       private projectPath: string, private classMetadata: ClassMetadataMap,
-      private host: ts.CompilerHost) {}
+      private host: ts.CompilerHost, private compilerModule: typeof import('@angular/compiler')) {}
 
   /**
    * Sets up the template strategy by creating the AngularCompilerProgram. Returns false if
@@ -54,8 +54,8 @@ export class QueryTemplateStrategy implements TimingStrategy {
     // breaks the analysis of the project because we instantiate a standalone AOT compiler
     // program which does not contain the custom logic by the Angular CLI Webpack compiler plugin.
     const directiveNormalizer = this.metadataResolver!['_directiveNormalizer'];
-    directiveNormalizer['_normalizeStylesheet'] = function(metadata: CompileStylesheetMetadata) {
-      return new CompileStylesheetMetadata(
+    directiveNormalizer['_normalizeStylesheet'] = (metadata: CompileStylesheetMetadata) => {
+      return new this.compilerModule.CompileStylesheetMetadata(
           {styles: metadata.styles, styleUrls: [], moduleUrl: metadata.moduleUrl!});
     };
 
@@ -83,7 +83,7 @@ export class QueryTemplateStrategy implements TimingStrategy {
     }
 
     const parsedTemplate = this._parseTemplate(metadata, ngModule);
-    const queryTimingMap = findStaticQueryIds(parsedTemplate);
+    const queryTimingMap = this.findStaticQueryIds(parsedTemplate);
     const {staticQueryIds} = staticViewQueryIds(queryTimingMap);
 
     metadata.viewQueries.forEach((query, index) => {
@@ -187,45 +187,45 @@ export class QueryTemplateStrategy implements TimingStrategy {
   private _getViewQueryUniqueKey(filePath: string, className: string, propName: string) {
     return `${resolve(filePath)}#${className}-${propName}`;
   }
+
+  /** Figures out which queries are static and which ones are dynamic. */
+  private findStaticQueryIds(
+      nodes: TemplateAst[], result = new Map<TemplateAst, StaticAndDynamicQueryIds>()):
+      Map<TemplateAst, StaticAndDynamicQueryIds> {
+    nodes.forEach((node) => {
+      const staticQueryIds = new Set<number>();
+      const dynamicQueryIds = new Set<number>();
+      let queryMatches: QueryMatch[] = undefined!;
+      if (node instanceof this.compilerModule.ElementAst) {
+        this.findStaticQueryIds(node.children, result);
+        node.children.forEach((child) => {
+          const childData = result.get(child)!;
+          childData.staticQueryIds.forEach(queryId => staticQueryIds.add(queryId));
+          childData.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
+        });
+        queryMatches = node.queryMatches;
+      } else if (node instanceof this.compilerModule.EmbeddedTemplateAst) {
+        this.findStaticQueryIds(node.children, result);
+        node.children.forEach((child) => {
+          const childData = result.get(child)!;
+          childData.staticQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
+          childData.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
+        });
+        queryMatches = node.queryMatches;
+      }
+      if (queryMatches) {
+        queryMatches.forEach((match) => staticQueryIds.add(match.queryId));
+      }
+      dynamicQueryIds.forEach(queryId => staticQueryIds.delete(queryId));
+      result.set(node, {staticQueryIds, dynamicQueryIds});
+    });
+    return result;
+  }
 }
 
 interface StaticAndDynamicQueryIds {
   staticQueryIds: Set<number>;
   dynamicQueryIds: Set<number>;
-}
-
-/** Figures out which queries are static and which ones are dynamic. */
-function findStaticQueryIds(
-    nodes: TemplateAst[], result = new Map<TemplateAst, StaticAndDynamicQueryIds>()):
-    Map<TemplateAst, StaticAndDynamicQueryIds> {
-  nodes.forEach((node) => {
-    const staticQueryIds = new Set<number>();
-    const dynamicQueryIds = new Set<number>();
-    let queryMatches: QueryMatch[] = undefined!;
-    if (node instanceof ElementAst) {
-      findStaticQueryIds(node.children, result);
-      node.children.forEach((child) => {
-        const childData = result.get(child)!;
-        childData.staticQueryIds.forEach(queryId => staticQueryIds.add(queryId));
-        childData.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
-      });
-      queryMatches = node.queryMatches;
-    } else if (node instanceof EmbeddedTemplateAst) {
-      findStaticQueryIds(node.children, result);
-      node.children.forEach((child) => {
-        const childData = result.get(child)!;
-        childData.staticQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
-        childData.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
-      });
-      queryMatches = node.queryMatches;
-    }
-    if (queryMatches) {
-      queryMatches.forEach((match) => staticQueryIds.add(match.queryId));
-    }
-    dynamicQueryIds.forEach(queryId => staticQueryIds.delete(queryId));
-    result.set(node, {staticQueryIds, dynamicQueryIds});
-  });
-  return result;
 }
 
 /** Splits queries into static and dynamic. */

--- a/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/template_usage_visitor.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/template_usage_visitor.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ImplicitReceiver, ParseSourceSpan, PropertyRead, RecursiveAstVisitor} from '@angular/compiler';
-import {BoundAttribute, BoundEvent, BoundText, Element, Node, NullVisitor, Template, visitAll} from '@angular/compiler/src/render3/r3_ast';
+import {ImplicitReceiver, ParseSourceSpan, PropertyRead, RecursiveAstVisitor, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstTemplate} from '@angular/compiler';
+import {NullVisitor, visitAll} from '@angular/compiler/src/render3/r3_ast';
 
 /**
  * AST visitor that traverses the Render3 HTML AST in order to check if the given
@@ -22,7 +22,7 @@ export class TemplateUsageVisitor extends NullVisitor {
   }
 
   /** Checks whether the given query is statically accessed within the specified HTML nodes. */
-  isQueryUsedStatically(htmlNodes: Node[]): boolean {
+  isQueryUsedStatically(htmlNodes: TmplAstNode[]): boolean {
     this.hasQueryTemplateReference = false;
     this.expressionAstVisitor.hasQueryPropertyRead = false;
 
@@ -32,7 +32,7 @@ export class TemplateUsageVisitor extends NullVisitor {
     return !this.hasQueryTemplateReference && this.expressionAstVisitor.hasQueryPropertyRead;
   }
 
-  override visitElement(element: Element): void {
+  override visitElement(element: TmplAstElement): void {
     // In case there is a template references variable that matches the query property
     // name, we can finish this visitor as such a template variable can be used in the
     // entire template and the query therefore can't be accessed from the template.
@@ -47,7 +47,7 @@ export class TemplateUsageVisitor extends NullVisitor {
     visitAll(this, element.children);
   }
 
-  override visitTemplate(template: Template): void {
+  override visitTemplate(template: TmplAstTemplate): void {
     visitAll(this, template.attributes);
     visitAll(this, template.inputs);
     visitAll(this, template.outputs);
@@ -57,15 +57,15 @@ export class TemplateUsageVisitor extends NullVisitor {
     // lifecycle hook at the earliest.
   }
 
-  override visitBoundAttribute(attribute: BoundAttribute) {
+  override visitBoundAttribute(attribute: TmplAstBoundAttribute) {
     attribute.value.visit(this.expressionAstVisitor, attribute.sourceSpan);
   }
 
-  override visitBoundText(text: BoundText) {
+  override visitBoundText(text: TmplAstBoundText) {
     text.value.visit(this.expressionAstVisitor, text.sourceSpan);
   }
 
-  override visitBoundEvent(node: BoundEvent) {
+  override visitBoundEvent(node: TmplAstBoundEvent) {
     node.handler.visit(this.expressionAstVisitor, node.handlerSpan);
   }
 }

--- a/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/template_usage_visitor.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/template_usage_visitor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ImplicitReceiver, ParseSourceSpan, PropertyRead, RecursiveAstVisitor, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstTemplate} from '@angular/compiler';
+import type {ParseSourceSpan, PropertyRead, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstTemplate} from '@angular/compiler';
 import {TemplateAstVisitor} from '../../../../utils/template_ast_visitor';
 
 /**
@@ -15,10 +15,33 @@ import {TemplateAstVisitor} from '../../../../utils/template_ast_visitor';
  */
 export class TemplateUsageVisitor extends TemplateAstVisitor {
   private hasQueryTemplateReference = false;
-  private expressionAstVisitor = new ExpressionAstVisitor(this.queryPropertyName);
+  private expressionAstVisitor;
 
-  constructor(public queryPropertyName: string) {
-    super();
+  constructor(
+      public queryPropertyName: string, compilerModule: typeof import('@angular/compiler')) {
+    super(compilerModule);
+
+    // AST visitor that checks if the given expression contains property reads that
+    // refer to the specified query property name.
+    // This class must be defined within the template visitor due to the need to extend from a class
+    // value found within `@angular/compiler` which is dynamically imported and provided to the
+    // visitor.
+    this.expressionAstVisitor = new (class extends compilerModule.RecursiveAstVisitor {
+      hasQueryPropertyRead = false;
+
+
+      override visitPropertyRead(node: PropertyRead, span: ParseSourceSpan): any {
+        // The receiver of the property read needs to be "implicit" as queries are accessed
+        // from the component instance and not from other objects.
+        if (node.receiver instanceof compilerModule.ImplicitReceiver &&
+            node.name === queryPropertyName) {
+          this.hasQueryPropertyRead = true;
+          return;
+        }
+
+        super.visitPropertyRead(node, span);
+      }
+    })();
   }
 
   /** Checks whether the given query is statically accessed within the specified HTML nodes. */
@@ -67,28 +90,5 @@ export class TemplateUsageVisitor extends TemplateAstVisitor {
 
   override visitBoundEvent(node: TmplAstBoundEvent) {
     node.handler.visit(this.expressionAstVisitor, node.handlerSpan);
-  }
-}
-
-/**
- * AST visitor that checks if the given expression contains property reads that
- * refer to the specified query property name.
- */
-class ExpressionAstVisitor extends RecursiveAstVisitor {
-  hasQueryPropertyRead = false;
-
-  constructor(private queryPropertyName: string) {
-    super();
-  }
-
-  override visitPropertyRead(node: PropertyRead, span: ParseSourceSpan): any {
-    // The receiver of the property read needs to be "implicit" as queries are accessed
-    // from the component instance and not from other objects.
-    if (node.receiver instanceof ImplicitReceiver && node.name === this.queryPropertyName) {
-      this.hasQueryPropertyRead = true;
-      return;
-    }
-
-    super.visitPropertyRead(node, span);
   }
 }

--- a/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/template_usage_visitor.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/template_usage_visitor.ts
@@ -7,13 +7,13 @@
  */
 
 import {ImplicitReceiver, ParseSourceSpan, PropertyRead, RecursiveAstVisitor, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstTemplate} from '@angular/compiler';
-import {NullVisitor, visitAll} from '@angular/compiler/src/render3/r3_ast';
+import {TemplateAstVisitor} from '../../../../utils/template_ast_visitor';
 
 /**
  * AST visitor that traverses the Render3 HTML AST in order to check if the given
  * query property is accessed statically in the template.
  */
-export class TemplateUsageVisitor extends NullVisitor {
+export class TemplateUsageVisitor extends TemplateAstVisitor {
   private hasQueryTemplateReference = false;
   private expressionAstVisitor = new ExpressionAstVisitor(this.queryPropertyName);
 
@@ -27,7 +27,7 @@ export class TemplateUsageVisitor extends NullVisitor {
     this.expressionAstVisitor.hasQueryPropertyRead = false;
 
     // Visit all AST nodes and check if the query property is used statically.
-    visitAll(this, htmlNodes);
+    this.visitAll(htmlNodes);
 
     return !this.hasQueryTemplateReference && this.expressionAstVisitor.hasQueryPropertyRead;
   }
@@ -41,16 +41,16 @@ export class TemplateUsageVisitor extends NullVisitor {
       return;
     }
 
-    visitAll(this, element.attributes);
-    visitAll(this, element.inputs);
-    visitAll(this, element.outputs);
-    visitAll(this, element.children);
+    this.visitAll(element.attributes);
+    this.visitAll(element.inputs);
+    this.visitAll(element.outputs);
+    this.visitAll(element.children);
   }
 
   override visitTemplate(template: TmplAstTemplate): void {
-    visitAll(this, template.attributes);
-    visitAll(this, template.inputs);
-    visitAll(this, template.outputs);
+    this.visitAll(template.attributes);
+    this.visitAll(template.inputs);
+    this.visitAll(template.outputs);
 
     // We don't want to visit any children of the template as these never can't
     // access a query statically. The templates can be rendered in the ngAfterViewInit"

--- a/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/usage_strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/usage_strategy.ts
@@ -35,7 +35,9 @@ const STATIC_QUERY_LIFECYCLE_HOOKS = {
  * this strategy here: https://hackmd.io/s/Hymvc2OKE
  */
 export class QueryUsageStrategy implements TimingStrategy {
-  constructor(private classMetadata: ClassMetadataMap, private typeChecker: ts.TypeChecker) {}
+  constructor(
+      private classMetadata: ClassMetadataMap, private typeChecker: ts.TypeChecker,
+      private compilerModule: typeof import('@angular/compiler')) {}
 
   setup() {}
 
@@ -101,8 +103,9 @@ export class QueryUsageStrategy implements TimingStrategy {
     // can be marked as static.
     if (classMetadata.template && hasPropertyNameText(query.property!.name)) {
       const template = classMetadata.template;
-      const parsedHtml = parseHtmlGracefully(template.content, template.filePath);
-      const htmlVisitor = new TemplateUsageVisitor(query.property!.name.text);
+      const parsedHtml =
+          parseHtmlGracefully(template.content, template.filePath, this.compilerModule);
+      const htmlVisitor = new TemplateUsageVisitor(query.property!.name.text, this.compilerModule);
 
       if (parsedHtml && htmlVisitor.isQueryUsedStatically(parsedHtml)) {
         return ResolvedUsage.SYNCHRONOUS;

--- a/packages/core/schematics/migrations/template-var-assignment/analyze_template.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/analyze_template.ts
@@ -7,7 +7,6 @@
  */
 
 import {PropertyWrite} from '@angular/compiler';
-import {visitAll} from '@angular/compiler/src/render3/r3_ast';
 import {ResolvedTemplate} from '../../utils/ng_component_template';
 import {parseHtmlGracefully} from '../../utils/parse_html';
 import {HtmlVariableAssignmentVisitor} from './angular/html_variable_assignment_visitor';
@@ -33,7 +32,7 @@ export function analyzeResolvedTemplate(template: ResolvedTemplate): TemplateVar
   const visitor = new HtmlVariableAssignmentVisitor();
 
   // Analyze the Angular Render3 HTML AST and collect all template variable assignments.
-  visitAll(visitor, templateNodes);
+  visitor.visitAll(templateNodes);
 
   return visitor.variableAssignments.map(
       ({node, start, end}) => ({node, start: start + node.span.start, end}));

--- a/packages/core/schematics/migrations/template-var-assignment/analyze_template.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/analyze_template.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PropertyWrite} from '@angular/compiler';
+import type {PropertyWrite} from '@angular/compiler';
 import {ResolvedTemplate} from '../../utils/ng_component_template';
 import {parseHtmlGracefully} from '../../utils/parse_html';
 import {HtmlVariableAssignmentVisitor} from './angular/html_variable_assignment_visitor';
@@ -21,15 +21,16 @@ export interface TemplateVariableAssignment {
  * Analyzes a given resolved template by looking for property assignments to local
  * template variables within bound events.
  */
-export function analyzeResolvedTemplate(template: ResolvedTemplate): TemplateVariableAssignment[]|
-    null {
-  const templateNodes = parseHtmlGracefully(template.content, template.filePath);
+export function analyzeResolvedTemplate(
+    template: ResolvedTemplate,
+    compilerModule: typeof import('@angular/compiler')): TemplateVariableAssignment[]|null {
+  const templateNodes = parseHtmlGracefully(template.content, template.filePath, compilerModule);
 
   if (!templateNodes) {
     return null;
   }
 
-  const visitor = new HtmlVariableAssignmentVisitor();
+  const visitor = new HtmlVariableAssignmentVisitor(compilerModule);
 
   // Analyze the Angular Render3 HTML AST and collect all template variable assignments.
   visitor.visitAll(templateNodes);

--- a/packages/core/schematics/migrations/template-var-assignment/angular/html_variable_assignment_visitor.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/angular/html_variable_assignment_visitor.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ImplicitReceiver, ParseSourceSpan, PropertyWrite, RecursiveAstVisitor} from '@angular/compiler';
-import {BoundEvent, Element, NullVisitor, Template, Variable, visitAll} from '@angular/compiler/src/render3/r3_ast';
+import {ImplicitReceiver, ParseSourceSpan, PropertyWrite, RecursiveAstVisitor, TmplAstBoundEvent, TmplAstElement, TmplAstTemplate, TmplAstVariable} from '@angular/compiler';
+import {NullVisitor, visitAll} from '@angular/compiler/src/render3/r3_ast';
 
 export interface TemplateVariableAssignment {
   start: number;
@@ -22,16 +22,16 @@ export interface TemplateVariableAssignment {
 export class HtmlVariableAssignmentVisitor extends NullVisitor {
   variableAssignments: TemplateVariableAssignment[] = [];
 
-  private currentVariables: Variable[] = [];
+  private currentVariables: TmplAstVariable[] = [];
   private expressionAstVisitor =
       new ExpressionAstVisitor(this.variableAssignments, this.currentVariables);
 
-  override visitElement(element: Element): void {
+  override visitElement(element: TmplAstElement): void {
     visitAll(this, element.outputs);
     visitAll(this, element.children);
   }
 
-  override visitTemplate(template: Template): void {
+  override visitTemplate(template: TmplAstTemplate): void {
     // Keep track of the template variables which can be accessed by the template
     // child nodes through the implicit receiver.
     this.currentVariables.push(...template.variables);
@@ -52,7 +52,7 @@ export class HtmlVariableAssignmentVisitor extends NullVisitor {
     });
   }
 
-  override visitBoundEvent(node: BoundEvent) {
+  override visitBoundEvent(node: TmplAstBoundEvent) {
     node.handler.visit(this.expressionAstVisitor, node.handlerSpan);
   }
 }
@@ -61,7 +61,7 @@ export class HtmlVariableAssignmentVisitor extends NullVisitor {
 class ExpressionAstVisitor extends RecursiveAstVisitor {
   constructor(
       private variableAssignments: TemplateVariableAssignment[],
-      private currentVariables: Variable[]) {
+      private currentVariables: TmplAstVariable[]) {
     super();
   }
 

--- a/packages/core/schematics/migrations/template-var-assignment/angular/html_variable_assignment_visitor.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/angular/html_variable_assignment_visitor.ts
@@ -7,7 +7,8 @@
  */
 
 import {ImplicitReceiver, ParseSourceSpan, PropertyWrite, RecursiveAstVisitor, TmplAstBoundEvent, TmplAstElement, TmplAstTemplate, TmplAstVariable} from '@angular/compiler';
-import {NullVisitor, visitAll} from '@angular/compiler/src/render3/r3_ast';
+import {TemplateAstVisitor} from '../../../utils/template_ast_visitor';
+
 
 export interface TemplateVariableAssignment {
   start: number;
@@ -19,7 +20,7 @@ export interface TemplateVariableAssignment {
  * HTML AST visitor that traverses the Render3 HTML AST in order to find all
  * expressions that write to local template variables within bound events.
  */
-export class HtmlVariableAssignmentVisitor extends NullVisitor {
+export class HtmlVariableAssignmentVisitor extends TemplateAstVisitor {
   variableAssignments: TemplateVariableAssignment[] = [];
 
   private currentVariables: TmplAstVariable[] = [];
@@ -27,8 +28,8 @@ export class HtmlVariableAssignmentVisitor extends NullVisitor {
       new ExpressionAstVisitor(this.variableAssignments, this.currentVariables);
 
   override visitElement(element: TmplAstElement): void {
-    visitAll(this, element.outputs);
-    visitAll(this, element.children);
+    this.visitAll(element.outputs);
+    this.visitAll(element.children);
   }
 
   override visitTemplate(template: TmplAstTemplate): void {
@@ -39,7 +40,7 @@ export class HtmlVariableAssignmentVisitor extends NullVisitor {
     // Visit all children of the template. The template proxies the outputs of the
     // immediate child elements, so we just ignore outputs on the "Template" in order
     // to not visit similar bound events twice.
-    visitAll(this, template.children);
+    this.visitAll(template.children);
 
     // Remove all previously added variables since all children that could access
     // these have been visited already.

--- a/packages/core/schematics/migrations/template-var-assignment/index.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/index.ts
@@ -10,6 +10,7 @@ import {logging, normalize} from '@angular-devkit/core';
 import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
 import {relative} from 'path';
 
+import {loadEsmModule} from '../../utils/load_esm';
 import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
 import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
 import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
@@ -33,8 +34,20 @@ export default function(): Rule {
           'assignments.');
     }
 
+    let compilerModule;
+    try {
+      // Load ESM `@angular/compiler` using the TypeScript dynamic import workaround.
+      // Once TypeScript provides support for keeping the dynamic import this workaround can be
+      // changed to a direct dynamic import.
+      compilerModule = await loadEsmModule<typeof import('@angular/compiler')>('@angular/compiler');
+    } catch (e) {
+      throw new SchematicsException(
+          `Unable to load the '@angular/compiler' package. Details: ${e.message}`);
+    }
+
     for (const tsconfigPath of [...buildPaths, ...testPaths]) {
-      runTemplateVariableAssignmentCheck(tree, tsconfigPath, basePath, context.logger);
+      runTemplateVariableAssignmentCheck(
+          tree, tsconfigPath, basePath, context.logger, compilerModule);
     }
   };
 }
@@ -44,7 +57,8 @@ export default function(): Rule {
  * if values are assigned to template variables within output bindings.
  */
 function runTemplateVariableAssignmentCheck(
-    tree: Tree, tsconfigPath: string, basePath: string, logger: Logger) {
+    tree: Tree, tsconfigPath: string, basePath: string, logger: Logger,
+    compilerModule: typeof import('@angular/compiler')) {
   const {program} = createMigrationProgram(tree, tsconfigPath, basePath);
   const typeChecker = program.getTypeChecker();
   const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
@@ -61,7 +75,7 @@ function runTemplateVariableAssignmentCheck(
   // template variables.
   resolvedTemplates.forEach(template => {
     const filePath = template.filePath;
-    const nodes = analyzeResolvedTemplate(template);
+    const nodes = analyzeResolvedTemplate(template, compilerModule);
 
     if (!nodes) {
       return;

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/create_ngc_program.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/create_ngc_program.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompiler} from '@angular/compiler';
+import type {AotCompiler} from '@angular/compiler';
 import {CompilerHost, createProgram, readConfiguration} from '@angular/compiler-cli';
 import * as ts from 'typescript';
 

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/decorator_rewrite/decorator_rewriter.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/decorator_rewrite/decorator_rewriter.ts
@@ -6,7 +6,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AotCompiler} from '@angular/compiler';
+import type {AotCompiler} from '@angular/compiler';
 import {PartialEvaluator} from '@angular/compiler-cli/src/ngtsc/partial_evaluator';
 import * as ts from 'typescript';
 

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/decorator_rewrite/import_rewrite_visitor.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/decorator_rewrite/import_rewrite_visitor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompilerHost} from '@angular/compiler';
+import type {AotCompilerHost} from '@angular/compiler';
 import {dirname, resolve} from 'path';
 import * as ts from 'typescript';
 

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/transform.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/transform.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompiler, AotCompilerHost, CompileMetadataResolver, StaticSymbol, StaticSymbolResolver, SummaryResolver} from '@angular/compiler';
+import type {AotCompiler, AotCompilerHost, CompileMetadataResolver, StaticSymbol, StaticSymbolResolver, SummaryResolver} from '@angular/compiler';
 import {PartialEvaluator} from '@angular/compiler-cli/src/ngtsc/partial_evaluator';
 import {ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
 import * as ts from 'typescript';
@@ -58,7 +58,8 @@ export class UndecoratedClassesTransform {
   constructor(
       private typeChecker: ts.TypeChecker, private compiler: AotCompiler,
       private evaluator: PartialEvaluator,
-      private getUpdateRecorder: (sf: ts.SourceFile) => UpdateRecorder) {
+      private getUpdateRecorder: (sf: ts.SourceFile) => UpdateRecorder,
+      private compilerModule: typeof import('@angular/compiler')) {
     this.symbolResolver = compiler['_symbolResolver'];
     this.compilerHost = compiler['_host'];
     this.metadataResolver = compiler['_metadataResolver'];
@@ -328,7 +329,7 @@ export class UndecoratedClassesTransform {
       directiveMetadata: DeclarationMetadata, targetSourceFile: ts.SourceFile): ts.Decorator|null {
     try {
       const decoratorExpr = convertDirectiveMetadataToExpression(
-          directiveMetadata.metadata,
+          this.compilerModule, directiveMetadata.metadata,
           staticSymbol =>
               this.compilerHost
                   .fileNameToModuleName(staticSymbol.filePath, targetSourceFile.fileName)

--- a/packages/core/schematics/utils/load_esm.ts
+++ b/packages/core/schematics/utils/load_esm.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {URL} from 'url';
+
+/**
+ * This uses a dynamic import to load a module which may be ESM.
+ * CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript
+ * will currently, unconditionally downlevel dynamic import into a require call.
+ * require calls cannot load ESM code and will result in a runtime error. To workaround
+ * this, a Function constructor is used to prevent TypeScript from changing the dynamic import.
+ * Once TypeScript provides support for keeping the dynamic import this workaround can
+ * be dropped.
+ * This is only intended to be used with Angular framework packages.
+ *
+ * @param modulePath The path of the module to load.
+ * @returns A Promise that resolves to the dynamically imported module.
+ */
+export async function loadEsmModule<T>(modulePath: string|URL): Promise<T> {
+  const namespaceObject =
+      (await new Function('modulePath', `return import(modulePath);`)(modulePath));
+
+  // If it is not ESM then the values needed will be stored in the `default` property.
+  // TODO_ESM: This can be removed once `@angular/*` packages are ESM only.
+  if (namespaceObject.default) {
+    return namespaceObject.default;
+  } else {
+    return namespaceObject;
+  }
+}

--- a/packages/core/schematics/utils/parse_html.ts
+++ b/packages/core/schematics/utils/parse_html.ts
@@ -6,15 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {parseTemplate, TmplAstNode} from '@angular/compiler';
+import type {TmplAstNode} from '@angular/compiler';
 
 /**
  * Parses the given HTML content using the Angular compiler. In case the parsing
  * fails, null is being returned.
  */
-export function parseHtmlGracefully(htmlContent: string, filePath: string): TmplAstNode[]|null {
+export function parseHtmlGracefully(
+    htmlContent: string, filePath: string,
+    compilerModule: typeof import('@angular/compiler')): TmplAstNode[]|null {
   try {
-    return parseTemplate(htmlContent, filePath).nodes;
+    return compilerModule.parseTemplate(htmlContent, filePath).nodes;
   } catch {
     // Do nothing if the template couldn't be parsed. We don't want to throw any
     // exception if a template is syntactically not valid. e.g. template could be

--- a/packages/core/schematics/utils/parse_html.ts
+++ b/packages/core/schematics/utils/parse_html.ts
@@ -6,14 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {parseTemplate} from '@angular/compiler';
-import {Node} from '@angular/compiler/src/render3/r3_ast';
+import {parseTemplate, TmplAstNode} from '@angular/compiler';
 
 /**
  * Parses the given HTML content using the Angular compiler. In case the parsing
  * fails, null is being returned.
  */
-export function parseHtmlGracefully(htmlContent: string, filePath: string): Node[]|null {
+export function parseHtmlGracefully(htmlContent: string, filePath: string): TmplAstNode[]|null {
   try {
     return parseTemplate(htmlContent, filePath).nodes;
   } catch {

--- a/packages/core/schematics/utils/template_ast_visitor.ts
+++ b/packages/core/schematics/utils/template_ast_visitor.ts
@@ -24,6 +24,15 @@ import type {TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAst
  * interface `Visitor<T>` is not exported.
  */
 export class TemplateAstVisitor implements TmplAstRecursiveVisitor {
+  /**
+   * Creates a new Render3 Template AST visitor using an instance of the `@angular/compiler`
+   * package. Passing in the compiler is required due to the need to dynamically import the
+   * ESM `@angular/compiler` into a CommonJS schematic.
+   *
+   * @param compilerModule The compiler instance that should be used within the visitor.
+   */
+  constructor(protected readonly compilerModule: typeof import('@angular/compiler')) {}
+
   visitElement(element: TmplAstElement): void {}
   visitTemplate(template: TmplAstTemplate): void {}
   visitContent(content: TmplAstContent): void {}

--- a/packages/core/schematics/utils/template_ast_visitor.ts
+++ b/packages/core/schematics/utils/template_ast_visitor.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import type {TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstContent, TmplAstElement, TmplAstIcu, TmplAstNode, TmplAstRecursiveVisitor, TmplAstReference, TmplAstTemplate, TmplAstText, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
+
+/**
+ * A base class that can be used to implement a Render3 Template AST visitor.
+ * This class is used instead of the `NullVisitor` found within the `@angular/compiler` because
+ * the `NullVisitor` requires a deep import which is no longer supported with the ESM bundled
+ * packages as of v13.
+ * Schematics are also currently required to be CommonJS to support execution within the Angular
+ * CLI. As a result, the ESM `@angular/compiler` package must be loaded via a native dynamic import.
+ * Using a dynamic import makes classes extending from classes present in `@angular/compiler`
+ * complicated due to the class not being present at module evaluation time. The classes using a
+ * base class found within `@angular/compiler` must be wrapped in a factory to allow the class value
+ * to be accessible at runtime after the dynamic import has completed. This class implements the
+ * interface of the `TmplAstRecursiveVisitor` class (but does not extend) as the
+ * `TmplAstRecursiveVisitor` as an interface provides the required set of visit methods. The base
+ * interface `Visitor<T>` is not exported.
+ */
+export class TemplateAstVisitor implements TmplAstRecursiveVisitor {
+  visitElement(element: TmplAstElement): void {}
+  visitTemplate(template: TmplAstTemplate): void {}
+  visitContent(content: TmplAstContent): void {}
+  visitVariable(variable: TmplAstVariable): void {}
+  visitReference(reference: TmplAstReference): void {}
+  visitTextAttribute(attribute: TmplAstTextAttribute): void {}
+  visitBoundAttribute(attribute: TmplAstBoundAttribute): void {}
+  visitBoundEvent(attribute: TmplAstBoundEvent): void {}
+  visitText(text: TmplAstText): void {}
+  visitBoundText(text: TmplAstBoundText): void {}
+  visitIcu(icu: TmplAstIcu): void {}
+
+  /**
+   * Visits all the provided nodes in order using this Visitor's visit methods.
+   * This is a simplified variant of the `visitAll` function found inside of (but not
+   * exported from) the `@angular/compiler` that does not support returning a value
+   * since the migrations do not directly transform the nodes.
+   *
+   * @param nodes An iterable of nodes to visit using this visitor.
+   */
+  visitAll(nodes: Iterable<TmplAstNode>): void {
+    for (const node of nodes) {
+      node.visit(this);
+    }
+  }
+}


### PR DESCRIPTION
Currently, migrations and schematics must be in CommonJS format. However, framework packages will only be ESM from v13 and onward. To support this configuration, dynamic import expressions are now used to load `@angular/compiler`. Dynamic imports within Node.js allow the `@angular/core` migrations’ CommonJS code to load ESM code. Unfortunately, TypeScript will currently, unconditionally down-level dynamic import into a require call. `require` calls cannot load ESM code and will result in a runtime error. To workaround this, a Function constructor is used to prevent TypeScript from changing the dynamic import. Once TypeScript provides support for keeping the dynamic import this workaround can be dropped and replaced with a standard dynamic import.  Due to the use of the dynamic import, a reference to the compiler module must now be passed to all locations that use values from the `@angular/compiler` package. Type only imports are also used for the `@angular/compiler`, where appropriate, to better ensure that value imports are not accidentally used.