### PR TITLE
docs: update commit message guidelines to reflect current requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,8 +235,6 @@ When the body is present it must be at least 20 characters long and must conform
 
 The `footer` is optional. The [Commit Message Footer](#commit-footer) format describes what the footer is used for and the structure it must have.
 
-Any line of the commit message cannot be longer than 100 characters.
-
 
 #### <a name="commit-header"></a>Commit Message Header
 
@@ -333,7 +331,8 @@ You can include a comparison of the previous behavior with the new behavior in o
 
 #### <a name="commit-footer"></a>Commit Message Footer
 
-The footer can contain information about breaking changes and is also the place to reference GitHub issues, Jira tickets, and other PRs that this commit closes or is related to.
+The footer can contain information about breaking changes and deprecations and is also the place to reference GitHub issues, Jira tickets, and other PRs that this commit closes or is related to.
+For example:
 
 ```
 BREAKING CHANGE: <breaking change summary>
@@ -344,7 +343,20 @@ BREAKING CHANGE: <breaking change summary>
 Fixes #<issue number>
 ```
 
+or
+
+```
+DEPRECATED: <what is deprecated>
+<BLANK LINE>
+<deprecation description + recommended update path>
+<BLANK LINE>
+<BLANK LINE>
+Closes #<pr number>
+```
+
 Breaking Change section should start with the phrase "BREAKING CHANGE: " followed by a summary of the breaking change, a blank line, and a detailed description of the breaking change that also includes migration instructions.
+
+Similarly, a Deprecation section should start with "DEPRECATED: " followed by a short description of what is deprecated, a blank line, and a detailed description of the deprecation that also mentions the recommended update path.
 
 
 ### Revert commits


### PR DESCRIPTION
Update the commit message guidelines in `CONTRIBUTING.md` to reflect recent changes in our dev-infra tooling:
- Remove the mention of the 100 chars/line limit, since that is [no longer in effect][1].
- Mention Deprecation sections:
  According to our [Deprecation practices][2], we should document deprecations in the Changelog, which our tooling supports via [DEPRECATED][3] sections in commit messages. Yet this was not mentioned in the commit message guidelines.

[1]: https://github.com/angular/angular/blob/a07cb097e9124738880f7978658a2972d25b892e/.ng-dev/commit-message.ts#L7
[2]: https://angular.io/guide/releases#deprecation-practices
[3]: https://github.com/angular/dev-infra/blob/b51360a7cc39cb3deb5ae1bf0bfb121fe7ee0a4e/ng-dev/commit-message/parse.ts#L77
