### PR TITLE
docs: add missing declaration of `CartComponent` in tutorial

### DIFF
--- a/aio/content/examples/getting-started/src/app/app.module.ts
+++ b/aio/content/examples/getting-started/src/app/app.module.ts
@@ -14,13 +14,15 @@ import { ProductListComponent } from './product-list/product-list.component';
 import { ProductAlertsComponent } from './product-alerts/product-alerts.component';
 // #enddocregion declare-product-alerts
 import { ProductDetailsComponent } from './product-details/product-details.component';
+// #docregion declare-cart
 import { CartComponent } from './cart/cart.component';
+// #enddocregion declare-cart
 import { ShippingComponent } from './shipping/shipping.component';
 
-// #docregion product-details-route, http-client-module, shipping-route, cart-route, declare-product-alerts
+// #docregion product-details-route, http-client-module, shipping-route, cart-route, declare-product-alerts, declare-cart
 
 @NgModule({
-  // #enddocregion declare-product-alerts
+  // #enddocregion declare-product-alerts, declare-cart
   imports: [
     BrowserModule,
     // #enddocregion product-details-route, cart-route
@@ -39,7 +41,7 @@ import { ShippingComponent } from './shipping/shipping.component';
     ])
   ],
   // #enddocregion cart-route
-  // #docregion declare-product-alerts
+  // #docregion declare-product-alerts, declare-cart
   declarations: [
     AppComponent,
     TopBarComponent,
@@ -49,11 +51,12 @@ import { ShippingComponent } from './shipping/shipping.component';
     ProductDetailsComponent,
     // #enddocregion product-details-route
     CartComponent,
+    // #enddocregion declare-cart
 // #enddocregion http-client-module
     ShippingComponent
-  // #docregion declare-product-alerts, http-client-module, product-details-route
+  // #docregion declare-product-alerts, http-client-module, product-details-route, declare-cart
   ],
-  // #enddocregion declare-product-alerts, product-details-route
+  // #enddocregion declare-product-alerts, product-details-route, declare-cart
   bootstrap: [
     AppComponent
   ]

--- a/aio/content/start/start-data.md
+++ b/aio/content/start/start-data.md
@@ -105,7 +105,12 @@ For customers to see their cart, you can create the cart view in two steps:
 
     StackBlitz also generates an `ngOnInit()` by default in components.  You can ignore the `CartComponent` `ngOnInit()` for this tutorial.
 
-1. Open `app.module.ts` and add a route for the component `CartComponent`, with a `path` of `cart`.
+1. Ensure that the newly created `CartComponent` is added to the module's `declarations` in `app.module.ts`.
+
+    <code-example header="src/app/app.module.ts" path="getting-started/src/app/app.module.ts" region="declare-cart">
+    </code-example>
+
+1. Still in `app.module.ts`, add a route for the component `CartComponent`, with a `path` of `cart`.
 
     <code-example header="src/app/app.module.ts" path="getting-started/src/app/app.module.ts" region="cart-route">
     </code-example>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] [N/A] Tests for the changes have been added (for bug fixes / features)
- [ ] [N/A] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

In the "Getting Started" tutorial, in the "Managing Data" chapter, in the ["Set up the cart component" section](https://angular.io/start/start-data#set-up-the-cart-component), the user is instructed to create a `cart` component and add a `/cart` route to this component.

The [Getting Started](https://angular.io/start) tutorial uses [StackBlitz](https://stackblitz.com/), and when adding a component through **Right-click** (on the `app` folder) > **Angular Generator** > **Component** in StackBlitz, the new component is **not** automatically declared in the module.

This might be a bug on StackBlitz's end, but I think that asking the user to explicitly ensure the component is added to the `declarations` array of the `@NgModule` would prevent them from getting stuck with errors which source is not immediately clear for newcomers.



## What is the new behavior?

A step is added in ["Set up the cart component"](https://angular.io/start/start-data#set-up-the-cart-component), to instruct the user to ensure that the `CartComponent` component is present in the module's `declarations`.

```typescript
@NgModule({
  declarations: [
    ...
    CartComponent,
    ...
  ],
})
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
