### PR TITLE
docs: update getting started experience to use only one tutorial

### DIFF
--- a/aio/content/examples/toh-pt0/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/toh-pt0/e2e/src/app.e2e-spec.ts
@@ -3,8 +3,8 @@ import { browser, element, by } from 'protractor';
 describe('Tour of Heroes', () => {
   beforeEach(() => browser.get('/'));
 
-  it('should display "Tour of Heroes"', async () => {
+  it('should display "Hello Angular!"', async () => {
     const title = await element(by.css('app-root h1')).getText();
-    expect(title).toEqual('Tour of Heroes');
+    expect(title).toEqual('Hello Angular!');
   });
 });

--- a/aio/content/examples/toh-pt0/src/app/app.component.1.html
+++ b/aio/content/examples/toh-pt0/src/app/app.component.1.html
@@ -1,0 +1,1 @@
+<h1>{{title}}<img [src]="logo"></h1>

--- a/aio/content/examples/toh-pt0/src/app/app.component.1.ts
+++ b/aio/content/examples/toh-pt0/src/app/app.component.1.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+export class AppComponent {
+    // #docregion text-interpolation
+    title = 'Tour of Heroes';
+    // #enddocregion text-interpolation
+    // #docregion property-binding
+    logo = 'https://angular.io/assets/images/logos/angular/angular.svg';
+    // #enddocregion property-binding
+    // #docregion attribute-binding
+    logoWidth = '25%';
+    // #enddocregion attribute-binding
+  }

--- a/aio/content/examples/toh-pt0/src/app/app.component.2.html
+++ b/aio/content/examples/toh-pt0/src/app/app.component.2.html
@@ -1,0 +1,1 @@
+<h1>{{title}}<img [src]="logo" [attr.width]="logoWidth"></h1>

--- a/aio/content/examples/toh-pt0/src/app/app.component.3.html
+++ b/aio/content/examples/toh-pt0/src/app/app.component.3.html
@@ -1,0 +1,5 @@
+<h1>{{title}}<img [src]="logo" [attr.width]="logoWidth"></h1>
+
+<!-- #docregion event-binding-->
+<button (click)="showGreeting()">Show Greeting</button>
+<!-- #enddocregion event-binding -->

--- a/aio/content/examples/toh-pt0/src/app/app.component.3.ts
+++ b/aio/content/examples/toh-pt0/src/app/app.component.3.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.css']
+})
+export class AppComponent {
+    // #docregion text-interpolation
+    title = 'Tour of Heroes';
+    // #enddocregion text-interpolation
+    // #docregion property-binding
+    logo = 'https://angular.io/assets/images/logos/angular/angular.svg';
+    // #enddocregion property-binding
+    // #docregion attribute-binding
+    logoWidth = '25%';
+    // #enddocregion attribute-binding
+  }

--- a/aio/content/examples/toh-pt0/src/app/app.component.3.ts
+++ b/aio/content/examples/toh-pt0/src/app/app.component.3.ts
@@ -5,14 +5,14 @@ import { Component } from '@angular/core';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
+// #docregion event-binding
 export class AppComponent {
-    // #docregion text-interpolation
     title = 'Tour of Heroes';
-    // #enddocregion text-interpolation
-    // #docregion property-binding
     logo = 'https://angular.io/assets/images/logos/angular/angular.svg';
-    // #enddocregion property-binding
-    // #docregion attribute-binding
     logoWidth = '25%';
-    // #enddocregion attribute-binding
+
+    showGreeting() {
+      alert('Hello, Angular developer!');
+    }
   }
+// #enddocregion event-binding

--- a/aio/content/examples/toh-pt0/src/app/app.component.ts
+++ b/aio/content/examples/toh-pt0/src/app/app.component.ts
@@ -6,7 +6,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
-// #docregion set-title
   title = 'Hello Angular!';
-// #enddocregion set-title
 }

--- a/aio/content/examples/toh-pt0/src/app/app.component.ts
+++ b/aio/content/examples/toh-pt0/src/app/app.component.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
 // #docregion set-title
-  title = 'Tour of Heroes';
+  title = 'Hello Angular!';
 // #enddocregion set-title
 }

--- a/aio/content/examples/toh-pt1/src/app/heroes/heroes.component.ts
+++ b/aio/content/examples/toh-pt1/src/app/heroes/heroes.component.ts
@@ -2,7 +2,9 @@
 // #docregion, v1
 import { Component, OnInit } from '@angular/core';
 // #enddocregion v1
+// #docregion import-interface
 import { Hero } from '../hero';
