### PR TITLE
refactor(compiler): show meaningful diagnostic when reporting a template error fails

### DIFF
--- a/packages/compiler-cli/src/ngtsc/diagnostics/index.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/index.ts
@@ -7,7 +7,7 @@
  */
 
 export {COMPILER_ERRORS_WITH_GUIDES} from './src/docs';
-export {FatalDiagnosticError, isFatalDiagnosticError, makeDiagnostic, makeDiagnosticChain, makeRelatedInformation} from './src/error';
+export {addDiagnosticChain, FatalDiagnosticError, isFatalDiagnosticError, makeDiagnostic, makeDiagnosticChain, makeRelatedInformation} from './src/error';
 export {ErrorCode} from './src/error_code';
 export {ERROR_DETAILS_PAGE_BASE_URL} from './src/error_details_base_url';
 export {ExtendedTemplateDiagnosticName} from './src/extended_template_diagnostic_name';

--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error.ts
@@ -65,6 +65,22 @@ export function makeRelatedInformation(
   };
 }
 
+export function addDiagnosticChain(
+    messageText: string|ts.DiagnosticMessageChain,
+    add: ts.DiagnosticMessageChain[]): ts.DiagnosticMessageChain {
+  if (typeof messageText === 'string') {
+    return makeDiagnosticChain(messageText, add);
+  }
+
+  if (messageText.next === undefined) {
+    messageText.next = add;
+  } else {
+    messageText.next.push(...add);
+  }
+
+  return messageText;
+}
+
 export function isFatalDiagnosticError(err: any): err is FatalDiagnosticError {
   return err._isFatalDiagnosticError === true;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/BUILD.bazel
@@ -9,6 +9,7 @@ ts_library(
     deps = [
         "//packages:types",
         "//packages/compiler",
+        "//packages/compiler-cli/src/ngtsc/diagnostics",
         "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/typecheck/api",
         "@npm//typescript",

--- a/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
@@ -85,7 +85,7 @@ export function makeTemplateDiagnostic(
       sf = parseTemplateAsSourceFile(fileName, mapping.template);
     } catch (e) {
       const failureChain = makeDiagnosticChain(
-          `A failure occurred to report this error in '${fileName}' at ${span.start.line + 1}:${
+          `Failed to report an error in '${fileName}' at ${span.start.line + 1}:${
               span.start.col + 1}`,
           [
             makeDiagnosticChain((e as Error)?.stack ?? `${e}`),

--- a/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/diagnostics/src/diagnostic.ts
@@ -9,6 +9,7 @@
 import {ParseSourceSpan} from '@angular/compiler';
 import ts from 'typescript';
 
+import {addDiagnosticChain, makeDiagnosticChain} from '../../../diagnostics';
 import {ExternalTemplateSourceMapping, TemplateDiagnostic, TemplateId, TemplateSourceMapping} from '../../api';
 
 /**
@@ -64,11 +65,6 @@ export function makeTemplateDiagnostic(
     const fileName = mapping.type === 'indirect' ?
         `${componentSf.fileName} (${componentName} template)` :
         (mapping as ExternalTemplateSourceMapping).templateUrl;
-    // TODO(alxhub): investigate creating a fake `ts.SourceFile` here instead of invoking the TS
-    // parser against the template (HTML is just really syntactically invalid TypeScript code ;).
-    // Also investigate caching the file to avoid running the parser multiple times.
-    const sf = ts.createSourceFile(
-        fileName, mapping.template, ts.ScriptTarget.Latest, false, ts.ScriptKind.JSX);
 
     let relatedInformation: ts.DiagnosticRelatedInformation[] = [];
     if (relatedMessages !== undefined) {
@@ -82,6 +78,32 @@ export function makeTemplateDiagnostic(
           messageText: relatedMessage.text,
         });
       }
+    }
+
+    let sf: ts.SourceFile;
+    try {
+      sf = parseTemplateAsSourceFile(fileName, mapping.template);
+    } catch (e) {
+      const failureChain = makeDiagnosticChain(
+          `A failure occurred to report this error in '${fileName}' at ${span.start.line + 1}:${
+              span.start.col + 1}`,
+          [
+            makeDiagnosticChain((e as Error)?.stack ?? `${e}`),
+          ]);
+      return {
+        source: 'ngtsc',
+        category,
+        code,
+        messageText: addDiagnosticChain(messageText, [failureChain]),
+        file: componentSf,
+        componentFile: componentSf,
+        templateId,
+        // mapping.node represents either the 'template' or 'templateUrl' expression. getStart()
+        // and getEnd() are used because they don't include surrounding whitespace.
+        start: mapping.node.getStart(),
+        length: mapping.node.getEnd() - mapping.node.getStart(),
+        relatedInformation,
+      };
     }
 
     relatedInformation.push({
@@ -111,6 +133,28 @@ export function makeTemplateDiagnostic(
   } else {
     throw new Error(`Unexpected source mapping type: ${(mapping as {type: string}).type}`);
   }
+}
+
+let parseTemplateAsSourceFileForTest: typeof parseTemplateAsSourceFile|null = null;
+
+export function setParseTemplateAsSourceFileForTest(fn: typeof parseTemplateAsSourceFile): void {
+  parseTemplateAsSourceFileForTest = fn;
+}
+
+export function resetParseTemplateAsSourceFileForTest(): void {
+  parseTemplateAsSourceFileForTest = null;
+}
+
+function parseTemplateAsSourceFile(fileName: string, template: string): ts.SourceFile {
+  if (parseTemplateAsSourceFileForTest !== null) {
+    return parseTemplateAsSourceFileForTest(fileName, template);
+  }
+
+  // TODO(alxhub): investigate creating a fake `ts.SourceFile` here instead of invoking the TS
+  // parser against the template (HTML is just really syntactically invalid TypeScript code ;).
+  // Also investigate caching the file to avoid running the parser multiple times.
+  return ts.createSourceFile(
+      fileName, template, ts.ScriptTarget.Latest, /* setParentNodes */ false, ts.ScriptKind.JSX);
 }
 
 export function isTemplateDiagnostic(diagnostic: ts.Diagnostic): diagnostic is TemplateDiagnostic {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -889,7 +889,7 @@ class TestComponent {
           .toContain(
               `main.ts(2, 20): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
   Type 'undefined' is not assignable to type 'string'.
-  A failure occurred to report this error in 'TestComponent.html' at 1:20
+  Failed to report an error in 'TestComponent.html' at 1:20
     Error: Simulated parse failure`);
     });
 
@@ -909,7 +909,7 @@ class TestComponent {
           .toContain(
               `main.ts(2, 20): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
   Type 'undefined' is not assignable to type 'string'.
-  A failure occurred to report this error in 'TestComponent.html' at 1:20
+  Failed to report an error in 'TestComponent.html' at 1:20
     Simulated parse failure`);
     });
   });

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -11,6 +11,7 @@ import ts from 'typescript';
 import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem, TestFile} from '../../file_system/testing';
 import {OptimizeFor, TypeCheckingConfig} from '../api';
+import {resetParseTemplateAsSourceFileForTest, setParseTemplateAsSourceFileForTest} from '../diagnostics';
 import {ngForDeclaration, ngForDts, ngIfDeclaration, ngIfDts, setup, TestDeclaration} from '../testing';
 
 runInEachFileSystem(() => {
@@ -488,7 +489,8 @@ runInEachFileSystem(() => {
           }`);
 
         expect(messages).toEqual([
-          `TestComponent.html(1, 19): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.`
+          `TestComponent.html(1, 19): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.`
         ]);
       });
 
@@ -517,7 +519,8 @@ runInEachFileSystem(() => {
           }`);
 
         expect(messages).toEqual([
-          `TestComponent.html(1, 19): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.`
+          `TestComponent.html(1, 19): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.`
         ]);
       });
     });
@@ -852,6 +855,64 @@ class TestComponent {
       ]);
     });
   });
+
+  // https://github.com/angular/angular/issues/43970
+  describe('template parse failures', () => {
+    afterEach(resetParseTemplateAsSourceFileForTest);
+
+    it('baseline test without parse failure', () => {
+      const messages = diagnose(`<div (click)="test(name)"></div>`, `
+      export class TestComponent {
+        name: string | undefined;
+        test(n: string): void {}
+      }`);
+
+      expect(messages).toEqual([
+        `TestComponent.html(1, 20): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.`
+      ]);
+    });
+
+    it('should handle TypeScript parse failures gracefully', () => {
+      setParseTemplateAsSourceFileForTest(() => {
+        throw new Error('Simulated parse failure');
+      });
+
+      const messages = diagnose(`<div (click)="test(name)"></div>`, `
+      export class TestComponent {
+        name: string | undefined;
+        test(n: string): void {}
+      }`);
+
+      expect(messages.length).toBe(1);
+      expect(messages[0])
+          .toContain(
+              `main.ts(2, 20): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
+  A failure occurred to report this error in 'TestComponent.html' at 1:20
+    Error: Simulated parse failure`);
+    });
+
+    it('should handle non-Error failures gracefully', () => {
+      setParseTemplateAsSourceFileForTest(() => {
+        throw 'Simulated parse failure';
+      });
+
+      const messages = diagnose(`<div (click)="test(name)"></div>`, `
+      export class TestComponent {
+        name: string | undefined;
+        test(n: string): void {}
+      }`);
+
+      expect(messages.length).toBe(1);
+      expect(messages[0])
+          .toContain(
+              `main.ts(2, 20): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
+  A failure occurred to report this error in 'TestComponent.html' at 1:20
+    Simulated parse failure`);
+    });
+  });
 });
 
 function diagnose(
@@ -879,8 +940,7 @@ function diagnose(
   const sf = getSourceFileOrError(program, sfPath);
   const diagnostics = templateTypeChecker.getDiagnosticsForFile(sf, OptimizeFor.WholeProgram);
   return diagnostics.map(diag => {
-    const text =
-        typeof diag.messageText === 'string' ? diag.messageText : diag.messageText.messageText;
+    const text = ts.flattenDiagnosticMessageText(diag.messageText, '\n');
     const fileName = diag.file!.fileName;
     const {line, character} = ts.getLineAndCharacterOfPosition(diag.file!, diag.start!);
     return `${fileName}(${line + 1}, ${character + 1}): ${text}`;


### PR DESCRIPTION
When the Angular compiler emits a diagnostic in a template file, it
forces TypeScript to parse that template. Templates are not TypeScript,
so this parse finds a bunch of parsing errors, which Angular then
ignores and we show the diagnostic anyways because we have more context.
This can lead to strange behavior in TypeScript because templates are so
weird that it can break the parser and crash the whole compiler.

For example, certain Angular templates can encounter failures fixed by
microsoft/TypeScript#45987, which are not easily debuggable and require
a TS upgrade to fix.

This commit introduces logic to handle the error gracefully, by falling
back to report the template error on the component class itself. The
diagnostic is extended to still reference the template location and
includes the failure's stack trace, to allow the parsing failure to be
reported to TypeScript (as parsing should in theory not cause a crash).

Closes #43970

---

@dgp1130 PTAL, curious to hear if you think this is sufficient or if you have suggestions to improve it.