### PR TITLE
ci(docs-infra): temporary fix for angular.io stable deployment

### DIFF
--- a/aio/scripts/deploy-to-firebase/index.mjs
+++ b/aio/scripts/deploy-to-firebase/index.mjs
@@ -222,8 +222,12 @@ function computeDeploymentsInfo(
       projectId: 'angular-io',
       siteId: `v${currentBranchMajorVersion}-angular-io-site`,
       deployedUrl: `https://v${currentBranchMajorVersion}.angular.io/`,
-      preDeployActions: [pre.redirectAllToStable],
-      postDeployActions: [pre.undo.redirectAllToStable, post.testRedirectToStable],
+      // Temporarily disable rdirecting `v12.angular.io` to `angular.io`, while we remove the
+      // redirects from Firebase console/DNS.
+      // preDeployActions: [pre.redirectAllToStable],
+      // postDeployActions: [pre.undo.redirectAllToStable, post.testRedirectToStable],
+      preDeployActions: [],
+      postDeployActions: [],
     },
     // Config for deploying the stable build to the RC Firebase site when there is no active RC.
     // See https://github.com/angular/angular/issues/39760 for more info on the purpose of this

--- a/aio/scripts/deploy-to-firebase/index.spec.mjs
+++ b/aio/scripts/deploy-to-firebase/index.spec.mjs
@@ -253,8 +253,8 @@ describe('deploy-to-firebase:', () => {
         projectId: 'angular-io',
         siteId: 'v4-angular-io-site',
         deployedUrl: 'https://v4.angular.io/',
-        preDeployActions: ['function:redirectAllToStable'],
-        postDeployActions: ['function:undoRedirectAllToStable', 'function:testRedirectToStable'],
+        preDeployActions: [],
+        postDeployActions: [],
       },
     ]);
   });
@@ -287,8 +287,8 @@ describe('deploy-to-firebase:', () => {
         projectId: 'angular-io',
         siteId: `v${stableMajorVersion}-angular-io-site`,
         deployedUrl: `https://v${stableMajorVersion}.angular.io/`,
-        preDeployActions: ['function:redirectAllToStable'],
-        postDeployActions: ['function:undoRedirectAllToStable', 'function:testRedirectToStable'],
+        preDeployActions: [],
+        postDeployActions: [],
       },
       {
         name: 'redirectRcToStable',


### PR DESCRIPTION
With #43963, we started configuring the `v12-angular-io-site` Firebase site to redirect to `angular.io`. This was done with the assumption that the `angular.io` domain would be connected to the `stable-angular-io-site`. However, currently the `angular.io` domain is connected (via the Firebase console) to the `v12-angular-io-site`, resulting in infinite redirect loops when trying to access `angular.io`.

This commit temporarily fixes the infinite loop by not configuring `v12-angular-io-site` to redirect to `angular.io`. Once the `angular.io` (and `www.angular.io`) domain is connected to `stable-angular-io-site`, we can start redirecting `v12-angular-io-site` to `angular.io` again.

Fixes #43989 and #43990.