### PR TITLE
ci: remove `cla/google` from required statues

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -113,7 +113,6 @@ merge:
       - 'ci/circleci: build'
       - 'ci/circleci: lint'
       - 'ci/angular: size'
-      - 'cla/google'
       - 'google3'
       - 'pullapprove'
 


### PR DESCRIPTION

The CLA tools no longer report statuses as it is being run as Github actions. 