### PR TITLE
fix(common): stricter type for http methods

### DIFF
--- a/goldens/public-api/common/http/http.md
+++ b/goldens/public-api/common/http/http.md
@@ -1405,7 +1405,7 @@ export class HttpClient {
         withCredentials?: boolean;
     }): Observable<T>;
     request<R>(req: HttpRequest<any>): Observable<HttpEvent<R>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1419,7 +1419,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1433,7 +1433,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1447,7 +1447,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1461,7 +1461,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1475,7 +1475,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1489,7 +1489,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1503,7 +1503,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<any>>;
-    request<R>(method: string, url: string, options: {
+    request<R>(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1517,7 +1517,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<R>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1531,7 +1531,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1545,7 +1545,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1559,7 +1559,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1573,7 +1573,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
-    request<R>(method: string, url: string, options: {
+    request<R>(method: HttpMethod, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1587,7 +1587,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<R>>;
-    request(method: string, url: string, options?: {
+    request(method: HttpMethod, url: string, options?: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1601,7 +1601,7 @@ export class HttpClient {
         reportProgress?: boolean;
         withCredentials?: boolean;
     }): Observable<Object>;
-    request<R>(method: string, url: string, options?: {
+    request<R>(method: HttpMethod, url: string, options?: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1615,7 +1615,7 @@ export class HttpClient {
         reportProgress?: boolean;
         withCredentials?: boolean;
     }): Observable<R>;
-    request(method: string, url: string, options?: {
+    request(method: HttpMethod, url: string, options?: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1768,6 +1768,9 @@ export interface HttpInterceptor {
     intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>>;
 }
 
+// @public (undocumented)
+export type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH' | 'JSONP' | 'get' | 'head' | 'post' | 'put' | 'delete' | 'connect' | 'options' | 'trace' | 'patch' | 'jsonp';
+
 // @public
 export interface HttpParameterCodec {
     // (undocumented)
@@ -1830,7 +1833,7 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
     });
-    constructor(method: string, url: string, body: T | null, init?: {
+    constructor(method: HttpMethod, url: string, body: T | null, init?: {
         headers?: HttpHeaders;
         context?: HttpContext;
         reportProgress?: boolean;
@@ -1850,7 +1853,7 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
         body?: T | null;
-        method?: string;
+        method?: HttpMethod;
         url?: string;
         setHeaders?: {
             [name: string]: string | string[];
@@ -1868,7 +1871,7 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
         body?: V | null;
-        method?: string;
+        method?: HttpMethod;
         url?: string;
         setHeaders?: {
             [name: string]: string | string[];
@@ -1880,7 +1883,7 @@ export class HttpRequest<T> {
     readonly context: HttpContext;
     detectContentTypeHeader(): string | null;
     readonly headers: HttpHeaders;
-    readonly method: string;
+    readonly method: HttpMethod;
     readonly params: HttpParams;
     readonly reportProgress: boolean;
     readonly responseType: 'arraybuffer' | 'blob' | 'json' | 'text';

--- a/goldens/public-api/common/http/testing/testing.md
+++ b/goldens/public-api/common/http/testing/testing.md
@@ -6,6 +6,7 @@
 
 import { HttpEvent } from '@angular/common/http';
 import { HttpHeaders } from '@angular/common/http';
+import { HttpMethod } from '@angular/common/http';
 import { HttpRequest } from '@angular/common/http';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/common/http';
@@ -40,7 +41,7 @@ export abstract class HttpTestingController {
 // @public
 export interface RequestMatch {
     // (undocumented)
-    method?: string;
+    method?: HttpMethod;
     // (undocumented)
     url?: string;
 }

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -33,6 +33,7 @@ export {HttpContext, HttpContextToken} from './src/context';
 export {HttpHeaders} from './src/headers';
 export {HTTP_INTERCEPTORS, HttpInterceptor} from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
+export {HttpMethod} from './src/method';
 export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule, HttpInterceptingHandler as ɵHttpInterceptingHandler} from './src/module';
 export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec} from './src/params';
 export {HttpRequest} from './src/request';

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -13,6 +13,7 @@ import {concatMap, filter, map} from 'rxjs/operators';
 import {HttpHandler} from './backend';
 import {HttpContext} from './context';
 import {HttpHeaders} from './headers';
+import {HttpMethod} from './method';
 import {HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
@@ -129,7 +130,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as an `ArrayBuffer`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -150,7 +151,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type `Blob`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -171,7 +172,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type string.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -193,7 +194,7 @@ export class HttpClient {
    * @return An `Observable` of the response, with the response body as an array of `HttpEvent`s for
    * the request.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -215,7 +216,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type `Blob`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
@@ -236,7 +237,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type string.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
@@ -257,7 +258,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type `Object`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -279,7 +280,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type `R`.
    */
-  request<R>(method: string, url: string, options: {
+  request<R>(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -300,7 +301,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body as an `ArrayBuffer`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
@@ -319,7 +320,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of type `Blob`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
@@ -339,7 +340,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the HTTP response, with the response body of type string.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
@@ -360,7 +361,7 @@ export class HttpClient {
    * @return An `Observable` of the full `HttpResponse`,
    * with the response body of type `Object`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -381,7 +382,7 @@ export class HttpClient {
    *
    * @return  An `Observable` of the full `HttpResponse`, with the response body of type `R`.
    */
-  request<R>(method: string, url: string, options: {
+  request<R>(method: HttpMethod, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -402,7 +403,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of type `Object`.
    */
-  request(method: string, url: string, options?: {
+  request(method: HttpMethod, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -424,7 +425,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of type `R`.
    */
-  request<R>(method: string, url: string, options?: {
+  request<R>(method: HttpMethod, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -445,7 +446,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the requested response, with body of type `any`.
    */
-  request(method: string, url: string, options?: {
+  request(method: HttpMethod, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -483,7 +484,7 @@ export class HttpClient {
    *   * An `observe` value of body returns an observable of `<T>` with the same `T` body type.
    *
    */
-  request(first: string|HttpRequest<any>, url?: string, options: {
+  request(first: HttpMethod|HttpRequest<any>, url?: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,

--- a/packages/common/http/src/method.ts
+++ b/packages/common/http/src/method.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export type HttpMethod = 'GET'|'HEAD'|'POST'|'PUT'|'DELETE'|'CONNECT'|'OPTIONS'|'TRACE'|'PATCH'|
+    'JSONP'|'get'|'head'|'post'|'put'|'delete'|'connect'|'options'|'trace'|'patch'|'jsonp';

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -8,6 +8,7 @@
 
 import {HttpContext} from './context';
 import {HttpHeaders} from './headers';
+import {HttpMethod} from './method';
 import {HttpParams} from './params';
 
 
@@ -132,7 +133,7 @@ export class HttpRequest<T> {
   /**
    * The outgoing HTTP request method.
    */
-  readonly method: string;
+  readonly method: HttpMethod;
 
   /**
    * Outgoing URL parameters.
@@ -168,7 +169,7 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
   });
-  constructor(method: string, url: string, body: T|null, init?: {
+  constructor(method: HttpMethod, url: string, body: T|null, init?: {
     headers?: HttpHeaders,
     context?: HttpContext,
     reportProgress?: boolean,
@@ -177,7 +178,7 @@ export class HttpRequest<T> {
     withCredentials?: boolean,
   });
   constructor(
-      method: string, readonly url: string, third?: T|{
+      method: HttpMethod, readonly url: string, third?: T|{
         headers?: HttpHeaders,
         context?: HttpContext,
         reportProgress?: boolean,
@@ -193,7 +194,7 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer'|'blob'|'json'|'text',
         withCredentials?: boolean,
       }) {
-    this.method = method.toUpperCase();
+    this.method = method.toUpperCase() as HttpMethod;
     // Next, need to figure out which argument holds the HttpRequestInit
     // options, if any.
     let options: HttpRequestInit|undefined;
@@ -349,7 +350,7 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
     body?: T|null,
-    method?: string,
+    method?: HttpMethod,
     url?: string,
     setHeaders?: {[name: string]: string|string[]},
     setParams?: {[param: string]: string},
@@ -362,7 +363,7 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
     body?: V|null,
-    method?: string,
+    method?: HttpMethod,
     url?: string,
     setHeaders?: {[name: string]: string|string[]},
     setParams?: {[param: string]: string},
@@ -375,7 +376,7 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
     body?: any|null,
-    method?: string,
+    method?: HttpMethod,
     url?: string,
     setHeaders?: {[name: string]: string|string[]},
     setParams?: {[param: string]: string};

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -18,7 +18,7 @@ const TEST_STRING = `I'm a body!`;
   describe('HttpRequest', () => {
     describe('constructor', () => {
       it('initializes url', () => {
-        const req = new HttpRequest('', TEST_URL, null);
+        const req = new HttpRequest('GET', TEST_URL, null);
         expect(req.url).toBe(TEST_URL);
       });
       it('doesn\'t require a body for body-less methods', () => {
@@ -36,8 +36,8 @@ const TEST_STRING = `I'm a body!`;
         expect(req.body).toBeNull();
       });
       it('accepts a string request method', () => {
-        const req = new HttpRequest('TEST', TEST_URL, null);
-        expect(req.method).toBe('TEST');
+        const req = new HttpRequest('GET', TEST_URL, null);
+        expect(req.method).toBe('GET');
       });
       it('accepts a string body', () => {
         const req = new HttpRequest('POST', TEST_URL, TEST_STRING);

--- a/packages/common/http/testing/src/api.ts
+++ b/packages/common/http/testing/src/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpRequest} from '@angular/common/http';
+import {HttpMethod, HttpRequest} from '@angular/common/http';
 
 import {TestRequest} from './request';
 
@@ -16,7 +16,7 @@ import {TestRequest} from './request';
  * @publicApi
  */
 export interface RequestMatch {
-  method?: string;
+  method?: HttpMethod;
   url?: string;
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe: 


## What is the current behavior?
It's currently possible to use any string as the HTTP method.
As discussed with Pete and @AndrewKushnir it could be interesting to have a more strictly typed API,
and only allow valid HTTP methods (both in lowercase and uppercase to preserve the existing behavior)

## What is the new behavior?

This commit tightens the API to only accept one of the possible HTTP verb, either in lowercase or in uppercase (to preserve the existing behavior).

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

The HTTP method must now be one of `'GET'|'HEAD'|'POST'|'PUT'|'DELETE'|'CONNECT'|'OPTIONS'|'TRACE'|'PATCH'|'JSONP'` (or one of these in lowercase) instead of a `string`. This helps developers to catch possible typos like `http.request('POTS', ...)`, but can result in compilation errors when updating if you have such typos in your code. In the rare cases where developers used a temporary string variable to store the method, the type of this variable must be updated to be a string literal, for example `const method = 'GET' as const`.


## Other information
