### PR TITLE
perf(common): code size reduction of `ngFor` directive

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4436,
-        "main": 459047,
+        "main": 458504,
         "polyfills": 37271,
         "styles": 70719,
         "light-theme": 77717,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1083,
-        "main": 138491,
+        "main": 138071,
         "polyfills": 36964
       }
     }
@@ -52,7 +52,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 163342,
+        "main": 162474,
         "polyfills": 36975
       }
     }

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -208,11 +208,19 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
       // React on ngForOf changes only once all inputs have been initialized
       const value = this._ngForOf;
       if (!this._differ && value) {
-        try {
+        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+          try {
+            // CAUTION: this logic is duplicated for production mode below, as the try-catch
+            // is only present in development builds.
+            this._differ = this._differs.find(value).create(this.ngForTrackBy);
+          } catch {
+            throw new Error(`Cannot find a differ supporting object '${value}' of type '${
+                getTypeName(value)}'. NgFor only supports binding to Iterables such as Arrays.`);
+          }
+        } else {
+          // CAUTION: this logic is duplicated for development mode above, as the try-catch
+          // is only present in development builds.
           this._differ = this._differs.find(value).create(this.ngForTrackBy);
-        } catch {
-          throw new Error(`Cannot find a differ supporting object '${value}' of type '${
-              getTypeName(value)}'. NgFor only supports binding to Iterables such as Arrays.`);
         }
       }
     }
@@ -223,51 +231,39 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
   }
 
   private _applyChanges(changes: IterableChanges<T>) {
-    const insertTuples: RecordViewTuple<T, U>[] = [];
+    const viewContainer = this._viewContainer;
     changes.forEachOperation(
-        (item: IterableChangeRecord<any>, adjustedPreviousIndex: number|null,
+        (item: IterableChangeRecord<T>, adjustedPreviousIndex: number|null,
          currentIndex: number|null) => {
           if (item.previousIndex == null) {
             // NgForOf is never "null" or "undefined" here because the differ detected
             // that a new item needs to be inserted from the iterable. This implies that
             // there is an iterable value for "_ngForOf".
-            const view = this._viewContainer.createEmbeddedView(
-                this._template, new NgForOfContext<T, U>(null!, this._ngForOf!, -1, -1),
+            viewContainer.createEmbeddedView(
+                this._template, new NgForOfContext<T, U>(item.item, this._ngForOf!, -1, -1),
                 currentIndex === null ? undefined : currentIndex);
-            const tuple = new RecordViewTuple<T, U>(item, view);
-            insertTuples.push(tuple);
           } else if (currentIndex == null) {
-            this._viewContainer.remove(
+            viewContainer.remove(
                 adjustedPreviousIndex === null ? undefined : adjustedPreviousIndex);
           } else if (adjustedPreviousIndex !== null) {
-            const view = this._viewContainer.get(adjustedPreviousIndex)!;
-            this._viewContainer.move(view, currentIndex);
-            const tuple = new RecordViewTuple(item, <EmbeddedViewRef<NgForOfContext<T, U>>>view);
-            insertTuples.push(tuple);
+            const view = viewContainer.get(adjustedPreviousIndex)!;
+            viewContainer.move(view, currentIndex);
+            applyViewChange(view as EmbeddedViewRef<NgForOfContext<T, U>>, item);
           }
         });
 
-    for (let i = 0; i < insertTuples.length; i++) {
-      this._perViewChange(insertTuples[i].view, insertTuples[i].record);
-    }
-
-    for (let i = 0, ilen = this._viewContainer.length; i < ilen; i++) {
-      const viewRef = <EmbeddedViewRef<NgForOfContext<T, U>>>this._viewContainer.get(i);
-      viewRef.context.index = i;
-      viewRef.context.count = ilen;
-      viewRef.context.ngForOf = this._ngForOf!;
+    for (let i = 0, ilen = viewContainer.length; i < ilen; i++) {
+      const viewRef = <EmbeddedViewRef<NgForOfContext<T, U>>>viewContainer.get(i);
+      const context = viewRef.context;
+      context.index = i;
+      context.count = ilen;
+      context.ngForOf = this._ngForOf!;
     }
 
     changes.forEachIdentityChange((record: any) => {
-      const viewRef =
-          <EmbeddedViewRef<NgForOfContext<T, U>>>this._viewContainer.get(record.currentIndex);
-      viewRef.context.$implicit = record.item;
+      const viewRef = <EmbeddedViewRef<NgForOfContext<T, U>>>viewContainer.get(record.currentIndex);
+      applyViewChange(viewRef, record);
     });
-  }
-
-  private _perViewChange(
-      view: EmbeddedViewRef<NgForOfContext<T, U>>, record: IterableChangeRecord<any>) {
-    view.context.$implicit = record.item;
   }
 
   /**
@@ -282,8 +278,9 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
   }
 }
 
-class RecordViewTuple<T, U extends NgIterable<T>> {
-  constructor(public record: any, public view: EmbeddedViewRef<NgForOfContext<T, U>>) {}
+function applyViewChange<T>(
+    view: EmbeddedViewRef<NgForOfContext<T>>, record: IterableChangeRecord<T>) {
+  view.context.$implicit = record.item;
 }
 
 function getTypeName(type: any): string {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -435,9 +435,6 @@
     "name": "ReactiveFormsModule"
   },
   {
-    "name": "RecordViewTuple"
-  },
-  {
     "name": "RefCountOperator"
   },
   {
@@ -655,6 +652,9 @@
   },
   {
     "name": "applyView"
+  },
+  {
+    "name": "applyViewChange"
   },
   {
     "name": "attachInjectFlag"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -420,9 +420,6 @@
     "name": "RadioControlRegistryModule"
   },
   {
-    "name": "RecordViewTuple"
-  },
-  {
     "name": "RefCountOperator"
   },
   {
@@ -643,6 +640,9 @@
   },
   {
     "name": "applyView"
+  },
+  {
+    "name": "applyViewChange"
   },
   {
     "name": "attachInjectFlag"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -102,9 +102,6 @@
     "name": "R3ViewContainerRef"
   },
   {
-    "name": "RecordViewTuple"
-  },
-  {
     "name": "RendererFactory2"
   },
   {
@@ -235,6 +232,9 @@
   },
   {
     "name": "applyView"
+  },
+  {
+    "name": "applyViewChange"
   },
   {
     "name": "assertTemplate"


### PR DESCRIPTION
This commit makes several changes to the implementation of `NgForOf` to
reduce its code size in production builds:

1. The tailor-made message for an unsupported differ is fully
   tree-shaken in production builds, in favor of the exception from the
   differ factory itself.
2. The private `_perViewChange` method was changed into a free-standing
   function, to allow its name to be minimized.
3. The need for an intermediate `RecordViewTuple` was avoided by
   applying the operation in-place, instead of collection all insertions
   into a buffer first. This is safe as the `_perViewChange` operation
   that used to be done on each `RecordViewTuple` is entirely local to
   the tuple itself. Hence, it is invariant to execution ordering which
   means that the `_perViewChange` can be executed directly during the
   `forEachOperation` loop.