### PR TITLE
fix(compiler): generate correct code for safe method calls

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
@@ -63,3 +63,48 @@ export declare class MyModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: safe_method_call.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <span [title]="person?.getName(false)"></span>
+    <span [title]="person?.getName(false) || ''"></span>
+    <span [title]="person?.getName(false)?.toLowerCase()"></span>
+    <span [title]="person?.getName(config.get('title')?.enabled)"></span>
+    <span [title]="person?.getName(config.get('title')?.enabled ?? true)"></span>
+`, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <span [title]="person?.getName(false)"></span>
+    <span [title]="person?.getName(false) || ''"></span>
+    <span [title]="person?.getName(false)?.toLowerCase()"></span>
+    <span [title]="person?.getName(config.get('title')?.enabled)"></span>
+    <span [title]="person?.getName(config.get('title')?.enabled ?? true)"></span>
+`
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: safe_method_call.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    person?: {
+        getName: (includeTitle: boolean | undefined) => string;
+    };
+    config: {
+        get: (name: string) => {
+            enabled: boolean;
+        } | undefined;
+    };
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
@@ -17,6 +17,23 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should handle safe method calls inside templates",
+      "inputFiles": [
+        "safe_method_call.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "safe_method_call.js",
+              "generated": "safe_method_call.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_method_call.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_method_call.js
@@ -1,0 +1,19 @@
+template: function MyApp_Template(rf, $ctx$) {
+  if (rf & 1) {
+    // ...
+  }
+  if (rf & 2) {
+    let $tmp_0_0$;
+    let $tmp_1_0$;
+    let $tmp_2_0$;
+    $i0$.ɵɵproperty("title", $ctx$.person == null ? null : $ctx$.person.getName(false));
+    $i0$.ɵɵadvance(1);
+    $i0$.ɵɵproperty("title", ($ctx$.person == null ? null : $ctx$.person.getName(false)) || "");
+    $i0$.ɵɵadvance(1);
+    $i0$.ɵɵproperty("title", $ctx$.person == null ? null : ($tmp_0_0$ = $ctx$.person.getName(false)) == null ? null : $tmp_0_0$.toLowerCase());
+    $i0$.ɵɵadvance(1);
+    $i0$.ɵɵproperty("title", $ctx$.person == null ? null : $ctx$.person.getName(($tmp_1_0$ = $ctx$.config.get("title")) == null ? null : $tmp_1_0$.enabled));
+    $i0$.ɵɵadvance(1);
+    $i0$.ɵɵproperty("title", $ctx$.person == null ? null : $ctx$.person.getName(($tmp_2_0$ = ($tmp_2_0$ = $ctx$.config.get("title")) == null ? null : $tmp_2_0$.enabled) !== null && $tmp_2_0$ !== undefined ? $tmp_2_0$ : true));
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_method_call.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_method_call.ts
@@ -1,0 +1,21 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <span [title]="person?.getName(false)"></span>
+    <span [title]="person?.getName(false) || ''"></span>
+    <span [title]="person?.getName(false)?.toLowerCase()"></span>
+    <span [title]="person?.getName(config.get('title')?.enabled)"></span>
+    <span [title]="person?.getName(config.get('title')?.enabled ?? true)"></span>
+`
+})
+export class MyApp {
+  person?: {getName: (includeTitle: boolean|undefined) => string;};
+  config: {
+    get:
+        (name: string) => {
+          enabled: boolean
+        } |
+        undefined;
+  }
+}

--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -596,6 +596,11 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
   }
 
   visitCall(ast: cdAst.Call, mode: _Mode): any {
+    const leftMostSafe = this.leftMostSafeNode(ast);
+    if (leftMostSafe) {
+      return this.convertSafeAccess(ast, leftMostSafe, mode);
+    }
+
     const convertedArgs = this.visitAll(ast.args, _Mode.Expression);
 
     if (ast instanceof BuiltinFunctionCall) {
@@ -614,11 +619,6 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
           mode,
           (convertedArgs[0] as o.Expression)
               .cast(o.DYNAMIC_TYPE, this.convertSourceSpan(ast.span)));
-    }
-
-    const leftMostSafe = this.leftMostSafeNode(ast);
-    if (leftMostSafe) {
-      return this.convertSafeAccess(ast, leftMostSafe, mode);
     }
 
     const call = this._visit(receiver, _Mode.Expression)
@@ -674,7 +674,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
     // which comes in as leftMostSafe to this routine.
 
     let guardedExpression = this._visit(leftMostSafe.receiver, _Mode.Expression);
-    let temporary: o.ReadVarExpr = undefined!;
+    let temporary: o.ReadVarExpr|undefined = undefined;
     if (this.needsTemporaryInSafeAccess(leftMostSafe.receiver)) {
       // If the expression has method calls or pipes then we need to save the result into a
       // temporary variable to avoid calling stateful or impure code more than once.


### PR DESCRIPTION
fix(compiler): generate correct code for safe method calls

When a safe method call such as `person?.getName()` is used, the
compiler would generate invalid code if the argument list also contained
a safe method call. For example, the following code:

```
person?.getName(config?.get('title').enabled)
```

would generate

```
let tmp;
ctx.person == null ? null : ctx.person.getName((tmp = tmp) == null ?
null : tmp.enabled)
```

Notice how the call to `config.get('title')` has completely disappeared,
with `(tmp = tmp)` having taken its place.

The issue occurred due to how the argument list would be converted
from expression AST to output AST twice. First, the outer safe method
call would first convert its arguments list. This resulted in a
temporary being allocated for `config.get('title')`, which was stored in
the internal `_resultMap`. Only after the argument list has been
converted would the outer safe method call realize that it should be 
guarded by a safe access of `person`, entering the `convertSafeAccess` 
procedure to convert itself. This would convert the argument list once 
again, but this time the `_resultMap` would already contain the
temporary `tmp` for `config?.get('title')`. Consequently, the safe 
method in the argument list would be emitted as `tmp`.

This commit fixes the issue by ensuring that nodes are only converted
once.

Closes #44069