### PR TITLE
refactor(service-worker): avoid unnecessary writes to cache when version fails

### DIFF
--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -819,14 +819,6 @@ export class Driver implements Debuggable, UpdateSource {
       // but caches continue to be valid for previous versions. This is unfortunate but unavoidable.
       this.state = DriverReadyState.EXISTING_CLIENTS_ONLY;
       this.stateMessage = `Degraded due to: ${errorToString(err)}`;
-
-      try {
-        await this.sync();
-      } catch (err2) {
-        // We are already in a bad state. No need to make things worse.
-        // Just log the error and move on.
-        this.debugger.log(err2, `Driver.versionFailed(${err.message || err})`);
-      }
     }
   }
 


### PR DESCRIPTION
When an app version is detected as broken, the SW calls the `Driver#versionFailed()` method. Previously, this method would in turn call the `Driver#sync()` method, which writes some metadata about the SW's state to the `ngsw:/:db:contol` cache. More specifically, `Driver#sync()` persists info about all known app versions, which one is the latest and also what version each client is assigned to.

However, no relevant info is changed inside `Driver#versionFailed()`, so the call to `Driver#sync()` is redundant (since there are no changes that need to be synced with the cache). This is a left-over from before #43518, when `Driver#versionFailed()` used to update version assignments and thus did require synchronization with the cache.

This commit removes the redundant `Driver#sync()` call to avoid an unnecessary write to the cache.
