### PR TITLE
docs: fix typos in the workspace config guide

### DIFF
--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -54,7 +54,7 @@ The following configuration properties are a set of options that customize the A
 | `analyticsSharing`  | A set of analytics sharing options.                                                              | [Analytics sharing options](#analytics-sharing-options)  |
 | `cache`             | Control [persistent disk cache](cli/cache) used by [Angular CLI Builders](guide/cli-builder).    | [Cache options](#cache-options)                          |
 | `defaultCollection` | The default schematics collection to use.                                                        | `string`                                                 |
-| `packageManager`    | The prefered package manager tool to use.                                                        | `npm` \| `cnpm` \| `pnpm` \| `yarn`                      |
+| `packageManager`    | The preferred package manager tool to use.                                                        | `npm` \| `cnpm` \| `pnpm` \| `yarn`                      |
 | `warnings`          | Control CLI specific console warnings.                                                           | [Warnings options](#warnings-options)                    |
 
 ### Analytics sharing options
@@ -66,7 +66,7 @@ The following configuration properties are a set of options that customize the A
 
 ### Cache options
 
-| Property      | Description                                           | Value Type               | Dafault Value    |
+| Property      | Description                                           | Value Type               | Default Value    |
 | :------------ | :---------------------------------------------------- | :----------------------- | :--------------- |
 | `enabled`     | Configure whether disk caching is enabled.            | `boolean`                | `true`           |
 | `environment` | Configure in which environment disk cache is enabled. | `local` \| `ci` \| `all` | `local`          |
@@ -74,7 +74,7 @@ The following configuration properties are a set of options that customize the A
 
 ### Warnings options
 
-| Property          | Description                                                                     | Value Type | Dafault Value |
+| Property          | Description                                                                     | Value Type | Default Value |
 | :---------------- | :------------------------------------------------------------------------------ | :--------- | :------------ |
 | `versionMismatch` | Show a warning when the global Angular CLI version is newer than the local one. | `boolean`  | `true`        |
 
@@ -401,7 +401,7 @@ The `optimization` browser builder option can be either a Boolean or an Object f
 
 There are several options that can be used to fine-tune the optimization of an application.
 
-| Option    | Description                                                                     | Value Type                                                               | Dafault Value |
+| Option    | Description                                                                     | Value Type                                                               | Default Value |
 |:---       |:---                                                                             |:---                                                                      |:---           |
 | `scripts` | Enables optimization of the scripts output.                                     | `boolean`                                                                | `true`        |
 | `styles`  | Enables optimization of the styles output.                                      | `boolean` \| [Styles optimization options](#styles-optimization-options) | `true`        |
@@ -409,14 +409,14 @@ There are several options that can be used to fine-tune the optimization of an a
 
 #### Styles optimization options
 
-| Option           | Description                                                                                                              | Value Type | Dafault Value |
+| Option           | Description                                                                                                              | Value Type | Default Value |
 |:---              |:---                                                                                                                      |:---        |:---           |
 | `minify`         | Minify CSS definitions by removing extraneous whitespace and comments, merging identifiers and minimizing values.        | `boolean`  | `true`        |
 | `inlineCritical` | Extract and inline critical CSS definitions to improve [First Contentful Paint](https://web.dev/first-contentful-paint). | `boolean`  | `true`        |
 
 #### Fonts optimization options
 
-| Option   | Description                                                                                                                                                                                                                          | Value Type | Dafault Value |
+| Option   | Description                                                                                                                                                                                                                          | Value Type | Default Value |
 |:---      |:---                                                                                                                                                                                                                                  |:---        |:---           |
 | `inline` | Reduce [render blocking requests](https://web.dev/render-blocking-resources) by inlining external Google Fonts and Adobe Fonts CSS definitions in the application's HTML index file. <br /> **NOTE**: This requires internet access. | `boolean`  | `true`        |
 
@@ -445,7 +445,7 @@ For [Universal](guide/glossary#universal), you can reduce the code rendered in t
 
 The `sourceMap` browser builder option can be either a Boolean or an Object for more fine-tune configuration to control the source maps of an application.
 
-| Option    | Description                                        | Value Type | Dafault Value |
+| Option    | Description                                        | Value Type | Default Value |
 |:---       |:---                                                |:---        |:---           |
 | `scripts` | Output source maps for all scripts.                | `boolean`  | `true`        |
 | `styles`  | Output source maps for all styles.                 | `boolean`  | `true`        |


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The "dafault value" header has a typo in it "d**a**fault". Also, "prefered" has a typo in it.

Issue Number: N/A


## What is the new behavior?

The header has a correct value "d**e**fault" without a typo. Fixed "prefer**r**ed" typo as well.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
