### PR TITLE
fix(docs-infra): prevent automatic linking of 'number'

### DIFF
--- a/aio/content/guide/ajs-quick-reference.md
+++ b/aio/content/guide/ajs-quick-reference.md
@@ -931,7 +931,7 @@ For more information on pipes, see [Pipes](guide/pipes).
       <code-example hideCopy path="ajs-quick-reference/src/app/app.component.html" region="number"></code-example>
 
 
-      The Angular `number` pipe is similar.
+      The Angular [`number`](api/common/DecimalPipe) pipe is similar.
       It provides more functionality when defining
       the decimal places, as shown in the second example above.
 

--- a/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
+++ b/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
@@ -5,6 +5,6 @@
  */
 
 module.exports = function ignoreGenericWords() {
-  const ignoredWords = new Set(['a', 'classes', 'create', 'error', 'group', 'request', 'state', 'target', 'value', '_']);
+  const ignoredWords = new Set(['a', 'classes', 'create', 'error', 'group', 'number', 'request', 'state', 'target', 'value', '_']);
   return (docs, words, index) => ignoredWords.has(words[index].toLowerCase()) ? [] : docs;
 };


### PR DESCRIPTION
add 'number' to the ignoreGenericWords set so that it doesn't get
wrongly linked to the decimalPipe during the aio docs generation
as it is a generic typescript term

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Various docs pages wrongly automatically link `number` to the decimalPipe

like:

- the [animate docs](https://angular.io/api/animations/animate):
![number-animate](https://user-images.githubusercontent.com/61631103/139580706-0ad9224f-7e37-4146-a62b-7628dc8c9482.png)

- the [docs style guide](https://angular.io/guide/docs-style-guide):
![number-docs-style-guide](https://user-images.githubusercontent.com/61631103/139580760-d08b3260-a23e-4142-8670-3937912381af.png)

- and even the [decimalPipe](https://angular.io/api/common/DecimalPipe) docs themselves:
![number-number](https://user-images.githubusercontent.com/61631103/139580796-1f7f0354-979a-4eed-9183-4b3c3752e2b2.png)

- since this will be present for any instance with the number typescript type I can bet there must be lots more instances of this wrong linking

## What is the new behavior?

The term has been added to the ignoreGenericWords set so that the automatic linking is not performed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- @gkalpak I think this PR is your cup of tea :slightly_smiling_face: 
- I checked and I think that there are no instances in which the linking is necessary/wanted (I would have added manual linking had I found any), but I am by no means sure of it, I think with something as generic as `number` it's a bit tricky being sure.... but at the very least I believe that the number of unwanted auto-linkings must by far surpass the wanted ones (if there actually are any), so either way I think this change is beneficial (and if someone could suggest how/where to look for instances I must have missed I am all ears :slightly_smiling_face:)
- look at the docs style guide image, can you see the `json` at the bottom? I think that should probably also be added to the ignoreGenericWords set, what do you think? :slightly_smiling_face: (shall I have a look here? or just do it in a separate PR?)
- ah another small thing, in the animate docs the `number` present in `animate(timings: string | number, ...` that is actually a link, but it doesn't have any link styling (except getting underlined on hover) is that ok? :thinking: 