### PR TITLE
refactor(router): add stub files for g3 patch of NgModuleFactoryLoader

### DIFF
--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -22,6 +22,7 @@ export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 export * from './zone';
 export * from './render';
 export * from './linker';
+export * from './linker/ng_module_factory_loader_impl';
 export {DebugElement, DebugEventListener, DebugNode, asNativeElements, getDebugNode, Predicate} from './debug/debug_node';
 export {GetTestability, Testability, TestabilityRegistry, setTestabilityGetter} from './testability/testability';
 export * from './change_detection';

--- a/packages/core/src/linker/ng_module_factory_loader_impl.ts
+++ b/packages/core/src/linker/ng_module_factory_loader_impl.ts
@@ -6,10 +6,5 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-/**
- * @module
- * @description
- * Entry point for all public APIs of the router/testing package.
- */
-export * from './router_testing_module';
-export * from './spy_ng_module_factory_loader';
+// This file exists for easily patching NgModuleFactoryLoader in g3
+export default {};

--- a/packages/core/src/linker/ng_module_factory_loader_impl.ts
+++ b/packages/core/src/linker/ng_module_factory_loader_impl.ts
@@ -6,11 +6,5 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModuleFactory} from './ng_module_factory';
-
-/**
- * Used to load ng module factories.
- */
-export abstract class NgModuleFactoryLoader {
-  abstract load(path: string): Promise<NgModuleFactory<any>>;
-}
+// This file exists for easily patching NgModuleFactoryLoader in g3
+export default {};

--- a/packages/core/src/linker/ng_module_factory_loader_impl.ts
+++ b/packages/core/src/linker/ng_module_factory_loader_impl.ts
@@ -6,5 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// This file exists for easily patching NgModuleFactoryLoader in g3
-export default {};
+import {NgModuleFactory} from './ng_module_factory';
+
+/**
+ * Used to load ng module factories.
+ */
+export abstract class NgModuleFactoryLoader {
+  abstract load(path: string): Promise<NgModuleFactory<any>>;
+}

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -7,6 +7,7 @@
  */
 
 import {Compiler, InjectFlags, InjectionToken, Injector, NgModuleFactory} from '@angular/core';
+import {NgModuleFactoryLoader} from '@angular/core';
 import {ConnectableObservable, from, Observable, of, Subject} from 'rxjs';
 import {catchError, map, mergeMap, refCount, tap} from 'rxjs/operators';
 
