### PR TITLE
fix(compiler): do not error if $any is used inside a listener

### DIFF
--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -3557,6 +3557,23 @@ function allTests(os: string) {
       expect(trim(jsContents)).toContain(trim(hostBindingsFn));
     });
 
+    it('should handle $any used inside a listener', () => {
+      env.write('test.ts', `
+        import {Component} from '@angular/core';
+
+        @Component({
+          selector: 'test-cmp',
+          template: '<div (click)="$any(123)"></div>',
+        })
+        export class TestCmp {}
+    `);
+
+      env.driveMain();
+      expect(env.getContents('test.js'))
+          .toContain(
+              `ɵɵlistener("click", function TestCmp_Template_div_click_0_listener() { return 123; });`);
+    });
+
     it('should accept dynamic host attribute bindings', () => {
       env.write('other.d.ts', `
       export declare const foo: any;

--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -610,8 +610,10 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
         throw new Error(`Invalid call to $any, expected 1 argument but received ${
             convertedArgs.length || 'none'}`);
       }
-      return (convertedArgs[0] as o.Expression)
-          .cast(o.DYNAMIC_TYPE, this.convertSourceSpan(ast.span));
+      return convertToStatementIfNeeded(
+          mode,
+          (convertedArgs[0] as o.Expression)
+              .cast(o.DYNAMIC_TYPE, this.convertSourceSpan(ast.span)));
     }
 
     const leftMostSafe = this.leftMostSafeNode(ast);


### PR DESCRIPTION
Fixes that `$any` casts weren't being converted to statements inside listeners which resulted in a compiler error.

Fixes #43841.