### PR TITLE
refactor(language-service): fix typo in method name

### DIFF
--- a/packages/language-service/ivy/test/references_and_rename_spec.ts
+++ b/packages/language-service/ivy/test/references_and_rename_spec.ts
@@ -1628,7 +1628,7 @@ describe('find references and rename locations', () => {
 
   function getRenameLocationsAtPosition(file: OpenBuffer) {
     env.expectNoSourceDiagnostics();
-    const result = file.fineRenameLocations();
+    const result = file.findRenameLocations();
     return result?.map((item) => humanizeDocumentSpanLike(item, env));
   }
 });

--- a/packages/language-service/ivy/testing/src/buffer.ts
+++ b/packages/language-service/ivy/testing/src/buffer.ts
@@ -96,7 +96,7 @@ export class OpenBuffer {
     return this.ngLS.getReferencesAtPosition(this.scriptInfo.fileName, this._cursor);
   }
 
-  fineRenameLocations() {
+  findRenameLocations() {
     return this.ngLS.findRenameLocations(this.scriptInfo.fileName, this._cursor);
   }
 


### PR DESCRIPTION
The `fineRenameLocations` method should be called `findRenameLocations`.