### PR TITLE
ci: instruct renovate to apply patch label to avoid divergence with other version branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "semanticPrefix": "build",
   "separateMajorMinor": false,
   "prHourlyLimit": 2,
-  "labels": ["target: minor", "comp: build & ci", "action: review"],
+  "labels": ["target: patch", "comp: build & ci", "action: review"],
   "timezone": "America/Tijuana",
   "lockFileMaintenance": {
     "enabled": true


### PR DESCRIPTION
Renovate currently always applies the minor label. This often causes
the patch/FF/RC branches to quickly diverge. We should always apply
the patch label with the goal of keeping infra-related changes in sync
as much as possible.. Then it is still possible to selectively apply the
minor/major label if needed (this forces the reviewer to actually think
about where this should go in, if it fails!).
