### PR TITLE
feat(router): allow passing an ActivatedRouteSnapshot for relative link resolution in Router.createUrlTree

### DIFF
--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -747,7 +747,7 @@ export interface UrlCreationOptions {
     preserveFragment?: boolean;
     queryParams?: Params | null;
     queryParamsHandling?: QueryParamsHandling | null;
-    relativeTo?: ActivatedRoute | null;
+    relativeTo?: ActivatedRoute | ActivatedRouteSnapshot | null;
 }
 
 // @public

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ActivatedRoute} from './router_state';
+import {ActivatedRoute, ActivatedRouteSnapshot} from './router_state';
 import {Params, PRIMARY_OUTLET} from './shared';
 import {UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
 import {forEach, last, shallowEqual} from './utils/collection';
 
 export function createUrlTree(
-    route: ActivatedRoute, urlTree: UrlTree, commands: any[], queryParams: Params|null,
-    fragment: string|null): UrlTree {
+    route: ActivatedRoute|ActivatedRouteSnapshot, urlTree: UrlTree, commands: any[],
+    queryParams: Params|null, fragment: string|null): UrlTree {
   if (commands.length === 0) {
     return tree(urlTree.root, urlTree.root, urlTree, queryParams, fragment);
   }
@@ -150,13 +150,16 @@ class Position {
   }
 }
 
-function findStartingPosition(nav: Navigation, tree: UrlTree, route: ActivatedRoute): Position {
+function findStartingPosition(
+    nav: Navigation, tree: UrlTree, route: ActivatedRoute|ActivatedRouteSnapshot): Position {
   if (nav.isAbsolute) {
     return new Position(tree.root, true, 0);
   }
 
-  if (route.snapshot._lastPathIndex === -1) {
-    const segmentGroup = route.snapshot._urlSegment;
+  const routeSnapshot = route instanceof ActivatedRoute ? route.snapshot : route;
+
+  if (routeSnapshot._lastPathIndex === -1) {
+    const segmentGroup = routeSnapshot._urlSegment;
     // Pathless ActivatedRoute has _lastPathIndex === -1 but should not process children
     // see issue #26224, #13011, #35687
     // However, if the ActivatedRoute is the root we should process children like above.
@@ -165,9 +168,8 @@ function findStartingPosition(nav: Navigation, tree: UrlTree, route: ActivatedRo
   }
 
   const modifier = isMatrixParams(nav.commands[0]) ? 0 : 1;
-  const index = route.snapshot._lastPathIndex + modifier;
-  return createPositionApplyingDoubleDots(
-      route.snapshot._urlSegment, index, nav.numberOfDoubleDots);
+  const index = routeSnapshot._lastPathIndex + modifier;
+  return createPositionApplyingDoubleDots(routeSnapshot._urlSegment, index, nav.numberOfDoubleDots);
 }
 
 function createPositionApplyingDoubleDots(

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -24,7 +24,7 @@ import {switchTap} from './operators/switch_tap';
 import {DefaultRouteReuseStrategy, RouteReuseStrategy} from './route_reuse_strategy';
 import {RouterConfigLoader} from './router_config_loader';
 import {ChildrenOutletContexts} from './router_outlet_context';
-import {ActivatedRoute, createEmptyState, RouterState, RouterStateSnapshot} from './router_state';
+import {ActivatedRoute, ActivatedRouteSnapshot, createEmptyState, RouterState, RouterStateSnapshot} from './router_state';
 import {isNavigationCancelingError, navigationCancelingError, Params} from './shared';
 import {DefaultUrlHandlingStrategy, UrlHandlingStrategy} from './url_handling_strategy';
 import {containsTree, createEmptyUrlTree, IsActiveMatchOptions, UrlSerializer, UrlTree} from './url_tree';
@@ -84,7 +84,7 @@ export interface UrlCreationOptions {
    * A value of `null` or `undefined` indicates that the navigation commands should be applied
    * relative to the root.
    */
-  relativeTo?: ActivatedRoute|null;
+  relativeTo?: ActivatedRoute|ActivatedRouteSnapshot|null;
 
   /**
    * Sets query parameters to the URL.

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -296,6 +296,12 @@ describe('createUrlTree', () => {
       expect(serializer.serialize(t)).toEqual('/a/(c2//left:cp)(left:ap)');
     });
 
+    it('should work when given a snapshot', () => {
+      const p = serializer.parse('/a/(c//left:cp)(left:ap)');
+      const t = createWithSnapshot(p.root.children[PRIMARY_OUTLET], 0, p, ['c2']);
+      expect(serializer.serialize(t)).toEqual('/a/(c2//left:cp)(left:ap)');
+    });
+
     it('should work when the first command starts with a ./', () => {
       const p = serializer.parse('/a/(c//left:cp)(left:ap)');
       const t = create(p.root.children[PRIMARY_OUTLET], 0, p, ['./c2']);
@@ -433,4 +439,16 @@ function create(
       new BehaviorSubject(null!), new BehaviorSubject(null!), PRIMARY_OUTLET, 'someComponent', s);
   advanceActivatedRoute(a);
   return createUrlTree(a, tree, commands, queryParams ?? null, fragment ?? null);
+}
+
+function createWithSnapshot(
+    segment: UrlSegmentGroup, startIndex: number, tree: UrlTree, commands: any[],
+    queryParams?: Params, fragment?: string) {
+  if (!segment) {
+    expect(segment).toBeDefined();
+  }
+  const s = new (ActivatedRouteSnapshot as any)(
+      segment.segments, <any>{}, <any>{}, '', <any>{}, PRIMARY_OUTLET, 'someComponent', null,
+      <any>segment, startIndex, <any>null);
+  return createUrlTree(s, tree, commands, queryParams ?? null, fragment ?? null);
 }


### PR DESCRIPTION
The relativeTo property of the navigationExtras parameter in the createUrlTree method of the Router class may now be an ActivatedRoute or an ActivatedRouteSnapshot.
The latter is useful in CanActivate route guards when building an alternative UrlTree to navigate to, relative to the URL that the current navigation is attempting to access.

Fixes #22763

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

As reported in Issue Number: #22763, when implementing a CanActivate route guard, there is no way to return a UrlTree relative to the route that would otherwise have been activated, as the current ActivatedRoute is the previous navigation, and the next navigation is only available via the ActivatedRouteSnapshot given to the guard.


## What is the new behavior?

This change allows passing an ActivatedRouteSnapshot to as the relativeTo value, thus enabling the following pattern in a route guard:

```ts
export class ExampleGuard implements CanActivate {
  constructor(private readonly router: Router) {}

  canActivate(next: ActivatedRouteSnapshot): UrlTree | boolean {
    return this.routeIsAvailable() || this.buildRedirectUrlTree(next);
  }

  private buildRedirectUrlTree(next: ActivatedRouteSnapshot): UrlTree {
    return this.router.createUrlTree('../default-place', {relativeTo: next});
  }

  private routeIsAvailable(): boolean {
    // check state to see if route available at this time and return true/false
    return true;
  }
}
```


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

