### PR TITLE
fix(docs-infra): add paddings to docs-card titles

### DIFF
--- a/aio/src/styles/2-modules/card/_card.scss
+++ b/aio/src/styles/2-modules/card/_card.scss
@@ -28,7 +28,7 @@
       @include mixins.font-size(20);
       @include mixins.line-height(24);
       margin: 0;
-      padding: 2.7rem 0 2.1rem;
+      padding: 2.7rem 1.5rem 2.1rem;
       text-transform: none;
       text-align: center;
     }
@@ -46,7 +46,7 @@
       margin-bottom: 0;
       box-sizing: border-box;
       @include mixins.line-height(24);
-      padding: 1.3rem 15px;
+      padding: 1.3rem 1.5rem;
       text-align: right;
 
       a {


### PR DESCRIPTION
improve the aio docs-card title by adding some padding
so that it doesn't get too close to the card's edges

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The aio docs-card titles can come too close to the card's edges

For example:
![Screenshot at 2021-10-15 20-05-11](https://user-images.githubusercontent.com/61631103/137539738-fdb794bb-8744-462d-98bd-72bc61476a7e.png)

Issue Number: N/A


## What is the new behavior?

Some padding has been added so that the title stays neatly inside the card

For example:
![Screenshot at 2021-10-15 20-05-24](https://user-images.githubusercontent.com/61631103/137539949-6ff5e854-dedc-4b53-ac4d-ad4dda85be8e.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

As suggested by @petebacondarwin [here](https://github.com/angular/angular/pull/43844#pullrequestreview-780665532) :slightly_smiling_face::+1: 
