### PR TITLE
feat(router): extend logging of navigation events with call stack

### DIFF
--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -451,6 +451,9 @@ export function setupRouter(
       console.group?.(`Router Event: ${(<any>e.constructor).name}`);
       console.log(e.toString());
       console.log(e);
+      console?.groupCollapsed('Call Stack');
+      console.trace();
+      console.groupEnd?.();
       console.groupEnd?.();
       // tslint:enable:no-console
     });


### PR DESCRIPTION
Complex angular applications could have a lot of internal redirects
with imperative navigations via angular router API,
and sometimes it's difficult to detect the initiator of the navigation,
with printed call stack it'll be much easier.

_Collapsed:_
<img width="1071" alt="collapsed" src="https://user-images.githubusercontent.com/14943911/135483280-d163727f-c547-4331-ab3f-759ea9ee7928.png">
_Expanded:_
<img width="1071" alt="expanded" src="https://user-images.githubusercontent.com/14943911/135483435-789bb038-baca-4439-91a7-94ee73a00202.png">
