### PR TITLE
fix(router): fix Router's public API for canceledNavigationResolution

### DIFF
--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -184,6 +184,7 @@ export { Event_2 as Event }
 // @public
 export interface ExtraOptions {
     anchorScrolling?: 'disabled' | 'enabled';
+    canceledNavigationResolution?: 'replace' | 'computed';
     enableTracing?: boolean;
     errorHandler?: ErrorHandler;
     initialNavigation?: InitialNavigation;

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -426,6 +426,29 @@ export interface ExtraOptions {
    * The default in v11 is `corrected`.
    */
   relativeLinkResolution?: 'legacy'|'corrected';
+
+  /**
+   * Configures how the Router attempts to restore state when a navigation is cancelled.
+   *
+   * 'replace' - Always uses `location.replaceState` to set the browser state to the state of the
+   * router before the navigation started. This means that if the URL of the browser is updated
+   * _before_ the navigation is canceled, the Router will simply replace the item in history rather
+   * than trying to restore to the previous location in the session history. This happens most
+   * frequently with `urlUpdateStrategy: 'eager'` and navigations with the browser back/forward
+   * buttons.
+   *
+   * 'computed' - Will attempt to return to the same index in the session history that corresponds
+   * to the Angular route when the navigation gets cancelled. For example, if the browser back
+   * button is clicked and the navigation is cancelled, the Router will trigger a forward navigation
+   * and vice versa.
+   *
+   * Note: the 'computed' option is incompatible with any `UrlHandlingStrategy` which only
+   * handles a portion of the URL because the history restoration navigates to the previous place in
+   * the browser history rather than simply resetting a portion of the URL.
+   *
+   * The default value is `replace` when not set.
+   */
+  canceledNavigationResolution?: 'replace'|'computed';
 }
 
 export function setupRouter(
@@ -482,6 +505,10 @@ export function assignExtraOptionsToRouter(opts: ExtraOptions, router: Router): 
 
   if (opts.urlUpdateStrategy) {
     router.urlUpdateStrategy = opts.urlUpdateStrategy;
+  }
+
+  if (opts.canceledNavigationResolution) {
+    router.canceledNavigationResolution = opts.canceledNavigationResolution;
   }
 }
 

--- a/packages/router/test/computed_state_restoration.spec.ts
+++ b/packages/router/test/computed_state_restoration.spec.ts
@@ -81,7 +81,6 @@ describe('`restoredState#ɵrouterPageId`', () => {
       ]
     });
     const router = TestBed.inject(Router);
-    (router as any).canceledNavigationResolution = 'computed';
     const location = TestBed.inject(Location);
     fixture = createRoot(router, RootCmp);
     router.resetConfig([
@@ -486,7 +485,9 @@ function advance(fixture: ComponentFixture<any>, millis?: number): void {
 }
 
 @NgModule({
-  imports: [RouterTestingModule, CommonModule],
+  imports: [
+    RouterTestingModule.withRoutes([], {canceledNavigationResolution: 'computed'}), CommonModule
+  ],
   exports: [SimpleCmp, RootCmp, ThrowingCmp],
   entryComponents: [SimpleCmp, RootCmp, ThrowingCmp],
   declarations: [SimpleCmp, RootCmp, ThrowingCmp]


### PR DESCRIPTION
The commit which made the `canceledNavigationResolution` property on the `Router`
public did not add the corresponding configuration in the `ExtraOptions`.
https://github.com/angular/angular/commit/3c6b653089837459809a370ebcaf8911c3bab9ed
This was a mistake and is being corrected in this commit. We should not
encourage changing the properties post-setup (i.e.
`inject(Router).canceledNavigationResolution = 'computed'`). This manner
of configuration makes the options non-tree shakeable because we have to
keep both implementations in case the value changes at runtime.
