### PR TITLE
Revert "Revert "refactor(migrations): support use of an ESM `@angular/compiler` package (#43627)""

### DIFF
--- a/packages/core/schematics/migrations/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/google3/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     tsconfig = "//packages/core/schematics:tsconfig.json",
     visibility = ["//packages/core/schematics/test/google3:__pkg__"],
     deps = [
+        "//packages/compiler",
         "//packages/core/schematics/migrations/activated-route-snapshot-fragment",
         "//packages/core/schematics/migrations/can-activate-with-redirect-to",
         "//packages/core/schematics/migrations/dynamic-queries",

--- a/packages/core/schematics/migrations/google3/explicitQueryTimingRule.ts
+++ b/packages/core/schematics/migrations/google3/explicitQueryTimingRule.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as compiler from '@angular/compiler';
 import {Replacement, RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
 
@@ -49,7 +50,7 @@ export class Rule extends Rules.TypedRule {
     });
 
     const queries = resolvedQueries.get(sourceFile);
-    const usageStrategy = new QueryUsageStrategy(classMetadata, typeChecker);
+    const usageStrategy = new QueryUsageStrategy(classMetadata, typeChecker, compiler);
 
     // No queries detected for the given source file.
     if (!queries) {

--- a/packages/core/schematics/migrations/google3/noTemplateVariableAssignmentRule.ts
+++ b/packages/core/schematics/migrations/google3/noTemplateVariableAssignmentRule.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import * as compiler from '@angular/compiler';
 import {RuleFailure, Rules} from 'tslint';
 import * as ts from 'typescript';
 
@@ -34,7 +35,7 @@ export class Rule extends Rules.TypedRule {
     // template variables.
     resolvedTemplates.forEach(template => {
       const filePath = template.filePath;
-      const nodes = analyzeResolvedTemplate(template);
+      const nodes = analyzeResolvedTemplate(template, compiler);
       const templateFile =
           template.inline ? sourceFile : createHtmlSourceFile(filePath, template.content);
 

--- a/packages/core/schematics/migrations/router-link-empty-expression/analyze_template.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/analyze_template.ts
@@ -6,21 +6,23 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TmplAstBoundAttribute} from '@angular/compiler';
+import type {TmplAstBoundAttribute} from '@angular/compiler';
 
 import {ResolvedTemplate} from '../../utils/ng_component_template';
 import {parseHtmlGracefully} from '../../utils/parse_html';
 
 import {RouterLinkEmptyExprVisitor} from './angular/html_routerlink_empty_expr_visitor';
 
-export function analyzeResolvedTemplate(template: ResolvedTemplate): TmplAstBoundAttribute[]|null {
-  const templateNodes = parseHtmlGracefully(template.content, template.filePath);
+export function analyzeResolvedTemplate(
+    template: ResolvedTemplate,
+    compilerModule: typeof import('@angular/compiler')): TmplAstBoundAttribute[]|null {
+  const templateNodes = parseHtmlGracefully(template.content, template.filePath, compilerModule);
 
   if (!templateNodes) {
     return null;
   }
 
-  const visitor = new RouterLinkEmptyExprVisitor();
+  const visitor = new RouterLinkEmptyExprVisitor(compilerModule);
 
   // Analyze the Angular Render3 HTML AST and collect all template variable assignments.
   visitor.visitAll(templateNodes);

--- a/packages/core/schematics/migrations/router-link-empty-expression/angular/html_routerlink_empty_expr_visitor.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/angular/html_routerlink_empty_expr_visitor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ASTWithSource, EmptyExpr, TmplAstBoundAttribute, TmplAstElement, TmplAstTemplate} from '@angular/compiler';
+import type {TmplAstBoundAttribute, TmplAstElement, TmplAstTemplate} from '@angular/compiler';
 import {TemplateAstVisitor} from '../../../utils/template_ast_visitor';
 
 /**
@@ -27,8 +27,8 @@ export class RouterLinkEmptyExprVisitor extends TemplateAstVisitor {
   }
 
   override visitBoundAttribute(node: TmplAstBoundAttribute) {
-    if (node.name === 'routerLink' && node.value instanceof ASTWithSource &&
-        node.value.ast instanceof EmptyExpr) {
+    if (node.name === 'routerLink' && node.value instanceof this.compilerModule.ASTWithSource &&
+        node.value.ast instanceof this.compilerModule.EmptyExpr) {
       this.emptyRouterLinkExpressions.push(node);
     }
   }

--- a/packages/core/schematics/migrations/static-queries/index.ts
+++ b/packages/core/schematics/migrations/static-queries/index.ts
@@ -11,6 +11,7 @@ import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit
 import {relative} from 'path';
 import * as ts from 'typescript';
 
+import {loadEsmModule} from '../../utils/load_esm';
 import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
 import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
 import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
@@ -69,9 +70,21 @@ async function runMigration(tree: Tree, context: SchematicContext) {
     }
   }
 
+  let compilerModule;
+  try {
+    // Load ESM `@angular/compiler` using the TypeScript dynamic import workaround.
+    // Once TypeScript provides support for keeping the dynamic import this workaround can be
+    // changed to a direct dynamic import.
+    compilerModule = await loadEsmModule<typeof import('@angular/compiler')>('@angular/compiler');
+  } catch (e) {
+    throw new SchematicsException(
+        `Unable to load the '@angular/compiler' package. Details: ${e.message}`);
+  }
+
   if (buildProjects.size) {
     for (let project of Array.from(buildProjects.values())) {
-      failures.push(...await runStaticQueryMigration(tree, project, strategy, logger));
+      failures.push(
+          ...await runStaticQueryMigration(tree, project, strategy, logger, compilerModule));
     }
   }
 
@@ -80,8 +93,8 @@ async function runMigration(tree: Tree, context: SchematicContext) {
   for (const tsconfigPath of testPaths) {
     const project = await analyzeProject(tree, tsconfigPath, basePath, analyzedFiles, logger);
     if (project) {
-      failures.push(
-          ...await runStaticQueryMigration(tree, project, SELECTED_STRATEGY.TESTS, logger));
+      failures.push(...await runStaticQueryMigration(
+          tree, project, SELECTED_STRATEGY.TESTS, logger, compilerModule));
     }
   }
 
@@ -150,7 +163,8 @@ function analyzeProject(
  */
 async function runStaticQueryMigration(
     tree: Tree, project: AnalyzedProject, selectedStrategy: SELECTED_STRATEGY,
-    logger: logging.LoggerApi): Promise<string[]> {
+    logger: logging.LoggerApi,
+    compilerModule: typeof import('@angular/compiler')): Promise<string[]> {
   const {sourceFiles, typeChecker, host, queryVisitor, tsconfigPath, basePath} = project;
   const printer = ts.createPrinter();
   const failureMessages: string[] = [];
@@ -177,11 +191,11 @@ async function runStaticQueryMigration(
 
   let strategy: TimingStrategy;
   if (selectedStrategy === SELECTED_STRATEGY.USAGE) {
-    strategy = new QueryUsageStrategy(classMetadata, typeChecker);
+    strategy = new QueryUsageStrategy(classMetadata, typeChecker, compilerModule);
   } else if (selectedStrategy === SELECTED_STRATEGY.TESTS) {
     strategy = new QueryTestStrategy();
   } else {
-    strategy = new QueryTemplateStrategy(tsconfigPath, classMetadata, host);
+    strategy = new QueryTemplateStrategy(tsconfigPath, classMetadata, host, compilerModule);
   }
 
   try {

--- a/packages/core/schematics/migrations/static-queries/strategies/template_strategy/template_strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/template_strategy/template_strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompiler, CompileDirectiveMetadata, CompileMetadataResolver, CompileNgModuleMetadata, CompileStylesheetMetadata, ElementAst, EmbeddedTemplateAst, NgAnalyzedModules, QueryMatch, StaticSymbol, TemplateAst} from '@angular/compiler';
+import type {AotCompiler, CompileDirectiveMetadata, CompileMetadataResolver, CompileNgModuleMetadata, CompileStylesheetMetadata, ElementAst, EmbeddedTemplateAst, NgAnalyzedModules, QueryMatch, StaticSymbol, TemplateAst} from '@angular/compiler';
 import {createProgram, Diagnostic, readConfiguration} from '@angular/compiler-cli';
 import {resolve} from 'path';
 import * as ts from 'typescript';
@@ -25,7 +25,7 @@ export class QueryTemplateStrategy implements TimingStrategy {
 
   constructor(
       private projectPath: string, private classMetadata: ClassMetadataMap,
-      private host: ts.CompilerHost) {}
+      private host: ts.CompilerHost, private compilerModule: typeof import('@angular/compiler')) {}
 
   /**
    * Sets up the template strategy by creating the AngularCompilerProgram. Returns false if
@@ -54,8 +54,8 @@ export class QueryTemplateStrategy implements TimingStrategy {
     // breaks the analysis of the project because we instantiate a standalone AOT compiler
     // program which does not contain the custom logic by the Angular CLI Webpack compiler plugin.
     const directiveNormalizer = this.metadataResolver!['_directiveNormalizer'];
-    directiveNormalizer['_normalizeStylesheet'] = function(metadata: CompileStylesheetMetadata) {
-      return new CompileStylesheetMetadata(
+    directiveNormalizer['_normalizeStylesheet'] = (metadata: CompileStylesheetMetadata) => {
+      return new this.compilerModule.CompileStylesheetMetadata(
           {styles: metadata.styles, styleUrls: [], moduleUrl: metadata.moduleUrl!});
     };
 
@@ -83,7 +83,7 @@ export class QueryTemplateStrategy implements TimingStrategy {
     }
 
     const parsedTemplate = this._parseTemplate(metadata, ngModule);
-    const queryTimingMap = findStaticQueryIds(parsedTemplate);
+    const queryTimingMap = this.findStaticQueryIds(parsedTemplate);
     const {staticQueryIds} = staticViewQueryIds(queryTimingMap);
 
     metadata.viewQueries.forEach((query, index) => {
@@ -187,45 +187,45 @@ export class QueryTemplateStrategy implements TimingStrategy {
   private _getViewQueryUniqueKey(filePath: string, className: string, propName: string) {
     return `${resolve(filePath)}#${className}-${propName}`;
   }
+
+  /** Figures out which queries are static and which ones are dynamic. */
+  private findStaticQueryIds(
+      nodes: TemplateAst[], result = new Map<TemplateAst, StaticAndDynamicQueryIds>()):
+      Map<TemplateAst, StaticAndDynamicQueryIds> {
+    nodes.forEach((node) => {
+      const staticQueryIds = new Set<number>();
+      const dynamicQueryIds = new Set<number>();
+      let queryMatches: QueryMatch[] = undefined!;
+      if (node instanceof this.compilerModule.ElementAst) {
+        this.findStaticQueryIds(node.children, result);
+        node.children.forEach((child) => {
+          const childData = result.get(child)!;
+          childData.staticQueryIds.forEach(queryId => staticQueryIds.add(queryId));
+          childData.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
+        });
+        queryMatches = node.queryMatches;
+      } else if (node instanceof this.compilerModule.EmbeddedTemplateAst) {
+        this.findStaticQueryIds(node.children, result);
+        node.children.forEach((child) => {
+          const childData = result.get(child)!;
+          childData.staticQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
+          childData.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
+        });
+        queryMatches = node.queryMatches;
+      }
+      if (queryMatches) {
+        queryMatches.forEach((match) => staticQueryIds.add(match.queryId));
+      }
+      dynamicQueryIds.forEach(queryId => staticQueryIds.delete(queryId));
+      result.set(node, {staticQueryIds, dynamicQueryIds});
+    });
+    return result;
+  }
 }
 
 interface StaticAndDynamicQueryIds {
   staticQueryIds: Set<number>;
   dynamicQueryIds: Set<number>;
-}
-
-/** Figures out which queries are static and which ones are dynamic. */
-function findStaticQueryIds(
-    nodes: TemplateAst[], result = new Map<TemplateAst, StaticAndDynamicQueryIds>()):
-    Map<TemplateAst, StaticAndDynamicQueryIds> {
-  nodes.forEach((node) => {
-    const staticQueryIds = new Set<number>();
-    const dynamicQueryIds = new Set<number>();
-    let queryMatches: QueryMatch[] = undefined!;
-    if (node instanceof ElementAst) {
-      findStaticQueryIds(node.children, result);
-      node.children.forEach((child) => {
-        const childData = result.get(child)!;
-        childData.staticQueryIds.forEach(queryId => staticQueryIds.add(queryId));
-        childData.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
-      });
-      queryMatches = node.queryMatches;
-    } else if (node instanceof EmbeddedTemplateAst) {
-      findStaticQueryIds(node.children, result);
-      node.children.forEach((child) => {
-        const childData = result.get(child)!;
-        childData.staticQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
-        childData.dynamicQueryIds.forEach(queryId => dynamicQueryIds.add(queryId));
-      });
-      queryMatches = node.queryMatches;
-    }
-    if (queryMatches) {
-      queryMatches.forEach((match) => staticQueryIds.add(match.queryId));
-    }
-    dynamicQueryIds.forEach(queryId => staticQueryIds.delete(queryId));
-    result.set(node, {staticQueryIds, dynamicQueryIds});
-  });
-  return result;
 }
 
 /** Splits queries into static and dynamic. */

--- a/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/template_usage_visitor.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/template_usage_visitor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ImplicitReceiver, ParseSourceSpan, PropertyRead, RecursiveAstVisitor, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstTemplate} from '@angular/compiler';
+import type {ParseSourceSpan, PropertyRead, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstTemplate} from '@angular/compiler';
 import {TemplateAstVisitor} from '../../../../utils/template_ast_visitor';
 
 /**
@@ -15,10 +15,33 @@ import {TemplateAstVisitor} from '../../../../utils/template_ast_visitor';
  */
 export class TemplateUsageVisitor extends TemplateAstVisitor {
   private hasQueryTemplateReference = false;
-  private expressionAstVisitor = new ExpressionAstVisitor(this.queryPropertyName);
+  private expressionAstVisitor;
 
-  constructor(public queryPropertyName: string) {
-    super();
+  constructor(
+      public queryPropertyName: string, compilerModule: typeof import('@angular/compiler')) {
+    super(compilerModule);
+
+    // AST visitor that checks if the given expression contains property reads that
+    // refer to the specified query property name.
+    // This class must be defined within the template visitor due to the need to extend from a class
+    // value found within `@angular/compiler` which is dynamically imported and provided to the
+    // visitor.
+    this.expressionAstVisitor = new (class extends compilerModule.RecursiveAstVisitor {
+      hasQueryPropertyRead = false;
+
+
+      override visitPropertyRead(node: PropertyRead, span: ParseSourceSpan): any {
+        // The receiver of the property read needs to be "implicit" as queries are accessed
+        // from the component instance and not from other objects.
+        if (node.receiver instanceof compilerModule.ImplicitReceiver &&
+            node.name === queryPropertyName) {
+          this.hasQueryPropertyRead = true;
+          return;
+        }
+
+        super.visitPropertyRead(node, span);
+      }
+    })();
   }
 
   /** Checks whether the given query is statically accessed within the specified HTML nodes. */
@@ -67,28 +90,5 @@ export class TemplateUsageVisitor extends TemplateAstVisitor {
 
   override visitBoundEvent(node: TmplAstBoundEvent) {
     node.handler.visit(this.expressionAstVisitor, node.handlerSpan);
-  }
-}
-
-/**
- * AST visitor that checks if the given expression contains property reads that
- * refer to the specified query property name.
- */
-class ExpressionAstVisitor extends RecursiveAstVisitor {
-  hasQueryPropertyRead = false;
-
-  constructor(private queryPropertyName: string) {
-    super();
-  }
-
-  override visitPropertyRead(node: PropertyRead, span: ParseSourceSpan): any {
-    // The receiver of the property read needs to be "implicit" as queries are accessed
-    // from the component instance and not from other objects.
-    if (node.receiver instanceof ImplicitReceiver && node.name === this.queryPropertyName) {
-      this.hasQueryPropertyRead = true;
-      return;
-    }
-
-    super.visitPropertyRead(node, span);
   }
 }

--- a/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/usage_strategy.ts
+++ b/packages/core/schematics/migrations/static-queries/strategies/usage_strategy/usage_strategy.ts
@@ -35,7 +35,9 @@ const STATIC_QUERY_LIFECYCLE_HOOKS = {
  * this strategy here: https://hackmd.io/s/Hymvc2OKE
  */
 export class QueryUsageStrategy implements TimingStrategy {
-  constructor(private classMetadata: ClassMetadataMap, private typeChecker: ts.TypeChecker) {}
+  constructor(
+      private classMetadata: ClassMetadataMap, private typeChecker: ts.TypeChecker,
+      private compilerModule: typeof import('@angular/compiler')) {}
 
   setup() {}
 
@@ -101,8 +103,9 @@ export class QueryUsageStrategy implements TimingStrategy {
     // can be marked as static.
     if (classMetadata.template && hasPropertyNameText(query.property!.name)) {
       const template = classMetadata.template;
-      const parsedHtml = parseHtmlGracefully(template.content, template.filePath);
-      const htmlVisitor = new TemplateUsageVisitor(query.property!.name.text);
+      const parsedHtml =
+          parseHtmlGracefully(template.content, template.filePath, this.compilerModule);
+      const htmlVisitor = new TemplateUsageVisitor(query.property!.name.text, this.compilerModule);
 
       if (parsedHtml && htmlVisitor.isQueryUsedStatically(parsedHtml)) {
         return ResolvedUsage.SYNCHRONOUS;

--- a/packages/core/schematics/migrations/template-var-assignment/analyze_template.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/analyze_template.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {PropertyWrite} from '@angular/compiler';
+import type {PropertyWrite} from '@angular/compiler';
 import {ResolvedTemplate} from '../../utils/ng_component_template';
 import {parseHtmlGracefully} from '../../utils/parse_html';
 import {HtmlVariableAssignmentVisitor} from './angular/html_variable_assignment_visitor';
@@ -21,15 +21,16 @@ export interface TemplateVariableAssignment {
  * Analyzes a given resolved template by looking for property assignments to local
  * template variables within bound events.
  */
-export function analyzeResolvedTemplate(template: ResolvedTemplate): TemplateVariableAssignment[]|
-    null {
-  const templateNodes = parseHtmlGracefully(template.content, template.filePath);
+export function analyzeResolvedTemplate(
+    template: ResolvedTemplate,
+    compilerModule: typeof import('@angular/compiler')): TemplateVariableAssignment[]|null {
+  const templateNodes = parseHtmlGracefully(template.content, template.filePath, compilerModule);
 
   if (!templateNodes) {
     return null;
   }
 
-  const visitor = new HtmlVariableAssignmentVisitor();
+  const visitor = new HtmlVariableAssignmentVisitor(compilerModule);
 
   // Analyze the Angular Render3 HTML AST and collect all template variable assignments.
   visitor.visitAll(templateNodes);

--- a/packages/core/schematics/migrations/template-var-assignment/index.ts
+++ b/packages/core/schematics/migrations/template-var-assignment/index.ts
@@ -10,6 +10,7 @@ import {logging, normalize} from '@angular-devkit/core';
 import {Rule, SchematicContext, SchematicsException, Tree} from '@angular-devkit/schematics';
 import {relative} from 'path';
 
+import {loadEsmModule} from '../../utils/load_esm';
 import {NgComponentTemplateVisitor} from '../../utils/ng_component_template';
 import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
 import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
@@ -33,8 +34,20 @@ export default function(): Rule {
           'assignments.');
     }
 
+    let compilerModule;
+    try {
+      // Load ESM `@angular/compiler` using the TypeScript dynamic import workaround.
+      // Once TypeScript provides support for keeping the dynamic import this workaround can be
+      // changed to a direct dynamic import.
+      compilerModule = await loadEsmModule<typeof import('@angular/compiler')>('@angular/compiler');
+    } catch (e) {
+      throw new SchematicsException(
+          `Unable to load the '@angular/compiler' package. Details: ${e.message}`);
+    }
+
     for (const tsconfigPath of [...buildPaths, ...testPaths]) {
-      runTemplateVariableAssignmentCheck(tree, tsconfigPath, basePath, context.logger);
+      runTemplateVariableAssignmentCheck(
+          tree, tsconfigPath, basePath, context.logger, compilerModule);
     }
   };
 }
@@ -44,7 +57,8 @@ export default function(): Rule {
  * if values are assigned to template variables within output bindings.
  */
 function runTemplateVariableAssignmentCheck(
-    tree: Tree, tsconfigPath: string, basePath: string, logger: Logger) {
+    tree: Tree, tsconfigPath: string, basePath: string, logger: Logger,
+    compilerModule: typeof import('@angular/compiler')) {
   const {program} = createMigrationProgram(tree, tsconfigPath, basePath);
   const typeChecker = program.getTypeChecker();
   const templateVisitor = new NgComponentTemplateVisitor(typeChecker);
@@ -61,7 +75,7 @@ function runTemplateVariableAssignmentCheck(
   // template variables.
   resolvedTemplates.forEach(template => {
     const filePath = template.filePath;
-    const nodes = analyzeResolvedTemplate(template);
+    const nodes = analyzeResolvedTemplate(template, compilerModule);
 
     if (!nodes) {
       return;

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/create_ngc_program.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/create_ngc_program.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompiler} from '@angular/compiler';
+import type {AotCompiler} from '@angular/compiler';
 import {CompilerHost, createProgram, readConfiguration} from '@angular/compiler-cli';
 import * as ts from 'typescript';
 

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/decorator_rewrite/decorator_rewriter.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/decorator_rewrite/decorator_rewriter.ts
@@ -6,7 +6,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {AotCompiler} from '@angular/compiler';
+import type {AotCompiler} from '@angular/compiler';
 import {PartialEvaluator} from '@angular/compiler-cli/src/ngtsc/partial_evaluator';
 import * as ts from 'typescript';
 

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/decorator_rewrite/import_rewrite_visitor.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/decorator_rewrite/import_rewrite_visitor.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompilerHost} from '@angular/compiler';
+import type {AotCompilerHost} from '@angular/compiler';
 import {dirname, resolve} from 'path';
 import * as ts from 'typescript';
 

--- a/packages/core/schematics/migrations/undecorated-classes-with-di/transform.ts
+++ b/packages/core/schematics/migrations/undecorated-classes-with-di/transform.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AotCompiler, AotCompilerHost, CompileMetadataResolver, StaticSymbol, StaticSymbolResolver, SummaryResolver} from '@angular/compiler';
+import type {AotCompiler, AotCompilerHost, CompileMetadataResolver, StaticSymbol, StaticSymbolResolver, SummaryResolver} from '@angular/compiler';
 import {PartialEvaluator} from '@angular/compiler-cli/src/ngtsc/partial_evaluator';
 import {ChangeDetectionStrategy, ViewEncapsulation} from '@angular/core';
 import * as ts from 'typescript';
@@ -58,7 +58,8 @@ export class UndecoratedClassesTransform {
   constructor(
       private typeChecker: ts.TypeChecker, private compiler: AotCompiler,
       private evaluator: PartialEvaluator,
-      private getUpdateRecorder: (sf: ts.SourceFile) => UpdateRecorder) {
+      private getUpdateRecorder: (sf: ts.SourceFile) => UpdateRecorder,
+      private compilerModule: typeof import('@angular/compiler')) {
     this.symbolResolver = compiler['_symbolResolver'];
     this.compilerHost = compiler['_host'];
     this.metadataResolver = compiler['_metadataResolver'];
@@ -328,7 +329,7 @@ export class UndecoratedClassesTransform {
       directiveMetadata: DeclarationMetadata, targetSourceFile: ts.SourceFile): ts.Decorator|null {
     try {
       const decoratorExpr = convertDirectiveMetadataToExpression(
-          directiveMetadata.metadata,
+          this.compilerModule, directiveMetadata.metadata,
           staticSymbol =>
               this.compilerHost
                   .fileNameToModuleName(staticSymbol.filePath, targetSourceFile.fileName)

--- a/packages/core/schematics/utils/load_esm.ts
+++ b/packages/core/schematics/utils/load_esm.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {URL} from 'url';
+
+/**
+ * This uses a dynamic import to load a module which may be ESM.
+ * CommonJS code can load ESM code via a dynamic import. Unfortunately, TypeScript
+ * will currently, unconditionally downlevel dynamic import into a require call.
+ * require calls cannot load ESM code and will result in a runtime error. To workaround
+ * this, a Function constructor is used to prevent TypeScript from changing the dynamic import.
+ * Once TypeScript provides support for keeping the dynamic import this workaround can
+ * be dropped.
+ * This is only intended to be used with Angular framework packages.
+ *
+ * @param modulePath The path of the module to load.
+ * @returns A Promise that resolves to the dynamically imported module.
+ */
+export async function loadEsmModule<T>(modulePath: string|URL): Promise<T> {
+  const namespaceObject =
+      (await new Function('modulePath', `return import(modulePath);`)(modulePath));
+
+  // If it is not ESM then the values needed will be stored in the `default` property.
+  // TODO_ESM: This can be removed once `@angular/*` packages are ESM only.
+  if (namespaceObject.default) {
+    return namespaceObject.default;
+  } else {
+    return namespaceObject;
+  }
+}

--- a/packages/core/schematics/utils/parse_html.ts
+++ b/packages/core/schematics/utils/parse_html.ts
@@ -6,15 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {parseTemplate, TmplAstNode} from '@angular/compiler';
+import type {TmplAstNode} from '@angular/compiler';
 
 /**
  * Parses the given HTML content using the Angular compiler. In case the parsing
  * fails, null is being returned.
  */
-export function parseHtmlGracefully(htmlContent: string, filePath: string): TmplAstNode[]|null {
+export function parseHtmlGracefully(
+    htmlContent: string, filePath: string,
+    compilerModule: typeof import('@angular/compiler')): TmplAstNode[]|null {
   try {
-    return parseTemplate(htmlContent, filePath).nodes;
+    return compilerModule.parseTemplate(htmlContent, filePath).nodes;
   } catch {
     // Do nothing if the template couldn't be parsed. We don't want to throw any
     // exception if a template is syntactically not valid. e.g. template could be

--- a/packages/core/schematics/utils/template_ast_visitor.ts
+++ b/packages/core/schematics/utils/template_ast_visitor.ts
@@ -24,6 +24,15 @@ import type {TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAst
  * interface `Visitor<T>` is not exported.
  */
 export class TemplateAstVisitor implements TmplAstRecursiveVisitor {
+  /**
+   * Creates a new Render3 Template AST visitor using an instance of the `@angular/compiler`
+   * package. Passing in the compiler is required due to the need to dynamically import the
+   * ESM `@angular/compiler` into a CommonJS schematic.
+   *
+   * @param compilerModule The compiler instance that should be used within the visitor.
+   */
+  constructor(protected readonly compilerModule: typeof import('@angular/compiler')) {}
+
   visitElement(element: TmplAstElement): void {}
   visitTemplate(template: TmplAstTemplate): void {}
   visitContent(content: TmplAstContent): void {}


### PR DESCRIPTION
This reverts commit ab3de40ba3e45a0e6df30f62d41cf65ed0b021e2, which is
itself a revert of the original commit. Thus, this restores the changes
to schematics in support of ESM.

Now that g3 has a local modification for load_esm, we can restore this
functionality.
