### PR TITLE
docs: fix missing step in get started example

### DIFF
--- a/aio/content/examples/getting-started/src/app/app.module.ts
+++ b/aio/content/examples/getting-started/src/app/app.module.ts
@@ -38,7 +38,7 @@ import { ShippingComponent } from './shipping/shipping.component';
 // #docregion product-details-route, http-client-module, shipping-route, cart-route
     ])
   ],
-  // #enddocregion product-details-route, cart-route
+  // #enddocregion cart-route
   // #docregion declare-product-alerts
   declarations: [
     AppComponent,
@@ -47,12 +47,13 @@ import { ShippingComponent } from './shipping/shipping.component';
     ProductAlertsComponent,
     // #enddocregion declare-product-alerts
     ProductDetailsComponent,
+    // #enddocregion product-details-route
     CartComponent,
 // #enddocregion http-client-module
     ShippingComponent
-  // #docregion declare-product-alerts, http-client-module
+  // #docregion declare-product-alerts, http-client-module, product-details-route
   ],
-  // #enddocregion declare-product-alerts
+  // #enddocregion declare-product-alerts, product-details-route
   bootstrap: [
     AppComponent
   ]

--- a/aio/content/start/start-routing.md
+++ b/aio/content/start/start-routing.md
@@ -21,7 +21,7 @@ This section shows you how to define a route to show individual product details.
     In the file list, right-click the `app` folder, choose `Angular Generator` and `Component`.
     Name the component `product-details`.
 
-1. In `app.module.ts`, add a route for product details, with a `path` of `products/:productId` and `ProductDetailsComponent` for the `component`.
+1. In `app.module.ts`, add a route for product details, with a `path` of `products/:productId` and `ProductDetailsComponent` for the `component`, include `ProductDetailsComponent` in `AppModule`'s declarations.
 
     <code-example header="src/app/app.module.ts" path="getting-started/src/app/app.module.ts" region="product-details-route">
     </code-example>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the step 2 of [Associate a URL path with a component](https://angular.io/start/start-routing#associate-a-url-path-with-a-component), we forgot to include `ProductDetailsComponent` in `AppModule`'s declarations, which cause the get started example won't work as expected. This issue maybe trivial for the experienced, but can be frustrating to new comer. 

Issue Number: N/A


## What is the new behavior?

Add back the missing step.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information