+// #enddocregion import-interface
 // #docregion v1
 
 @Component({
@@ -17,11 +19,12 @@ export class HeroesComponent implements OnInit {
   hero = 'Windstorm';
   // #enddocregion add-hero
   */
-  // #docregion
+  // #docregion, hero-interface
   hero: Hero = {
     id: 1,
     name: 'Windstorm'
   };
+  // #enddocregion hero-interface
   // #docregion v1
 
   constructor() { }

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.1.html
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.1.html
@@ -2,7 +2,7 @@
 <h2>My Heroes</h2>
 <ul class="heroes">
   <li>
-    <span class="badge">{{hero.id}}</span> {{hero.name}}
+    <a class="badge">{{hero.id}}</a> {{hero.name}}
   </li>
 </ul>
 <!-- #enddocregion list -->

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.html
@@ -14,12 +14,9 @@
 <div *ngIf="selectedHero">
 
   <!-- #docregion selectedHero-details -->
-  <h2>{{selectedHero.name | uppercase}} Details</h2>
+  <h2>{{selectedHero.name }} Details</h2>
   <div><span>id: </span>{{selectedHero.id}}</div>
-  <div>
-    <label for="hero-name">Hero name: </label>
-    <input id="hero-name" [(ngModel)]="selectedHero.name" placeholder="name">
-  </div>
+  <div><span>name: </span>{{selectedHero.name}}</div>
   <!-- #enddocregion selectedHero-details -->
 
 </div>

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -691,14 +691,19 @@
               "tooltip": "Introduction to the Tour of Heroes app and tutorial"
             },
             {
-              "url": "tutorial/toh-pt0",
-              "title": "Create a Project",
-              "tooltip": "Creating the application shell"
+              "url": "tutorial/toh-hello-angular",
+              "title": "Hello Angular!",
+              "tooltip": "A five minute overview of the Angular developer experience."
             },
             {
-              "url": "tutorial/toh-pt1",
-              "title": "1. The Hero Editor",
-              "tooltip": "Part 1: Build a simple editor"
+              "url": "tutorial/toh-templates",
+              "title": "Templates",
+              "tooltip": "Learn about Angular templates."
+            },
+            {
+              "url": "tutorial/toh-components",
+              "title": "Components",
+              "tooltip": "Learn about Angular components."
             },
             {
               "url": "tutorial/toh-pt2",

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -706,6 +706,11 @@
               "tooltip": "Learn about Angular components."
             },
             {
+              "url": "tutorial/toh-directives",
+              "title": "Directives",
+              "tooltip": "Learn about Angular directives."
+            },
+            {
               "url": "tutorial/toh-pt2",
               "title": "2. Display a List",
               "tooltip": "Part 2: Build a master/detail page with a list of heroes."

--- a/aio/content/tutorial/index.md
+++ b/aio/content/tutorial/index.md
@@ -1,26 +1,14 @@
-<h1 class="no-toc">Tour of Heroes app and tutorial</h1>
+# Tour of Heroes app and tutorial
 
-<div class="callout is-helpful">
-<header>Getting Started</header>
+Welcome to Angular!
 
-In this tutorial, you build your own application from the ground up, providing experience with the typical development process, as well as an introduction to basic app-design concepts, tools, and terminology.
+In this introductory tutorial, you'll build an application to help a staffing agency manage its stable of heroes. Along the way, you'll learn about the concepts and features that make the Angular framework an ideal environment for building your applications.
 
-If you're completely new to Angular, you might want to try the [**Try it now**](start) quick-start application first.
-It is based on a ready-made  partially-completed project, which you can examine and modify in the StackBlitz interactive development environment, where you can see the results in real time.
-
-The "Try it" tutorial covers the same major topics&mdash;components, template syntax, routing, services, and accessing data using HTTP&mdash;in a condensed format, following the most current best practices.
-
-</div>
-
-This _Tour of Heroes_ tutorial shows you how to set up your local development environment and develop an application using the [Angular CLI tool](cli "CLI command reference"), and provides an introduction to the fundamentals of Angular.
-
-The _Tour of Heroes_ application that you build helps a staffing agency manage its stable of heroes.
-The application has many of the features you'd expect to find in any data-driven application.
-The finished application acquires and displays a list of heroes, edits a selected hero's detail, and navigates among different views of heroic data.
-
-You will find references to and expansions of this application domain in many of the examples used throughout the Angular documentation, but you don't necessarily need to work through this tutorial to understand those examples.
+## Objectives
 
 By the end of this tutorial you will be able to do the following:
+
+<!-- TODO: Change order to reflect tutorial flow -->
 
 * Use built-in Angular [directives](guide/glossary#directive "Directives definition") to show and hide elements and display lists of hero data.
 * Create Angular [components](guide/glossary#component "Components definition") to display hero details and show an array of heroes.
@@ -32,9 +20,6 @@ By the end of this tutorial you will be able to do the following:
 * Create a shared [service](guide/glossary#service "Service definition") to assemble the heroes.
 * Use [routing](guide/glossary#router "Router definition") to navigate among different views and their components.
 
-You'll learn enough Angular to get started and gain confidence that
-Angular can do whatever you need it to do.
-
 <div class="callout is-helpful">
 <header>Solution</header>
 
@@ -42,47 +27,16 @@ After completing all tutorial steps, the final application will look like this: 
 
 </div>
 
-## What you'll build
+## Prerequisites
 
-Here's a visual idea of where this tutorial leads, beginning with the "Dashboard"
-view and the most heroic heroes:
+To get the most out of this tutorial you should already have a basic understanding of the following.
 
-<div class="lightbox">
-  <img src='generated/images/guide/toh/heroes-dashboard-1.png' alt="Output of heroes dashboard">
-</div>
+* [HTML](https://developer.mozilla.org/en-US/docs/Learn/HTML "Learning HTML: Guides and tutorials")
+* [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript "JavaScript")
+* [TypeScript](https://www.typescriptlang.org/ "The TypeScript language")
 
-You can click the two links above the dashboard ("Dashboard" and "Heroes")
-to navigate between this Dashboard view and a Heroes view.
+## Get started learning about Angular
 
-If you click the dashboard hero "Magneta," the router opens a "Hero Details" view
-where you can change the hero's name.
+This tutorial is divided into several sections. We recommend completing all of the sections as they introduce you to many of the concepts and features you'll use as an Angular developer. However, you can also complete each section in any order, allowing you to explore Angular at your own pace.
 
-<div class="lightbox">
-  <img src='generated/images/guide/toh/hero-details-1.png' alt="Details of hero in app">
-</div>
-
-Clicking the "Back" button returns you to the Dashboard.
-Links at the top take you to either of the main views.
-If you click "Heroes," the application displays the "Heroes" master list view.
-
-
-<div class="lightbox">
-  <img src='generated/images/guide/toh/heroes-list-2.png' alt="Output of heroes list app">
-</div>
-
-When you click a different hero name, the read-only mini detail beneath the list reflects the new choice.
-
-You can click the "View Details" button to drill into the
-editable details of the selected hero.
-
-The following diagram captures all of the navigation options.
-
-<div class="lightbox">
-  <img src='generated/images/guide/toh/nav-diagram.png' alt="View navigations">
-</div>
-
-Here's the application in action:
-
-<div class="lightbox">
-  <img src='generated/images/guide/toh/toh-anim.gif' alt="Tour of Heroes in Action">
-</div>
+<!-- TODO: Add cards -->

--- a/aio/content/tutorial/toh-components.md
+++ b/aio/content/tutorial/toh-components.md
@@ -17,7 +17,6 @@ In this tutorial, you'll do the following:
 
 1. Use the Angular CLI to create a new component.
 1. Update the application view to display the component.
-1. Learn how to pass data between a parent component and a child component using Angular's `@Input` and `@Output` decorators.
 
 ## Create a heroes component
 
@@ -49,7 +48,7 @@ Open the component file, `heroes.component.ts`. The contents of this file should
 1. `templateUrl`&mdash; the location of the component's template file. In this tutorial, the file is `heroes.component.html`.
 1. `styleUrls`&mdash; the location of the component's private CSS styles. In this tutorial, the file is `heroes.component.css`.
 
-## Update the heroes component
+## Update the `heroes` component
 
 In this section, you'll add some additional functionality to the new `heroes` component. You'll add a new property, `hero` and bind that to the component's template. You'll also update your application to include the `heroes` component as a child component.
 
@@ -62,7 +61,7 @@ To update the `heroes` component
 
 ## Show the `HeroesComponent` view
 
-At this point, you can now display the heroes component in your application.
+At this point, you can now display the `heroes` component in your application.
 
 To display the component:
 
@@ -73,4 +72,25 @@ To display the component:
 
 Your application should update to display the name of a single hero, `Windstorm`.
 
-<!-- TODO Add Feature Component, Hero Details -->
+## Expanding the `heroes` component
+
+In this section, you'll define an interface for use within the `heroes` component. You'll then update the `heroes` component to use this new interface. These additions support additional features made in other Tour of Heroes tutorials.
+
+To expand the `heroes` component:
+
+1. From the terminal window in your Stackblitz project, create a new interface, `hero`.
+   <code-example language="sh">
+   ng generate interface hero
+   </code-example>
+1. Open the newly created `hero.ts` file and update its contents with the following code.
+   <code-example path="toh-pt1/src/app/hero.ts" header="src/app/heroes/hero.ts"></code-example>
+1. Open `heroes.component.ts` file.
+1. Add an `import` statement to import the `Hero` interface.
+   <code-example path="toh-pt1/src/app/heroes/heroes.component.ts" header="src/app/heroes/heroes.component.ts" region="import-interface"></code-example>
+1. Refactor the component's `hero` property to be of type `Hero`, with an initial ID of `1` and the name `Windstorm`.
+   <code-example path="toh-pt1/src/app/heroes/heroes.component.ts" header="src/app/heroes/heroes.component.ts" region="hero-interface"></code-example>
+1. Update the template for the `heroes` component to display the properties of a `hero` object.
+   <code-example path="toh-pt1/src/app/heroes/heroes.component.1.html" region="show-hero-2" header="heroes.component.html (HeroesComponent's template)"></code-example>
+
+Notice that the application updates to display the new information.
+

--- a/aio/content/tutorial/toh-components.md
+++ b/aio/content/tutorial/toh-components.md
@@ -1,0 +1,76 @@
+# Tour of Heroes: Components
+
+Most Angular applications consist of the following:
+
+* A component that defines a class that contains application data and logic
+* A template that defines a view to display in a target environment.
+
+In this tutorial, you'll explore some of the key capabilities of Angular components.
+
+## Prerequisites
+
+Before you start this tutorial, you should understand the concepts covered in [Tour of Heroes: Hello Angular](tutorial/toh-hello-angular). Specifically, you'll need a Stackblitz Angular application.
+
+## Objectives
+
+In this tutorial, you'll do the following:
+
+1. Use the Angular CLI to create a new component.
+1. Update the application view to display the component.
+1. Learn how to pass data between a parent component and a child component using Angular's `@Input` and `@Output` decorators.
+
+## Create a heroes component
+
+The [Angular CLI](cli) is the fastest, straightforward, and recommended way to develop Angular applications. In this section, you'll use the Angular CLI to  generate a new component named `heroes`.
+
+To generate the `heroes` component:
+
+1. In your Stackblitz environment, open a new terminal window. You can open a new terminal window by clicking the plus sign in the upper right corner of the terminal pane.
+1. In the new terminal window, run the following Angular CLI command:
+   <code-example language="sh">
+   ng generate component heroes
+   </code-example>
+
+   The CLI creates a new folder, `src/app/heroes/`, and generates
+   the following files:
+
+   * heroes.component.ts, the component's TypeScript file.
+   * heroes.component.html, the component's HTML template file.
+   * heroes.component.css, the component's CSS file.
+   * heroes.component.spec.ts, the component's testing file.
+
+Open the component file, `heroes.component.ts`. The contents of this file should resemble the following:
+
+<code-example path="toh-pt1/src/app/heroes/heroes.component.ts" region="v1" header="app/heroes/heroes.component.ts (initial version)"></code-example>
+
+`@Component` is a decorator function that specifies the Angular metadata for the component. This decorator is required, and is imported from the Angular core library. The CLI command, `ng generate component`, generates three of these metadata properties:
+
+1. `selector`&mdash; the component's CSS element selector. In this case, the selector is `app-heroes`. This selector matches the name of the HTML element that identifies this component within a parent component's template.
+1. `templateUrl`&mdash; the location of the component's template file. In this tutorial, the file is `heroes.component.html`.
+1. `styleUrls`&mdash; the location of the component's private CSS styles. In this tutorial, the file is `heroes.component.css`.
+
+## Update the heroes component
+
+In this section, you'll add some additional functionality to the new `heroes` component. You'll add a new property, `hero` and bind that to the component's template. You'll also update your application to include the `heroes` component as a child component.
+
+To update the `heroes` component
+
+1. Add a `hero` property to the `HeroesComponent` for a hero named "Windstorm."
+   <code-example path="toh-pt1/src/app/heroes/heroes.component.ts" region="add-hero" header="heroes.component.ts (hero property)"></code-example>
+1. Open the `heroes.component.html` template file and replace its contents with a data binding to the new `hero` property.
+   <code-example path="toh-pt1/src/app/heroes/heroes.component.1.html" header="heroes.component.html" region="show-hero-1"></code-example>
+
+## Show the `HeroesComponent` view
+
+At this point, you can now display the heroes component in your application.
+
+To display the component:
+
+1. Open the `app.component.html` file.
+1. Add an `<app-heroes>` element to the file, just below the title.
+
+<code-example path="toh-pt1/src/app/app.component.html" header="src/app/app.component.html"></code-example>
+
+Your application should update to display the name of a single hero, `Windstorm`.
+
+<!-- TODO Add Feature Component, Hero Details -->

--- a/aio/content/tutorial/toh-directives.md
+++ b/aio/content/tutorial/toh-directives.md
@@ -1,0 +1,81 @@
+# Tour of Heroes: Directives
+
+One key feature of Angular is its support of directives. Directives are classes that add additional behavior to elements in your Angular applications.
+
+## Prerequisites
+
+Before you start this tutorial, you should understand the concepts covered in [Tour of Heroes: Hello Angular](tutorial/toh-hello-angular). Specifically, you'll need a Stackblitz Angular application.
+
+## Objectives
+
+In this tutorial, you'll do the following:
+
+1. Display a list of of items using the `*ngFor` directive.
+1. Display a selected hero in your Tour of Heroes application using `*ngIf`.
+
+## Display a list of heroes using `*ngFor`
+
+The `heroes` component of the current Tour of Heroes application has a property, `hero`. This property contains a single object that consists of a hero's ID and name.
+
+<code-example path="toh-pt1/src/app/heroes/heroes.component.ts" header="src/app/heroes/heroes.component.ts" region="hero-interface"></code-example>
+
+The template for this component displays the information about the hero to the user.
+
+<code-example path="toh-pt1/src/app/heroes/heroes.component.1.html" region="show-hero-2" header="heroes.component.html (HeroesComponent's template)"></code-example>
+
+In this section, you'll update this code to display a list of heroes using one of Angular's built-in directives, `*ngFor`.
+
+To display a list of heroes using `*ngFor`:
+
+1. Right-click the `app` folder in your Stackblitz environment and select `Add file`.
+1. Name the file `mock-heroes.ts`.
+1. Open the file and update its contents as follows:
+   <code-example path="toh-pt2/src/app/mock-heroes.ts" header="src/app/mock-heroes.ts"></code-example>
+1. Import the new file into the `heroes` component.
+   <code-example path="toh-pt2/src/app/heroes/heroes.component.ts" region="import-heroes" header="src/app/heroes/heroes.component.ts (import HEROES)"></code-example>
+1. In the `heroes` component file, define a component property called `heroes` to expose the `HEROES` array for binding.
+   <code-example path="toh-pt2/src/app/heroes/heroes.component.ts" header="src/app/heroes/heroes.component.ts" region="component"></code-example>
+1. Update the template files, `heroes.component.html` to display the information about a hero in an unordered list.
+   <code-example path="toh-pt2/src/app/heroes/heroes.component.1.html" region="list" header="heroes.component.html (heroes template)"></code-example>
+1. Add an `*ngFor` to the `<li>` element.
+  <code-example path="toh-pt2/src/app/heroes/heroes.component.1.html" region="li"></code-example>
+
+The application updates to display a list of heroes to the user.
+
+<div class="alert is-helpful">
+
+You can now delete the existing `hero` property that you created previously.
+
+</div>
+
+The [`*ngFor`](guide/built-in-directives#ngFor) is Angular's _repeater_ directive.
+It repeats the host element for each element in a list.
+
+The syntax in this example is as follows:
+
+* `<li>` is the host element.
+* `heroes` holds the mock heroes list from the `HeroesComponent` class, the mock heroes list.
+* `hero` holds the current hero object for each iteration through the list.
+
+<div class="alert is-important">
+
+Don't forget the asterisk (*) in front of `ngFor`. It's a critical part of the syntax.
+
+</div>
+
+## Display a selected hero using `*ngIf`
+
+Another built-in directive used in many application is `*ngIf`. With `*ngIf`, Angular renders an element in the DOM only when specific conditions are met.
+
+In the following steps, you'll update the Tour of Heroes application to display additional information about a hero when the user selects one from the list. 
+
+To display a selected hero using `*ngIf`:
+
+1. Add a click event binding to the `<li>` element.
+   <code-example path="toh-pt2/src/app/heroes/heroes.component.1.html" region="selectedHero-click" header="heroes.component.html (template excerpt)"></code-example>
+1. Add the corresponding event handler, `onSelect()`, which assigns the clicked hero from the template to the component's `selectedHero`.
+   <code-example path="toh-pt2/src/app/heroes/heroes.component.ts" region="on-select" header="src/app/heroes/heroes.component.ts (onSelect)"></code-example>
+1. Update the template for the `heroes` component to include a `Hero Details` section.
+   <code-example path="toh-pt2/src/app/heroes/heroes.component.html" region="ng-if" header="src/app/heroes/heroes.component.html (*ngIf)"></code-example>
+
+Notice the `div` element that includes the `*ngIf`. This directive ensures that the application renders the hero details section only after the user selects a hero from the list.

--- a/aio/content/tutorial/toh-directives.md
+++ b/aio/content/tutorial/toh-directives.md
@@ -79,3 +79,5 @@ To display a selected hero using `*ngIf`:
    <code-example path="toh-pt2/src/app/heroes/heroes.component.html" region="ng-if" header="src/app/heroes/heroes.component.html (*ngIf)"></code-example>
 
 Notice the `div` element that includes the `*ngIf`. This directive ensures that the application renders the hero details section only after the user selects a hero from the list.
+
+<!-- TODO: Add what's next -->

--- a/aio/content/tutorial/toh-hello-angular.md
+++ b/aio/content/tutorial/toh-hello-angular.md
@@ -1,0 +1,48 @@
+# Tour of Heroes: Hello Angular
+
+This tutorial introduces you to the basics of creating an Angular application. You'll create a starter application and test out Angular text interpolation feature.
+
+## Prerequisites
+
+To get the most out of this tutorial you should already have a basic understanding of the following.
+
+* [HTML](https://developer.mozilla.org/en-US/docs/Learn/HTML "Learning HTML: Guides and tutorials")
+* [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript "JavaScript")
+* [TypeScript](https://www.typescriptlang.org/ "The TypeScript language")
+
+## Objectives
+
+In this tutorial, you'll do the following:
+
+1. Create a new Angular project, using [Stackblitz][stackblitz].
+1. Display the application title using [text interpolation](guide/text-interpolation).
+1. Explore some of the key files that are part of any Angular application.
+
+## Create the sample project
+
+To create the sample project:
+
+1. Open the <live-example name="toh-pt0" noDownload>starter project</live-example>  in StackBlitz.
+1. Log into Stackblitz using your GitHub account.
+1. Fork the project.
+
+For more information on Angular's directory structure, see [Workspace and project file structure](guide/file-structure).
+
+## Update the application title
+
+One of Angular's basic features is text interpolation. You'll use this feature to update the title of your new application.
+
+To update the application title:
+
+1. Open the component class file `app.component.ts`.
+1. Set the value of the `title` property to `Hello Angular!`.
+
+<code-example path="toh-pt0/src/app/app.component.1.ts" header="app.component.ts" region="text-interpolation"></code-example>
+
+The browser refreshes and displays the new application title.
+
+## What's next
+
+You now have a basic Angular application and are ready to explore more of Angular's features and capabilities.
+
+To continue the Tour of Heroes tutorial, see [Tour of Heroes: Templates](tutorial/toh-templates).

--- a/aio/content/tutorial/toh-hello-angular.md
+++ b/aio/content/tutorial/toh-hello-angular.md
@@ -15,7 +15,7 @@ To get the most out of this tutorial you should already have a basic understandi
 In this tutorial, you'll do the following:
 
 1. Create a new Angular project, using [Stackblitz][stackblitz].
-1. Display the application title using [text interpolation](guide/text-interpolation).
+1. Display the application title using [text interpolation](guide/interpolation).
 1. Explore some of the key files that are part of any Angular application.
 
 ## Create the sample project

--- a/aio/content/tutorial/toh-pt0.md
+++ b/aio/content/tutorial/toh-pt0.md
@@ -7,7 +7,7 @@ This tutorial introduces you to the basics of creating an Angular application. Y
 In this part of the tutorial, you'll do the following:
 
 1. Create a new Angular project, using [Stackblitz][stackblitz].
-1. Display the application title using [text interpolation](guide/text-interpolation).
+1. Display the application title using [text interpolation](guide/interpolation).
 1. Add a logo with [property binding](guide/property-binding).
 1. Change the logo size using [attribute binding](guide/attribute-binding).
 
@@ -27,7 +27,7 @@ To create the sample project:
 
 ## Display the application title with text interpolation
 
-In this section, you'll use Angular's [text interpolation][text-interpolation] to display the application's title.
+In this section, you'll use Angular's [text interpolation](interpolation] to display the application's title.
 
 To update the application title:
 

--- a/aio/content/tutorial/toh-pt0.md
+++ b/aio/content/tutorial/toh-pt0.md
@@ -1,14 +1,8 @@
 # Tour of Heroes: Components and templates
 
-This tutorial introduces you to Angular components.
-Components are the fundamental building blocks of Angular applications.
-They display data on the screen, listen for user input, and take action based on that input.
+This tutorial introduces you to the basics of creating an Angular application. You'll create a starter application and test out Angular text interpolation feature.
 
-A component consists of three things:
-
-* **A component class** that handles data and functionality.
-* **An HTML template** that determines the UI.
-* **Component-specific styles** that define the look and feel.
+## Objectives
 
 In this part of the tutorial, you'll do the following:
 
@@ -30,17 +24,16 @@ To create the sample project:
 1. Log into Stackblitz using your GitHub account.
 1. Fork the project.
 
-## Update the application title
+## Display the application title with text interpolation
 
-In this section, you'll use Angular's [text interpolation][text-interpolation] to update the application title.
+In this section, you'll use Angular's [text interpolation][text-interpolation] to display the application's title.
 
 To update the application title:
 
 1. Open the component class file `app.component.ts`.
-1. Locate the `title` property.
-1. Change the value of the `title` property to `Tour of Heroes`.
+1. Set the value of the `title` property to `Tour of Heroes`.
 
-<code-example path="toh-pt0/src/app/app.component.ts" header="app.component.ts"></code-example>
+<code-example path="toh-pt0/src/app/app.component.1.ts" header="app.component.ts" region="text-interpolation"></code-example>
 
 The double curly braces are Angular's *interpolation binding* syntax.
 This interpolation binding presents the component's `title` property value
@@ -49,6 +42,36 @@ inside the HTML header tag.
 The browser refreshes and displays the new application title.
 
 {@a app-wide-styles}
+
+## Add a logo with property binding
+
+Next, you'll add the Angular logo to the application title using Angular's [property binding](guide/property-binding) feature.
+
+To add the Angular logo:
+
+1. Open the component class file `app.component.ts`.
+1. Add a new property, `logo` and set its value to `https://angular.io/assets/images/logos/angular/angular.svg`.
+   <code-example path="toh-pt0/src/app/app.component.1.ts" header="app.component.ts" region="property-binding"></code-example>
+1. Open the component template file, `app.component.html`.
+1. Update the title as follows.
+   <code-example path="toh-pt0/src/app/app.component.1.html" header="app.component.html"></code-example>
+
+The square brackets, `[]`, that surround the `src` property indicates to Angular that this property is a target property. A target property is the DOM property to which you want to assign a value.
+
+For more information on property binding, see [Property binding](guide/property-binding).
+
+## Change the logo size using attribute binding
+
+At present, the logo you added in the previous section is too large. In this section, you'll adjust the size using Angular's [attribute binding](guide/attribute-binding) feature.
+
+To change the logo size:
+
+1. Open the component class file `app.component.ts`.
+1. Add a new property, `logoWidth` and set its value to `25%`.
+   <code-example path="toh-pt0/src/app/app.component.1.ts" header="app.component.ts" region="attribute-binding"></code-example>
+1. Open the component template file, `app.component.html`.
+1. Update the title as follows.
+   <code-example path="toh-pt0/src/app/app.component.2.html" header="app.component.html"></code-example>
 
 ## Add application styles
 

--- a/aio/content/tutorial/toh-pt0.md
+++ b/aio/content/tutorial/toh-pt0.md
@@ -8,7 +8,9 @@ In this part of the tutorial, you'll do the following:
 
 1. Create a new Angular project, using [Stackblitz][stackblitz].
 1. Serve the application.
-1. Try out [text interpolation][text-interpolation], a basic feature that allows you to incorporate dynamic string values into an Angular template.
+1. Display the application title using [text interpolation](guide/text-interpolation).
+1. Add a logo with [property binding](guide/property-binding).
+1. Change the logo size using [attribute binding](guide/attribute-binding).
 
 <!-- <div class="alert is-helpful">
 

--- a/aio/content/tutorial/toh-pt0.md
+++ b/aio/content/tutorial/toh-pt0.md
@@ -1,100 +1,46 @@
-# Create a new project
+# Tour of Heroes: Components and templates
 
-You begin by creating an initial application using the Angular CLI. Throughout this tutorial, you’ll modify and extend that starter application to create the Tour of Heroes application.
+This tutorial introduces you to Angular components.
+Components are the fundamental building blocks of Angular applications.
+They display data on the screen, listen for user input, and take action based on that input.
+
+A component consists of three things:
+
+* **A component class** that handles data and functionality.
+* **An HTML template** that determines the UI.
+* **Component-specific styles** that define the look and feel.
 
 In this part of the tutorial, you'll do the following:
 
-1. Set up your environment.
-2. Create a new workspace and initial application project.
-3. Serve the application.
-4. Make changes to the application.
+1. Create a new Angular project, using [Stackblitz][stackblitz].
+1. Serve the application.
+1. Try out [text interpolation][text-interpolation], a basic feature that allows you to incorporate dynamic string values into an Angular template.
 
-<div class="alert is-helpful">
+<!-- <div class="alert is-helpful">
 
   For the sample application that this page describes, see the <live-example></live-example>.
 
-</div>
+</div> -->
 
-## Set up your environment
+## Create the sample project
 
-To set up your development environment, follow the instructions in [Local Environment Setup](guide/setup-local "Setting up for Local Development").
+To create the sample project:
 
+1. Open the <live-example name="toh-pt0" noDownload>starter project</live-example>  in StackBlitz.
+1. Log into Stackblitz using your GitHub account.
+1. Fork the project.
 
-## Create a new workspace and an initial application
+## Update the application title
 
-You develop applications in the context of an Angular [workspace](guide/glossary#workspace). A workspace contains the files for one or more [projects](guide/glossary#project). A project is the set of files that comprise an application or a library. For this tutorial, you will create a new workspace.
+In this section, you'll use Angular's [text interpolation][text-interpolation] to update the application title.
 
-To create a new workspace and an initial application project:
+To update the application title:
 
-  1. Ensure that you are not already in an Angular workspace folder. For example, if you have previously created the Getting Started workspace, change to the parent of that folder.
-  2. Run the CLI command `ng new` and provide the name `angular-tour-of-heroes`, as shown here:
+1. Open the component class file `app.component.ts`.
+1. Locate the `title` property.
+1. Change the value of the `title` property to `Tour of Heroes`.
 
-  <code-example language="sh">
-     ng new angular-tour-of-heroes
-  </code-example>
-
-  3. The `ng new` command prompts you for information about features to include in the initial application project. Accept the defaults by pressing the Enter or Return key.
-
-The Angular CLI installs the necessary Angular `npm` packages and other dependencies. This can take a few minutes.
-
-It also creates the following workspace and starter project files:
-
-  * A new workspace, with a root folder named `angular-tour-of-heroes`.
-  * An initial skeleton app project in the `src/app` subfolder.
-  * Related configuration files.
-
-The initial app project contains a simple Welcome application, ready to run.
-
-## Serve the application
-
-Go to the workspace directory and launch the application.
-
-<code-example language="sh">
-  cd angular-tour-of-heroes
-  ng serve --open
-</code-example>
-
-<div class="alert is-helpful">
-
-The `ng serve` command builds the app, starts the development server,
-watches the source files, and rebuilds the application as you make changes to those files.
-
-The `--open` flag opens a browser to `http://localhost:4200/`.
-
-</div>
-
-You should see the application running in your browser.
-
-## Angular components
-
-The page you see is the _application shell_.
-The shell is controlled by an Angular **component** named `AppComponent`.
-
-_Components_ are the fundamental building blocks of Angular applications.
-They display data on the screen, listen for user input, and take action based on that input.
-
-## Make changes to the application
-
-Open the project in your favorite editor or IDE and navigate to the `src/app` folder to make some changes to the starter application.
-
-You'll find the implementation of the shell `AppComponent` distributed over three files:
-
-1. `app.component.ts`&mdash; the component class code, written in TypeScript.
-1. `app.component.html`&mdash; the component template, written in HTML.
-1. `app.component.css`&mdash; the component's private CSS styles.
-
-### Change the application title
-
-Open the component class file (`app.component.ts`) and change the value of the `title` property to 'Tour of Heroes'.
-
-<code-example path="toh-pt0/src/app/app.component.ts" region="set-title" header="app.component.ts (class title property)"></code-example>
-
-Open the component template file (`app.component.html`) and
-delete the default template generated by the Angular CLI.
-Replace it with the following line of HTML.
-
-<code-example path="toh-pt0/src/app/app.component.html"
-  header="app.component.html (template)"></code-example>
+<code-example path="toh-pt0/src/app/app.component.ts" header="app.component.ts"></code-example>
 
 The double curly braces are Angular's *interpolation binding* syntax.
 This interpolation binding presents the component's `title` property value
@@ -104,16 +50,18 @@ The browser refreshes and displays the new application title.
 
 {@a app-wide-styles}
 
-### Add application styles
+## Add application styles
 
-Most apps strive for a consistent look across the application.
-The CLI generated an empty `styles.css` for this purpose.
-Put your application-wide styles there.
+Define application-wide styles in the `app.component.css` file.
+Angular applies these styles across all application components.
 
-Open `src/styles.css` and add the code below to the file.
+To add application styles:
 
-<code-example path="toh-pt0/src/styles.1.css" header="src/styles.css (excerpt)">
-</code-example>
+1. Open the `src/styles.css` file.
+1. Add the following code to the file.
+
+   <code-example path="toh-pt0/src/styles.1.css" header="src/styles.css (excerpt)">
+   </code-example>
 
 ## Final code review
 
@@ -138,3 +86,6 @@ Here are the code files discussed on this page.
 * You created the initial application structure using the Angular CLI.
 * You learned that Angular components display data.
 * You used the double curly braces of interpolation to display the application title.
+
+[stackblitz]: https://stackblitz.com/
+[text-interpolation]: guide/interpolation

--- a/aio/content/tutorial/toh-pt1.md
+++ b/aio/content/tutorial/toh-pt1.md
@@ -1,8 +1,14 @@
-# The hero editor
+# Tour of Heroes: Components and templates
 
-The application now has a basic title.
-Next you will create a new component to display hero information
-and place that component in the application shell.
+This tutorial introduces you to Angular components.
+Components are the fundamental building blocks of Angular applications.
+They display data on the screen, listen for user input, and take action based on that input.
+
+A component consists of three things:
+
+* **A component class** that handles data and functionality.
+* **An HTML template** that determines the UI.
+* **Component-specific styles** that define the look and feel.
 
 <div class="alert is-helpful">
 

--- a/aio/content/tutorial/toh-templates.md
+++ b/aio/content/tutorial/toh-templates.md
@@ -1,29 +1,23 @@
-# Tour of Heroes: Getting started
+# Tour of Heroes: Templates
 
-This tutorial introduces you to the basics of creating an Angular application. You'll create a starter application and test out Angular text interpolation feature.
+Most Angular applications consist of the following:
+
+* A component that defines a class that contains application data and logic
+* A template that defines a view to display in a target environment.
+
+In this tutorial, you'll explore some of the key capabilities of Angular templates.
+
+## Prerequisites
+
+Before you start this tutorial, you should understand the concepts covered in [Tour of Heroes: Hello Angular](tutorial/toh-hello-angular). Specifically, you'll need a Stackblitz Angular application.
 
 ## Objectives
 
-In this part of the tutorial, you'll do the following:
+In this tutorial, you'll do the following:
 
-1. Create a new Angular project, using [Stackblitz][stackblitz].
-1. Display the application title using [text interpolation](guide/text-interpolation).
+1. Display a new application title using [text interpolation](guide/text-interpolation).
 1. Add a logo with [property binding](guide/property-binding).
 1. Change the logo size using [attribute binding](guide/attribute-binding).
-
-<!-- <div class="alert is-helpful">
-
-  For the sample application that this page describes, see the <live-example></live-example>.
-
-</div> -->
-
-## Create the sample project
-
-To create the sample project:
-
-1. Open the <live-example name="toh-pt0" noDownload>starter project</live-example>  in StackBlitz.
-1. Log into Stackblitz using your GitHub account.
-1. Fork the project.
 
 ## Display the application title with text interpolation
 
@@ -74,42 +68,14 @@ To change the logo size:
 1. Update the title as follows.
    <code-example path="toh-pt0/src/app/app.component.2.html" header="app.component.html"></code-example>
 
-## Add application styles
+## Display a greeting using event binding
 
-Define application-wide styles in the `app.component.css` file.
-Angular applies these styles across all application components.
+Another important type of binding that Angular supports is [event binding](guide/event-binding). To see event binding in action, add a button to your application that displays a greeting when clicked.
 
-To add application styles:
+To display a greeting using event binding:
 
-1. Open the `src/styles.css` file.
-1. Add the following code to the file.
-
-   <code-example path="toh-pt0/src/styles.1.css" header="src/styles.css (excerpt)">
-   </code-example>
-
-## Final code review
-
-Here are the code files discussed on this page.
-
-<code-tabs>
-
-  <code-pane header="src/app/app.component.ts" path="toh-pt0/src/app/app.component.ts">
-  </code-pane>
-
-  <code-pane header="src/app/app.component.html" path="toh-pt0/src/app/app.component.html">
-  </code-pane>
-
-  <code-pane
-    header="src/styles.css (excerpt)"
-    path="toh-pt0/src/styles.1.css">
-  </code-pane>
-</code-tabs>
-
-## Summary
-
-* You created the initial application structure using the Angular CLI.
-* You learned that Angular components display data.
-* You used the double curly braces of interpolation to display the application title.
-
-[stackblitz]: https://stackblitz.com/
-[text-interpolation]: guide/interpolation
+1. Open the component template file, `app.component.html`.
+1. Add a `button` element as follows.
+   <code-example path="toh-pt0/src/app/app.component.3.html" header="app.component.html" region="event-binding"></code-example>
+1. Open the component class file, `app.component.ts`.
+1. Add a `showGreeting` method, as follows.

--- a/aio/content/tutorial/toh-templates.md
+++ b/aio/content/tutorial/toh-templates.md
@@ -15,13 +15,13 @@ Before you start this tutorial, you should understand the concepts covered in [T
 
 In this tutorial, you'll do the following:
 
-1. Display a new application title using [text interpolation](guide/text-interpolation).
+1. Display a new application title using [text interpolation](guide/interpolation).
 1. Add a logo with [property binding](guide/property-binding).
 1. Change the logo size using [attribute binding](guide/attribute-binding).
 
 ## Display the application title with text interpolation
 
-In this section, you'll use Angular's [text interpolation][text-interpolation] to display the application's title.
+In this section, you'll use Angular's [text interpolation](guide/interpolation) to display the application's title.
 
 To update the application title:
 
@@ -79,3 +79,12 @@ To display a greeting using event binding:
    <code-example path="toh-pt0/src/app/app.component.3.html" header="app.component.html" region="event-binding"></code-example>
 1. Open the component class file, `app.component.ts`.
 1. Add a `showGreeting` method, as follows.
+   <code-example path="toh-pt0/src/app/app.component.3.ts" header="app.component.ts" region="event-binding"></code-example>
+
+Your application now has a button labeled `Show Greeting`. When you click on the button, an alert box displays the message: `Hello, Angular developer!`.
+
+## What's next
+
+In this tutorial, you've explored how an Angular template works. You've added features such as interpolation, property binding, attribute binding, and event binding.
+
+To continue the Tour of Heroes tutorial, see [Tour of Heroes: Components](tutorial/toh-components).


### PR DESCRIPTION
Currently we have two tutorials to introduce users to Angular. Two tutorials makes it difficult to maintain and confusing to our audience. This PR will remove the "phone" tutorial and replace it with the Tour of Heroes tutorial, updating the ToH tutorial to use Stackblitz instead of a local environment.