### PR TITLE
refactor(forms): update required validator and checkbox validator to inherit abstractValidator

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -695,9 +695,8 @@ export class ReactiveFormsModule {
 // @public
 export class RequiredValidator extends AbstractValidatorDirective {
     // (undocumented)
-    enabled(): boolean;
-    get required(): boolean;
-    set required(value: boolean | string);
+    enabled(input: boolean): boolean;
+    required: boolean | string;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<RequiredValidator, ":not([type=checkbox])[required][formControlName],:not([type=checkbox])[required][formControl],:not([type=checkbox])[required][ngModel]", never, { "required": "required"; }, {}, never>;
     // (undocumented)

--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -167,7 +167,6 @@ export class CheckboxControlValueAccessor extends BuiltInControlValueAccessor im
 
 // @public
 export class CheckboxRequiredValidator extends RequiredValidator {
-    validate(control: AbstractControl): ValidationErrors | null;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<CheckboxRequiredValidator, "input[type=checkbox][required][formControlName],input[type=checkbox][required][formControl],input[type=checkbox][required][ngModel]", never, {}, {}, never>;
     // (undocumented)
@@ -694,11 +693,11 @@ export class ReactiveFormsModule {
 }
 
 // @public
-export class RequiredValidator implements Validator {
-    registerOnValidatorChange(fn: () => void): void;
-    get required(): boolean | string;
+export class RequiredValidator extends AbstractValidatorDirective {
+    // (undocumented)
+    enabled(): boolean;
+    get required(): boolean;
     set required(value: boolean | string);
-    validate(control: AbstractControl): ValidationErrors | null;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<RequiredValidator, ":not([type=checkbox])[required][formControlName],:not([type=checkbox])[required][formControl],:not([type=checkbox])[required][ngModel]", never, { "required": "required"; }, {}, never>;
     // (undocumented)

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -52,8 +52,8 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 162121,
-        "polyfills": 37206
+        "main": 163160,
+        "polyfills": 36975
       }
     }
   },

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -30,6 +30,9 @@
     "name": "AbstractFormGroupDirective"
   },
   {
+    "name": "AbstractValidatorDirective"
+  },
+  {
     "name": "AnonymousSubject"
   },
   {
@@ -1311,6 +1314,9 @@
     "name": "notFoundValueOrThrow"
   },
   {
+    "name": "nullValidator"
+  },
+  {
     "name": "observable"
   },
   {
@@ -1399,6 +1405,9 @@
   },
   {
     "name": "renderView"
+  },
+  {
+    "name": "requiredValidator"
   },
   {
     "name": "resetPreOrderHookFlags"

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -15,22 +15,33 @@ import {emailValidator, maxLengthValidator, maxValidator, minLengthValidator, mi
 /**
  * Method that updates string to integer if not already a number
  *
- * @param value The value to convert to integer
- * @returns value of parameter in number or integer.
+ * @param value The value to convert to integer.
+ * @returns value of parameter converted to number or integer.
  */
 function toInteger(value: string|number): number {
   return typeof value === 'number' ? value : parseInt(value, 10);
 }
 
 /**
+ * Method that converts null, false or 'false' string to boolean.
+ *
+ * @param value input value.
+ * @returns value of parameter converted to boolean.
+ */
+function toBoolean(input: unknown): boolean {
+  return input != null && input !== false && `${input}` !== 'false';
+}
+
+/**
  * Method that ensures that provided value is a float (and converts it to float if needed).
  *
- * @param value The value to convert to float
- * @returns value of parameter in number or float.
+ * @param value The value to convert to float.
+ * @returns value of parameter converted to number or float.
  */
 function toFloat(value: string|number): number {
   return typeof value === 'number' ? value : parseFloat(value);
 }
+
 /**
  * @description
  * Defines the map of errors returned from failed validation checks.
@@ -356,41 +367,34 @@ export const CHECKBOX_REQUIRED_VALIDATOR: StaticProvider = {
   selector:
       ':not([type=checkbox])[required][formControlName],:not([type=checkbox])[required][formControl],:not([type=checkbox])[required][ngModel]',
   providers: [REQUIRED_VALIDATOR],
-  host: {'[attr.required]': 'required ? "" : null'}
+  host: {'[attr.required]': 'enabled() ? "" : null'}
 })
-export class RequiredValidator implements Validator {
+export class RequiredValidator extends AbstractValidatorDirective {
   private _required = false;
-  private _onChange?: () => void;
-
   /**
    * @description
    * Tracks changes to the required attribute bound to this directive.
    */
   @Input()
-  get required(): boolean|string {
+  get required(): boolean {
     return this._required;
   }
 
   set required(value: boolean|string) {
-    this._required = value != null && value !== false && `${value}` !== 'false';
-    if (this._onChange) this._onChange();
+    this._required = toBoolean(value);
   }
 
-  /**
-   * Method that validates whether the control is empty.
-   * Returns the validation result if enabled, otherwise null.
-   * @nodoc
-   */
-  validate(control: AbstractControl): ValidationErrors|null {
-    return this.required ? requiredValidator(control) : null;
-  }
+  /** @internal */
+  override inputName = 'required';
 
-  /**
-   * Registers a callback function to call when the validator inputs change.
-   * @nodoc
-   */
-  registerOnValidatorChange(fn: () => void): void {
-    this._onChange = fn;
+  /** @internal */
+  override normalizeInput = (input: unknown) => input;
+
+  /** @internal */
+  override createValidator = (input: unknown): ValidatorFn => requiredValidator;
+
+  override enabled(): boolean {
+    return this.required;
   }
 }
 
@@ -420,17 +424,11 @@ export class RequiredValidator implements Validator {
   selector:
       'input[type=checkbox][required][formControlName],input[type=checkbox][required][formControl],input[type=checkbox][required][ngModel]',
   providers: [CHECKBOX_REQUIRED_VALIDATOR],
-  host: {'[attr.required]': 'required ? "" : null'}
+  host: {'[attr.required]': 'enabled() ? "" : null'}
 })
 export class CheckboxRequiredValidator extends RequiredValidator {
-  /**
-   * Method that validates whether or not the checkbox has been checked.
-   * Returns the validation result if enabled, otherwise null.
-   * @nodoc
-   */
-  override validate(control: AbstractControl): ValidationErrors|null {
-    return this.required ? requiredTrueValidator(control) : null;
-  }
+  /** @internal */
+  override createValidator = (input: unknown): ValidatorFn => requiredTrueValidator;
 }
 
 /**

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -367,35 +367,27 @@ export const CHECKBOX_REQUIRED_VALIDATOR: StaticProvider = {
   selector:
       ':not([type=checkbox])[required][formControlName],:not([type=checkbox])[required][formControl],:not([type=checkbox])[required][ngModel]',
   providers: [REQUIRED_VALIDATOR],
-  host: {'[attr.required]': 'enabled() ? "" : null'}
+  host: {'[attr.required]': '_enabled ? "" : null'}
 })
 export class RequiredValidator extends AbstractValidatorDirective {
-  private _required = false;
   /**
    * @description
    * Tracks changes to the required attribute bound to this directive.
    */
-  @Input()
-  get required(): boolean {
-    return this._required;
-  }
-
-  set required(value: boolean|string) {
-    this._required = toBoolean(value);
-  }
+  @Input() required!: boolean|string;
 
   /** @internal */
   override inputName = 'required';
 
   /** @internal */
-  override normalizeInput = (input: unknown) => input;
+  override normalizeInput = (input: unknown): boolean => toBoolean(input);
 
   /** @internal */
-  override createValidator = (input: unknown): ValidatorFn => requiredValidator;
+  override createValidator = (input: boolean): ValidatorFn => requiredValidator;
 
   /** @nodoc */
-  override enabled(): boolean {
-    return this.required;
+  override enabled(input: boolean): boolean {
+    return input;
   }
 }
 
@@ -425,7 +417,7 @@ export class RequiredValidator extends AbstractValidatorDirective {
   selector:
       'input[type=checkbox][required][formControlName],input[type=checkbox][required][formControl],input[type=checkbox][required][ngModel]',
   providers: [CHECKBOX_REQUIRED_VALIDATOR],
-  host: {'[attr.required]': 'enabled() ? "" : null'}
+  host: {'[attr.required]': '_enabled ? "" : null'}
 })
 export class CheckboxRequiredValidator extends RequiredValidator {
   /** @internal */

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -393,6 +393,7 @@ export class RequiredValidator extends AbstractValidatorDirective {
   /** @internal */
   override createValidator = (input: unknown): ValidatorFn => requiredValidator;
 
+  /** @nodoc */
   override enabled(): boolean {
     return this.required;
   }

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -2268,6 +2268,21 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
         expect(checkbox.nativeElement.checked).toBe(true);
         expect(control.hasError('required')).toEqual(false);
+
+        checkbox.nativeElement.required = false;
+        dispatchEvent(checkbox.nativeElement, 'change');
+        fixture.detectChanges();
+
+        expect(checkbox.nativeElement.checked).toBe(true);
+        expect(control.hasError('required')).toEqual(false);
+
+        checkbox.nativeElement.checked = false;
+        checkbox.nativeElement.required = true;
+        dispatchEvent(checkbox.nativeElement, 'change');
+        fixture.detectChanges();
+
+        expect(checkbox.nativeElement.checked).toBe(false);
+        expect(control.hasError('required')).toEqual(true);
       });
 
       // Note: this scenario goes against validator function rules were `null` is the only

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -1315,6 +1315,14 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
            expect(input.nativeElement.checked).toBe(false);
            expect(control.hasError('required')).toBe(true);
+
+           fixture.componentInstance.required = false;
+           dispatchEvent(input.nativeElement, 'change');
+           fixture.detectChanges();
+           tick();
+
+           expect(input.nativeElement.checked).toBe(false);
+           expect(control.hasError('required')).toBe(false);
          }));
 
       it('should validate email', fakeAsync(() => {


### PR DESCRIPTION

Modified required validator and checkbox validator to inherit abstractValidator.

For every validato type different PR will be raised as discussed in #42378.

Closes #42267

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #42378


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
