### PR TITLE
refactor(language-service): enable extended template diagnostics when strict templates is forced

### DIFF
--- a/packages/language-service/ivy/language_service.ts
+++ b/packages/language-service/ivy/language_service.ts
@@ -501,6 +501,7 @@ function parseNgCompilerOptions(
   // regardless of its value in tsconfig.json.
   if (config.forceStrictTemplates === true) {
     options.strictTemplates = true;
+    options._extendedTemplateDiagnostics = true;
   }
 
   return options;

--- a/packages/language-service/ivy/test/legacy/language_service_spec.ts
+++ b/packages/language-service/ivy/test/legacy/language_service_spec.ts
@@ -82,6 +82,7 @@ describe('language service adapter', () => {
       // is enabled.
       expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
         strictTemplates: true,
+        _extendedTemplateDiagnostics: true,
       }));
     });
   });


### PR DESCRIPTION
This effectively enables extended template diagnostics in the VSCode extension in google3. This uses the existing `forceStrictTemplates` option to enable since that is already a prerequisite for extended template diagnostics and we don't distinguish between them at the configuration-level in google3 anyways.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Feature

## What is the current behavior?

Issue Number: http://b/199443160

Extended template diagnostics are not shown in the VSCode extension for google3 applications.

## What is the new behavior?

Extended template diagnostics are now shown in the VSCode extension for google3 applications.

## Does this PR introduce a breaking change?

- [X] No

## Other information

This is *technically* a feature, but only for google3 devs, so I left the commit as a `refactor` just so it doesn't show up in the public changelog and reduces noise.

The package also seems to have existing test failures and I'm not sure how to properly use it in a test build of the extension, so I can't actually confirm that this does what I expect, however it's simple enough to be reasonably confident this works as intended.

/cc @alxhub