### PR TITLE
docs: deprecate ViewEngine-based JIT Compiler symbols

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -44,6 +44,11 @@ v13 -> v16
 | `@angular/core`           | [Factory-based signature of `ApplicationRef.bootstrap`](#core)                                | <!--v13--> v15        |
 | `@angular/core`           | [`PlatformRef.bootstrapModuleFactory`](#core)                                                 | <!--v13--> v15        |
 | `@angular/core`         | [`getModuleFactory`](#core)                                                                       | <!--v13--> v16        |
+| `@angular/core`         | [`ModuleWithComponentFactories`](#core)                                                                       | <!--v13--> v16        |
+| `@angular/core`         | [`Compiler`](#core)                                                                       | <!--v13--> v16        |
+| `@angular/core`         | [`CompilerFactory`](#core)                                                                       | <!--v13--> v16        |
+| `@angular/core`         | [`NgModuleFactory`](#core)                                                                       | <!--v13--> v16        |
+| `@angular/platform-browser-dynamic`         | [`JitCompilerFactory`](#platform-browser-dynamic)                                                                       | <!--v13--> v16        |
 | `@angular/forms`          | [`ngModel` with reactive forms](#ngmodel-reactive)                                            | <!--v6--> v11         |
 | `@angular/upgrade`        | [`@angular/upgrade`](#upgrade)                                                                | <!--v8--> v11         |
 | `@angular/upgrade`        | [`getAngularLib`](#upgrade-static)                                                            | <!--v8--> v11         |
@@ -113,7 +118,19 @@ This section contains a complete list all of the currently-deprecated APIs, with
 | `ViewChildren.emitDistinctChangesOnly` / `ContentChildren.emitDistinctChangesOnly` | none (was part of [issue #40091](https://github.com/angular/angular/issues/40091)) |                       | This is a temporary flag introduced as part of bugfix of [issue #40091](https://github.com/angular/angular/issues/40091) and will be removed.                                                                                            |
 | Factory-based signature of [`ApplicationRef.bootstrap`](api/core/ApplicationRef#bootstrap)                          | Type-based signature of [`ApplicationRef.bootstrap`](api/core/ApplicationRef#bootstrap)                                                                                 | v13                    | With Ivy, there is no need to resolve Component factory and Component Type can be provided directly.                                                                                                                                                                                                                  |
 | [`PlatformRef.bootstrapModuleFactory`](api/core/PlatformRef#bootstrapModuleFactory)                          | [`PlatformRef.bootstrapModule`](api/core/PlatformRef#bootstrapModule)                                                                                 | v13                    | With Ivy, there is no need to resolve NgModule factory and NgModule Type can be provided directly.                                                                                                                                                                                                                  |
+| [`ModuleWithComponentFactories`](api/core/ModuleWithComponentFactories)                          | none                                                                                 | v13                    | Ivy JIT mode doesn't require accessing this symbol. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context.                                                                                                                                                                                                                  |
+| [`Compiler`](api/core/Compiler)                          | none                                                                                 | v13                    | Ivy JIT mode doesn't require accessing this symbol. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context.                                                                                                                                                                                                                  |
+| [`CompilerFactory`](api/core/CompilerFactory)                          | none                                                                                 | v13                    | Ivy JIT mode doesn't require accessing this symbol. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context.                                                                                                                                                                                                                  |
+| [`NgModuleFactory`](api/core/NgModuleFactory)                          | Use non-factory based framework APIs like [PlatformRef.bootstrapModule](api/core/PlatformRef#bootstrapModule) and [createNgModuleRef](api/core/createNgModuleRef)                                                                                 | v13                    | Ivy JIT mode doesn't require accessing this symbol. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context.                                                                                                                                                                                                                 |
 | [Factory-based signature of `ViewContainerRef.createComponent`](api/core/ViewContainerRef#createComponent)                                                  | [Type-based signature of `ViewContainerRef.createComponent`](api/core/ViewContainerRef#createComponent)                                    | v13                   | Angular no longer requires component factories to dynamically create components. Use different signature of the `createComponent` method, which allows passing Component class directly. |
+
+{@a platform-browser-dynamic}
+
+### @angular/platform-browser-dynamic
+
+| API                                           | Replacement                                         | Deprecation announced | Notes                                         |
+|:---                                           |:---                                                 |:---                   |:---                                           |
+| [[`JitCompilerFactory`](api/platform-browser-dynamic/JitCompilerFactory) | none | v13                    | Ivy JIT mode doesn't require accessing this symbol. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context.                  |
 
 {@a testing}
 
@@ -575,6 +592,15 @@ Projects that currently have `fullTemplateTypeCheck: true` configured can migrat
 }
 
 </code-example>
+
+{@a jit-api-changes}
+
+## JIT API changes due to ViewEngine deprecation
+
+In ViewEngine, [JIT compilation](https://angular.io/guide/glossary#jit) required special providers (like `Compiler`, `CompilerFactory`, etc) to be injected in the app and corresponding methods to be invoked. With Ivy, JIT compilation takes place implicitly if the Component, NgModule, etc have not already been [AOT compiled](https://angular.io/guide/glossary#aot). Those special providers were made available in Ivy for backwards-compatibility with ViewEngine to make the transition to Ivy smoother. Since ViewEngine is deprecated and will soon be removed, those symbols are now deprecated as well.
+
+Important note: this deprecation doesn't affect JIT mode in Ivy (JIT remains available with Ivy, however we are exploring a possibility of deprecating it in the future. See [RFC: Exploration of use-cases for Angular JIT compilation mode](https://github.com/angular/angular/issues/43133)).
+
 
 {@a deprecated-cli-flags}
 

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -130,7 +130,7 @@ This section contains a complete list all of the currently-deprecated APIs, with
 
 | API                                           | Replacement                                         | Deprecation announced | Notes                                         |
 |:---                                           |:---                                                 |:---                   |:---                                           |
-| [[`JitCompilerFactory`](api/platform-browser-dynamic/JitCompilerFactory) | none | v13                    | Ivy JIT mode doesn't require accessing this symbol. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context.                  |
+| [`JitCompilerFactory`](api/platform-browser-dynamic/JitCompilerFactory) | none | v13                    | Ivy JIT mode doesn't require accessing this symbol. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context.                  |
 
 {@a testing}
 

--- a/goldens/public-api/core/core.md
+++ b/goldens/public-api/core/core.md
@@ -135,7 +135,7 @@ export interface ClassSansProvider {
     useClass: Type<any>;
 }
 
-// @public
+// @public @deprecated
 export class Compiler {
     clearCache(): void;
     clearCacheFor(type: Type<any>): void;
@@ -153,7 +153,7 @@ export class Compiler {
 // @public
 export const COMPILER_OPTIONS: InjectionToken<CompilerOptions[]>;
 
-// @public
+// @public @deprecated
 export abstract class CompilerFactory {
     // (undocumented)
     abstract createCompiler(options?: CompilerOptions[]): Compiler;
@@ -785,7 +785,7 @@ export enum MissingTranslationStrategy {
     Warning = 1
 }
 
-// @public
+// @public @deprecated
 export class ModuleWithComponentFactories<T> {
     constructor(ngModuleFactory: NgModuleFactory<T>, componentFactories: ComponentFactory<any>[]);
     // (undocumented)
@@ -829,7 +829,7 @@ export interface NgModuleDecorator {
     new (obj?: NgModule): NgModule;
 }
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export abstract class NgModuleFactory<T> {
     // (undocumented)
     abstract create(parentInjector: Injector | null): NgModuleRef<T>;

--- a/goldens/public-api/platform-browser-dynamic/platform-browser-dynamic.md
+++ b/goldens/public-api/platform-browser-dynamic/platform-browser-dynamic.md
@@ -12,11 +12,11 @@ import { Provider } from '@angular/core';
 import { StaticProvider } from '@angular/core';
 import { Version } from '@angular/core';
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export class JitCompilerFactory implements CompilerFactory {
     // (undocumented)
     createCompiler(options?: CompilerOptions[]): Compiler;
-    }
+}
 
 // @public (undocumented)
 export const platformBrowserDynamic: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
@@ -26,7 +26,6 @@ export const RESOURCE_CACHE_PROVIDER: Provider[];
 
 // @public (undocumented)
 export const VERSION: Version;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/core/src/linker/compiler.ts
+++ b/packages/core/src/linker/compiler.ts
@@ -26,6 +26,11 @@ import {NgModuleFactory} from './ng_module_factory';
  * Combination of NgModuleFactory and ComponentFactories.
  *
  * @publicApi
+ *
+ * @deprecated
+ * Ivy JIT mode doesn't require accessing this symbol.
+ * See [JIT API changes due to ViewEngine deprecation](guide/deprecations#jit-api-changes) for
+ * additional context.
  */
 export class ModuleWithComponentFactories<T> {
   constructor(
@@ -93,6 +98,11 @@ const Compiler_compileModuleAndAllComponentsAsync =
  * of components.
  *
  * @publicApi
+ *
+ * @deprecated
+ * Ivy JIT mode doesn't require accessing this symbol.
+ * See [JIT API changes due to ViewEngine deprecation](guide/deprecations#jit-api-changes) for
+ * additional context.
  */
 @Injectable()
 export class Compiler {
@@ -162,6 +172,11 @@ export const COMPILER_OPTIONS = new InjectionToken<CompilerOptions[]>('compilerO
  * A factory for creating a Compiler
  *
  * @publicApi
+ *
+ * @deprecated
+ * Ivy JIT mode doesn't require accessing this symbol.
+ * See [JIT API changes due to ViewEngine deprecation](guide/deprecations#jit-api-changes) for
+ * additional context.
  */
 export abstract class CompilerFactory {
   abstract createCompiler(options?: CompilerOptions[]): Compiler;

--- a/packages/core/src/linker/ng_module_factory.ts
+++ b/packages/core/src/linker/ng_module_factory.ts
@@ -54,6 +54,14 @@ export interface InternalNgModuleRef<T> extends NgModuleRef<T> {
 
 /**
  * @publicApi
+ *
+ * @deprecated
+ * This class was mostly used as a part of ViewEngine-based JIT API and is no longer needed in Ivy
+ * JIT mode. See [JIT API changes due to ViewEngine deprecation](guide/deprecations#jit-api-changes)
+ * for additional context. Angular provides APIs that accept NgModule classes directly (such as
+ * [PlatformRef.bootstrapModule](api/core/PlatformRef#bootstrapModule) and
+ * [createNgModuleRef](api/core/createNgModuleRef)), consider switching to those APIs instead of
+ * using factory-based ones.
  */
 export abstract class NgModuleFactory<T> {
   abstract get moduleType(): Type<T>;

--- a/packages/platform-browser-dynamic/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/src/compiler_factory.ts
@@ -171,6 +171,11 @@ export const COMPILER_PROVIDERS__POST_R3__ =
 export const COMPILER_PROVIDERS = COMPILER_PROVIDERS__PRE_R3__;
 /**
  * @publicApi
+ *
+ * @deprecated
+ * Ivy JIT mode doesn't require accessing this symbol.
+ * See [JIT API changes due to ViewEngine deprecation](guide/deprecations#jit-api-changes) for
+ * additional context.
  */
 export class JitCompilerFactory implements CompilerFactory {
   private _defaultOptions: CompilerOptions[];


### PR DESCRIPTION
**NOTE: JIT compiler in Ivy is available, these deprecations are for ViewEngine only.**

DEPRECATION:

Some of the symbols that are used in ViewEngine-based JIT Compiler API are now deprecated:

- `ModuleWithComponentFactories`
- `Compiler`
- `CompilerFactory`
- `JitCompilerFactory`
- `NgModuleFactory`

In Ivy JIT mode those symbols are unused and they are currently present for backwards-compatibility with ViewEngine only. Since ViewEngine is deprecated and will shortly be fully removed, those symbols are now deprecated as well.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No