### PR TITLE
fix(compiler): ensure that partially compiled queries can handle forward references

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ChangeDetectionStrategy, compileComponentFromMetadata, ConstantPool, DeclarationListEmitMode, DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig, makeBindingParser, outputAst as o, parseTemplate, R3ComponentMetadata, R3DeclareComponentMetadata, R3DeclareUsedDirectiveMetadata, R3PartialDeclaration, R3UsedDirectiveMetadata, ViewEncapsulation} from '@angular/compiler';
+import {ChangeDetectionStrategy, compileComponentFromMetadata, ConstantPool, DeclarationListEmitMode, DEFAULT_INTERPOLATION_CONFIG, ForwardRefHandling, InterpolationConfig, makeBindingParser, outputAst as o, parseTemplate, R3ComponentMetadata, R3DeclareComponentMetadata, R3DeclareUsedDirectiveMetadata, R3PartialDeclaration, R3UsedDirectiveMetadata, ViewEncapsulation} from '@angular/compiler';
 
 import {AbsoluteFsPath} from '../../../../src/ngtsc/file_system';
 import {Range} from '../../ast/ast_host';
@@ -69,8 +69,8 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
             const type = directiveExpr.getValue('type');
             const selector = directiveExpr.getString('selector');
 
-            const {expression: typeExpr, isForwardRef} = extractForwardRef(type);
-            if (isForwardRef) {
+            const {expression: typeExpr, forwardRef} = extractForwardRef(type);
+            if (forwardRef === ForwardRefHandling.Unwrapped) {
               declarationListEmitMode = DeclarationListEmitMode.Closure;
             }
 
@@ -101,8 +101,8 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
     let pipes = new Map<string, o.Expression>();
     if (metaObj.has('pipes')) {
       pipes = metaObj.getObject('pipes').toMap(pipe => {
-        const {expression: pipeType, isForwardRef} = extractForwardRef(pipe);
-        if (isForwardRef) {
+        const {expression: pipeType, forwardRef} = extractForwardRef(pipe);
+        if (forwardRef === ForwardRefHandling.Unwrapped) {
           declarationListEmitMode = DeclarationListEmitMode.Closure;
         }
         return pipeType;

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
@@ -13,7 +13,7 @@ import {AstObject, AstValue} from '../../ast/ast_value';
 import {FatalLinkerError} from '../../fatal_linker_error';
 
 import {PartialLinker} from './partial_linker';
-import {wrapReference} from './util';
+import {extractForwardRef, wrapReference} from './util';
 
 /**
  * A `PartialLinker` that is designed to process `ɵɵngDeclareDirective()` call expressions.
@@ -140,7 +140,7 @@ function toQueryMetadata<TExpression>(obj: AstObject<R3DeclareQueryMetadata, TEx
   if (predicateExpr.isArray()) {
     predicate = predicateExpr.getArray().map(entry => entry.getString());
   } else {
-    predicate = predicateExpr.getOpaque();
+    predicate = extractForwardRef(predicateExpr);
   }
   return {
     propertyName: obj.getString('propertyName'),

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_injectable_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_injectable_linker_1.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {compileInjectable, ConstantPool, createMayBeForwardRefExpression, outputAst as o, R3DeclareInjectableMetadata, R3InjectableMetadata, R3PartialDeclaration} from '@angular/compiler';
+import {compileInjectable, ConstantPool, createMayBeForwardRefExpression, ForwardRefHandling, outputAst as o, R3DeclareInjectableMetadata, R3InjectableMetadata, R3PartialDeclaration} from '@angular/compiler';
 
 import {AstObject} from '../../ast/ast_value';
 import {FatalLinkerError} from '../../fatal_linker_error';
@@ -43,8 +43,9 @@ export function toR3InjectableMeta<TExpression>(
     type: wrapReference(typeExpr.getOpaque()),
     internalType: typeExpr.getOpaque(),
     typeArgumentCount: 0,
-    providedIn: metaObj.has('providedIn') ? extractForwardRef(metaObj.getValue('providedIn')) :
-                                            createMayBeForwardRefExpression(o.literal(null), false),
+    providedIn: metaObj.has('providedIn') ?
+        extractForwardRef(metaObj.getValue('providedIn')) :
+        createMayBeForwardRefExpression(o.literal(null), ForwardRefHandling.None),
   };
 
   if (metaObj.has('useClass')) {

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_injectable_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_injectable_linker_1.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {compileInjectable, ConstantPool, createR3ProviderExpression, outputAst as o, R3DeclareInjectableMetadata, R3InjectableMetadata, R3PartialDeclaration} from '@angular/compiler';
+import {compileInjectable, ConstantPool, createMayBeForwardRefExpression, outputAst as o, R3DeclareInjectableMetadata, R3InjectableMetadata, R3PartialDeclaration} from '@angular/compiler';
 
 import {AstObject} from '../../ast/ast_value';
 import {FatalLinkerError} from '../../fatal_linker_error';
@@ -44,7 +44,7 @@ export function toR3InjectableMeta<TExpression>(
     internalType: typeExpr.getOpaque(),
     typeArgumentCount: 0,
     providedIn: metaObj.has('providedIn') ? extractForwardRef(metaObj.getValue('providedIn')) :
-                                            createR3ProviderExpression(o.literal(null), false),
+                                            createMayBeForwardRefExpression(o.literal(null), false),
   };
 
   if (metaObj.has('useClass')) {

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/util.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/util.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {createR3ProviderExpression, outputAst as o, R3DeclareDependencyMetadata, R3DependencyMetadata, R3ProviderExpression, R3Reference} from '@angular/compiler';
+import {createMayBeForwardRefExpression, MaybeForwardRefExpression, outputAst as o, R3DeclareDependencyMetadata, R3DependencyMetadata, R3Reference} from '@angular/compiler';
 
 import {AstObject, AstValue} from '../../ast/ast_value';
 import {FatalLinkerError} from '../../fatal_linker_error';
@@ -66,9 +66,9 @@ export function getDependency<TExpression>(
  * If there is no forwardRef call expression then we just return the opaque type.
  */
 export function extractForwardRef<TExpression>(expr: AstValue<unknown, TExpression>):
-    R3ProviderExpression<o.WrappedNodeExpr<TExpression>> {
+    MaybeForwardRefExpression<o.WrappedNodeExpr<TExpression>> {
   if (!expr.isCallExpression()) {
-    return createR3ProviderExpression(expr.getOpaque(), /* isForwardRef */ false);
+    return createMayBeForwardRefExpression(expr.getOpaque(), /* isForwardRef */ false);
   }
 
   const callee = expr.getCallee();
@@ -90,5 +90,5 @@ export function extractForwardRef<TExpression>(expr: AstValue<unknown, TExpressi
         wrapperFn, 'Unsupported `forwardRef(fn)` call, expected its argument to be a function');
   }
 
-  return createR3ProviderExpression(wrapperFn.getFunctionReturnValue().getOpaque(), true);
+  return createMayBeForwardRefExpression(wrapperFn.getFunctionReturnValue().getOpaque(), true);
 }

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/util.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/util.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {createMayBeForwardRefExpression, MaybeForwardRefExpression, outputAst as o, R3DeclareDependencyMetadata, R3DependencyMetadata, R3Reference} from '@angular/compiler';
+import {createMayBeForwardRefExpression, ForwardRefHandling, MaybeForwardRefExpression, outputAst as o, R3DeclareDependencyMetadata, R3DependencyMetadata, R3Reference} from '@angular/compiler';
 
 import {AstObject, AstValue} from '../../ast/ast_value';
 import {FatalLinkerError} from '../../fatal_linker_error';
@@ -68,7 +68,7 @@ export function getDependency<TExpression>(
 export function extractForwardRef<TExpression>(expr: AstValue<unknown, TExpression>):
     MaybeForwardRefExpression<o.WrappedNodeExpr<TExpression>> {
   if (!expr.isCallExpression()) {
-    return createMayBeForwardRefExpression(expr.getOpaque(), /* isForwardRef */ false);
+    return createMayBeForwardRefExpression(expr.getOpaque(), ForwardRefHandling.None);
   }
 
   const callee = expr.getCallee();
@@ -90,5 +90,6 @@ export function extractForwardRef<TExpression>(expr: AstValue<unknown, TExpressi
         wrapperFn, 'Unsupported `forwardRef(fn)` call, expected its argument to be a function');
   }
 
-  return createMayBeForwardRefExpression(wrapperFn.getFunctionReturnValue().getOpaque(), true);
+  return createMayBeForwardRefExpression(
+      wrapperFn.getFunctionReturnValue().getOpaque(), ForwardRefHandling.Unwrapped);
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {compileClassMetadata, CompileClassMetadataFn, compileDeclareClassMetadata, compileDeclareInjectableFromMetadata, compileInjectable, createR3ProviderExpression, Expression, FactoryTarget, LiteralExpr, R3ClassMetadata, R3CompiledExpression, R3DependencyMetadata, R3InjectableMetadata, R3ProviderExpression, Statement, WrappedNodeExpr} from '@angular/compiler';
+import {compileClassMetadata, CompileClassMetadataFn, compileDeclareClassMetadata, compileDeclareInjectableFromMetadata, compileInjectable, createMayBeForwardRefExpression, FactoryTarget, LiteralExpr, MaybeForwardRefExpression, R3ClassMetadata, R3CompiledExpression, R3DependencyMetadata, R3InjectableMetadata, WrappedNodeExpr} from '@angular/compiler';
 import ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
@@ -162,7 +162,7 @@ function extractInjectableMetadata(
       type,
       typeArgumentCount,
       internalType,
-      providedIn: createR3ProviderExpression(new LiteralExpr(null), false),
+      providedIn: createMayBeForwardRefExpression(new LiteralExpr(null), false),
     };
   } else if (decorator.args.length === 1) {
     const metaNode = decorator.args[0];
@@ -180,7 +180,7 @@ function extractInjectableMetadata(
 
     const providedIn = meta.has('providedIn') ?
         getProviderExpression(meta.get('providedIn')!, reflector) :
-        createR3ProviderExpression(new LiteralExpr(null), false);
+        createMayBeForwardRefExpression(new LiteralExpr(null), false);
 
     let deps: R3DependencyMetadata[]|undefined = undefined;
     if ((meta.has('useClass') || meta.has('useFactory')) && meta.has('deps')) {
@@ -220,9 +220,9 @@ function extractInjectableMetadata(
  * object to indicate whether the value needed unwrapping.
  */
 function getProviderExpression(
-    expression: ts.Expression, reflector: ReflectionHost): R3ProviderExpression {
+    expression: ts.Expression, reflector: ReflectionHost): MaybeForwardRefExpression {
   const forwardRefValue = tryUnwrapForwardRef(expression, reflector);
-  return createR3ProviderExpression(
+  return createMayBeForwardRefExpression(
       new WrappedNodeExpr(forwardRefValue ?? expression), forwardRefValue !== null);
 }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {compileClassMetadata, CompileClassMetadataFn, compileDeclareClassMetadata, compileDeclareInjectableFromMetadata, compileInjectable, createMayBeForwardRefExpression, FactoryTarget, LiteralExpr, MaybeForwardRefExpression, R3ClassMetadata, R3CompiledExpression, R3DependencyMetadata, R3InjectableMetadata, WrappedNodeExpr} from '@angular/compiler';
+import {compileClassMetadata, CompileClassMetadataFn, compileDeclareClassMetadata, compileDeclareInjectableFromMetadata, compileInjectable, createMayBeForwardRefExpression, FactoryTarget, ForwardRefHandling, LiteralExpr, MaybeForwardRefExpression, R3ClassMetadata, R3CompiledExpression, R3DependencyMetadata, R3InjectableMetadata, WrappedNodeExpr} from '@angular/compiler';
 import ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../diagnostics';
@@ -162,7 +162,7 @@ function extractInjectableMetadata(
       type,
       typeArgumentCount,
       internalType,
-      providedIn: createMayBeForwardRefExpression(new LiteralExpr(null), false),
+      providedIn: createMayBeForwardRefExpression(new LiteralExpr(null), ForwardRefHandling.None),
     };
   } else if (decorator.args.length === 1) {
     const metaNode = decorator.args[0];
@@ -180,7 +180,7 @@ function extractInjectableMetadata(
 
     const providedIn = meta.has('providedIn') ?
         getProviderExpression(meta.get('providedIn')!, reflector) :
-        createMayBeForwardRefExpression(new LiteralExpr(null), false);
+        createMayBeForwardRefExpression(new LiteralExpr(null), ForwardRefHandling.None);
 
     let deps: R3DependencyMetadata[]|undefined = undefined;
     if ((meta.has('useClass') || meta.has('useFactory')) && meta.has('deps')) {
@@ -223,7 +223,8 @@ function getProviderExpression(
     expression: ts.Expression, reflector: ReflectionHost): MaybeForwardRefExpression {
   const forwardRefValue = tryUnwrapForwardRef(expression, reflector);
   return createMayBeForwardRefExpression(
-      new WrappedNodeExpr(forwardRefValue ?? expression), forwardRefValue !== null);
+      new WrappedNodeExpr(forwardRefValue ?? expression),
+      forwardRefValue !== null ? ForwardRefHandling.Unwrapped : ForwardRefHandling.None);
 }
 
 function extractInjectableCtorDeps(

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/GOLDEN_PARTIAL.js
@@ -80,6 +80,92 @@ export declare class MyModule {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: view_query_forward_ref.js
+ ****************************************************************************************************/
+import { Component, Directive, forwardRef, NgModule, ViewChild, ViewChildren } from '@angular/core';
+import * as i0 from "@angular/core";
+export class ViewQueryComponent {
+}
+ViewQueryComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ViewQueryComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+ViewQueryComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: ViewQueryComponent, selector: "view-query-component", viewQueries: [{ propertyName: "someDir", first: true, predicate: i0.forwardRef(function () { return SomeDirective; }), descendants: true }, { propertyName: "someDirList", predicate: i0.forwardRef(function () { return SomeDirective; }), descendants: true }], ngImport: i0, template: `
+    <div someDir></div>
+  `, isInline: true, directives: [{ type: i0.forwardRef(function () { return SomeDirective; }), selector: "[someDir]" }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ViewQueryComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'view-query-component',
+                    template: `
+    <div someDir></div>
+  `
+                }]
+        }], propDecorators: { someDir: [{
+                type: ViewChild,
+                args: [forwardRef(() => SomeDirective)]
+            }], someDirList: [{
+                type: ViewChildren,
+                args: [forwardRef(() => SomeDirective)]
+            }] } });
+export class MyApp {
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "my-app", ngImport: i0, template: `
+    <view-query-component></view-query-component>
+  `, isInline: true, components: [{ type: ViewQueryComponent, selector: "view-query-component" }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-app',
+                    template: `
+    <view-query-component></view-query-component>
+  `
+                }]
+        }] });
+export class SomeDirective {
+}
+SomeDirective.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeDirective, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+SomeDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: SomeDirective, selector: "[someDir]", ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeDirective, decorators: [{
+            type: Directive,
+            args: [{
+                    selector: '[someDir]',
+                }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [SomeDirective, ViewQueryComponent, MyApp] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [SomeDirective, ViewQueryComponent, MyApp] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: view_query_forward_ref.d.ts
+ ****************************************************************************************************/
+import { QueryList } from '@angular/core';
+import * as i0 from "@angular/core";
+export declare class ViewQueryComponent {
+    someDir: SomeDirective;
+    someDirList: QueryList<SomeDirective>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ViewQueryComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ViewQueryComponent, "view-query-component", never, {}, {}, never, never>;
+}
+export declare class MyApp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "my-app", never, {}, {}, never, never>;
+}
+export declare class SomeDirective {
+    static ɵfac: i0.ɵɵFactoryDeclaration<SomeDirective, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<SomeDirective, "[someDir]", never, {}, {}, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof SomeDirective, typeof ViewQueryComponent, typeof MyApp], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: view_query_for_local_ref.js
  ****************************************************************************************************/
 import { Component, NgModule, ViewChild, ViewChildren } from '@angular/core';
@@ -407,6 +493,96 @@ export declare class MyApp {
 export declare class MyModule {
     static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
     static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof i1.SomeDirective, typeof ContentQueryComponent, typeof MyApp], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: content_query_forward_ref.js
+ ****************************************************************************************************/
+import { Component, ContentChild, ContentChildren, Directive, forwardRef, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class ContentQueryComponent {
+}
+ContentQueryComponent.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ContentQueryComponent, deps: [], target: i0.ɵɵFactoryTarget.Component });
+ContentQueryComponent.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: ContentQueryComponent, selector: "content-query-component", queries: [{ propertyName: "someDir", first: true, predicate: i0.forwardRef(function () { return SomeDirective; }), descendants: true }, { propertyName: "someDirList", predicate: i0.forwardRef(function () { return SomeDirective; }) }], ngImport: i0, template: `
+    <div><ng-content></ng-content></div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: ContentQueryComponent, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'content-query-component',
+                    template: `
+    <div><ng-content></ng-content></div>
+  `
+                }]
+        }], propDecorators: { someDir: [{
+                type: ContentChild,
+                args: [forwardRef(() => SomeDirective)]
+            }], someDirList: [{
+                type: ContentChildren,
+                args: [forwardRef(() => SomeDirective)]
+            }] } });
+export class MyApp {
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "my-app", ngImport: i0, template: `
+    <content-query-component>
+      <div someDir></div>
+    </content-query-component>
+  `, isInline: true, components: [{ type: i0.forwardRef(function () { return ContentQueryComponent; }), selector: "content-query-component" }], directives: [{ type: i0.forwardRef(function () { return SomeDirective; }), selector: "[someDir]" }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    selector: 'my-app',
+                    template: `
+    <content-query-component>
+      <div someDir></div>
+    </content-query-component>
+  `
+                }]
+        }] });
+export class SomeDirective {
+}
+SomeDirective.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeDirective, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+SomeDirective.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: SomeDirective, selector: "[someDir]", ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeDirective, decorators: [{
+            type: Directive,
+            args: [{
+                    selector: '[someDir]',
+                }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [SomeDirective, ContentQueryComponent, MyApp] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [SomeDirective, ContentQueryComponent, MyApp] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: content_query_forward_ref.d.ts
+ ****************************************************************************************************/
+import { QueryList } from '@angular/core';
+import * as i0 from "@angular/core";
+export declare class ContentQueryComponent {
+    someDir: SomeDirective;
+    someDirList: QueryList<SomeDirective>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ContentQueryComponent, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ContentQueryComponent, "content-query-component", never, {}, {}, ["someDir", "someDirList"], ["*"]>;
+}
+export declare class MyApp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "my-app", never, {}, {}, never, never>;
+}
+export declare class SomeDirective {
+    static ɵfac: i0.ɵɵFactoryDeclaration<SomeDirective, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<SomeDirective, "[someDir]", never, {}, {}, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof SomeDirective, typeof ContentQueryComponent, typeof MyApp], never, never>;
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/TEST_CASES.json
@@ -17,6 +17,20 @@
       ]
     },
     {
+      "description": "should support view queries with forwardRefs",
+      "inputFiles": [
+        "view_query_forward_ref.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Invalid ViewQuery declaration",
+          "files": [
+            "view_query_forward_ref.js"
+          ]
+        }
+      ]
+    },
+    {
       "description": "should support view queries with local refs",
       "inputFiles": [
         "view_query_for_local_ref.ts"
@@ -71,6 +85,20 @@
           "failureMessage": "Invalid ContentQuery declaration",
           "files": [
             "content_query_for_directive.js"
+          ]
+        }
+      ]
+    },
+    {
+      "description": "should support content queries with forwardRefs",
+      "inputFiles": [
+        "content_query_forward_ref.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Invalid ContentQuery declaration",
+          "files": [
+            "content_query_forward_ref.js"
           ]
         }
       ]

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_forward_ref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_forward_ref.js
@@ -1,0 +1,27 @@
+ContentQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
+  type: ContentQueryComponent,
+  selectors: [["content-query-component"]],
+  contentQueries: function ContentQueryComponent_ContentQueries(rf, ctx, dirIndex) {
+    if (rf & 1) {
+      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
+      $r3$.ɵɵcontentQuery(dirIndex, SomeDirective, __QueryFlags.emitDistinctChangesOnly__);
+    }
+    if (rf & 2) {
+      let $tmp$;
+      $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDir = $tmp$.first);
+      $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDirList = $tmp$);
+    }
+  },
+  ngContentSelectors: _c0,
+  decls: 2,
+  vars: 0,
+  template: function ContentQueryComponent_Template(rf, ctx) {
+    if (rf & 1) {
+      $r3$.ɵɵprojectionDef();
+      $r3$.ɵɵelementStart(0, "div");
+      $r3$.ɵɵprojection(1);
+      $r3$.ɵɵelementEnd();
+    }
+  },
+  encapsulation: 2
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_forward_ref.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/content_query_forward_ref.ts
@@ -1,0 +1,34 @@
+import {Component, ContentChild, ContentChildren, Directive, forwardRef, NgModule, QueryList} from '@angular/core';
+
+@Component({
+  selector: 'content-query-component',
+  template: `
+    <div><ng-content></ng-content></div>
+  `
+})
+export class ContentQueryComponent {
+  @ContentChild(forwardRef(() => SomeDirective)) someDir!: SomeDirective;
+  @ContentChildren(forwardRef(() => SomeDirective)) someDirList!: QueryList<SomeDirective>;
+}
+
+@Component({
+  selector: 'my-app',
+  template: `
+    <content-query-component>
+      <div someDir></div>
+    </content-query-component>
+  `
+})
+export class MyApp {
+}
+
+
+@Directive({
+  selector: '[someDir]',
+})
+export class SomeDirective {
+}
+
+@NgModule({declarations: [SomeDirective, ContentQueryComponent, MyApp]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_forward_ref.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_forward_ref.js
@@ -1,0 +1,16 @@
+ViewQueryComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
+  type: ViewQueryComponent,
+  selectors: [["view-query-component"]],
+  viewQuery: function ViewQueryComponent_Query(rf, ctx) {
+    if (rf & 1) {
+      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
+      $r3$.ɵɵviewQuery(SomeDirective, __QueryFlags.descendants__|__QueryFlags.emitDistinctChangesOnly__);
+    }
+    if (rf & 2) {
+      let $tmp$;
+      $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDir = $tmp$.first);
+      $r3$.ɵɵqueryRefresh($tmp$ = $r3$.ɵɵloadQuery()) && (ctx.someDirList = $tmp$);
+    }
+  },
+  // ...
+});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_forward_ref.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/view_query_forward_ref.ts
@@ -1,0 +1,32 @@
+import {Component, Directive, forwardRef, NgModule, QueryList, ViewChild, ViewChildren} from '@angular/core';
+
+@Component({
+  selector: 'view-query-component',
+  template: `
+    <div someDir></div>
+  `
+})
+export class ViewQueryComponent {
+  @ViewChild(forwardRef(() => SomeDirective)) someDir!: SomeDirective;
+  @ViewChildren(forwardRef(() => SomeDirective)) someDirList!: QueryList<SomeDirective>;
+}
+
+@Component({
+  selector: 'my-app',
+  template: `
+    <view-query-component></view-query-component>
+  `
+})
+export class MyApp {
+}
+
+
+@Directive({
+  selector: '[someDir]',
+})
+export class SomeDirective {
+}
+
+@NgModule({declarations: [SomeDirective, ViewQueryComponent, MyApp]})
+export class MyModule {
+}

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -103,7 +103,7 @@ export {compileNgModule, R3NgModuleMetadata} from './render3/r3_module_compiler'
 export {compileInjector, R3InjectorMetadata} from './render3/r3_injector_compiler';
 export {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
 export {makeBindingParser, ParsedTemplate, parseTemplate, ParseTemplateOptions} from './render3/view/template';
-export {MaybeForwardRefExpression, R3CompiledExpression, R3Reference, createMayBeForwardRefExpression, devOnlyGuardedExpression, getSafePropertyAccessString} from './render3/util';
+export {ForwardRefHandling, MaybeForwardRefExpression, R3CompiledExpression, R3Reference, createMayBeForwardRefExpression, devOnlyGuardedExpression, getSafePropertyAccessString} from './render3/util';
 export {compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings, ParsedHostBindings, verifyHostBindings} from './render3/view/compiler';
 export {compileDeclareClassMetadata} from './render3/partial/class_metadata';
 export {compileDeclareComponentFromMetadata, DeclareComponentTemplateInfo} from './render3/partial/component';

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -103,7 +103,7 @@ export {compileNgModule, R3NgModuleMetadata} from './render3/r3_module_compiler'
 export {compileInjector, R3InjectorMetadata} from './render3/r3_injector_compiler';
 export {compilePipeFromMetadata, R3PipeMetadata} from './render3/r3_pipe_compiler';
 export {makeBindingParser, ParsedTemplate, parseTemplate, ParseTemplateOptions} from './render3/view/template';
-export {R3CompiledExpression, R3Reference, devOnlyGuardedExpression, getSafePropertyAccessString} from './render3/util';
+export {MaybeForwardRefExpression, R3CompiledExpression, R3Reference, createMayBeForwardRefExpression, devOnlyGuardedExpression, getSafePropertyAccessString} from './render3/util';
 export {compileComponentFromMetadata, compileDirectiveFromMetadata, parseHostBindings, ParsedHostBindings, verifyHostBindings} from './render3/view/compiler';
 export {compileDeclareClassMetadata} from './render3/partial/class_metadata';
 export {compileDeclareComponentFromMetadata, DeclareComponentTemplateInfo} from './render3/partial/component';

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -9,7 +9,7 @@
 import * as o from './output/output_ast';
 import {compileFactoryFunction, FactoryTarget, R3DependencyMetadata, R3FactoryDelegateType, R3FactoryMetadata} from './render3/r3_factory';
 import {Identifiers} from './render3/r3_identifiers';
-import {generateForwardRef, MaybeForwardRefExpression, R3CompiledExpression, R3Reference, typeWithParameters} from './render3/util';
+import {convertFromMaybeForwardRefExpression, ForwardRefHandling, generateForwardRef, MaybeForwardRefExpression, R3CompiledExpression, R3Reference, typeWithParameters} from './render3/util';
 import {DefinitionMap} from './render3/view/util';
 
 export interface R3InjectableMetadata {
@@ -116,10 +116,7 @@ export function compileInjectable(
 
   // Only generate providedIn property if it has a non-null value
   if ((meta.providedIn.expression as o.LiteralExpr).value !== null) {
-    injectableProps.set(
-        'providedIn',
-        meta.providedIn.isForwardRef ? generateForwardRef(meta.providedIn.expression) :
-                                       meta.providedIn.expression);
+    injectableProps.set('providedIn', convertFromMaybeForwardRefExpression(meta.providedIn));
   }
 
   const expression = o.importExpr(Identifiers.ɵɵdefineInjectable)

--- a/packages/compiler/src/injectable_compiler_2.ts
+++ b/packages/compiler/src/injectable_compiler_2.ts
@@ -7,10 +7,9 @@
  */
 
 import * as o from './output/output_ast';
-import {generateForwardRef} from './render3/partial/util';
 import {compileFactoryFunction, FactoryTarget, R3DependencyMetadata, R3FactoryDelegateType, R3FactoryMetadata} from './render3/r3_factory';
 import {Identifiers} from './render3/r3_identifiers';
-import {R3CompiledExpression, R3Reference, typeWithParameters} from './render3/util';
+import {generateForwardRef, MaybeForwardRefExpression, R3CompiledExpression, R3Reference, typeWithParameters} from './render3/util';
 import {DefinitionMap} from './render3/view/util';
 
 export interface R3InjectableMetadata {
@@ -18,46 +17,12 @@ export interface R3InjectableMetadata {
   type: R3Reference;
   internalType: o.Expression;
   typeArgumentCount: number;
-  providedIn: R3ProviderExpression;
-  useClass?: R3ProviderExpression;
+  providedIn: MaybeForwardRefExpression;
+  useClass?: MaybeForwardRefExpression;
   useFactory?: o.Expression;
-  useExisting?: R3ProviderExpression;
-  useValue?: R3ProviderExpression;
+  useExisting?: MaybeForwardRefExpression;
+  useValue?: MaybeForwardRefExpression;
   deps?: R3DependencyMetadata[];
-}
-
-/**
- * An expression used when instantiating an injectable.
- *
- * This is the type of the `useClass`, `useExisting` and `useValue` properties of
- * `R3InjectableMetadata` since those can refer to types that may eagerly reference types that have
- * not yet been defined.
- */
-export interface R3ProviderExpression<T extends o.Expression = o.Expression> {
-  /**
-   * The expression that is used to instantiate the Injectable.
-   */
-  expression: T;
-  /**
-   * If true, then the `expression` contains a reference to something that has not yet been
-   * defined.
-   *
-   * This means that the expression must not be eagerly evaluated. Instead it must be wrapped in a
-   * function closure that will be evaluated lazily to allow the definition of the expression to be
-   * evaluated first.
-   *
-   * In some cases the expression will naturally be placed inside such a function closure, such as
-   * in a fully compiled factory function. In those case nothing more needs to be done.
-   *
-   * But in other cases, such as partial-compilation the expression will be located in top level
-   * code so will need to be wrapped in a function that is passed to a `forwardRef()` call.
-   */
-  isForwardRef: boolean;
-}
-
-export function createR3ProviderExpression<T extends o.Expression>(
-    expression: T, isForwardRef: boolean): R3ProviderExpression<T> {
-  return {expression, isForwardRef};
 }
 
 export function compileInjectable(

--- a/packages/compiler/src/render3/partial/api.ts
+++ b/packages/compiler/src/render3/partial/api.ts
@@ -233,8 +233,8 @@ export interface R3DeclareQueryMetadata {
   first?: boolean;
 
   /**
-   * Either an expression representing a type or `InjectionToken` for the query
-   * predicate, or a set of string selectors.
+   * Either an expression representing a type (possibly wrapped in a `forwardRef()`) or
+   * `InjectionToken` for the query predicate, or a set of string selectors.
    */
   predicate: o.Expression|string[];
 

--- a/packages/compiler/src/render3/partial/component.ts
+++ b/packages/compiler/src/render3/partial/component.ts
@@ -10,7 +10,7 @@ import {DEFAULT_INTERPOLATION_CONFIG} from '../../ml_parser/interpolation_config
 import * as o from '../../output/output_ast';
 import {ParseLocation, ParseSourceFile, ParseSourceSpan} from '../../parse_util';
 import {Identifiers as R3} from '../r3_identifiers';
-import {R3CompiledExpression} from '../util';
+import {generateForwardRef, R3CompiledExpression} from '../util';
 import {DeclarationListEmitMode, R3ComponentMetadata, R3UsedDirectiveMetadata} from '../view/api';
 import {createComponentType} from '../view/compiler';
 import {ParsedTemplate} from '../view/template';
@@ -18,7 +18,7 @@ import {DefinitionMap} from '../view/util';
 
 import {R3DeclareComponentMetadata, R3DeclareUsedDirectiveMetadata} from './api';
 import {createDirectiveDefinitionMap} from './directive';
-import {generateForwardRef, toOptionalLiteralArray} from './util';
+import {toOptionalLiteralArray} from './util';
 
 export interface DeclareComponentTemplateInfo {
   /**

--- a/packages/compiler/src/render3/partial/directive.ts
+++ b/packages/compiler/src/render3/partial/directive.ts
@@ -7,7 +7,7 @@
  */
 import * as o from '../../output/output_ast';
 import {Identifiers as R3} from '../r3_identifiers';
-import {R3CompiledExpression} from '../util';
+import {convertFromMaybeForwardRefExpression, R3CompiledExpression} from '../util';
 import {R3DirectiveMetadata, R3HostMetadata, R3QueryMetadata} from '../view/api';
 import {createDirectiveType} from '../view/compiler';
 import {asLiteral, conditionallyCreateMapObjectLiteral, DefinitionMap} from '../view/util';
@@ -96,7 +96,9 @@ function compileQuery(query: R3QueryMetadata): o.LiteralMapExpr {
     meta.set('first', o.literal(true));
   }
   meta.set(
-      'predicate', Array.isArray(query.predicate) ? asLiteral(query.predicate) : query.predicate);
+      'predicate',
+      Array.isArray(query.predicate) ? asLiteral(query.predicate) :
+                                       convertFromMaybeForwardRefExpression(query.predicate));
   if (!query.emitDistinctChangesOnly) {
     // `emitDistinctChangesOnly` is special because we expect it to be `true`.
     // Therefore we explicitly emit the field, and explicitly place it only when it's `false`.

--- a/packages/compiler/src/render3/partial/injectable.ts
+++ b/packages/compiler/src/render3/partial/injectable.ts
@@ -5,14 +5,14 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {createInjectableType, R3InjectableMetadata, R3ProviderExpression} from '../../injectable_compiler_2';
+import {createInjectableType, R3InjectableMetadata} from '../../injectable_compiler_2';
 import * as o from '../../output/output_ast';
 import {Identifiers as R3} from '../r3_identifiers';
-import {R3CompiledExpression} from '../util';
+import {convertFromMaybeForwardRefExpression, R3CompiledExpression} from '../util';
 import {DefinitionMap} from '../view/util';
 
 import {R3DeclareInjectableMetadata} from './api';
-import {compileDependency, generateForwardRef} from './util';
+import {compileDependency} from './util';
 
 /**
  * Every time we make a breaking change to the declaration interface or partial-linker behavior, we
@@ -50,20 +50,20 @@ export function createInjectableDefinitionMap(meta: R3InjectableMetadata):
 
   // Only generate providedIn property if it has a non-null value
   if (meta.providedIn !== undefined) {
-    const providedIn = convertFromProviderExpression(meta.providedIn);
+    const providedIn = convertFromMaybeForwardRefExpression(meta.providedIn);
     if ((providedIn as o.LiteralExpr).value !== null) {
       definitionMap.set('providedIn', providedIn);
     }
   }
 
   if (meta.useClass !== undefined) {
-    definitionMap.set('useClass', convertFromProviderExpression(meta.useClass));
+    definitionMap.set('useClass', convertFromMaybeForwardRefExpression(meta.useClass));
   }
   if (meta.useExisting !== undefined) {
-    definitionMap.set('useExisting', convertFromProviderExpression(meta.useExisting));
+    definitionMap.set('useExisting', convertFromMaybeForwardRefExpression(meta.useExisting));
   }
   if (meta.useValue !== undefined) {
-    definitionMap.set('useValue', convertFromProviderExpression(meta.useValue));
+    definitionMap.set('useValue', convertFromMaybeForwardRefExpression(meta.useValue));
   }
   // Factories do not contain `ForwardRef`s since any types are already wrapped in a function call
   // so the types will not be eagerly evaluated. Therefore we do not need to process this expression
@@ -77,27 +77,4 @@ export function createInjectableDefinitionMap(meta: R3InjectableMetadata):
   }
 
   return definitionMap;
-}
-
-/**
- * Convert an `R3ProviderExpression` to an `Expression`, possibly wrapping its expression in a
- * `forwardRef()` call.
- *
- * If `R3ProviderExpression.isForwardRef` is true then the expression was originally wrapped in a
- * `forwardRef()` call to prevent the value from being eagerly evaluated in the code.
- *
- * Normally, the linker will statically process the code, putting the `expression` inside a factory
- * function so the `forwardRef()` wrapper is not evaluated before it has been defined. But if the
- * partial declaration is evaluated by the JIT compiler the `forwardRef()` call is still needed to
- * prevent eager evaluation of the `expression`.
- *
- * So in partial declarations, expressions that could be forward-refs are wrapped in `forwardRef()`
- * calls, and this is then unwrapped in the linker as necessary.
- *
- * See `packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts` and
- * `packages/compiler/src/jit_compiler_facade.ts` for more information.
- */
-function convertFromProviderExpression({expression, isForwardRef}: R3ProviderExpression):
-    o.Expression {
-  return isForwardRef ? generateForwardRef(expression) : expression;
 }

--- a/packages/compiler/src/render3/partial/util.ts
+++ b/packages/compiler/src/render3/partial/util.ts
@@ -7,7 +7,6 @@
  */
 import * as o from '../../output/output_ast';
 import {R3DependencyMetadata} from '../r3_factory';
-import {Identifiers} from '../r3_identifiers';
 import {DefinitionMap} from '../view/util';
 import {R3DeclareDependencyMetadata} from './api';
 
@@ -83,15 +82,4 @@ export function compileDependency(dep: R3DependencyMetadata): o.LiteralMapExpr {
     depMeta.set('skipSelf', o.literal(true));
   }
   return depMeta.toLiteralMap();
-}
-
-/**
- * Generate an expression that has the given `expr` wrapped in the following form:
- *
- * ```
- * forwardRef(() => expr)
- * ```
- */
-export function generateForwardRef(expr: o.Expression): o.Expression {
-  return o.importExpr(Identifiers.forwardRef).callFn([o.fn([], [new o.ReturnStatement(expr)])]);
 }

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -12,7 +12,7 @@ import * as o from '../../output/output_ast';
 import {ParseSourceSpan} from '../../parse_util';
 import * as t from '../r3_ast';
 import {R3DependencyMetadata} from '../r3_factory';
-import {R3Reference} from '../util';
+import {MaybeForwardRefExpression, R3Reference} from '../util';
 
 
 /**
@@ -302,7 +302,7 @@ export interface R3QueryMetadata {
    * Either an expression representing a type or `InjectionToken` for the query
    * predicate, or a set of string selectors.
    */
-  predicate: o.Expression|string[];
+  predicate: MaybeForwardRefExpression|string[];
 
   /**
    * Whether to include only direct children or all descendants.

--- a/packages/core/test/render3/jit/declare_directive_spec.ts
+++ b/packages/core/test/render3/jit/declare_directive_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ElementRef, ɵɵngDeclareDirective} from '@angular/core';
+import {ElementRef, forwardRef, ɵɵngDeclareDirective} from '@angular/core';
 import {AttributeMarker, DirectiveDef} from '../../../src/render3';
 import {functionContaining} from './matcher';
 
@@ -118,6 +118,27 @@ describe('directive declaration jit compilation', () => {
     });
   });
 
+  it('should compile content queries with forwardRefs', () => {
+    const def = ɵɵngDeclareDirective({
+                  type: TestClass,
+                  queries: [
+                    {
+                      propertyName: 'byRef',
+                      predicate: forwardRef(() => Child),
+                    },
+                  ],
+                }) as DirectiveDef<TestClass>;
+
+    class Child {}
+
+    expectDirectiveDef(def, {
+      contentQueries: functionContaining([
+        /contentQuery[^(]*\(dirIndex,[^,]*resolveForwardRef[^,]*forward_ref[^,]*,[\s]*4\)/,
+        '(ctx.byRef = _t)',
+      ]),
+    });
+  });
+
   it('should compile view queries', () => {
     const def = ɵɵngDeclareDirective({
                   type: TestClass,
@@ -152,6 +173,27 @@ describe('directive declaration jit compilation', () => {
         // NOTE: the `anonymous` match is to support IE11, as functions don't have a name there.
         /(?:viewQuery|anonymous)[^(]*\([^,]*String[^,]*,3,[^)]*ElementRef[^)]*\)/,
         '(ctx.byToken = _t.first)',
+      ]),
+    });
+  });
+
+  it('should compile view queries with forwardRefs', () => {
+    const def = ɵɵngDeclareDirective({
+                  type: TestClass,
+                  viewQueries: [
+                    {
+                      propertyName: 'byRef',
+                      predicate: forwardRef(() => Child),
+                    },
+                  ],
+                }) as DirectiveDef<TestClass>;
+
+    class Child {}
+
+    expectDirectiveDef(def, {
+      viewQuery: functionContaining([
+        /viewQuery[^(]*\([^,]*resolveForwardRef[^,]*forward_ref[^,]*,[\s]*4\)/,
+        '(ctx.byRef = _t)',
       ]),
     });
   });


### PR DESCRIPTION
When a partially compiled component or directive is "linked" in JIT mode, the body
of its declaration is evaluated by the JavaScript runtime. If a class is referenced
in a query (e.g. `ViewQuery` or `ContentQuery`) but its definition is later in the
file, then the reference must be wrapped in a `forwardRef()` call.

Previously, query predicates were not wrapped correctly in partial declarations
causing the code to crash at runtime. In AOT mode, this code is never evaluated
but instead transformed as part of the build, so this bug did not become apparent
until Angular Material started running JIT mode tests on its distributable output.

This change fixes this problem by noting when queries are wrapped in `forwardRef()`
calls and ensuring that this gets passed through to partial compilation declarations
and then suitably stripped during linking.

See https://github.com/angular/components/pull/23882 and https://github.com/angular/components/issues/23907

**Unfortunately, any libraries that were published before this gets merged will potentially have the problem going forward, if they have forwardRefs in their query definitions. The resolution it to simply build and release a new version. With that in mind, it might be worth landing this in 12.2.x LTS as well.**