### PR TITLE
fix(forms): make the `FormControlStatus` available as a public API

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -362,6 +362,9 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
 }
 
 // @public
+export type FormControlStatus = 'VALID' | 'INVALID' | 'PENDING' | 'DISABLED';
+
+// @public
 export class FormGroup extends AbstractControl {
     constructor(controls: {
         [key: string]: AbstractControl;

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -38,14 +38,12 @@ export {RangeValueAccessor} from './directives/range_value_accessor';
 export {FormControlDirective} from './directives/reactive_directives/form_control_directive';
 export {FormControlName} from './directives/reactive_directives/form_control_name';
 export {FormGroupDirective} from './directives/reactive_directives/form_group_directive';
-export {FormArrayName} from './directives/reactive_directives/form_group_name';
-export {FormGroupName} from './directives/reactive_directives/form_group_name';
+export {FormArrayName, FormGroupName} from './directives/reactive_directives/form_group_name';
 export {NgSelectOption, SelectControlValueAccessor} from './directives/select_control_value_accessor';
-export {SelectMultipleControlValueAccessor} from './directives/select_multiple_control_value_accessor';
-export {ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
+export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup} from './model';
+export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlStatus, FormGroup} from './model';
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';
 export {VERSION} from './version';
 


### PR DESCRIPTION
This commit makes the `FormControlStatus` symbol available as a public API. The symbol itself
was intended to become a part of the public API, but due to the missing re-export, the symbol
remains private.

Fixes #44176.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No