### PR TITLE
fix(docs-infra): fix aio homepage breaking on certain widths

### DIFF
--- a/aio/src/styles/1-layouts/footer/_footer.scss
+++ b/aio/src/styles/1-layouts/footer/_footer.scss
@@ -82,7 +82,7 @@ footer {
         }
       }
 
-      @media (max-width: 480px) {
+      @media (max-width: 40rem) {
         flex-direction: column;
 
         .footer-block {

--- a/aio/src/styles/1-layouts/footer/_footer.scss
+++ b/aio/src/styles/1-layouts/footer/_footer.scss
@@ -82,7 +82,7 @@ footer {
         }
       }
 
-      @media (max-width: 40rem) {
+      @media (max-width: 32rem) {
         flex-direction: column;
 
         .footer-block {

--- a/aio/src/styles/1-layouts/marketing-layout/_marketing-layout.scss
+++ b/aio/src/styles/1-layouts/marketing-layout/_marketing-layout.scss
@@ -41,7 +41,8 @@ section#intro {
   display: flex;
   align-items: center;
   position: relative;
-  width: 900px;
+  max-width: 900px;
+  width: 100%;
   height: 480px;
   margin: 0 auto -32px;
   padding: 48px 0 0;
@@ -50,11 +51,9 @@ section#intro {
     background-image: url(/assets/images/logos/angular/angular.svg);
   }
 
-  @media (max-width: 780px) {
+  @media (max-width: 65rem) {
     flex-direction: column;
     justify-content: center;
-    width: 100%;
-    max-width: 100vw;
     padding: 40px 0 32px;
 
     button {
@@ -71,7 +70,7 @@ section#intro {
     padding-top: 0;
     padding-bottom: 0;
 
-    @media  (max-width: 780px) {
+    @media  (max-width: 65rem) {
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -91,7 +90,7 @@ section#intro {
       display: none;
     }
 
-    @media (max-width: 780px) {
+    @media (max-width: 65rem) {
       text-align: center;
     }
 

--- a/aio/src/styles/1-layouts/marketing-layout/_marketing-layout.scss
+++ b/aio/src/styles/1-layouts/marketing-layout/_marketing-layout.scss
@@ -44,7 +44,7 @@ section#intro {
   max-width: 900px;
   width: 100%;
   height: 480px;
-  margin: 0 auto -32px;
+  margin: 0 auto;
   padding: 48px 0 0;
 
   .hero-logo {
@@ -240,9 +240,11 @@ section#intro {
 
   article {
     padding: 3rem;
+    padding-top: 0;
 
     @media (max-width: 800px) {
       padding: 2.2rem;
+      padding-top: 0;
     }
   }
 }


### PR DESCRIPTION
the aio homepage has a fixed width for its hero content,
that is not handling well certain window widths, fix that by removing
the fixed width and tweaking related media queries

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The aio homepage does handle well certain window widths:

![Peek 2021-11-09 22-05](https://user-images.githubusercontent.com/61631103/141016991-876cbfb4-ff30-4c02-8c50-baccf81d4a2e.gif)

## What is the new behavior?

The issue does not happen anymore and all window width's are handled

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

