### PR TITLE
docs(animations): fix wrong code links present in the animations guide

### DIFF
--- a/aio/content/guide/animations.md
+++ b/aio/content/guide/animations.md
@@ -263,7 +263,7 @@ What it does
 </tr>
 
 <tr>
-<td><code>[state](api/animations/state)()</code></td>
+<td><code><a href="api/animations/state" class="code-anchor">state</a>()</code></td>
 <td>Creates a named set of CSS styles that should be applied on successful transition to a given state. The state can then be referenced by name within other animation functions.</td>
 </tr>
 
@@ -283,7 +283,7 @@ What it does
 </tr>
 
 <tr>
-<td><code>[group](api/animations/group)()</code></td>
+<td><code><a href="api/animations/group" class="code-anchor">group</a>()</code></td>
 <td>Specifies a group of animation steps (<em>inner animations</em>) to be run in parallel. Animation continues only after all inner animation steps have completed. Used within <code>sequence()</code> or <code>transition()</code>.</td>
 </tr>
 


### PR DESCRIPTION
fix the links present in the animations guide under td elements written as
`<code>[text](link)()</code>` which are not rendered properly

Note:
  - the bug was introduced in PR #42885
  - the bug seems to be only present for code blocks inside a td element,
    the aforementioned format can be used in the normal sections without issues

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Some links in the aio animation guides are rendered incorrectly:
![Screenshot at 2021-10-09 13-54-51](https://user-images.githubusercontent.com/61631103/136658667-c180e6a6-e12d-4572-8606-6d69998f1c2b.png)


Issue Number: N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

@gkalpak sorry I missed this [here](https://github.com/angular/angular/pull/42885#discussion_r716716518) :sob:  :sob:  :sob:

Strangely as I mentioned in the commit this only applies for such `code`s in `td` elements, the other instances seem to be fine