### PR TITLE
feat(router): router link respect preventDefault

### DIFF
--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -532,7 +532,7 @@ export class RouterLink implements OnChanges {
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
-    onClick(): boolean;
+    onClick(defaultPrevented: boolean): boolean;
     preserveFragment: boolean;
     queryParams?: Params | null;
     queryParamsHandling?: QueryParamsHandling | null;
@@ -589,7 +589,7 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
     // (undocumented)
     ngOnDestroy(): any;
     // (undocumented)
-    onClick(button: number, ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean): boolean;
+    onClick(button: number, ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean, defaultPrevented: boolean): boolean;
     preserveFragment: boolean;
     queryParams?: Params | null;
     queryParamsHandling?: QueryParamsHandling | null;

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -111,6 +111,21 @@ import {UrlTree} from '../url_tree';
  * });
  * ```
  *
+ * Navigation will be prevented when a propagating click event is detected, which had its
+ * [`preventDefault()`
+ * method](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) called, but is
+ * still expected to propagate further up the DOM:
+ *
+ * ```
+ * <div (click)="recordPropagatingEvent($event)>
+ *   <a [routerLink]="['/user/bob']">
+ *     link to user component
+ *     <span (click)="$event.preventDefault()">
+ *       some utility that has already handled the click
+ *     </span>
+ *   </a>
+ * <div>
+ *
  * @ngModule RouterModule
  *
  * @publicApi
@@ -235,9 +250,9 @@ export class RouterLink implements OnChanges {
   }
 
   /** @nodoc */
-  @HostListener('click')
-  onClick(): boolean {
-    if (this.urlTree === null) {
+  @HostListener('click', ['$event.defaultPrevented'])
+  onClick(defaultPrevented: boolean): boolean {
+    if (defaultPrevented || this.urlTree === null) {
       return true;
     }
 
@@ -394,10 +409,14 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
   /** @nodoc */
   @HostListener(
       'click',
-      ['$event.button', '$event.ctrlKey', '$event.shiftKey', '$event.altKey', '$event.metaKey'])
-  onClick(button: number, ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean):
-      boolean {
-    if (button !== 0 || ctrlKey || shiftKey || altKey || metaKey) {
+      [
+        '$event.button', '$event.ctrlKey', '$event.shiftKey', '$event.altKey', '$event.metaKey',
+        '$event.defaultPrevented'
+      ])
+  onClick(
+      button: number, ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean,
+      defaultPrevented: boolean): boolean {
+    if (button !== 0 || ctrlKey || shiftKey || altKey || metaKey || defaultPrevented) {
       return true;
     }
 

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -101,4 +101,96 @@ describe('RouterLink', () => {
       expect(link.outerHTML).not.toContain('href');
     });
   });
+
+  describe('event preventDefault handling', () => {
+    describe('RouterLink', () => {
+      @Component({
+        template: `
+            <div [routerLink]="'/'">
+                <span id="navigate"></span>
+                <span id="prevent" (click)="$event.preventDefault()"></span>
+            </div>`
+      })
+      class TestComponent {
+      }
+
+      let fixture: ComponentFixture<TestComponent>;
+      let router: Router;
+      let div: HTMLDivElement;
+      let navigate: HTMLSpanElement;
+      let prevent: HTMLSpanElement;
+
+      beforeEach(() => {
+        TestBed.configureTestingModule(
+            {imports: [RouterTestingModule], declarations: [TestComponent]});
+        router = TestBed.inject(Router);
+        spyOn(router, 'navigateByUrl');
+        fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+        div = fixture.debugElement.query(By.css('div')).nativeElement;
+        navigate = fixture.debugElement.query(By.css('#navigate')).nativeElement;
+        prevent = fixture.debugElement.query(By.css('#prevent')).nativeElement;
+      });
+
+      it('should navigate on direct click', () => {
+        div.click();
+        expect(router.navigateByUrl).toHaveBeenCalled();
+      });
+
+      it('should navigate on propagating event with defaultPrevented not set', () => {
+        navigate.click();
+        expect(router.navigateByUrl).toHaveBeenCalled();
+      });
+
+      it('should not navigate on propagating event with defaultPrevented set to true', () => {
+        prevent.click();
+        expect(router.navigateByUrl).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('RouterLinkWithHref', () => {
+      @Component({
+        template: `
+            <a [routerLink]="'/'">
+                <span id="navigate"></span>
+                <span id="prevent" (click)="$event.preventDefault()"></span>
+            </a>`
+      })
+      class TestComponent {
+      }
+
+      let router: Router;
+      let fixture: ComponentFixture<TestComponent>;
+      let link: HTMLAnchorElement;
+      let navigate: HTMLSpanElement;
+      let prevent: HTMLSpanElement;
+
+      beforeEach(() => {
+        TestBed.configureTestingModule(
+            {imports: [RouterTestingModule], declarations: [TestComponent]});
+        router = TestBed.inject(Router);
+        spyOn(router, 'navigateByUrl');
+        fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+        link = fixture.debugElement.query(By.css('a')).nativeElement;
+        navigate = fixture.debugElement.query(By.css('#navigate')).nativeElement;
+        prevent = fixture.debugElement.query(By.css('#prevent')).nativeElement;
+      });
+
+      it('should navigate on direct click', () => {
+        link.click();
+        expect(router.navigateByUrl).toHaveBeenCalled();
+      });
+
+      it('should navigate on propagating event with defaultPrevented not set', () => {
+        navigate.click();
+        expect(router.navigateByUrl).toHaveBeenCalled();
+      });
+
+      it('should not navigate on propagating event with defaultPrevented set to true', () => {
+        prevent.click();
+        expect(router.navigateByUrl).not.toHaveBeenCalled();
+      });
+    });
+  });
 });


### PR DESCRIPTION
RouterLink should not trigger navigation if a propagating click event has already been handled.
`stopPropagation()` is not always a desirable solution.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #43877 


## What is the new behavior?
`RouterLink` does not trigger navigation any longer when `preventDefault()` was called on a propagating click event. This
is closer to default user agent behavior, where navigation is prevented when a click event has its `defaultPrevented` property set to `true`.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
In case an expected router navigation suddenly stops working, check the following:
1) Is the `[routerLink]` directive involved?
2) If yes, is `preventDefault()` executed on the responsible event before it reaches the directive?
3) If yes, verify that it can be removed. 

## Other information
