### PR TITLE
fix(compiler-cli): ensure that ngcc does not write a lock-file into node_modules package directories

### DIFF
--- a/integration/ngcc/test.sh
+++ b/integration/ngcc/test.sh
@@ -209,7 +209,7 @@ ngcc --formats fesm2015
 assertFailed "Expected 'ngcc --formats fesm2015' to fail (since '--formats' is deprecated)."
 
 # Does it timeout if there is another ngcc process running
-LOCKFILE=node_modules/@angular/compiler-cli/bundles/ngcc/__ngcc_lock_file__
+LOCKFILE=node_modules/.ngcc_lock_file
 touch $LOCKFILE
 trap "[[ -f $LOCKFILE ]] && rm $LOCKFILE" EXIT
 ngcc

--- a/packages/compiler-cli/ngcc/src/locking/lock_file.ts
+++ b/packages/compiler-cli/ngcc/src/locking/lock_file.ts
@@ -10,6 +10,9 @@ import module from 'module';
 
 import {AbsoluteFsPath, PathManipulation} from '../../../src/ngtsc/file_system';
 
+const lockFileName = '.ngcc_lock_file';
+const nodeModulesDirectory = 'node_modules';
+
 export function getLockFilePath(fs: PathManipulation) {
   // This is an interop allowing for the unlocking script to be determined in both
   // a CommonJS module, or an ES module which does not come with `require` by default.
@@ -20,7 +23,13 @@ export function getLockFilePath(fs: PathManipulation) {
   // on `__dirname` (or equivalent) as this code is being bundled and different entry-points
   // will have dedicated bundles where the lock file location would differ then.
   const ngccEntryPointFile = requireFn.resolve('@angular/compiler-cli/ngcc');
-  return fs.resolve(ngccEntryPointFile, '../__ngcc_lock_file__');
+  const nodeModulesIndex = ngccEntryPointFile.lastIndexOf(nodeModulesDirectory);
+  const lockFilePath = nodeModulesIndex === -1 ?
+      fs.resolve(ngccEntryPointFile, '..', lockFileName) :
+      fs.resolve(
+          ngccEntryPointFile.slice(0, nodeModulesIndex + nodeModulesDirectory.length),
+          lockFileName);
+  return lockFilePath;
 }
 
 export interface LockFile {

--- a/packages/compiler-cli/ngcc/src/locking/lock_file.ts
+++ b/packages/compiler-cli/ngcc/src/locking/lock_file.ts
@@ -10,9 +10,6 @@ import module from 'module';
 
 import {AbsoluteFsPath, PathManipulation} from '../../../src/ngtsc/file_system';
 
-const lockFileName = '.ngcc_lock_file';
-const nodeModulesDirectory = 'node_modules';
-
 export function getLockFilePath(fs: PathManipulation) {
   // This is an interop allowing for the unlocking script to be determined in both
   // a CommonJS module, or an ES module which does not come with `require` by default.
@@ -22,14 +19,8 @@ export function getLockFilePath(fs: PathManipulation) {
   // allows us to have a consistent position for the lock file to reside. We are unable to rely
   // on `__dirname` (or equivalent) as this code is being bundled and different entry-points
   // will have dedicated bundles where the lock file location would differ then.
-  const ngccEntryPointFile = requireFn.resolve('@angular/compiler-cli/ngcc');
-  const nodeModulesIndex = ngccEntryPointFile.lastIndexOf(nodeModulesDirectory);
-  const lockFilePath = nodeModulesIndex === -1 ?
-      fs.resolve(ngccEntryPointFile, '..', lockFileName) :
-      fs.resolve(
-          ngccEntryPointFile.slice(0, nodeModulesIndex + nodeModulesDirectory.length),
-          lockFileName);
-  return lockFilePath;
+  const ngccEntryPointFile = requireFn.resolve('@angular/compiler-cli/package.json');
+  return fs.resolve(ngccEntryPointFile, '../../../.ngcc_lock_file');
 }
 
 export interface LockFile {

--- a/packages/compiler-cli/ngcc/test/helpers/utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/utils.ts
@@ -119,3 +119,18 @@ var __assign${suffix} = null;
 export function getRootFiles(testFiles: TestFile[]): AbsoluteFsPath[] {
   return testFiles.filter(f => f.isRoot !== false).map(f => absoluteFrom(f.name));
 }
+
+/**
+ * Mock out the lockfile path resolution, which uses `require.resolve()`.
+ */
+export function mockRequireResolveForLockfile() {
+  const moduleConstructor: any = module.constructor;
+  const originalResolveFileName = moduleConstructor._resolveFilename;
+  spyOn<any>(moduleConstructor, '_resolveFilename').and.callFake(function(request: string) {
+    if (request === '@angular/compiler-cli/package.json') {
+      return '/node_modules/' + request;
+    } else {
+      return originalResolveFileName.apply(null, arguments as any);
+    }
+  });
+}

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -22,6 +22,7 @@ import {EntryPointJsonProperty, EntryPointPackageJson, SUPPORTED_FORMAT_PROPERTI
 import {EntryPointManifestFile} from '../../src/packages/entry_point_manifest';
 import {Transformer} from '../../src/packages/transformer';
 import {DirectPackageJsonUpdater, PackageJsonUpdater} from '../../src/writing/package_json_updater';
+import {mockRequireResolveForLockfile} from '../helpers/utils';
 
 import {compileIntoApf, compileIntoFlatEs2015Package, compileIntoFlatEs5Package, loadNgccIntegrationTestFiles} from './util';
 
@@ -46,6 +47,7 @@ runInEachFileSystem(() => {
       _ = absoluteFrom;
       fs = getFileSystem();
       pkgJsonUpdater = new DirectPackageJsonUpdater(fs);
+      mockRequireResolveForLockfile();
       initMockFileSystem(fs, testFiles);
 
       // Force single-process execution in unit tests by mocking available CPUs to 1.

--- a/packages/compiler-cli/ngcc/test/locking/lockfile_with_child_process/index_spec.ts
+++ b/packages/compiler-cli/ngcc/test/locking/lockfile_with_child_process/index_spec.ts
@@ -13,6 +13,7 @@ import {runInEachFileSystem} from '../../../../src/ngtsc/file_system/testing';
 import {MockLogger} from '../../../../src/ngtsc/logging/testing';
 import {getLockFilePath} from '../../../src/locking/lock_file';
 import {LockFileWithChildProcess} from '../../../src/locking/lock_file_with_child_process';
+import {mockRequireResolveForLockfile} from '../../helpers/utils';
 
 runInEachFileSystem(() => {
   describe('LockFileWithChildProcess', () => {
@@ -54,6 +55,10 @@ runInEachFileSystem(() => {
         };
       }
     }
+
+    beforeEach(() => {
+      mockRequireResolveForLockfile();
+    });
 
     describe('constructor', () => {
       it('should create the unlocker process', () => {


### PR DESCRIPTION
When executing, ngcc writes a lock-file that is used to coordinate multiple concurrent instances of ngcc.
Previously, this file was written at `node_modules/@angular/compiler-cli/ngcc`, or similar depending upon the bundling of the package.
But this causes problems for setups where `node_modules` package directories are expected to be read-only.
Now, the lock-file is written as `.ngcc_lock_file` into the top of the `node_modules`, which is an acceptable place to store transient files.

This change should help to unblock use of tools like pnpm and lerna, which can use symlinks to readonly package directories.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
