### PR TITLE
fix(compiler): support i18n interpolated only attribute bindings

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/GOLDEN_PARTIAL.js
@@ -373,7 +373,9 @@ MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "
   <div
   title="title {{name}}" i18n-title
   attr.label="label {{name}}" i18n-label="@@id1"
-  attr.lang="lang {{name}}" i18n-attr.lang="@@id2">
+  attr.lang="lang {{name}}" i18n-attr.lang="@@id2"
+  attr.dir="dir {{name}}" i18n-attr.dir="@@id3" i18n-dir="@@id4"
+  attr.draggable="draggable {{name}}" i18n-draggable="@@id5" i18n-attr.draggable="@@id6">
   </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
@@ -384,7 +386,9 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
   <div
   title="title {{name}}" i18n-title
   attr.label="label {{name}}" i18n-label="@@id1"
-  attr.lang="lang {{name}}" i18n-attr.lang="@@id2">
+  attr.lang="lang {{name}}" i18n-attr.lang="@@id2"
+  attr.dir="dir {{name}}" i18n-attr.dir="@@id3" i18n-dir="@@id4"
+  attr.draggable="draggable {{name}}" i18n-draggable="@@id5" i18n-attr.draggable="@@id6">
   </div>
   `
                 }]

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/GOLDEN_PARTIAL.js
@@ -372,8 +372,8 @@ MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.
 MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, selector: "my-component", ngImport: i0, template: `
   <div
   title="title {{name}}" i18n-title
-  attr.label="label {{name}}" i18n-label
-  attr.lang="lang {{name}}" i18n-attr.lang>
+  attr.label="label {{name}}" i18n-label="@@id1"
+  attr.lang="lang {{name}}" i18n-attr.lang="@@id2">
   </div>
   `, isInline: true });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
@@ -383,8 +383,8 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDE
                     template: `
   <div
   title="title {{name}}" i18n-title
-  attr.label="label {{name}}" i18n-label
-  attr.lang="lang {{name}}" i18n-attr.lang>
+  attr.label="label {{name}}" i18n-label="@@id1"
+  attr.lang="lang {{name}}" i18n-attr.lang="@@id2">
   </div>
   `
                 }]

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/GOLDEN_PARTIAL.js
@@ -359,6 +359,62 @@ export declare class MyModule {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: interpolated_attributes.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComponent {
+    constructor() {
+        this.name = 'Angular';
+    }
+}
+MyComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: MyComponent, selector: "my-component", ngImport: i0, template: `
+  <div
+  title="title {{name}}" i18n-title
+  attr.label="label {{name}}" i18n-label
+  attr.lang="lang {{name}}" i18n-attr.lang>
+  </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-component',
+                    template: `
+  <div
+  title="title {{name}}" i18n-title
+  attr.label="label {{name}}" i18n-label
+  attr.lang="lang {{name}}" i18n-attr.lang>
+  </div>
+  `
+                }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyComponent] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [MyComponent] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: interpolated_attributes.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComponent {
+    name: string;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComponent, "my-component", never, {}, {}, never, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyComponent], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: static_attributes.js
  ****************************************************************************************************/
 import { Component, NgModule } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/TEST_CASES.json
