### PR TITLE
docs: deprecate `@angular-devkit/build-optimizer`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -622,6 +622,12 @@ This section contains a complete list all of the currently deprecated CLI flags.
 | ------------------------------- | ----------------- |-------------------------------------------------------------------------------- |
 | `lintFix`                       | <!--v11--> v12    | Deprecated as part of TSLint deprecation.                                      |
 
+### @angular-devkit/build-optimizer
+
+The entire NPM package is deprecated. It has always been experimental (never hit `1.0.0`) and has
+been an internal package for the Angular CLI. All the relevant functionality has been moved to
+`@angular-devkit/build-angular`.
+
 {@a removed}
 
 ## Removed APIs


### PR DESCRIPTION
The entire package is deprecated in v13. Deprecation message is mostly copied from the package's [README](https://github.com/angular/angular-cli/blob/13.0.0-next.9/packages/angular_devkit/build_optimizer/README.md), with just some minor edits.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
Documenting deprecating of a package.

- [X] Documentation content changes


## What is the current behavior?

Package deprecated is not documented.

## What is the new behavior?

Package deprecation is now documented.

## Does this PR introduce a breaking change?

- [X] No