### PR TITLE
test: remove `progress` option from `dev-server` builder

### DIFF
--- a/integration/cli-hello-world-ivy-compat/angular.json
+++ b/integration/cli-hello-world-ivy-compat/angular.json
@@ -69,11 +69,9 @@
               "browserTarget": "cli-hello-world-ivy-compat:build:production"
             },
             "ci": {
-              "progress": false
             },
             "ci-production": {
               "browserTarget": "cli-hello-world-ivy-compat:build:production",
-              "progress": false
             }
           }
         },

--- a/integration/cli-hello-world-ivy-minimal/angular.json
+++ b/integration/cli-hello-world-ivy-minimal/angular.json
@@ -69,11 +69,9 @@
               "browserTarget": "cli-hello-world-ivy-minimal:build:production"
             },
             "ci": {
-              "progress": false
             },
             "ci-production": {
               "browserTarget": "cli-hello-world-ivy-minimal:build:production",
-              "progress": false
             }
           }
         },

--- a/integration/cli-hello-world/angular.json
+++ b/integration/cli-hello-world/angular.json
@@ -72,11 +72,9 @@
               "browserTarget": "cli-hello-world:build:production"
             },
             "ci": {
-              "progress": false
             },
             "ci-production": {
               "browserTarget": "cli-hello-world:build:production",
-              "progress": false
             }
           }
         },

--- a/integration/forms/angular.json
+++ b/integration/forms/angular.json
@@ -72,11 +72,9 @@
               "browserTarget": "forms:build:production"
             },
             "ci": {
-              "progress": false
             },
             "ci-production": {
               "browserTarget": "forms:build:production",
-              "progress": false
             }
           }
         },

--- a/integration/ivy-i18n/angular.json
+++ b/integration/ivy-i18n/angular.json
@@ -103,15 +103,12 @@
               "browserTarget": "cli-hello-world-ivy-i18n:build:production"
             },
             "ci": {
-              "progress": false
             },
             "ci-production": {
               "browserTarget": "cli-hello-world-ivy-i18n:build:production",
-              "progress": false
             },
             "runtime-translations": {
               "browserTarget": "cli-hello-world-ivy-i18n:build:runtime-translations",
-              "progress": false
             }
           }
         },

--- a/integration/trusted-types/angular.json
+++ b/integration/trusted-types/angular.json
@@ -75,12 +75,9 @@
             "production": {
               "browserTarget": "trusted-types:build:production"
             },
-            "ci": {
-              "progress": false
-            },
+            "ci": { },
             "ci-production": {
               "browserTarget": "trusted-types:build:production",
-              "progress": false
             }
           }
         },


### PR DESCRIPTION
This change addresses the following failures
```
Schema validation failed with the following errors:
  Data path "" must NOT have additional properties(progress)
```

See failures in https://app.circleci.com/pipelines/github/angular/angular/38086/workflows/7fd378bb-2c9c-4b7e-9b1e-82c9fb3ba58d/jobs/1064226
Needed to unblock https://github.com/angular/angular/pull/43583