### PR TITLE
docs: update config path in per user tracking section

### DIFF
--- a/aio/content/cli/usage-analytics-gathering.md
+++ b/aio/content/cli/usage-analytics-gathering.md
@@ -36,11 +36,11 @@ You can add a custom user ID to the global configuration, in order to identify u
 If that user enables CLI analytics for their own project, your analytics display tracks and labels their individual usage.
 
 <code-example language="sh">
-ng config --global cli.analyticsSharing.user SOME_USER_NAME
+ng config --global cli.analyticsSharing.uuid SOME_USER_NAME
 </code-example>
 
 To generate a new random user ID, run the following command:
 
 <code-example language="sh">
-ng config --global cli.analyticsSharing.user ""
+ng config --global cli.analyticsSharing.uuid ""
 </code-example>

--- a/aio/content/cli/usage-analytics-gathering.md
+++ b/aio/content/cli/usage-analytics-gathering.md
@@ -27,7 +27,7 @@ ng config --global cli.analyticsSharing.tracking UA-123456-12
 To turn off this feature, run the following command:
 
 <code-example language="sh">
-ng config --global --remove cli.analyticsSharing
+ng config --global cli.analyticsSharing undefined
 </code-example>
 
 ## Per user tracking


### PR DESCRIPTION

`cli.analyticsSharing.user` is not a valid config path. `cli.analyticsSharing.uuid` is the correct one.

Partially addresses https://github.com/angular/angular-cli/issues/21916
