### PR TITLE
refactor(core): remove outdated comment

### DIFF
--- a/packages/core/src/metadata/view.ts
+++ b/packages/core/src/metadata/view.ts
@@ -19,6 +19,8 @@
  * @publicApi
  */
 export enum ViewEncapsulation {
+  // TODO: consider making `ViewEncapsulation` a `const enum` instead. See https://github.com/angular/angular/issues/44119 for additional information.
+
   /**
    * Emulate `Native` scoping of styles by adding an attribute containing surrogate id to the Host
    * Element and pre-processing the style rules provided via {@link Component#styles styles} or

--- a/packages/core/src/metadata/view.ts
+++ b/packages/core/src/metadata/view.ts
@@ -19,7 +19,8 @@
  * @publicApi
  */
 export enum ViewEncapsulation {
-  // TODO: consider making `ViewEncapsulation` a `const enum` instead. See https://github.com/angular/angular/issues/44119 for additional information.
+  // TODO: consider making `ViewEncapsulation` a `const enum` instead. See
+  // https://github.com/angular/angular/issues/44119 for additional information.
 
   /**
    * Emulate `Native` scoping of styles by adding an attribute containing surrogate id to the Host

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -315,8 +315,6 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
       viewQuery: componentDefinition.viewQuery || null,
       features: componentDefinition.features as DirectiveDefFeature[] || null,
       data: componentDefinition.data || {},
-      // TODO(misko): convert ViewEncapsulation into const enum so that it can be used
-      // directly in the next line. Also `None` should be 0 not 2.
       encapsulation: componentDefinition.encapsulation || ViewEncapsulation.Emulated,
       id: 'c',
       styles: componentDefinition.styles || EMPTY_ARRAY,


### PR DESCRIPTION
remove the comment suggesting to use an enum for ViewEncapsulation as
the change seems to have already been applied in PR #25255

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

A code comment seems to be present but no longer valid.

Prior to PR #25255 the check for the encapsulation was done using a `2` and the comment suggested to substitute that with an enum, that seems to have been already done in the aforementioned PR

As you can see here:
![Screenshot at 2021-11-06 17-11-54](https://user-images.githubusercontent.com/61631103/140618009-3a96416d-f9b0-41a6-aa25-a7b4e3a25438.png)


## What is the new behavior?

The comment has been removed

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - The comment also suggest that `None` should be `0` and not `2`, is such a change still on the table?
   seems pretty risky and not too beneficial to me at this point, but since the enum is used maybe it could be fine? :man_shrugging:
   anyways if that's the case I would suggest to put a comment for that in the enum itself
   (
by the way, there's also a `1` not being used anymore there https://github.com/angular/angular/blob/a92a89b0eb127a59d7e071502b5850e57618ec2d/packages/core/src/metadata/view.ts#L32   )