### PR TITLE
build(docs-infra): remove unnecessary work-around for SW config generation

### DIFF
--- a/aio/ngsw-config.template.json
+++ b/aio/ngsw-config.template.json
@@ -13,10 +13,7 @@
           "/assets/images/favicons/favicon.ico",
           "/assets/js/*.js",
           "/*.css",
-          "/*.js",
-          "!/ngsw-worker.js",
-          "!/safety-worker.js",
-          "!/worker-basic.min.js"
+          "/*.js"
         ],
         "urls": [
           "https://fonts.googleapis.com/**",

--- a/aio/package.json
+++ b/aio/package.json
@@ -74,7 +74,7 @@
     "~~clean-generated": "node --eval \"require('shelljs').rm('-rf', 'src/generated')\"",
     "pre~~build": "node scripts/build-ngsw-config",
     "~~build": "ng build --configuration=stable",
-    "post~~build": "yarn build-404-page && ngsw-config dist src/generated/ngsw-config.json",
+    "post~~build": "yarn build-404-page",
     "~~light-server": "light-server --bind=localhost --historyindex=/index.html --no-reload"
   },
   "//engines-comment": "If applicable, also update /package.json and /aio/tools/examples/shared/package.json",


### PR DESCRIPTION
Since angular.io is now updated to a version that includes the fix from #43679, the work-around added in 841c5aebbfc7f40fdf838cc3e73395cf8b94bdf9 can now be removed.
