### PR TITLE
fix(compiler-cli): interpret string concat calls

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/builtin.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/builtin.ts
@@ -9,7 +9,7 @@
 import ts from 'typescript';
 
 import {DynamicValue} from './dynamic';
-import {KnownFn, ResolvedValue, ResolvedValueArray} from './result';
+import {EnumValue, KnownFn, ResolvedValue, ResolvedValueArray} from './result';
 
 export class ArraySliceBuiltinFn extends KnownFn {
   constructor(private lhs: ResolvedValueArray) {
@@ -39,6 +39,29 @@ export class ArrayConcatBuiltinFn extends KnownFn {
         result.push(...arg);
       } else {
         result.push(arg);
+      }
+    }
+    return result;
+  }
+}
+
+export class StringConcatBuiltinFn extends KnownFn {
+  constructor(private lhs: string) {
+    super();
+  }
+
+  override evaluate(node: ts.CallExpression, args: ResolvedValueArray): ResolvedValue {
+    let result = this.lhs;
+    for (const arg of args) {
+      const resolved = arg instanceof EnumValue ? arg.resolved : arg;
+
+      if (typeof resolved === 'string' || typeof resolved === 'number' ||
+          typeof resolved === 'boolean' || resolved == null) {
+        // Cast to `any`, because `concat` will convert
+        // anything to a string, but TS only allows strings.
+        result = result.concat(resolved as any);
+      } else {
+        return DynamicValue.fromUnknown(node);
       }
     }
     return result;

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -14,7 +14,7 @@ import {DependencyTracker} from '../../incremental/api';
 import {Declaration, DeclarationKind, DeclarationNode, EnumMember, FunctionDefinition, isConcreteDeclaration, ReflectionHost, SpecialDeclarationKind} from '../../reflection';
 import {isDeclaration} from '../../util/src/typescript';
 
-import {ArrayConcatBuiltinFn, ArraySliceBuiltinFn} from './builtin';
+import {ArrayConcatBuiltinFn, ArraySliceBuiltinFn, StringConcatBuiltinFn} from './builtin';
 import {DynamicValue} from './dynamic';
 import {ForeignFunctionResolver} from './interface';
 import {resolveKnownDeclaration} from './known_declaration';
@@ -399,6 +399,8 @@ export class StaticInterpreter {
         return DynamicValue.fromInvalidExpressionType(node, rhs);
       }
       return lhs[rhs];
+    } else if (typeof lhs === 'string' && rhs === 'concat') {
+      return new StringConcatBuiltinFn(lhs);
     } else if (lhs instanceof Reference) {
       const ref = lhs.node;
       if (this.host.isClass(ref)) {

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -533,6 +533,17 @@ runInEachFileSystem(() => {
           .toBe('a.test.b');
     });
 
+    it('string `concat` function works', () => {
+      expect(evaluate(`const a = '12', b = '34';`, 'a[\'concat\'](b)')).toBe('1234');
+      expect(evaluate(`const a = '12', b = '3';`, 'a[\'concat\'](b)')).toBe('123');
+      expect(evaluate(`const a = '12', b = '3', c = '45';`, 'a[\'concat\'](b,c)')).toBe('12345');
+      expect(
+          evaluate(`const a = '1', b = 2, c = '3', d = true, e = null;`, 'a[\'concat\'](b,c,d,e)'))
+          .toBe('123truenull');
+      expect(evaluate('enum Test { VALUE = "test" };', '"a."[\'concat\'](Test.VALUE, ".b")'))
+          .toBe('a.test.b');
+    });
+
     it('should resolve non-literals as dynamic string', () => {
       const value = evaluate(`const a: any = [];`, '`a.${a}.b`');
 


### PR DESCRIPTION
These changes add support for interpreting `String.prototype.concat` calls. We need to support it, because in TypeScript 4.5 string template expressions are transpiled to `concat` calls, rather than string concatenations. See https://github.com/microsoft/TypeScript/pull/45304.