### PR TITLE
docs: deprecate ViewEngine-based `renderModuleFactory`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -68,6 +68,7 @@ v13 -> v16
 | `@angular/core/testing`   | [`aotSummaries` field of the `TestModuleMetadata` type](#testing)                             | <!--v13--> v14        |
 | `@angular/forms`          | [`FormBuilder.group` legacy options parameter](api/forms/FormBuilder#group)                   | <!--v11--> v14        |
 | `@angular/router`         | [`ActivatedRoute` params and `queryParams` properties](#activatedroute-props)                 | unspecified           |
+| `@angular/platform-server`| [`renderModuleFactory`](#platform-server)                                                     | <!--v13--> v15        |
 | `@angular/service-worker` | [`SwUpdate#activated`](api/service-worker/SwUpdate#activated)                                 | <!--v13--> v16        |
 | `@angular/service-worker` | [`SwUpdate#available`](api/service-worker/SwUpdate#available)                                 | <!--v13--> v16        |
 | template syntax           | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector)                            | <!--v7--> unspecified |
@@ -124,14 +125,6 @@ This section contains a complete list all of the currently-deprecated APIs, with
 | [`NgModuleFactory`](api/core/NgModuleFactory)                          | Use non-factory based framework APIs like [PlatformRef.bootstrapModule](api/core/PlatformRef#bootstrapModule) and [createNgModuleRef](api/core/createNgModuleRef)                                                                                 | v13                    | Ivy JIT mode doesn't require accessing this symbol. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context.                                                                                                                                                                                                                 |
 | [Factory-based signature of `ViewContainerRef.createComponent`](api/core/ViewContainerRef#createComponent)                                                  | [Type-based signature of `ViewContainerRef.createComponent`](api/core/ViewContainerRef#createComponent)                                    | v13                   | Angular no longer requires component factories to dynamically create components. Use different signature of the `createComponent` method, which allows passing Component class directly. |
 
-{@a platform-browser-dynamic}
-
-### @angular/platform-browser-dynamic
-
-| API                                           | Replacement                                         | Deprecation announced | Notes                                         |
-|:---                                           |:---                                                 |:---                   |:---                                           |
-| [`JitCompilerFactory`](api/platform-browser-dynamic/JitCompilerFactory) | none | v13                    | Ivy JIT mode doesn't require accessing this symbol. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context.                  |
-
 {@a testing}
 
 ### @angular/core/testing
@@ -142,6 +135,24 @@ This section contains a complete list all of the currently-deprecated APIs, with
 | [`async`](api/core/testing/async)             | [`waitForAsync`](api/core/testing/waitForAsync)     | v10                   | Same behavior, but rename to avoid confusion. |
 | [`aotSummaries` argument in `TestBed.initTestEnvironment`](api/core/testing/TestBed#inittestenvironment)             | No replacement needed     | v13                   | Summary files are unused in Ivy. |
 | [`aotSummaries` field of the `TestModuleMetadata` type](api/core/testing/TestModuleMetadata)             | No replacement needed     | v13                   | Summary files are unused in Ivy. |
+
+{@a platform-browser-dynamic}
+
+### @angular/platform-browser-dynamic
+
+| API                                           | Replacement                                         | Deprecation announced | Notes                                         |
+|:---                                           |:---                                                 |:---                   |:---                                           |
+| [`JitCompilerFactory`](api/platform-browser-dynamic/JitCompilerFactory) | none | v13                    | This symbol is no longer necessary. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context. |
+
+
+{@a platform-server}
+
+### @angular/platform-server
+
+| API                             | Replacement                                     | Deprecation announced | Notes                                          |
+|:---                             |:---                                             |:---                   |:---                                            |
+| [`renderModuleFactory`](api/platform-server/renderModuleFactory) | [`renderModule`](api/platform-server/renderModule) | v13                    | This symbol is no longer necessary. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context. |
+
 
 {@a forms}
 

--- a/goldens/public-api/platform-server/platform-server.md
+++ b/goldens/public-api/platform-server/platform-server.md
@@ -53,7 +53,7 @@ export function renderModule<T>(module: Type<T>, options: {
     extraProviders?: StaticProvider[];
 }): Promise<string>;
 
-// @public
+// @public @deprecated
 export function renderModuleFactory<T>(moduleFactory: NgModuleFactory<T>, options: {
     document?: string;
     url?: string;

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -93,11 +93,6 @@ the server-rendered app can be properly bootstrapped into a client app.`);
  * `url` is the URL for the current render request.
  * `extraProviders` are the platform level providers for the current render request.
  *
- * If compiling with the ViewEngine renderer, do not use this in a production server environment.
- * Use pre-compiled {@link NgModuleFactory} with {@link renderModuleFactory} instead. If
- * compiling with the Ivy renderer, this method is the recommended rendering method for
- * platform-server.
- *
  * @publicApi
  */
 export function renderModule<T>(
@@ -115,6 +110,10 @@ export function renderModule<T>(
  * `extraProviders` are the platform level providers for the current render request.
  *
  * @publicApi
+ *
+ * @deprecated
+ * This symbol is no longer necessary as of Angular v13.
+ * Use {@link renderModule} API instead.
  */
 export function renderModuleFactory<T>(
     moduleFactory: NgModuleFactory<T>,


### PR DESCRIPTION


DEPRECATED:

The `renderModuleFactory` symbol in `@angular/platform-server` is no longer necessary as of Angular v13.

The `renderModuleFactory` calls can be replaced with `renderModule`.