### PR TITLE
Revert "refactor(router): clean up internal hooks (#43804)"

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -42,7 +42,7 @@
     "master": {
       "uncompressed": {
         "runtime": 2843,
-        "main": 237487,
+        "main": 238453,
         "polyfills": 37064,
         "src_app_lazy_lazy_module_ts": 795
       }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1146,6 +1146,9 @@
     "name": "defaultMalformedUriErrorHandler"
   },
   {
+    "name": "defaultRouterHook"
+  },
+  {
     "name": "defaultScheduler"
   },
   {

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -527,7 +527,7 @@ export class RouterInitializer implements OnDestroy {
       } else if (
           // TODO: enabled is deprecated as of v11, can be removed in v13
           opts.initialNavigation === 'enabled' || opts.initialNavigation === 'enabledBlocking') {
-        router.afterPreactivation = () => {
+        router.hooks.afterPreactivation = () => {
           // only the initial navigation should be delayed
           if (!this.initNavigation) {
             this.initNavigation = true;
@@ -536,7 +536,7 @@ export class RouterInitializer implements OnDestroy {
 
             // subsequent navigations should not be delayed
           } else {
-            return of(void 0);
+            return of(null) as any;
           }
         };
         router.initialNavigation();
@@ -567,7 +567,7 @@ export class RouterInitializer implements OnDestroy {
     preloader.setUpPreloading();
     routerScroller.init();
     router.resetRootComponentType(ref.componentTypes[0]);
-    this.resultOfPreactivationDone.next(void 0);
+    this.resultOfPreactivationDone.next(null!);
     this.resultOfPreactivationDone.complete();
   }
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -871,7 +871,7 @@ describe('Integration', () => {
     });
 
 
-    it('should eagerly update the URL with urlUpdateStrategy="eager"',
+    it('should eagerly update the URL with urlUpdateStrategy="eagar"',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
          const fixture = TestBed.createComponent(RootCmp);
          advance(fixture);
@@ -885,21 +885,18 @@ describe('Integration', () => {
          expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
 
          router.urlUpdateStrategy = 'eager';
-         router.events.subscribe(e => {
-           if (!(e instanceof GuardsCheckStart)) {
-             return;
-           }
+         (router as any).hooks.beforePreactivation = () => {
            expect(location.path()).toEqual('/team/33');
            expect(fixture.nativeElement).toHaveText('team 22 [ , right:  ]');
            return of(null);
-         });
+         };
          router.navigateByUrl('/team/33');
 
          advance(fixture);
          expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
        })));
 
-    it('should eagerly update the URL with urlUpdateStrategy="eager"',
+    it('should eagerly update the URL with urlUpdateStrategy="eagar"',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
          const fixture = TestBed.createComponent(RootCmp);
          advance(fixture);
@@ -929,7 +926,7 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/login');
        })));
 
-    it('should set browserUrlTree with urlUpdateStrategy="eager" and false `shouldProcessUrl`',
+    it('should set browserUrlTree with urlUpdateStrategy="eagar" and false `shouldProcessUrl`',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
          const fixture = TestBed.createComponent(RootCmp);
          advance(fixture);
@@ -956,7 +953,7 @@ describe('Integration', () => {
          expect((router as any).browserUrlTree.toString()).toBe('/team/22');
        })));
 
-    it('should eagerly update URL after redirects are applied with urlUpdateStrategy="eager"',
+    it('should eagerly update URL after redirects are applied with urlUpdateStrategy="eagar"',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
          const fixture = TestBed.createComponent(RootCmp);
          advance(fixture);
@@ -990,7 +987,7 @@ describe('Integration', () => {
          expect(fixture.nativeElement).toHaveText('team 33 [ , right:  ]');
        })));
 
-    it('should set `state` with urlUpdateStrategy="eager"',
+    it('should set `state` with urlUpdateStrategy="eagar"',
        fakeAsync(inject([Router, Location], (router: Router, location: SpyLocation) => {
          router.urlUpdateStrategy = 'eager';
          router.resetConfig([


### PR DESCRIPTION
This reverts commit 5cc51880db2f0905b456065f339fbc792ae2d03f.

A team internally relies on this through `(router as any). beforePreactivation` and `(router as any). afterPreactivation`