### PR TITLE
fix(core): support cyclic metadata in TestBed overrides

### DIFF
--- a/packages/core/testing/src/metadata_overrider.ts
+++ b/packages/core/testing/src/metadata_overrider.ts
@@ -7,6 +7,7 @@
  */
 
 import {ɵstringify as stringify} from '@angular/core';
+
 import {MetadataOverride} from './metadata_override';
 
 type StringMap = {
@@ -89,8 +90,20 @@ function setMetadata(metadata: StringMap, set: any) {
 }
 
 function _propHashKey(propName: any, propValue: any, references: Map<any, string>): string {
+  let nextObjectId = 0;
+  const objectIds = new Map<object, string>();
   const replacer = (key: any, value: any) => {
-    if (typeof value === 'function') {
+    if (value !== null && typeof value === 'object') {
+      if (objectIds.has(value)) {
+        return objectIds.get(value);
+      }
+      // Record an id for this object such that any later references use the object's id instead
+      // of the object itself, in order to break cyclic pointers in objects.
+      objectIds.set(value, `ɵobj#${nextObjectId++}`);
+
+      // The first time an object is seen the object itself is serialized.
+      return value;
+    } else if (typeof value === 'function') {
       value = _serializeReference(value, references);
     }
     return value;


### PR DESCRIPTION
The TestBed APIs to override metadata would crash when the metadata
contained objects with cyclic references. Metadata overrides use the
JSON serialized representation of a value to compare objects, which
throws an error if the value has cyclic references. This commit avoids
the error by replacing multiple occurrences of the same object using
a unique string representation for the object.

Fixes #43948