### PR TITLE
refactor(router): avoid using deprecated `Compiler` symbol in Router

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1452,6 +1452,9 @@
     "name": "isNameOnlyAttributeMarker"
   },
   {
+    "name": "isNgModuleFactory"
+  },
+  {
     "name": "isNodeMatchingSelector"
   },
   {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -585,10 +585,11 @@ export class Router {
   /**
    * Creates the router service.
    */
-  // TODO: vsavkin make internal after the final is out.
   constructor(
       private rootComponentType: Type<any>|null, private urlSerializer: UrlSerializer,
       private rootContexts: ChildrenOutletContexts, private location: Location, injector: Injector,
+      // Note: the `compiler` argument is unused, but dropping it would be a breaking change.
+      // TODO: remove the `compiler` argument in the next major release (v14).
       compiler: Compiler, public config: Routes) {
     const onLoadStart = (r: Route) => this.triggerEvent(new RouteConfigLoadStart(r));
     const onLoadEnd = (r: Route) => this.triggerEvent(new RouteConfigLoadEnd(r));
@@ -603,7 +604,7 @@ export class Router {
     this.rawUrlTree = this.currentUrlTree;
     this.browserUrlTree = this.currentUrlTree;
 
-    this.configLoader = new RouterConfigLoader(injector, compiler, onLoadStart, onLoadEnd);
+    this.configLoader = new RouterConfigLoader(injector, onLoadStart, onLoadEnd);
     this.routerState = createEmptyState(this.currentUrlTree, this.rootComponentType);
 
     this.transitions = new BehaviorSubject<NavigationTransition>({

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -77,12 +77,14 @@ export class RouterPreloader implements OnDestroy {
   private subscription?: Subscription;
 
   constructor(
+      // Note: the `compiler` argument is unused, but dropping it would be a breaking change.
+      // TODO: remove the `compiler` argument in the next major release (v14).
       private router: Router, compiler: Compiler, private injector: Injector,
       private preloadingStrategy: PreloadingStrategy) {
     const onStartLoad = (r: Route) => router.triggerEvent(new RouteConfigLoadStart(r));
     const onEndLoad = (r: Route) => router.triggerEvent(new RouteConfigLoadEnd(r));
 
-    this.loader = new RouterConfigLoader(injector, compiler, onStartLoad, onEndLoad);
+    this.loader = new RouterConfigLoader(injector, onStartLoad, onEndLoad);
   }
 
   setUpPreloading(): void {


### PR DESCRIPTION
The `Compiler` symbol was deprecated in v13 as a part of the factory-less cleanup in public APIs. This commit updates the logic inside of the Router package to avoid using it in favor of replacement API (the `createNgModuleRef` function).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No