### PR TITLE
refactor(core): add `ViewRef` to private exports

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -287,6 +287,7 @@ export {
   publishDefaultGlobalUtils as ɵpublishDefaultGlobalUtils
 ,
   publishGlobalUtil as ɵpublishGlobalUtil} from './render3/util/global_utils';
+export {ViewRef as ɵViewRef} from './render3/view_ref';
 export {
   bypassSanitizationTrustHtml as ɵbypassSanitizationTrustHtml,
   bypassSanitizationTrustResourceUrl as ɵbypassSanitizationTrustResourceUrl,


### PR DESCRIPTION
This commit adds `ViewRef` to private exports, so it can be reused in internal packages.

The `ViewRef` symbol remains *private* and should not be referenced directly.

// cc: @josephperrott

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No