### PR TITLE
fix(docs-infra): apply minor style fixes to aio contributor cards

### DIFF
--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -106,6 +106,7 @@ aio-contributor {
 
     h3 {
       margin: 0.8rem 0;
+      text-align: center;
     }
 
     .card-front, .card-back {
@@ -119,6 +120,7 @@ aio-contributor {
       align-items: center;
       border: none;
       background: transparent;
+      padding: 0 1.5rem;
     }
 
     .card-back {


### PR DESCRIPTION
improve the aio contributors card by aligning centrally the
contributor's name and adding some padding so that it doesn't
get too close to the card's edges

Note: the name's aligning was already present by wrongly removed in
PR #43355

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The name of contributors, it too long gets split over multiple lines and left aligned

Like so:
![Screenshot at 2021-10-14 19-43-11](https://user-images.githubusercontent.com/61631103/137389427-7489b2fb-cf9b-4f4b-98c8-71e36e316267.png)

Issue Number: N/A


## What is the new behavior?

![Screenshot at 2021-10-14 19-43-45](https://user-images.githubusercontent.com/61631103/137389456-f7c99bd1-2e4f-4d0a-a20e-03ac84c71adc.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

@gkalpak I am pretty sure I created the bug in #43355 I hope you can find it in your heart to forgive me :sob: :sob: :sob: 

Besides the aforementioned issue I also noticed that the name can get very very close to the card's edges so I added some padding as I thought it just looked better

for example:
before:
![Screenshot at 2021-10-14 19-43-59](https://user-images.githubusercontent.com/61631103/137389751-4199d68a-7835-4736-9c41-9ef7eeb1f010.png)

after:
![Screenshot at 2021-10-14 21-13-17](https://user-images.githubusercontent.com/61631103/137389773-2f1911fd-652a-44ff-90cf-2e82bb6c40ea.png)


