### PR TITLE
build: update to latest @angular/dev-infra-private to address issues related to verifying environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
   },
   "// 2": "devDependencies are not used under Bazel. Many can be removed after test.sh is deleted.",
   "devDependencies": {
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#3fa82dcb0d0a6edd2c3653b7d4582714c1cebb7b",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#2cfe4b98a157927b319a3a00b467ff6233dc3337",
     "@bazel/bazelisk": "^1.7.5",
     "@bazel/buildifier": "^4.0.1",
     "@bazel/ibazel": "^0.15.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,9 +225,9 @@
   dependencies:
     tslib "^2.0.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#3fa82dcb0d0a6edd2c3653b7d4582714c1cebb7b":
-  version "0.0.0"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#3fa82dcb0d0a6edd2c3653b7d4582714c1cebb7b"
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#2cfe4b98a157927b319a3a00b467ff6233dc3337":
+  version "0.0.0-0474a28f6c7dbc47b8075e78223b2eeb8cd37c2e"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#2cfe4b98a157927b319a3a00b467ff6233dc3337"
   dependencies:
     "@actions/core" "^1.4.0"
     "@actions/github" "^5.0.0"
@@ -252,6 +252,7 @@
     "@rollup/plugin-commonjs" "^21.0.0"
     "@rollup/plugin-node-resolve" "^13.0.4"
     "@types/tmp" "^0.2.1"
+    "@yarnpkg/lockfile" "^1.1.0"
     chalk "^4.1.0"
     clang-format "^1.4.0"
     cli-progress "^3.7.0"


### PR DESCRIPTION
Update to the latest package which properly checks if the running version of ng-dev is the version
described in yarn lock.
