### PR TITLE
build: remove "remark" renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -63,11 +63,6 @@
       "pinVersions": false
     },
     {
-      "packagePatterns": ["^remark-.*", "remark"],
-      "groupName": "remark",
-      "pinVersions": false
-    },
-    {
       "packageNames": ["typescript", "rxjs", "tslib"],
       "separateMinorPatch": true
     },

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,8 @@
     "angular-mocks-1.7",
     "angular-mocks-1.8",
     "puppeteer",
+    "remark",
+    "remark-html",
     "rollup",
     "selenium-webdriver",
     "watchr"


### PR DESCRIPTION
This group was causing an immortal PR to keep being created, even though
we do not want, currently, to update the versions of the "remark*" packages.
