### PR TITLE
docs: update CHANGELOG.md readme to include entry separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ libraries are used that are still using `WrappedValue`. The usage of
 ## Special Thanks
 Daniel Díaz, George Kalpakas, JoostK, Paul Gschwendtner, Pete Bacon Darwin, dario-piotrowicz, little-pinecone and xiaohanxu-nick
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="13.0.0-next.9"></a>
 # 13.0.0-next.9 (2021-09-30)
@@ -205,6 +206,7 @@ parameter, as an argument for that parameter can no longer be created.
 ## Special Thanks
 Adrien Crivelli, Alex Rickabaugh, Andrew Kushnir, Andrew Scott, Bobby Galli, Charles Lyding, Chris, Daniel Díaz, Dmitrij Kuba, Doug Parker, JoostK, Kristiyan Kostadinov, Pete Bacon Darwin, Rafael Santana, Raj Sekhar, Ricardo Chavarria, Teri Glover, dario-piotrowicz, enisfr and wszgrcy
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.8"></a>
 # 12.2.8 (2021-09-30)
@@ -227,6 +229,7 @@ Adrien Crivelli, Alex Rickabaugh, Andrew Kushnir, Andrew Scott, Bobby Galli, Cha
 ## Special Thanks
 Adrien Crivelli, Alex Rickabaugh, Andrew Scott, Bobby Galli, Chris, Daniel Díaz, Dario Piotrowicz, George Kalpakas, Joe Martin (Crowdstaffing), JoostK, Pete Bacon Darwin, Rafael Santana, Raj Sekhar, Ricardo Chavarria, Teri Glover, Virginia Dooley, dario-piotrowicz, enisfr and wszgrcy
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="13.0.0-next.8"></a>
 # 13.0.0-next.8 (2021-09-27)
@@ -245,6 +248,7 @@ Adrien Crivelli, Alex Rickabaugh, Andrew Scott, Bobby Galli, Chris, Daniel Díaz
 ## Special Thanks
 Alan Agius, Daniel Díaz, Dario Piotrowicz, George Kalpakas, Joe Martin (Crowdstaffing), Kristiyan Kostadinov, Teri Glover, Virginia Dooley and iRealNirmal
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="13.0.0-next.7"></a>
 # 13.0.0-next.7 (2021-09-22)
@@ -289,6 +293,7 @@ triggered.
 ## Special Thanks
 Andrew Scott, Daniel Díaz, George Kalpakas, Jessica Janiuk, JoostK, Kristiyan Kostadinov, Mwiku, Pei Wang, Pete Bacon Darwin, Teri Glover, Virginia Dooley, Xiaohanxu1996, dario-piotrowicz and kirjs
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.7"></a>
 # 12.2.7 (2021-09-22)
@@ -311,6 +316,7 @@ Andrew Scott, Daniel Díaz, George Kalpakas, Jessica Janiuk, JoostK, Kristiyan K
 ## Special Thanks
 Andrew Scott, Daniel Díaz, George Kalpakas, JoostK, Kristiyan Kostadinov, Mwiku, Pete Bacon Darwin, Teri Glover, Virginia Dooley, Xiaohanxu1996, dario-piotrowicz and kirjs
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="13.0.0-next.6"></a>
 # 13.0.0-next.6 (2021-09-15)
@@ -335,6 +341,7 @@ Andrew Scott, Daniel Díaz, George Kalpakas, JoostK, Kristiyan Kostadinov, Mwiku
 ## Special Thanks
 Alan Agius, Amadou Sall, Andrew Kushnir, Andrew Scott, Aristeidis Bampakos, Bjarki, Charles Lyding, David Shevitz, George Kalpakas, Joe Martin (Crowdstaffing), Michele Stieven, Naveed Ahmed, Pei Wang, dario-piotrowicz, mezhik91 and mgechev
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.6"></a>
 # 12.2.6 (2021-09-15)
@@ -357,6 +364,7 @@ Alan Agius, Amadou Sall, Andrew Kushnir, Andrew Scott, Aristeidis Bampakos, Bjar
 ## Special Thanks
 Alan Agius, Amadou Sall, Andrew Kushnir, Andrew Scott, Aristeidis Bampakos, Bjarki, David Shevitz, George Kalpakas, Joe Martin (Crowdstaffing), Michele Stieven, Naveed Ahmed, dario-piotrowicz, mezhik91 and mgechev
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="13.0.0-next.5"></a>
 # 13.0.0-next.5 (2021-09-08)
@@ -391,6 +399,7 @@ simulate browser URL changes should be evaluated on a case-by-case basis.
 ## Special Thanks
 Ahmed Ayed, Alan Agius, Andrew Scott, Charles Barnes, Enea Jahollari, George Kalpakas, Ikko Ashimine, Paul Gschwendtner, Pete Bacon Darwin, William Sedlacek, dario-piotrowicz and ivanwonder
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.5"></a>
 # 12.2.5 (2021-09-08)
@@ -401,6 +410,7 @@ Ahmed Ayed, Alan Agius, Andrew Scott, Charles Barnes, Enea Jahollari, George Kal
 ## Special Thanks:
 Alan Agius, Charles Barnes, Enea Jahollari, George Kalpakas, Ikko Ashimine, Paul Gschwendtner, Pete Bacon Darwin, William Sedlacek and dario-piotrowicz
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="13.0.0-next.4"></a>
 # 13.0.0-next.4 (2021-09-01)
@@ -415,6 +425,7 @@ Alan Agius, Charles Barnes, Enea Jahollari, George Kalpakas, Ikko Ashimine, Paul
 ## Special Thanks:
 Alan Agius, Andrew Scott, Daniel Trevino, George Kalpakas, Jessica Janiuk, Joey Perrott, JoostK, Kristiyan Kostadinov, anandtiwary, nickreid and segunb
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.4"></a>
 # 12.2.4 (2021-09-01)
@@ -425,6 +436,7 @@ Alan Agius, Andrew Scott, Daniel Trevino, George Kalpakas, Jessica Janiuk, Joey 
 ## Special Thanks:
 Andrew Scott, Daniel Trevino, George Kalpakas, Joey Perrott, Kristiyan Kostadinov, nickreid and segunb
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="13.0.0-next.3"></a>
 # 13.0.0-next.3 (2021-08-25)
@@ -461,6 +473,7 @@ rather than the internal value of the `RouterLink` `href` property.
 ## Special Thanks:
 Alex Rickabaugh, Andrew Scott, Daniel Trevino, George Kalpakas, Paul Gschwendtner, dario-piotrowicz and shlasouski
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.3"></a>
 # 12.2.3 (2021-08-25)
@@ -471,6 +484,7 @@ Alex Rickabaugh, Andrew Scott, Daniel Trevino, George Kalpakas, Paul Gschwendtne
 ## Special Thanks:
 Daniel Trevino, Erik Slack, George Kalpakas, dario-piotrowicz and shlasouski
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="13.0.0-next.2"></a>
 # 13.0.0-next.2 (2021-08-18)
@@ -497,6 +511,7 @@ Daniel Trevino, Erik Slack, George Kalpakas, dario-piotrowicz and shlasouski
 ## Special Thanks:
 Alan Agius, Andrew Scott, Aristeidis Bampakos, Charles Lyding, Dylan Hunn, Edoardo Dusi, Erik Slack, George Kalpakas, Joe Martin (Crowdstaffing), Joey Perrott, Kirk Larkin, Kristiyan Kostadinov, Paul Gschwendtner, Pete Bacon Darwin, TIffany Davis, Theoklitos Bampouris, ali, dario-piotrowicz, ivanwonder and pichuser
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.2"></a>
 # 12.2.2 (2021-08-18)
@@ -519,6 +534,7 @@ Alan Agius, Andrew Scott, Aristeidis Bampakos, Charles Lyding, Dylan Hunn, Edoar
 ## Special Thanks:
 Andrew Scott, Aristeidis Bampakos, Charles Lyding, Edoardo Dusi, George Kalpakas, Joe Martin (Crowdstaffing), Joey Perrott, Kirk Larkin, Kristiyan Kostadinov, Pete Bacon Darwin, TIffany Davis, Theoklitos Bampouris, ali, dario-piotrowicz and pichuser
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="13.0.0-next.1"></a>
 # 13.0.0-next.1 (2021-08-11)
@@ -545,6 +561,7 @@ above example to be `{v: 'hello?', other: '123'}`.
 ## Special Thanks:
 Amadou Sall, Andrew Kushnir, Andrew Scott, Daniel Trevino, Dylan Hunn, Erik Slack, Fabien BERNARD, George Kalpakas, Jeroen van Warmerdam, Joey Perrott, Jon Rimmer, Tim Gates and Vugar_Abdullayev
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.1"></a>
 # 12.2.1 (2021-08-11)
@@ -555,6 +572,7 @@ Amadou Sall, Andrew Kushnir, Andrew Scott, Daniel Trevino, Dylan Hunn, Erik Slac
 ## Special Thanks:
 Amadou Sall, Andrew Kushnir, Andrew Scott, Daniel Trevino, Erik Slack, Fabien BERNARD, George Kalpakas, Jeroen van Warmerdam, Joey Perrott, Tim Gates and Vugar_Abdullayev
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="13.0.0-next.0"></a>
 # 13.0.0-next.0 (2021-08-04)
@@ -586,6 +604,7 @@ Amadou Sall, Andrew Kushnir, Andrew Scott, Daniel Trevino, Erik Slack, Fabien BE
 ## Special Thanks:
 Alex Rickabaugh, Andrew Kushnir, Andrew Scott, Daniel Trevino, Dmitrij Kuba, Dylan Hunn, George Kalpakas, Joe Martin, Joey Perrott, JoostK, Kristiyan Kostadinov, Nichola Alkhouri, Paul Gschwendtner, Pete Bacon Darwin, Steven Masala, Teri Glover, Vladyslav, Yuvaraj, atscott, codebriefcase, dario-piotrowicz, iRealNirmal and ivanwonder
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.0"></a>
 # 12.2.0 (2021-08-04)
@@ -600,11 +619,13 @@ Alex Rickabaugh, Andrew Kushnir, Andrew Scott, Daniel Trevino, Dmitrij Kuba, Dyl
 ## Special Thanks:
 Alex Rickabaugh, Joe Martin, Joey Perrott, Kristiyan Kostadinov, Nichola Alkhouri, Paul Gschwendtner, Pete Bacon Darwin, atscott, dario-piotrowicz and ivanwonder
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.1.5"></a>
 # 12.1.5 (2021-08-04)
 This release contains various API docs improvements.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.0-rc.0"></a>
 # 12.2.0-rc.0 (2021-07-28)
@@ -634,6 +655,7 @@ This release contains various API docs improvements.
 ## Special Thanks:
 Andrew Scott, Daniel Trevino, Dmitrij Kuba, Dylan Hunn, George Kalpakas, Joey Perrott, JoostK, Paul Gschwendtner, Pete Bacon Darwin, Steven Masala, Teri Glover, Vladyslav, Yuvaraj, codebriefcase, iRealNirmal and ivanwonder
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.1.4"></a>
 # 12.1.4 (2021-07-28)
