### PR TITLE
refactor(compiler): shorten Closure-based i18n const names

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -3691,7 +3691,7 @@ function allTests(os: string) {
     });
 
     it('should use proper default value for i18nUseExternalIds config param', () => {
-      env.tsconfig();  // default is `true`
+      env.tsconfig();  // default value of `i18nUseExternalIds` is `true`
       env.write(`test.ts`, `
       import {Component} from '@angular/core';
        @Component({
@@ -3702,7 +3702,7 @@ function allTests(os: string) {
     `);
       env.driveMain();
       const jsContents = env.getContents('test.js');
-      expect(jsContents).toContain('MSG_EXTERNAL_8321000940098097247$$TEST_TS_1');
+      expect(jsContents).toContain('MSG_EXTERNAL_8321000940098097247$$7296664567837709624_1');
     });
 
     it('should take i18nUseExternalIds config option into account', () => {
@@ -3719,6 +3719,29 @@ function allTests(os: string) {
       const jsContents = env.getContents('test.js');
       expect(jsContents).not.toContain('MSG_EXTERNAL_');
     });
+
+    it('should produce hash-based suffix for Closure const names when `i18nUseExternalIds` is true (default)',
+       () => {
+         env.tsconfig();  // default value of `i18nUseExternalIds` is `true`
+         env.write(`test.ts`, `
+            import {Component} from '@angular/core';
+            @Component({
+              selector: 'test',
+              template: \`
+                <div i18n="@@idA" i18n-title="@@idB" title="Some title">
+                  Some content
+                </div>
+              \`
+            })
+            class FooCmp {}
+          `);
+         env.driveMain();
+         const jsContents = env.getContents('test.js');
+         expect(jsContents)
+             .toContain('MSG_EXTERNAL_idB$$7296664567837709624_1 = goog.getMsg("Some title")');
+         expect(jsContents)
+             .toContain('MSG_EXTERNAL_idA$$7296664567837709624_3 = goog.getMsg(" Some content ")');
+       });
 
     it('should render legacy ids when `enableI18nLegacyMessageIdFormat` is not false', () => {
       env.tsconfig({});

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -11,6 +11,7 @@ import {BindingForm, convertPropertyBinding} from '../../compiler_util/expressio
 import {ConstantPool} from '../../constant_pool';
 import * as core from '../../core';
 import {AST, ParsedEvent, ParsedEventType, ParsedProperty} from '../../expression_parser/ast';
+import {computeMsgId} from '../../i18n/digest';
 import * as o from '../../output/output_ast';
 import {ParseError, ParseSourceSpan, sanitizeIdentifier} from '../../parse_util';
 import {CssSelector, SelectorMatcher} from '../../selector';
@@ -169,10 +170,16 @@ export function compileComponentFromMetadata(
   const changeDetection = meta.changeDetection;
 
   const template = meta.template;
+
+  // Use relative context file path to compute a hash that would be added to all
+  // Closure-specific i18n `MSG_` const names to make sure they are unique in the final bundle
+  // (this is a Closure requirement).
+  const i18nUniqueClosureSuffix = computeMsgId(meta.relativeContextFilePath ?? '');
+
   const templateBuilder = new TemplateDefinitionBuilder(
       constantPool, BindingScope.createRootScope(), 0, templateTypeName, null, null, templateName,
       directiveMatcher, directivesUsed, meta.pipes, pipesUsed, R3.namespaceHTML,
-      meta.relativeContextFilePath, meta.i18nUseExternalIds);
+      i18nUniqueClosureSuffix, meta.i18nUseExternalIds);
 
   const templateFunctionExpression = templateBuilder.buildTemplateFunction(template.nodes, []);
 

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -183,8 +183,6 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   // Number of binding slots
   private _bindingSlots = 0;
 
-  private fileBasedI18nSuffix: string;
-
   // Projection slots found in the template. Projection slots can distribute projected
   // nodes based on a selector, or can just use the wildcard selector to match
   // all nodes which aren't matching any selector.
@@ -204,15 +202,10 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       private templateIndex: number|null, private templateName: string|null,
       private directiveMatcher: SelectorMatcher|null, private directives: Set<o.Expression>,
       private pipeTypeByName: Map<string, o.Expression>, private pipes: Set<o.Expression>,
-      private _namespace: o.ExternalReference, relativeContextFilePath: string,
+      private _namespace: o.ExternalReference, private i18nUniqueClosureSuffix: string,
       private i18nUseExternalIds: boolean,
       private _constants: ComponentDefConsts = createComponentDefConsts()) {
     this._bindingScope = parentBindingScope.nestedScope(level);
-
-    // Turn the relative context file path into an identifier by replacing non-alphanumeric
-    // characters with underscores.
-    this.fileBasedI18nSuffix = relativeContextFilePath.replace(/[^A-Za-z0-9]/g, '_') + '_';
-
     this._valueConverter = new ValueConverter(
         constantPool, () => this.allocateDataSlot(),
         (numSlots: number) => this.allocatePureFunctionSlots(numSlots),
@@ -421,7 +414,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   // Generates vars with Closure-specific names for i18n blocks (i.e. `MSG_XXX`).
   private i18nGenerateClosureVar(messageId: string): o.ReadVarExpr {
     let name: string;
-    const suffix = this.fileBasedI18nSuffix.toUpperCase();
+    const suffix = this.i18nUniqueClosureSuffix + '_';
     if (this.i18nUseExternalIds) {
       const prefix = getTranslationConstPrefix(`EXTERNAL_`);
       const uniqueSuffix = this.constantPool.uniqueName(suffix);
@@ -913,7 +906,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     const templateVisitor = new TemplateDefinitionBuilder(
         this.constantPool, this._bindingScope, this.level + 1, contextName, this.i18n,
         templateIndex, templateName, this.directiveMatcher, this.directives, this.pipeTypeByName,
-        this.pipes, this._namespace, this.fileBasedI18nSuffix, this.i18nUseExternalIds,
+        this.pipes, this._namespace, this.i18nUniqueClosureSuffix, this.i18nUseExternalIds,
         this._constants);
 
     // Nested templates must not be visited until after their parent templates have completed


### PR DESCRIPTION
This commit refactors the code to use shorter version of the i18n Closure-based consts, so that it's easier to work with compiled code.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No