### PR TITLE
refactor(language-service): Remove option and bundle generation for V…

### DIFF
--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -60,6 +60,5 @@ pkg_npm(
         ":api",
         # min bundle is not used at the moment; omit from package to speed up build
         "//packages/language-service/bundles:language-service.js",
-        "//packages/language-service/bundles:ivy.js",
     ],
 )

--- a/packages/language-service/api.ts
+++ b/packages/language-service/api.ts
@@ -21,11 +21,6 @@ export interface PluginConfig {
    */
   angularOnly: boolean;
   /**
-   * If true, return factory function for Ivy LS during plugin initialization.
-   * Otherwise return factory function for View Engine LS.
-   */
-  ivy: boolean;
-  /**
    * If true, enable `strictTemplates` in Angular compiler options regardless
    * of its value in tsconfig.json.
    */

--- a/packages/language-service/bundles/BUILD.bazel
+++ b/packages/language-service/bundles/BUILD.bazel
@@ -3,27 +3,6 @@ load("@npm//@angular/dev-infra-private/bazel/benchmark/ng_rollup_bundle:ng_rollu
 ng_rollup_bundle(
     name = "language-service",
     build_optimizer = False,
-    entry_point = "//packages/language-service:src/ts_plugin.ts",
-    format = "amd",
-    globals = {
-        "os": "os",
-        "fs": "fs",
-        "path": "path",
-        "typescript": "ts",
-        "typescript/lib/tsserverlibrary": "tss",
-    },
-    license_banner = ":banner",
-    visibility = ["//packages/language-service:__pkg__"],
-    deps = [
-        "//packages/language-service",
-        "@npm//rxjs",
-        "@npm//tslib",
-    ],
-)
-
-ng_rollup_bundle(
-    name = "ivy",
-    build_optimizer = False,
     entry_point = "//packages/language-service/ivy:ts_plugin.ts",
     format = "amd",
     globals = {

--- a/packages/language-service/index.ts
+++ b/packages/language-service/index.ts
@@ -19,9 +19,7 @@ const factory: ts.server.PluginModuleFactory = (tsModule): PluginModule => {
 
   return {
     create(info: ts.server.PluginCreateInfo): NgLanguageService {
-      const config: PluginConfig = info.config;
-      const bundleName = config.ivy ? 'ivy.js' : 'language-service.js';
-      plugin = require(`./bundles/${bundleName}`)(tsModule);
+      plugin = require(`./bundles/language-service.js`)(tsModule);
       return plugin.create(info);
     },
     getExternalFiles(project: ts.server.Project): string[] {


### PR DESCRIPTION
…iew Engine

This commit removes the option to enable the VE language service and removes the VE bundle entirely.
It also updates the name of the ivy bundle to "language-service.js" now that there is only one.
