### PR TITLE
fix(bazel): ngc-wrapped should not rely on linker for external workspaces

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -17,7 +17,8 @@
   "bazelBin": {
     "ngc-wrapped": {
       "additionalAttributes": {
-        "configuration_env_vars": "[\"angular_ivy_enabled\"]"
+        "configuration_env_vars": "[\"angular_ivy_enabled\"]",
+        "templated_args": "[\"--bazel_patch_module_resolver\"]"
       }
     }
   },


### PR DESCRIPTION
Currently when `ngc-wrapped` runs in external/consumer workspaces, like
in the Angular Components project, the `ngc-wrapped` binary relies on
the linker due to the patched module resolution in `rules_nodejs` no
longer being default. The reliance on the linker of `rules_nodejs` is
problematic for workers as the required `node_modules` are not
re-linked for every build. This was previously not an issue before the
APF v13 changes because the `compiler-cli` module was loaded only once
through an import statement.

As of APF v13, the compiler-cli module is loaded dynamically for every
build. This dynamic import can then break for subsequent builds where
the node modules are no longer linked properly (due to e.g. other
targets running at the same time; or before a rebuild). We fix thi
issue by doing the following things:

1. Enabling the patched module resolution for consumer/external
   workspaces. This would match how we use ngc-wrapped inside FW as
   well.

2. Caching the compiler CLI module. Instead of re-fetching the module
   through dynamic imports for every build (in a worker), we should use
   the cached version. This is semantically the same as with APF v12
   where a single import statement at file top-level was used.