### PR TITLE
fix(core): add missing info about a component in the "pipe could not be found" error message

### DIFF
--- a/packages/core/test/acceptance/pipe_spec.ts
+++ b/packages/core/test/acceptance/pipe_spec.ts
@@ -42,21 +42,6 @@ describe('pipe', () => {
     expect(fixture.nativeElement.textContent).toBe('bob state:0');
   });
 
-  it('should throw if pipe is not found', () => {
-    @Component({
-      template: '{{1 | randomPipeName}}',
-    })
-    class App {
-    }
-
-    TestBed.configureTestingModule({declarations: [App]});
-
-    expect(() => {
-      const fixture = TestBed.createComponent(App);
-      fixture.detectChanges();
-    }).toThrowError(/The pipe 'randomPipeName' could not be found/);
-  });
-
   it('should support bindings', () => {
     @Directive({selector: '[my-dir]'})
     class Dir {
@@ -719,6 +704,131 @@ describe('pipe', () => {
              expect(log).toEqual([]);
            });
       }
+    });
+  });
+
+  describe('missing pipe detection logic', () => {
+    it('should throw an error if a pipe is not found in a component', () => {
+      @Component({
+        template: '{{ 1 | testMissingPipe }}',
+      })
+      class TestComponent {
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComponent]});
+
+      expect(() => {
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+      })
+          .toThrowError(
+              /The pipe 'testMissingPipe' could not be found in the 'TestComponent' component!/);
+    });
+
+    it('should throw an error if a pipe is not found inside an inline template', () => {
+      @Component({
+        template: `
+          <ng-container *ngIf="true">
+            {{ value | testMissingPipe }}
+          </ng-container>`
+      })
+      class TestComponent {
+        value: string = 'test';
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComponent]});
+
+      expect(() => {
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+      })
+          .toThrowError(
+              /The pipe 'testMissingPipe' could not be found in the 'TestComponent' component!/);
+    });
+
+    it('should throw an error if a pipe is not found inside a projected content', () => {
+      @Component({selector: 'app-test-child', template: '<ng-content></ng-content>'})
+      class TestChildComponent {
+      }
+
+      @Component({
+        template: `
+          <app-test-child>
+            {{ value | testMissingPipe }}
+          </app-test-child>`
+      })
+      class TestComponent {
+        value: string = 'test';
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComponent, TestChildComponent]});
+
+      expect(() => {
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+      })
+          .toThrowError(
+              /The pipe 'testMissingPipe' could not be found in the 'TestComponent' component!/);
+    });
+
+    it('should throw an error if a pipe is not found inside a projected content in an inline template',
+       () => {
+         @Component({selector: 'app-test-child', template: '<ng-content></ng-content>'})
+         class TestChildComponent {
+         }
+
+         @Component({
+           template: `
+          <app-test-child>
+            <ng-container *ngIf="true">
+              {{ value | testMissingPipe }}
+            </ng-container>
+          </app-test-child>`
+         })
+         class TestComponent {
+           value: string = 'test';
+         }
+
+         TestBed.configureTestingModule({declarations: [TestComponent, TestChildComponent]});
+
+         expect(() => {
+           const fixture = TestBed.createComponent(TestComponent);
+           fixture.detectChanges();
+         })
+             .toThrowError(
+                 /The pipe 'testMissingPipe' could not be found in the 'TestComponent' component!/);
+       });
+
+    it('should throw an error if a pipe is not found in a property binding', () => {
+      @Component({template: '<div [title]="value | testMissingPipe"></div>'})
+      class TestComponent {
+        value: string = 'test';
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComponent]});
+
+      expect(() => {
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+      })
+          .toThrowError(
+              /The pipe 'testMissingPipe' could not be found in the 'TestComponent' component!/);
+    });
+
+    it('should throw an error if a pipe is not found inside a structural directive input', () => {
+      @Component({template: '<div *ngIf="isVisible | testMissingPipe"></div>'})
+      class TestComponent {
+        isVisible: boolean = true;
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComponent]});
+
+      expect(() => {
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+      })
+          .toThrowError(
+              /The pipe 'testMissingPipe' could not be found in the 'TestComponent' component!/);
     });
   });
 });


### PR DESCRIPTION
Add error handling for pipe with component class name in which it has a problem. Add it in ngDevMode, so that it will be a tree-shake away from the production bundle.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [43855](https://github.com/angular/angular/issues/43855)


## What is the new behavior?
Before

Currently Angular throws the following error message at runtime when a pipe can not be found. However there is no information on which component has this problem, which makes debugging harder.
```
The pipe 'testMissingPipe' could not be found!
```

After

Add error message for pipe with component class name in which it has a problem.
```
The pipe 'testMissingPipe' could not be found  in the 'TestComponent' component!
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information