### PR TITLE
docs: add missing CartService inside providers in tutorial

### DIFF
--- a/aio/content/examples/getting-started/src/app/app.module.ts
+++ b/aio/content/examples/getting-started/src/app/app.module.ts
@@ -18,11 +18,14 @@ import { ProductDetailsComponent } from './product-details/product-details.compo
 import { CartComponent } from './cart/cart.component';
 // #enddocregion declare-cart
 import { ShippingComponent } from './shipping/shipping.component';
+// #docregion declare-cart-service
+import {CartService} from './cart.service';
+// #enddocregion declare-cart-service
 
 // #docregion product-details-route, http-client-module, shipping-route, cart-route, declare-product-alerts, declare-cart
-
+// #docregion declare-cart-service
 @NgModule({
-  // #enddocregion declare-product-alerts, declare-cart
+  // #enddocregion declare-product-alerts, declare-cart, declare-cart-service
   imports: [
     BrowserModule,
     // #enddocregion product-details-route, cart-route
@@ -57,8 +60,9 @@ import { ShippingComponent } from './shipping/shipping.component';
   // #docregion declare-product-alerts, http-client-module, product-details-route, declare-cart
   ],
   // #enddocregion declare-product-alerts, product-details-route, declare-cart
-  bootstrap: [
-    AppComponent
-  ]
+  bootstrap: [AppComponent],
+  // #docregion declare-cart-service
+  providers: [CartService],
+  // #enddocregion declare-cart-service
 })
 export class AppModule { }

--- a/aio/content/examples/getting-started/src/app/app.module.ts
+++ b/aio/content/examples/getting-started/src/app/app.module.ts
@@ -18,14 +18,14 @@ import { ProductDetailsComponent } from './product-details/product-details.compo
 import { CartComponent } from './cart/cart.component';
 // #enddocregion declare-cart
 import { ShippingComponent } from './shipping/shipping.component';
-// #docregion declare-cart-service
+// #docregion provide-cart-service
 import {CartService} from './cart.service';
-// #enddocregion declare-cart-service
+// #enddocregion provide-cart-service
 
 // #docregion product-details-route, http-client-module, shipping-route, cart-route, declare-product-alerts, declare-cart
-// #docregion declare-cart-service
+// #docregion provide-cart-service
 @NgModule({
-  // #enddocregion declare-product-alerts, declare-cart, declare-cart-service
+  // #enddocregion declare-product-alerts, declare-cart, provide-cart-service
   imports: [
     BrowserModule,
     // #enddocregion product-details-route, cart-route
@@ -61,8 +61,8 @@ import {CartService} from './cart.service';
   ],
   // #enddocregion declare-product-alerts, product-details-route, declare-cart
   bootstrap: [AppComponent],
-  // #docregion declare-cart-service
+  // #docregion provide-cart-service
   providers: [CartService],
-  // #enddocregion declare-cart-service
+  // #enddocregion provide-cart-service
 })
 export class AppModule { }

--- a/aio/content/start/start-data.md
+++ b/aio/content/start/start-data.md
@@ -44,10 +44,10 @@ This section walks you through adding a **Buy** button and setting up a cart ser
     * The `getItems()` method collects the items users add to the cart and returns each item with its associated quantity.
 
     * The `clearCart()` method returns an empty array of items, which empties the cart.
-    
+
 1. To make `CartService` available to the components in the application, add it to `AppModule`'s providers in `app.module.ts`.
 
-    <code-example path="getting-started/src/app/app.module.ts" header="src/app/app.module.ts" region="declare-cart-service"></code-example>
+    <code-example path="getting-started/src/app/app.module.ts" header="src/app/app.module.ts" region="provide-cart-service"></code-example>
 
 {@a product-details-use-cart-service}
 

--- a/aio/content/start/start-data.md
+++ b/aio/content/start/start-data.md
@@ -44,6 +44,10 @@ This section walks you through adding a **Buy** button and setting up a cart ser
     * The `getItems()` method collects the items users add to the cart and returns each item with its associated quantity.
 
     * The `clearCart()` method returns an empty array of items, which empties the cart.
+    
+1. To make `CartService` available to the components in the application, add it to `AppModule`'s providers in `app.module.ts`.
+
+    <code-example path="getting-started/src/app/app.module.ts" header="src/app/app.module.ts" region="declare-cart-service"></code-example>
 
 {@a product-details-use-cart-service}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] [N/A] Tests for the changes have been added (for bug fixes / features)
- [ ] [N/A] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the "Getting Started" tutorial, in the "Managing Data" chapter, in the "Create the shopping cart service" section, under the "[Define a cart service](https://angular.io/start/start-data#define-a-cart-service)" subsection, the user is instructed to create a cart service.

The Getting Started tutorial uses StackBlitz, and when adding a service through Right-click (on the app folder) > Angular Generator > Service in StackBlitz, the new service is not automatically added as a provider in the module.

This might be a bug on StackBlitz's end, but I think that asking the user to explicitly ensure the service is added to the providers array would prevent them from getting stuck with errors which source is not immediately clear for newcomers.

## What is the new behavior?
A step is added in the "Define a cart service" section, to instruct the user to ensure that the CartService is present in the module's providers.

```
import {CartService} from './cart.service';
@NgModule({
    ...
    providers: [CartService],
    ...
})
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