@@ -100,6 +100,20 @@
       ]
     },
     {
+      "description": "should create translations for interpolated attributes",
+      "inputFiles": [
+        "interpolated_attributes.ts"
+      ],
+      "expectations": [
+        {
+          "extraChecks": [
+            "verifyPlaceholdersIntegrity",
+            "verifyUniqueConsts"
+          ]
+        }
+      ]
+    },
+    {
       "description": "should translate static attributes",
       "inputFiles": [
         "static_attributes.ts"

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.js
@@ -1,7 +1,7 @@
 consts: function () {
   __i18nMsg__('title {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {})
-  __i18nMsg__('label {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {})
-  __i18nMsg__('lang {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {})
+  __i18nMsg__('label {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {id: 'id1'})
+  __i18nMsg__('lang {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {id: 'id2'})
   return [
     [6, "title", "label", "lang"], ["title", $i18n_1$, "label", $i18n_2$, "lang", $i18n_3$]
   ];

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.js
@@ -1,0 +1,19 @@
+consts: function () {
+  __i18nMsg__('title {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {})
+  __i18nMsg__('label {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {})
+  __i18nMsg__('lang {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {})
+  return [
+    [6, "title", "label", "lang"], ["title", $i18n_1$, "label", $i18n_2$, "lang", $i18n_3$]
+  ];
+},
+template: function MyComponent_Template(rf, ctx) {
+  if (rf & 1) {
+    i0.ɵɵelementStart(0, "div", 0);
+    i0.ɵɵi18nAttributes(1, 1);
+    i0.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    i0.ɵɵi18nExp(ctx.name)(ctx.name)(ctx.name);
+    i0.ɵɵi18nApply(1);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.js
@@ -2,8 +2,10 @@ consts: function () {
   __i18nMsg__('title {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {})
   __i18nMsg__('label {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {id: 'id1'})
   __i18nMsg__('lang {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {id: 'id2'})
+  __i18nMsg__('dir {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {id: 'id3'})
+  __i18nMsg__('draggable {$interpolation}', [['interpolation', String.raw`\uFFFD0\uFFFD`]], {id: 'id6'})
   return [
-    [6, "title", "label", "lang"], ["title", $i18n_1$, "label", $i18n_2$, "lang", $i18n_3$]
+    [6, "title", "label", "lang", "dir", "draggable"], ["title", $i18n_1$, "label", $i18n_2$, "lang", $i18n_3$, "dir", $i18n_4$, "draggable", $i18n_5$]
   ];
 },
 template: function MyComponent_Template(rf, ctx) {
@@ -13,7 +15,7 @@ template: function MyComponent_Template(rf, ctx) {
     i0.ɵɵelementEnd();
   }
   if (rf & 2) {
-    i0.ɵɵi18nExp(ctx.name)(ctx.name)(ctx.name);
+    i0.ɵɵi18nExp(ctx.name)(ctx.name)(ctx.name)(ctx.name)(ctx.name);
     i0.ɵɵi18nApply(1);
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.ts
@@ -6,7 +6,9 @@ import {Component, NgModule} from '@angular/core';
   <div
   title="title {{name}}" i18n-title
   attr.label="label {{name}}" i18n-label="@@id1"
-  attr.lang="lang {{name}}" i18n-attr.lang="@@id2">
+  attr.lang="lang {{name}}" i18n-attr.lang="@@id2"
+  attr.dir="dir {{name}}" i18n-attr.dir="@@id3" i18n-dir="@@id4"
+  attr.draggable="draggable {{name}}" i18n-draggable="@@id5" i18n-attr.draggable="@@id6">
   </div>
   `
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.ts
@@ -5,8 +5,8 @@ import {Component, NgModule} from '@angular/core';
   template: `
   <div
   title="title {{name}}" i18n-title
-  attr.label="label {{name}}" i18n-label
-  attr.lang="lang {{name}}" i18n-attr.lang>
+  attr.label="label {{name}}" i18n-label="@@id1"
+  attr.lang="lang {{name}}" i18n-attr.lang="@@id2">
   </div>
   `
 })

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolated_attributes.ts
@@ -1,0 +1,19 @@
+import {Component, NgModule} from '@angular/core';
+
+@Component({
+  selector: 'my-component',
+  template: `
+  <div
+  title="title {{name}}" i18n-title
+  attr.label="label {{name}}" i18n-label
+  attr.lang="lang {{name}}" i18n-attr.lang>
+  </div>
+  `
+})
+export class MyComponent {
+  name = 'Angular';
+}
+
+@NgModule({declarations: [MyComponent]})
+export class MyModule {
+}

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -107,6 +107,8 @@ export class I18nMetaVisitor implements html.Visitor {
       // set i18n meta for attributes
       if (Object.keys(attrsMeta).length) {
         for (const attr of attrs) {
+          // First try to match the metadata to the attribute name as-is.
+          // If that cannot be found try removing any `attr.` prefix from the attribute name.
           const meta =
               attrsMeta[attr.name] ?? attrsMeta[attr.name.replace(ATTR_BINDING_MATCHER, '')];
           // do not create translation for empty attributes

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -16,7 +16,7 @@ import {ParseTreeResult} from '../../../ml_parser/parser';
 import * as o from '../../../output/output_ast';
 import {isTrustedTypesSink} from '../../../schema/trusted_types_sinks';
 
-import {hasI18nAttrs, I18N_ATTR, I18N_ATTR_PREFIX, icuFromI18nMessage} from './util';
+import {ATTR_BINDING_MATCHER, hasI18nAttrs, I18N_ATTR, I18N_ATTR_PREFIX, icuFromI18nMessage} from './util';
 
 export type I18nMeta = {
   id?: string,
@@ -81,7 +81,7 @@ export class I18nMetaVisitor implements html.Visitor {
 
       for (const attr of element.attrs) {
         if (attr.name === I18N_ATTR) {
-          // root 'i18n' node attribute
+          // 'i18n' attribute that marks the element contents as an i18n message
           const i18n = element.i18n || attr.value;
           const message = this._generateI18nMessage(element.children, i18n, setI18nRefs);
           // do not assign empty i18n meta
@@ -107,7 +107,8 @@ export class I18nMetaVisitor implements html.Visitor {
       // set i18n meta for attributes
       if (Object.keys(attrsMeta).length) {
         for (const attr of attrs) {
-          const meta = attrsMeta[attr.name];
+          const meta =
+              attrsMeta[attr.name] ?? attrsMeta[attr.name.replace(ATTR_BINDING_MATCHER, '')];
           // do not create translation for empty attributes
           if (meta !== undefined && attr.value) {
             attr.i18n = this._generateI18nMessage([attr], attr.i18n || meta);

--- a/packages/compiler/src/render3/view/i18n/util.ts
+++ b/packages/compiler/src/render3/view/i18n/util.ts
@@ -24,6 +24,12 @@ export const TRANSLATION_VAR_PREFIX = 'i18n_';
 /** Name of the i18n attributes **/
 export const I18N_ATTR = 'i18n';
 export const I18N_ATTR_PREFIX = 'i18n-';
+/**
+ * Matches the prefix used when binding to an attribute rather than a property.
+ *
+ * For example: `[attr.title]="expression"`.
+ * */
+export const ATTR_BINDING_MATCHER = /^attr\./i;
 
 /** Prefix of var expressions used in ICUs */
 export const I18N_ICU_VAR_PREFIX = 'VAR_';

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -656,7 +656,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     element.inputs.forEach(input => {
       const stylingInputWasSet = stylingBuilder.registerBoundInput(input);
       if (!stylingInputWasSet) {
-        if (input.type === BindingType.Property && input.i18n) {
+        if ((input.type === BindingType.Property || input.type === BindingType.Attribute) &&
+            input.i18n) {
           boundI18nAttrs.push(input);
         } else {
           allOtherInputs.push(input);

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -1616,6 +1616,17 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
       expect(fixture.nativeElement.innerHTML).toEqual(`<div title="bonjour John"></div>`);
     });
 
+    it('interpolated "attr." bindings', () => {
+      loadTranslations({[computeMsgId('hello {$INTERPOLATION}')]: 'bonjour {$INTERPOLATION}'});
+      const fixture =
+          initWithTemplate(AppComp, `<div i18n-attr.title attr.title="hello {{name}}"></div>`);
+      expect(fixture.nativeElement.innerHTML).toEqual(`<div title="bonjour Angular"></div>`);
+
+      fixture.componentRef.instance.name = 'John';
+      fixture.detectChanges();
+      expect(fixture.nativeElement.innerHTML).toEqual(`<div title="bonjour John"></div>`);
+    });
+
     it('with pipes', () => {
       loadTranslations({[computeMsgId('hello {$INTERPOLATION}')]: 'bonjour {$INTERPOLATION}'});
       const fixture = initWithTemplate(

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -1617,14 +1617,24 @@ onlyInIvy('Ivy i18n logic').describe('runtime i18n', () => {
     });
 
     it('interpolated "attr." bindings', () => {
-      loadTranslations({[computeMsgId('hello {$INTERPOLATION}')]: 'bonjour {$INTERPOLATION}'});
-      const fixture =
-          initWithTemplate(AppComp, `<div i18n-attr.title attr.title="hello {{name}}"></div>`);
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div title="bonjour Angular"></div>`);
+      loadTranslations({
+        [computeMsgId('hello {$INTERPOLATION}')]: 'bonjour {$INTERPOLATION}',
+        custom: 'translated-{$INTERPOLATION}'
+      });
+      const fixture = initWithTemplate(AppComp, `
+        <div i18n-attr.title attr.title="hello {{name}}"></div>
+        <div i18n-title attr.title="hello {{name}}"></div>
+        <div i18n-attr.title="@@custom" attr.title="original-{{name}}"></div>
+      `);
+      expect(fixture.nativeElement.innerHTML)
+          .toEqual(
+              `<div title="bonjour Angular"></div><div title="bonjour Angular"></div><div title="translated-Angular"></div>`);
 
       fixture.componentRef.instance.name = 'John';
       fixture.detectChanges();
-      expect(fixture.nativeElement.innerHTML).toEqual(`<div title="bonjour John"></div>`);
+      expect(fixture.nativeElement.innerHTML)
+          .toEqual(
+              `<div title="bonjour John"></div><div title="bonjour John"></div><div title="translated-John"></div>`);
     });
 
     it('with pipes', () => {


### PR DESCRIPTION
While fully dynamic bound properties (and attributes) cannot be marked for localization, properties that only contain interpolation can.

This commit ensure that attribute bindings that only contain interpolation can also be marked for localization.

Closes #43260
