### PR TITLE
fix(router): unset attachRef when router-outlet is destroyed to avoid mounting a destroyed component

### DIFF
--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -50,6 +50,7 @@ export class ChildrenOutletContexts {
     const context = this.getContext(childName);
     if (context) {
       context.outlet = null;
+      context.attachRef = null;
     }
   }
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -5959,7 +5959,7 @@ describe('Integration', () => {
           CommonModule,
           RouterTestingModule.withRoutes([
             {path: 'a', component: SimpleCmp},
-            {path: 'b', component: SimpleCmp},
+            {path: 'b', component: BlankCmp},
           ]),
         ],
         providers: [{provide: RouteReuseStrategy, useClass: AttachDetachReuseStrategy}]

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -5942,6 +5942,59 @@ describe('Integration', () => {
          advance(fixture);
          expect(fixture).toContainComponent(Tool2Component, '(e)');
        }));
+
+    it('should not remount a destroyed component', fakeAsync(() => {
+      @Component({
+        selector: 'root-cmp',
+        template:
+          '<div *ngIf="showRouterOutlet"><router-outlet></router-outlet></div>'
+      })
+      class RootCmpWithCondOutlet {
+        public showRouterOutlet: boolean = true;
+      }
+
+      @NgModule({
+        declarations: [RootCmpWithCondOutlet],
+        imports: [
+          CommonModule,
+          RouterTestingModule.withRoutes([
+            {path: 'a', component: SimpleCmp},
+            {path: 'b', component: SimpleCmp},
+          ]),
+        ],
+        providers: [{provide: RouteReuseStrategy, useClass: AttachDetachReuseStrategy}]
+      })
+      class TestModule {}
+      TestBed.configureTestingModule({imports: [TestModule]});
+
+      const router: Router = TestBed.inject(Router);
+      const fixture = createRoot(router, RootCmpWithCondOutlet);
+
+      // Activate 'a'
+      router.navigate(['a']);
+      advance(fixture);
+      expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
+
+      // Deactivate 'a' and detach the route
+      router.navigate(['b']);
+      advance(fixture);
+      expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeNull();
+
+      // Activate 'a' again, the route should be re-attached
+      router.navigate(['a']);
+      advance(fixture);
+      expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
+
+      // Hide the router-outlet, SimpleCmp should be destroyed
+      fixture.componentInstance.showRouterOutlet = false;
+      advance(fixture);
+      expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeNull();
+
+      // Show the router-outlet, SimpleCmp should be re-created
+      fixture.componentInstance.showRouterOutlet = true;
+      advance(fixture);
+      expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
+    }));
   });
 
   describe('RouterInitializer', () => {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -5944,57 +5944,57 @@ describe('Integration', () => {
        }));
 
     it('should not remount a destroyed component', fakeAsync(() => {
-      @Component({
-        selector: 'root-cmp',
-        template:
-          '<div *ngIf="showRouterOutlet"><router-outlet></router-outlet></div>'
-      })
-      class RootCmpWithCondOutlet {
-        public showRouterOutlet: boolean = true;
-      }
+         @Component({
+           selector: 'root-cmp',
+           template: '<div *ngIf="showRouterOutlet"><router-outlet></router-outlet></div>'
+         })
+         class RootCmpWithCondOutlet {
+           public showRouterOutlet: boolean = true;
+         }
 
-      @NgModule({
-        declarations: [RootCmpWithCondOutlet],
-        imports: [
-          CommonModule,
-          RouterTestingModule.withRoutes([
-            {path: 'a', component: SimpleCmp},
-            {path: 'b', component: BlankCmp},
-          ]),
-        ],
-        providers: [{provide: RouteReuseStrategy, useClass: AttachDetachReuseStrategy}]
-      })
-      class TestModule {}
-      TestBed.configureTestingModule({imports: [TestModule]});
+         @NgModule({
+           declarations: [RootCmpWithCondOutlet],
+           imports: [
+             CommonModule,
+             RouterTestingModule.withRoutes([
+               {path: 'a', component: SimpleCmp},
+               {path: 'b', component: BlankCmp},
+             ]),
+           ],
+           providers: [{provide: RouteReuseStrategy, useClass: AttachDetachReuseStrategy}]
+         })
+         class TestModule {
+         }
+         TestBed.configureTestingModule({imports: [TestModule]});
 
-      const router: Router = TestBed.inject(Router);
-      const fixture = createRoot(router, RootCmpWithCondOutlet);
+         const router: Router = TestBed.inject(Router);
+         const fixture = createRoot(router, RootCmpWithCondOutlet);
 
-      // Activate 'a'
-      router.navigate(['a']);
-      advance(fixture);
-      expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
+         // Activate 'a'
+         router.navigate(['a']);
+         advance(fixture);
+         expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
 
-      // Deactivate 'a' and detach the route
-      router.navigate(['b']);
-      advance(fixture);
-      expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeNull();
+         // Deactivate 'a' and detach the route
+         router.navigate(['b']);
+         advance(fixture);
+         expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeNull();
 
-      // Activate 'a' again, the route should be re-attached
-      router.navigate(['a']);
-      advance(fixture);
-      expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
+         // Activate 'a' again, the route should be re-attached
+         router.navigate(['a']);
+         advance(fixture);
+         expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
 
-      // Hide the router-outlet, SimpleCmp should be destroyed
-      fixture.componentInstance.showRouterOutlet = false;
-      advance(fixture);
-      expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeNull();
+         // Hide the router-outlet, SimpleCmp should be destroyed
+         fixture.componentInstance.showRouterOutlet = false;
+         advance(fixture);
+         expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeNull();
 
-      // Show the router-outlet, SimpleCmp should be re-created
-      fixture.componentInstance.showRouterOutlet = true;
-      advance(fixture);
-      expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
-    }));
+         // Show the router-outlet, SimpleCmp should be re-created
+         fixture.componentInstance.showRouterOutlet = true;
+         advance(fixture);
+         expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
+       }));
   });
 
   describe('RouterInitializer', () => {


### PR DESCRIPTION
Previously, when a `router-outlet` is conditionally shown with an `ngIf`, and a sub-route was re-attached
via a custom `RouteReuseStrategy`, `router-outlet` would try to mount a destroyed component into the view
if the `router-outlet` is destroyed and re-initialized.

This commit fixes it by unsetting `context.attachRef` when `router-outlet` is destroyed, so when the
`router-outlet` is being initialized again, it no longer sees an `attachRef` that it needs to mount to the
view.

Fixes #43696

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #43696


## What is the new behavior?
Router-outlet re-creates the component for child route if it is previously destroyed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
