### PR TITLE
fix(docs-infra): move aio footer inside mat-sidenav-container

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -68,8 +68,9 @@
     <aio-lazy-ce selector="aio-toc"></aio-lazy-ce>
   </div>
 
+  <footer class="no-print">
+    <aio-footer [nodes]="footerNodes" [versionInfo]="versionInfo"></aio-footer>
+  </footer>
+
 </mat-sidenav-container>
 
-<footer class="no-print">
-  <aio-footer [nodes]="footerNodes" [versionInfo]="versionInfo"></aio-footer>
-</footer>

--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -13,7 +13,7 @@ mat-sidenav-container.sidenav-container {
   transform: none;
 
   &.has-floating-toc {
-    .mat-sidenav-content {
+    .sidenav-content {
       margin-right: 18vw;
     }
   }


### PR DESCRIPTION
currently the aio footer sits outside the mat-sidenav-container, as a
result when the mat-sidenav in over mode appears, the footer is not
placed under the sidenav backdrop, move the footer inside the
mat-sidenav-container so that it does

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: N/A

The aio sidenav backdrop does not cover the aio footer and the user can still interact with it, this does look strange and not intentional to me :sweat_smile: 

![before](https://user-images.githubusercontent.com/61631103/142701140-9d3a95de-d163-4ef3-aeef-daa5a552b739.gif)

## What is the new behavior?

The footer gets covered by the backdrop and the user can't interact with it as long as the sidenav is open (in over mode)

![after](https://user-images.githubusercontent.com/61631103/142701191-9f8241de-a355-401a-946c-c77b6452fb0d.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Fixes #34038.
