### PR TITLE
fix(compiler-cli): handle pre-release versions when checking version

### DIFF
--- a/packages/compiler-cli/src/diagnostics/typescript_version.ts
+++ b/packages/compiler-cli/src/diagnostics/typescript_version.ts
@@ -15,7 +15,7 @@ export function toNumbers(value: string): number[] {
   // Drop any suffixes starting with `-` so that versions like `1.2.3-rc.5` are treated as `1.2.3`.
   const suffixIndex = value.lastIndexOf('-');
   return value.slice(0, suffixIndex === -1 ? value.length : suffixIndex).split('.').map(segment => {
-    const parsed = parseInt(segment);
+    const parsed = parseInt(segment, 10);
 
     if (isNaN(parsed)) {
       throw Error(`Unable to parse version string ${value}.`);

--- a/packages/compiler-cli/src/diagnostics/typescript_version.ts
+++ b/packages/compiler-cli/src/diagnostics/typescript_version.ts
@@ -12,7 +12,17 @@
  * toNumbers('2.0.1'); // returns [2, 0, 1]
  */
 export function toNumbers(value: string): number[] {
-  return value.split('.').map(Number);
+  // Drop any suffixes starting with `-` so that versions like `1.2.3-rc.5` are treated as `1.2.3`.
+  const suffixIndex = value.lastIndexOf('-');
+  return value.slice(0, suffixIndex === -1 ? value.length : suffixIndex).split('.').map(segment => {
+    const parsed = parseInt(segment);
+
+    if (isNaN(parsed)) {
+      throw Error(`Unable to parse version string ${value}.`);
+    }
+
+    return parsed;
+  });
 }
 
 /**

--- a/packages/compiler-cli/test/BUILD.bazel
+++ b/packages/compiler-cli/test/BUILD.bazel
@@ -145,3 +145,22 @@ jasmine_node_test(
         "//packages/core",
     ],
 )
+
+ts_library(
+    name = "typescript_support_lib",
+    testonly = True,
+    srcs = [
+        "typescript_support_spec.ts",
+    ],
+    deps = [
+        "//packages/compiler-cli",
+    ],
+)
+
+jasmine_node_test(
+    name = "typescript_support",
+    bootstrap = ["//tools/testing:node_es5"],
+    deps = [
+        ":typescript_support_lib",
+    ],
+)

--- a/packages/compiler-cli/test/typescript_support_spec.ts
+++ b/packages/compiler-cli/test/typescript_support_spec.ts
@@ -32,4 +32,16 @@ describe('checkVersion', () => {
     expect(() => checkVersion('2.8.0', MIN_TS_VERSION, MAX_TS_VERSION))
         .toThrowError(versionError('2.8.0'));
   });
+
+  it('should throw when an out-of-bounds pre-release version is used', () => {
+    expect(() => checkVersion('2.7.0-beta', MIN_TS_VERSION, MAX_TS_VERSION))
+        .toThrowError(versionError('2.7.0-beta'));
+    expect(() => checkVersion('2.8.5-rc.3', MIN_TS_VERSION, MAX_TS_VERSION))
+        .toThrowError(versionError('2.8.5-rc.3'));
+  });
+
+  it('should not throw when a valid pre-release version is used', () => {
+    expect(() => checkVersion('2.7.2-beta', MIN_TS_VERSION, MAX_TS_VERSION)).not.toThrow();
+    expect(() => checkVersion('2.7.9-rc.8', MIN_TS_VERSION, MAX_TS_VERSION)).not.toThrow();
+  });
 });


### PR DESCRIPTION
Currently the TS version checking function interprets a version like `1.2.3-rc.5` as `1.2.NaN` which would allow it to bypass the version checking altogether.

These changes add a little bit more logic to ensure that such versions are handled correctly. There's also an error if we don't manage to parse the version string.

Also it seemed like we never actually ran the version check unit tests, because they didn't have a test target.