### PR TITLE
docs: release notes for the v13.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="13.0.2"></a>
+# 13.0.2 (2021-11-17)
+
+This release contains various API docs improvements.
+
+## Special Thanks
+Andrew Kushnir, Armen Vardanyan, Dylan Hunn, Joey Perrott, Martin von Gagern, Paul Gschwendtner, Pete Bacon Darwin, Ramesh Thiruchelvam, dario-piotrowicz and fusho-takahashi
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="13.1.0-next.1"></a>
 # 13.1.0-next.1 (2021-11-10)
 ### compiler


### PR DESCRIPTION
Cherry-picks the changelog from the "13.0.x" branch to the next branch (master).