### PR TITLE
ci: update owners for fw-benchmarks

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -717,7 +717,9 @@ groups:
           ])
     reviewers:
       users:
+        - alxhub
         - IgorMinar
+        - jelbourn
         # OOO as of 2020-09-28 - pkozlowski-opensource
 
   # =========================================================


### PR DESCRIPTION
Add alxhub and jelbourn to owners for fw-benchmarks group.
