### PR TITLE
docs: updates typescript configuration file links

### DIFF
--- a/aio/content/guide/migration-update-module-and-target-compiler-options.md
+++ b/aio/content/guide/migration-update-module-and-target-compiler-options.md
@@ -2,7 +2,7 @@
 
 ## What does this migration do?
 
-This migration adjusts the [`target`](https://www.typescriptlang.org/v2/en/tsconfig#target) and [`module`](https://www.typescriptlang.org/v2/en/tsconfig#module) settings within the [TypeScript configuration files](guide/typescript-configuration) for the workspace.
+This migration adjusts the [`target`](https://www.typescriptlang.org/tsconfig#target) and [`module`](https://www.typescriptlang.org/tsconfig#module) settings within the [TypeScript configuration files](guide/typescript-configuration) for the workspace.
 The changes to each option vary based on the builder or command that uses the TypeScript configuration file.
 Unless otherwise noted, changes are only made if the existing value was not changed since the project was created.
 This process helps ensure that intentional changes to the options are kept in place.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The links for 
The links for `tsconfig.json` target and module sections no longer valid in [Angular docs](https://angular.io/guide/migration-update-module-and-target-compiler-options). 
Issue Number: N/A


## What is the new behavior?
This commit updates the document with correct links

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
