### PR TITLE
test(core): clean up tests relying on entryComponents

### DIFF
--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -135,17 +135,7 @@ describe('change detection', () => {
         noop() {}
       }
 
-      // We need to declare a module so that we can specify `entryComponents`
-      // for when the test is run against ViewEngine.
-      @NgModule({
-        declarations: [App, ViewManipulation, DynamicComp],
-        exports: [App, ViewManipulation, DynamicComp],
-        entryComponents: [DynamicComp]
-      })
-      class AppModule {
-      }
-
-      TestBed.configureTestingModule({imports: [AppModule]});
+      TestBed.configureTestingModule({declarations: [App, ViewManipulation, DynamicComp]});
       const fixture = TestBed.createComponent(App);
       const vm: ViewManipulation = fixture.debugElement.childNodes[0].references['vm'];
       const factory = TestBed.get(ComponentFactoryResolver).resolveComponentFactory(DynamicComp);
@@ -201,7 +191,7 @@ describe('change detection', () => {
       class DynamicCmpt {
       }
 
-      @NgModule({declarations: [DynamicCmpt], entryComponents: [DynamicCmpt]})
+      @NgModule({declarations: [DynamicCmpt]})
       class DynamicModule {
       }
 

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -58,59 +58,10 @@ describe('component', () => {
     });
   });
 
-  it('should support entry components from another module', () => {
-    @Component({selector: 'other-component', template: `bar`})
-    class OtherComponent {
-    }
-
-    @NgModule({
-      declarations: [OtherComponent],
-      exports: [OtherComponent],
-      entryComponents: [OtherComponent]
-    })
-    class OtherModule {
-    }
-
-    @Component({
-      selector: 'test_component',
-      template: `foo|<ng-template #vc></ng-template>`,
-      entryComponents: [OtherComponent]
-    })
-    class TestComponent {
-      @ViewChild('vc', {read: ViewContainerRef, static: true}) vcref!: ViewContainerRef;
-
-      constructor(private _cfr: ComponentFactoryResolver) {}
-
-      createComponentView<T>(cmptType: Type<T>): ComponentRef<T> {
-        const cf = this._cfr.resolveComponentFactory(cmptType);
-        return this.vcref.createComponent(cf);
-      }
-    }
-
-    TestBed.configureTestingModule({declarations: [TestComponent], imports: [OtherModule]});
-    const fixture = TestBed.createComponent(TestComponent);
-    fixture.detectChanges();
-
-    fixture.componentInstance.createComponentView(OtherComponent);
-    fixture.detectChanges();
-    expect(fixture.nativeElement).toHaveText('foo|bar');
-  });
-
   it('should be able to dynamically insert a component into a view container at the root of a component',
      () => {
        @Component({template: 'hello'})
        class HelloComponent {
-       }
-
-       // TODO: This module is only used to declare the `entryComponets` since
-       //  `configureTestingModule` doesn't support it. The module can be removed
-       // once ViewEngine is removed.
-       @NgModule({
-         declarations: [HelloComponent],
-         exports: [HelloComponent],
-         entryComponents: [HelloComponent]
-       })
-       class HelloModule {
        }
 
        @Component({selector: 'wrapper', template: '<ng-content></ng-content>'})
@@ -129,7 +80,7 @@ describe('component', () => {
          constructor(public componentFactoryResolver: ComponentFactoryResolver) {}
        }
 
-       TestBed.configureTestingModule({declarations: [App, Wrapper], imports: [HelloModule]});
+       TestBed.configureTestingModule({declarations: [App, Wrapper, HelloComponent]});
        const fixture = TestBed.createComponent(App);
        fixture.detectChanges();
 
@@ -246,13 +197,6 @@ describe('component', () => {
          }
        }
 
-       @NgModule({
-         declarations: [DynamicComponent],
-         entryComponents: [DynamicComponent],  // needed only for ViewEngine
-       })
-       class TestModule {
-       }
-
        @Component({
          selector: 'button',
          template: `
@@ -280,7 +224,7 @@ describe('component', () => {
          }
        }
 
-       TestBed.configureTestingModule({imports: [TestModule], declarations: [App]});
+       TestBed.configureTestingModule({declarations: [App, DynamicComponent]});
        const fixture = TestBed.createComponent(App);
        fixture.detectChanges();
 
@@ -326,13 +270,6 @@ describe('component', () => {
            class DynamicComponent {
            }
 
-           @NgModule({
-             declarations: [DynamicComponent],
-             entryComponents: [DynamicComponent],  // needed only for ViewEngine
-           })
-           class TestModule {
-           }
-
            @Component({
              selector: 'button',
              template: '<div id="app-root" #anchor></div>',
@@ -356,7 +293,7 @@ describe('component', () => {
              }
            }
 
-           TestBed.configureTestingModule({imports: [TestModule], declarations: [App]});
+           TestBed.configureTestingModule({declarations: [App, DynamicComponent]});
            const fixture = TestBed.createComponent(App);
            fixture.detectChanges();
 
@@ -537,17 +474,11 @@ describe('component', () => {
       }
     }
 
-    @NgModule({
-      declarations: [CompA],
-      entryComponents: [CompA],
-    })
+    @NgModule({declarations: [CompA]})
     class MyModuleA {
     }
 
-    @NgModule({
-      declarations: [CompB],
-      entryComponents: [CompB],
-    })
+    @NgModule({declarations: [CompB]})
     class MyModuleB {
     }
 
@@ -579,14 +510,7 @@ describe('component', () => {
     class AttSelectorCmp {
     }
 
-    @NgModule({
-      declarations: [AttSelectorCmp],
-      entryComponents: [AttSelectorCmp],
-    })
-    class AppModule {
-    }
-
-    TestBed.configureTestingModule({imports: [AppModule]});
+    TestBed.configureTestingModule({declarations: [AttSelectorCmp]});
     const cmpFactoryResolver = TestBed.inject(ComponentFactoryResolver);
     const cmpFactory = cmpFactoryResolver.resolveComponentFactory(AttSelectorCmp);
 
@@ -598,14 +522,7 @@ describe('component', () => {
     class ComplexSelectorCmp {
     }
 
-    @NgModule({
-      declarations: [ComplexSelectorCmp],
-      entryComponents: [ComplexSelectorCmp],
-    })
-    class AppModule {
-    }
-
-    TestBed.configureTestingModule({imports: [AppModule]});
+    TestBed.configureTestingModule({declarations: [ComplexSelectorCmp]});
     const cmpFactoryResolver = TestBed.inject(ComponentFactoryResolver);
     const cmpFactory = cmpFactoryResolver.resolveComponentFactory(ComplexSelectorCmp);
 
@@ -643,14 +560,6 @@ describe('component', () => {
         }
       }
 
-      // View Engine requires DynamicComponent to be in entryComponents.
-      @NgModule({
-        declarations: [App, DynamicComponent],
-        entryComponents: [App, DynamicComponent],
-      })
-      class AppModule {
-      }
-
       function _document(): any {
         // Tell Ivy about the global document
         ɵsetDocument(document);
@@ -658,7 +567,7 @@ describe('component', () => {
       }
 
       TestBed.configureTestingModule({
-        imports: [AppModule],
+        declarations: [App, DynamicComponent],
         providers: [
           {provide: DOCUMENT, useFactory: _document, deps: []},
           rendererProviders,

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -522,8 +522,7 @@ describe('di', () => {
               <ng-container #childOrigin></ng-container>
               <ng-container #childOriginWithDirB dirB></ng-container>
             </div>
-          </projector>`,
-          entryComponents: [Child]
+          </projector>`
         })
         class MyApp {
           @ViewChild('childOrigin', {read: ViewContainerRef, static: true})
@@ -2552,16 +2551,8 @@ describe('di', () => {
           }
         }
 
-        // this module is needed, so that View Engine can generate factory for ChildComp
-        @NgModule({
-          declarations: [DirectiveA, RootComp, ChildComp],
-          entryComponents: [RootComp, ChildComp],
-        })
-        class ModuleA {
-        }
-
         TestBed.configureTestingModule({
-          imports: [ModuleA],
+          declarations: [DirectiveA, RootComp, ChildComp],
           providers: [ServiceA],
         });
 

--- a/packages/core/test/acceptance/host_binding_spec.ts
+++ b/packages/core/test/acceptance/host_binding_spec.ts
@@ -157,14 +157,7 @@ describe('host bindings', () => {
         prop2 = 1;
       }
 
-      @NgModule({
-        entryComponents: [ChildCmp],
-        declarations: [ChildCmp],
-      })
-      class ChildCmpModule {
-      }
-
-      TestBed.configureTestingModule({declarations: [App, ParentCmp], imports: [ChildCmpModule]});
+      TestBed.configureTestingModule({declarations: [App, ParentCmp, ChildCmp]});
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
 

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -1569,15 +1569,7 @@ describe('onInit', () => {
       }
     }
 
-    // View Engine requires that DynamicComp be in entryComponents.
-    @NgModule({
-      declarations: [App, MyComp, DynamicComp],
-      entryComponents: [DynamicComp, App],
-    })
-    class AppModule {
-    }
-
-    TestBed.configureTestingModule({imports: [AppModule]});
+    TestBed.configureTestingModule({declarations: [App, MyComp, DynamicComp]});
 
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -2651,14 +2651,7 @@ describe('styling', () => {
          prop = 'a';
        }
 
-       @NgModule({
-         entryComponents: [ChildCmp],
-         declarations: [ChildCmp],
-       })
-       class ChildCmpModule {
-       }
-
-       TestBed.configureTestingModule({declarations: [App, ParentCmp], imports: [ChildCmpModule]});
+       TestBed.configureTestingModule({declarations: [App, ParentCmp, ChildCmp]});
        const fixture = TestBed.createComponent(App);
        fixture.detectChanges(false);
 
@@ -2730,14 +2723,7 @@ describe('styling', () => {
          @ViewChild('parent', {static: true}) public parent: ParentCmp|null = null;
        }
 
-       @NgModule({
-         entryComponents: [ChildCmp],
-         declarations: [ChildCmp],
-       })
-       class ChildCmpModule {
-       }
-
-       TestBed.configureTestingModule({declarations: [App, ParentCmp], imports: [ChildCmpModule]});
+       TestBed.configureTestingModule({declarations: [App, ParentCmp, ChildCmp]});
        const fixture = TestBed.createComponent(App);
        fixture.detectChanges(false);
 

--- a/packages/core/test/acceptance/template_ref_spec.ts
+++ b/packages/core/test/acceptance/template_ref_spec.ts
@@ -186,23 +186,13 @@ describe('TemplateRef', () => {
         @ViewChild('templateRef', {static: true}) templateRef!: TemplateRef<any>;
       }
 
-      @NgModule({
-        declarations: [DynamicCmp],
-        entryComponents: [DynamicCmp],
-      })
-      class WithDynamicCmpModule {
-      }
-
       @Component({selector: 'test', template: ''})
       class TestCmp {
         constructor(public cfr: ComponentFactoryResolver) {}
       }
 
       beforeEach(() => {
-        TestBed.configureTestingModule({
-          declarations: [TestCmp],
-          imports: [WithDynamicCmpModule],
-        });
+        TestBed.configureTestingModule({declarations: [TestCmp, DynamicCmp]});
       });
 
       it('should return projectable nodes when provided', () => {

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -74,10 +74,6 @@ describe('ViewContainerRef', () => {
       class HelloComp {
       }
 
-      @NgModule({entryComponents: [HelloComp], declarations: [HelloComp]})
-      class HelloCompModule {
-      }
-
       @Component({
         template: `
           <ng-container vcref></ng-container>
@@ -87,8 +83,7 @@ describe('ViewContainerRef', () => {
         @ViewChild(VCRefDirective, {static: true}) vcRefDir!: VCRefDirective;
       }
 
-      TestBed.configureTestingModule(
-          {declarations: [TestComp, VCRefDirective], imports: [HelloCompModule]});
+      TestBed.configureTestingModule({declarations: [TestComp, VCRefDirective, HelloComp]});
       const fixture = TestBed.createComponent(TestComp);
       const {vcref, cfr, elementRef} = fixture.componentInstance.vcRefDir;
       fixture.detectChanges();
@@ -120,10 +115,6 @@ describe('ViewContainerRef', () => {
       class HelloComp {
       }
 
-      @NgModule({entryComponents: [HelloComp], declarations: [HelloComp]})
-      class HelloCompModule {
-      }
-
       @Component({
         template: `
           <ng-container #container></ng-container>
@@ -140,7 +131,7 @@ describe('ViewContainerRef', () => {
         }
       }
 
-      TestBed.configureTestingModule({declarations: [TestComp], imports: [HelloCompModule]});
+      TestBed.configureTestingModule({declarations: [TestComp, HelloComp]});
       const fixture = TestBed.createComponent(TestComp);
       fixture.detectChanges();
       expect(fixture.debugElement.nativeElement.innerHTML).not.toContain('Hello');
@@ -165,17 +156,6 @@ describe('ViewContainerRef', () => {
             template: '<math><matrix></matrix></math>',
           })
           class MathMLComp {
-          }
-
-          @NgModule({
-            entryComponents: [SvgComp, MathMLComp],
-            declarations: [SvgComp, MathMLComp],
-            // View Engine doesn't have MathML tags listed in `DomElementSchemaRegistry`, thus
-            // throwing "unknown element" error (':math:matrix' is not a known element). Ignore
-            // these errors by adding `NO_ERRORS_SCHEMA` to this NgModule.
-            schemas: [NO_ERRORS_SCHEMA],
-          })
-          class RootModule {
           }
 
           @Component({
@@ -206,8 +186,7 @@ describe('ViewContainerRef', () => {
           }
 
           TestBed.configureTestingModule({
-            declarations: [TestComp],
-            imports: [RootModule],
+            declarations: [TestComp, SvgComp, MathMLComp],
             providers: [
               {provide: DOCUMENT, useFactory: _document, deps: []},
               // TODO(FW-811): switch back to default server renderer (i.e. remove the line below)
@@ -243,10 +222,6 @@ describe('ViewContainerRef', () => {
       class HelloComp {
       }
 
-      @NgModule({entryComponents: [HelloComp], declarations: [HelloComp]})
-      class HelloCompModule {
-      }
-
       @Component({
         template: `
           <div id="factory" attr-a="a-original" class="class-original"></div>
@@ -271,7 +246,7 @@ describe('ViewContainerRef', () => {
         }
       }
 
-      TestBed.configureTestingModule({declarations: [TestComp], imports: [HelloCompModule]});
+      TestBed.configureTestingModule({declarations: [TestComp, HelloComp]});
       const fixture = TestBed.createComponent(TestComp);
       fixture.detectChanges();
       fixture.componentInstance.createComponentViaVCRef();
@@ -1144,14 +1119,8 @@ describe('ViewContainerRef', () => {
         }
       }
 
-      @NgModule({entryComponents: [EmbeddedComponent], declarations: [EmbeddedComponent]})
-      class EmbeddedComponentModule {
-      }
-
-      TestBed.configureTestingModule({
-        declarations: [EmbeddedViewInsertionComp, VCRefDirective],
-        imports: [EmbeddedComponentModule]
-      });
+      TestBed.configureTestingModule(
+          {declarations: [EmbeddedViewInsertionComp, VCRefDirective, EmbeddedComponent]});
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
           fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
@@ -1196,14 +1165,8 @@ describe('ViewContainerRef', () => {
         }
       }
 
-      @NgModule({entryComponents: [EmbeddedComponent], declarations: [EmbeddedComponent]})
-      class EmbeddedComponentModule {
-      }
-
-      TestBed.configureTestingModule({
-        declarations: [EmbeddedViewInsertionComp, VCRefDirective],
-        imports: [EmbeddedComponentModule]
-      });
+      TestBed.configureTestingModule(
+          {declarations: [EmbeddedViewInsertionComp, VCRefDirective, EmbeddedComponent]});
 
       @NgModule({
         providers: [
@@ -1260,8 +1223,7 @@ describe('ViewContainerRef', () => {
 
     it('should support projectable nodes', () => {
       TestBed.configureTestingModule({
-        declarations: [EmbeddedViewInsertionComp, VCRefDirective],
-        imports: [EmbeddedComponentWithNgZoneModule]
+        declarations: [EmbeddedViewInsertionComp, VCRefDirective, EmbeddedComponentWithNgContent],
       });
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
@@ -1296,17 +1258,10 @@ describe('ViewContainerRef', () => {
       class Reprojector {
       }
 
-      @NgModule({
-        exports: [Reprojector, EmbeddedComponentWithNgContent],
-        declarations: [Reprojector, EmbeddedComponentWithNgContent],
-        entryComponents: [Reprojector]
-      })
-      class ReprojectorModule {
-      }
-
       TestBed.configureTestingModule({
-        declarations: [EmbeddedViewInsertionComp, VCRefDirective],
-        imports: [ReprojectorModule]
+        declarations: [
+          EmbeddedViewInsertionComp, VCRefDirective, Reprojector, EmbeddedComponentWithNgContent
+        ],
       });
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
@@ -1332,8 +1287,7 @@ describe('ViewContainerRef', () => {
 
     it('should support many projectable nodes with many slots', () => {
       TestBed.configureTestingModule({
-        declarations: [EmbeddedViewInsertionComp, VCRefDirective],
-        imports: [EmbeddedComponentWithNgZoneModule]
+        declarations: [EmbeddedViewInsertionComp, VCRefDirective, EmbeddedComponentWithNgContent]
       });
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
@@ -1385,12 +1339,7 @@ describe('ViewContainerRef', () => {
       class DynamicComponent {
       }
 
-      @NgModule({declarations: [DynamicComponent], entryComponents: [DynamicComponent]})
-      class DeclaresDynamicComponent {
-      }
-
-      TestBed.configureTestingModule(
-          {imports: [DeclaresDynamicComponent], declarations: [TestComp]});
+      TestBed.configureTestingModule({declarations: [DynamicComponent]});
       const fixture = TestBed.createComponent(TestComp);
 
       // Note: it's important that we **don't** call `fixture.detectChanges` between here and
@@ -1863,14 +1812,6 @@ describe('ViewContainerRef', () => {
       }
     }
 
-    @NgModule({
-      declarations: [ComponentWithHooks],
-      exports: [ComponentWithHooks],
-      entryComponents: [ComponentWithHooks]
-    })
-    class ComponentWithHooksModule {
-    }
-
     it('should call all hooks in correct order when creating with createEmbeddedView', () => {
       @Component({
         template: `
@@ -1969,7 +1910,7 @@ describe('ViewContainerRef', () => {
       log.length = 0;
 
       TestBed.configureTestingModule(
-          {declarations: [SomeComponent, VCRefDirective], imports: [ComponentWithHooksModule]});
+          {declarations: [SomeComponent, VCRefDirective, ComponentWithHooks]});
       const fixture = TestBed.createComponent(SomeComponent);
       const vcRefDir =
           fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
@@ -2053,12 +1994,8 @@ describe('ViewContainerRef', () => {
         @ViewChild(VCRefDirective, {static: true}) vcRefDir!: VCRefDirective;
       }
 
-      @NgModule({declarations: [HostBindingCmpt], entryComponents: [HostBindingCmpt]})
-      class TestModule {
-      }
-
       TestBed.configureTestingModule(
-          {declarations: [TestComponent, VCRefDirective], imports: [TestModule]});
+          {declarations: [TestComponent, VCRefDirective, HostBindingCmpt]});
       const fixture = TestBed.createComponent(TestComponent);
       const {vcRefDir} = fixture.componentInstance;
 
@@ -2358,15 +2295,9 @@ describe('ViewContainerRef', () => {
         constructor(public vcRef: ViewContainerRef, public cfResolver: ComponentFactoryResolver) {}
       }
 
-      @NgModule(
-          {entryComponents: [DynamicCompWithBindings], declarations: [DynamicCompWithBindings]})
-      class DynamicCompWithBindingsModule {
-      }
-
 
       TestBed.configureTestingModule({
-        declarations: [TestComp],
-        imports: [DynamicCompWithBindingsModule],
+        declarations: [TestComp, DynamicCompWithBindings],
         providers: [TEST_COMPONENT_RENDERER]
       });
       const fixture = TestBed.createComponent(TestComp);
@@ -2405,16 +2336,9 @@ describe('ViewContainerRef', () => {
       class DynamicCompWithChildren {
       }
 
-      @NgModule({
-        entryComponents: [DynamicCompWithChildren],
-        declarations: [DynamicCompWithChildren, Child]
-      })
-      class DynamicCompWithChildrenModule {
-      }
 
       TestBed.configureTestingModule({
-        declarations: [TestComp],
-        imports: [DynamicCompWithChildrenModule],
+        declarations: [TestComp, DynamicCompWithChildren, Child],
         providers: [TEST_COMPONENT_RENDERER]
       });
 
@@ -2478,14 +2402,6 @@ class VCRefDirective {
   template: `<ng-content></ng-content><hr><ng-content></ng-content>`
 })
 class EmbeddedComponentWithNgContent {
-}
-
-@NgModule({
-  exports: [EmbeddedComponentWithNgContent],
-  entryComponents: [EmbeddedComponentWithNgContent],
-  declarations: [EmbeddedComponentWithNgContent],
-})
-class EmbeddedComponentWithNgZoneModule {
 }
 
 @Component({

--- a/packages/core/test/acceptance/view_insertion_spec.ts
+++ b/packages/core/test/acceptance/view_insertion_spec.ts
@@ -504,15 +504,8 @@ describe('view insertion', () => {
         }
 
 
-        @NgModule({
-          declarations: [TestCmpt, ViewInsertingDir, DynamicComponent],
-          imports: [CommonModule],
-          entryComponents: [DynamicComponent]
-        })
-        class TestModule {
-        }
-
-        TestBed.configureTestingModule({imports: [TestModule]});
+        TestBed.configureTestingModule(
+            {declarations: [TestCmpt, ViewInsertingDir, DynamicComponent]});
 
         const fixture = TestBed.createComponent(TestCmpt);
         fixture.detectChanges();
@@ -553,16 +546,8 @@ describe('view insertion', () => {
            }
          }
 
-         @NgModule({
-           declarations: [DynamicComponent],
-           entryComponents: [DynamicComponent],
-         })
-         class TestModule {
-         }
-
          TestBed.configureTestingModule({
-           declarations: [AppComponent],
-           imports: [TestModule],
+           declarations: [AppComponent, DynamicComponent],
          });
          const fixture = TestBed.createComponent(AppComponent);
          fixture.detectChanges();

--- a/packages/core/test/acceptance/view_ref_spec.ts
+++ b/packages/core/test/acceptance/view_ref_spec.ts
@@ -37,11 +37,7 @@ describe('ViewRef', () => {
       }
     }
 
-    @NgModule({declarations: [App, DynamicComponent], entryComponents: [DynamicComponent]})
-    class MyTestModule {
-    }
-
-    TestBed.configureTestingModule({imports: [MyTestModule]});
+    TestBed.configureTestingModule({declarations: [App, DynamicComponent]});
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
 
@@ -96,11 +92,7 @@ describe('ViewRef', () => {
       }
     }
 
-    @NgModule({declarations: [App, DynamicComponent], entryComponents: [DynamicComponent]})
-    class MyTestModule {
-    }
-
-    TestBed.configureTestingModule({imports: [MyTestModule]});
+    TestBed.configureTestingModule({declarations: [App, DynamicComponent]});
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     fixture.componentInstance.create();
@@ -134,11 +126,7 @@ describe('ViewRef', () => {
       }
     }
 
-    @NgModule({declarations: [App, DynamicComponent], entryComponents: [DynamicComponent]})
-    class MyTestModule {
-    }
-
-    TestBed.configureTestingModule({imports: [MyTestModule]});
+    TestBed.configureTestingModule({declarations: [App, DynamicComponent]});
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     fixture.componentInstance.create();

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -66,7 +66,6 @@ class SomeComponent {
         providers: [{provide: ErrorHandler, useValue: errorHandler}, options.providers || []],
         imports: [platformModule],
         declarations: [options.component || SomeComponent],
-        entryComponents: [options.component || SomeComponent],
         bootstrap: options.bootstrap || []
       })
       class MyModule {
@@ -92,7 +91,6 @@ class SomeComponent {
              @NgModule({
                providers: [{provide: helloToken, useValue: 'component'}],
                declarations: [SomeComponent],
-               entryComponents: [SomeComponent],
              })
              class SomeModule {
              }
@@ -123,7 +121,6 @@ class SomeComponent {
              @NgModule({
                providers: [{provide: helloToken, useValue: 'component'}],
                declarations: [SomeComponent],
-               entryComponents: [SomeComponent],
              })
              class SomeModule {
              }

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -976,17 +976,8 @@ describe('integration tests', function() {
 
     describe('ViewContainerRef', () => {
       beforeEach(() => {
-        // we need a module to declarate ChildCompUsingService as an entryComponent otherwise the
-        // factory doesn't get created
-        @NgModule({
-          declarations: [MyComp, DynamicViewport, ChildCompUsingService],
-          entryComponents: [ChildCompUsingService],
-          schemas: [NO_ERRORS_SCHEMA],
-        })
-        class MyModule {
-        }
-
-        TestBed.configureTestingModule({imports: [MyModule]});
+        TestBed.configureTestingModule(
+            {declarations: [MyComp, DynamicViewport, ChildCompUsingService]});
         TestBed.overrideComponent(
             MyComp, {add: {template: '<div><dynamic-vp #dynamic></dynamic-vp></div>'}});
       });
@@ -1069,7 +1060,6 @@ describe('integration tests', function() {
 
           @NgModule({
             declarations: [RootComp, MyComp],
-            entryComponents: [MyComp],
             providers: [{provide: 'someToken', useValue: 'someRootValue'}],
           })
           class RootModule {
@@ -1115,7 +1105,6 @@ describe('integration tests', function() {
 
           @NgModule({
             declarations: [MyComp],
-            entryComponents: [MyComp],
             providers: [{provide: 'someToken', useValue: 'someValue'}],
           })
           class MyModule {
@@ -1401,7 +1390,7 @@ describe('integration tests', function() {
       class NoSelectorComponent {
       }
 
-      @Component({selector: 'some-comp', template: '', entryComponents: [NoSelectorComponent]})
+      @Component({selector: 'some-comp', template: ''})
       class SomeComponent {
         constructor(componentFactoryResolver: ComponentFactoryResolver) {
           // grab its own component factory
@@ -1484,13 +1473,6 @@ describe('integration tests', function() {
       itemContent!: string;
     }
 
-    @NgModule({
-      declarations: [DynamicMenuItem],
-      entryComponents: [DynamicMenuItem],
-    })
-    class DynamicMenuItemModule {
-    }
-
     @Component({selector: 'test', template: `<ng-container #menuItemsContainer></ng-container>`})
     class TestCmp {
       constructor(public cfr: ComponentFactoryResolver) {}
@@ -1499,10 +1481,7 @@ describe('integration tests', function() {
     }
 
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        declarations: [TestCmp],
-        imports: [DynamicMenuItemModule],
-      });
+      TestBed.configureTestingModule({declarations: [TestCmp, DynamicMenuItem]});
     });
 
     const createElWithContent = (content: string, tagName = 'span') => {
@@ -1567,8 +1546,7 @@ describe('integration tests', function() {
              DynamicMenuItem,
              `<ng-template #templateRef><ng-content select="span"></ng-content>{{itemContent}}<ng-content select="button"></ng-content></ng-template>`);
 
-         TestBed.configureTestingModule(
-             {declarations: [TestCmp], imports: [DynamicMenuItemModule]});
+         TestBed.configureTestingModule({declarations: [TestCmp, DynamicMenuItem]});
 
          const fixture = TestBed.createComponent(TestCmp);
          const menuItemsContainer = fixture.componentInstance.menuItemsContainer;

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -246,11 +246,6 @@ describe('NgModule', () => {
          @NgModule({
            schemas: [CUSTOM_ELEMENTS_SCHEMA],
            declarations: [ComponentUsingInvalidProperty],
-
-           // Note that we need to add the component to `entryComponents`, because of the
-           // `createComp` call below. In Ivy the property validation happens during the
-           //  update phase so we need to create the component, in order for it to run.
-           entryComponents: [ComponentUsingInvalidProperty]
          })
          class SomeModule {
          }
@@ -462,10 +457,7 @@ describe('NgModule', () => {
   describe('directives and pipes', () => {
     describe('declarations', () => {
       it('should be supported in root modules', () => {
-        @NgModule({
-          declarations: [CompUsingModuleDirectiveAndPipe, SomeDirective, SomePipe],
-          entryComponents: [CompUsingModuleDirectiveAndPipe]
-        })
+        @NgModule({declarations: [CompUsingModuleDirectiveAndPipe, SomeDirective, SomePipe]})
         class SomeModule {
         }
 
@@ -477,10 +469,7 @@ describe('NgModule', () => {
       });
 
       it('should be supported in imported modules', () => {
-        @NgModule({
-          declarations: [CompUsingModuleDirectiveAndPipe, SomeDirective, SomePipe],
-          entryComponents: [CompUsingModuleDirectiveAndPipe]
-        })
+        @NgModule({declarations: [CompUsingModuleDirectiveAndPipe, SomeDirective, SomePipe]})
         class SomeImportedModule {
         }
 
@@ -507,8 +496,7 @@ describe('NgModule', () => {
           declarations: [
             ParentCompUsingModuleDirectiveAndPipe, CompUsingModuleDirectiveAndPipe, SomeDirective,
             SomePipe
-          ],
-          entryComponents: [ParentCompUsingModuleDirectiveAndPipe]
+          ]
         })
         class SomeModule {
         }
@@ -526,11 +514,7 @@ describe('NgModule', () => {
         class SomeImportedModule {
         }
 
-        @NgModule({
-          declarations: [CompUsingModuleDirectiveAndPipe],
-          imports: [SomeImportedModule],
-          entryComponents: [CompUsingModuleDirectiveAndPipe]
-        })
+        @NgModule({declarations: [CompUsingModuleDirectiveAndPipe], imports: [SomeImportedModule]})
         class SomeModule {
         }
 
@@ -549,8 +533,7 @@ describe('NgModule', () => {
 
            @NgModule({
              declarations: [CompUsingModuleDirectiveAndPipe],
-             imports: [{ngModule: SomeImportedModule}],
-             entryComponents: [CompUsingModuleDirectiveAndPipe]
+             imports: [{ngModule: SomeImportedModule}]
            })
            class SomeModule {
            }
@@ -571,11 +554,7 @@ describe('NgModule', () => {
         class SomeImportedModule {
         }
 
-        @NgModule({
-          declarations: [CompUsingModuleDirectiveAndPipe],
-          imports: [SomeImportedModule],
-          entryComponents: [CompUsingModuleDirectiveAndPipe]
-        })
+        @NgModule({declarations: [CompUsingModuleDirectiveAndPipe], imports: [SomeImportedModule]})
         class SomeModule {
         }
 
@@ -594,11 +573,7 @@ describe('NgModule', () => {
         class SomeImportedModule {
         }
 
-        @NgModule({
-          declarations: [CompUsingModuleDirectiveAndPipe],
-          imports: [SomeImportedModule],
-          entryComponents: [CompUsingModuleDirectiveAndPipe]
-        })
+        @NgModule({declarations: [CompUsingModuleDirectiveAndPipe], imports: [SomeImportedModule]})
         class SomeModule {
         }
 
@@ -615,11 +590,7 @@ describe('NgModule', () => {
         class SomeImportedModule {
         }
 
-        @NgModule({
-          declarations: [CompUsingModuleDirectiveAndPipe],
-          imports: [SomeImportedModule],
-          entryComponents: [CompUsingModuleDirectiveAndPipe]
-        })
+        @NgModule({declarations: [CompUsingModuleDirectiveAndPipe], imports: [SomeImportedModule]})
         class SomeModule {
         }
 

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -117,15 +117,7 @@ describe('projection', () => {
     class MultipleContentTagsComponent {
     }
 
-    @NgModule({
-      declarations: [MultipleContentTagsComponent],
-      entryComponents: [MultipleContentTagsComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-    })
-    class MyModule {
-    }
-
-    TestBed.configureTestingModule({imports: [MyModule]});
+    TestBed.configureTestingModule({declarations: [MultipleContentTagsComponent]});
     const injector: Injector = TestBed.inject(Injector);
 
     const componentFactoryResolver: ComponentFactoryResolver =
@@ -710,18 +702,14 @@ describe('projection', () => {
       }
     }
 
-    @NgModule({
-      declarations: [WithContentCmpt, InsertTplRef, DelayedInsertTplRef, ReProjectCmpt],
-      entryComponents: [WithContentCmpt]
-    })
-    class TestModule {
-    }
-
     let fixture: ComponentFixture<TestComponent>;
 
     function createCmptInstance(
         tpl: string, projectableNodes: any[][]): ComponentRef<WithContentCmpt> {
-      TestBed.configureTestingModule({declarations: [TestComponent], imports: [TestModule]});
+      TestBed.configureTestingModule({
+        declarations:
+            [WithContentCmpt, InsertTplRef, DelayedInsertTplRef, ReProjectCmpt, TestComponent],
+      });
       TestBed.overrideTemplate(WithContentCmpt, tpl);
 
       fixture = TestBed.createComponent(TestComponent);

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -347,12 +347,7 @@ describe('regressions', () => {
     class App {
     }
 
-    @NgModule({declarations: [App], entryComponents: [App]})
-    class MyModule {
-    }
-
-    const modRef = TestBed.configureTestingModule({imports: [MyModule]}).get(NgModuleRef) as
-        NgModuleRef<MyModule>;
+    const modRef = TestBed.configureTestingModule({declarations: [App]}).inject(NgModuleRef);
     const compRef =
         modRef.componentFactoryResolver.resolveComponentFactory(App).create(Injector.NULL);
 

--- a/packages/core/test/linker/view_injector_integration_spec.ts
+++ b/packages/core/test/linker/view_injector_integration_spec.ts
@@ -854,20 +854,13 @@ describe('View injector', () => {
         constructor(public vcr: ViewContainerRef) {}
       }
 
-      @NgModule({
-        declarations: [TestComp],
-        entryComponents: [TestComp],
-      })
-      class TestModule {
-      }
-
       const testInjector = <Injector>{
         get: (token: any, notFoundValue: any) =>
             token === 'someToken' ? 'someNewValue' : notFoundValue
       };
 
-      const compFactory = TestBed.configureTestingModule({imports: [TestModule]})
-                              .get(ComponentFactoryResolver)
+      const compFactory = TestBed.configureTestingModule({declarations: [TestComp]})
+                              .inject(ComponentFactoryResolver)
                               .resolveComponentFactory(TestComp);
       const component = compFactory.create(testInjector);
       expect(component.instance.vcr.parentInjector.get('someToken')).toBe('someNewValue');
@@ -946,17 +939,11 @@ describe('View injector', () => {
     class SomeComponent {
     }
 
-    @NgModule(
-        {declarations: [SomeComponent], exports: [SomeComponent], entryComponents: [SomeComponent]})
-    class SomeModule {
-    }
-
     @Component({selector: 'listener-and-on-destroy', template: ''})
     class ComponentThatLoadsAnotherComponentThenMovesIt {
       constructor(
           private viewContainerRef: ViewContainerRef,
           private componentFactoryResolver: ComponentFactoryResolver) {}
-
 
       ngOnInit() {
         // Dynamically load some component.
@@ -978,8 +965,7 @@ describe('View injector', () => {
 
     it('should not error when destroying a component that has been moved in the DOM', () => {
       TestBed.configureTestingModule({
-        imports: [SomeModule],
-        declarations: [ComponentThatLoadsAnotherComponentThenMovesIt],
+        declarations: [ComponentThatLoadsAnotherComponentThenMovesIt, SomeComponent],
       });
       const fixture = createComponentFixture(`<listener-and-on-destroy></listener-and-on-destroy>`);
       fixture.detectChanges();


### PR DESCRIPTION
Cleans up all the tests that had to declare a separate module in order to pass in `entryComponents` when creating components dynamically. This covers almost all of the `entryComponents` usages, except for a few which I've left for now, because they're testing some of the existing leftover `entryComponents` logic in core.