### PR TITLE
refactor(animations): improve some animations comments

### DIFF
--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -487,7 +487,8 @@ function normalizeSelector(selector: string): [string, boolean] {
     selector = selector.replace(SELF_TOKEN_REGEX, '');
   }
 
-  // the :enter and :leave selectors are filled in at runtime during timeline building
+  // Note: the :enter and :leave aren't normalized here since those
+  // selectors are filled in at runtime during timeline building
   selector = selector.replace(/@\*/g, NG_TRIGGER_SELECTOR)
                  .replace(/@\w+/g, match => NG_TRIGGER_SELECTOR + '-' + match.substr(1))
                  .replace(/:animating/g, NG_ANIMATING_SELECTOR);

--- a/packages/animations/browser/src/dsl/animation_timeline_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_builder.ts
@@ -57,14 +57,14 @@ const LEAVE_TOKEN_REGEX = new RegExp(LEAVE_TOKEN, 'g');
  * [TimelineBuilder]
  * This class is responsible for tracking the styles and building a series of keyframe objects for a
  * timeline between a start and end time. The builder starts off with an initial timeline and each
- * time the AST comes across a `group()`, `keyframes()` or a combination of the two wihtin a
+ * time the AST comes across a `group()`, `keyframes()` or a combination of the two within a
  * `sequence()` then it will generate a sub timeline for each step as well as a new one after
  * they are complete.
  *
  * As the AST is traversed, the timing state on each of the timelines will be incremented. If a sub
  * timeline was created (based on one of the cases above) then the parent timeline will attempt to
  * merge the styles used within the sub timelines into itself (only with group() this will happen).
- * This happens with a merge operation (much like how the merge works in mergesort) and it will only
+ * This happens with a merge operation (much like how the merge works in mergeSort) and it will only
  * copy the most recently used styles from the sub timelines into the parent timeline. This ensures
  * that if the styles are used later on in another phase of the animation then they will be the most
  * up-to-date values.
@@ -89,7 +89,7 @@ const LEAVE_TOKEN_REGEX = new RegExp(LEAVE_TOKEN, 'g');
  * from all previous keyframes up until where it is first used. For the timeline keyframe generation
  * to properly fill in the style it will place the previous value (the value from the parent
  * timeline) or a default value of `*` into the backFill object. Given that each of the keyframe
- * styles are objects that prototypically inhert from the backFill object, this means that if a
+ * styles are objects that prototypically inherits from the backFill object, this means that if a
  * value is added into the backFill then it will automatically propagate any missing values to all
  * keyframes. Therefore the missing `height` value will be properly filled into the already
  * processed keyframes.
