### PR TITLE
fix(docs-infra): fix heritage links

### DIFF
--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -3,10 +3,10 @@
 
 {%- macro renderHeritage(exportDoc) -%}
   {%- if exportDoc.extendsClauses.length %} extends {% for clause in exportDoc.extendsClauses -%}
-  {% if clause.doc.path %}<a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text $}</a>{% else %}{$ clause.text $}{% endif %}{% if not loop.last %}, {% endif -%}
+  {% if clause.doc.path %}<a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% else %}{$ clause.text | escape $}{% endif %}{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
   {%- if exportDoc.implementsClauses.length %} implements {% for clause in exportDoc.implementsClauses -%}
-  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text $}</a>{% if not loop.last %}, {% endif -%}
+  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
 {%- endmacro -%}
 


### PR DESCRIPTION
Fix incorrect escape of special characters when rendering member heritage docs.

Example: [DefaultIterableDiffer](https://angular.io/api/core/DefaultIterableDiffer) docs incorrectly render what this class implements - it does not fully display generic types of implemented interfaces. The docs render:

```ts
class DefaultIterableDiffer<V> implements IterableDiffer, IterableChanges
```

while it [should be](https://github.com/angular/angular/blob/13.0.0-rc.1/packages/core/src/change_detection/differs/default_iterable_differ.ts#L32):

```ts
class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChanges<V>
```

Basically, the docs is missing generic type declaration (`<V>`) for `IterableDiffer` and `IterableChanges` interfaces.

I have discovered this while I was investigating the similar issue in the RxJS docs (ReactiveX/rxjs#6427) where this is even more obvious (please check the link for more details and images). (I plan to create a PR in the RxJS repo to fix it there as well.)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: N/A

## What is the new behavior?
This PR fixes rendered HTML in the docs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
If you need more deep dive info why this happens, please let me know so I can write an extensive description.

This is how this looked like in the browser before this fix (plus, this is what was rendered in the DOM):
![image](https://user-images.githubusercontent.com/28087049/138945121-bef79e40-e76a-4083-810f-b7863fe9f1f0.png)

Please notice the empty `<v>` tag in the DOM - the generic type (`<V>`) hasn't been escaped properly and it got converted to the HTML tag.

This is how this looks like with this fix:
![image](https://user-images.githubusercontent.com/28087049/138946080-058c0972-b1b5-47cf-a467-c7226d6e4439.png)
 