### PR TITLE
build(docs-infra): update `.browserslistrc` to align with new CLI apps

### DIFF
--- a/aio/.browserslistrc
+++ b/aio/.browserslistrc
@@ -2,10 +2,15 @@
 # For additional information regarding the format and rule options, please see:
 # https://github.com/browserslist/browserslist#queries
 
-# Googlebot uses an older version of Chrome
-# For additional information see: https://developers.google.com/search/docs/guides/rendering
+# For the full list of supported browsers by the Angular framework, please see:
+# https://angular.io/guide/browser-support
 
-> 0.5%
-last 2 major versions
+# You can see what browsers were selected by your queries by running:
+#   npx browserslist
+
+last 1 Chrome version
+last 1 Firefox version
+last 2 Edge major versions
+last 2 Safari major versions
+last 2 iOS major versions
 Firefox ESR
-not dead

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -3,11 +3,11 @@
     "master": {
       "uncompressed": {
         "runtime": 4436,
-        "main": 460307,
+        "main": 460179,
         "polyfills": 37123,
-        "styles": 70719,
-        "light-theme": 77717,
-        "dark-theme": 77897
+        "styles": 70149,
+        "light-theme": 77369,
+        "dark-theme": 77549
       }
     }
   },
@@ -15,11 +15,11 @@
     "master": {
       "uncompressed": {
         "runtime": 4436,
-        "main": 458504,
+        "main": 458430,
         "polyfills": 37271,
-        "styles": 70719,
-        "light-theme": 77717,
-        "dark-theme": 77897
+        "styles": 70149,
+        "light-theme": 77369,
+        "dark-theme": 77549
       }
     }
   }


### PR DESCRIPTION
_This is a backport of #44283 to the `13.0.x` branch._

##
Update `.browserslistrc` to align with new CLI apps. This drops some older browsers that are no longer supported by Angular v13+. See the [list of supported browsers][1].

[1]: https://angular.io/guide/browser-support
