### PR TITLE
refactor(platform-browser-dynamic): remove private export of `Resourc…

### DIFF
--- a/packages/platform-browser-dynamic/src/private_export.ts
+++ b/packages/platform-browser-dynamic/src/private_export.ts
@@ -8,4 +8,3 @@
 
 export {platformCoreDynamic as ɵplatformCoreDynamic} from './platform_core_dynamic';
 export {INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS as ɵINTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS} from './platform_providers';
-export {ResourceLoaderImpl as ɵResourceLoaderImpl} from './resource_loader/resource_loader_impl';


### PR DESCRIPTION
…eLoaderImpl`

This type was exported for the ViewEngine compiler as it needed to
reference the class in its DI codegen. This is no longer a requirement
with Ivy, hence the private export can be removed.

This change prevents an import of `@angular/compiler` to be referenced
in the .d.ts file of `@angular/platform-browser-dynamic`, which is
beneficial for application compilations as that prevents the
`@angular/compiler` .d.ts files from being included in the `ts.Program`
of an application.

Closes #44157.