### PR TITLE
docs: improve consuming partial-Ivy code outside the Angular CLI

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1089,6 +1089,7 @@ groups:
       - *can-be-global-docs-approved
       - >
         contains_any_globs(files, [
+          'aio/content/examples/angular-linker-plugin/webpack.config.mjs',
           'aio/content/guide/creating-libraries.md',
           'aio/content/guide/libraries.md',
           'aio/content/guide/using-libraries.md',

--- a/aio/content/examples/angular-linker-plugin/webpack.config.mjs
+++ b/aio/content/examples/angular-linker-plugin/webpack.config.mjs
@@ -1,0 +1,26 @@
+// #docplaster ...
+// #docregion webpack-config
+import linkerPlugin from '@angular/compiler-cli/linker/babel';
+
+export default {
+  // #enddocregion webpack-config
+  // #docregion webpack-config
+  module: {
+    rules: [
+      {
+        test: /\.m?js$/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            plugins: [linkerPlugin],
+            compact: false,
+            cacheDirectory: true,
+          }
+        }
+      }
+    ]
+  }
+  // #enddocregion webpack-config
+  // #docregion webpack-config
+}
+// #enddocregion webpack-config

--- a/aio/content/guide/creating-libraries.md
+++ b/aio/content/guide/creating-libraries.md
@@ -251,14 +251,18 @@ An application installs many Angular libraries from npm into its `node_modules` 
 However, the code in these libraries cannot be bundled directly along with the built application as it is not fully compiled.
 To finish compilation, use the Angular linker.
 
-For applications that don't use the Angular CLI, the linker is available as a Babel plugin.
-Use the Babel plugin using the module `@angular/compiler-cli/linker/babel` to incorporate into your builds.
-For example, integrate the plugin into a custom Webpack build by registering the linker as a plugin for `babel-loader`.
-
-Previously, if you ran `yarn install` or `npm install` you had to re-run `ngcc`.
-Now, libraries only need to be processed by the linker a single time, regardless of other npm operations.
+For applications that don't use the Angular CLI, the linker is available as a [Babel](https://babeljs.io/) plugin.
+The plugin is to be imported from `@angular/compiler-cli/linker/babel`.
 
 The Angular linker Babel plugin supports build caching, meaning that libraries only need to be processed by the linker a single time, regardless of other npm operations.
+
+Example of integrating the plugin into a custom [Webpack](https://webpack.js.org/) build by registering the linker as a [Babel](https://babeljs.io/) plugin using [babel-loader](https://webpack.js.org/loaders/babel-loader/#options).
+
+<code-example
+  path="angular-linker-plugin/webpack.config.mjs"
+  region="webpack-config"
+  header="webpack.config.mjs">
+</code-example>
 
 <div class="alert is-helpful">
 
@@ -266,4 +270,4 @@ The Angular CLI integrates the linker plugin automatically, so if consumers of y
 
 </div>
 
-@reviewed 2021-10-29
+@reviewed 2021-11-03

--- a/aio/tools/transforms/examples-package/services/region-parser.js
+++ b/aio/tools/transforms/examples-package/services/region-parser.js
@@ -10,6 +10,7 @@ module.exports = function regionParser() {
   regionParserImpl.regionMatchers = {
     ts: inlineC,
     js: inlineC,
+    mjs: inlineCOnly,
     es6: inlineC,
     dart: inlineC,
     html: html,


### PR DESCRIPTION
With this change we add an example of how to consume the linker plugin and also clean up the parts of this section.

Closes #44026
