### PR TITLE
refactor(core): clean up isDevMode for tree-shaking

### DIFF
--- a/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
+++ b/packages/upgrade/src/dynamic/src/upgrade_adapter.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Compiler, CompilerOptions, Injector, isDevMode, NgModule, NgModuleRef, NgZone, resolveForwardRef, StaticProvider, Testability, Type} from '@angular/core';
+import {Compiler, CompilerOptions, Injector, NgModule, NgModuleRef, NgZone, resolveForwardRef, StaticProvider, Testability, Type} from '@angular/core';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 
 import {bootstrap, element as angularElement, IAngularBootstrapConfig, IAugmentedJQuery, IInjectorService, IModule, IProvideService, IRootScopeService, ITestabilityService, module_ as angularModule} from '../../common/src/angular1';
@@ -605,7 +605,7 @@ export class UpgradeAdapter {
                     let subscription = this.ngZone.onMicrotaskEmpty.subscribe({
                       next: () => {
                         if (rootScope.$$phase) {
-                          if (isDevMode()) {
+                          if (typeof ngDevMode === 'undefined' || ngDevMode) {
                             console.warn(
                                 'A digest was triggered while one was already in progress. This may mean that something is triggering digests outside the Angular zone.');
                           }

--- a/packages/upgrade/static/src/upgrade_module.ts
+++ b/packages/upgrade/static/src/upgrade_module.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, isDevMode, NgModule, NgZone, PlatformRef, Testability} from '@angular/core';
+import {Injector, NgModule, NgZone, PlatformRef, Testability} from '@angular/core';
 
 import {bootstrap, element as angularElement, IInjectorService, IIntervalService, IProvideService, ITestabilityService, module_ as angularModule} from '../../src/common/src/angular1';
 import {$$TESTABILITY, $DELEGATE, $INJECTOR, $INTERVAL, $PROVIDE, INJECTOR_KEY, LAZY_MODULE_REF, UPGRADE_APP_TYPE_KEY, UPGRADE_MODULE_NAME} from '../../src/common/src/constants';
@@ -279,7 +279,7 @@ export class UpgradeModule {
             setTimeout(() => {
               const subscription = this.ngZone.onMicrotaskEmpty.subscribe(() => {
                 if ($rootScope.$$phase) {
-                  if (isDevMode()) {
+                  if (typeof ngDevMode === 'undefined' || ngDevMode) {
                     console.warn(
                         'A digest was triggered while one was already in progress. This may mean that something is triggering digests outside the Angular zone.');
                   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`isDevMode` is used instead of checking for `ngDevMode`

Issue Number: N/A

## What is the new behavior?

Influenced by the pull request [44208](https://github.com/angular/angular/pull/44208) by @crisbeto removed usage of `isDevMode` with `ngDevMode` flag . This will helps to tree-shake dev-mode code from production builds.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
