### PR TITLE
ci: change ownership of `goldens/public-api/manage.js`

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1172,6 +1172,7 @@ groups:
           'docs/*.md',
           'docs/images/**',
           'goldens/*',
+          'goldens/public-api/manage.js',
           'modules/*',
           'packages/*',
           'packages/examples/test-utils/**',
@@ -1215,7 +1216,7 @@ groups:
       - *no-groups-above-this-rejected
       - *can-be-global-approved
       - >
-        contains_any_globs(files, [
+        contains_any_globs(files.exclude("goldens/public-api/manage.js"), [
           'goldens/public-api/**',
           'docs/NAMING.md',
           'aio/content/errors/*.md',


### PR DESCRIPTION
With this change we change ownership of `goldens/public-api/manage.js` from `public-api` to `dev-infra`. This file is a script to manage public-api golden files and therefore it should fall under the dev-infra umbrella.

//cc @AndrewKushnir, who brought this up in https://github.com/angular/angular/pull/43644#pullrequestreview-768349243