### PR TITLE
fix(docs-infra): ensure deprecated styling is not overridden

### DIFF
--- a/aio/src/styles/2-modules/code/_code.scss
+++ b/aio/src/styles/2-modules/code/_code.scss
@@ -142,7 +142,6 @@ aio-code {
 
   .code-anchor {
     cursor: pointer;
-    text-decoration: none;
     font-size: inherit;
 
     &:hover {


### PR DESCRIPTION
The `.code-anchor` styling was overriding the `.deprecated-api-item` styling.
The `text-decoration` is not needed on `.code-anchor` since it inherits this from the `a` rule in the typography.scss file.

Fixes #44264
