### PR TITLE
fix(docs-infra): search box input line-height

### DIFF
--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -169,6 +169,7 @@ mat-toolbar.app-toolbar {
       margin-left: 8px;
       width: 180px;
       max-width: 240px;
+      line-height: normal;
       height: 50%;
       -webkit-appearance: none;
 


### PR DESCRIPTION
This fixes an issue on Safari which caused the text to be pushed down when blurring out of the search input field. The root cause of the problem appears to be that previously the computed line height was that of 32px, which caused a shift in content.

Closes #43935
