### PR TITLE
20114 reuse route strategy children fix

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -42,7 +42,7 @@
     "master": {
       "uncompressed": {
         "runtime": 2843,
-        "main": 238453,
+        "main": 237895,
         "polyfills": 37064,
         "src_app_lazy_lazy_module_ts": 795
       }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -942,9 +942,6 @@
     "name": "advanceActivatedRoute"
   },
   {
-    "name": "advanceActivatedRouteNodeAndItsChildren"
-  },
-  {
     "name": "allocExpando"
   },
   {
@@ -1921,9 +1918,6 @@
   },
   {
     "name": "setDirectiveInputsWhichShadowsStyling"
-  },
-  {
-    "name": "setFutureSnapshotsOfActivatedRoutes"
   },
   {
     "name": "setIncludeViewProviders"

--- a/packages/router/src/create_router_state.ts
+++ b/packages/router/src/create_router_state.ts
@@ -34,7 +34,8 @@ function createNode(
       const detachedRouteHandle = routeReuseStrategy.retrieve(curr.value);
       if (detachedRouteHandle !== null) {
         const tree = (detachedRouteHandle as DetachedRouteHandleInternal).route;
-        setFutureSnapshotsOfActivatedRoutes(curr, tree);
+        tree.value._futureSnapshot = curr.value;
+        tree.children = curr.children.map(c => createNode(routeReuseStrategy, c));
         return tree;
       }
     }
@@ -42,20 +43,6 @@ function createNode(
     const value = createActivatedRoute(curr.value);
     const children = curr.children.map(c => createNode(routeReuseStrategy, c));
     return new TreeNode<ActivatedRoute>(value, children);
-  }
-}
-
-function setFutureSnapshotsOfActivatedRoutes(
-    curr: TreeNode<ActivatedRouteSnapshot>, result: TreeNode<ActivatedRoute>): void {
-  if (curr.value.routeConfig !== result.value.routeConfig) {
-    throw new Error('Cannot reattach ActivatedRouteSnapshot created from a different route');
-  }
-  if (curr.children.length !== result.children.length) {
-    throw new Error('Cannot reattach ActivatedRouteSnapshot with a different number of children');
-  }
-  result.value._futureSnapshot = curr.value;
-  for (let i = 0; i < curr.children.length; ++i) {
-    setFutureSnapshotsOfActivatedRoutes(curr.children[i], result.children[i]);
   }
 }
 

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -99,6 +99,13 @@ export class ActivateRoutes {
   private detachAndStoreRouteSubtree(
       route: TreeNode<ActivatedRoute>, parentContexts: ChildrenOutletContexts): void {
     const context = parentContexts.getContext(route.value.outlet);
+    const contexts = context && route.value.component ? context.children : parentContexts;
+    const children: {[outletName: string]: TreeNode<ActivatedRoute>} = nodeChildrenAsMap(route);
+
+    for (const childOutlet of Object.keys(children)) {
+      this.deactivateRouteAndItsChildren(children[childOutlet], contexts);
+    }
+
     if (context && context.outlet) {
       const componentRef = context.outlet.detach();
       const contexts = context.children.onOutletDeactivated();
@@ -179,7 +186,9 @@ export class ActivateRoutes {
             // Otherwise attach from `RouterOutlet.ngOnInit` when it is instantiated
             context.outlet.attach(stored.componentRef, stored.route.value);
           }
-          advanceActivatedRouteNodeAndItsChildren(stored.route);
+
+          advanceActivatedRoute(stored.route.value);
+          this.activateChildRoutes(futureNode, null, context.children);
         } else {
           const config = parentLoadedConfig(future.snapshot);
           const cmpFactoryResolver = config ? config.module.componentFactoryResolver : null;
@@ -201,11 +210,6 @@ export class ActivateRoutes {
       }
     }
   }
-}
-
-function advanceActivatedRouteNodeAndItsChildren(node: TreeNode<ActivatedRoute>): void {
-  advanceActivatedRoute(node.value);
-  node.children.forEach(advanceActivatedRouteNodeAndItsChildren);
 }
 
 function parentLoadedConfig(snapshot: ActivatedRouteSnapshot): LoadedRouterConfig|null {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, it's impossible to cache (detach/attach) parent route without caching child routes. This produces a bug, when navigating from `a/b` to `c`, then to `a/d`, where `a` route is cached. On the last navigation, we incorrectly restore `a/b` route instead of `a/d`.

Issue Number: https://github.com/angular/angular/issues/17333


## What is the new behavior?

If the route should be detached/attached, we do so, but we check also child routes recursively.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The behaviour described above will probably break some user defined `ReuseRouteStrategies` if it does involve child routes caching (detaching/attaching). If we don't want to introduce such a breaking change, I think it should be a part of the new `ReuseRouteStrategy` (https://github.com/angular/angular/issues/27290).

## Other information
