### PR TITLE
fix(compiler-cli): updates `ngc` to pass the build when only warnings are emitted

### DIFF
--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -19,10 +19,6 @@ import {createMessageDiagnostic} from './transformers/util';
 
 export type Diagnostics = ReadonlyArray<ts.Diagnostic|api.Diagnostic>;
 
-export function filterErrorsAndWarnings(diagnostics: Diagnostics): Diagnostics {
-  return diagnostics.filter(d => d.category !== ts.DiagnosticCategory.Message);
-}
-
 const defaultFormatHost: ts.FormatDiagnosticsHost = {
   getCurrentDirectory: () => ts.sys.getCurrentDirectory(),
   getCanonicalFileName: fileName => fileName,
@@ -274,7 +270,8 @@ export interface PerformCompilationResult {
 }
 
 export function exitCodeFromResult(diags: Diagnostics|undefined): number {
-  if (!diags || filterErrorsAndWarnings(diags).length === 0) {
+  if (!diags) return 0;
+  if (diags.every((diag) => diag.category !== ts.DiagnosticCategory.Error)) {
     // If we have a result and didn't get any errors, we succeeded.
     return 0;
   }

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -231,7 +231,7 @@ export class NgtscTestEnvironment {
   /**
    * Run the compiler to completion, and return any `ts.Diagnostic` errors that may have occurred.
    */
-  driveDiagnostics(): ReadonlyArray<ts.Diagnostic> {
+  driveDiagnostics(expectedExitCode?: number): ReadonlyArray<ts.Diagnostic> {
     // ngtsc only produces ts.Diagnostic messages.
     let reuseProgram: {program: Program|undefined}|undefined = undefined;
     if (this.multiCompileHostExt !== null) {
@@ -240,16 +240,21 @@ export class NgtscTestEnvironment {
       };
     }
 
-    const diags = mainDiagnosticsForTest(
+    const {exitCode, diagnostics} = mainDiagnosticsForTest(
         this.commandLineArgs, undefined, reuseProgram, this.changedResources, tsickle);
-
+    if (expectedExitCode !== undefined) {
+      expect(exitCode)
+          .withContext(`Expected program to exit with code ${
+              expectedExitCode}, but it actually exited with code ${exitCode}.`)
+          .toBe(expectedExitCode);
+    }
 
     if (this.multiCompileHostExt !== null) {
       this.oldProgram = reuseProgram!.program!;
     }
 
     // In ngtsc, only `ts.Diagnostic`s are produced.
-    return diags as ReadonlyArray<ts.Diagnostic>;
+    return diagnostics as ReadonlyArray<ts.Diagnostic>;
   }
 
   async driveDiagnosticsAsync(): Promise<ReadonlyArray<ts.Diagnostic>> {

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -7569,6 +7569,30 @@ export const Foo = Foo__PRE_R3__;
          expect(diags[0].messageText)
              .toEqual(`Could not find stylesheet file './non-existent-file.css'.`);
        });
+
+    it('passes the build when only warnings are emitted', () => {
+      env.tsconfig({
+        strictTemplates: true,
+        _extendedTemplateDiagnostics: true,
+      });
+
+      env.write('test.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test-component',
+          // Invalid banana in box (should be \`[(foo)]="bar"\`).
+          template: '<div ([foo])="bar"></div>',
+        })
+        class TestComponent {
+          bar = 'test';
+        }
+      `);
+
+      const diagnostics = env.driveDiagnostics(0 /* expectedExitCode */);
+      const codes = diagnostics.map((diag) => diag.code);
+      expect(codes).toEqual([ngErrorCode(ErrorCode.INVALID_BANANA_IN_BOX)]);
+    });
   });
 
   function expectTokenAtPosition<T extends ts.Node>(
@@ -7577,9 +7601,5 @@ export const Foo = Foo__PRE_R3__;
     const node = (ts as any).getTokenAtPosition(sf, pos) as ts.Node;
     expect(guard(node)).toBe(true);
     return node as T;
-  }
-
-  function normalize(input: string): string {
-    return input.replace(/\s+/g, ' ').trim();
   }
 }


### PR DESCRIPTION
Refs #42966.

Previously, a build when emitted one warning and no errors would fail with a non-zero exit code. This is not what users would expect, but had not been an issue before since the compiler did not actually emit any warnings. With upcoming extended template diagnostics and other warnings, this is now a case that needs to be supported. Warnings are printed to `stderr` as before, but `ngc` now exits with code `0` and the build is considered successful.

Implemented this by adding a new `driveMainWithWarnings()` test method which returns the exit code and any messages logged to `stderr`. Most importantly, it does not **require** the the build to pass, so it is up to the test to assert this as well as many messages printed to make sure they are acceptable. This is useful for testing warnings and ensuring the build still passes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix

## What is the current behavior?

Issue Number: #42966.

`ngc` fails when a compilation returns warnings but no errors. It should succeed as long as no errors are emitted, regardless of any warnings.

## What is the new behavior?

`ngc` now exits with code 0 (passes) when a compilation returns no errors, even if warnings are emitted.

## Does this PR introduce a breaking change?

- [X] No

The compiler does not currently produce warnings, so there is no change in behavior. This is intended to unblock future compiler changes.

## Other information

/cc @atscott.