### PR TITLE
build(docs-infra): add a box around CLI command line reference syntax

### DIFF
--- a/aio/tools/transforms/templates/cli/lib/cli.html
+++ b/aio/tools/transforms/templates/cli/lib/cli.html
@@ -1,6 +1,6 @@
 {% macro renderSyntax(container, prefix) -%}
 {% for name in container.names %}
-<code-example hideCopy="true" class="no-box api-heading no-auto-link{% if container.deprecated %} deprecated-api-item{% endif %}">ng {%if prefix %}{$ prefix $} {% endif %}<span class="cli-name">{$ name $}</span>
+<code-example hideCopy="true" class="api-heading no-auto-link{% if container.deprecated %} deprecated-api-item{% endif %}">ng {%if prefix %}{$ prefix $} {% endif %}<span class="cli-name">{$ name $}</span>
   {%- for arg in container.positionalOptions %} &lt;<var>{$ arg.name $}</var>&gt;{% endfor %}
   {%- if container.namedOptions.length %} [<var>options</var>]{% endif -%}
 </code-example>


### PR DESCRIPTION
This commit helps to make the section that describes an overview of the syntax of a CLI command stand out from the surrounding text.

Closes #26574


<img width="1029" alt="Screenshot 2021-10-15 at 18 03 34" src="https://user-images.githubusercontent.com/15655/137526027-035bfa64-7c59-42b9-87d2-fbadfa8dec16.png">
