### PR TITLE
refactor(forms): inherit `ngOnChanges` hooks from the base class

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -454,10 +454,8 @@ export class FormsModule {
 }
 
 // @public
-export class MaxLengthValidator extends AbstractValidatorDirective implements OnChanges {
+export class MaxLengthValidator extends AbstractValidatorDirective {
     maxlength: string | number | null;
-    // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MaxLengthValidator, "[maxlength][formControlName],[maxlength][formControl],[maxlength][ngModel]", never, { "maxlength": "maxlength"; }, {}, never>;
     // (undocumented)
@@ -465,9 +463,8 @@ export class MaxLengthValidator extends AbstractValidatorDirective implements On
 }
 
 // @public
-export class MaxValidator extends AbstractValidatorDirective implements OnChanges {
+export class MaxValidator extends AbstractValidatorDirective {
     max: string | number | null;
-    ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MaxValidator, "input[type=number][max][formControlName],input[type=number][max][formControl],input[type=number][max][ngModel]", never, { "max": "max"; }, {}, never>;
     // (undocumented)
@@ -475,10 +472,8 @@ export class MaxValidator extends AbstractValidatorDirective implements OnChange
 }
 
 // @public
-export class MinLengthValidator extends AbstractValidatorDirective implements OnChanges {
+export class MinLengthValidator extends AbstractValidatorDirective {
     minlength: string | number | null;
-    // (undocumented)
-    ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MinLengthValidator, "[minlength][formControlName],[minlength][formControl],[minlength][ngModel]", never, { "minlength": "minlength"; }, {}, never>;
     // (undocumented)
@@ -486,9 +481,8 @@ export class MinLengthValidator extends AbstractValidatorDirective implements On
 }
 
 // @public
-export class MinValidator extends AbstractValidatorDirective implements OnChanges {
+export class MinValidator extends AbstractValidatorDirective {
     min: string | number | null;
-    ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<MinValidator, "input[type=number][min][formControlName],input[type=number][min][formControl],input[type=number][min][ngModel]", never, { "min": "min"; }, {}, never>;
     // (undocumented)

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -94,7 +94,7 @@ export interface Validator {
  * For internal use only, this class is not intended for use outside of the Forms package.
  */
 @Directive()
-abstract class AbstractValidatorDirective implements Validator {
+abstract class AbstractValidatorDirective implements Validator, OnChanges {
   private _validator: ValidatorFn = nullValidator;
   private _onChange!: () => void;
 
@@ -125,11 +125,8 @@ abstract class AbstractValidatorDirective implements Validator {
    */
   abstract normalizeInput(input: unknown): unknown;
 
-  /**
-   * Helper function invoked from child classes to process changes (from `ngOnChanges` hook).
-   * @nodoc
-   */
-  handleChanges(changes: SimpleChanges): void {
+  /** @nodoc */
+  ngOnChanges(changes: SimpleChanges): void {
     if (this.inputName in changes) {
       const input = this.normalizeInput(changes[this.inputName].currentValue);
       this._validator = this.enabled() ? this.createValidator(input) : nullValidator;
@@ -199,7 +196,7 @@ export const MAX_VALIDATOR: StaticProvider = {
   providers: [MAX_VALIDATOR],
   host: {'[attr.max]': 'enabled() ? max : null'}
 })
-export class MaxValidator extends AbstractValidatorDirective implements OnChanges {
+export class MaxValidator extends AbstractValidatorDirective {
   /**
    * @description
    * Tracks changes to the max bound to this directive.
@@ -211,15 +208,6 @@ export class MaxValidator extends AbstractValidatorDirective implements OnChange
   override normalizeInput = (input: string|number): number => toFloat(input);
   /** @internal */
   override createValidator = (max: number): ValidatorFn => maxValidator(max);
-  /**
-   * Declare `ngOnChanges` lifecycle hook at the main directive level (vs keeping it in base class)
-   * to avoid differences in handling inheritance of lifecycle hooks between Ivy and ViewEngine in
-   * AOT mode. This could be refactored once ViewEngine is removed.
-   * @nodoc
-   */
-  ngOnChanges(changes: SimpleChanges): void {
-    this.handleChanges(changes);
-  }
 }
 
 /**
@@ -259,7 +247,7 @@ export const MIN_VALIDATOR: StaticProvider = {
   providers: [MIN_VALIDATOR],
   host: {'[attr.min]': 'enabled() ? min : null'}
 })
-export class MinValidator extends AbstractValidatorDirective implements OnChanges {
+export class MinValidator extends AbstractValidatorDirective {
   /**
    * @description
    * Tracks changes to the min bound to this directive.
@@ -271,15 +259,6 @@ export class MinValidator extends AbstractValidatorDirective implements OnChange
   override normalizeInput = (input: string|number): number => toFloat(input);
   /** @internal */
   override createValidator = (min: number): ValidatorFn => minValidator(min);
-  /**
-   * Declare `ngOnChanges` lifecycle hook at the main directive level (vs keeping it in base class)
-   * to avoid differences in handling inheritance of lifecycle hooks between Ivy and ViewEngine in
-   * AOT mode. This could be refactored once ViewEngine is removed.
-   * @nodoc
-   */
-  ngOnChanges(changes: SimpleChanges): void {
-    this.handleChanges(changes);
-  }
 }
 
 /**
@@ -572,12 +551,13 @@ export const MIN_LENGTH_VALIDATOR: any = {
   providers: [MIN_LENGTH_VALIDATOR],
   host: {'[attr.minlength]': 'enabled() ? minlength : null'}
 })
-export class MinLengthValidator extends AbstractValidatorDirective implements OnChanges {
+export class MinLengthValidator extends AbstractValidatorDirective {
   /**
    * @description
    * Tracks changes to the minimum length bound to this directive.
    */
   @Input() minlength!: string|number|null;
+
   /** @internal */
   override inputName = 'minlength';
 
@@ -586,11 +566,6 @@ export class MinLengthValidator extends AbstractValidatorDirective implements On
 
   /** @internal */
   override createValidator = (minlength: number): ValidatorFn => minLengthValidator(minlength);
-
-  /** @nodoc */
-  ngOnChanges(changes: SimpleChanges): void {
-    this.handleChanges(changes);
-  }
 }
 
 /**
@@ -629,12 +604,13 @@ export const MAX_LENGTH_VALIDATOR: any = {
   providers: [MAX_LENGTH_VALIDATOR],
   host: {'[attr.maxlength]': 'enabled() ? maxlength : null'}
 })
-export class MaxLengthValidator extends AbstractValidatorDirective implements OnChanges {
+export class MaxLengthValidator extends AbstractValidatorDirective {
   /**
    * @description
    * Tracks changes to the minimum length bound to this directive.
    */
   @Input() maxlength!: string|number|null;
+
   /** @internal */
   override inputName = 'maxlength';
 
@@ -643,11 +619,6 @@ export class MaxLengthValidator extends AbstractValidatorDirective implements On
 
   /** @internal */
   override createValidator = (maxlength: number): ValidatorFn => maxLengthValidator(maxlength);
-
-  /** @nodoc */
-  ngOnChanges(changes: SimpleChanges): void {
-    this.handleChanges(changes);
-  }
 }
 
 /**


### PR DESCRIPTION
This commit updates the code of the min and max validator directives to inherit `ngOnChanges` hooks from the base class (the `AbstractValidatorDirective` one), rather than implementing the hooks on the child classes. This was needed to avoid issues with hooks inheritance in ViewEngine, but since it's deprecated, the code can be cleaned up.

## PR Type
What kind of change does this PR introduce?

- [ ] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No