### PR TITLE
fix(http): split headers by comma

### DIFF
--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright Google LLC All Rights Reserved.
+ * Copyright Google LLC. All Rights Reserved.
  *
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
@@ -132,7 +132,8 @@ export class HttpHeaders {
   getAll(name: string): string[]|null {
     this.init();
 
-    return this.headers.get(name.toLowerCase()) || null;
+    return this.headers.get(name.toLowerCase())?.flatMap(v => v.split(',')).map(v => v.trim()) ||
+        null;
   }
 
   /**

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -138,6 +138,13 @@ import {HttpHeaders} from '@angular/common/http/src/headers';
         expect(headers.get('Transfer-Encoding')).toEqual('chunked');
         expect(headers.get('Connection')).toEqual('keep-alive');
       });
+
+      it('should be split by comma', () => {
+        const response = `X-My-Custom-Header: value1, value2`;
+        const headers = new HttpHeaders(response);
+        expect(headers.getAll('X-My-Custom-Header')).toEqual(['value1', 'value2']);
+        expect(headers.get('X-My-Custom-Header')).toEqual('value1, value2');
+      });
     });
   });
 }


### PR DESCRIPTION
to match rfc7230 3.2.2 header fields with same name are split by ","

Closes fixes #44149

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #44149 


## What is the new behavior?
Headers are split by "," to match spec

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
