### PR TITLE
refactor(forms): minor refactoring of `SelectMultipleControlValueAccessor`

### DIFF
--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -137,23 +137,26 @@ export class SelectMultipleControlValueAccessor extends BuiltInControlValueAcces
    * @nodoc
    */
   override registerOnChange(fn: (value: any) => any): void {
-    this.onChange = (_: any) => {
+    this.onChange = (element: HTMLSelectElement) => {
       const selected: Array<any> = [];
-      if (_.selectedOptions !== undefined) {
-        const options: HTMLCollection = _.selectedOptions;
+      const selectedOptions = element.selectedOptions;
+      if (selectedOptions !== undefined) {
+        const options = selectedOptions;
         for (let i = 0; i < options.length; i++) {
-          const opt: any = options.item(i);
-          const val: any = this._getOptionValue(opt.value);
+          const opt = options[i];
+          const val = this._getOptionValue(opt.value);
           selected.push(val);
         }
       }
-      // Degrade on IE
+      // Degrade to use `options` when `selectedOptions` property is not available.
+      // Note: the `selectedOptions` is available in all supported browsers, but the Domino lib
+      // doesn't have it currently, see https://github.com/fgnass/domino/issues/177.
       else {
-        const options: HTMLCollection = <HTMLCollection>_.options;
+        const options = element.options;
         for (let i = 0; i < options.length; i++) {
-          const opt: HTMLOption = options.item(i);
+          const opt = options[i];
           if (opt.selected) {
-            const val: any = this._getOptionValue(opt.value);
+            const val = this._getOptionValue(opt.value);
             selected.push(val);
           }
         }

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -508,7 +508,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
              selectOptionViaUI('1: Object');
              assertOptionElementSelectedState([false, true, false]);
-             expect(spy.calls.count()).toBe(2);
+             expect(spy).toHaveBeenCalled();
            }));
 
         it('should reflect state of model after option selected and new options subsequently added',


### PR DESCRIPTION
This commit removes a branch in the code that was only needed for IE (which is no longer supported). The `selectedOptions` property of HTMLSelect elements is supported by all the browsers that Angular supports.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No