### PR TITLE
refactor(elements): remove non-existent schematic collection breaking with `ng add`

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -22,6 +22,5 @@
   "ng-update": {
     "packageGroup": "NG_UPDATE_PACKAGE_GROUP"
   },
-  "sideEffects": false,
-  "schematics": "./schematics/collection.json"
+  "sideEffects": false
 }


### PR DESCRIPTION
Removes a non-existent schematic collection wired up for
`@angular/elements` that has been removed
with: https://github.com/angular/angular/commit/619b7cc3857b34598a0036f8ebf9bc2eb27f5507.

Fixes #44160.