### PR TITLE
refactor(core): make the error messages tree shakable

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4436,
-        "main": 459822,
+        "main": 459047,
         "polyfills": 37271,
         "styles": 70719,
         "light-theme": 77717,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,8 +3,8 @@
     "master": {
       "uncompressed": {
         "runtime": 1083,
-        "main": 138745,
-        "polyfills": 37226
+        "main": 138491,
+        "polyfills": 36964
       }
     }
   },
@@ -24,7 +24,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1105,
-        "main": 144744,
+        "main": 144185,
         "polyfills": 36939
       }
     }
@@ -33,7 +33,7 @@
     "master": {
       "uncompressed": {
         "runtime": 929,
-        "main": 137444,
+        "main": 136770,
         "polyfills": 37933
       }
     }
@@ -42,7 +42,7 @@
     "master": {
       "uncompressed": {
         "runtime": 2843,
-        "main": 231164,
+        "main": 230506,
         "polyfills": 37064,
         "src_app_lazy_lazy_module_ts": 795
       }
@@ -52,7 +52,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 164069,
+        "main": 163342,
         "polyfills": 36975
       }
     }

--- a/packages/core/src/render3/error_code.ts
+++ b/packages/core/src/render3/error_code.ts
@@ -13,6 +13,7 @@ export const enum RuntimeErrorCode {
 
   // Change Detection Errors
   EXPRESSION_CHANGED_AFTER_CHECKED = '100',
+  RECURSIVE_APPLICATION_REF_TICK = '101',
 
   // Dependency Injection Errors
   CYCLIC_DI_DEPENDENCY = '200',
@@ -24,7 +25,15 @@ export const enum RuntimeErrorCode {
   PIPE_NOT_FOUND = '302',
   UNKNOWN_BINDING = '303',
   UNKNOWN_ELEMENT = '304',
-  TEMPLATE_STRUCTURE_ERROR = '305'
+  TEMPLATE_STRUCTURE_ERROR = '305',
+
+  // Bootstrap Errors
+  MULTIPLE_PLATFORMS = '400',
+  PLATFORM_NOT_FOUND = '401',
+  ERROR_HANDLER_NOT_FOUND = '402',
+  BOOTSTRAP_COMPONENTS_NOT_FOUND = '403',
+  ALREADY_DESTROYED_PLATFORM = '404',
+  ASYNC_INITIALIZERS_STILL_RUNNING = '405',
 
   // Styling Errors
 

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -169,7 +169,7 @@ class SomeComponent {
         appRef.attachView(fixture.componentRef.hostView);
         appRef.tick();
         expect(fixture.componentInstance.reenterErr.message)
-            .toBe('ApplicationRef.tick is called recursively');
+            .toBe('NG0101: ApplicationRef.tick is called recursively');
       });
 
       describe('APP_BOOTSTRAP_LISTENER', () => {
@@ -207,7 +207,7 @@ class SomeComponent {
                  createRootEl();
                  expect(() => ref.bootstrap(SomeComponent))
                      .toThrowError(
-                         'Cannot bootstrap as there are still asynchronous initializers running. Bootstrap components in the `ngDoBootstrap` method of the root module.');
+                         'NG0405: Cannot bootstrap as there are still asynchronous initializers running. Bootstrap components in the `ngDoBootstrap` method of the root module.');
                })));
       });
     });
@@ -276,7 +276,8 @@ class SomeComponent {
            return defaultPlatform.bootstrapModule(EmptyModule)
                .then(() => fail('expecting error'), (error) => {
                  expect(error.message)
-                     .toEqual('No ErrorHandler. Is platform module (BrowserModule) included?');
+                     .toEqual(
+                         'NG0402: No ErrorHandler. Is platform module (BrowserModule) included?');
                });
          }));
 
@@ -303,7 +304,7 @@ class SomeComponent {
            defaultPlatform.bootstrapModule(createModule({ngDoBootstrap: false}))
                .then(() => expect(false).toBe(true), (e) => {
                  const expectedErrMsg =
-                     `The module MyModule was bootstrapped, but it does not declare "@NgModule.bootstrap" components nor a "ngDoBootstrap" method. Please define one of these.`;
+                     `NG0403: The module MyModule was bootstrapped, but it does not declare "@NgModule.bootstrap" components nor a "ngDoBootstrap" method. Please define one of these.`;
                  expect(e.message).toEqual(expectedErrMsg);
                  expect(mockConsole.res[0].join('#')).toEqual('ERROR#Error: ' + expectedErrMsg);
                });


### PR DESCRIPTION
Long error messages can be tree-shaken in the production build.
Doing this, we will keep the throw and remove the long error messages.

See: https://github.com/angular/angular/pull/44210#pullrequestreview-810615849

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Long error messages are not tree-shakable in the production build.

Issue Number: N/A

## What is the new behavior?
Long error messages are made tree-shakable in the production build based on the suggestion by @AndrewKushnir in PR [44210](https://github.com/angular/angular/pull/44210#pullrequestreview-810615849).

For constancy, I've done this change on all the error messages in `application_ref.ts`. @AndrewKushnir, please check if it's necessary.
## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
