### PR TITLE
Throw an error when compiling with View Engine.

### DIFF
--- a/packages/compiler-cli/src/transformers/program.ts
+++ b/packages/compiler-cli/src/transformers/program.ts
@@ -38,6 +38,12 @@ import {createMessageDiagnostic, DTS, GENERATED_FILES, isInRootDir, ngToTsDiagno
  */
 const MAX_FILE_COUNT_FOR_SINGLE_FILE_EMIT = 20;
 
+/** Error message to show when attempting to build View Engine. */
+const VE_DISABLED_MESSAGE = `
+This compilation is using the View Engine compiler which is no longer supported by the Angular team
+and is being removed. Please upgrade to the Ivy compiler by switching to \`NgtscProgram\`. See
+https://angular.io/guide/ivy for more information.
+`.trim().split('\n').join(' ');
 
 /**
  * Fields to lower within metadata in render2 mode.
@@ -110,6 +116,10 @@ class AngularCompilerProgram implements Program {
   constructor(
       rootNames: ReadonlyArray<string>, private options: CompilerOptions,
       private host: CompilerHost, oldProgram?: Program) {
+    if (true as boolean) {
+      throw new Error(VE_DISABLED_MESSAGE);
+    }
+
     this.rootNames = [...rootNames];
 
     if (!options.disableTypeScriptVersionCheck) {


### PR DESCRIPTION
BREAKING CHANGE: The View Engine compiler now throws when constructed and will be removed shortly. Direct users should switch to `NgtscProgram` to build with [Ivy](https://angular.io/guide/ivy).

The View Engine compiler is being removed, so this makes it throw an error to ensure no one accidentally depends on code being removed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Other... Please describe:

Disables View Engine by deliberately breaking it. The View Engine codebase will be removed as refactoring PRs during v13's lifetime, doing this should prevent any unexpected usages of View Engine so those PRs can be considered pure refactors rather than breaking changes.

## What is the current behavior?

View Engine compiler can still be used directly, even though it has been unavailable via the CLI for some time.

## What is the new behavior?

View Engine compiler now throws on construction, making it impossible to use.

## Does this PR introduce a breaking change?

- [X] Yes

Users should migrate to Ivy, specifically [`NgtscProgram`](https://github.com/angular/angular/blob/b5eccde447ba4dc38384f95a7111900092a6c4e4/packages/compiler-cli/src/ngtsc/program.ts#L32).