### PR TITLE
feat(bazel): allow for custom conditions to be set in `ng_package` targets

### DIFF
--- a/packages/bazel/test/ng_package/example/BUILD.bazel
+++ b/packages/bazel/test/ng_package/example/BUILD.bazel
@@ -15,6 +15,7 @@ ng_module(
 ng_package(
     name = "npm_package",
     srcs = [
+        "_index.scss",
         "package.json",
         "some-file.txt",
     ],

--- a/packages/bazel/test/ng_package/example/_index.scss
+++ b/packages/bazel/test/ng_package/example/_index.scss
@@ -1,0 +1,1 @@
+/// test file which should ship as part of the NPM package.

--- a/packages/bazel/test/ng_package/example/package.json
+++ b/packages/bazel/test/ng_package/example/package.json
@@ -1,4 +1,9 @@
 {
   "name": "example",
-  "version": "0.0.0-PLACEHOLDER"
+  "version": "0.0.0-PLACEHOLDER",
+  "exports": {
+    ".": {
+      "sass": "./_index.scss"
+    }
+  }
 }

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -1,4 +1,5 @@
 README.md
+_index.scss
 a11y
   a11y/a11y.d.ts
   a11y/package.json
@@ -61,6 +62,11 @@ The sources for this package are in the main [Angular](https://github.com/angula
 Usage information and reference details can be found in [Angular documentation](https://angular.io/docs).
 
 License: MIT
+
+
+--- _index.scss ---
+
+/// test file which should ship as part of the NPM package.
 
 
 --- a11y/a11y.d.ts ---
@@ -773,24 +779,18 @@ export { }
 {
   "name": "example",
   "version": "0.0.0",
-  "fesm2020": "./fesm2020/waffels.mjs",
-  "fesm2015": "./fesm2015/waffels.mjs",
-  "esm2020": "./esm2020/example.mjs",
-  "typings": "./example.d.ts",
-  "module": "./fesm2015/waffels.mjs",
-  "es2020": "./fesm2020/waffels.mjs",
-  "type": "module",
   "exports": {
-    "./package.json": {
-      "default": "./package.json"
-    },
     ".": {
+      "sass": "./_index.scss",
       "types": "./example.d.ts",
       "esm2020": "./esm2020/example.mjs",
       "es2020": "./fesm2020/waffels.mjs",
       "es2015": "./fesm2015/waffels.mjs",
       "node": "./fesm2015/waffels.mjs",
       "default": "./fesm2020/waffels.mjs"
+    },
+    "./package.json": {
+      "default": "./package.json"
     },
     "./a11y": {
       "types": "./a11y/a11y.d.ts",
@@ -816,7 +816,14 @@ export { }
       "node": "./fesm2015/secondary.mjs",
       "default": "./fesm2020/secondary.mjs"
     }
-  }
+  },
+  "fesm2020": "./fesm2020/waffels.mjs",
+  "fesm2015": "./fesm2015/waffels.mjs",
+  "esm2020": "./esm2020/example.mjs",
+  "typings": "./example.d.ts",
+  "module": "./fesm2015/waffels.mjs",
+  "es2020": "./fesm2020/waffels.mjs",
+  "type": "module"
 }
 
 --- secondary/package.json ---


### PR DESCRIPTION
The APF v13 `ng_package` rule will generate the `exports` field if not
set. Currently it allows for additional subpath entries to be configured
manually. The packager does not allow for custom conditions in subpath
exports which are auto-generated though.

This is sometimes useful and necessary though. e.g. in Angular Material,
we also need to expose the index Sass file through a `sass` conditional
that the Webpack Sass loader will pick up. For this, the packager needs
to support manual additional conditions (as long as they do not
conflict).


**Note**: This should not fall under a feature for `feature-freeze` since this is
internal code only necessary for our own tooling across Angular.