@@ -228,7 +228,7 @@ export class AnimationTimelineBuilderVisitor implements AstVisitor {
     if (ast.steps.length) {
       ast.steps.forEach(s => visitDslNode(this, s, ctx));
 
-      // this is here just incase the inner steps only contain or end with a style() call
+      // this is here just in case the inner steps only contain or end with a style() call
       ctx.currentTimeline.applyStylesToKeyframe();
 
       // this means that some animation function within the sequence
@@ -567,7 +567,7 @@ export class AnimationTimelineContext {
     if (includeSelf) {
       results.push(this.element);
     }
-    if (selector.length > 0) {  // if :self is only used then the selector is empty
+    if (selector.length > 0) {  // only if :self is used then the selector can be empty
       selector = selector.replace(ENTER_TOKEN_REGEX, '.' + this._enterClassName);
       selector = selector.replace(LEAVE_TOKEN_REGEX, '.' + this._leaveClassName);
       const multi = limit != 1;
@@ -857,7 +857,7 @@ class SubTimelineBuilder extends TimelineBuilder {
         When the keyframe is stretched then it means that the delay before the animation
         starts is gone. Instead the first keyframe is placed at the start of the animation
         and it is then copied to where it starts when the original delay is over. This basically
-        means nothing animates during that delay, but the styles are still renderered. For this
+        means nothing animates during that delay, but the styles are still rendered. For this
         to work the original offset values that exist in the original keyframes must be "warped"
         so that they can take the new keyframe + delay into account.
 

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -244,7 +244,7 @@ export class AnimationTransitionNamespace {
       // only remove the player if it is queued on the EXACT same trigger/namespace
       // we only also deal with queued players here because if the animation has
       // started then we want to keep the player alive until the flush happens
-      // (which is where the previousPlayers are passed into the new palyer)
+      // (which is where the previousPlayers are passed into the new player)
       if (player.namespaceId == this.id && player.triggerName == triggerName && player.queued) {
         player.destroy();
       }
@@ -579,7 +579,7 @@ export class TransitionAnimationEngine {
       // the namespace list
       this.newHostElements.set(hostElement, ns);
 
-      // given that this host element is apart of the animation code, it
+      // given that this host element is a part of the animation code, it
       // may or may not be inserted by a parent node that is of an
       // animation renderer type. If this happens then we can still have
       // access to this item when we query for :enter nodes. If the parent
@@ -652,8 +652,8 @@ export class TransitionAnimationEngine {
     // normally there should only be one namespace per element, however
     // if @triggers are placed on both the component element and then
     // its host element (within the component code) then there will be
-    // two namespaces returned. We use a set here to simply the dedupe
-    // of namespaces incase there are multiple triggers both the elm and host
+    // two namespaces returned. We use a set here to simply deduplicate
+    // the namespaces in case (for the reason described above) there are multiple triggers
     const namespaces = new Set<AnimationTransitionNamespace>();
     const elementStates = this.statesByElement.get(element);
     if (elementStates) {
@@ -1008,10 +1008,10 @@ export class TransitionAnimationEngine {
           return;
         }
 
-        // even though the element may not be apart of the DOM, it may
-        // still be added at a later point (due to the mechanics of content
+        // even though the element may not be in the DOM, it may still
+        // be added at a later point (due to the mechanics of content
         // projection and/or dynamic component insertion) therefore it's
-        // important we still style the element.
+        // important to still style the element.
         if (nodeIsOrphaned) {
           player.onStart(() => eraseStyles(element, instruction.fromStyles));
           player.onDestroy(() => setStyles(element, instruction.toStyles));
@@ -1019,8 +1019,9 @@ export class TransitionAnimationEngine {
           return;
         }
 
-        // if a unmatched transition is queued to go then it SHOULD NOT render
-        // an animation and cancel the previously running animations.
+        // if an unmatched transition is queued and ready to go
+        // then it SHOULD NOT render an animation and cancel the
+        // previously running animations.
         if (entry.isFallbackTransition) {
           player.onStart(() => eraseStyles(element, instruction.fromStyles));
           player.onDestroy(() => setStyles(element, instruction.toStyles));
@@ -1028,11 +1029,11 @@ export class TransitionAnimationEngine {
           return;
         }
 
-        // this means that if a parent animation uses this animation as a sub trigger
-        // then it will instruct the timeline builder to not add a player delay, but
-        // instead stretch the first keyframe gap up until the animation starts. The
-        // reason this is important is to prevent extra initialization styles from being
-        // required by the user in the animation.
+        // this means that if a parent animation uses this animation as a sub-trigger
+        // then it will instruct the timeline builder not to add a player delay, but
+        // instead stretch the first keyframe gap until the animation starts. This is
+        // important in order to prevent extra initialization styles from being
+        // required by the user for the animation.
         instruction.timelines.forEach(tl => tl.stretchStartingKeyframe = true);
 
         subTimelines.append(element, instruction.timelines);
@@ -1078,10 +1079,10 @@ export class TransitionAnimationEngine {
     }
 
     const allPreviousPlayersMap = new Map<any, TransitionAnimationPlayer[]>();
-    // this map works to tell which element in the DOM tree is contained by
-    // which animation. Further down below this map will get populated once
-    // the players are built and in doing so it can efficiently figure out
-    // if a sub player is skipped due to a parent player having priority.
+    // this map tells us which element in the DOM tree is contained by
+    // which animation. Further down this map will get populated once
+    // the players are built and in doing so we can use it to efficiently
+    // figure out if a sub player is skipped due to a parent player having priority.
     const animationElementMap = new Map<any, any>();
     queuedInstructions.forEach(entry => {
       const element = entry.element;
@@ -1102,13 +1103,13 @@ export class TransitionAnimationEngine {
       });
     });
 
-    // this is a special case for nodes that will be removed (either by)
+    // this is a special case for nodes that will be removed either by
     // having their own leave animations or by being queried in a container
     // that will be removed once a parent animation is complete. The idea
     // here is that * styles must be identical to ! styles because of
     // backwards compatibility (* is also filled in by default in many places).
-    // Otherwise * styles will return an empty value or auto since the element
-    // that is being getComputedStyle'd will not be visible (since * = destination)
+    // Otherwise * styles will return an empty value or "auto" since the element
+    // passed to getComputedStyle will not be visible (since * === destination)
     const replaceNodes = allLeaveNodes.filter(node => {
       return replacePostStylesAsPre(node, allPreStyleElements, allPostStyleElements);
     });
@@ -1202,9 +1203,9 @@ export class TransitionAnimationEngine {
       }
     });
 
-    // find all of the sub players' corresponding inner animation player
+    // find all of the sub players' corresponding inner animation players
     subPlayers.forEach(player => {
-      // even if any players are not found for a sub animation then it
+      // even if no players are found for a sub animation it
       // will still complete itself after the next tick since it's Noop
       const playersForElement = skippedPlayersMap.get(player.element);
       if (playersForElement && playersForElement.length) {

--- a/packages/animations/src/animation_metadata.ts
+++ b/packages/animations/src/animation_metadata.ts
@@ -884,7 +884,7 @@ export function keyframes(steps: AnimationStyleMetadata[]): AnimationKeyframesSe
  * The animation steps run when the expression evaluates to true.
  *
  * - A state-change string takes the form "state1 => state2", where each side is a defined animation
- * state, or an asterix (*) to refer to a dynamic start or end state.
+ * state, or an asterisk (*) to refer to a dynamic start or end state.
  *   - The expression string can contain multiple comma-separated statements;
  * for example "state1 => state2, state3 => state4".
  *   - Special values `:enter` and `:leave` initiate a transition on the entry and exit states,

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -19,7 +19,7 @@ const DEFAULT_NAMESPACE_ID = 'id';
 const DEFAULT_COMPONENT_ID = '1';
 
 (function() {
-// these tests are only mean't to be run within the DOM (for now)
+// these tests are only meant to be run within the DOM (for now)
 if (isNode) return;
 
 describe('animation tests', function() {
@@ -3622,7 +3622,7 @@ describe('animation tests', function() {
       ]);
     });
 
-    it('should convert hyphenated properties to camelcase by default that are auto/pre style properties',
+    it('should convert hyphenated properties to camelCase by default that are auto/pre style properties',
        () => {
          @Component({
            selector: 'cmp',

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -30,8 +30,8 @@ export class AnimationRendererFactory implements RendererFactory2 {
   constructor(
       private delegate: RendererFactory2, private engine: AnimationEngine, private _zone: NgZone) {
     engine.onRemovalComplete = (element: any, delegate: Renderer2) => {
-      // Note: if an component element has a leave animation, and the component
-      // a host leave animation, the view engine will call `removeChild` for the parent
+      // Note: if a component element has a leave animation, and a host leave animation,
+      // the view engine will call `removeChild` for the parent
       // component renderer as well as for the child component renderer.
       // Therefore, we need to check if we already removed the element.
       if (delegate && delegate.parentNode(element)) {

--- a/packages/platform-browser/animations/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/test/animation_renderer_spec.ts
@@ -132,7 +132,7 @@ describe('AnimationRenderer', () => {
   });
 
   describe('flushing animations', () => {
-    // these tests are only mean't to be run within the DOM
+    // these tests are only meant to be run within the DOM
     if (isNode) return;
 
     it('should flush and fire callbacks when the zone becomes stable', (async) => {


### PR DESCRIPTION
Fix various typos and also improve sentences (by making them more clear
or grammatically correct) present in comments inside the animations package

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

- This is small unimportant stuff, I've just been readying through the animations package code and found various comments with typos and sentences that could be improved :slightly_smiling_face: 
