### PR TITLE
fix(docs-infra): improve accessibility by respecting `prefers-reduced-motion`

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -19,7 +19,7 @@
     </aio-notification>
   </mat-toolbar-row>
   <mat-toolbar-row>
-    <button mat-button class="hamburger" [class.starting]="isStarting" (click)="sidenav.toggle()" title="Docs menu">
+    <button mat-button class="hamburger" [class.no-animations]="disableAnimations" (click)="sidenav.toggle()" title="Docs menu">
       <mat-icon svgIcon="menu"></mat-icon>
     </button>
     <a class="nav-link home" href="/" [ngSwitch]="showTopMenu">
@@ -45,7 +45,7 @@
 
 <aio-search-results #searchResultsView *ngIf="showSearchResults" [searchResults]="searchResults | async" (resultSelected)="hideSearchResults()"></aio-search-results>
 
-<mat-sidenav-container class="sidenav-container" [class.starting]="isStarting" [class.has-floating-toc]="hasFloatingToc" role="main">
+<mat-sidenav-container class="sidenav-container" [class.no-animations]="disableAnimations" [class.has-floating-toc]="hasFloatingToc" role="main">
 
   <mat-sidenav [ngClass]="{'collapsed': !dockSideNav}" #sidenav class="sidenav" [mode]="mode" [opened]="isOpened" (openedChange)="updateHostClasses()">
     <aio-nav-menu *ngIf="!showTopMenu" [nodes]="topMenuNarrowNodes" [currentNode]="currentNodes?.TopBarNarrow" [isWide]="dockSideNav"></aio-nav-menu>
@@ -59,7 +59,7 @@
   <main class="sidenav-content" [id]="pageId" role="main">
     <div id="main-content" tabindex="-1"></div>
     <aio-mode-banner [mode]="deployment.mode" [version]="versionInfo"></aio-mode-banner>
