### PR TITLE
docs: update getting started links to provide a more consistent user …

### DIFF
--- a/aio/content/marketing/docs.md
+++ b/aio/content/marketing/docs.md
@@ -12,20 +12,20 @@ Tutorials and guides include downloadable examples to accelerate your projects.
     <p>Get a high-level overview of the Angular platform.</p>
     <p class="card-footer">Platform overview</p>
   </a>
-  <a href="guide/setup-local" class="docs-card" title="Angular Local Environment Setup">
-    <section>Get Started</section>
-    <p>Set up your local environment for development with the Angular CLI.</p>
-    <p class="card-footer">Local setup</p>
+  <a href="start" class="docs-card" title="Getting started">
+    <section>Getting started</section>
+    <p>Examine and work with a small ready-made Angular app, without any setup.</p>
+    <p class="card-footer">Try it now</p>
   </a>
   <a href="guide/architecture" class="docs-card" title="Angular Concepts">
     <section>Learn and Explore</section>
     <p>Learn about the fundamental design concepts and architecture of Angular apps.</p>
     <p class="card-footer">Introduction to Angular concepts</p>
   </a>
-  <a href="start" class="docs-card" title="Try out Angular">
-    <section>Take a Look</section>
-    <p>Examine and work with a small ready-made Angular app, without any setup.</p>
-    <p class="card-footer">Try it now</p>
+  <a href="guide/setup-local" class="docs-card" title="Angular Local Environment Setup">
+    <section>Set up your environment</section>
+    <p>Set up your local environment for development with the Angular CLI.</p>
+    <p class="card-footer">Local setup</p>
   </a>
   <a href="tutorial" class="docs-card" title="Work through a full tutorial">
     <section>Hello World</section>

--- a/aio/content/marketing/index.html
+++ b/aio/content/marketing/index.html
@@ -13,7 +13,7 @@
     <!-- CONTAINER -->
     <div class="homepage-container">
       <div class="hero-headline no-toc">The modern web<br>developer's platform</div>
-      <a class="button hero-cta no-print" href="docs">Get Started</a>
+      <a class="button hero-cta no-print" href="start">Get Started</a>
     </div>
 
   </section>


### PR DESCRIPTION
…experience

In PR #40179 we discovered we have an inconsistent experience with getting into the documentation and Angular. This update makes a few small changes that ensures that new developers are sent to the Getting Started tutorial, instead of sometimes the Getting Started tutorial and sometimes the documentation introduction.

We're assuming that most users want to explore Angular, as opposed to read an introduction! I think that's a good assumption.