### PR TITLE
fix(forms): retain 'DISABLED' status, if the value changes of child controls in the middle of disabling control

### DIFF
--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -1751,6 +1751,64 @@ describe('FormGroup', () => {
       expect(validator.calls.count()).toEqual(2);
     });
 
+    describe('retain "DISABLED" status', () => {
+      let logger: string[];
+      let c1: FormControl;
+      let c2: FormControl;
+      let group: FormGroup;
+
+      beforeEach(() => {
+        logger = [];
+        c1 = new FormControl(null);
+        c2 = new FormControl(null);
+        group = new FormGroup({one: c1, two: c2});
+      });
+
+      it('should retain the "DISABLED" status of the group, if the value changes on the child controls in the middle of disable state',
+         () => {
+           expect(group.status).toEqual('VALID');
+
+           c1.valueChanges.subscribe(() => {
+             logger.push(group.status);
+             c2.setValue('new!');
+             logger.push(group.status);
+           });
+
+           group.disable();
+           expect(group.status).toEqual('DISABLED');
+           expect(group.disabled).toEqual(true);
+           expect(logger).toEqual(['DISABLED', 'DISABLED']);
+         });
+
+      it('should change the "VALID" status', () => {
+        group.disable();
+
+        c1.valueChanges.subscribe(() => {
+          logger.push(group.status);
+          c2.setValue('new!');
+          logger.push(group.status);
+        });
+
+        group.enable();
+        expect(group.status).toEqual('VALID');
+        expect(group.enabled).toEqual(true);
+        expect(logger).toEqual(['VALID', 'VALID']);
+      });
+
+      it('should not fire event while changing the status', () => {
+        c1.valueChanges.subscribe(() => {
+          logger.push(group.status);
+          c2.setValue('new!');
+          logger.push(group.status);
+        });
+
+        group.disable({emitEvent: false});
+        expect(group.status).toEqual('DISABLED');
+        expect(group.disabled).toEqual(true);
+        expect(logger).toEqual([]);
+      });
+    });
+
     describe('disabled errors', () => {
       it('should clear out group errors when disabled', () => {
         const g = new FormGroup({'one': new FormControl()}, () => ({'expected': true}));


### PR DESCRIPTION
The problem is to call the ```disable()``` method of the instanced ```FormGroup```, if the child controls are subscribed the ```valueChanges``` of the controls to change the value of the any children ```FormControl``` then the disabled state is changed.

To fix this issue, This commit adds a new private property(```_disableInProgress```) in the ```AbstractControl``` class to check the disabled state is in progress or not in the respective affected methods.


## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X ] Bugfix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #31924


## What is the new behavior?
It's working as expected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
