### PR TITLE
ci: Windows support for tsec_test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "sauce-connect": "https://saucelabs.com/downloads/sc-4.6.2-linux.tar.gz",
     "semver": "^7.3.5",
     "ts-node": "^10.0.0",
-    "tsec": "0.1.10",
+    "tsec": "0.1.11",
     "tslint-eslint-rules": "5.4.0",
     "tslint-no-toplevel-property-access": "0.0.2",
     "typed-graphqlify": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,11 +1240,6 @@
   dependencies:
     "@bazel/worker" "4.4.2"
 
-"@bazel/runfiles@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@bazel/runfiles/-/runfiles-4.0.0.tgz#3d649d93710364515402b873add73947aaa702e8"
-  integrity sha512-1V0E1ooSw7DARfOBkr24O5GOpqODDd7RuJ2Xb+JljjdpUdJTIaVeqELBpSHAiYzqVJYWAn61sD5JP1CPCllixA==
-
 "@bazel/runfiles@4.4.2":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@bazel/runfiles/-/runfiles-4.4.2.tgz#9d424f0f9ad7505d2ff2f854a450b986e132ac8e"
@@ -13908,12 +13903,11 @@ ts-node@^10.0.0, ts-node@^10.2.1:
     make-error "^1.1.1"
     yn "3.1.1"
 
-tsec@0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/tsec/-/tsec-0.1.10.tgz#53b43cb5384d542f69cf3273e82308f814b31b2e"
-  integrity sha512-VedCZnZxHLcTFueWwU6TYww6WXEKg19y4Td9ypbhUQKOMJ4l7tEo0bBqlIodnu1C7K162jH2bFwK8xJTk1NfYg==
+tsec@0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/tsec/-/tsec-0.1.11.tgz#d24d0b36bfd73c83bf39db4211d29a0469457da4"
+  integrity sha512-GzUW2kyV8UgmEp0NPkcxsnlXimJj02kchmVde6FnzUfvpAp+l36MKT2swcCd0aS8QWfqaXNckXrFtjZhIGJWkw==
   dependencies:
-    "@bazel/runfiles" "4.0.0"
     glob "^7.1.1"
     minimatch "^3.0.3"
 


### PR DESCRIPTION
Contents of generated tsconfig for tsec_test now depend on whether Bazel uses symlinked runfiles for nodejs_test. The current implementation assumes that symlinked runfiles are not available on Windows.

Implementation-wise, this PR detects the platform on which Bazel is running and infers whether runfiles would be available to `nodejs_test`. And based on that, the `tsec_test` macro generates different `tsconfig.json` files to adapt to different directory layouts. `@bazel/runfiles` is not used since there are too many path-searching dynamics that we can't control inside the TypeScript APIs.

A new tsec version (0.1.11) is required to actually activate Windows support.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
