### PR TITLE
fix(docs-infra): prevent automatic linking of 'json'

### DIFF
--- a/aio/content/guide/ajs-quick-reference.md
+++ b/aio/content/guide/ajs-quick-reference.md
@@ -843,7 +843,7 @@ For more information on pipes, see [Pipes](guide/pipes).
       <code-example hideCopy path="ajs-quick-reference/src/app/app.component.html" region="json"></code-example>
 
 
-      The Angular `json` pipe does the same thing.
+      The Angular [`json`](api/common/JsonPipe) pipe does the same thing.
     </td>
 
   </tr>

--- a/aio/content/guide/forms.md
+++ b/aio/content/guide/forms.md
@@ -220,7 +220,7 @@ Any unique value will do, but using a descriptive name is helpful.
 
 2. You can now remove the diagnostic messages that show interpolated values.
 
-3. To confirm that two-way data binding works for the entire hero model, add a new text binding with the [`json` pipe](api/common/JsonPipe) (which would serialize the data to a string) at the top to the component's template.
+3. To confirm that two-way data binding works for the entire hero model, add a new text binding with the [`json`](api/common/JsonPipe) pipe (which would serialize the data to a string) at the top to the component's template.
 
 After these revisions, the form template should look like the following:
 

--- a/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
+++ b/aio/tools/transforms/angular-base-package/services/auto-link-filters/ignoreGenericWords.js
@@ -5,6 +5,19 @@
  */
 
 module.exports = function ignoreGenericWords() {
-  const ignoredWords = new Set(['a', 'classes', 'create', 'error', 'group', 'number', 'request', 'state', 'target', 'value', '_']);
+  const ignoredWords = new Set([
+    'a',
+    'classes',
+    'create',
+    'error',
+    'group',
+    'json',
+    'number',
+    'request',
+    'state',
+    'target',
+    'value',
+    '_'
+  ]);
   return (docs, words, index) => ignoredWords.has(words[index].toLowerCase()) ? [] : docs;
 };


### PR DESCRIPTION
add 'json' to the ignoreGenericWords set so that it doesn't get
wrongly linked to the jsonPipe during the aio docs generation
as it is a generic javarscript term

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
@gkalpak sorry it took me a while to get around to this one :sweat: 
 
By a search I've found 2 cases in which the autolinking was wrong and 2 in which it was actually correct:

![Screenshot at 2021-11-27 22-39-53](https://user-images.githubusercontent.com/61631103/143722427-013af28b-54ad-460f-af82-265e277146c1.png)

So adding it to the ignoredwords may not look too necessary, if you prefer I can instead break the unwanted autolinkings instead (but I think it would actually be a good addition there as a bit generic) :slightly_smiling_face: 