### PR TITLE
test(core): fix failing unit test

### DIFF
--- a/packages/core/test/linker/jit_summaries_integration_spec.ts
+++ b/packages/core/test/linker/jit_summaries_integration_spec.ts
@@ -242,8 +242,8 @@ import {obsoleteInIvy} from '@angular/private/testing';
                component,
              };
 
-             TestBed.resetTestingModule();
-
+             expect(() => TestBed.resetTestingModule())
+                 .toThrowError('1 component threw errors during cleanup');
              expect(console.error)
                  .toHaveBeenCalledWith('Error during cleanup of component', expectedObject);
            });


### PR DESCRIPTION
Fixes a unit test that now fails, because rethrowing errors is enabled by default. The problem is that we're checking the behavior of a component that throws during `ngOnDestroy`, but since the `resetTestingModule` call itself throws, the test is considered as failing.