### PR TITLE
build: fix lint errors in build-saucelabs legacy script

### DIFF
--- a/tools/legacy-saucelabs/build-saucelabs-test-bundle.mjs
+++ b/tools/legacy-saucelabs/build-saucelabs-test-bundle.mjs
@@ -1,5 +1,13 @@
 #!/usr/bin/env node
 
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
 import multimatch from 'multimatch';
 import esbuild from 'esbuild';
 import fs from 'fs';
@@ -165,7 +173,7 @@ async function createResolveEsbuildPlugin() {
         return stats !== null ? {path: resolvedPath} : undefined;
       });
     }
-  }
+  };
 }
 
 /**


### PR DESCRIPTION
Fixes lint errors in the build-saucelabs legacy script. Likely this only
surfaces now after merge due to some other lint-affecting changes
landing just before the script landed.