### PR TITLE
feat(upgrade): support NgModule class as an argument of the `downgradeModule` function

### DIFF
--- a/goldens/public-api/upgrade/static/static.md
+++ b/goldens/public-api/upgrade/static/static.md
@@ -34,7 +34,7 @@ export function downgradeComponent(info: {
 export function downgradeInjectable(token: any, downgradedModule?: string): Function;
 
 // @public
-export function downgradeModule<T>(moduleFactoryOrBootstrapFn: NgModuleFactory<T> | ((extraProviders: StaticProvider[]) => Promise<NgModuleRef<T>>)): string;
+export function downgradeModule<T>(moduleOrBootstrapFn: Type<T> | NgModuleFactory<T> | ((extraProviders: StaticProvider[]) => Promise<NgModuleRef<T>>)): string;
 
 // @public
 export function getAngularJSGlobal(): any;

--- a/packages/upgrade/src/common/src/util.ts
+++ b/packages/upgrade/src/common/src/util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, Type} from '@angular/core';
+import {Injector, Type, ɵNG_MOD_DEF} from '@angular/core';
 
 import {element as angularElement, IAugmentedJQuery, IInjectorService, INgModelController, IRootScopeService} from './angular1';
 import {$ROOT_ELEMENT, $ROOT_SCOPE, DOWNGRADED_MODULE_COUNT_KEY, UPGRADE_APP_TYPE_KEY} from './constants';
@@ -87,6 +87,11 @@ export function getUpgradeAppType($injector: IInjectorService): UpgradeAppType {
 
 export function isFunction(value: any): value is Function {
   return typeof value === 'function';
+}
+
+export function isNgModuleType(value: any): value is Type<unknown> {
+  // NgModule class should have the `ɵmod` static property attached by AOT or JIT compiler.
+  return isFunction(value) && !!value[ɵNG_MOD_DEF];
 }
 
 function isParentNode(node: Node|ParentNode): node is ParentNode {

--- a/packages/upgrade/static/test/BUILD.bazel
+++ b/packages/upgrade/static/test/BUILD.bazel
@@ -19,6 +19,7 @@ ts_library(
         "//packages/platform-browser",
         "//packages/platform-browser-dynamic",
         "//packages/platform-browser/testing",
+        "//packages/private/testing",
         "//packages/upgrade/src/common",
         "//packages/upgrade/src/common/test/helpers",
         "//packages/upgrade/static",

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -11,6 +11,7 @@ import {fakeAsync, tick, waitForAsync} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
+import {onlyInIvy} from '@angular/private/testing';
 import {downgradeComponent, downgradeModule, UpgradeComponent} from '@angular/upgrade/static';
 
 import * as angular from '../../../src/common/src/angular1';
@@ -22,57 +23,6 @@ import {setTempInjectorRef} from '../../src/angular1_providers';
 
 withEachNg1Version(() => {
   [true, false].forEach(propagateDigest => {
-    describe('downgradeModule with NgModule class', () => {
-      it('should support downgrading modules by providing NgModule class to `downgradeModule` call',
-         waitForAsync(() => {
-           @Component({selector: 'ng2A', template: 'a'})
-           class Ng2ComponentA {
-           }
-
-           @Component({selector: 'ng2B', template: 'b'})
-           class Ng2ComponentB {
-           }
-
-           @NgModule({
-             declarations: [Ng2ComponentA],
-             entryComponents: [Ng2ComponentA],
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleA {
-             ngDoBootstrap() {}
-           }
-
-           @NgModule({
-             declarations: [Ng2ComponentB],
-             entryComponents: [Ng2ComponentB],
-             imports: [BrowserModule],
-           })
-           class Ng2ModuleB {
-             ngDoBootstrap() {}
-           }
-
-           const downModA = downgradeModule(Ng2ModuleA);
-           const downModB = downgradeModule(Ng2ModuleB);
-           const ng1Module = angular.module_('ng1', [downModA, downModB])
-                                 .directive('ng2A', downgradeComponent({
-                                              component: Ng2ComponentA,
-                                              downgradedModule: downModA,
-                                              propagateDigest,
-                                            }))
-                                 .directive('ng2B', downgradeComponent({
-                                              component: Ng2ComponentB,
-                                              downgradedModule: downModB,
-                                              propagateDigest,
-                                            }));
-
-           const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
-           angular.bootstrap(element, [ng1Module.name]);
-
-           // Wait for the module to be bootstrapped.
-           setTimeout(() => expect(element.textContent).toBe('a | b'));
-         }));
-    });
-
     describe(`lazy-load ng2 module (propagateDigest: ${propagateDigest})`, () => {
       beforeEach(() => destroyPlatform());
       afterEach(() => destroyPlatform());
@@ -130,6 +80,56 @@ withEachNg1Version(() => {
            // Wait for the module to be bootstrapped.
            setTimeout(() => expect(element.textContent).toBe('a | b'));
          }));
+
+      onlyInIvy('Factory-less API of the `downgradeModule` is supported only in Ivy')
+          .it('should support downgrading modules by providing NgModule class to `downgradeModule` call',
+              waitForAsync(() => {
+                @Component({selector: 'ng2A', template: 'a'})
+                class Ng2ComponentA {
+                }
+
+                @Component({selector: 'ng2B', template: 'b'})
+                class Ng2ComponentB {
+                }
+
+                @NgModule({
+                  declarations: [Ng2ComponentA],
+                  entryComponents: [Ng2ComponentA],
+                  imports: [BrowserModule],
+                })
+                class Ng2ModuleA {
+                  ngDoBootstrap() {}
+                }
+
+                @NgModule({
+                  declarations: [Ng2ComponentB],
+                  entryComponents: [Ng2ComponentB],
+                  imports: [BrowserModule],
+                })
+                class Ng2ModuleB {
+                  ngDoBootstrap() {}
+                }
+
+                const downModA = downgradeModule(Ng2ModuleA);
+                const downModB = downgradeModule(Ng2ModuleB);
+                const ng1Module = angular.module_('ng1', [downModA, downModB])
+                                      .directive('ng2A', downgradeComponent({
+                                                   component: Ng2ComponentA,
+                                                   downgradedModule: downModA,
+                                                   propagateDigest,
+                                                 }))
+                                      .directive('ng2B', downgradeComponent({
+                                                   component: Ng2ComponentB,
+                                                   downgradedModule: downModB,
+                                                   propagateDigest,
+                                                 }));
+
+                const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+                angular.bootstrap(element, [ng1Module.name]);
+
+                // Wait for the module to be bootstrapped.
+                setTimeout(() => expect(element.textContent).toBe('a | b'));
+              }));
 
       it('should support nesting components from different downgraded modules', waitForAsync(() => {
            @Directive({selector: 'ng1A'})

--- a/packages/upgrade/static/test/integration/downgrade_module_spec.ts
+++ b/packages/upgrade/static/test/integration/downgrade_module_spec.ts
@@ -80,6 +80,55 @@ withEachNg1Version(() => {
            setTimeout(() => expect(element.textContent).toBe('a | b'));
          }));
 
+      it('should support downgrading modules by providing NgModule class to `downgradeModule` call',
+         waitForAsync(() => {
+           @Component({selector: 'ng2A', template: 'a'})
+           class Ng2ComponentA {
+           }
+
+           @Component({selector: 'ng2B', template: 'b'})
+           class Ng2ComponentB {
+           }
+
+           @NgModule({
+             declarations: [Ng2ComponentA],
+             entryComponents: [Ng2ComponentA],
+             imports: [BrowserModule],
+           })
+           class Ng2ModuleA {
+             ngDoBootstrap() {}
+           }
+
+           @NgModule({
+             declarations: [Ng2ComponentB],
+             entryComponents: [Ng2ComponentB],
+             imports: [BrowserModule],
+           })
+           class Ng2ModuleB {
+             ngDoBootstrap() {}
+           }
+
+           const downModA = downgradeModule(Ng2ModuleA);
+           const downModB = downgradeModule(Ng2ModuleB);
+           const ng1Module = angular.module_('ng1', [downModA, downModB])
+                                 .directive('ng2A', downgradeComponent({
+                                              component: Ng2ComponentA,
+                                              downgradedModule: downModA,
+                                              propagateDigest,
+                                            }))
+                                 .directive('ng2B', downgradeComponent({
+                                              component: Ng2ComponentB,
+                                              downgradedModule: downModB,
+                                              propagateDigest,
+                                            }));
+
+           const element = html('<ng2-a></ng2-a> | <ng2-b></ng2-b>');
+           angular.bootstrap(element, [ng1Module.name]);
+
+           // Wait for the module to be bootstrapped.
+           setTimeout(() => expect(element.textContent).toBe('a | b'));
+         }));
+
       it('should support nesting components from different downgraded modules', waitForAsync(() => {
            @Directive({selector: 'ng1A'})
            class Ng1ComponentA extends UpgradeComponent {


### PR DESCRIPTION
This commit extends the logic of the `downgradeModule` function to support NgModule class as an argument. This is needed to simplify the API surface to avoid the need to resolve NgModule factory before invoking the `downgradeModule` method.


## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No