### PR TITLE
ci: update payload size limit

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -39,7 +39,7 @@
     "master": {
       "uncompressed": {
         "runtime-es2015": 2854,
-        "main-es2015": 296436,
+        "main-es2015": 296960,
         "polyfills-es2015": 37064,
         "src_app_lazy_lazy_module_ts-es2015": 822
       }


### PR DESCRIPTION
This commit updates the payload size limit for one of the test apps to prevent CI failures.

Only patch branch (12.2.x) is affected, the 13.0.x and master don't require this size increase.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No