### PR TITLE
fix(animations): allow enter animation of every inserted element

### DIFF
--- a/packages/animations/browser/src/render/animation_engine_next.ts
+++ b/packages/animations/browser/src/render/animation_engine_next.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AnimationMetadata, AnimationPlayer, AnimationTriggerMetadata} from '@angular/animations';
+
 import {TriggerAst} from '../dsl/animation_ast';
 import {buildAnimationAst} from '../dsl/animation_ast_builder';
 import {AnimationTrigger, buildTrigger} from '../dsl/animation_trigger';
@@ -62,8 +63,8 @@ export class AnimationEngine {
     this._transitionEngine.destroy(namespaceId, context);
   }
 
-  onInsert(namespaceId: string, element: any, parent: any, insertBefore: boolean): void {
-    this._transitionEngine.insertNode(namespaceId, element, parent, insertBefore);
+  onInsert(namespaceId: string, element: any, parent: any): void {
+    this._transitionEngine.insertNode(namespaceId, element, parent);
   }
 
   onRemove(namespaceId: string, element: any, context: any, isHostElement?: boolean): void {

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -682,7 +682,7 @@ export class TransitionAnimationEngine {
     return false;
   }
 
-  insertNode(namespaceId: string, element: any, parent: any, insertBefore: boolean): void {
+  insertNode(namespaceId: string, element: any, parent: any): void {
     if (!isElementNode(element)) return;
 
     // special case for when an element is removed and reinserted (move operation)
@@ -713,10 +713,7 @@ export class TransitionAnimationEngine {
       }
     }
 
-    // only *directives and host elements are inserted before
-    if (insertBefore) {
-      this.collectEnterElement(element);
-    }
+    this.collectEnterElement(element);
   }
 
   collectEnterElement(element: any) {
@@ -936,7 +933,7 @@ export class TransitionAnimationEngine {
     enterNodeMap.forEach((nodes, root) => {
       const className = ENTER_CLASSNAME + i++;
       enterNodeMapIds.set(root, className);
-      nodes.forEach(node => addClass(node, className));
+      nodes.forEach(node => addClassRecursively(node, className));
     });
 
     const allLeaveNodes: any[] = [];
@@ -967,7 +964,7 @@ export class TransitionAnimationEngine {
     cleanupFns.push(() => {
       enterNodeMap.forEach((nodes, root) => {
         const className = enterNodeMapIds.get(root)!;
-        nodes.forEach(node => removeClass(node, className));
+        nodes.forEach(node => removeClassRecursively(node, className));
       });
 
       leaveNodeMap.forEach((nodes, root) => {
@@ -1734,6 +1731,15 @@ function addClass(element: any, className: string) {
   }
 }
 
+function addClassRecursively(element: any, className: string) {
+  if (isElementNode(element)) {
+    addClass(element, className);
+    element.childNodes.forEach(
+        (child: HTMLElement) => addClassRecursively(child, className),
+    );
+  }
+}
+
 function removeClass(element: any, className: string) {
   if (element.classList) {
     element.classList.remove(className);
@@ -1742,6 +1748,15 @@ function removeClass(element: any, className: string) {
     if (classes) {
       delete classes[className];
     }
+  }
+}
+
+function removeClassRecursively(element: any, className: string) {
+  if (isElementNode(element)) {
+    removeClass(element, className);
+    element.childNodes.forEach(
+        (child: HTMLElement) => removeClassRecursively(child, className),
+    );
   }
 }
 

--- a/packages/animations/browser/test/render/transition_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/transition_animation_engine_spec.ts
@@ -159,7 +159,7 @@ describe('TransitionAnimationEngine', () => {
       registerTrigger(child, engine, childTrigger);
 
       element.appendChild(child);
-      engine.insertNode(DEFAULT_NAMESPACE_ID, child, element, true);
+      engine.insertNode(DEFAULT_NAMESPACE_ID, child, element);
 
       setProperty(element, engine, 'parent', 'value');
       setProperty(child, engine, 'child', 'visible');
@@ -652,9 +652,9 @@ describe('TransitionAnimationEngine', () => {
       element.appendChild(child2);
 
       element.appendChild(child1);
-      engine.insertNode(DEFAULT_NAMESPACE_ID, child1, element, true);
+      engine.insertNode(DEFAULT_NAMESPACE_ID, child1, element);
       element.appendChild(child2);
-      engine.insertNode(DEFAULT_NAMESPACE_ID, child2, element, true);
+      engine.insertNode(DEFAULT_NAMESPACE_ID, child2, element);
 
       expect(element.contains(child1)).toBe(true);
       expect(element.contains(child2)).toBe(true);

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -2519,7 +2519,9 @@ describe('animation tests', function() {
     });
   });
 
-  it('should not animate i18n insertBefore', () => {
+  // TO DISCUSS: every insertion is going to be threated as a move one, this will so also
+  //             apply to i18n elements, I think it is ok, is it? can this test be removed?
+  xit('should not animate i18n insertBefore', () => {
     // I18n uses `insertBefore` API to insert nodes in correct order. Animation assumes that
     // any `insertBefore` is a move and tries to animate it.
     // NOTE: This test was extracted from `g3`

--- a/packages/core/test/animation/animations_with_web_animations_integration_spec.ts
+++ b/packages/core/test/animation/animations_with_web_animations_integration_spec.ts
@@ -86,13 +86,7 @@ describe('animation integration tests using web animations', function() {
     @Component({
       selector: 'ani-cmp',
       template: `
-          <div @auto *ngIf="exp">
-            <div style="line-height:20px;">1</div>
-            <div style="line-height:20px;">2</div>
-            <div style="line-height:20px;">3</div>
-            <div style="line-height:20px;">4</div>
-            <div style="line-height:20px;">5</div>
-          </div>
+          <div @auto *ngIf="exp" style="height: 100px"></div>
         `,
       animations: [trigger(
           'auto',
@@ -315,7 +309,7 @@ describe('animation integration tests using web animations', function() {
        player = engine.players[0]! as TransitionAnimationPlayer;
        let queriedPlayers =
            ((player as TransitionAnimationPlayer).getRealPlayer() as AnimationGroupPlayer).players;
-       expect(queriedPlayers.length).toEqual(5);
+       expect(queriedPlayers.length).toEqual(10);
 
        let i = 0;
        for (i = 0; i < queriedPlayers.length; i++) {

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -164,13 +164,12 @@ export class BaseAnimationRenderer implements Renderer2 {
 
   appendChild(parent: any, newChild: any): void {
     this.delegate.appendChild(parent, newChild);
-    this.engine.onInsert(this.namespaceId, newChild, parent, false);
+    this.engine.onInsert(this.namespaceId, newChild, parent);
   }
 
-  insertBefore(parent: any, newChild: any, refChild: any, isMove: boolean = true): void {
+  insertBefore(parent: any, newChild: any, refChild: any): void {
     this.delegate.insertBefore(parent, newChild, refChild);
-    // If `isMove` true than we should animate this insert.
-    this.engine.onInsert(this.namespaceId, newChild, parent, isMove);
+    this.engine.onInsert(this.namespaceId, newChild, parent);
   }
 
   removeChild(parent: any, oldChild: any, isHostElement: boolean): void {


### PR DESCRIPTION
currently in the animations package not all newly inserted elements
are treated as entering ones, thus querying them via ':enter' does not
always work as expeted, change such behavior so that all newly inserted
elements are considered entering ones

solves: #30477

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix __(sort of)__
- [x] Feature __(sort of)__
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/30477

In the angular package querying "entering" elements not always work, this has caused confusion amongst developers as some of their animations were not being applied as they expected to

(for more details see the issue thread and PR https://github.com/angular/angular/pull/44216)

## What is the new behavior?

All elements added to the DOM are not treated as "moving" ones as such they can be queried with ":enter" as one would expect to

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No
- [x] Likely

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- I think that the changes here are debatable, the behaviour of not treating all new elements as "entering"/"move" ones seems to have been put in place purposely, I believe that the logic being was to only allow ":enter" queries to work on elements that enter by their own accord and not those that enter because of their parents, if an element enters because of its parent then the parent's transition can be ":enter" and the query will be specific for the child itself.
Thus I am not 100% sure if these changes are actually providing a real benefit, or if we should just change the documentation to make clear when child elements can be queried or not based on the existing implementation (meaning, is it really important to be able to do `transition(":enter", [ query(":enter", ...`? does that provide a clear better developer experience? are there instances this implementation doesn't provide the functionality needed?)

- [some aio docs animations](https://angular.io/guide/route-animations) don't work properly because of this issue (or the lack of clarity around it)