@@ -648,6 +670,8 @@ Andrew Scott, Daniel Trevino, Dmitrij Kuba, Dylan Hunn, George Kalpakas, Joey Pe
 | [a779a1029b](https://github.com/angular/angular/commit/a779a1029b90039ea39d579ecbc98812c301080a) | fix(core): correctly handle `null` or `undefined` in `ErrorHandler#handleError()` ([#42881](https://github.com/angular/angular/pull/42881)) |
 ## Special Thanks:
 Andrew Scott, Daniel Trevino, Dylan Hunn, George Kalpakas, Joey Perrott, JoostK, Paul Gschwendtner, Pete Bacon Darwin, Teri Glover, Vladyslav, Yuvaraj and codebriefcase
+
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.0-next.3"></a>
 # 12.2.0-next.3 (2021-07-21)
@@ -667,6 +691,8 @@ Andrew Scott, Daniel Trevino, Dylan Hunn, George Kalpakas, Joey Perrott, JoostK,
 ## Special Thanks:
 Alan Agius, Alex Rickabaugh, David Shevitz, George Kalpakas, Joey Perrott, JoostK, Krzysztof Kotowicz, Minko Gechev, Paul Gschwendtner and dario-piotrowicz
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="12.1.3"></a>
 # 12.1.3 (2021-07-21)
 ### animations
@@ -685,6 +711,7 @@ Alan Agius, Alex Rickabaugh, David Shevitz, George Kalpakas, Joey Perrott, Joost
 ## Special Thanks:
 Alan Agius, David Shevitz, George Kalpakas, Joey Perrott, JoostK, Krzysztof Kotowicz, Minko Gechev, Paul Gschwendtner and dario-piotrowicz
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.0-next.2"></a>
 # 12.2.0-next.2 (2021-07-14)
@@ -727,6 +754,7 @@ Alan Agius, David Shevitz, George Kalpakas, Joey Perrott, JoostK, Krzysztof Koto
 ## Special Thanks:
 Alan Agius, Andrew Kushnir, Andrew Scott, Arthur Ming, Bastian, Borislav Ivanov, Daniel Trevino, David Gilson, David Shevitz, Gabriele Franchitto, George Kalpakas, Joey Perrott, JoostK, Kristiyan Kostadinov, Mark Goho, Meir Blumenfeld, Paul Gschwendtner, Pete Bacon Darwin, Ryan Andersen, Theoklitos Bampouris, behrooz bozorg chami, dario-piotrowicz, ivanwonder and mgechev
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.1.2"></a>
 # 12.1.2 (2021-07-14)
@@ -768,6 +796,7 @@ Alan Agius, Andrew Kushnir, Andrew Scott, Arthur Ming, Bastian, Borislav Ivanov,
 ## Special Thanks:
 Alan Agius, Andrew Kushnir, Andrew Scott, Arthur Ming, Bastian, Borislav Ivanov, David Gilson, David Shevitz, Gabriele Franchitto, George Kalpakas, Joey Perrott, JoostK, Kristiyan Kostadinov, Mark Goho, Meir Blumenfeld, Paul Gschwendtner, Pete Bacon Darwin, Ryan Andersen, Theoklitos Bampouris, behrooz bozorg chami, dario-piotrowicz, ivanwonder and mgechev
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.0-next.1"></a>
 # 12.2.0-next.1 (2021-06-30)
@@ -786,6 +815,7 @@ Alan Agius, Andrew Kushnir, Andrew Scott, Arthur Ming, Bastian, Borislav Ivanov,
 ## Special Thanks:
 Alan Agius, Alex Rickabaugh, Dario Piotrowicz, George Kalpakas, George Looshch, Joey Perrott, Kristiyan Kostadinov, Lars Gyrup Brink Nielsen, Paul Gschwendtner, Pete Bacon Darwin, Zach Arend, codebriefcase, dario-piotrowicz, marvinbeckert, mgechev and pavlenko
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.1.1"></a>
 # 12.1.1 (2021-06-30)
@@ -800,12 +830,14 @@ Alan Agius, Alex Rickabaugh, Dario Piotrowicz, George Kalpakas, George Looshch, 
 ## Special Thanks:
 Alan Agius, Dario Piotrowicz, George Kalpakas, George Looshch, Lars Gyrup Brink Nielsen, Paul Gschwendtner, Pete Bacon Darwin, Zach Arend, codebriefcase, dario-piotrowicz, marvinbeckert, mgechev and pavlenko
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.0-next.0"></a>
 # 12.2.0-next.0 (2021-06-24)
 
 This release contains the same set of changes as 12.1.0.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.1.0"></a>
 # 12.1.0 (2021-06-24)
@@ -842,6 +874,8 @@ This release contains the same set of changes as 12.1.0.
 ## Special Thanks:
 Alex Rickabaugh, Dale Harris, George Kalpakas, Joey Perrott, JoostK, Kristiyan Kostadinov, Németh Tamás, Paul Gschwendtner, Pete Bacon Darwin, Renovate Bot, Umair Hafeez, codingnuclei and mgechev
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="12.1.0-next.6"></a>
 # 12.1.0-next.6 (2021-06-16)
 ### compiler
@@ -868,6 +902,7 @@ Alex Rickabaugh, Dale Harris, George Kalpakas, Joey Perrott, JoostK, Kristiyan K
 ## Special Thanks:
 Ahmed Ayed, Alan Agius, Alex Rickabaugh, Andrew Scott, Ankit Choudhary, Aristeidis Bampakos, Daniel Trevino, Dario Piotrowicz, Dylan Hunn, George Kalpakas, Igor Minar, JiaLiPassion, JoostK, Kapunahele Wong, Kristiyan Kostadinov, Marius Bethge, Mladen Jakovljević, Paul Gschwendtner, Pete Bacon Darwin, Pham Huu Hien, Renovate Bot, dario-piotrowicz and gobika21f
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.0.5"></a>
 # 12.0.5 (2021-06-16)
@@ -895,6 +930,7 @@ Ahmed Ayed, Alan Agius, Alex Rickabaugh, Andrew Scott, Ankit Choudhary, Aristeid
 ## Special Thanks:
 Ahmed Ayed, Alan Agius, Andrew Scott, Ankit Choudhary, Aristeidis Bampakos, Daniel Trevino, Dario Piotrowicz, Dylan Hunn, George Kalpakas, Igor Minar, JiaLiPassion, JoostK, Kapunahele Wong, Kristiyan Kostadinov, Marius Bethge, Pete Bacon Darwin, Pham Huu Hien, dario-piotrowicz and gobika21
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.1.0-next.5"></a>
 # 12.1.0-next.5 (2021-06-09)
@@ -933,6 +969,7 @@ Ahmed Ayed, Alan Agius, Andrew Scott, Ankit Choudhary, Aristeidis Bampakos, Dani
 ## Special Thanks:
 Alex, Alex Inkin, Andrew Kushnir, Andrew Scott, Chris, David Shevitz, Dylan Hunn, George Kalpakas, Gourav102, Igor Minar, Jessica Janiuk, Joey Perrott, JoostK, Kapunahele Wong, Kristiyan Kostadinov, MarsiBarsi, MrJithil, Paul Gschwendtner, Pete Bacon Darwin, Renovate Bot, Sam Severance, Santosh Yadav, Teri Glover, Tiago Temporin, Vahid Mohammadi, anups1, cindygk, iRealNirmal, kuncevic and mgechev
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.0.4"></a>
 # 12.0.4 (2021-06-09)
@@ -960,6 +997,7 @@ Alex, Alex Inkin, Andrew Kushnir, Andrew Scott, Chris, David Shevitz, Dylan Hunn
 ## Special Thanks:
 Alex, Alex Inkin, Andrew Kushnir, Andrew Scott, Chris, David Shevitz, George Kalpakas, Gourav102, Igor Minar, Joey Perrott, JoostK, Kapunahele Wong, Kristiyan Kostadinov, MarsiBarsi, MrJithil, Paul Gschwendtner, Pete Bacon Darwin, Sam Severance, Santosh Yadav, Teri Glover, Tiago Temporin, Vahid Mohammadi, anups1, cindygk, iRealNirmal, kuncevic and mgechev
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.1.0-next.4"></a>
 # 12.1.0-next.4 (2021-06-02)
@@ -970,6 +1008,7 @@ Alex, Alex Inkin, Andrew Kushnir, Andrew Scott, Chris, David Shevitz, George Kal
 ## Special Thanks:
 AleksanderBodurri, Alex Rickabaugh, Andrew Kushnir, Andrew Scott, David Pfeiffer, David Shevitz, Doug Parker, Dylan Hunn, George Kalpakas, Igor Minar, Joey Perrott, JoostK, Kristiyan Kostadinov, Renovate Bot, Sam Severance, Serguei Cambour, Suguru Inatomi, Teri Glover, Wagner Maciel, Zach Arend, mgechev and 不肖・高橋
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.0.3"></a>
 # 12.0.3 (2021-06-02)
@@ -980,6 +1019,7 @@ AleksanderBodurri, Alex Rickabaugh, Andrew Kushnir, Andrew Scott, David Pfeiffer
 ## Special Thanks:
 AleksanderBodurri, Alex Rickabaugh, Andrew Kushnir, Andrew Scott, David Pfeiffer, David Shevitz, Doug Parker, Dylan Hunn, George Kalpakas, Igor Minar, Joey Perrott, JoostK, Kristiyan Kostadinov, Sam Severance, Serguei Cambour, Suguru Inatomi, Teri Glover, Wagner Maciel, Zach Arend, mgechev and 不肖・高橋
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.0.2"></a>
 # 12.0.2 (2021-05-26)
@@ -998,6 +1038,8 @@ AleksanderBodurri, Alex Rickabaugh, Andrew Kushnir, Andrew Scott, David Pfeiffer
 ## Special Thanks:
 Alan Agius, Andrew Scott, David Shevitz, George Kalpakas, Igor Minar, Joey Perrott, Kapunahele Wong, Madleina Scheidegger, Paul Gschwendtner, Pete Bacon Darwin, Sam Severance, Teri Glover, Zach Arend, chenyunhsin, iRealNirmal, mgechev and twerske
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="12.1.0-next.3"></a>
 # 12.1.0-next.3 (2021-05-26)
 ### forms
@@ -1015,6 +1057,7 @@ Alan Agius, Andrew Scott, David Shevitz, George Kalpakas, Igor Minar, Joey Perro
 ## Special Thanks:
 Alan Agius, Andrew Scott, David Shevitz, George Kalpakas, Igor Minar, Joey Perrott, Kapunahele Wong, Madleina Scheidegger, Paul Gschwendtner, Pete Bacon Darwin, Renovate Bot, Sam Severance, Teri Glover, Zach Arend, chenyunhsin, iRealNirmal, mgechev and twerske
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.1.0-next.2"></a>
 # 12.1.0-next.2 (2021-05-19)
@@ -1030,6 +1073,7 @@ Alan Agius, Andrew Scott, David Shevitz, George Kalpakas, Igor Minar, Joey Perro
 ## Special Thanks:
 Ajit Singh, Alan Agius, Alan Cohen, Alex Rickabaugh, Amadou Sall, Andrew J Asche, Andrew Kushnir, Andrew Scott, Aristeidis Bampakos, Ben Lesh, Bendik Skarpnes, Benjamin Kindle, Charles Lyding, Chau Tran, Cosmin Ababei, Daniel Díaz, David Shevitz, Dharmen Shah, Dmitrij Kuba, Dylan Hunn, Eduard Bondarenko, Emily Wenberg, Front-end developer, George Kalpakas, Georgii Dolzhykov, Gopal Jayaraman, Gourav102, Gérôme Grignon, Hugo Mejia, Igor Minar, Jesse Palmer, Jessica Janiuk, JiaLiPassion, Joey Perrott, JoostK, Julien Marcou, Kapunahele Wong, Keen Yee Liau, Kirk Larkin, Kristiyan Kostadinov, Lars Gyrup Brink Nielsen, Martin Sikora, Mathias Schäfer, Michael Hladky, Mikhail, Misko Hevery, MrJithil, Nishu Goel, Oluwole Majiyagbe, Paul Gschwendtner, Paul Muriel Biya-Bi, Pete Bacon Darwin, Pierre Portejoie, Richard Sithole, Sagar Pandita, Sam Severance, Sumit Arora, Talha Azhar, Teri Glover, Wojciech Okoński, Zach Arend, Zack DeRose, aschaap, cexbrayat, iRealNirmal, iron, jeripeierSBB, mgechev, nirmal bhagwani, pavlenko, profanis, rachid Oussanaa, sovtara, unknown, va-stefanek and wagnermaciel
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.0.1"></a>
 # 12.0.1 (2021-05-19)
@@ -1052,6 +1096,7 @@ Ajit Singh, Alan Agius, Alan Cohen, Alex Rickabaugh, Amadou Sall, Andrew J Asche
 ## Special Thanks:
 Alex Rickabaugh, Daniel Díaz, David Shevitz, Dylan Hunn, Front-end developer, George Kalpakas, Joey Perrott, Kristiyan Kostadinov, Lars Gyrup Brink Nielsen, MrJithil, Paul Gschwendtner, Renovate Bot, Sam Severance, Sumit Arora, iRealNirmal, iron, mgechev, rachid Oussanaa and wagnermaciel
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.0.0"></a>
 # 12.0.0 (2021-05-12)
@@ -1329,7 +1374,7 @@ Migration path: add null check.
 expanded to allow more fine-tuned control. Code that previously read
 this property may need to be updated to account for the new type.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.2.14"></a>
 # 11.2.14 (2021-05-12)
@@ -1569,7 +1614,7 @@ migrate their message ids using the `localize-migrate` command line tool.
 * **core:** use `ngDevMode` to tree-shake warning ([#40876](https://github.com/angular/angular/issues/40876)) ([c8a2e3a](https://github.com/angular/angular/commit/c8a2e3ae1c12cadd505cdd5a12e26a7231682415))
 * **language-service:** short-circuit LS operations when we know there is no Angular information to provide ([#40946](https://github.com/angular/angular/issues/40946)) ([73a3ff1](https://github.com/angular/angular/commit/73a3ff11cbca21ec0a64e064c7968c93c0bd8e0a))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.2.1"></a>
 ## 11.2.1 (2021-02-17)
@@ -1586,7 +1631,7 @@ migrate their message ids using the `localize-migrate` command line tool.
 * **router:** fix load interaction of navigation and preload strategies ([#40389](https://github.com/angular/angular/issues/40389)) ([4906bf6](https://github.com/angular/angular/commit/4906bf6a50f307fb69080d276c3b91a60ba7fbae)), closes [#26557](https://github.com/angular/angular/issues/26557) [#22842](https://github.com/angular/angular/issues/22842) [#26557](https://github.com/angular/angular/issues/26557) [#26557](https://github.com/angular/angular/issues/26557) [#22842](https://github.com/angular/angular/issues/22842) [#26557](https://github.com/angular/angular/issues/26557)
 * **router:** fix load interaction of navigation and preload strategies ([#40389](https://github.com/angular/angular/issues/40389)) ([bba1981](https://github.com/angular/angular/commit/bba1981c6e1963e5cd1f2c704bb656ca8fcec531)), closes [#26557](https://github.com/angular/angular/issues/26557) [#22842](https://github.com/angular/angular/issues/22842) [#26557](https://github.com/angular/angular/issues/26557) [#26557](https://github.com/angular/angular/issues/26557) [#22842](https://github.com/angular/angular/issues/22842) [#26557](https://github.com/angular/angular/issues/26557)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.2.0"></a>
 # 11.2.0 (2021-02-10)
@@ -1604,13 +1649,14 @@ migrate their message ids using the `localize-migrate` command line tool.
 * **localize:** support downleveled inlined helper localize calls ([#40754](https://github.com/angular/angular/issues/40754)) ([415ad8d](https://github.com/angular/angular/commit/415ad8d)), closes [#40702](https://github.com/angular/angular/issues/40702)
 * **router:** stop emitting to event observable on destroy ([#40638](https://github.com/angular/angular/issues/40638)) ([737bc7a](https://github.com/angular/angular/commit/737bc7a)), closes [#40502](https://github.com/angular/angular/issues/40502)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.2.0-rc.0"></a>
 # 11.2.0-rc.0 (2021-02-03)
 
 This release contains the same set the of changes as 11.2.0-next.1.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.2.0-next.1"></a>
 # 11.2.0-next.1 (2021-02-03)
@@ -1631,6 +1677,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 
 * **language-service:** update NgCompiler via resource-only path when able ([#40585](https://github.com/angular/angular/issues/40585)) ([07a3d7a](https://github.com/angular/angular/commit/07a3d7a))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.1.2"></a>
 ## 11.1.2 (2021-02-03)
@@ -1651,6 +1698,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 
 * **language-service:** update NgCompiler via resource-only path when able ([#40680](https://github.com/angular/angular/issues/40680)) ([0047eb3](https://github.com/angular/angular/commit/0047eb3))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.1.1"></a>
 ## 11.1.1 (2021-01-27)
@@ -1682,7 +1730,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **compiler-cli:** introduce fast path for resource-only updates ([#40561](https://github.com/angular/angular/issues/40561)) ([156103c](https://github.com/angular/angular/commit/156103c))
 * **core:** simplify bloom bucket computation ([#40489](https://github.com/angular/angular/issues/40489)) ([106734a](https://github.com/angular/angular/commit/106734a))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.1.0"></a>
 # 11.1.0 (2021-01-20)
@@ -1798,7 +1846,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **platform-browser:** add doubletap HammerJS support ([#26362](https://github.com/angular/angular/issues/26362)) ([b5c0f9d](https://github.com/angular/angular/commit/b5c0f9d)), closes [#23954](https://github.com/angular/angular/issues/23954)
 * **router:** add `relativeTo` as an input to `routerLink` ([#39720](https://github.com/angular/angular/issues/39720)) ([112324a](https://github.com/angular/angular/commit/112324a)), closes [#13523](https://github.com/angular/angular/issues/13523)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.0.9"></a>
 ## 11.0.9 (2021-01-13)
@@ -1813,7 +1861,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **service-worker:** allow checking for updates when constantly polling the server ([#40234](https://github.com/angular/angular/issues/40234)) ([a7befd5](https://github.com/angular/angular/commit/a7befd5)), closes [#40207](https://github.com/angular/angular/issues/40207)
 * **service-worker:** ensure SW stays alive while notifying clients about unrecoverable state ([#40234](https://github.com/angular/angular/issues/40234)) ([c01b5ea](https://github.com/angular/angular/commit/c01b5ea))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.0.8"></a>
 ## 11.0.8 (2021-01-11)
@@ -1825,7 +1873,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **forms:** handle standalone `<form>` tag correctly in `NgControlStatusGroup` directive ([#40344](https://github.com/angular/angular/issues/40344)) ([b3f322f](https://github.com/angular/angular/commit/b3f322f)), closes [#38391](https://github.com/angular/angular/issues/38391)
 * **router:** Remove usage of `Object.values` to avoid the need for a polyfill ([#40370](https://github.com/angular/angular/issues/40370)) ([c44dd84](https://github.com/angular/angular/commit/c44dd84))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.0.7"></a>
 ## 11.0.7 (2021-01-07)
@@ -1836,7 +1884,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **router:** correctly deactivate children with componentless parent ([#40196](https://github.com/angular/angular/issues/40196)) ([7060ae2](https://github.com/angular/angular/commit/7060ae2)), closes [/github.com/angular/angular/blob/362f45c4bf1bb49a90b014d2053f4c4474d132c0/packages/router/src/operators/activate_routes.ts#L151-L158](https://github.com//github.com/angular/angular/blob/362f45c4bf1bb49a90b014d2053f4c4474d132c0/packages/router/src/operators/activate_routes.ts/issues/L151-L158) [#20694](https://github.com/angular/angular/issues/20694)
 * **router:** Remove usage of `Object.entries` to avoid the need for a polyfill ([#40340](https://github.com/angular/angular/issues/40340)) ([6429be1](https://github.com/angular/angular/commit/6429be1))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.0.6"></a>
 ## 11.0.6 (2021-01-06)
@@ -1856,7 +1904,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **router:** Ensure named outlets with empty path parents are recognized ([#40029](https://github.com/angular/angular/issues/40029)) ([#40315](https://github.com/angular/angular/issues/40315)) ([c722c43](https://github.com/angular/angular/commit/c722c43))
 * **router:** Router should focus element after scrolling ([#40241](https://github.com/angular/angular/issues/40241)) ([a1dcfc5](https://github.com/angular/angular/commit/a1dcfc5)), closes [#30067](https://github.com/angular/angular/issues/30067)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.0.5"></a>
 ## 11.0.5 (2020-12-16)
@@ -1869,7 +1917,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **core:** set `ngDevMode` to `false` when calling `enableProdMode()` ([#40124](https://github.com/angular/angular/issues/40124)) ([922f492](https://github.com/angular/angular/commit/922f492))
 * **upgrade:** fix HMR for hybrid applications ([#40045](https://github.com/angular/angular/issues/40045)) ([c4c7509](https://github.com/angular/angular/commit/c4c7509)), closes [#39935](https://github.com/angular/angular/issues/39935)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.0.4"></a>
 ## 11.0.4 (2020-12-09)
@@ -1897,7 +1945,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **core:** use `ngDevMode` to tree-shake warnings ([#39959](https://github.com/angular/angular/issues/39959)) ([1e3534f](https://github.com/angular/angular/commit/1e3534f))
 * **forms:** use `ngDevMode` to tree-shake `_ngModelWarning` ([#39964](https://github.com/angular/angular/issues/39964)) ([735556d](https://github.com/angular/angular/commit/735556d))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.0.3"></a>
 ## 11.0.3 (2020-12-02)
@@ -1925,7 +1973,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 
 * **forms:** Mark the {[key: string]: any} type for the options property of the FormBuilder.group method as deprecated. Using AbstractControlOptions gives the same functionality and is type-safe.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.0.2"></a>
 ## 11.0.2 (2020-11-19)
@@ -1935,7 +1983,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 
 * **router:** migration incorrectly replacing deprecated key ([#39763](https://github.com/angular/angular/issues/39763)) ([0237845](https://github.com/angular/angular/commit/0237845)), closes [#38762](https://github.com/angular/angular/issues/38762) [#39755](https://github.com/angular/angular/issues/39755)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.0.1"></a>
 ## 11.0.1 (2020-11-18)
@@ -1953,7 +2001,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **compiler:** use raw bytes to represent utf-8 encoded strings ([#39694](https://github.com/angular/angular/issues/39694)) ([882ff8f](https://github.com/angular/angular/commit/882ff8f))
 * **compiler-cli:** reduce filesystem hits during resource resolution ([#39604](https://github.com/angular/angular/issues/39604)) ([a7adcbd](https://github.com/angular/angular/commit/a7adcbd))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="11.0.0"></a>
 # 11.0.0 (2020-11-11)
@@ -2177,8 +2225,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **compiler:** remove support for TypeScript 3.9 ([#39313](https://github.com/angular/angular/issues/39313)) ([736e064](https://github.com/angular/angular/commit/736e0644b02bc4606a7ae0c974d1b06e993708f6))
 * **router:** adjust type of parameter in `navigateByUrl` and `createUrlTree` to be more accurate ([#38227](https://github.com/angular/angular/issues/38227)) ([e4f4d18](https://github.com/angular/angular/commit/e4f4d18)), closes [#18798](https://github.com/angular/angular/issues/18798)
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.2.3"></a>
 ## 10.2.3 (2020-11-09)
@@ -2191,7 +2238,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **compiler-cli:** avoid duplicate diagnostics about unknown pipes ([#39517](https://github.com/angular/angular/issues/39517)) ([861e4fa](https://github.com/angular/angular/commit/861e4fa))
 * **compiler-cli:** do not drop non-Angular decorators when downleveling ([#39577](https://github.com/angular/angular/issues/39577)) ([1c6cf8a](https://github.com/angular/angular/commit/1c6cf8a)), closes [#39574](https://github.com/angular/angular/issues/39574)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.2.2"></a>
 ## 10.2.2 (2020-11-04)
@@ -2208,7 +2255,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 
 * **core:** do not recurse into modules that have already been registered ([#39514](https://github.com/angular/angular/issues/39514)) ([812355c](https://github.com/angular/angular/commit/812355c)), closes [#39487](https://github.com/angular/angular/issues/39487)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.2.1"></a>
 ## 10.2.1 (2020-10-28)
@@ -2222,7 +2269,7 @@ This release contains the same set the of changes as 11.2.0-next.1.
 * **localize:** serialize all the message locations to XLIFF ([#39411](https://github.com/angular/angular/issues/39411)) ([db51de8](https://github.com/angular/angular/commit/db51de8)), closes [#39330](https://github.com/angular/angular/issues/39330)
 * **ngcc:** capture UMD/CommonJS inner class implementation node correctly ([#39346](https://github.com/angular/angular/issues/39346)) ([bdaa714](https://github.com/angular/angular/commit/bdaa714))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.2.0"></a>
 # 10.2.0 (2020-10-21)
@@ -2243,7 +2290,7 @@ because if `useAbsoluteUrl` is set to `true` then the behavior of the
 application could be unpredictable, resulting in issues that are hard to
 discover but could be affecting production environments.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.1.6"></a>
 ## 10.1.6 (2020-10-14)
@@ -2269,7 +2316,7 @@ discover but could be affecting production environments.
 
 * **ngcc:** do not rescan program source files when referenced from multiple root files ([#39254](https://github.com/angular/angular/issues/39254)) ([5221df8](https://github.com/angular/angular/commit/5221df8)), closes [#39240](https://github.com/angular/angular/issues/39240)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.1.5"></a>
 ## 10.1.5 (2020-10-07)
@@ -2280,7 +2327,7 @@ discover but could be affecting production environments.
 * **router:** update getRouteGuards to check if the context outlet is activated ([#39049](https://github.com/angular/angular/issues/39049)) ([771f731](https://github.com/angular/angular/commit/771f731)), closes [#39030](https://github.com/angular/angular/issues/39030)
 * **compiler:** Recover on malformed keyed reads and keyed writes ([#39004](https://github.com/angular/angular/issues/39004)) ([f50313f](https://github.com/angular/angular/commit/f50313f)), closes [#38596](https://github.com/angular/angular/issues/38596)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.1.4"></a>
 ## 10.1.4 (2020-09-30)
@@ -2290,7 +2337,7 @@ discover but could be affecting production environments.
 
 * **compiler-cli:** enable [@types](https://github.com/types) discovery in incremental rebuilds ([#39011](https://github.com/angular/angular/issues/39011)) ([6e99427](https://github.com/angular/angular/commit/6e99427)), closes [#38979](https://github.com/angular/angular/issues/38979)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.1.3"></a>
 ## 10.1.3 (2020-09-23)
@@ -2306,8 +2353,7 @@ discover but could be affecting production environments.
 
 * feat(router): better warning message when a router outlet has not been instantiated ([#38920](https://github.com/angular/angular/issues/38920)) ([04d0aa6](https://github.com/angular/angular/commit/04d0aa6))
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.1.2"></a>
 ## 10.1.2 (2020-09-16)
@@ -2329,7 +2375,7 @@ discover but could be affecting production environments.
 * **ngcc:** introduce cache for sharing data across entry-points ([#38840](https://github.com/angular/angular/issues/38840)) ([58411e7](https://github.com/angular/angular/commit/58411e7))
 * **ngcc:** reduce maximum worker count ([#38840](https://github.com/angular/angular/issues/38840)) ([ea36466](https://github.com/angular/angular/commit/ea36466))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.1.1"></a>
 ## 10.1.1 (2020-09-09)
@@ -2354,7 +2400,7 @@ discover but could be affecting production environments.
 
 * **core:** use `ngDevMode` to tree-shake error messages ([#38612](https://github.com/angular/angular/issues/38612)) ([b084bff](https://github.com/angular/angular/commit/b084bff))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.1.0"></a>
 # 10.1.0 (2020-09-02)
@@ -2427,11 +2473,12 @@ discover but could be affecting production environments.
 * **ngcc:** use `EntryPointManifest` to speed up noop `ProgramBaseEntryPointFinder` ([#37665](https://github.com/angular/angular/issues/37665)) ([9318e23](https://github.com/angular/angular/commit/9318e23))
 * **router:** apply prioritizedGuardValue operator to optimize CanLoad guards ([#37523](https://github.com/angular/angular/issues/37523)) ([d7dd295](https://github.com/angular/angular/commit/d7dd295))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.14"></a>
 ## 10.0.14 (2020-08-26)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.12"></a>
 ## 10.0.12 (2020-08-24)
@@ -2449,6 +2496,7 @@ discover but could be affecting production environments.
 
 * **language-service:** introduce hybrid visitor to locate AST node ([#38540](https://github.com/angular/angular/issues/38540)) ([66d8c22](https://github.com/angular/angular/commit/66d8c22))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.11"></a>
 ## 10.0.11 (2020-08-19)
@@ -2458,7 +2506,7 @@ discover but could be affecting production environments.
 
 * **router:** ensure routerLinkActive updates when associated routerLinks change (resubmit of [#38349](https://github.com/angular/angular/issues/38349)) ([#38511](https://github.com/angular/angular/issues/38511)) ([0af9533](https://github.com/angular/angular/commit/0af9533)), closes [#18469](https://github.com/angular/angular/issues/18469)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.10"></a>
 ## 10.0.10 (2020-08-17)
@@ -2473,7 +2521,7 @@ discover but could be affecting production environments.
 * **ngcc:** detect synthesized delegate constructors for downleveled ES2015 classes ([#38500](https://github.com/angular/angular/issues/38500)) ([f3dd6c2](https://github.com/angular/angular/commit/f3dd6c2)), closes [#38453](https://github.com/angular/angular/issues/38453) [#38453](https://github.com/angular/angular/issues/38453)
 * **router:** ensure routerLinkActive updates when associated routerLinks change ([#38349](https://github.com/angular/angular/issues/38349)) ([989e8a1](https://github.com/angular/angular/commit/989e8a1)), closes [#18469](https://github.com/angular/angular/issues/18469)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.9"></a>
 ## 10.0.9 (2020-08-12)
@@ -2495,6 +2543,7 @@ discover but could be affecting production environments.
 * **router:** prevent calling unsubscribe on undefined subscription in RouterPreloader ([#38344](https://github.com/angular/angular/issues/38344)) ([4151314](https://github.com/angular/angular/commit/4151314))
 * **service-worker:** fix the chrome debugger syntax highlighter ([#38332](https://github.com/angular/angular/issues/38332)) ([f5d5bac](https://github.com/angular/angular/commit/f5d5bac))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.8"></a>
 ## 10.0.8 (2020-08-04)
@@ -2505,7 +2554,7 @@ discover but could be affecting production environments.
 * **compiler:** add PURE annotation to getInheritedFactory calls ([#38291](https://github.com/angular/angular/issues/38291)) ([03d8e31](https://github.com/angular/angular/commit/03d8e31))
 * **compiler:** update unparsable character reference entity error messages ([#38319](https://github.com/angular/angular/issues/38319)) ([cea4678](https://github.com/angular/angular/commit/cea4678)), closes [#26067](https://github.com/angular/angular/issues/26067)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.7"></a>
 ## 10.0.7 (2020-07-30)
@@ -2515,7 +2564,7 @@ discover but could be affecting production environments.
 
 * **compiler:** Metadata should not include methods on Object.prototype ([#38292](https://github.com/angular/angular/issues/38292)) ([879ff08](https://github.com/angular/angular/commit/879ff08))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.6"></a>
 ## 10.0.6 (2020-07-28)
@@ -2528,7 +2577,7 @@ discover but could be affecting production environments.
 * **core:** `Attribute` decorator `attributeName` is mandatory ([#38131](https://github.com/angular/angular/issues/38131)) ([1c4fcce](https://github.com/angular/angular/commit/1c4fcce)), closes [#32658](https://github.com/angular/angular/issues/32658)
 * **core:** unify the signature between ngZone and noopZone ([#37581](https://github.com/angular/angular/issues/37581)) ([d5264f5](https://github.com/angular/angular/commit/d5264f5))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.5"></a>
 ## 10.0.5 (2020-07-22)
@@ -2542,7 +2591,7 @@ discover but could be affecting production environments.
 * **core:** error due to integer overflow when there are too many host bindings ([#38014](https://github.com/angular/angular/issues/38014)) ([7b6e73c](https://github.com/angular/angular/commit/7b6e73c)), closes [#37876](https://github.com/angular/angular/issues/37876) [#37876](https://github.com/angular/angular/issues/37876)
 * **core:** incorrectly validating properties on ng-content and ng-container ([#37773](https://github.com/angular/angular/issues/37773)) ([17ddab9](https://github.com/angular/angular/commit/17ddab9))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.4"></a>
 ## 10.0.4 (2020-07-15)
@@ -2563,6 +2612,7 @@ discover but could be affecting production environments.
 
 * **bazel:** provide LinkablePackageInfo from ng_module ([#37778](https://github.com/angular/angular/issues/37778)) ([6cd10a1](https://github.com/angular/angular/commit/6cd10a1)), closes [/github.com/bazelbuild/rules_nodejs/blob/9a5de3728b05bf1647bbb87ad99f54e626604705/internal/linker/link_node_modules.bzl#L144-L146](https://github.com//github.com/bazelbuild/rules_nodejs/blob/9a5de3728b05bf1647bbb87ad99f54e626604705/internal/linker/link_node_modules.bzl/issues/L144-L146)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.3"></a>
 ## 10.0.3 (2020-07-08)
@@ -2572,7 +2622,7 @@ discover but could be affecting production environments.
 
 * **core:** handle spaces after `select` and `plural` ICU keywords ([#37866](https://github.com/angular/angular/issues/37866)) ([790bb94](https://github.com/angular/angular/commit/790bb94))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.12"></a>
 ## [9.1.12](https://github.com/angular/angular/compare/9.1.11...9.1.12) (2020-07-08)
@@ -2582,7 +2632,7 @@ discover but could be affecting production environments.
 
 * **core:** infinite loop if injectable using inheritance has a custom decorator ([6c1ab47](https://github.com/angular/angular/commit/6c1ab47)), closes [#35733](https://github.com/angular/angular/issues/35733)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.2"></a>
 ## [10.0.2](https://github.com/angular/angular/compare/10.0.1...10.0.2) (2020-06-30)
@@ -2606,7 +2656,7 @@ discover but could be affecting production environments.
 
 * **compiler-cli:** fix memory leak in retained incremental state ([#37835](https://github.com/angular/angular/issues/37835)) ([57a518a](https://github.com/angular/angular/commit/57a518a))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.1"></a>
 ## [10.0.1](https://github.com/angular/angular/compare/10.0.0...10.0.1) (2020-06-26)
@@ -2629,7 +2679,7 @@ discover but could be affecting production environments.
 
 * **compiler-cli:** fix regressions in incremental program reuse ([#37690](https://github.com/angular/angular/issues/37690)) ([96b96fb](https://github.com/angular/angular/commit/96b96fb))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="10.0.0"></a>
 # [10.0.0](https://github.com/angular/angular/compare/10.0.0-rc.6...10.0.0) (2020-06-24)
@@ -2952,8 +3002,7 @@ subscribe to the observable and call markForCheck as needed.
     If you implemented your own Router or Recognizer class, please update it to
     handle matcher returning null.
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.11"></a>
 ## [9.1.11](https://github.com/angular/angular/compare/9.1.10...9.1.11) (2020-06-10)
@@ -2962,6 +3011,7 @@ subscribe to the observable and call markForCheck as needed.
 
 * **elements:** fire custom element output events during component initialization ([dc9da17](https://github.com/angular/angular/commit/dc9da17))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.10"></a>
 ## [9.1.10](https://github.com/angular/angular/compare/9.1.9...9.1.10) (2020-06-09)
@@ -2976,7 +3026,7 @@ subscribe to the observable and call markForCheck as needed.
 
 * **ngcc:** cache parsed tsconfig between runs ([1aae94a](https://github.com/angular/angular/commit/1aae94a)), closes [#37417](https://github.com/angular/angular/issues/37417) [#36882](https://github.com/angular/angular/issues/36882)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.9"></a>
 ## [9.1.9](https://github.com/angular/angular/compare/9.1.8...9.1.9) (2020-05-20)
@@ -2989,7 +3039,7 @@ This release contains a re-submit of the following 3 commits with fixes for TS 3
 * **elements:** correctly handle getting/setting properties before connecting the element ([#36114](https://github.com/angular/angular/issues/36114)) ([#37226](https://github.com/angular/angular/issues/37226)) ([6ac0042](https://github.com/angular/angular/commit/6ac0042)), closes [/github.com/angular/angular/pull/31416/files#r300326698](https://github.com/angular/angular/pull/31416/files/issues/r300326698)
 * **elements:** do not break when the constructor of an Angular Element is not called ([#36114](https://github.com/angular/angular/issues/36114)) ([#37226](https://github.com/angular/angular/issues/37226)) ([1465372](https://github.com/angular/angular/commit/1465372))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.8"></a>
 ## [9.1.8](https://github.com/angular/angular/compare/9.1.6...9.1.8) (2020-05-20)
@@ -3004,12 +3054,14 @@ This release contains a re-submit of the following 3 commits with fixes for TS 3
 * **elements:** do not break when the constructor of an Angular Element is not called ([#36114](https://github.com/angular/angular/issues/36114)) ([87b9f08](https://github.com/angular/angular/commit/87b9f08))
 * **router:** update type for routerLink to include null and undefined ([#37018](https://github.com/angular/angular/issues/37018)) ([7de7871](https://github.com/angular/angular/commit/7de7871)), closes [#13380](https://github.com/angular/angular/issues/13380) [#36544](https://github.com/angular/angular/issues/36544)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.7"></a>
 ## [9.1.7](https://github.com/angular/angular/compare/9.1.6...9.1.7) (2020-05-13)
 
 This release contains various API docs improvements.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.6"></a>
 ## [9.1.6](https://github.com/angular/angular/compare/9.1.5...9.1.6) (2020-05-08)
@@ -3018,7 +3070,7 @@ This release contains various API docs improvements.
 
 * **compiler-cli**: Revert "fix(compiler-cli): fix case-sensitivity issues in NgtscCompilerHost (#36968)" (#37003)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.5"></a>
 ## [9.1.5](https://github.com/angular/angular/compare/9.1.4...9.1.5) (2020-05-07)
@@ -3050,7 +3102,7 @@ This release contains various API docs improvements.
 * **ngcc:** only compute basePaths in TargetedEntryPointFinder when needed ([#36881](https://github.com/angular/angular/issues/36881)) ([5ea51b2](https://github.com/angular/angular/commit/5ea51b2)), closes [#36874](https://github.com/angular/angular/issues/36874)
 * **ngcc:** speed up the `getBasePaths()` computation ([#36881](https://github.com/angular/angular/issues/36881)) ([b6d0e21](https://github.com/angular/angular/commit/b6d0e21))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.4"></a>
 ## [9.1.4](https://github.com/angular/angular/compare/9.1.3...9.1.4) (2020-04-29)
@@ -3064,7 +3116,7 @@ This release contains various API docs improvements.
 * **localize:** include legacy ids when describing messages ([#36761](https://github.com/angular/angular/issues/36761)) ([aa94cd5](https://github.com/angular/angular/commit/aa94cd5))
 * **ngcc:** recognize enum declarations emitted in JavaScript ([#36550](https://github.com/angular/angular/issues/36550)) ([c440165](https://github.com/angular/angular/commit/c440165)), closes [#35584](https://github.com/angular/angular/issues/35584)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.3"></a>
 ## [9.1.3](https://github.com/angular/angular/compare/9.1.2...9.1.3) (2020-04-22)
@@ -3083,7 +3135,7 @@ This release contains various API docs improvements.
 * **ngcc:** display unlocker process output in sync mode ([#36637](https://github.com/angular/angular/issues/36637)) ([da159bd](https://github.com/angular/angular/commit/da159bd)), closes [/github.com/nodejs/node/issues/3596#issuecomment-250890218](https://github.com/nodejs/node/issues/3596/issues/issuecomment-250890218)
 * **ngcc:** do not use cached file-system ([#36687](https://github.com/angular/angular/issues/36687)) ([18be33a](https://github.com/angular/angular/commit/18be33a)), closes [/github.com/angular/angular-cli/issues/16860#issuecomment-614694269](https://github.com/angular/angular-cli/issues/16860/issues/issuecomment-614694269)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.2"></a>
 ## [9.1.2](https://github.com/angular/angular/compare/9.1.1...9.1.2) (2020-04-15)
@@ -3105,6 +3157,7 @@ This release contains various API docs improvements.
 * **ngcc:** only load  if it is needed ([#36486](https://github.com/angular/angular/issues/36486)) ([e06512b](https://github.com/angular/angular/commit/e06512b))                                                                             * **ngcc:** read dependencies from entry-point manifest ([#36486](https://github.com/angular/angular/issues/36486)) ([918e628](https://github.com/angular/angular/commit/918e628)), closes [#issuecomment-608401834](https://github.com/angular/angular/issues/issuecomment-608401834)
 * **ngcc:** reduce the size of the entry-point manifest file ([#36486](https://github.com/angular/angular/issues/36486)) ([603b094](https://github.com/angular/angular/commit/603b094))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.1"></a>
 ## [9.1.1](https://github.com/angular/angular/compare/9.1.0...9.1.1) (2020-04-07)
@@ -3139,6 +3192,7 @@ This release contains various API docs improvements.
 * **platform-server:** update `xhr2` dependency ([#36366](https://github.com/angular/angular/issues/36366)) ([14ae3c0](https://github.com/angular/angular/commit/14ae3c0)), closes [#36358](https://github.com/angular/angular/issues/36358)
 * **router:** state data missing in routerLink ([#36462](https://github.com/angular/angular/issues/36462)) ([0e7a89a](https://github.com/angular/angular/commit/0e7a89a)), closes [#33173](https://github.com/angular/angular/issues/33173)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.1.0"></a>
 # [9.1.0](https://github.com/angular/angular/compare/9.0.0...9.1.0) (2020-03-25)
@@ -3295,6 +3349,8 @@ To learn about the release highlights and our CLI-powered automated update workf
 * **service-worker:** treat 503 as offline ([#35595](https://github.com/angular/angular/issues/35595)) ([96cdf03](https://github.com/angular/angular/commit/96cdf03)), closes [#35571](https://github.com/angular/angular/issues/35571)
 * fix flaky test cases of passive events ([#35679](https://github.com/angular/angular/issues/35679)) ([8ef29b6](https://github.com/angular/angular/commit/8ef29b6))
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="9.0.7"></a>
 ## [9.0.7](https://github.com/angular/angular/compare/9.0.6...9.0.7) (2020-03-18)
 
@@ -3318,7 +3374,7 @@ To learn about the release highlights and our CLI-powered automated update workf
 * **ngcc:** use binary search when flattening mappings ([#36027](https://github.com/angular/angular/issues/36027)) ([8768fc4](https://github.com/angular/angular/commit/8768fc4))
 * **ngcc:** use line start positions for computing offsets in source-map flattening ([#36027](https://github.com/angular/angular/issues/36027)) ([daa2a08](https://github.com/angular/angular/commit/daa2a08))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.0.6"></a>
 ## [9.0.6](https://github.com/angular/angular/compare/9.0.5...9.0.6) (2020-03-10)
@@ -3346,6 +3402,7 @@ To learn about the release highlights and our CLI-powered automated update workf
 
 * **ngcc:** reduce directory traversing ([#35756](https://github.com/angular/angular/issues/35756)) ([2eaf420](https://github.com/angular/angular/commit/2eaf420)), closes [#35717](https://github.com/angular/angular/issues/35717)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.0.5"></a>
 ## [9.0.5](https://github.com/angular/angular/compare/9.0.4...9.0.5) (2020-03-04)
@@ -3383,6 +3440,7 @@ To learn about the release highlights and our CLI-powered automated update workf
 * **ngcc:** only create tasks for non-processed formats ([#35719](https://github.com/angular/angular/issues/35719)) ([#35832](https://github.com/angular/angular/issues/35832)) ([3fdd304](https://github.com/angular/angular/commit/3fdd304))
 * **ngcc:** spawn workers lazily ([#35719](https://github.com/angular/angular/issues/35719)) ([#35832](https://github.com/angular/angular/issues/35832)) ([525dc6a](https://github.com/angular/angular/commit/525dc6a)), closes [#35717](https://github.com/angular/angular/issues/35717)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.0.4"></a>
 ## [9.0.4](https://github.com/angular/angular/compare/9.0.3...9.0.4) (2020-02-27)
@@ -3394,6 +3452,7 @@ To learn about the release highlights and our CLI-powered automated update workf
 * **ngcc:** handle mappings outside the content when flattening source-maps ([#35718](https://github.com/angular/angular/issues/35718)) ([bfe7657](https://github.com/angular/angular/commit/bfe7657)), closes [#35709](https://github.com/angular/angular/issues/35709)
 * **ngcc:** handle missing sources when flattening source-maps ([#35718](https://github.com/angular/angular/issues/35718)) ([7ff845b](https://github.com/angular/angular/commit/7ff845b)), closes [#35709](https://github.com/angular/angular/issues/35709)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.0.3"></a>
 ## [9.0.3](https://github.com/angular/angular/compare/9.0.2...9.0.3) (2020-02-27)
@@ -3440,7 +3499,7 @@ To learn about the release highlights and our CLI-powered automated update workf
 * **core:** avoid recursive scope recalculation when TestBed.overrideModule is used ([#35454](https://github.com/angular/angular/issues/35454)) ([349539e](https://github.com/angular/angular/commit/349539e))
 * **core:** remove unused event argument in listener instructions ([#35097](https://github.com/angular/angular/issues/35097)) ([afc5b3e](https://github.com/angular/angular/commit/afc5b3e))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.0.2"></a>
 ## [9.0.2](https://github.com/angular/angular/compare/9.0.1...9.0.2) (2020-02-19)
@@ -3457,7 +3516,7 @@ To learn about the release highlights and our CLI-powered automated update workf
 * **ivy:** queries should match elements inside ng-container with the descendants: false option ([#35384](https://github.com/angular/angular/issues/35384)) ([fd4ce84](https://github.com/angular/angular/commit/fd4ce84)), closes [#34768](https://github.com/angular/angular/issues/34768)
 * **ivy:** wrong context passed to ngOnDestroy when resolved multiple times ([#35249](https://github.com/angular/angular/issues/35249)) ([0671e54](https://github.com/angular/angular/commit/0671e54)), closes [#35167](https://github.com/angular/angular/issues/35167)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.0.1"></a>
 ## [9.0.1](https://github.com/angular/angular/compare/9.0.0...9.0.1) (2020-02-12)
@@ -3477,7 +3536,7 @@ To learn about the release highlights and our CLI-powered automated update workf
 * **language-service:** Suggest ? and ! operator on nullable receiver ([#35200](https://github.com/angular/angular/issues/35200)) ([3cc24a9](https://github.com/angular/angular/commit/3cc24a9))
 * **ngcc:** ensure that path-mapped secondary entry-points are processed correctly ([#35227](https://github.com/angular/angular/issues/35227)) ([c3c1140](https://github.com/angular/angular/commit/c3c1140)), closes [#35188](https://github.com/angular/angular/issues/35188)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="9.0.0"></a>
 # [9.0.0](https://github.com/angular/angular/compare/8.2.14...9.0.0) (2020-02-06)
@@ -4215,6 +4274,7 @@ If you aren't familiar with Ivy, read our [blog post about the Ivy preview](http
 
 * **core:** TestBed.get function is marked as deprecated, use TestBed.inject instead.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.14"></a>
 ## [8.2.14](https://github.com/angular/angular/compare/8.2.13...8.2.14) (2019-11-13)
@@ -4225,6 +4285,7 @@ If you aren't familiar with Ivy, read our [blog post about the Ivy preview](http
 * **bazel:** exclude [@angular](https://github.com/angular)/cli from metadata build ([b43ae44](https://github.com/angular/angular/commit/b43ae44)), closes [#33502](https://github.com/angular/angular/issues/33502)
 * **service-worker:** ensure initialization before handling messages ([#32525](https://github.com/angular/angular/issues/32525)) ([2840670](https://github.com/angular/angular/commit/2840670)), closes [#25611](https://github.com/angular/angular/issues/25611)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.13"></a>
 ## [8.2.13](https://github.com/angular/angular/compare/8.2.12...8.2.13) (2019-10-30)
@@ -4234,6 +4295,7 @@ If you aren't familiar with Ivy, read our [blog post about the Ivy preview](http
 
 * **compiler:** i18n - ignore `alt-trans` tags in XLIFF 1.2 ([#33464](https://github.com/angular/angular/issues/33464)) ([f97c464](https://github.com/angular/angular/commit/f97c464)), closes [#33161](https://github.com/angular/angular/issues/33161)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.12"></a>
 ## [8.2.12](https://github.com/angular/angular/compare/8.2.11...8.2.12) (2019-10-23)
@@ -4243,6 +4305,7 @@ If you aren't familiar with Ivy, read our [blog post about the Ivy preview](http
 
 * **upgrade:** remove unused version export ([#33180](https://github.com/angular/angular/issues/33180)) ([37cbcfa](https://github.com/angular/angular/commit/37cbcfa))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.11"></a>
 ## [8.2.11](https://github.com/angular/angular/compare/8.2.10...8.2.11) (2019-10-15)
@@ -4252,12 +4315,14 @@ If you aren't familiar with Ivy, read our [blog post about the Ivy preview](http
 
 * **service-worker:** continue serving api requests on cache failure ([#33165](https://github.com/angular/angular/issues/33165)) ([a2716ac](https://github.com/angular/angular/commit/a2716ac)), closes [#32996](https://github.com/angular/angular/issues/32996) [#21412](https://github.com/angular/angular/issues/21412)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.10"></a>
 ## [8.2.10](https://github.com/angular/angular/compare/8.2.9...8.2.10) (2019-10-09)
 
 This release contains various API docs improvements.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.9"></a>
 ## [8.2.9](https://github.com/angular/angular/compare/8.2.8...8.2.9) (2019-10-02)
@@ -4267,12 +4332,14 @@ This release contains various API docs improvements.
 
 * **upgrade:** fix AngularJsUrlCodec to support Safari ([#32959](https://github.com/angular/angular/issues/32959)) ([57457fb](https://github.com/angular/angular/commit/57457fb))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.8"></a>
 ## [8.2.8](https://github.com/angular/angular/compare/8.2.7...8.2.8) (2019-09-25)
 
 This release contains various API docs improvements.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.7"></a>
 ## [8.2.7](https://github.com/angular/angular/compare/8.2.6...8.2.7) (2019-09-18)
@@ -4284,12 +4351,14 @@ This release contains various API docs improvements.
 * **compiler-cli:** fix typo in diagnostic template info. ([#32684](https://github.com/angular/angular/issues/32684)) ([947c076](https://github.com/angular/angular/commit/947c076)), closes [#32662](https://github.com/angular/angular/issues/32662)
 * **language-service:** cache module resolution ([#32483](https://github.com/angular/angular/issues/32483)) ([1c5b157](https://github.com/angular/angular/commit/1c5b157))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.6"></a>
 ## [8.2.6](https://github.com/angular/angular/compare/8.2.5...8.2.6) (2019-09-11)
 
 This release contains various API docs improvements.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.5"></a>
 ## [8.2.5](https://github.com/angular/angular/compare/8.2.4...8.2.5) (2019-09-04)
@@ -4302,12 +4371,14 @@ This release contains various API docs improvements.
 
 * **common:** HttpParams fromObject accepts ReadonlyArray<string> ([#31072](https://github.com/angular/angular/issues/31072)) ([b3ea698](https://github.com/angular/angular/commit/b3ea698)), closes [#28452](https://github.com/angular/angular/issues/28452)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.4"></a>
 ## [8.2.4](https://github.com/angular/angular/compare/8.2.3...8.2.4) (2019-08-28)
 
 This release contains various API docs improvements.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.3"></a>
 ## [8.2.3](https://github.com/angular/angular/compare/8.2.2...8.2.3) (2019-08-21)
@@ -4317,6 +4388,7 @@ This release contains various API docs improvements.
 
 * **bazel:** pin `[@microsoft](https://github.com/microsoft)/api-extractor` ([#32187](https://github.com/angular/angular/issues/32187)) ([a7b9478](https://github.com/angular/angular/commit/a7b9478))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.2"></a>
 ## [8.2.2](https://github.com/angular/angular/compare/8.2.1...8.2.2) (2019-08-12)
@@ -4326,6 +4398,7 @@ This release contains various API docs improvements.
 
 * **bazel:** disable treeshaking when generating FESM and UMD bundles ([#32069](https://github.com/angular/angular/issues/32069)) ([3420d29](https://github.com/angular/angular/commit/3420d29))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.1"></a>
 ## [8.2.1](https://github.com/angular/angular/compare/8.2.0...8.2.1) (2019-08-08)
@@ -4335,6 +4408,7 @@ This release contains various API docs improvements.
 
 * **upgrade:** compile downgraded components synchronously (if possible) ([#31840](https://github.com/angular/angular/issues/31840)) ([04ebd59](https://github.com/angular/angular/commit/04ebd59)), closes [#27217](https://github.com/angular/angular/issues/27217) [#30330](https://github.com/angular/angular/issues/30330)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.2.0"></a>
 # [8.2.0](https://github.com/angular/angular/compare/8.2.0-rc.0...8.2.0) (2019-07-31)
@@ -4370,7 +4444,7 @@ This release contains various API docs improvements.
 * **service-worker:** cache opaque responses in data groups with `freshness` strategy ([#30977](https://github.com/angular/angular/issues/30977)) ([d7be38f](https://github.com/angular/angular/commit/d7be38f)), closes [#30968](https://github.com/angular/angular/issues/30968)
 * **service-worker:** cache opaque responses when requests exceeds timeout threshold ([#30977](https://github.com/angular/angular/issues/30977)) ([93abc35](https://github.com/angular/angular/commit/93abc35))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.1.3"></a>
 ## [8.1.3](https://github.com/angular/angular/compare/8.1.2...8.1.3) (2019-07-26)
@@ -4385,8 +4459,7 @@ This release contains various API docs improvements.
 
 * **compiler:** avoid copying from prototype while cloning an object ([#31638](https://github.com/angular/angular/issues/31638)) ([1f3daa0](https://github.com/angular/angular/commit/1f3daa0)), closes [#31627](https://github.com/angular/angular/issues/31627)
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.1.2"></a>
 ## [8.1.2](https://github.com/angular/angular/compare/8.1.0...8.1.2) (2019-07-17)
@@ -4397,6 +4470,7 @@ This release contains various API docs improvements.
 * use the correct WTF array to iterate over ([#31208](https://github.com/angular/angular/issues/31208)) ([4aed480](https://github.com/angular/angular/commit/4aed480))
 * **compiler-cli:** Return original sourceFile instead of redirected sourceFile from getSourceFile ([#26036](https://github.com/angular/angular/issues/26036)) ([13dbb98](https://github.com/angular/angular/commit/13dbb98)), closes [#22524](https://github.com/angular/angular/issues/22524)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.1.1"></a>
 ## [8.1.1](https://github.com/angular/angular/compare/8.1.0...8.1.1) (2019-07-10)
@@ -4406,7 +4480,7 @@ This release contains various API docs improvements.
 
 * **core:** export provider interfaces that are part of the public API types ([#31377](https://github.com/angular/angular/issues/31377)) ([bebf089](https://github.com/angular/angular/commit/bebf089)), closes [/github.com/angular/angular/pull/31377#discussion_r299254408](https://github.com/angular/angular/pull/31377/issues/discussion_r299254408) [/github.com/angular/angular/blob/9e34670b2/packages/core/src/di/interface/provider.ts#L365-L366](https://github.com/angular/angular/blob/9e34670b2/packages/core/src/di/interface/provider.ts/issues/L365-L366) [/github.com/angular/angular/blob/9e34670b2/packages/core/src/di/interface/provider.ts#L283-L284](https://github.com/angular/angular/blob/9e34670b2/packages/core/src/di/interface/provider.ts/issues/L283-L284) [/github.com/angular/angular/blob/9e34670b2/packages/core/src/di/index.ts#L23](https://github.com/angular/angular/blob/9e34670b2/packages/core/src/di/index.ts/issues/L23)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.1.0"></a>
 # [8.1.0](https://github.com/angular/angular/compare/8.1.0-rc.0...8.1.0) (2019-07-02)
@@ -4418,7 +4492,7 @@ This release contains various API docs improvements.
 * **service-worker:** cache opaque responses in data groups with `freshness` strategy ([#30977](https://github.com/angular/angular/issues/30977)) ([b0c3453](https://github.com/angular/angular/commit/b0c3453)), closes [#30968](https://github.com/angular/angular/issues/30968)
 * **service-worker:** cache opaque responses when requests exceeds timeout threshold ([#30977](https://github.com/angular/angular/issues/30977)) ([a9038ef](https://github.com/angular/angular/commit/a9038ef))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.1.0-rc.0"></a>
 # [8.1.0-rc.0](https://github.com/angular/angular/compare/8.1.0-next.3...8.1.0-rc.0) (2019-06-26)
@@ -4438,7 +4512,7 @@ This release contains various API docs improvements.
 
 * **upgrade:** provide unit test helpers for wiring up injectors ([#16848](https://github.com/angular/angular/issues/16848)) ([3fb78aa](https://github.com/angular/angular/commit/3fb78aa))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.0.3"></a>
 ## [8.0.3](https://github.com/angular/angular/compare/8.0.2...8.0.3) (2019-06-26)
@@ -4451,7 +4525,7 @@ This release contains various API docs improvements.
 * **bazel:** update ng new schema to match the current ng new schema of [@schematics](https://github.com/schematics)/angular ([#31234](https://github.com/angular/angular/issues/31234)) ([48f7f65](https://github.com/angular/angular/commit/48f7f65)), closes [#31233](https://github.com/angular/angular/issues/31233)
 * **service-worker:** registration failed on Safari ([#31140](https://github.com/angular/angular/issues/31140)) ([f470e69](https://github.com/angular/angular/commit/f470e69)), closes [#31061](https://github.com/angular/angular/issues/31061)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.1.0-next.3"></a>
 # [8.1.0-next.3](https://github.com/angular/angular/compare/8.1.0-next.2...8.1.0-next.3) (2019-06-19)
@@ -4463,7 +4537,7 @@ This release contains various API docs improvements.
 * **core:** temporarily remove [@deprecated](https://github.com/deprecated) jsdoc tag for a TextBedStatic.get overload ([#30714](https://github.com/angular/angular/issues/30714)) ([6bc9c78](https://github.com/angular/angular/commit/6bc9c78)), closes [#30514](https://github.com/angular/angular/issues/30514)
 * **language-service:** Remove 'any' in getQuickInfoAtPosition ([#31014](https://github.com/angular/angular/issues/31014)) ([a4601ec](https://github.com/angular/angular/commit/a4601ec))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.0.2"></a>
 ## [8.0.2](https://github.com/angular/angular/compare/8.0.1...8.0.2) (2019-06-19)
@@ -4475,7 +4549,7 @@ This release contains various API docs improvements.
 * **core:** temporarily remove [@deprecated](https://github.com/deprecated) jsdoc tag for a TextBedStatic.get overload ([#30714](https://github.com/angular/angular/issues/30714)) ([0a7aebb](https://github.com/angular/angular/commit/0a7aebb)), closes [#30514](https://github.com/angular/angular/issues/30514)
 * **language-service:** Remove 'any' in getQuickInfoAtPosition ([#31014](https://github.com/angular/angular/issues/31014)) ([7f21449](https://github.com/angular/angular/commit/7f21449))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.1.0-next.2"></a>
 # [8.1.0-next.2](https://github.com/angular/angular/compare/8.1.0-next.1...8.1.0-next.2) (2019-06-13)
@@ -4489,7 +4563,7 @@ This release contains various API docs improvements.
 * **common:** expose the `HttpUploadProgressEvent` interface as public API ([#30852](https://github.com/angular/angular/issues/30852)) ([5c18f23](https://github.com/angular/angular/commit/5c18f23)), closes [#30814](https://github.com/angular/angular/issues/30814)
 * **service-worker:** avoid uncaught rejection warning when registration fails ([#30876](https://github.com/angular/angular/issues/30876)) ([81c2a94](https://github.com/angular/angular/commit/81c2a94))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.0.1"></a>
 ## [8.0.1](https://github.com/angular/angular/compare/8.0.0...8.0.1) (2019-06-13)
@@ -4503,7 +4577,7 @@ This release contains various API docs improvements.
 * **core:** TypeScript related migrations should cater for BOM ([#30719](https://github.com/angular/angular/issues/30719)) ([26e3615](https://github.com/angular/angular/commit/26e3615)), closes [/github.com/angular/angular-cli/blob/master/packages/angular_devkit/schematics/src/tree/recorder.ts#L72](https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/schematics/src/tree/recorder.ts/issues/L72) [#30713](https://github.com/angular/angular/issues/30713)
 * **service-worker:** avoid uncaught rejection warning when registration fails ([#30876](https://github.com/angular/angular/issues/30876)) ([08c38a1](https://github.com/angular/angular/commit/08c38a1))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.1.0-next.1"></a>
 # [8.1.0-next.1](https://github.com/angular/angular/compare/8.1.0-beta.0...8.1.0-next.1) (2019-06-05)
@@ -4513,7 +4587,7 @@ This release contains various API docs improvements.
 
 * **core:** TypeScript related migrations should cater for BOM ([#30719](https://github.com/angular/angular/issues/30719)) ([80394ce](https://github.com/angular/angular/commit/80394ce)), closes [/github.com/angular/angular-cli/blob/master/packages/angular_devkit/schematics/src/tree/recorder.ts#L72](https://github.com/angular/angular-cli/blob/master/packages/angular_devkit/schematics/src/tree/recorder.ts/issues/L72) [#30713](https://github.com/angular/angular/issues/30713)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.1.0-beta.0"></a>
 # [8.1.0-beta.0](https://github.com/angular/angular/compare/8.0.0...8.1.0-beta.0) (2019-05-30)
@@ -4562,7 +4636,7 @@ This release contains various API docs improvements.
 * **language-service:** Implement `definitionAndBoundSpan` ([#30125](https://github.com/angular/angular/issues/30125)) ([f491673](https://github.com/angular/angular/commit/f491673))
 * **platform-webworker:** deprecate platform-webworker ([#30642](https://github.com/angular/angular/issues/30642)) ([ccc76f7](https://github.com/angular/angular/commit/ccc76f7))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.0.0"></a>
 # [8.0.0](https://github.com/angular/angular/compare/7.2.0...8.0.0) (2019-05-28)
@@ -4870,7 +4944,7 @@ For details on how to migrate, please refer to [the deprecations guide](https://
 
   Please update your TypeScript version to 3.4, as version 3.3 is also not supported.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.15"></a>
 ## [7.2.15](https://github.com/angular/angular/compare/7.2.14...7.2.15) (2019-05-07)
@@ -4880,6 +4954,7 @@ For details on how to migrate, please refer to [the deprecations guide](https://
 
 * **upgrade:** do not break if `onMicrotaskEmpty` emits while a `$digest` is in progress ([#29794](https://github.com/angular/angular/issues/29794)) ([#30107](https://github.com/angular/angular/issues/30107)) ([1084c19](https://github.com/angular/angular/commit/1084c19)), closes [#24680](https://github.com/angular/angular/issues/24680) [/github.com/angular/angular/blob/78146c189/packages/core/src/util/ng_dev_mode.ts#L12](https://github.com/angular/angular/blob/78146c189/packages/core/src/util/ng_dev_mode.ts/issues/L12) [#24680](https://github.com/angular/angular/issues/24680)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.13"></a>
 ## [7.2.13](https://github.com/angular/angular/compare/7.2.12...7.2.13) (2019-04-12)
@@ -4890,7 +4965,7 @@ For details on how to migrate, please refer to [the deprecations guide](https://
 * **bazel:** use //:tsconfig.json as the default for ng_module ([#29670](https://github.com/angular/angular/issues/29670)) ([#29711](https://github.com/angular/angular/issues/29711)) ([9e33dc3](https://github.com/angular/angular/commit/9e33dc3))
 * **platform-browser:** insert APP_ID in styles, contentAttr and hostAttr ([#17745](https://github.com/angular/angular/issues/17745)) ([ca14509](https://github.com/angular/angular/commit/ca14509))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.12"></a>
 ## [7.2.12](https://github.com/angular/angular/compare/7.2.11...7.2.12) (2019-04-03)
@@ -4901,12 +4976,14 @@ For details on how to migrate, please refer to [the deprecations guide](https://
 * **common:** escape query selector used when anchor scrolling ([#29577](https://github.com/angular/angular/issues/29577)) ([7671c73](https://github.com/angular/angular/commit/7671c73)), closes [#28193](https://github.com/angular/angular/issues/28193)
 * **router:** adjust setting navigationTransition when a new navigation cancels an existing one ([#29636](https://github.com/angular/angular/issues/29636)) ([e884c0c](https://github.com/angular/angular/commit/e884c0c)), closes [#29389](https://github.com/angular/angular/issues/29389) [#29590](https://github.com/angular/angular/issues/29590)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.11"></a>
 ## [7.2.11](https://github.com/angular/angular/compare/7.2.10...7.2.11) (2019-03-26)
 
 This release contains various API docs improvements.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.10"></a>
 ## [7.2.10](https://github.com/angular/angular/compare/7.2.9...7.2.10) (2019-03-20)
@@ -4916,12 +4993,14 @@ This release contains various API docs improvements.
 
 * **compiler-cli:** incorrect metadata bundle for multiple unnamed re-exports ([#29360](https://github.com/angular/angular/issues/29360)) ([cf8d934](https://github.com/angular/angular/commit/cf8d934)), closes [github.com/angular/material2/blob/master/tools/package-tools/build-release.ts#L78-L85](https://github.com/angular/material2/blob/master/tools/package-tools/build-release.ts#L78-L85)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.9"></a>
 ## [7.2.9](https://github.com/angular/angular/compare/7.2.8...7.2.9) (2019-03-12)
 
 This release contains various API docs improvements.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.8"></a>
 ## [7.2.8](https://github.com/angular/angular/compare/7.2.7...7.2.8) (2019-03-06)
@@ -4934,6 +5013,7 @@ This release contains various API docs improvements.
 * **service-worker:** detect new version even if files are identical to an old one ([#26006](https://github.com/angular/angular/issues/26006)) ([5669333](https://github.com/angular/angular/commit/5669333)), closes [#24338](https://github.com/angular/angular/issues/24338)
 * **service-worker:** ignore passive mixed content requests ([#25994](https://github.com/angular/angular/issues/25994)) ([b598e88](https://github.com/angular/angular/commit/b598e88)), closes [/github.com/angular/angular/issues/23012#issuecomment-376430187](https://github.com/angular/angular/issues/23012/issues/issuecomment-376430187) [#23012](https://github.com/angular/angular/issues/23012)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.7"></a>
 ## [7.2.7](https://github.com/angular/angular/compare/7.2.6...7.2.7) (2019-02-27)
@@ -4945,6 +5025,7 @@ This release contains various API docs improvements.
 * **core:** traverse and sanitize content of unsafe elements ([#28804](https://github.com/angular/angular/issues/28804)) ([fdcf877](https://github.com/angular/angular/commit/fdcf877)), closes [#25879](https://github.com/angular/angular/issues/25879) [#25879](https://github.com/angular/angular/issues/25879) [#26007](https://github.com/angular/angular/issues/26007) [#28427](https://github.com/angular/angular/issues/28427)
 * **language-service:** Fix completions for input/output with alias ([#28904](https://github.com/angular/angular/issues/28904)) ([d0018e6](https://github.com/angular/angular/commit/d0018e6)), closes [#27959](https://github.com/angular/angular/issues/27959)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.6"></a>
 ## [7.2.6](https://github.com/angular/angular/compare/7.2.5...7.2.6) (2019-02-20)
@@ -4954,6 +5035,7 @@ This release contains various API docs improvements.
 
 * **compiler-cli:** incorrect bundled metadata for static class member call expressions ([#28762](https://github.com/angular/angular/issues/28762)) ([ab69c31](https://github.com/angular/angular/commit/ab69c31)), closes [/github.com/angular/angular/blob/master/packages/core/src/change_detection/differs/keyvalue_differs.ts#L121](https://github.com/angular/angular/blob/master/packages/core/src/change_detection/differs/keyvalue_differs.ts/issues/L121) [#28741](https://github.com/angular/angular/issues/28741)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.5"></a>
 ## [7.2.5](https://github.com/angular/angular/compare/7.2.4...7.2.5)
@@ -4974,6 +5056,7 @@ This release contains various API docs improvements.
   ([d491a20](https://github.com/angular/angular/commit/d491a20)), closes
   [#28401](https://github.com/angular/angular/issues/28401)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.4"></a>
 ## [7.2.4](https://github.com/angular/angular/compare/7.2.3...7.2.4) (2019-02-06)
@@ -4989,6 +5072,7 @@ This release contains various API docs improvements.
 
 * pngcrush all pngs ([#28479](https://github.com/angular/angular/issues/28479)) ([1a25144](https://github.com/angular/angular/commit/1a25144)), closes [#18243](https://github.com/angular/angular/issues/18243)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.3"></a>
 ## [7.2.3](https://github.com/angular/angular/compare/7.2.2...7.2.3) (2019-01-30)
@@ -5006,6 +5090,7 @@ This release contains various API docs improvements.
 
 * yarn version upgrade ([#28360](https://github.com/angular/angular/issues/28360)) ([cc1b2a5](https://github.com/angular/angular/commit/cc1b2a5))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.2"></a>
 ## [7.2.2](https://github.com/angular/angular/compare/7.2.1...7.2.2) (2019-01-22)
@@ -5022,7 +5107,7 @@ This release contains various API docs improvements.
 * **bazel:** Add support for SASS ([#28167](https://github.com/angular/angular/issues/28167)) ([a4d9192](https://github.com/angular/angular/commit/a4d9192))
 * **compiler-cli:** resolve generated Sass/Less files to .css inputs ([#28166](https://github.com/angular/angular/issues/28166)) ([4c00059](https://github.com/angular/angular/commit/4c00059))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="8.0.0-beta.0"></a>
 # [8.0.0-beta.0](https://github.com/angular/angular/compare/7.2.0...8.0.0-beta.0) (2019-01-16)
@@ -5030,8 +5115,7 @@ This release contains various API docs improvements.
 
 ### Performance Improvements
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.1"></a>
 ## [7.2.1](https://github.com/angular/angular/compare/7.2.0...7.2.1) (2019-01-16)
@@ -5058,7 +5142,7 @@ This release contains various API docs improvements.
 
 * **platform-server:** use shared `DomElementSchemaRegistry` instance ([#28150](https://github.com/angular/angular/issues/28150)) ([#28151](https://github.com/angular/angular/issues/28151)) ([6851581](https://github.com/angular/angular/commit/6851581))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.2.0"></a>
 # [7.2.0](https://github.com/angular/angular/compare/7.1.4...7.2.0) (2019-01-07)
@@ -5113,7 +5197,7 @@ This release contains various API docs improvements.
 * **upgrade:** upgrade Directive facade should not return different instance from constructor ([#27660](https://github.com/angular/angular/issues/27660)) ([c986d3d](https://github.com/angular/angular/commit/c986d3d))
 * **upgrade:** don't rely upon the runtime to resolve forward refs ([#27132](https://github.com/angular/angular/issues/27132)) ([a4462c2](https://github.com/angular/angular/commit/a4462c2))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.1.4"></a>
 ## [7.1.4](https://github.com/angular/angular/compare/7.1.3...7.1.4) (2018-12-18)
@@ -5132,7 +5216,7 @@ This release contains various API docs improvements.
 * **bazel:** Set module_name and enable ng test ([#27715](https://github.com/angular/angular/issues/27715)) ([183f278](https://github.com/angular/angular/commit/183f278))
 * **common:** KeyValuePipe should return empty array for empty objects ([#27258](https://github.com/angular/angular/issues/27258)) ([fa3af8b](https://github.com/angular/angular/commit/fa3af8b))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.1.3"></a>
 ## [7.1.3](https://github.com/angular/angular/compare/7.1.2...7.1.3) (2018-12-11)
@@ -5142,7 +5226,7 @@ This release contains various API docs improvements.
 
 * **bazel:** tsickle dependency not working with typescript 3.1.x ([#27402](https://github.com/angular/angular/issues/27402)) ([a9f39a4](https://github.com/angular/angular/commit/a9f39a4))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.1.2"></a>
 ## [7.1.2](https://github.com/angular/angular/compare/7.1.1...7.1.2) (2018-12-06)
@@ -5159,7 +5243,7 @@ This release contains various API docs improvements.
 * **compiler-cli:** ngtsc shim files not being generated on case-insensitive platforms ([#27466](https://github.com/angular/angular/issues/27466)) ([84f2928](https://github.com/angular/angular/commit/84f2928)), closes [/github.com/Microsoft/TypeScript/blob/3e4c5c95abd515eb9713b881d27ab3a93cc00461/src/compiler/sys.ts#L681-L682](https://github.com/Microsoft/TypeScript/blob/3e4c5c95abd515eb9713b881d27ab3a93cc00461/src/compiler/sys.ts/issues/L681-L682)
 * **platform-server:** add @angular/http to the list of peerDependencies ([#27307](https://github.com/angular/angular/issues/27307)) ([236ac06](https://github.com/angular/angular/commit/236ac06)), closes [#26154](https://github.com/angular/angular/issues/26154)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.1.1"></a>
 ## [7.1.1](https://github.com/angular/angular/compare/7.1.0...7.1.1) (2018-11-28)
@@ -5169,7 +5253,7 @@ This release contains various API docs improvements.
 
 * **core:** export a value for InjectFlags ([#27279](https://github.com/angular/angular/issues/27279)) ([bdf5f3e](https://github.com/angular/angular/commit/bdf5f3e)), closes [#27251](https://github.com/angular/angular/issues/27251)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.1.0"></a>
 # [7.1.0](https://github.com/angular/angular/compare/7.1.0-rc.0...7.1.0) (2018-11-21)
@@ -5179,6 +5263,7 @@ This release contains various API docs improvements.
 
 * **bazel:** Bazel workspace schematics ([#26971](https://github.com/angular/angular/issues/26971)) ([b07bd30](https://github.com/angular/angular/commit/b07bd30))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.1.0-rc.0"></a>
 # [7.1.0-rc.0](https://github.com/angular/angular/compare/7.1.0-beta.2...7.1.0-rc.0) (2018-11-14)
@@ -5195,7 +5280,7 @@ This release contains various API docs improvements.
 
 * **router:** add pathParamsChange mode for runGuardsAndResolvers ([#26861](https://github.com/angular/angular/issues/26861)) ([bf6ac6c](https://github.com/angular/angular/commit/bf6ac6c)), closes [#18253](https://github.com/angular/angular/issues/18253)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.0.4"></a>
 ## [7.0.4](https://github.com/angular/angular/compare/7.0.3...7.0.4) (2018-11-14)
@@ -5207,7 +5292,7 @@ This release contains various API docs improvements.
 * **compiler-cli:** only pass canonical genfile paths to compiler host ([#27062](https://github.com/angular/angular/issues/27062)) ([188e9ce](https://github.com/angular/angular/commit/188e9ce))
 * **router:** add `relativeLinkResolution` to `recognize` operator ([#26990](https://github.com/angular/angular/issues/26990)) ([d304427](https://github.com/angular/angular/commit/d304427)), closes [#26983](https://github.com/angular/angular/issues/26983)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.1.0-beta.2"></a>
 # [7.1.0-beta.2](https://github.com/angular/angular/compare/7.1.0-beta.1...7.1.0-beta.2) (2018-11-07)
@@ -5235,7 +5320,7 @@ This release contains various API docs improvements.
 * **service-worker:** handle 'notificationclick' events ([#25860](https://github.com/angular/angular/issues/25860)) ([cf6ea28](https://github.com/angular/angular/commit/cf6ea28)), closes [#20956](https://github.com/angular/angular/issues/20956) [#22311](https://github.com/angular/angular/issues/22311)
 * **upgrade:** support downgrading multiple modules ([#26217](https://github.com/angular/angular/issues/26217)) ([93837e9](https://github.com/angular/angular/commit/93837e9)), closes [#26062](https://github.com/angular/angular/issues/26062)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.0.3"></a>
 ## [7.0.3](https://github.com/angular/angular/compare/7.0.2...7.0.3) (2018-11-07)
@@ -5247,7 +5332,7 @@ This release contains various API docs improvements.
 * **router:** remove type bludgeoning of context and outlet when running CanDeactivate ([#26496](https://github.com/angular/angular/issues/26496)) ([dc05385](https://github.com/angular/angular/commit/dc05385)), closes [#18253](https://github.com/angular/angular/issues/18253)
 * **upgrade:** make typings compatible with older AngularJS typings ([#26880](https://github.com/angular/angular/issues/26880)) ([315d95c](https://github.com/angular/angular/commit/315d95c)), closes [#26420](https://github.com/angular/angular/issues/26420)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.1.0-beta.1"></a>
 # [7.1.0-beta.1](https://github.com/angular/angular/compare/7.1.0-beta.0...7.1.0-beta.1) (2018-10-31)
@@ -5261,7 +5346,7 @@ This release contains various API docs improvements.
 * **core:** Remove static dependency from @angular/core to @angular/compiler ([#26734](https://github.com/angular/angular/issues/26734)) ([d042c4a](https://github.com/angular/angular/commit/d042c4a))
 * **core:** support computed base class in metadata inheritance ([#24014](https://github.com/angular/angular/issues/24014)) ([95743e3](https://github.com/angular/angular/commit/95743e3))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.0.2"></a>
 ## [7.0.2](https://github.com/angular/angular/compare/7.0.1...7.0.2) (2018-10-31)
@@ -5273,7 +5358,7 @@ This release contains various API docs improvements.
 * **core:** Remove static dependency from @angular/core to @angular/compiler ([#26734](https://github.com/angular/angular/issues/26734)) ([#26879](https://github.com/angular/angular/issues/26879)) ([257ac83](https://github.com/angular/angular/commit/257ac83))
 * **core:** support computed base class in metadata inheritance ([#24014](https://github.com/angular/angular/issues/24014)) ([b3c6409](https://github.com/angular/angular/commit/b3c6409))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.1.0-beta.0"></a>
 # [7.1.0-beta.0](https://github.com/angular/angular/compare/7.0.0-rc.1...7.1.0-beta.0) (2018-10-24)
@@ -5287,13 +5372,12 @@ This release contains various API docs improvements.
 
 * **router:** add prioritizedGuardValue operator optimization and allowing UrlTree return from guard ([#26478](https://github.com/angular/angular/issues/26478)) ([fdfedce](https://github.com/angular/angular/commit/fdfedce))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.0.1"></a>
 ## [7.0.1](https://github.com/angular/angular/compare/7.0.0...7.0.1) (2018-10-24)
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="7.0.0"></a>
 # [7.0.0](https://github.com/angular/angular/compare/7.0.0-rc.1...7.0.0) (2018-10-18)
@@ -5362,8 +5446,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **upgrade:** properly destroy upgraded component elements and descendants ([#26209](https://github.com/angular/angular/issues/26209)) ([071934e](https://github.com/angular/angular/commit/071934e)), closes [#26208](https://github.com/angular/angular/issues/26208)
 * **upgrade:** trigger `$destroy` event on upgraded component element ([#25357](https://github.com/angular/angular/issues/25357)) ([2a672a9](https://github.com/angular/angular/commit/2a672a9)), closes [#25334](https://github.com/angular/angular/issues/25334)
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.1.10"></a>
 ## [6.1.10](https://github.com/angular/angular/compare/6.1.9...6.1.10) (2018-10-10)
@@ -5374,14 +5457,12 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **platform-browser:** fix [#22155](https://github.com/angular/angular/issues/22155), destroy hammer manager when `HammerInstance.off()` is run ([#22156](https://github.com/angular/angular/issues/22156)) ([3b4d9dc](https://github.com/angular/angular/commit/3b4d9dc))
 * **upgrade:** properly destroy upgraded component elements and descendants ([#26209](https://github.com/angular/angular/issues/26209)) ([623adbb](https://github.com/angular/angular/commit/623adbb)), closes [#26208](https://github.com/angular/angular/issues/26208)
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.1.9"></a>
 ## [6.1.9](https://github.com/angular/angular/compare/6.1.8...6.1.9) (2018-09-26)
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.1.7"></a>
 ## [6.1.7](https://github.com/angular/angular/compare/6.1.6...6.1.7) (2018-09-06)
@@ -5394,7 +5475,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **upgrade:** trigger `$destroy` event on upgraded component element ([#25357](https://github.com/angular/angular/issues/25357)) ([82e0676](https://github.com/angular/angular/commit/82e0676)), closes [#25334](https://github.com/angular/angular/issues/25334)
 * **router:** warn if navigation triggered outside Angular zone ([#24959](https://github.com/angular/angular/issues/24959)) ([23a96dc](https://github.com/angular/angular/commit/23a96dc)), closes [#15770](https://github.com/angular/angular/issues/15770) [#15946](https://github.com/angular/angular/issues/15946) [#24728](https://github.com/angular/angular/issues/24728)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.1.6"></a>
 ## [6.1.6](https://github.com/angular/angular/compare/6.1.5...6.1.6) (2018-08-29)
@@ -5408,7 +5489,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 
 Note: the 6.1.5 release on npm accidentally glitched-out midway, so we cut 6.1.6 instead. sorry! :-)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.1.4"></a>
 ## [6.1.4](https://github.com/angular/angular/compare/6.1.3...6.1.4) (2018-08-22)
@@ -5418,7 +5499,7 @@ Note: the 6.1.5 release on npm accidentally glitched-out midway, so we cut 6.1.6
 
 * **router:** default scroll position restoration to disabled ([#25586](https://github.com/angular/angular/issues/25586)) ([7e61645](https://github.com/angular/angular/commit/7e61645)), closes [#25145](https://github.com/angular/angular/issues/25145)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.1.3"></a>
 ## [6.1.3](https://github.com/angular/angular/compare/6.1.2...6.1.3) (2018-08-15)
@@ -5428,7 +5509,7 @@ Note: the 6.1.5 release on npm accidentally glitched-out midway, so we cut 6.1.6
 
 * **service-worker:** `Cache-Control: no-cache` on assets breaks service worker ([#25408](https://github.com/angular/angular/issues/25408)) ([1319ff4](https://github.com/angular/angular/commit/1319ff4)), closes [#25442](https://github.com/angular/angular/issues/25442)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.1.2"></a>
 ## [6.1.2](https://github.com/angular/angular/compare/6.1.1...6.1.2) (2018-08-08)
@@ -5439,14 +5520,14 @@ Note: the 6.1.5 release on npm accidentally glitched-out midway, so we cut 6.1.6
 * **router:** take base uri into account in `setUpLocationSync()` ([#20244](https://github.com/angular/angular/issues/20244)) ([ae9b4e6](https://github.com/angular/angular/commit/ae9b4e6)), closes [#20061](https://github.com/angular/angular/issues/20061)
 * add mappings for ngfactory & ngsummary files to their module names in aot summary resolver ([#25335](https://github.com/angular/angular/issues/25335)) ([054fbbe](https://github.com/angular/angular/commit/054fbbe))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.1.1"></a>
 ## [6.1.1](https://github.com/angular/angular/compare/6.1.0...6.1.1) (2018-08-02)
 
 * **compiler-cli:** correct tsickle dependency version to fix typescript 2.9 compatibility ([fec29fa](https://github.com/angular/angular/commit/317c7087c56b72aa74cd6d6a8f719e6e7fec29fa))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.1.0"></a>
 # [6.1.0](https://github.com/angular/angular/compare/6.0.0-rc.5...6.1.0) (2018-07-25)
@@ -5547,6 +5628,8 @@ For example:
 
     ng_setup_workspace()
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="6.0.9"></a>
 ## [6.0.9](https://github.com/angular/angular/compare/6.0.8...6.0.9) (2018-07-11)
 
@@ -5554,6 +5637,7 @@ For example:
 ### Bug Fixes
 * **common:** format fractional seconds ([#24844](https://github.com/angular/angular/issues/24844)) ([3c93d07](https://github.com/angular/angular/commit/3c93d07)), closes [#24831](https://github.com/angular/angular/issues/24831)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.0.8"></a>
 ## [6.0.8](https://github.com/angular/angular/compare/6.0.7...6.0.8) (2018-07-11)
@@ -5575,6 +5659,8 @@ For example:
 
 * **core:** add support for ShadowDOM v1 ([#24718](https://github.com/angular/angular/issues/24718)) ([6c55a13](https://github.com/angular/angular/commit/6c55a13))
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="6.0.7"></a>
 ## [6.0.7](https://github.com/angular/angular/compare/6.0.6...6.0.7) (2018-06-27)
 
@@ -5583,6 +5669,8 @@ For example:
 
 * **animations:** set animations styles properly on platform-server ([#24624](https://github.com/angular/angular/issues/24624)) ([0b356d4](https://github.com/angular/angular/commit/0b356d4))
 * **common:** use correct ICU plural for locale mk ([#24659](https://github.com/angular/angular/issues/24659)) ([64a8584](https://github.com/angular/angular/commit/64a8584))
+
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.0.6"></a>
 ## [6.0.6](https://github.com/angular/angular/compare/6.0.5...6.0.6) (2018-06-20)
@@ -5593,6 +5681,8 @@ For example:
 * **compiler:** support `.` in import statements. ([#20634](https://github.com/angular/angular/issues/20634)) ([e543c73](https://github.com/angular/angular/commit/e543c73)), closes [#20363](https://github.com/angular/angular/issues/20363)
 * **core:** Injector correctly honors the @Self flag ([#24520](https://github.com/angular/angular/issues/24520)) ([f5b3661](https://github.com/angular/angular/commit/f5b3661))
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="6.0.5"></a>
 ## [6.0.5](https://github.com/angular/angular/compare/6.0.4...6.0.5) (2018-06-13)
 
@@ -5600,6 +5690,8 @@ For example:
 * **bazel:** Allow ng_module to depend on targets w no deps ([#24446](https://github.com/angular/angular/issues/24446)) ([ea3669e](https://github.com/angular/angular/commit/ea3669e))
 * **router:** fix lazy loading of aux routes ([#23459](https://github.com/angular/angular/issues/23459)) ([d20877b](https://github.com/angular/angular/commit/d20877b)), closes [#10981](https://github.com/angular/angular/issues/10981)
 * **service-worker:** fix `SwPush.unsubscribe()` ([#24162](https://github.com/angular/angular/issues/24162)) ([ea2987c](https://github.com/angular/angular/commit/ea2987c)), closes [#24095](https://github.com/angular/angular/issues/24095)
+
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.0.4"></a>
 ## [6.0.4](https://github.com/angular/angular/compare/6.0.3...6.0.4) (2018-06-06)
@@ -5615,6 +5707,7 @@ For example:
 * **platform-server:** don't reflect innerHTML property to attibute ([#24213](https://github.com/angular/angular/issues/24213)) ([c17098d](https://github.com/angular/angular/commit/c17098d)), closes [#19278](https://github.com/angular/angular/issues/19278)
 * **platform-server:** provide Domino DOM types globally ([#24116](https://github.com/angular/angular/issues/24116)) ([906b3ec](https://github.com/angular/angular/commit/906b3ec)), closes [#23280](https://github.com/angular/angular/issues/23280) [#23133](https://github.com/angular/angular/issues/23133)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.0.3"></a>
 ## [6.0.3](https://github.com/angular/angular/compare/6.0.2...6.0.3) (2018-05-22)
@@ -5624,7 +5717,7 @@ For example:
 
 * **service-worker:** check platformBrowser before accessing navigator.serviceWorker ([#21231](https://github.com/angular/angular/issues/21231)) ([0ee5b7e](https://github.com/angular/angular/commit/0ee5b7e))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.0.2"></a>
 ## [6.0.2](https://github.com/angular/angular/compare/6.0.1...6.0.2) (2018-05-15)
@@ -5635,7 +5728,7 @@ For example:
 * **animations:** do not throw errors when a destroyed component is animated ([#23836](https://github.com/angular/angular/issues/23836)) ([752b83a](https://github.com/angular/angular/commit/752b83a))
 * **service-worker:** deprecate `versionedFiles` in asset-group resources ([#23584](https://github.com/angular/angular/issues/23584)) ([c6b618d](https://github.com/angular/angular/commit/c6b618d))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.0.1"></a>
 # [6.0.1](https://github.com/angular/angular/compare/6.0.0...6.0.1) (2018-05-11)
@@ -5651,7 +5744,7 @@ For example:
 * **router:** correct the segment parsing so it won't break on ampersand ([#23684](https://github.com/angular/angular/issues/23684)) ([8733843](https://github.com/angular/angular/commit/8733843))
 * **service-worker:** correctly handle requests with empty `clientId` ([#23625](https://github.com/angular/angular/issues/23625)) ([2254ac2](https://github.com/angular/angular/commit/2254ac2)), closes [#23526](https://github.com/angular/angular/issues/23526)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="6.0.0"></a>
 # [6.0.0](https://github.com/angular/angular/compare/6.0.0-beta.0...6.0.0) (2018-05-03)
@@ -5874,7 +5967,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
   You will only need to update your app if it has relied on this bug to keep track of the old control value.
   If that is the case, you should be able to track the old value directly by saving it on your component.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.10"></a>
 ## [5.2.10](https://github.com/angular/angular/compare/5.2.9...5.2.10) (2018-04-16)
@@ -5895,7 +5988,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **upgrade:** propagate return value of resumeBootstrap ([#22754](https://github.com/angular/angular/issues/22754)) ([ae76eec](https://github.com/angular/angular/commit/ae76eec)), closes [#22723](https://github.com/angular/angular/issues/22723)
 * **upgrade:** two-way binding and listening for event ([#22772](https://github.com/angular/angular/issues/22772)) ([5391f96](https://github.com/angular/angular/commit/5391f96)), closes [#22734](https://github.com/angular/angular/issues/22734)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.4.7"></a>
 ## [4.4.7](https://github.com/angular/angular/compare/4.4.6...4.4.7) (2018-04-16)
@@ -5905,7 +5998,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 
 * **core:** use appropriate inert document strategy for Firefox & Safari ([#22077](https://github.com/angular/angular/issues/22077)) ([2c5cf19](https://github.com/angular/angular/commit/2c5cf19))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.9"></a>
 ## [5.2.9](https://github.com/angular/angular/compare/5.2.8...5.2.9) (2018-03-14)
@@ -5916,7 +6009,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **platform-server:** add styles to elements correctly ([#22527](https://github.com/angular/angular/issues/22527)) ([fc6dfc2](https://github.com/angular/angular/commit/fc6dfc2))
 * **router:** correct over-encoding of URL fragment ([#22687](https://github.com/angular/angular/issues/22687)) ([86517f2](https://github.com/angular/angular/commit/86517f2))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.8"></a>
 ## [5.2.8](https://github.com/angular/angular/compare/5.2.7...5.2.8) (2018-03-07)
@@ -5926,7 +6019,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 
 * **router:** fix URL serialization so special characters are only encoded where needed ([#22337](https://github.com/angular/angular/issues/22337)) ([789a47e](https://github.com/angular/angular/commit/789a47e)), closes [#10280](https://github.com/angular/angular/issues/10280)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.7"></a>
 ## [5.2.7](https://github.com/angular/angular/compare/5.2.6...5.2.7) (2018-02-28)
@@ -5940,7 +6033,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **upgrade:** correctly handle `=` bindings in `@angular/upgrade` ([#22167](https://github.com/angular/angular/issues/22167)) ([6638390](https://github.com/angular/angular/commit/6638390))
 * **upgrade:** fix empty transclusion content with AngularJS@>=1.5.8 ([#22167](https://github.com/angular/angular/issues/22167)) ([a9a0e27](https://github.com/angular/angular/commit/a9a0e27)), closes [#22175](https://github.com/angular/angular/issues/22175)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.6"></a>
 ## [5.2.6](https://github.com/angular/angular/compare/5.2.5...5.2.6) (2018-02-22)
@@ -5953,7 +6046,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **core:** properly handle function without prototype in reflector ([#22284](https://github.com/angular/angular/issues/22284)) ([5ec38f2](https://github.com/angular/angular/commit/5ec38f2)), closes [#19978](https://github.com/angular/angular/issues/19978)
 * **core:** support metadata reflection for native class types ([#22356](https://github.com/angular/angular/issues/22356)) ([ee91de9](https://github.com/angular/angular/commit/ee91de9)), closes [#21731](https://github.com/angular/angular/issues/21731)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.5"></a>
 ## [5.2.5](https://github.com/angular/angular/compare/5.2.4...5.2.5) (2018-02-14)
@@ -5972,7 +6065,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **language-service:** correct instructions to install the language service ([#22000](https://github.com/angular/angular/issues/22000)) ([0b23573](https://github.com/angular/angular/commit/0b23573))
 * **platform-browser:** support 0/false/null values in transfer_state ([#22179](https://github.com/angular/angular/issues/22179)) ([da6ab91](https://github.com/angular/angular/commit/da6ab91))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.4"></a>
 ## [5.2.4](https://github.com/angular/angular/compare/5.2.3...5.2.4) (2018-02-07)
@@ -5985,7 +6078,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **core:** fix proper propagation of subscriptions in EventEmitter ([#22016](https://github.com/angular/angular/issues/22016)) ([c6645e7](https://github.com/angular/angular/commit/c6645e7)), closes [#21999](https://github.com/angular/angular/issues/21999)
 * **core:** should check Zone existence when scheduleMicroTask ([#20656](https://github.com/angular/angular/issues/20656)) ([aa9ba7f](https://github.com/angular/angular/commit/aa9ba7f))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.3"></a>
 ## [5.2.3](https://github.com/angular/angular/compare/5.2.2...5.2.3) (2018-01-31)
@@ -6002,7 +6095,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **language-service:** spell diagnostics correctly ([#21812](https://github.com/angular/angular/issues/21812)) ([778e6e7](https://github.com/angular/angular/commit/778e6e7))
 * **router:** remove [@internal](https://github.com/internal) tag on ParamInheritanceType ([#21773](https://github.com/angular/angular/issues/21773)) ([35a0721](https://github.com/angular/angular/commit/35a0721)), closes [#21456](https://github.com/angular/angular/issues/21456)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.2"></a>
 ## [5.2.2](https://github.com/angular/angular/compare/5.2.1...5.2.2) (2018-01-25)
@@ -6021,7 +6114,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **compiler-cli:** do not lower expressions in non-modules ([#21649](https://github.com/angular/angular/issues/21649)) ([ba4ea82](https://github.com/angular/angular/commit/ba4ea82))
 * **router:** don't use ParamsInheritanceStrategy in declarations ([#21574](https://github.com/angular/angular/issues/21574)) ([8b3fbb5](https://github.com/angular/angular/commit/8b3fbb5)), closes [#21456](https://github.com/angular/angular/issues/21456)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.1"></a>
 ## [5.2.1](https://github.com/angular/angular/compare/5.2.0...5.2.1) (2018-01-17)
@@ -6044,7 +6137,7 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 * **core:** add binding name to content changed error ([#20352](https://github.com/angular/angular/issues/20352)) ([4556532](https://github.com/angular/angular/commit/4556532))
 * **forms:** handle string with and without line boundary on pattern validator ([#19256](https://github.com/angular/angular/issues/19256)) ([75f8522](https://github.com/angular/angular/commit/75f8522))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.0"></a>
 # [5.2.0](https://github.com/angular/angular/compare/5.2.0-rc.0...5.2.0) (2018-01-10)
@@ -6061,6 +6154,8 @@ To learn about the release highlights and our new CLI-powered update workflow fo
 
 Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angular/angular/commit/c2b3792a3b5fa5215fe2ef7e0ac6511086ffe4c1)) which allows for nested :leave queries to work within animation sequences, all elements that are dynamically inserted (*ngIf, *ngFor, etc…) now contain the special CSS class: “ng-star-inserted”. This may cause failures within unit tests if there are any assertions that match against element.className directly. (An easy fix for this is to match using a regular expression instead of asserting the className string directly.)
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="5.2.0-rc.0"></a>
 # [5.2.0-rc.0](https://github.com/angular/angular/compare/5.2.0-beta.1...5.2.0-rc.0) (2018-01-04)
 
@@ -6073,7 +6168,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **language-service:** ignore null metadatas ([#20557](https://github.com/angular/angular/issues/20557)) ([3e47ea2](https://github.com/angular/angular/commit/3e47ea2)), closes [#20260](https://github.com/angular/angular/issues/20260)
 * **router:** fix wildcard route with lazy loaded module (again) ([#18139](https://github.com/angular/angular/issues/18139)) ([5ba1cf1](https://github.com/angular/angular/commit/5ba1cf1)), closes [#13848](https://github.com/angular/angular/issues/13848)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.1.3"></a>
 ## [5.1.3](https://github.com/angular/angular/compare/5.1.2...5.1.3) (2018-01-03)
@@ -6087,6 +6182,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **language-service:** ignore null metadatas ([#20557](https://github.com/angular/angular/issues/20557)) ([48a1f32](https://github.com/angular/angular/commit/48a1f32)), closes [#20260](https://github.com/angular/angular/issues/20260)
 * **router:** fix wildcard route with lazy loaded module (again) ([#18139](https://github.com/angular/angular/issues/18139)) ([8c99175](https://github.com/angular/angular/commit/8c99175)), closes [#13848](https://github.com/angular/angular/issues/13848)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.0-beta.1"></a>
 # [5.2.0-beta.1](https://github.com/angular/angular/compare/5.2.0-beta.0...5.2.0-beta.1) (2017-12-20)
@@ -6103,7 +6199,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **compiler:** allow ngIf to use the ngIf expression directly as a guard ([82bcd83](https://github.com/angular/angular/commit/82bcd83))
 * **router:** add "paramsInheritanceStrategy" router configuration option ([5efea2f](https://github.com/angular/angular/commit/5efea2f)), closes [#20572](https://github.com/angular/angular/issues/20572)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.1.2"></a>
 ## [5.1.2](https://github.com/angular/angular/compare/5.1.1...5.1.2) (2017-12-20)
@@ -6119,7 +6215,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **service-worker:** check for updates on navigation ([a33182c](https://github.com/angular/angular/commit/a33182c)), closes [#20877](https://github.com/angular/angular/issues/20877)
 * **upgrade:** replaces get/setAngularLib with get/setAngularJSGlobal ([66cc2fa](https://github.com/angular/angular/commit/66cc2fa))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.2.0-beta.0"></a>
 # [5.2.0-beta.0](https://github.com/angular/angular/compare/5.1.0...5.2.0-beta.0) (2017-12-13)
@@ -6133,7 +6229,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **core:** add source to `StaticInjectorError` message ([#20817](https://github.com/angular/angular/issues/20817)) ([b7738e1](https://github.com/angular/angular/commit/b7738e1)), closes [#19302](https://github.com/angular/angular/issues/19302)
 * **forms:** allow nulls on setAsyncValidators ([#20327](https://github.com/angular/angular/issues/20327)) ([d41d2c4](https://github.com/angular/angular/commit/d41d2c4)), closes [#20296](https://github.com/angular/angular/issues/20296)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.1.1"></a>
 ## [5.1.1](https://github.com/angular/angular/compare/5.1.0...5.1.1) (2017-12-13)
@@ -6152,7 +6248,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **compiler-cli:** merge [@fileoverview](https://github.com/fileoverview) comments. ([#20870](https://github.com/angular/angular/issues/20870)) ([be9a737](https://github.com/angular/angular/commit/be9a737))
 * **router:** NavigationError and NavigationCancel should be emitted after resetting the URL ([#20803](https://github.com/angular/angular/issues/20803)) ([baeec4d](https://github.com/angular/angular/commit/baeec4d))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.1.0"></a>
 # [5.1.0](https://github.com/angular/angular/compare/5.1.0-rc.1...5.1.0) (2017-12-06)
@@ -6166,7 +6262,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **service-worker:** initialize in browser only ([#20782](https://github.com/angular/angular/issues/20782)) ([7cabaa0](https://github.com/angular/angular/commit/7cabaa0)), closes [#20360](https://github.com/angular/angular/issues/20360)
 * **service-worker:** esm2015 points to wrong path ([#20800](https://github.com/angular/angular/issues/20800)) ([da3563c](https://github.com/angular/angular/commit/da3563c))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.1.0-rc.1"></a>
 # [5.1.0-rc.1](https://github.com/angular/angular/compare/5.1.0-rc.0...5.1.0-rc.1) (2017-12-01)
@@ -6180,7 +6276,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **service-worker:** send initialization signal from the application ([3fbcde9](https://github.com/angular/angular/commit/3fbcde9))
 * **service-worker:** use relative path for ngsw.json ([f582620](https://github.com/angular/angular/commit/f582620))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.0.5"></a>
 ## [5.0.5](https://github.com/angular/angular/compare/5.0.4...5.0.5) (2017-12-01)
@@ -6194,7 +6290,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **service-worker:** send initialization signal from the application ([6bf07b4](https://github.com/angular/angular/commit/6bf07b4))
 * **service-worker:** use relative path for ngsw.json ([56c98f7](https://github.com/angular/angular/commit/56c98f7))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.1.0-rc.0"></a>
 # [5.1.0-rc.0](https://github.com/angular/angular/compare/5.1.0-beta.2...5.1.0-rc.0) (2017-12-01)
@@ -6224,7 +6320,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **common:** add locale id parameter to `registerLocaleData` ([#20623](https://github.com/angular/angular/issues/20623)) ([24bf3e2](https://github.com/angular/angular/commit/24bf3e2))
 * **compiler-cli:** improve error messages produced during structural errors ([#20459](https://github.com/angular/angular/issues/20459)) ([8ecda94](https://github.com/angular/angular/commit/8ecda94))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.0.4"></a>
 ## [5.0.4](https://github.com/angular/angular/compare/5.0.3...5.0.4) (2017-12-01)
@@ -6241,7 +6337,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **compiler-cli:** fix memory leak in program creation ([#20692](https://github.com/angular/angular/issues/20692)) ([38be44d](https://github.com/angular/angular/commit/38be44d)), closes [#20691](https://github.com/angular/angular/issues/20691)
 * **compiler-cli:** normalize sourcepaths for i18n extracted files ([#20417](https://github.com/angular/angular/issues/20417)) ([2b0c896](https://github.com/angular/angular/commit/2b0c896)), closes [#20416](https://github.com/angular/angular/issues/20416)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.1.0-beta.2"></a>
 # [5.1.0-beta.2](https://github.com/angular/angular/compare/5.1.0-beta.1...5.1.0-beta.2) (2017-11-22)
@@ -6265,7 +6361,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 
 * **platform-browser-dynamic:** export `JitCompilerFactory` ([#20478](https://github.com/angular/angular/issues/20478)) ([d7a727c](https://github.com/angular/angular/commit/d7a727c)), closes [#20125](https://github.com/angular/angular/issues/20125)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.0.3"></a>
 ## [5.0.3](https://github.com/angular/angular/compare/5.0.2...5.0.3) (2017-11-22)
@@ -6283,6 +6379,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **core:** should support event.stopImmediatePropagation ([#20469](https://github.com/angular/angular/issues/20469)) ([82aace6](https://github.com/angular/angular/commit/82aace6))
 * **forms:** updateOn should check if change occurred ([#20358](https://github.com/angular/angular/issues/20358)) ([f9f2c20](https://github.com/angular/angular/commit/f9f2c20)), closes [#20259](https://github.com/angular/angular/issues/20259)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.1.0-beta.1"></a>
 # [5.1.0-beta.1](https://github.com/angular/angular/compare/5.1.0-beta.0...5.1.0-beta.1) (2017-11-16)
@@ -6307,6 +6404,8 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 
 > Note, if you do `Injector.get(Token)` where `Token` has static members, you'll run into https://github.com/Microsoft/TypeScript/issues/20102 where the returned type is `{}` rather than `Token`. Use `Injector.get<Token>(Token)` to work around.
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="5.0.2"></a>
 ## [5.0.2](https://github.com/angular/angular/compare/5.0.1...5.0.2) (2017-11-16)
 
@@ -6319,6 +6418,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **compiler:** show explanatory text in template errors ([#20313](https://github.com/angular/angular/issues/20313)) ([424a323](https://github.com/angular/angular/commit/424a323))
 * **router:** 'merge' queryParamHandling strategy should be able to remove query params ([#19733](https://github.com/angular/angular/issues/19733)) ([b732fb9](https://github.com/angular/angular/commit/b732fb9)), closes [#18463](https://github.com/angular/angular/issues/18463) [#17202](https://github.com/angular/angular/issues/17202)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.1.0-beta.0"></a>
 # [5.1.0-beta.0](https://github.com/angular/angular/compare/5.0.0-rc.4...5.1.0-beta.0) (2017-11-08)
@@ -6327,6 +6427,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 
 * **compiler:** introduce `TestBed.overrideTemplateUsingTestingModule` ([a460066](https://github.com/angular/angular/commit/a460066)), closes [#19815](https://github.com/angular/angular/issues/19815)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.0.1"></a>
 ## [5.0.1](https://github.com/angular/angular/compare/5.0.0...5.0.1) (2017-11-08)
@@ -6341,6 +6442,7 @@ Note: Due to an animation fix back in 5.1.1 ([c2b3792](https://github.com/angula
 * **core:** should support event.stopImmediatePropagation ([#19222](https://github.com/angular/angular/issues/19222)) ([7083791](https://github.com/angular/angular/commit/7083791))
 * **platform-browser:** support Symbols in custom `jasmineToString()` method ([#19794](https://github.com/angular/angular/issues/19794)) ([5a6efa7](https://github.com/angular/angular/commit/5a6efa7))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="5.0.0"></a>
 # [5.0.0](https://github.com/angular/angular/compare/5.0.0-rc.9...5.0.0) pentagonal-donut (2017-11-01)
@@ -6533,7 +6635,7 @@ Because of multiple bugs and browser inconsistencies, we have dropped the intl a
 * **platform-browser**: `NgProbeToken` has been removed from `@angular/platform-browser` as it was deprecated since v4. Import it from `@angular/core` instead. ([#18760](https://github.com/angular/angular/issues/18760)) ([d7f42bf](https://github.com/angular/angular/commit/d7f42bf))
 * **platform-webworker**: `PRIMITIVE` has been removed as it was deprecated since v4. Use `SerializerTypes.PRIMITIVE` instead. ([#18761](https://github.com/angular/angular/issues/18761)) ([a56468c](https://github.com/angular/angular/commit/a56468c))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.4.6"></a>
 ## [4.4.6](https://github.com/angular/angular/compare/4.4.5...4.4.6) (2017-10-18)
@@ -6550,7 +6652,7 @@ Because of multiple bugs and browser inconsistencies, we have dropped the intl a
 
 * **animations:** reduce size of bundle by removing AST classes ([#19673](https://github.com/angular/angular/issues/19673)) ([76d2496](https://github.com/angular/angular/commit/76d2496))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.4.5"></a>
 ## [4.4.5](https://github.com/angular/angular/compare/4.4.4...4.4.5) (2017-10-12)
@@ -6565,6 +6667,7 @@ Because of multiple bugs and browser inconsistencies, we have dropped the intl a
 * **platform-browser:** support customEqualityTesters when overriding Jasmine toEqual ([cc8ae32](https://github.com/angular/angular/commit/cc8ae32))
 * **tsc-wrapped:** don't rewrite imports when annotating for closure ([#19579](https://github.com/angular/angular/issues/19579)) ([c9f8718](https://github.com/angular/angular/commit/c9f8718))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.4.4"></a>
 ## [4.4.4](https://github.com/angular/angular/compare/4.4.3...4.4.4) (2017-09-28)
@@ -6578,6 +6681,7 @@ Because of multiple bugs and browser inconsistencies, we have dropped the intl a
 * **compiler:** skip &nbsp; when trimming / removing whitespaces ([#19310](https://github.com/angular/angular/issues/19310)) ([c7aa8a1](https://github.com/angular/angular/commit/c7aa8a1)), closes [#19304](https://github.com/angular/angular/issues/19304)
 * **tsc-wrapped:** add metadata for `type` declarations ([#19040](https://github.com/angular/angular/issues/19040)) ([ae52851](https://github.com/angular/angular/commit/ae52851))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.4.3"></a>
 ## [4.4.3](https://github.com/angular/angular/compare/4.4.2...4.4.3) (2017-09-19)
@@ -6587,6 +6691,7 @@ Because of multiple bugs and browser inconsistencies, we have dropped the intl a
 
 * **tsc-wrapped:** deduplicate metadata only when the module is the same ([#19261](https://github.com/angular/angular/issues/19261)) ([0371538](https://github.com/angular/angular/commit/0371538)), closes [#19219](https://github.com/angular/angular/issues/19219)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.4.2"></a>
 ## [4.4.2](https://github.com/angular/angular/compare/4.4.1...4.4.2) (2017-09-18)
@@ -6596,6 +6701,7 @@ Because of multiple bugs and browser inconsistencies, we have dropped the intl a
 
 * **platform-server**: fix for packaging issues [#19250](https://github.com/angular/angular/issues/19250)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.4.1"></a>
 ## [4.4.1](https://github.com/angular/angular/compare/4.3.6...4.4.1) (2017-09-15)
@@ -6621,7 +6727,7 @@ Because of multiple bugs and browser inconsistencies, we have dropped the intl a
 
 Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1 instead. oops :-)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.3.6"></a>
 ## [4.3.6](https://github.com/angular/angular/compare/4.3.5...4.3.6) (2017-08-23)
@@ -6643,7 +6749,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **animations:** allow @.disabled property to work without an expression ([#18713](https://github.com/angular/angular/issues/18713)) ([ac58914](https://github.com/angular/angular/commit/ac58914))
 * **common:** add an empty DeprecatedI18NPipesModule module ([793f31b](https://github.com/angular/angular/commit/793f31b))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.3.5"></a>
 ## [4.3.5](https://github.com/angular/angular/compare/4.3.4...4.3.5) (2017-08-16)
@@ -6654,6 +6760,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **core:** forbid destroyed views to be inserted or moved in VC ([972538b](https://github.com/angular/angular/commit/972538b)), closes [#18615](https://github.com/angular/angular/issues/18615)
 * **forms:** re-assigning options should not clear select ([a1624f2](https://github.com/angular/angular/commit/a1624f2)), closes [#18330](https://github.com/angular/angular/issues/18330)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.3.4"></a>
 ## [4.3.4](https://github.com/angular/angular/compare/4.3.3...4.3.4) (2017-08-10)
@@ -6666,6 +6773,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **compiler:** cleanly compile with TypeScript 2.4 ([#18456](https://github.com/angular/angular/issues/18456)) ([5e4054b](https://github.com/angular/angular/commit/5e4054b))
 * **compiler:** ignore [@import](https://github.com/import) in multi-line css ([#18452](https://github.com/angular/angular/issues/18452)) ([e7e7622](https://github.com/angular/angular/commit/e7e7622)), closes [#18038](https://github.com/angular/angular/issues/18038)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.3.3"></a>
 ## [4.3.3](https://github.com/angular/angular/compare/4.3.2...4.3.3) (2017-08-02)
@@ -6674,6 +6782,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 
 * **compiler:** fix for element needing implicit parent placed in top-level ng-container ([f5cbc2e](https://github.com/angular/angular/commit/f5cbc2e)), closes [#18314](https://github.com/angular/angular/issues/18314)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.3.2"></a>
 ## [4.3.2](https://github.com/angular/angular/compare/4.3.1...4.3.2) (2017-07-26)
@@ -6690,7 +6799,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **router:** should throw when lazy loaded module doesn't define any routes ([#15001](https://github.com/angular/angular/issues/15001)) ([be49e0e](https://github.com/angular/angular/commit/be49e0e)), closes [#14596](https://github.com/angular/angular/issues/14596)
 * **upgrade:** throw error if trying to get injector before setting ([#18209](https://github.com/angular/angular/issues/18209)) ([1f106d7](https://github.com/angular/angular/commit/1f106d7))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.3.1"></a>
 ## [4.3.1](https://github.com/angular/angular/compare/4.3.0...4.3.1) (2017-07-19)
@@ -6711,7 +6820,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **router:** should run resolvers for the same route concurrently ([ec89f37](https://github.com/angular/angular/commit/ec89f37)), closes [#14279](https://github.com/angular/angular/issues/14279)
 * **router:** terminal route in custom matcher ([5d275e9](https://github.com/angular/angular/commit/5d275e9))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.3.0"></a>
 # [4.3.0](https://github.com/angular/angular/compare/4.3.0-rc.0...4.3.0) (2017-07-14)
@@ -6762,8 +6871,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **router:** add router-level events for GuardsCheck and Resolve ([#17601](https://github.com/angular/angular/issues/17601)) ([8a1a989](https://github.com/angular/angular/commit/8a1a989))
 * **upgrade:** fix support for `directive.link` in upgraded components ([0193be7](https://github.com/angular/angular/commit/0193be7))
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.6"></a>
 ## [4.2.6](https://github.com/angular/angular/compare/4.2.5...4.2.6) (2017-07-08)
@@ -6794,7 +6902,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 
 * **core:** refactor NgZone, decrease size by 1.2Kb ([#17773](https://github.com/angular/angular/issues/17773)) ([6d55a80](https://github.com/angular/angular/commit/6d55a80))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.5"></a>
 ## [4.2.5](https://github.com/angular/angular/compare/4.2.4...4.2.5) (2017-06-29)
@@ -6808,7 +6916,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **animations:** properly collect :enter nodes that exist within multi-level DOM trees ([79b6346](https://github.com/angular/angular/commit/79b6346)), closes [#17632](https://github.com/angular/angular/issues/17632)
 * **core:** add needed closure compiler warning suppression ([f31b0d6](https://github.com/angular/angular/commit/f31b0d6))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.4"></a>
 ## [4.2.4](https://github.com/angular/angular/compare/4.2.3...4.2.4) (2017-06-21)
@@ -6825,7 +6933,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **router:** update the version placeholder so that it gets replaced during the build ([7de1ae2](https://github.com/angular/angular/commit/7de1ae2)), closes [#17403](https://github.com/angular/angular/issues/17403)
 * **tsc-wrapped:** skip collecting metadata for default functions ([3390648](https://github.com/angular/angular/commit/3390648))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.3"></a>
 ## [4.2.3](https://github.com/angular/angular/compare/4.2.1...4.2.3) (2017-06-16)
@@ -6838,7 +6946,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **animations:** remove duplicate license header ([b192dd5](https://github.com/angular/angular/commit/b192dd5))
 * **forms:** temp roll back breaking change with min/max directives ([b8c39cd](https://github.com/angular/angular/commit/b8c39cd)), closes [#17491](https://github.com/angular/angular/issues/17491)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.2"></a>
 ## [4.2.2](https://github.com/angular/angular/compare/4.2.1...4.2.2) (2017-06-12)
@@ -6851,7 +6959,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **animations:** properly collect :enter nodes in a partially updated collection ([6ca4692](https://github.com/angular/angular/commit/6ca4692)), closes [#17440](https://github.com/angular/angular/issues/17440)
 * **compiler:** don’t always compile `.ngfactory.ts` files by default ([ed73d4f](https://github.com/angular/angular/commit/ed73d4f3ac6b542bf5ea3eb73fbe91e2ceabcdb4))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.1"></a>
 ## [4.2.1](https://github.com/angular/angular/compare/4.2.0-rc.2...4.2.1) (2017-06-09)
@@ -6863,7 +6971,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **compiler:** don’t write summaries for jit by default ([d3a5f1a](https://github.com/angular/angular/commit/d3a5f1a))
 * **http:** move destructuring inside {Request,Response}Options ctor ([c2d31fb](https://github.com/angular/angular/commit/c2d31fb)), closes [#16663](https://github.com/angular/angular/issues/16663)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.0"></a>
 # [4.2.0](https://github.com/angular/angular/compare/4.2.0-rc.2...4.2.0) salubrious-stratagem (2017-06-08)
@@ -6888,7 +6996,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **animations:** do not create a closure each time a node is removed ([fe6b39d](https://github.com/angular/angular/commit/fe6b39d))
 * **animations:** only apply `:leave` flags if animations are set to run ([b55adee](https://github.com/angular/angular/commit/b55adee))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.0-rc.2"></a>
 # [4.2.0-rc.2](https://github.com/angular/angular/compare/4.2.0-rc.1...4.2.0-rc.2) (2017-06-01)
@@ -6911,6 +7019,8 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 
 * **animations:** do not place enterId values on elements for querying purposes ([#17150](https://github.com/angular/angular/issues/17150)) ([ad6a57e](https://github.com/angular/angular/commit/ad6a57e))
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="4.2.0-rc.1"></a>
 # [4.2.0-rc.1](https://github.com/angular/angular/compare/4.2.0-rc.0...4.2.0-rc.1) (2017-05-26)
 
@@ -6931,7 +7041,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **core:** update zone.js to 0.8.10 and expose the flush method ([#16860](https://github.com/angular/angular/issues/16860)) ([85d4c4b](https://github.com/angular/angular/commit/85d4c4b))
 * **tsc-wrapped:** support template literals in metadata collection ([#16880](https://github.com/angular/angular/issues/16880)) ([6e41add](https://github.com/angular/angular/commit/6e41add))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.0-rc.0"></a>
 # [4.2.0-rc.0](https://github.com/angular/angular/compare/4.2.0-beta.0...4.2.0-rc.0) (2017-05-19)
@@ -6965,7 +7075,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 
 * **animations:** reduce size of animations bundle ([712630c](https://github.com/angular/angular/commit/712630c))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.1.3"></a>
 ## [4.1.3](https://github.com/angular/angular/compare/4.1.2...4.1.3) (2017-05-17)
@@ -6980,7 +7090,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **upgrade:** Prevent renaming of $inject property ([#16706](https://github.com/angular/angular/issues/16706)) ([afb7540](https://github.com/angular/angular/commit/afb7540))
 * **upgrade:** use quote to prevent ClossureCompiler obfuscating $event. ([#16724](https://github.com/angular/angular/issues/16724)) ([47df3d6](https://github.com/angular/angular/commit/47df3d6))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.0-beta.1"></a>
 # [4.2.0-beta.1](https://github.com/angular/angular/compare/4.2.0-beta.0...4.2.0-beta.1) (2017-05-10)
@@ -6990,7 +7100,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 
 * add .ngsummary.ts files to support AOT unit tests ([547c363](https://github.com/angular/angular/commit/547c363))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.1.2"></a>
 ## [4.1.2](https://github.com/angular/angular/compare/4.1.1...4.1.2) (2017-05-10)
@@ -7006,7 +7116,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **http:** introduce encodingHint for text() for better ArrayBuffer support ([ec3b6e9](https://github.com/angular/angular/commit/ec3b6e9)), closes [#15932](https://github.com/angular/angular/issues/15932) [#16420](https://github.com/angular/angular/issues/16420)
 * **router:** fix redirect to a URL with a param having multiple values ([#16376](https://github.com/angular/angular/issues/16376)) ([915eae5](https://github.com/angular/angular/commit/915eae5)), closes [#16310](https://github.com/angular/angular/issues/16310)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.2.0-beta.0"></a>
 # [4.2.0-beta.0](https://github.com/angular/angular/compare/4.1.0...4.2.0-beta.0) (2017-05-04)
@@ -7032,7 +7142,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **forms:** introduce min and max validators ([#15813](https://github.com/angular/angular/issues/15813)) ([81925fa](https://github.com/angular/angular/commit/81925fa))
 * **language-service:** provide external file list to TypeScript ([#16417](https://github.com/angular/angular/issues/16417)) ([f4b771a](https://github.com/angular/angular/commit/f4b771a))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.1.1"></a>
 ## [4.1.1](https://github.com/angular/angular/compare/4.1.0...4.1.1) (2017-05-04)
@@ -7048,7 +7158,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **language-service:** remove asserts for non-null expressions ([#16422](https://github.com/angular/angular/issues/16422)) ([c060110](https://github.com/angular/angular/commit/c060110))
 * **upgrade:** initialize all inputs in time for `ngOnChanges()` ([dd4e501](https://github.com/angular/angular/commit/dd4e501)), closes [#16212](https://github.com/angular/angular/issues/16212)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.1.0"></a>
 # [4.1.0](https://github.com/angular/angular/compare/4.1.0-rc.0...4.1.0) (2017-04-26)
@@ -7059,6 +7169,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **router:** forward the query parameters in the ng1 -> ng2 url sync ([#16249](https://github.com/angular/angular/issues/16249)) ([2f97731](https://github.com/angular/angular/commit/2f97731)), closes [#16067](https://github.com/angular/angular/issues/16067)
 * **upgrade:** use correct attribute name for upgraded component's bindings ([#16128](https://github.com/angular/angular/issues/16128)) ([d1fb066](https://github.com/angular/angular/commit/d1fb066)), closes [#8856](https://github.com/angular/angular/issues/8856)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.1.0-rc.0"></a>
 # [4.1.0-rc.0](https://github.com/angular/angular/compare/4.1.0-beta.0...4.1.0-rc.0) (2017-04-21)
@@ -7120,7 +7231,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * add support for TS 2.2 ([3c8a61e](https://github.com/angular/angular/commit/3c8a61e))
 * add support for TS 2.3 ([014594f](https://github.com/angular/angular/commit/014594f))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.3"></a>
 ## [4.0.3](https://github.com/angular/angular/compare/4.0.2...4.0.3) (2017-04-21)
@@ -7152,7 +7263,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **upgrade:** fixes for allow setting the angularjs lib at runtime ([bb6932d](https://github.com/angular/angular/commit/bb6932d))
 * add support for TS 2.3 ([5cf101f](https://github.com/angular/angular/commit/5cf101f))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.1.0-beta.1"></a>
 # [4.1.0-beta.1](https://github.com/angular/angular/compare/4.1.0-beta.0...4.1.0-beta.1) (2017-04-12)
@@ -7180,7 +7291,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **compiler:** Update types for TypeScript nullability support ([09d9f5f](https://github.com/angular/angular/commit/09d9f5f))
 * **language-service:** Update types for TypeScript nullability support ([540581d](https://github.com/angular/angular/commit/540581d))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.2"></a>
 ## [4.0.2](https://github.com/angular/angular/compare/4.0.1...4.0.2) (2017-04-11)
@@ -7199,7 +7310,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 * **router:** the preloader use the module from the loaded config ([978f809](https://github.com/angular/angular/commit/978f809))
 * **tsc-wrapped:** ensure valid path separators in metadata ([c10e50c](https://github.com/angular/angular/commit/c10e50c))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.1.0-beta.0"></a>
 # [4.1.0-beta.0](https://github.com/angular/angular/compare/4.0.0...4.1.0-beta.0) (2017-03-29)
@@ -7210,6 +7321,7 @@ Note: the 4.4.0 release on npm accidentally glitched-out midway, so we cut 4.4.1
 
 Note: 4.1.0-beta.0 release also contains all the changes present in the 4.0.1 release.
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.1"></a>
 ## [4.0.1](https://github.com/angular/angular/compare/4.0.0...4.0.1) (2017-03-29)
@@ -7239,6 +7351,8 @@ Note: 4.1.0-beta.0 release also contains all the changes present in the 4.0.1 re
 
 * **router:** don't create new serializer every time UrlTree.toString is called ([#15565](https://github.com/angular/angular/issues/15565)) ([fd61145](https://github.com/angular/angular/commit/fd61145))
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="4.0.0"></a>
 # [4.0.0](https://github.com/angular/angular/compare/4.0.0-rc.6...4.0.0) invisible-makeover (2017-03-23)
 
@@ -7254,6 +7368,8 @@ Note: 4.1.0-beta.0 release also contains all the changes present in the 4.0.1 re
 ### BREAKING CHANGES
 
 From 4.0.0 @angular/core uses a [`WeakMap`](https://github.com/angular/angular/commit/52b21275f4c2c26c46627f5648b41a33bb5c8283), a polyfill needs to be included for [browsers that do not support it natively](https://kangax.github.io/compat-table/es6/#test-WeakMap).
+
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-rc.6"></a>
 # [4.0.0-rc.6](https://github.com/angular/angular/compare/4.0.0-rc.5...4.0.0-rc.6) (2017-03-23)
@@ -7300,7 +7416,7 @@ From 4.0.0 @angular/core uses a [`WeakMap`](https://github.com/angular/angular/c
 * **tsc-wrapped:** record original location of flattened symbols ([#15367](https://github.com/angular/angular/issues/15367)) ([7354949](https://github.com/angular/angular/commit/7354949))
 * **upgrade:** use `ComponentFactory.inputs/outputs/ngContentSelectors` ([#15214](https://github.com/angular/angular/issues/15214)) ([9429032](https://github.com/angular/angular/commit/9429032))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-rc.5"></a>
 # [4.0.0-rc.5](https://github.com/angular/angular/compare/4.0.0-rc.4...4.0.0-rc.5) (2017-03-17)
@@ -7310,7 +7426,7 @@ From 4.0.0 @angular/core uses a [`WeakMap`](https://github.com/angular/angular/c
 
 * **compiler-cli:** update the tsc-wrapped dependency version ([#15226](https://github.com/angular/angular/issues/15226)) ([7fb4528](https://github.com/angular/angular/commit/7fb4528))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-rc.4"></a>
 # [4.0.0-rc.4](https://github.com/angular/angular/compare/4.0.0-rc.3...4.0.0-rc.4) (2017-03-17)
@@ -7389,7 +7505,7 @@ From 4.0.0 @angular/core uses a [`WeakMap`](https://github.com/angular/angular/c
   - `Renderer2.setStyle` no longer takes booleans but rather a
      bit mask of flags.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.4.10"></a>
 ## [2.4.10](https://github.com/angular/angular/compare/2.4.9...2.4.10) (2017-03-17)
@@ -7399,6 +7515,7 @@ From 4.0.0 @angular/core uses a [`WeakMap`](https://github.com/angular/angular/c
 * **compiler:** fix decoding surrogate pairs ([#15154](https://github.com/angular/angular/issues/15154)) ([e5c9bbc](https://github.com/angular/angular/commit/e5c9bbc))
 * **router:** do not finish bootstrap until all the routes are resolved ([#15121](https://github.com/angular/angular/issues/15121)) ([34403cd](https://github.com/angular/angular/commit/34403cd))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-rc.3"></a>
 # [4.0.0-rc.3](https://github.com/angular/angular/compare/4.0.0-rc.2...4.0.0-rc.3) (2017-03-10)
@@ -7421,6 +7538,8 @@ From 4.0.0 @angular/core uses a [`WeakMap`](https://github.com/angular/angular/c
 - rename `RendererTypeV2` to `RendererType2`
 - rename `RendererFactoryV2` to `RendererFactory2`
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="2.4.9"></a>
 ## [2.4.9](https://github.com/angular/angular/compare/2.4.8...2.4.9) (2017-03-02)
 
@@ -7435,7 +7554,7 @@ From 4.0.0 @angular/core uses a [`WeakMap`](https://github.com/angular/angular/c
 
 * fix(router): do not finish bootstrap until all the routes are resolved ([#14327](https://github.com/angular/angular/issues/14327)) ([de36f8a](https://github.com/angular/angular/commit/de36f8a)), closes [#14681](https://github.com/angular/angular/issues/14681) [#14588](https://github.com/angular/angular/issues/14588)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-rc.2"></a>
 ## [4.0.0-rc.2](https://github.com/angular/angular/compare/4.0.0-rc.1...4.0.0-rc.2) (2017-03-02)
@@ -7460,7 +7579,7 @@ From 4.0.0 @angular/core uses a [`WeakMap`](https://github.com/angular/angular/c
 * delete pre-view-engine core, compiler, platform-browser, etc code ([#14788](https://github.com/angular/angular/issues/14788)) ([126fda2](https://github.com/angular/angular/commit/126fda2))
 * **compiler:** make identifiers for generated code small to improve dev size ([5caab71](https://github.com/angular/angular/commit/5caab71f7dc64b10f3544b2a3b2650e1666adbf1))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-rc.1"></a>
 # [4.0.0-rc.1](https://github.com/angular/angular/compare/4.0.0-beta.8...4.0.0-rc.1) (2017-02-24)
@@ -7608,7 +7727,7 @@ We have [three more release candidates scheduled](https://github.com/angular/ang
 
 Note: the 4.0.0-rc.0 release on npm accidentally omitted one bug fix, so we cut rc.1 instead. oops :-)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-beta.8"></a>
 ## [4.0.0-beta.8](https://github.com/angular/angular/compare/4.0.0-beta.7...4.0.0-beta.8) (2017-02-18)
@@ -7667,7 +7786,7 @@ templates is unaffected. We expect no or little impact on apps from this change,
 
   * Mitigation: Update derived classes of `AsyncPipe` that override `transform()` to include the type parameter overloads.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.4.8"></a>
 ## [2.4.8](https://github.com/angular/angular/compare/2.4.7...2.4.8) (2017-02-18)
@@ -7682,7 +7801,7 @@ templates is unaffected. We expect no or little impact on apps from this change,
 * **upgrade:** correctly project content on downgraded components with structural directives ([#14274](https://github.com/angular/angular/issues/14274)) ([74cb575](https://github.com/angular/angular/commit/74cb575)), closes [#14260](https://github.com/angular/angular/issues/14260)
 * **upgrade:** pass correct values to `ngOnChanges` for interpolation bindings ([#14400](https://github.com/angular/angular/issues/14400)) ([7c87c52](https://github.com/angular/angular/commit/7c87c52))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-beta.7"></a>
 ## [4.0.0-beta.7](https://github.com/angular/angular/compare/4.0.0-beta.6...4.0.0-beta.7) (2017-02-09)
@@ -7708,7 +7827,7 @@ templates is unaffected. We expect no or little impact on apps from this change,
 
 * Angular 4 will support only TypeScript 2.1, so we no longer provide backwards compatibility to TS 1.8.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.4.7"></a>
 ## [2.4.7](https://github.com/angular/angular/compare/2.4.6...2.4.7) (2017-02-09)
@@ -7718,6 +7837,7 @@ templates is unaffected. We expect no or little impact on apps from this change,
 
 * **upgrade:** allow non-element selectors for downgraded components ([#14291](https://github.com/angular/angular/issues/14291)) ([5bb47db](https://github.com/angular/angular/commit/5bb47db))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-beta.6"></a>
 ## [4.0.0-beta.6](https://github.com/angular/angular/compare/4.0.0-beta.5...4.0.0-beta.6) (2017-02-03)
@@ -7813,7 +7933,7 @@ to be used for registering AngularJS injectable services, but it is possible
 that type-checking might fail or that current code breaks if it relies on the
 returned value being an array.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.4.6"></a>
 ## [2.4.6](https://github.com/angular/angular/compare/2.4.5...2.4.6) (2017-02-03)
@@ -7841,7 +7961,7 @@ returned value being an array.
 * **testing:** async/fakeAsync/inject/withModule helpers should pass through context to callback functions ([#13718](https://github.com/angular/angular/issues/13718)) ([70bbdf5](https://github.com/angular/angular/commit/70bbdf5))
 * **upgrade:** detect async downgrade component changes ([#14039](https://github.com/angular/angular/issues/14039)) ([117fa79](https://github.com/angular/angular/commit/117fa79)), closes [#6385](https://github.com/angular/angular/issues/6385) [#6385](https://github.com/angular/angular/issues/6385)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-beta.5"></a>
 ## [4.0.0-beta.5](https://github.com/angular/angular/compare/4.0.0-beta.3...4.0.0-beta.5) (2017-01-25)
@@ -7902,7 +8022,7 @@ function myTest(injector: Injector) {
 }
 ```
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.4.5"></a>
 ## [2.4.5](https://github.com/angular/angular/compare/2.4.4...2.4.5) (2017-01-25)
@@ -7915,7 +8035,7 @@ function myTest(injector: Injector) {
 * **core:** export animation classes required for Renderer impl ([#14002](https://github.com/angular/angular/issues/14002)) ([fd4f9ac](https://github.com/angular/angular/commit/fd4f9ac)), closes [#14001](https://github.com/angular/angular/issues/14001)
 * **upgrade:** ensure upgraded injector is initialized early enough ([#14065](https://github.com/angular/angular/issues/14065)) ([3b2fb23](https://github.com/angular/angular/commit/3b2fb23)), closes [#13811](https://github.com/angular/angular/issues/13811)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-beta.4"></a>
 ## [4.0.0-beta.4](https://github.com/angular/angular/compare/4.0.0-beta.3...4.0.0-beta.4) (2017-01-19)
@@ -7969,7 +8089,7 @@ function myTest(injector: Injector) {
 }
 ```
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.4.4"></a>
 ## [2.4.4](https://github.com/angular/angular/compare/2.4.3...2.4.4) (2017-01-19)
@@ -7982,7 +8102,7 @@ function myTest(injector: Injector) {
 * **security:** allow calc and gradient functions. ([#13943](https://github.com/angular/angular/issues/13943)) ([bd15110](https://github.com/angular/angular/commit/bd15110))
 * **upgrade:** detect async downgrade component changes ([#13812](https://github.com/angular/angular/issues/13812)) ([2250082](https://github.com/angular/angular/commit/2250082)), closes [#6385](https://github.com/angular/angular/issues/6385) [#6385](https://github.com/angular/angular/issues/6385) [#10660](https://github.com/angular/angular/issues/10660) [#12318](https://github.com/angular/angular/issues/12318) [#12034](https://github.com/angular/angular/issues/12034)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-beta.3"></a>
 ## [4.0.0-beta.3](https://github.com/angular/angular/compare/4.0.0-beta.2...4.0.0-beta.3) (2017-01-11)
@@ -8034,7 +8154,7 @@ function myTest(injector: Injector) {
 * Deprecate `IterableDiffers#factories` as it is private field which
   was erroneously exposed.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.4.3"></a>
 ## [2.4.3](https://github.com/angular/angular/compare/2.4.2...2.4.3) (2017-01-11)
@@ -8051,7 +8171,7 @@ function myTest(injector: Injector) {
 * **router:** throw an error when navigate to null/undefined path ([61ba223](https://github.com/angular/angular/commit/61ba223)), closes [#10560](https://github.com/angular/angular/issues/10560) [#13384](https://github.com/angular/angular/issues/13384)
 * **router:** fix checking for object intersection ([1692265](https://github.com/angular/angular/commit/1692265))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.4.2"></a>
 ## [2.4.2](https://github.com/angular/angular/compare/2.4.1...2.4.2) (2017-01-06)
@@ -8076,7 +8196,7 @@ function myTest(injector: Injector) {
 * **router:** update route snapshot before emit new values ([#13558](https://github.com/angular/angular/issues/13558)) ([9f6a647](https://github.com/angular/angular/commit/9f6a647)), closes [#12912](https://github.com/angular/angular/issues/12912)
 * **upgrade:** fix/improve support for lifecycle hooks ([#13020](https://github.com/angular/angular/issues/13020)) ([21942a8](https://github.com/angular/angular/commit/21942a8))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-beta.2"></a>
 ## [4.0.0-beta.2](https://github.com/angular/angular/compare/4.0.0-beta.1...4.0.0-beta.2) (2017-01-06)
@@ -8105,8 +8225,7 @@ Note: 4.0.0-beta.2 release also contains all the changes present in the 2.4.2 re
 change or not. This is a low profile API and we don't expect anyone to be affected by this change.
 If you are impacted by this change please file an issue. ([465516b](https://github.com/angular/angular/commit/465516b))
 
-
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-beta.1"></a>
 ## [4.0.0-beta.1](https://github.com/angular/angular/compare/2.4.0-marker...4.0.0-beta.1) (2016-12-22)
@@ -8116,6 +8235,8 @@ If you are impacted by this change please file an issue. ([465516b](https://gith
 * **upgrade:** support the `$doCheck()` lifecycle hook in `UpgradeComponent` ([#13015](https://github.com/angular/angular/issues/13015)) ([9da4c25](https://github.com/angular/angular/commit/9da4c25))
 
 Note: 4.0.0-beta.1 release also contains all the changes present in the 2.4.0 and the 2.4.1 releases.
+
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.4.1"></a>
 ## [2.4.1](https://github.com/angular/angular/compare/2.4.0...2.4.1) (2016-12-21)
@@ -8128,7 +8249,7 @@ Note: 4.0.0-beta.1 release also contains all the changes present in the 2.4.0 an
 * **core:** improve error message when component factory cannot be found ([#13541](https://github.com/angular/angular/issues/13541)) ([b9e979e](https://github.com/angular/angular/commit/b9e979e)), closes [#12678](https://github.com/angular/angular/issues/12678)
 * **router:** should reset location if a navigation by location is successful ([#13545](https://github.com/angular/angular/issues/13545)) ([a38f14b](https://github.com/angular/angular/commit/a38f14b)), closes [#13491](https://github.com/angular/angular/issues/13491)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.4.0"></a>
 # [2.4.0 stability-interjection](https://github.com/angular/angular/compare/2.3.1...2.4.0) (2016-12-20)
@@ -8148,6 +8269,7 @@ Note: 4.0.0-beta.1 release also contains all the changes present in the 2.4.0 an
 
 * update to `rxjs@5.0.1` and unpin the rxjs peerDeps via `^5.0.1` ([#13572](https://github.com/angular/angular/issues/13572)) ([8d5da1e](https://github.com/angular/angular/commit/8d5da1e)), closes [#13561](https://github.com/angular/angular/issues/13561) [#13478](https://github.com/angular/angular/issues/13478)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="4.0.0-beta.0"></a>
 ## [4.0.0-beta.0](https://github.com/angular/angular/compare/2.3.0...4.0.0-beta.0) (2016-12-15)
@@ -8168,6 +8290,8 @@ Note: 4.0.0-beta.1 release also contains all the changes present in the 2.4.0 an
 * **common** ngIf now supports else; saves condition to local var ([b4db73d](https://github.com/angular/angular/commit/b4db73d)), closes [#13061](https://github.com/angular/angular/issues/13061) [#13297](https://github.com/angular/angular/issues/13297)
 
 Note: 4.0.0-beta.0 release also contains all the changes present in the 2.3.1 release.
+
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.3.1"></a>
 ## [2.3.1](https://github.com/angular/angular/compare/2.3.0...2.3.1) (2016-12-15)
@@ -8222,6 +8346,8 @@ The >=2.3.1 compiler will issue is the following error if it encounters componen
 
 We are adding more tests to our test suite to catch these kinds of problems before we cut a release.
 
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="2.3.0"></a>
 # [2.3.0](https://github.com/angular/angular/compare/2.3.0-rc.0...2.3.0) (2016-12-07)
 
@@ -8253,7 +8379,7 @@ We are adding more tests to our test suite to catch these kinds of problems befo
 
 * **compiler:** read and write `.ngsummary.json` files ([614a35d](https://github.com/angular/angular/commit/614a35d)), closes [#12787](https://github.com/angular/angular/issues/12787)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.3.0-rc.0"></a>
 # [2.3.0-rc.0](https://github.com/angular/angular/compare/2.3.0-beta.0...2.3.0-rc.0) (2016-11-30)
@@ -8295,7 +8421,7 @@ We are adding more tests to our test suite to catch these kinds of problems befo
 * **router:** add support for custom route reuse strategies ([42cf06f](https://github.com/angular/angular/commit/42cf06f))
 * **tools:** allow disabling annotation lowering ([c1a62e2](https://github.com/angular/angular/commit/c1a62e2))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.2.4"></a>
 ## [2.2.4](https://github.com/angular/angular/compare/2.2.3...2.2.4) (2016-11-30)
@@ -8307,7 +8433,7 @@ We are adding more tests to our test suite to catch these kinds of problems befo
 * **compiler:** fix performance regression caused by 5b0f9e2 ([ee2d6e5](https://github.com/angular/angular/commit/ee2d6e5)), closes [#13146](https://github.com/angular/angular/issues/13146)
 * **compiler-cli:** fix paths in source maps to be relative ([eb173bc](https://github.com/angular/angular/commit/eb173bc)), closes [#13040](https://github.com/angular/angular/issues/13040)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.2.3"></a>
 ## [2.2.3](https://github.com/angular/angular/compare/2.2.2...2.2.3) (2016-11-23)
@@ -8317,7 +8443,7 @@ We are adding more tests to our test suite to catch these kinds of problems befo
 * **compiler:** Revert: fix versions of `@angular/tsc-wrapped` ([015ca47](https://github.com/angular/angular/commit/015ca47))
 * **animations:** Revert: blend in all previously transitioned styles into next animation if interrupted ([c12e56e](https://github.com/angular/angular/commit/c12e56e))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.2.2"></a>
 ## [2.2.2](https://github.com/angular/angular/compare/2.2.1...2.2.2) (2016-11-22)
@@ -8336,7 +8462,7 @@ We are adding more tests to our test suite to catch these kinds of problems befo
 * **router:** support redirects to named outlets ([09226d9](https://github.com/angular/angular/commit/09226d9)), closes [#12740](https://github.com/angular/angular/issues/12740) [#9921](https://github.com/angular/angular/issues/9921)
 * **upgrade:** call ng1 lifecycle hooks ([#12875](https://github.com/angular/angular/issues/12875)) ([462316b](https://github.com/angular/angular/commit/462316b))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.3.0-beta.0"></a>
 # [2.3.0-beta.0](https://github.com/angular/angular/compare/2.2.0...2.3.0-beta.0) (2016-11-17)
@@ -8360,7 +8486,7 @@ We are adding more tests to our test suite to catch these kinds of problems befo
 
 Note: The 2.3.0-beta.0 release also contains all the changes present in the 2.2.1 release.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.2.1"></a>
 ## [2.2.1](https://github.com/angular/angular/compare/2.2.0...2.2.1) (2016-11-17)
@@ -8382,6 +8508,7 @@ Note: The 2.3.0-beta.0 release also contains all the changes present in the 2.2.
 * **common:** select should allow for null values in HTML select options bound with ngValue ([e02c180](https://github.com/angular/angular/commit/e02c180)), closes [#12829](https://github.com/angular/angular/issues/12829)
 * **compiler-cli:** support ctorParams in function closure ([#12876](https://github.com/angular/angular/issues/12876)) ([6cdc3b5](https://github.com/angular/angular/commit/6cdc3b5))
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.2.0"></a>
 # [2.2.0 upgrade-firebooster](https://github.com/angular/angular/compare/2.2.0-rc.0...2.2.0) (2016-11-14)
@@ -8450,7 +8577,7 @@ Note: The 2.3.0-beta.0 release also contains all the changes present in the 2.2.
 * **platform-browser:** provide the ability to register global hammer.js events ([768cddb](https://github.com/angular/angular/commit/768cddb)), closes [#12797](https://github.com/angular/angular/issues/12797)
 * **tsc-wrapped:** harden collector against invalid asts ([#12793](https://github.com/angular/angular/issues/12793)) ([69f87ca](https://github.com/angular/angular/commit/69f87ca))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.2.0-rc.0"></a>
 # [2.2.0-rc.0](https://github.com/angular/angular/compare/2.2.0-beta.1...2.2.0-rc.0) (2016-11-02)
@@ -8476,7 +8603,7 @@ Note: The 2.3.0-beta.0 release also contains all the changes present in the 2.2.
 
 * **core:** add the find method to QueryList ([7c16ef9](https://github.com/angular/angular/commit/7c16ef9))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.1.2"></a>
 # [2.1.2](https://github.com/angular/angular/compare/2.1.1...2.1.2) (2016-10-27)
@@ -8496,7 +8623,7 @@ Note: The 2.3.0-beta.0 release also contains all the changes present in the 2.2.
 * **router:** disallow component routes with named outlets ([8f2fa0f](https://github.com/angular/angular/commit/8f2fa0f)), closes [#11208](https://github.com/angular/angular/issues/11208) [#11082](https://github.com/angular/angular/issues/11082)
 * **router:** preserve resolve data ([6ccbfd4](https://github.com/angular/angular/commit/6ccbfd4)), closes [#12306](https://github.com/angular/angular/issues/12306)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.2.0-beta.1"></a>
 # [2.2.0-beta.1](https://github.com/angular/angular/compare/2.2.0-beta.0...2.2.0-beta.1) (2016-10-27)
@@ -8541,7 +8668,7 @@ Note: The 2.2.0-beta.1 release also contains all the changes present in the 2.1.
 
 * **common:** optimize NgSwitch default case ([fdf4309](https://github.com/angular/angular/commit/fdf4309))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.2.0-beta.0"></a>
 # [2.2.0-beta.0](https://github.com/angular/angular/compare/2.1.0...2.2.0-beta.0) (2016-10-20)
@@ -8559,7 +8686,7 @@ Note: The 2.2.0-beta.1 release also contains all the changes present in the 2.1.
 
 Note: The 2.2.0-beta.0 release also contains all the changes present in the 2.1.1 release.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.1.0"></a>
 # [2.1.0 incremental-metamorphosis](https://github.com/angular/angular/compare/2.1.0-rc.0...2.1.0) (2016-10-12)
@@ -8584,7 +8711,7 @@ Note: The 2.2.0-beta.0 release also contains all the changes present in the 2.1.
 * **router:** wildcards routes should support lazy loading ([40b92dd](https://github.com/angular/angular/commit/40b92dd)), closes [#12024](https://github.com/angular/angular/issues/12024)
 * **upgrade:** allow compilerOptions in bootstrap ([#10575](https://github.com/angular/angular/issues/10575)) ([5effc33](https://github.com/angular/angular/commit/5effc33))
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.1.0-rc.0"></a>
 # [2.1.0-rc.0](https://github.com/angular/angular/compare/2.1.0-beta.0...2.1.0-rc.0) (2016-10-05)
@@ -8595,7 +8722,7 @@ Note: The 2.2.0-beta.0 release also contains all the changes present in the 2.1.
 
 Note: 2.1.0-rc.0 release also contains all the changes present in the 2.0.2 release.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.1.0-beta.0"></a>
 # [2.1.0-beta.0](https://github.com/angular/angular/compare/2.0.0...2.1.0-beta.0) (2016-09-23)
@@ -8610,7 +8737,7 @@ Note: 2.1.0-rc.0 release also contains all the changes present in the 2.0.2 rele
 
 Note: 2.1.0-beta.0 release also contains all the changes present in the 2.0.1 release.
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.0.2"></a>
 ## [2.0.2](https://github.com/angular/angular/compare/2.0.1...2.0.2) (2016-10-05)
@@ -8634,6 +8761,7 @@ Note: 2.1.0-beta.0 release also contains all the changes present in the 2.0.1 re
 * **router:** do not reset the router state when updating the component ([#11867](https://github.com/angular/angular/issues/11867)) ([cf750e1](https://github.com/angular/angular/commit/cf750e1))
 * **upgrade:** bind optional properties when upgrading from ng1 ([#11411](https://github.com/angular/angular/issues/11411)) ([0851238](https://github.com/angular/angular/commit/0851238)), closes [#10181](https://github.com/angular/angular/issues/10181)
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.0.1"></a>
 ## [2.0.1](https://github.com/angular/angular/compare/2.0.0...2.0.1) (2016-09-23)
@@ -8652,7 +8780,7 @@ Note: 2.1.0-beta.0 release also contains all the changes present in the 2.0.1 re
 * **forms:** support unbound disabled in ngModel ([#11736](https://github.com/angular/angular/issues/11736)) ([39e251e](https://github.com/angular/angular/commit/39e251e))
 * **upgrade:** allow attribute selectors for components in ng2 which are not part of upgrade ([#11808](https://github.com/angular/angular/issues/11808)) ([b81e2e7](https://github.com/angular/angular/commit/b81e2e7)), closes [#11280](https://github.com/angular/angular/issues/11280)
 
-
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="2.0.0"></a>
 # [2.0.0 proprioception-reinforcement](https://github.com/angular/angular/compare/2.0.0-rc.7...2.0.0) (2016-09-14)


### PR DESCRIPTION
Add `<!-- CHANGELOG SPLIT MARKER -->` between changelog entries to match the expected format of the CHANGELOG.md file for the repository tooling.