### PR TITLE
docs(docs-infra): fix a11y of external links

### DIFF
--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -213,7 +213,7 @@ code {
           position: relative;
 
           &::after {
-            content: "open_in_new";
+            content: "\e89e";
             font-family: "Material Icons";
             position: absolute;
             right: 0;

--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -213,7 +213,7 @@ code {
           position: relative;
 
           &::after {
-            content: "\e89e";
+            content: "\e89e"; // codepoint for "open_in_new"
             font-family: "Material Icons";
             position: absolute;
             right: 0;


### PR DESCRIPTION
prevent screen readers from falsely announcing "open_in_new" since they may not actually open new tabs/windows but simply send the current page to a domain outside angular.io

Fixes #43512

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features) - (EDIT: Can we easily simulate screen readers with an e2e?)
- [ ] Docs have been added / updated (for bug fixes / features) - (EDIT: not sure if applicable?)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [x] Other... Please describe: Screen reader a11y (accessibility).


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Screen readers literally say "open_in_new" as "open underscore in underscore new", but shouldn't even say that because the links don't open a new tab/window.

Issue Number: #43512


## What is the new behavior?
Screen readers won't announce the material icon `content: "open_in_new";`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

First time contributing to this project! :)
