### PR TITLE
build: add instructions for getting Angular version for bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yaml
@@ -59,7 +59,7 @@ body:
   - type: textarea
     id: environment
     attributes:
-      label: Please provide the environment you discovered this bug in
+      label: Please provide the environment you discovered this bug in (run `ng version`)
       render: true
       placeholder: |
         Angular CLI: 12.0.5


### PR DESCRIPTION
The template asked for the Angular version but did not say how to get it.

Closes #44158

