### PR TITLE
docs: add missing split marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The `renderModuleFactory` calls can be replaced with `renderModule`.
 ## Special Thanks
 Alan Agius, Andrew Scott, Daniel Díaz, David Shevitz, Doug Parker, George Kalpakas, Joe Martin (Crowdstaffing), Joey Perrott, Kristiyan Kostadinov, Paul Gschwendtner, Tanguy Nodet, Thomas Turrell-Croft, dario-piotrowicz, hchiam, markostanimirovic and mgechev
 
+<!-- CHANGELOG SPLIT MARKER -->
 
 <a name="12.2.10"></a>
 # 12.2.10 (2021-10-13)


### PR DESCRIPTION
Due to an outdated version of ng-dev running during release the changelog generated did not include a split marker,
it should be added to avoid issues in the future.