@@ -69,6 +70,9 @@ export class RouterConfigLoader {
   }
 
   private loadModuleFactory(loadChildren: LoadChildren): Observable<NgModuleFactory<any>> {
+    if (typeof loadChildren === 'string') {
+      return from(this.injector.get(NgModuleFactoryLoader).load(loadChildren));
+    }
     return wrapIntoObservable(loadChildren()).pipe(mergeMap((t: any) => {
       if (t instanceof NgModuleFactory) {
         return of(t);

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -7,7 +7,6 @@
  */
 
 import {Compiler, InjectFlags, InjectionToken, Injector, NgModuleFactory} from '@angular/core';
-import {NgModuleFactoryLoader} from '@angular/core';
 import {ConnectableObservable, from, Observable, of, Subject} from 'rxjs';
 import {catchError, map, mergeMap, refCount, tap} from 'rxjs/operators';
 
@@ -70,9 +69,6 @@ export class RouterConfigLoader {
   }
 
   private loadModuleFactory(loadChildren: LoadChildren): Observable<NgModuleFactory<any>> {
-    if (typeof loadChildren === 'string') {
-      return from(this.injector.get(NgModuleFactoryLoader).load(loadChildren));
-    }
     return wrapIntoObservable(loadChildren()).pipe(mergeMap((t: any) => {
       if (t instanceof NgModuleFactory) {
         return of(t);

--- a/packages/router/testing/src/extra_router_testing_providers.ts
+++ b/packages/router/testing/src/extra_router_testing_providers.ts
@@ -6,10 +6,5 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-/**
- * @module
- * @description
- * Entry point for all public APIs of the router/testing package.
- */
-export * from './router_testing_module';
-export * from './spy_ng_module_factory_loader';
+// This file exists to easily patch the SpyNgModuleFactoryLoader into g3
+export const EXTRA_ROUTER_TESTING_PROVIDERS = [];

--- a/packages/router/testing/src/extra_router_testing_providers.ts
+++ b/packages/router/testing/src/extra_router_testing_providers.ts
@@ -7,4 +7,8 @@
  */
 
 // This file exists to easily patch the SpyNgModuleFactoryLoader into g3
-export const EXTRA_ROUTER_TESTING_PROVIDERS = [];
+import {NgModuleFactoryLoader} from '@angular/core';
+import {SpyNgModuleFactoryLoader} from './spy_ng_module_factory_loader';
+
+export const EXTRA_ROUTER_TESTING_PROVIDERS =
+    [{provide: NgModuleFactoryLoader, useClass: SpyNgModuleFactoryLoader}];

--- a/packages/router/testing/src/extra_router_testing_providers.ts
+++ b/packages/router/testing/src/extra_router_testing_providers.ts
@@ -7,8 +7,4 @@
  */
 
 // This file exists to easily patch the SpyNgModuleFactoryLoader into g3
-import {NgModuleFactoryLoader} from '@angular/core';
-import {SpyNgModuleFactoryLoader} from './spy_ng_module_factory_loader';
-
-export const EXTRA_ROUTER_TESTING_PROVIDERS =
-    [{provide: NgModuleFactoryLoader, useClass: SpyNgModuleFactoryLoader}];
+export const EXTRA_ROUTER_TESTING_PROVIDERS = [];

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -10,6 +10,7 @@ import {Location, LocationStrategy} from '@angular/common';
 import {MockLocationStrategy, SpyLocation} from '@angular/common/testing';
 import {Compiler, Injector, ModuleWithProviders, NgModule, Optional} from '@angular/core';
 import {ChildrenOutletContexts, ExtraOptions, NoPreloading, PreloadingStrategy, provideRoutes, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, UrlHandlingStrategy, UrlSerializer, ɵassignExtraOptionsToRouter as assignExtraOptionsToRouter, ɵflatten as flatten, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS} from '@angular/router';
+import {EXTRA_ROUTER_TESTING_PROVIDERS} from './extra_router_testing_providers';
 
 function isUrlHandlingStrategy(opts: ExtraOptions|
                                UrlHandlingStrategy): opts is UrlHandlingStrategy {
@@ -79,8 +80,11 @@ export function setupTestingRouter(
 @NgModule({
   exports: [RouterModule],
   providers: [
-    ROUTER_PROVIDERS, {provide: Location, useClass: SpyLocation},
-    {provide: LocationStrategy, useClass: MockLocationStrategy}, {
+    ROUTER_PROVIDERS,
+    EXTRA_ROUTER_TESTING_PROVIDERS,
+    {provide: Location, useClass: SpyLocation},
+    {provide: LocationStrategy, useClass: MockLocationStrategy},
+    {
       provide: Router,
       useFactory: setupTestingRouter,
       deps: [
@@ -89,7 +93,8 @@ export function setupTestingRouter(
         [RouteReuseStrategy, new Optional()]
       ]
     },
-    {provide: PreloadingStrategy, useExisting: NoPreloading}, provideRoutes([])
+    {provide: PreloadingStrategy, useExisting: NoPreloading},
+    provideRoutes([]),
   ]
 })
 export class RouterTestingModule {

--- a/packages/router/testing/src/spy_ng_module_factory_loader.ts
+++ b/packages/router/testing/src/spy_ng_module_factory_loader.ts
@@ -6,10 +6,5 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-/**
- * @module
- * @description
- * Entry point for all public APIs of the router/testing package.
- */
-export * from './router_testing_module';
-export * from './spy_ng_module_factory_loader';
+// This file exists for easily patching SpyNgModuleFactoryLoader in g3
+export default {};

--- a/packages/router/testing/src/spy_ng_module_factory_loader.ts
+++ b/packages/router/testing/src/spy_ng_module_factory_loader.ts
@@ -5,40 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Compiler, Injectable, NgModuleFactory, NgModuleFactoryLoader} from '@angular/core';
 
-@Injectable()
-export class SpyNgModuleFactoryLoader implements NgModuleFactoryLoader {
-  /**
-   * @docsNotRequired
-   */
-  private _stubbedModules: {[path: string]: Promise<NgModuleFactory<any>>|undefined} = {};
-
-  /**
-   * @docsNotRequired
-   */
-  set stubbedModules(modules: {[path: string]: any}) {
-    const res: {[path: string]: any} = {};
-    for (const t of Object.keys(modules)) {
-      res[t] = this.compiler.compileModuleAsync(modules[t]);
-    }
-    this._stubbedModules = res;
-  }
-
-  /**
-   * @docsNotRequired
-   */
-  get stubbedModules(): {[path: string]: any} {
-    return this._stubbedModules;
-  }
-
-  constructor(private compiler: Compiler) {}
-
-  load(path: string): Promise<NgModuleFactory<any>> {
-    if (this._stubbedModules[path]) {
-      return this._stubbedModules[path]!;
-    } else {
-      return <any>Promise.reject(new Error(`Cannot find module ${path}`));
-    }
-  }
-}
+// This file exists for easily patching SpyNgModuleFactoryLoader in g3
+export default {};

--- a/packages/router/testing/src/spy_ng_module_factory_loader.ts
+++ b/packages/router/testing/src/spy_ng_module_factory_loader.ts
@@ -5,6 +5,40 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {Compiler, Injectable, NgModuleFactory, NgModuleFactoryLoader} from '@angular/core';
 
-// This file exists for easily patching SpyNgModuleFactoryLoader in g3
-export default {};
+@Injectable()
+export class SpyNgModuleFactoryLoader implements NgModuleFactoryLoader {
+  /**
+   * @docsNotRequired
+   */
+  private _stubbedModules: {[path: string]: Promise<NgModuleFactory<any>>|undefined} = {};
+
+  /**
+   * @docsNotRequired
+   */
+  set stubbedModules(modules: {[path: string]: any}) {
+    const res: {[path: string]: any} = {};
+    for (const t of Object.keys(modules)) {
+      res[t] = this.compiler.compileModuleAsync(modules[t]);
+    }
+    this._stubbedModules = res;
+  }
+
+  /**
+   * @docsNotRequired
+   */
+  get stubbedModules(): {[path: string]: any} {
+    return this._stubbedModules;
+  }
+
+  constructor(private compiler: Compiler) {}
+
+  load(path: string): Promise<NgModuleFactory<any>> {
+    if (this._stubbedModules[path]) {
+      return this._stubbedModules[path]!;
+    } else {
+      return <any>Promise.reject(new Error(`Cannot find module ${path}`));
+    }
+  }
+}


### PR DESCRIPTION
Internally, g3 code still uses the `loadChildren: string` syntax. We
need to continue to provide this functionality with an internal patch.
This change makes that patch easier by only touching stub files that
support the `loadChildren: string` (other than `router_config_loader`).

The fixup commits add the g3 patch and then revert it so we can
easily extract the patch with `git diff`.