### PR TITLE
fix(router): Update `Navigation#initialUrl` to match documentation and reality

### DIFF
--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -255,7 +255,7 @@ export interface Navigation {
     extras: NavigationExtras;
     finalUrl?: UrlTree;
     id: number;
-    initialUrl: string | UrlTree;
+    initialUrl: UrlTree;
     previousNavigation: Navigation | null;
     trigger: 'imperative' | 'popstate' | 'hashchange';
 }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -273,7 +273,7 @@ export interface Navigation {
    * The target URL passed into the `Router#navigateByUrl()` call before navigation. This is
    * the value before the router has parsed or applied redirects to it.
    */
-  initialUrl: string|UrlTree;
+  initialUrl: UrlTree;
   /**
    * The initial target URL after being parsed with `UrlSerializer.extract()`.
    */
@@ -644,7 +644,7 @@ export class Router {
                      tap(t => {
                        this.currentNavigation = {
                          id: t.id,
-                         initialUrl: t.currentRawUrl,
+                         initialUrl: t.rawUrl,
                          extractedUrl: t.extractedUrl,
                          trigger: t.source,
                          extras: t.extras,


### PR DESCRIPTION
BREAKING CHANGE:

* The type of `initialUrl` is set to `string|UrlTree` but in reality,
  the `Router` only sets it to a value that will always be `UrlTree`
* `initialUrl` is documented as "The target URL passed into the
  `Router#navigateByUrl()` call before navigation" but the value
  actually gets set to something completely different. It's set to the
  current internal `UrlTree` of the Router at the time navigation
  occurs.


PR-only note:
TGP showed no failures as a result of this change. We could consider
exposing the old `t.currentRawUrl` value as a new property on 
`Navigation` if this does end up breaking someone. That said,
I don't believe this value was intended to be exposed and it's likely
that anyone using it currently could or should use something else
to do the task it's being used for.