### PR TITLE
fix(docs-infra): add safari-only media query for aio footer flex

### DIFF
--- a/aio/src/styles/1-layouts/footer/_footer.scss
+++ b/aio/src/styles/1-layouts/footer/_footer.scss
@@ -89,6 +89,13 @@ footer {
           margin: 8px 24px;
         }
       }
+
+      @media not all and (min-resolution:.001dpcm) { // hack to detect safari
+        // tweak needed as safari handles rem based media queries differently
+        @media (max-width: 50rem) {
+          flex-direction: column;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
safari handles rem based media queries differently so in order to
provide a similar user-experience to safari users, add a new
safari-only media query for the footer's flex container

resolves #44242

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #44242


## What is the new behavior?

Added a new media query which only applies to safari which fixes the issue
without changing any style in non-safari browsers

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


