### PR TITLE
docs: add dynamic `import()` ES module change to v13 release notes

### DIFF
--- a/aio/content/guide/update-to-latest-version.md
+++ b/aio/content/guide/update-to-latest-version.md
@@ -58,6 +58,7 @@ For information about the deprecation and removal practices of Angular, see [Ang
 | [PR&nbsp;#43507][GithubAngularAngularPull43507]     | The `WrappedValue` class is no longer imported from `@angular/core`. This change may result in compile errors or failures at runtime, if outdated libraries are used that rely on `WrappedValue`. Dependancy on `WrappedValue` should be removed since no replacement is available.                                                                                                                                                                                                                                                                                                                                                                                                      |
 | [PR&nbsp;#43591][GithubAngularAngularPull43591]     | It is no longer possible to use `Route.loadChildren` with a string value. The following supporting classes were removed from `@angular/core`: <ul><li><code>NgModuleFactoryLoader</code></li><li><code>SystemJsNgModuleFactoryLoader</code></li></ul> The `@angular/router` package no longer exports the following symbols: <ul><li><code>SpyNgModuleFactoryLoader</code></li><li><code>DeprecatedLoadChildren</code></li></ul> The signature of the `setupTestingRouter` function from `@angular/core/testing` was changed to drop the `NgModuleFactoryLoader` parameter, since an value for that parameter can not be created.                                                        |
 | [PR&nbsp;#43668][GithubAngularAngularPull43668]     | The return type of `SwUpdate#activateUpdate` and `SwUpdate#checkForUpdate` changed to `Promise<boolean>`.<br />Although unlikely, this change may cause TypeScript type-checking to fail in some cases. If necessary, update your types to account for the new return type.                                                                                                                                                                                                                                                                                                                                                                                                              |
+| [Issue&nbsp;#22159][GithubAngularCliIssue22159]     | Scripts that load via dynamic `import()` are now treated as ES modules (meaning they must be strict mode-compatible). |
 
 ### New deprecations
 
@@ -132,6 +133,7 @@ For information about the deprecation and removal practices of Angular, see [Ang
 [GithubAngularAngularPull43740]: https://github.com/angular/angular/pull/43740 "feat(bazel): expose esm2020 and es2020 conditions in APF package exports #43740 | angular/angular | GitHub"
 
 [GithubAngularAngularCliIssues21545]: https://github.com/angular/angular-cli/issues/21545 "[RFC] Persistent build cache by default #21545 | angular/angular-cli | GitHub"
+[GithubAngularAngularCliIssues22159]: https://github.com/angular/angular-cli/issues/22159 "Script imports are modules by default #22159 | angular/angular-cli | GitHub"
 
 <!-- end links -->
 


### PR DESCRIPTION
Closes angular/angular-cli#22159.

See: https://github.com/angular/angular-cli/issues/22159#issuecomment-969251924

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Documentation content changes

## What is the current behavior?

v13 introduced a small change by requiring that dynamic `import()` statements are actual ES modules and executed with strict mode. It has always been expected that such scripts would be ES modules, but it wasn't enforced until v13.

## What is the new behavior?

Dynamic `import()` scripts are now treated as real ES modules and executed in strict mode.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