-    <aio-doc-viewer [class.no-animations]="isStarting" [doc]="currentDocument" (docReady)="onDocReady()" (docRemoved)="onDocRemoved()" (docInserted)="onDocInserted()" (docRendered)="onDocRendered()">
+    <aio-doc-viewer [class.no-animations]="disableAnimations" [doc]="currentDocument" (docReady)="onDocReady()" (docRemoved)="onDocRemoved()" (docInserted)="onDocInserted()" (docRendered)="onDocRendered()">
     </aio-doc-viewer>
     <aio-dt *ngIf="dtOn" [(doc)]="currentDocument"></aio-dt>
   </main>

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -926,70 +926,79 @@ describe('AppComponent', () => {
     });
 
     describe('initial rendering', () => {
-      beforeEach(jasmine.clock().install);
-      afterEach(jasmine.clock().uninstall);
+      const originialReducedMotion = AppComponent.reducedMotion;
+
+      beforeEach(() => {
+        jasmine.clock().install();
+        AppComponent.reducedMotion = false;
+      });
+
+      afterEach(() => {
+        jasmine.clock().uninstall();
+        AppComponent.reducedMotion = originialReducedMotion;
+      });
 
       it('should initially disable Angular animations until a document is rendered', () => {
         initializeTest(false);
         jasmine.clock().tick(1);  // triggers the HTTP response for the document
 
-        expect(component.isStarting).toBe(true);
+        expect(component.disableAnimations).toBe(true);
         expect(fixture.debugElement.properties['@.disabled']).toBe(true);
 
         triggerDocViewerEvent('docInserted');
         jasmine.clock().tick(startedDelay);
         fixture.detectChanges();
-        expect(component.isStarting).toBe(true);
+        expect(component.disableAnimations).toBe(true);
         expect(fixture.debugElement.properties['@.disabled']).toBe(true);
 
         triggerDocViewerEvent('docRendered');
         jasmine.clock().tick(startedDelay);
         fixture.detectChanges();
-        expect(component.isStarting).toBe(false);
+        expect(component.disableAnimations).toBe(false);
         expect(fixture.debugElement.properties['@.disabled']).toBe(false);
       });
 
-      it('should initially add the starting class until a document is rendered', () => {
+      it('should initially add the `no-animations` class until a document is rendered', () => {
         initializeTest(false);
         jasmine.clock().tick(1);  // triggers the HTTP response for the document
         const sidenavContainer = fixture.debugElement.query(By.css('mat-sidenav-container')).nativeElement;
 
-        expect(component.isStarting).toBe(true);
-        expect(hamburger.classList.contains('starting')).toBe(true);
-        expect(sidenavContainer.classList.contains('starting')).toBe(true);
+        expect(component.disableAnimations).toBe(true);
+        expect(hamburger.classList.contains('no-animations')).toBe(true);
+        expect(sidenavContainer.classList.contains('no-animations')).toBe(true);
 
         triggerDocViewerEvent('docInserted');
         jasmine.clock().tick(startedDelay);
         fixture.detectChanges();
-        expect(component.isStarting).toBe(true);
-        expect(hamburger.classList.contains('starting')).toBe(true);
-        expect(sidenavContainer.classList.contains('starting')).toBe(true);
+        expect(component.disableAnimations).toBe(true);
+        expect(hamburger.classList.contains('no-animations')).toBe(true);
+        expect(sidenavContainer.classList.contains('no-animations')).toBe(true);
 
         triggerDocViewerEvent('docRendered');
         jasmine.clock().tick(startedDelay);
         fixture.detectChanges();
-        expect(component.isStarting).toBe(false);
-        expect(hamburger.classList.contains('starting')).toBe(false);
-        expect(sidenavContainer.classList.contains('starting')).toBe(false);
+        expect(component.disableAnimations).toBe(false);
+        expect(hamburger.classList.contains('no-animations')).toBe(false);
+        expect(sidenavContainer.classList.contains('no-animations')).toBe(false);
       });
 
       it('should initially disable animations on the DocViewer for the first rendering', () => {
         initializeTest(false);
         jasmine.clock().tick(1);  // triggers the HTTP response for the document
 
-        expect(component.isStarting).toBe(true);
+        expect(component.disableAnimations).toBe(true);
         expect(docViewer.classList.contains('no-animations')).toBe(true);
 
         triggerDocViewerEvent('docInserted');
         jasmine.clock().tick(startedDelay);
         fixture.detectChanges();
-        expect(component.isStarting).toBe(true);
+        expect(component.disableAnimations).toBe(true);
         expect(docViewer.classList.contains('no-animations')).toBe(true);
 
         triggerDocViewerEvent('docRendered');
         jasmine.clock().tick(startedDelay);
         fixture.detectChanges();
-        expect(component.isStarting).toBe(false);
+        expect(component.disableAnimations).toBe(false);
         expect(docViewer.classList.contains('no-animations')).toBe(false);
       });
     });
@@ -1047,6 +1056,44 @@ describe('AppComponent', () => {
         triggerDocViewerEvent('docInserted');
         jasmine.clock().tick(0);
         expect(updateSideNavSpy).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('disableAnimations', () => {
+      const originialReducedMotion = AppComponent.reducedMotion;
+
+      beforeEach(() => {
+        jasmine.clock().install();
+        AppComponent.reducedMotion = false;
+      });
+
+      afterEach(() => {
+        jasmine.clock().uninstall();
+        AppComponent.reducedMotion = originialReducedMotion;
+      });
+
+      it('should initially be true', () => {
+        initializeTest(false);
+        expect(component.disableAnimations).toBe(true);
+      });
+
+      it('should become false after initial render', () => {
+        initializeTest(false);
+
+        triggerDocViewerEvent('docRendered');
+        jasmine.clock().tick(startedDelay);
+
+        expect(component.disableAnimations).toBe(false);
+      });
+
+      it('should remain true (even after initial render) if user prefers reduced motion', () => {
+        AppComponent.reducedMotion = true;
+        initializeTest(false);
+
+        triggerDocViewerEvent('docRendered');
+        jasmine.clock().tick(startedDelay);
+
+        expect(component.disableAnimations).toBe(true);
       });
     });
 

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -76,15 +76,16 @@ describe('AppComponent', () => {
 
 
   describe('with proper DocViewer', () => {
+    const originalReducedMotion = AppComponent.reducedMotion;
 
     beforeEach(async () => {
-      DocViewerComponent.animationsEnabled = false;
+      AppComponent.reducedMotion = true;
 
       createTestingModule('a/b');
       await initializeTest();
     });
 
-    afterEach(() => DocViewerComponent.animationsEnabled = true);
+    afterEach(() => AppComponent.reducedMotion = originalReducedMotion);
 
     it('should create', () => {
       expect(component).toBeDefined();

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -79,6 +79,7 @@ describe('AppComponent', () => {
     const originalReducedMotion = AppComponent.reducedMotion;
 
     beforeEach(async () => {
+      // Set `reducedMotion` to `true` to disable animations (such as view transitions) for the tests.
       AppComponent.reducedMotion = true;
 
       createTestingModule('a/b');

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -34,6 +34,12 @@ export const showFloatingTocWidth = 800;
 })
 export class AppComponent implements OnInit {
 
+  static reducedMotion = window.matchMedia('(prefers-reduced-motion)').matches;
+
+  // Disable all Angular animations if the user prefers reduced motion or for the initial render.
+  @HostBinding('@.disabled')
+  get disableAnimations(): boolean { return AppComponent.reducedMotion || this.isStarting; }
+
   currentDocument: DocumentContents;
   currentDocVersion: NavigationNode;
   currentNodes: CurrentNodes = {};
@@ -65,9 +71,7 @@ export class AppComponent implements OnInit {
   @HostBinding('class')
   hostClasses = '';
 
-  // Disable all Angular animations for the initial render.
-  @HostBinding('@.disabled')
-  isStarting = true;
+  private isStarting = true;
   isTransitioning = true;
   isFetching = false;
   showTopMenu = false;

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -146,7 +146,7 @@ export const svgIconProviders = [
 @NgModule({
   imports: [
     BrowserModule,
-    BrowserAnimationsModule,
+    BrowserAnimationsModule.withConfig({disableAnimations: AppComponent.reducedMotion}),
     CustomElementsModule,
     HttpClientModule,
     MatButtonModule,

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
@@ -594,146 +594,139 @@ describe('DocViewerComponent', () => {
     });
 
     [true, false].forEach(animationsEnabled => {
-      describe(`(animationsEnabled: ${animationsEnabled})`, () => {
-        beforeEach(() => DocViewerComponent.animationsEnabled = animationsEnabled);
-        afterEach(() => DocViewerComponent.animationsEnabled = true);
+      describe(`(animations enabled: ${animationsEnabled})`, () => {
+        beforeEach(() => !animationsEnabled && docViewerEl.classList.add(NO_ANIMATIONS));
 
-        [true, false].forEach(noAnimations => {
-          describe(`(.${NO_ANIMATIONS}: ${noAnimations})`, () => {
-            beforeEach(() => docViewerEl.classList[noAnimations ? 'add' : 'remove'](NO_ANIMATIONS));
-
-            it('should return an observable', done => {
-              docViewer.swapViews().subscribe(done, done.fail);
-            });
-
-            it('should swap the views', async () => {
-              await doSwapViews();
-
-              expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
-              expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
-              expect(docViewer.currViewContainer).toBe(oldNextViewContainer);
-              expect(docViewer.nextViewContainer).toBe(oldCurrViewContainer);
-
-              await doSwapViews();
-
-              expect(docViewerEl.contains(oldCurrViewContainer)).toBe(true);
-              expect(docViewerEl.contains(oldNextViewContainer)).toBe(false);
-              expect(docViewer.currViewContainer).toBe(oldCurrViewContainer);
-              expect(docViewer.nextViewContainer).toBe(oldNextViewContainer);
-            });
-
-            it('should emit `docRemoved` after removing the leaving view', async () => {
-              const onDocRemovedSpy = jasmine.createSpy('onDocRemoved').and.callFake(() => {
-                expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
-                expect(docViewerEl.contains(oldNextViewContainer)).toBe(false);
-              });
-
-              docViewer.docRemoved.subscribe(onDocRemovedSpy);
-
-              expect(docViewerEl.contains(oldCurrViewContainer)).toBe(true);
-              expect(docViewerEl.contains(oldNextViewContainer)).toBe(false);
-
-              await doSwapViews();
-
-              expect(onDocRemovedSpy).toHaveBeenCalledTimes(1);
-              expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
-              expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
-            });
-
-            it('should not emit `docRemoved` if the leaving view is already removed', async () => {
-              const onDocRemovedSpy = jasmine.createSpy('onDocRemoved');
-
-              docViewer.docRemoved.subscribe(onDocRemovedSpy);
-              docViewerEl.removeChild(oldCurrViewContainer);
-
-              await doSwapViews();
-
-              expect(onDocRemovedSpy).not.toHaveBeenCalled();
-            });
-
-            it('should emit `docInserted` after inserting the entering view', async () => {
-              const onDocInsertedSpy = jasmine.createSpy('onDocInserted').and.callFake(() => {
-                expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
-                expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
-              });
-
-              docViewer.docInserted.subscribe(onDocInsertedSpy);
-
-              expect(docViewerEl.contains(oldCurrViewContainer)).toBe(true);
-              expect(docViewerEl.contains(oldNextViewContainer)).toBe(false);
-
-              await doSwapViews();
-
-              expect(onDocInsertedSpy).toHaveBeenCalledTimes(1);
-              expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
-              expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
-            });
-
-            it('should call the callback after inserting the entering view', async () => {
-              const onInsertedCb = jasmine.createSpy('onInsertedCb').and.callFake(() => {
-                expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
-                expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
-              });
-              const onDocInsertedSpy = jasmine.createSpy('onDocInserted');
-
-              docViewer.docInserted.subscribe(onDocInsertedSpy);
-
-              expect(docViewerEl.contains(oldCurrViewContainer)).toBe(true);
-              expect(docViewerEl.contains(oldNextViewContainer)).toBe(false);
-
-              await doSwapViews(onInsertedCb);
-
-              expect(onInsertedCb).toHaveBeenCalledTimes(1);
-              expect(onInsertedCb).toHaveBeenCalledBefore(onDocInsertedSpy);
-              expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
-              expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
-            });
-
-            it('should empty the previous view', async () => {
-              await doSwapViews();
-
-              expect(docViewer.currViewContainer.innerHTML).toBe('Next view');
-              expect(docViewer.nextViewContainer.innerHTML).toBe('');
-
-              docViewer.nextViewContainer.innerHTML = 'Next view 2';
-              await doSwapViews();
-
-              expect(docViewer.currViewContainer.innerHTML).toBe('Next view 2');
-              expect(docViewer.nextViewContainer.innerHTML).toBe('');
-            });
-
-            if (animationsEnabled && !noAnimations) {
-              // Only test this when there are animations. Without animations, the views are swapped
-              // synchronously, so there is no need (or way) to abort.
-              it('should abort swapping if the returned observable is unsubscribed from', async () => {
-                docViewer.swapViews().subscribe().unsubscribe();
-                await doSwapViews();
-
-                // Since the first call was cancelled, only one swapping should have taken place.
-                expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
-                expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
-                expect(docViewer.currViewContainer).toBe(oldNextViewContainer);
-                expect(docViewer.nextViewContainer).toBe(oldCurrViewContainer);
-                expect(docViewer.currViewContainer.innerHTML).toBe('Next view');
-                expect(docViewer.nextViewContainer.innerHTML).toBe('');
-              });
-            } else {
-              it('should swap views synchronously when animations are disabled', () => {
-                const cbSpy = jasmine.createSpy('cb');
-
-                docViewer.swapViews(cbSpy).subscribe();
-
-                expect(cbSpy).toHaveBeenCalledTimes(1);
-                expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
-                expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
-                expect(docViewer.currViewContainer).toBe(oldNextViewContainer);
-                expect(docViewer.nextViewContainer).toBe(oldCurrViewContainer);
-                expect(docViewer.currViewContainer.innerHTML).toBe('Next view');
-                expect(docViewer.nextViewContainer.innerHTML).toBe('');
-              });
-            }
-          });
+        it('should return an observable', done => {
+          docViewer.swapViews().subscribe(done, done.fail);
         });
+
+        it('should swap the views', async () => {
+          await doSwapViews();
+
+          expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
+          expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
+          expect(docViewer.currViewContainer).toBe(oldNextViewContainer);
+          expect(docViewer.nextViewContainer).toBe(oldCurrViewContainer);
+
+          await doSwapViews();
+
+          expect(docViewerEl.contains(oldCurrViewContainer)).toBe(true);
+          expect(docViewerEl.contains(oldNextViewContainer)).toBe(false);
+          expect(docViewer.currViewContainer).toBe(oldCurrViewContainer);
+          expect(docViewer.nextViewContainer).toBe(oldNextViewContainer);
+        });
+
+        it('should emit `docRemoved` after removing the leaving view', async () => {
+          const onDocRemovedSpy = jasmine.createSpy('onDocRemoved').and.callFake(() => {
+            expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
+            expect(docViewerEl.contains(oldNextViewContainer)).toBe(false);
+          });
+
+          docViewer.docRemoved.subscribe(onDocRemovedSpy);
+
+          expect(docViewerEl.contains(oldCurrViewContainer)).toBe(true);
+          expect(docViewerEl.contains(oldNextViewContainer)).toBe(false);
+
+          await doSwapViews();
+
+          expect(onDocRemovedSpy).toHaveBeenCalledTimes(1);
+          expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
+          expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
+        });
+
+        it('should not emit `docRemoved` if the leaving view is already removed', async () => {
+          const onDocRemovedSpy = jasmine.createSpy('onDocRemoved');
+
+          docViewer.docRemoved.subscribe(onDocRemovedSpy);
+          docViewerEl.removeChild(oldCurrViewContainer);
+
+          await doSwapViews();
+
+          expect(onDocRemovedSpy).not.toHaveBeenCalled();
+        });
+
+        it('should emit `docInserted` after inserting the entering view', async () => {
+          const onDocInsertedSpy = jasmine.createSpy('onDocInserted').and.callFake(() => {
+            expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
+            expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
+          });
+
+          docViewer.docInserted.subscribe(onDocInsertedSpy);
+
+          expect(docViewerEl.contains(oldCurrViewContainer)).toBe(true);
+          expect(docViewerEl.contains(oldNextViewContainer)).toBe(false);
+
+          await doSwapViews();
+
+          expect(onDocInsertedSpy).toHaveBeenCalledTimes(1);
+          expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
+          expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
+        });
+
+        it('should call the callback after inserting the entering view', async () => {
+          const onInsertedCb = jasmine.createSpy('onInsertedCb').and.callFake(() => {
+            expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
+            expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
+          });
+          const onDocInsertedSpy = jasmine.createSpy('onDocInserted');
+
+          docViewer.docInserted.subscribe(onDocInsertedSpy);
+
+          expect(docViewerEl.contains(oldCurrViewContainer)).toBe(true);
+          expect(docViewerEl.contains(oldNextViewContainer)).toBe(false);
+
+          await doSwapViews(onInsertedCb);
+
+          expect(onInsertedCb).toHaveBeenCalledTimes(1);
+          expect(onInsertedCb).toHaveBeenCalledBefore(onDocInsertedSpy);
+          expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
+          expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
+        });
+
+        it('should empty the previous view', async () => {
+          await doSwapViews();
+
+          expect(docViewer.currViewContainer.innerHTML).toBe('Next view');
+          expect(docViewer.nextViewContainer.innerHTML).toBe('');
+
+          docViewer.nextViewContainer.innerHTML = 'Next view 2';
+          await doSwapViews();
+
+          expect(docViewer.currViewContainer.innerHTML).toBe('Next view 2');
+          expect(docViewer.nextViewContainer.innerHTML).toBe('');
+        });
+
+        if (animationsEnabled) {
+          // Only test this when there are animations. Without animations, the views are swapped
+          // synchronously, so there is no need (or way) to abort.
+          it('should abort swapping if the returned observable is unsubscribed from', async () => {
+            docViewer.swapViews().subscribe().unsubscribe();
+            await doSwapViews();
+
+            // Since the first call was cancelled, only one swapping should have taken place.
+            expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
+            expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
+            expect(docViewer.currViewContainer).toBe(oldNextViewContainer);
+            expect(docViewer.nextViewContainer).toBe(oldCurrViewContainer);
+            expect(docViewer.currViewContainer.innerHTML).toBe('Next view');
+            expect(docViewer.nextViewContainer.innerHTML).toBe('');
+          });
+        } else {
+          it('should swap views synchronously when animations are disabled', () => {
+            const cbSpy = jasmine.createSpy('cb');
+
+            docViewer.swapViews(cbSpy).subscribe();
+
+            expect(cbSpy).toHaveBeenCalledTimes(1);
+            expect(docViewerEl.contains(oldCurrViewContainer)).toBe(false);
+            expect(docViewerEl.contains(oldNextViewContainer)).toBe(true);
+            expect(docViewer.currViewContainer).toBe(oldNextViewContainer);
+            expect(docViewer.nextViewContainer).toBe(oldCurrViewContainer);
+            expect(docViewer.currViewContainer.innerHTML).toBe('Next view');
+            expect(docViewer.nextViewContainer.innerHTML).toBe('');
+          });
+        }
       });
     });
   });

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
@@ -595,7 +595,7 @@ describe('DocViewerComponent', () => {
 
     [true, false].forEach(animationsEnabled => {
       describe(`(animations enabled: ${animationsEnabled})`, () => {
-        beforeEach(() => !animationsEnabled && docViewerEl.classList.add(NO_ANIMATIONS));
+        beforeEach(() => docViewerEl.classList[animationsEnabled ? 'remove' : 'add'](NO_ANIMATIONS));
 
         it('should return an observable', done => {
           docViewer.swapViews().subscribe(done, done.fail);

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.ts
@@ -26,9 +26,6 @@ const initialDocViewerContent = initialDocViewerElement ? fromInnerHTML(initialD
   // encapsulation: ViewEncapsulation.ShadowDom
 })
 export class DocViewerComponent implements OnDestroy {
-  // Enable/Disable view transition animations.
-  static animationsEnabled = true;
-
   private hostElement: HTMLElement;
 
   private void$ = of<void>(undefined);
@@ -220,8 +217,7 @@ export class DocViewerComponent implements OnDestroy {
     >;
     const animateProp =
         (elem: HTMLElement, prop: StringValueCSSStyleDeclaration, from: string, to: string, duration = 200) => {
-          const animationsDisabled = !DocViewerComponent.animationsEnabled
-                                     || this.hostElement.classList.contains(NO_ANIMATIONS);
+          const animationsDisabled = this.hostElement.classList.contains(NO_ANIMATIONS);
           elem.style.transition = '';
           return animationsDisabled
               ? this.void$.pipe(tap(() => elem.style[prop] = to))

--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -2,7 +2,7 @@
 @use '../../mixins';
 
 // Disable sidenav animations for the initial render.
-.starting.mat-drawer-transition .mat-drawer-content {
+.no-animations.mat-drawer-transition .mat-drawer-content {
   transition: none;
 }
 

--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -58,7 +58,7 @@ mat-toolbar.app-toolbar {
       min-width: 15%;
     }
 
-    &:not(.starting) {
+    &:not(.no-animations) {
       transition-duration: 0.4s;
       transition-property: color, margin;
       transition-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1);

--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -22,7 +22,10 @@ aio-contributor {
   margin: 8px;
   border-radius: 4px;
   box-shadow: 0 2px 2px rgba(10, 16, 20, 0.24), 0 0 2px rgba(10, 16, 20, 0.12);
-  transition: all .3s;
+
+  @media not all and (prefers-reduced-motion) {
+    transition: all .3s;
+  }
 
   @media (hover) {
     &:focus-within,
@@ -102,7 +105,10 @@ aio-contributor {
     max-width: 310px;
     max-height: 340px;
     transform-style:preserve-3d;
-    transition:transform ease 500ms;
+
+    @media not all and (prefers-reduced-motion) {
+      transition:transform ease 500ms;
+    }
 
     h3 {
       margin: 0.8rem 0;
@@ -162,7 +168,6 @@ aio-contributor {
     background-size: cover;
     background-position: center;
     margin: 0.8rem auto;
-    transition: all .2s ease-in-out;
   }
 
   p {


### PR DESCRIPTION
Make the app easier to use for people with motion sensitivities by disabling several animations (esp. ones involving moving things around) when the user prefers reduced motion. The user's preference is detected using the [prefers-reduced-motion][1] CSS media feature.

Disabled animations include:
- View fade in/out transitions.
- Sidenav open/close animations.
- Top-menu color and size changes.
- Contributor cards flip animations.

For more details on using `prefers-reduced-motion` and disabling Angular animations see:
- [Designing with reduced motion for motion sensitivities][2]
- [Disabling Angular animations at runtime][3]

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
[2]: https://www.smashingmagazine.com/2020/09/design-reduced-motion-sensitivities/
[3]: https://dev.to/this-is-angular/disabling-angular-animations-at-runtime-9a6