### PR TITLE
fix(compiler): parse empty namespace as invalid

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -8,8 +8,8 @@
 
 import * as chars from '../chars';
 import {ParseError, ParseLocation, ParseSourceFile, ParseSourceSpan} from '../parse_util';
-import {NAMED_ENTITIES} from './entities';
 
+import {NAMED_ENTITIES} from './entities';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './interpolation_config';
 import {TagContentType, TagDefinition} from './tags';
 import {IncompleteTagOpenToken, TagOpenStartToken, Token, TokenType} from './tokens';
@@ -476,7 +476,7 @@ class _Tokenizer {
     this._endToken([content]);
   }
 
-  private _consumePrefixAndName(): string[] {
+  private _consumePrefixAndName(isTag: boolean = true): string[] {
     const nameOrPrefixStart = this._cursor.clone();
     let prefix: string = '';
     while (this._cursor.peek() !== chars.$COLON && !isPrefixEnd(this._cursor.peek())) {
@@ -485,7 +485,9 @@ class _Tokenizer {
     let nameStart: CharacterCursor;
     if (this._cursor.peek() === chars.$COLON) {
       prefix = this._cursor.getChars(nameOrPrefixStart);
-      this._cursor.advance();
+      if (!(prefix === '' && !isTag)) {
+        this._cursor.advance();
+      }
       nameStart = this._cursor.clone();
     } else {
       nameStart = nameOrPrefixStart;
@@ -573,7 +575,7 @@ class _Tokenizer {
       throw this._createError(_unexpectedCharacterErrorMsg(attrNameStart), this._cursor.getSpan());
     }
     this._beginToken(TokenType.ATTR_NAME);
-    const prefixAndName = this._consumePrefixAndName();
+    const prefixAndName = this._consumePrefixAndName(false);
     this._endToken(prefixAndName);
   }
 

--- a/packages/compiler/src/ml_parser/tags.ts
+++ b/packages/compiler/src/ml_parser/tags.ts
@@ -24,8 +24,11 @@ export interface TagDefinition {
   getContentType(prefix?: string): TagContentType;
 }
 
-export function splitNsName(elementName: string): [string|null, string] {
-  if (elementName[0] != ':') {
+export function splitNsName(
+    elementName: string, isElementName: boolean = true): [string|null, string] {
+  const isInvalidNamespace =
+      elementName.lastIndexOf(':') === 0 || (elementName.slice(0, 2) === '::');
+  if (elementName[0] !== ':' || (!isElementName && isInvalidNamespace)) {
     return [null, elementName];
   }
 

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -763,7 +763,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         const value = input.value.visit(this._valueConverter);
         if (value !== undefined) {
           const params: any[] = [];
-          const [attrNamespace, attrName] = splitNsName(input.name);
+          const [attrNamespace, attrName] = splitNsName(input.name, false);
           const isAttributeBinding = inputType === BindingType.Attribute;
           const sanitizationRef = resolveSanitizationFn(input.securityContext, isAttributeBinding);
           if (sanitizationRef) params.push(sanitizationRef);
@@ -1532,7 +1532,7 @@ function getLiteralFactory(
  * @param name Name of the attribute, including the namespace.
  */
 function getAttributeNameLiterals(name: string): o.LiteralExpr[] {
-  const [attributeNamespace, attributeName] = splitNsName(name);
+  const [attributeNamespace, attributeName] = splitNsName(name, false);
   const nameLiteral = o.literal(attributeName);
 
   if (attributeNamespace) {
@@ -1830,7 +1830,7 @@ export function createCssSelector(
   cssSelector.setElement(elementNameNoNs);
 
   Object.getOwnPropertyNames(attributes).forEach((name) => {
-    const nameNoNs = splitNsName(name)[1];
+    const nameNoNs = splitNsName(name, false)[1];
     const value = attributes[name];
 
     cssSelector.addAttribute(nameNoNs, value);

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -391,6 +391,14 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
           ]);
         });
 
+        it('should parse attributes when namespace is invalid', () => {
+          expect(humanizeDom(parser.parse('<svg:use :disabled="disabled" />', 'TestComp')))
+              .toEqual([
+                [html.Element, ':svg:use', 0],
+                [html.Attribute, ':disabled', 'disabled', ['disabled']],
+              ]);
+        });
+
         it('should support a prematurely terminated interpolation in attribute', () => {
           const {errors, rootNodes} = parser.parse('<div p="{{ abc"><span></span>', 'TestComp');
           expect(humanizeNodes(rootNodes, true)).toEqual([


### PR DESCRIPTION
when attribute begin with colon, it should not be parsed as namespace since namespce is empty

PR Close #44185

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
