### PR TITLE
fix(core): don't rethrow errors if test teardown has been disabled

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -12,6 +12,7 @@ import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {onlyInIvy} from '@angular/private/testing';
 import {TestBedRender3} from '../testing/src/r3_test_bed';
+import {TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT} from '../testing/src/test_bed_common';
 
 const NAME = new InjectionToken<string>('name');
 
@@ -1527,5 +1528,29 @@ describe('TestBed module teardown', () => {
     expect(fixtureDocument.body.contains(fixture.nativeElement)).toBe(true);
     TestBed.resetTestingModule();
     expect(fixtureDocument.body.contains(fixture.nativeElement)).toBe(false);
+  });
+
+  it('should rethrow errors based on the default teardown behavior', () => {
+    expect(TestBed.shouldRethrowTeardownErrors()).toBe(TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT);
+  });
+
+  it('should rethrow errors if the option is omitted and test teardown is enabled', () => {
+    TestBed.configureTestingModule({teardown: {destroyAfterEach: true}});
+    expect(TestBed.shouldRethrowTeardownErrors()).toBe(true);
+  });
+
+  it('should not rethrow errors if the option is omitted and test teardown is disabled', () => {
+    TestBed.configureTestingModule({teardown: {destroyAfterEach: false}});
+    expect(TestBed.shouldRethrowTeardownErrors()).toBe(false);
+  });
+
+  it('should rethrow errors if the option is enabled, but teardown is disabled', () => {
+    TestBed.configureTestingModule({teardown: {destroyAfterEach: false, rethrowErrors: true}});
+    expect(TestBed.shouldRethrowTeardownErrors()).toBe(true);
+  });
+
+  it('should not rethrow errors if the option is disabled, but teardown is enabled', () => {
+    TestBed.configureTestingModule({teardown: {destroyAfterEach: true, rethrowErrors: false}});
+    expect(TestBed.shouldRethrowTeardownErrors()).toBe(false);
   });
 });

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -469,17 +469,18 @@ export class TestBedRender3 implements TestBed {
     }
   }
 
-  private shouldRethrowTeardownErrors() {
+  shouldRethrowTeardownErrors() {
     const instanceOptions = this._instanceTeardownOptions;
     const environmentOptions = TestBedRender3._environmentTeardownOptions;
 
     // If the new teardown behavior hasn't been configured, preserve the old behavior.
     if (!instanceOptions && !environmentOptions) {
-      return false;
+      return TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT;
     }
 
     // Otherwise use the configured behavior or default to rethrowing.
-    return instanceOptions?.rethrowErrors ?? environmentOptions?.rethrowErrors ?? true;
+    return instanceOptions?.rethrowErrors ?? environmentOptions?.rethrowErrors ??
+        this.shouldTearDownTestingModule();
   }
 
   shouldTearDownTestingModule(): boolean {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -691,17 +691,18 @@ export class TestBedViewEngine implements TestBed {
     }
   }
 
-  private shouldRethrowTeardownErrors() {
+  shouldRethrowTeardownErrors() {
     const instanceOptions = this._instanceTeardownOptions;
     const environmentOptions = TestBedViewEngine._environmentTeardownOptions;
 
     // If the new teardown behavior hasn't been configured, preserve the old behavior.
     if (!instanceOptions && !environmentOptions) {
-      return false;
+      return TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT;
     }
 
     // Otherwise use the configured behavior or default to rethrowing.
-    return instanceOptions?.rethrowErrors ?? environmentOptions?.rethrowErrors ?? true;
+    return instanceOptions?.rethrowErrors ?? environmentOptions?.rethrowErrors ??
+        this.shouldTearDownTestingModule();
   }
 
   shouldTearDownTestingModule(): boolean {


### PR DESCRIPTION
Fixes that the current logic was set up so that error rethrowing was enabled even when teardown is disabled.