### PR TITLE
fix(docs-infra): remove extra anchor space in callouts

### DIFF
--- a/aio/content/guide/security.md
+++ b/aio/content/guide/security.md
@@ -8,9 +8,10 @@ For more information about the attacks and mitigations described below, see [OWA
 
 You can run the <live-example></live-example> in Stackblitz and download the code from there.
 
+{@a report-issues}
+
 <div class="callout is-important">
 
-{@a report-issues}
 <header>Reporting vulnerabilities</header>
 
 To report vulnerabilities in Angular itself, email us at [security@angular.io](mailto:security@angular.io).
@@ -20,9 +21,10 @@ philosophy](https://www.google.com/about/appsecurity/).
 
 </div>
 
+{@a best-practices}
+
 <div class="callout is-helpful">
 
-{@a best-practices}
 <header>Best practices</header>
 
 * **Keep current with the latest Angular library releases.**


### PR DESCRIPTION
in callout elements if an empty anchor is set as the first
element of a callout it creates extra space, that is caused
by the anchor's margin, remove such margin to clear the extra space

note: this would also apply to non-empty anchors, but there should not be
any such anchors as the callout's first child (as that should be the
header)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Invisible anchor elements cause ugly spaces in callout elements before the header:
![Screenshot at 2021-10-16 22-40-07](https://user-images.githubusercontent.com/61631103/137602798-347fbac9-708e-441d-86a4-7e89b997a0fb.png)

## What is the new behavior?

The space is removed, the functionality remains the same (you can still use the anchor as before):
![Screenshot at 2021-10-16 22-39-25](https://user-images.githubusercontent.com/61631103/137602952-c79e01f9-027b-4c5b-a2ee-9ec8e5ea78ad.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other Information

As far as I can tell this only happens for the callouts [here](http://localhost:4200/guide/security#report-issues)
caused by these type of anchors: https://github.com/angular/angular/blob/1317e193787ba80a0571d8bf292afc7455007c3c/aio/content/guide/security.md?plain=1#L13

So I guess this could also be solved in the following way:
```diff
- {@a report-issues}
+ <div id="report-issues" tabindex="-1"></div>
...
- {@a best-practices}
+ <div id="best-practices" tabindex="-1"></div>
```

if this solution is preferred please let me know and I'll update the PR :slightly_smiling_face: 