### PR TITLE
ci: update commit-message-based-labels job to be called labels

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  commit_message_based_labels:
+  labels:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Using the job name labels results in a more readable and better looking Github status.
