### PR TITLE
docs: add docs about build cache

### DIFF
--- a/aio/content/cli/cache.md
+++ b/aio/content/cli/cache.md
@@ -2,7 +2,7 @@
 # Persistent disk cache
 Angular CLI saves a number of cachable operations on disk by default.
 
-When you re-run the same build, the build system restores the state of the previous build and re-uses previously performed operations, which decreases the time taken to build and test your applications and libraries
+When you re-run the same build, the build system restores the state of the previous build and re-uses previously performed operations, which decreases the time taken to build and test your applications and libraries.
 
 To amend the default cache settings, add the `cli.cache` object to your [Workspace Configuration](guide/workspace-config).
 The object goes under `cli.cache` at the top level of the file, outside the `projects` sections.

--- a/aio/content/cli/cache.md
+++ b/aio/content/cli/cache.md
@@ -1,0 +1,74 @@
+
+# Persistent disk cache
+Angular CLI by default will save a number of cachable operations on disk.
+
+When the same build is re-run, the state of the previous build is restored from disk and re-uses previously performed operations which causes a decrease in the time taken to build and test your applications and libraries.
+
+To amend the default cache settings, add the `cli.cache` object to your [Workspace Configuration](guide/workspace-config).
+The object goes under `cli.cache` at the top level of the file, outside the `projects` sections.
+
+```json
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "cli": {
+    "cache": {
+      ...
+    }
+  },
+  "projects": {}
+}
+```
+
+To learn more about all the options, see [cache options](guide/workspace-config#cache-options).
+
+### Enabling and disabling the cache
+Caching is enabled by default, to disable caching run the following command:
+
+```bash
+ng config cli.cache.enabled false
+```
+
+To re-enable, use the same command with a value of `true`.
+
+### Cache environments
+By default, disk cache is only enabled for local environments.
+
+To enable caching for all environments run the following command:
+
+```bash
+ng config cli.cache.environment all
+```
+
+To learn more about all possible values, see `environment` in [cache options](guide/workspace-config#cache-options).
+
+<div class="alert is-helpful">
+
+The Angular CLI, checks for the presence and value of the `CI` environment variable to determine in which environment it is running.
+
+</div>
+
+### Cache path
+
+By default, `.angular/cache` is used as base directory to store cache results. To change this path, run the following command:
+
+```bash
+ng config cli.cache.path ".cache/ng"
+```
+
+### Clearing the cache
+
+In some cases you may want to clear the cache. To do so, run the following command:
+
+#### Unix based operating systems
+
+```bash
+rm -rf .angular/cache
+```
+
+#### Windows
+```bash
+rmdir /s /q .angular/cache
+```
+
+To learn more about the above commands, see [rm command](https://man7.org/linux/man-pages/man1/rm.1.html) and [rmdir command](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/rmdir).

--- a/aio/content/cli/cache.md
+++ b/aio/content/cli/cache.md
@@ -20,7 +20,7 @@ The object goes under `cli.cache` at the top level of the file, outside the `pro
 }
 ```
 
-To learn more about all the options, see [cache options](guide/workspace-config#cache-options).
+For more information, see [cache options](guide/workspace-config#cache-options).
 
 ### Enabling and disabling the cache
 Caching is enabled by default. To disable caching run the following command:

--- a/aio/content/cli/cache.md
+++ b/aio/content/cli/cache.md
@@ -29,7 +29,7 @@ Caching is enabled by default. To disable caching run the following command:
 ng config cli.cache.enabled false
 ```
 
-To enable, use the same command with a value of `true`.
+To re-enable caching, set `cli.cache.enabled` to `true`.
 
 ### Cache environments
 By default, disk cache is only enabled for local environments.
@@ -58,15 +58,15 @@ ng config cli.cache.path ".cache/ng"
 
 ### Clearing the cache
 
-To clear the cache, run the following command:
+To clear the cache, run one of the following commands.
 
-#### Unix based operating systems
+To clear the cache on Unix-based operating systems:
 
 ```bash
 rm -rf .angular/cache
 ```
 
-#### Windows
+To clear the cache on Windows:
 
 ```bash
 rmdir /s /q .angular/cache

--- a/aio/content/cli/cache.md
+++ b/aio/content/cli/cache.md
@@ -1,8 +1,8 @@
 
 # Persistent disk cache
-Angular CLI by default will save a number of cachable operations on disk.
+Angular CLI saves a number of cachable operations on disk by default.
 
-When the same build is re-run, the state of the previous build is restored from disk and re-uses previously performed operations which causes a decrease in the time taken to build and test your applications and libraries.
+When you re-run the same build, the build system restores the state of the previous build and re-uses previously performed operations, which decreases the time taken to build and test your applications and libraries
 
 To amend the default cache settings, add the `cli.cache` object to your [Workspace Configuration](guide/workspace-config).
 The object goes under `cli.cache` at the top level of the file, outside the `projects` sections.
@@ -23,34 +23,34 @@ The object goes under `cli.cache` at the top level of the file, outside the `pro
 To learn more about all the options, see [cache options](guide/workspace-config#cache-options).
 
 ### Enabling and disabling the cache
-Caching is enabled by default, to disable caching run the following command:
+Caching is enabled by default. To disable caching run the following command:
 
 ```bash
 ng config cli.cache.enabled false
 ```
 
-To re-enable, use the same command with a value of `true`.
+To enable, use the same command with a value of `true`.
 
 ### Cache environments
 By default, disk cache is only enabled for local environments.
 
-To enable caching for all environments run the following command:
+To enable caching for all environments, run the following command:
 
 ```bash
 ng config cli.cache.environment all
 ```
 
-To learn more about all possible values, see `environment` in [cache options](guide/workspace-config#cache-options).
+For more information, see `environment` in [cache options](guide/workspace-config#cache-options).
 
 <div class="alert is-helpful">
 
-The Angular CLI, checks for the presence and value of the `CI` environment variable to determine in which environment it is running.
+The Angular CLI checks for the presence and value of the `CI` environment variable to determine in which environment it is running.
 
 </div>
 
 ### Cache path
 
-By default, `.angular/cache` is used as base directory to store cache results. To change this path, run the following command:
+By default, `.angular/cache` is used as a base directory to store cache results. To change this path, run the following command:
 
 ```bash
 ng config cli.cache.path ".cache/ng"
@@ -58,7 +58,7 @@ ng config cli.cache.path ".cache/ng"
 
 ### Clearing the cache
 
-In some cases you may want to clear the cache. To do so, run the following command:
+To clear the cache, run the following command:
 
 #### Unix based operating systems
 
@@ -67,8 +67,9 @@ rm -rf .angular/cache
 ```
 
 #### Windows
+
 ```bash
 rmdir /s /q .angular/cache
 ```
 
-To learn more about the above commands, see [rm command](https://man7.org/linux/man-pages/man1/rm.1.html) and [rmdir command](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/rmdir).
+For more information, see [rm command](https://man7.org/linux/man-pages/man1/rm.1.html) and [rmdir command](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/rmdir).

--- a/aio/content/guide/build.md
+++ b/aio/content/guide/build.md
@@ -536,6 +536,38 @@ module.exports = setupForCorporateProxy(proxyConfig);
 
 {@a browser-compat}
 
+## Persistent disk cache
+Angular CLI by default will save a number of cachable operations on disk.
+
+When the same build is re-run, the state of the previous build is restored from disk and re-uses previously performed operations which causes a decrease in the time taken to build and test your applications and libraries.
+
+To amend the default cache settings, add the `cli.cache` object to your [Workspace Configuration](guide/workspace-config).
+The object goes under `cli.cache` at the top level of the file, outside the `projects` sections.
+
+<code-example language="json">
+
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "cli": {
+    "cache": {
+      ...
+    }
+  },
+  "projects": {}
+}
+
+</code-example>
+
+To learn more, see [cache options](guide/workspace-config#cache-options).
+
+<div class="alert is-important">
+
+By default, disk cache is not enabled on Continuous integration (CI) servers.
+The Angular CLI, checks for the presence and value of the `CI` environment variable to determine in which environment it is running.
+
+</div>
+
 ## Configuring browser compatibility
 
 See [browser support guide](guide/browser-support).

--- a/aio/content/guide/build.md
+++ b/aio/content/guide/build.md
@@ -536,38 +536,6 @@ module.exports = setupForCorporateProxy(proxyConfig);
 
 {@a browser-compat}
 
-## Persistent disk cache
-Angular CLI by default will save a number of cachable operations on disk.
-
-When the same build is re-run, the state of the previous build is restored from disk and re-uses previously performed operations which causes a decrease in the time taken to build and test your applications and libraries.
-
-To amend the default cache settings, add the `cli.cache` object to your [Workspace Configuration](guide/workspace-config).
-The object goes under `cli.cache` at the top level of the file, outside the `projects` sections.
-
-<code-example language="json">
-
-{
-  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
-  "version": 1,
-  "cli": {
-    "cache": {
-      ...
-    }
-  },
-  "projects": {}
-}
-
-</code-example>
-
-To learn more, see [cache options](guide/workspace-config#cache-options).
-
-<div class="alert is-important">
-
-By default, disk cache is not enabled on Continuous integration (CI) servers.
-The Angular CLI, checks for the presence and value of the `CI` environment variable to determine in which environment it is running.
-
-</div>
-
 ## Configuring browser compatibility
 
 See [browser support guide](guide/browser-support).

--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -5,13 +5,14 @@ Path values given in the configuration are relative to the root workspace folder
 
 ## Overall JSON structure
 
-At the top level of `angular.json`, a few properties configure the workspace, and a `projects` section contains the remaining per-project configuration options. CLI defaults set at the workspace level can be overridden by defaults set at the project level, and defaults set at the project level can be overridden on the command line.
+At the top-level of `angular.json`, a few properties configure the workspace, and a `projects` section contains the remaining per-project configuration options. CLI defaults set at the workspace level can be overridden by defaults set at the project level, and defaults set at the project level can be overridden on the command line.
 
-The following properties, at the top level of the file, configure the workspace.
+The following properties, at the top-level of the file, configure the workspace.
 
 *   `version`: The configuration-file version.
 *   `newProjectRoot`: Path where new projects are created. Absolute or relative to the workspace folder.
 *   `defaultProject`: Default project name to use in commands, where not provided as an argument. When you use `ng new` to create a new application in a new workspace, that application is the default project for the workspace until you change it here.
+*   `cli` : A set of options that customize the [Angular CLI](cli). See the [CLI configuration options](#cli-configuration-options) section.
 *   `schematics` : A set of [schematics](guide/glossary#schematic) that customize the `ng generate` sub-command option defaults for this workspace. See the [Generation schematics](#schematics) section.
 *   `projects` : Contains a subsection for each project (library or application) in the workspace, with the per-project configuration options.
 
@@ -41,6 +42,42 @@ For more information, see [Workspace and project file structure](guide/file-stru
 
 </div>
 
+{@a cli-configuration-options}
+
+## CLI configuration options
+
+The following configuration properties are a set of options that customize the Angular CLI.
+
+| Property            | Description                                                                                                               | Value Type                                               |
+| :------------------ | :------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------- |
+| `analytics`         | Share anonymous [usage data](cli/usage-analytics-gathering) with the Angular Team.                                        | `boolean` \| `ci`                                        |
+| `analyticsSharing`  | A set of analytics sharing options.                                                                                       | [Analytics sharing options](#analytics-sharing-options)  |
+| `cache`             | Control [persistent disk cache](guide/build/#persistent-disk-cache) used by [Angular CLI Builders](guide/cli-builder).    | [Cache options](#cache-options)                          |
+| `defaultCollection` | The default schematics collection to use.                                                                                 | `string`                                                 |
+| `packageManager`    | The prefered package manager tool to use.                                                                                 | `npm` \| `cnpm` \| `pnpm` \| `yarn`                      |
+| `warnings`          | Control CLI specific console warnings.                                                                                    | [Warnings options](#warnings-options)                    |
+
+### Analytics sharing options
+
+| Property   | Description                                                  | Value Type |
+| :--------- | :----------------------------------------------------------- | :--------- |
+| `tracking` | Analytics sharing info tracking ID.                          | `string`   |
+| `uuid`     | Analytics sharing info UUID (Universally Unique Identifier). | `string`   |
+
+### Cache options
+
+| Property      | Description                                           | Value Type               | Dafault Value    |
+| :------------ | :---------------------------------------------------- | :----------------------- | :--------------- |
+| `enabled`     | Configure whether disk caching is enabled.            | `boolean`                | `true`           |
+| `environment` | Configure in which environment disk cache is enabled. | `local` \| `ci` \| `all` | `local`          |
+| `path`        | The directory used to stored cache results.           | `string`                 | `.angular/cache` |
+
+### Warnings options
+
+| Property          | Description                                                                     | Value Type | Dafault Value |
+| :---------------- | :------------------------------------------------------------------------------ | :--------- | :------------ |
+| `versionMismatch` | Show a warning when the global Angular CLI version is newer than the local one. | `boolean`  | `true`        |
+
 ## Project configuration options
 
 The following top-level configuration properties are available for each project, under `projects:<project_name>`.
@@ -64,7 +101,7 @@ The following top-level configuration properties are available for each project,
 | `sourceRoot`    | The root folder for this project's source files.                                                                                                        |
 | `projectType`   | One of "application" or "library". An application can run independently in a browser, while a library cannot.                                           |
 | `prefix`        | A string that Angular prepends to generated selectors. Can be customized to identify an application or feature area.                                    |
-| `schematics`    | A set of schematics that customize the `ng generate` sub-command option defaults for this project. See the [Generation schematics](#schematics) section.      |
+| `schematics`    | A set of schematics that customize the `ng generate` sub-command option defaults for this project. See the [Generation schematics](#schematics) section.|
 | `architect`     | Configuration defaults for Architect builder targets for this project.                                                                                  |
 
 {@a schematics}
@@ -119,14 +156,14 @@ See the example in [Build target](#build-target) below.
 <code-example language="json">
 
 "architect": {
-  "build": { },
-  "serve": { },
-  "e2e" : { },
-  "test": { },
-  "lint": { },
-  "extract-i18n": { },
-  "server": { },
-  "app-shell": { }
+  "build": {},
+  "serve": {},
+  "e2e" : {},
+  "test": {},
+  "lint": {},
+  "extract-i18n": {},
+  "server": {},
+  "app-shell": {}
 }
 
 </code-example>

--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -5,7 +5,7 @@ Path values given in the configuration are relative to the root workspace folder
 
 ## Overall JSON structure
 
-At the top-level of `angular.json`, a few properties configure the workspace, and a `projects` section contains the remaining per-project configuration options. CLI defaults set at the workspace level can be overridden by defaults set at the project level, and defaults set at the project level can be overridden on the command line.
+At the top-level of `angular.json`, a few properties configure the workspace and a `projects` section contains the remaining per-project configuration options. You can override CLI defaults set at the workspace level through defaults set at the project level. You can also override defaults set at the project level using the command line.
 
 The following properties, at the top-level of the file, configure the workspace.
 

--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -48,14 +48,14 @@ For more information, see [Workspace and project file structure](guide/file-stru
 
 The following configuration properties are a set of options that customize the Angular CLI.
 
-| Property            | Description                                                                                                               | Value Type                                               |
-| :------------------ | :------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------- |
-| `analytics`         | Share anonymous [usage data](cli/usage-analytics-gathering) with the Angular Team.                                        | `boolean` \| `ci`                                        |
-| `analyticsSharing`  | A set of analytics sharing options.                                                                                       | [Analytics sharing options](#analytics-sharing-options)  |
-| `cache`             | Control [persistent disk cache](guide/build/#persistent-disk-cache) used by [Angular CLI Builders](guide/cli-builder).    | [Cache options](#cache-options)                          |
-| `defaultCollection` | The default schematics collection to use.                                                                                 | `string`                                                 |
-| `packageManager`    | The prefered package manager tool to use.                                                                                 | `npm` \| `cnpm` \| `pnpm` \| `yarn`                      |
-| `warnings`          | Control CLI specific console warnings.                                                                                    | [Warnings options](#warnings-options)                    |
+| Property            | Description                                                                                      | Value Type                                               |
+| :------------------ | :----------------------------------------------------------------------------------------------- | :------------------------------------------------------- |
+| `analytics`         | Share anonymous [usage data](cli/usage-analytics-gathering) with the Angular Team.               | `boolean` \| `ci`                                        |
+| `analyticsSharing`  | A set of analytics sharing options.                                                              | [Analytics sharing options](#analytics-sharing-options)  |
+| `cache`             | Control [persistent disk cache](cli/cache) used by [Angular CLI Builders](guide/cli-builder).    | [Cache options](#cache-options)                          |
+| `defaultCollection` | The default schematics collection to use.                                                        | `string`                                                 |
+| `packageManager`    | The prefered package manager tool to use.                                                        | `npm` \| `cnpm` \| `pnpm` \| `yarn`                      |
+| `warnings`          | Control CLI specific console warnings.                                                           | [Warnings options](#warnings-options)                    |
 
 ### Analytics sharing options
 

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -1034,6 +1034,11 @@
               "url": "cli"
             },
             {
+              "title": "Persistent Disk Cache",
+              "tooltip": "Details on the Angular CLI persistent disk cache.",
+              "url": "cli/cache"
+            },
+            {
               "title": "Usage Analytics",
               "tooltip": "For administrators, guide to gathering usage analytics from your users.",
               "url": "cli/usage-analytics-gathering"


### PR DESCRIPTION
With this change we add docs about persistent disk cache with was enabled by default in the CLI via https://github.com/angular/angular-cli/pull/21827

---
**NB:** I am uncertain if https://angular.io/guide/build is the right page for this, I can see that the contents of this page can also be in either https://angular.io/cli or new page under https://angular.io/cli similar to https://angular.io/cli/usage-analytics-gathering.

**_Following a convo with @dgp1130 and @clydin, it is preferred that to do a new page similar to https://angular.io/cli/usage-analytics-gathering_** 
