### PR TITLE
build(docs-infra): target webcontainers for stackblitz "live-example"…

### DIFF
--- a/aio/tools/stackblitz-builder/builder.mjs
+++ b/aio/tools/stackblitz-builder/builder.mjs
@@ -41,19 +41,6 @@ export class StackblitzBuilder {
     }
   }
 
-  _addDependencies(config, postData) {
-    // Extract npm package dependencies
-    const exampleType = this._getExampleType(config.basePath);
-    const packageJson = this._getBoilerplatePackageJson(exampleType) || this._getBoilerplatePackageJson('cli');
-    const exampleDependencies = packageJson.dependencies;
-
-    // Add unit test packages from devDependencies for unit test examples
-    const devDependencies = packageJson.devDependencies;
-    (config.devDependencies || []).forEach(dep => exampleDependencies[dep] = devDependencies[dep]);
-
-    postData.dependencies = JSON.stringify(exampleDependencies);
-  }
-
   _getExampleType(exampleDir) {
     const configPath = `${exampleDir}/example-config.json`;
     const configSrc = fs.existsSync(configPath) && fs.readFileSync(configPath, 'utf-8').trim();
@@ -103,7 +90,9 @@ export class StackblitzBuilder {
     try {
       const config = this._initConfigAndCollectFileNames(configFileName);
       const postData = this._createPostData(config, configFileName);
-      this._addDependencies(config, postData);
+
+      this._addStackblitzrc(postData);
+
       const html = this._createStackblitzHtml(config, postData);
       fs.writeFileSync(outputFileName, html, 'utf-8');
       if (altFileName) {
@@ -159,9 +148,19 @@ export class StackblitzBuilder {
     }
   }
 
+  _addStackblitzrc(postData) {
+    postData['project[files][.stackblitzrc]'] = JSON.stringify({
+      installDependencies: true,
+      startCommand: 'turbo start',
+      env: {
+        ENABLE_CJS_IMPORTS: true
+      }
+    });
+  }
+
   _createBaseStackblitzHtml(config) {
     const file = `?file=${this._getPrimaryFile(config)}`;
-    const action = `https://run.stackblitz.com/api/angular/v1${file}`;
+    const action = `https://stackblitz.com/run${file}`;
 
     return `
       <!DOCTYPE html><html lang="en"><body>
@@ -232,25 +231,14 @@ export class StackblitzBuilder {
 
       content = regionExtractor()(content, extn.substr(1)).contents;
 
-      postData[`files[${relativeFileName}]`] = content;
+      postData[`project[files][${relativeFileName}]`] = content;
     });
 
-    // Stackblitz defaults to ViewEngine unless `"enableIvy": true`
-    // So if there is a tsconfig.json file and there is no `enableIvy` property, we need to
-    // explicitly set it.
-    const tsConfigJSON = postData['files[tsconfig.json]'];
-    if (tsConfigJSON !== undefined) {
-      const tsConfig = json5.parse(tsConfigJSON);
-      if (tsConfig.angularCompilerOptions.enableIvy === undefined) {
-        tsConfig.angularCompilerOptions.enableIvy = true;
-        postData['files[tsconfig.json]'] = JSON.stringify(tsConfig, null, 2);
-      }
-    }
-
     const tags = ['angular', 'example', ...config.tags || []];
-    tags.forEach((tag, ix) => postData[`tags[${ix}]`] = tag);
+    tags.forEach((tag, ix) => postData[`project[tags][${ix}]`] = tag);
 
-    postData.description = `Angular Example - ${config.description}`;
+    postData['project[description]'] = `Angular Example - ${config.description}`;
+    postData['project[template]'] = 'node';
 
     return postData;
   }
@@ -309,14 +297,9 @@ export class StackblitzBuilder {
 
     const defaultExcludes = [
       '!**/e2e/**/*.*',
-      '!**/package.json',
       '!**/example-config.json',
       '!**/.editorconfig',
       '!**/wallaby.js',
-      '!**/karma-test-shim.js',
-      '!**/karma.conf.js',
-      '!**/test.ts',
-      '!**/tsconfig.app.json',
       '!**/*stackblitz.*'
     ];
 


### PR DESCRIPTION
… links

This commit changes the Stackblitz live examples to create "webcontainer" projects on Stackblitz.
This approach supports the new Angular v13 packaging formats but webcontainers are not supported on some browers. So this is a temporary solution.
