### PR TITLE
docs(docs-infra): change deprecated keyboardEvent.keyCode example to use keyboardEvent.code

### DIFF
--- a/aio/content/examples/observables/src/creating.spec.ts
+++ b/aio/content/examples/observables/src/creating.spec.ts
@@ -14,12 +14,12 @@ describe('observables', () => {
   });
 
   it('should listen to input changes', () => {
-    let triggerInputChange!: (e: {keyCode: number}) => void;
+    let triggerInputChange!: (e: {code: string}) => void;
     const input = {
       value: 'Test',
       addEventListener: jasmine
         .createSpy('addEvent')
-        .and.callFake((eventName: string, cb: (e: {keyCode: number}) => void) => {
+        .and.callFake((eventName: string, cb: (e: {code: string}) => void) => {
           if (eventName === 'keydown') {
             triggerInputChange = cb;
           }
@@ -29,10 +29,10 @@ describe('observables', () => {
 
     const document = { getElementById: () => input } as unknown as Document;
     docRegionFromEvent(document);
-    triggerInputChange({keyCode: 65});
+    triggerInputChange({code: 'A'});
     expect(input.value).toBe('Test');
 
-    triggerInputChange({keyCode: 27});
+    triggerInputChange({code: 'Escape'});
     expect(input.value).toBe('');
   });
 

--- a/aio/content/examples/observables/src/creating.ts
+++ b/aio/content/examples/observables/src/creating.ts
@@ -55,11 +55,11 @@ function fromEvent<T extends keyof HTMLElementEventMap>(target: HTMLElement, eve
 export function docRegionFromEvent(document: Document) {
   // #docregion fromevent_use
 
-  const ESC_KEY = 27;
+  const ESC_CODE = 'Escape';
   const nameInput = document.getElementById('name') as HTMLInputElement;
 
   const subscription = fromEvent(nameInput, 'keydown').subscribe((e: KeyboardEvent) => {
-    if (e.keyCode === ESC_KEY) {
+    if (e.code === ESC_CODE) {
       nameInput.value = '';
     }
   });


### PR DESCRIPTION
## PR Checklist

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
the old code-example used ```keyboardEvent.keyCode``` which is [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode).
Issue Number: #43928 


## What is the new behavior?
the new example-code uses ```KeyboardEvent.code``` to get the pressed key.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No




## Other information
