### PR TITLE
refactor(bazel): always add `strictTemplates` option to `tsconfig.json`

### DIFF
--- a/packages/bazel/src/ng_module/ng_module.bzl
+++ b/packages/bazel/src/ng_module/ng_module.bzl
@@ -348,6 +348,7 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
         "enableSummariesForJit": is_legacy_ngc,
         "enableIvy": is_ivy_enabled(ctx),
         "fullTemplateTypeCheck": ctx.attr.type_check,
+        "strictTemplates": ctx.attr.strict_templates,
         "_extendedTemplateDiagnostics": ctx.attr.experimental_extended_template_diagnostics,
         "compilationMode": compilation_mode,
         # In Google3 we still want to use the symbol factory re-exports in order to
@@ -366,12 +367,6 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
         "_useHostForImportGeneration": (not _is_bazel()),
         "_useManifestPathsAsModuleName": (not _is_bazel()),
     }
-
-    # Only add `strictTemplates` if it is requested, that way an existing patch in components won't
-    # be broken by duplicating the key.
-    # TODO(#42966): Inline this in the above dict once components' patch is removed.
-    if ctx.attr.strict_templates:
-        angular_compiler_options["strictTemplates"] = True
 
     if is_perf_requested(ctx):
         # In Ivy mode, set the `tracePerformance` Angular compiler option to enable performance


### PR DESCRIPTION
`strictTemplates` was only conditionally added to the `tsconfig.json` file to avoid breaking the angular/components repo (see https://github.com/angular/angular/pull/43582#issuecomment-928567758). Components has been updated (see https://github.com/angular/components/pull/23677#issuecomment-938193144), so this condition is no longer necessary and `strictTemplates` can always be included in `tsconfig.json` without breakage.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Refactoring (no functional changes, no api changes)

## What is the current behavior?

`strictTemplates` is only added to the `tsconfig.json` if `strict_templates = True`. This is awkward coding, but was necessary to avoid breaking components (see https://github.com/angular/angular/pull/43582#issuecomment-928567758).

## What is the new behavior?

`strictTemplates` is always added to the `tsconfig.json` (can be `false` if disabled). This is more natural and fits with the existing convention of the tsconfig.

## Does this PR introduce a breaking change?

- [X] No