### PR TITLE
test(platform-browser): complete component bootstrap before switching to the next test

### DIFF
--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -272,10 +272,10 @@ function bootstrap(
       });
     }
 
-    it('should create an injector promise', done => {
+    it('should create an injector promise', async () => {
       const refPromise = bootstrap(HelloRootCmp, testProviders);
       expect(refPromise).toEqual(jasmine.any(Promise));
-      refPromise.then(done, done.fail);
+      await refPromise;  // complete component initialization before switching to the next test
     });
 
     it('should set platform name to browser', done => {

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -272,9 +272,10 @@ function bootstrap(
       });
     }
 
-    it('should create an injector promise', () => {
+    it('should create an injector promise', done => {
       const refPromise = bootstrap(HelloRootCmp, testProviders);
       expect(refPromise).toEqual(jasmine.any(Promise));
+      refPromise.then(done, done.fail);
     });
 
     it('should set platform name to browser', done => {


### PR DESCRIPTION
The bootstrap tests that reused the same component (the `HelloRootCmp` one) were randomly failing due to the incomplete cleanup between tests. This commit ensures that the component bootstrap is fully cimpleted and there are no pending async actions before going to the next test.

## PR Type
What kind of change does this PR introduce?
- [x] Other... Please describe: test-only fix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No