### PR TITLE
feat(router): Add canDeactivateChild guard

### DIFF
--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -428,6 +428,7 @@ export interface Route {
     canActivate?: any[];
     canActivateChild?: any[];
     canDeactivate?: any[];
+    canDeactivateChild?: any[];
     canLoad?: any[];
     children?: Routes;
     component?: Type<any>;

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -439,6 +439,13 @@ export interface Route {
    */
   canDeactivate?: any[];
   /**
+   * An array of DI tokens used to look up `canDeactivate()`
+   * handlers for children's root, in order to determine if the current user is allowed to
+   * deactivate a child of the component. By default, any user can deactivate a child.
+   *
+   */
+  canDeactivateChild?: any[];
+  /**
    * An array of DI tokens used to look up `CanLoad()`
    * handlers, in order to determine if the current user is allowed to
    * load the component. By default, any user can load.

--- a/packages/router/src/utils/tree.ts
+++ b/packages/router/src/utils/tree.ts
@@ -98,12 +98,37 @@ export class TreeNode<T> {
 }
 
 // Return the list of T indexed by outlet name
-export function nodeChildrenAsMap<T extends {outlet: string}>(node: TreeNode<T>|null) {
+export function nodeChildrenAsMap < T extends {
+  outlet: string;
+  routeConfig?: {canDeactivateChild?: any[]; canDeactivate?: any[]}|null
+}
+> (node: TreeNode<T>|null) {
   const map: {[outlet: string]: TreeNode<T>} = {};
 
   if (node) {
-    node.children.forEach(child => map[child.value.outlet] = child);
+    node.children.forEach(child => {
+      generateChildConfigFromNode(child, node);
+      map[child.value.outlet] = child;
+    });
   }
 
   return map;
+}
+
+function generateChildConfigFromNode<
+    T extends {routeConfig?: {canDeactivateChild?: any[]; canDeactivate?: any[]} | null}>(
+    child: TreeNode<T>, node: TreeNode<T>) {
+  const canDeactivateChild =
+      node.value.routeConfig?.canDeactivateChild ? node.value.routeConfig.canDeactivateChild : [];
+  if (canDeactivateChild && canDeactivateChild.length > 0) {
+    child.value.routeConfig = {
+      ...child.value.routeConfig,
+      canDeactivateChild: child.value.routeConfig?.canDeactivateChild ?
+          [...child.value.routeConfig.canDeactivateChild, ...canDeactivateChild] :
+          canDeactivateChild,
+      canDeactivate: child.value.routeConfig?.canDeactivate ?
+          [...child.value.routeConfig.canDeactivate, ...canDeactivateChild] :
+          canDeactivateChild
+    };
+  }
 }


### PR DESCRIPTION
Add `canDeactivateChild` to determine if the current user is allowed to deactivate a child of the root.

resolves #11836

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
