### PR TITLE
perf(http): remove IE special status handling

### DIFF
--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -112,8 +112,6 @@ export class HttpXhrBackend implements HttpBackend {
           return headerResponse;
         }
 
-        // Read status and normalize an IE9 bug (https://bugs.jquery.com/ticket/1450).
-        const status: number = xhr.status === 1223 ? HttpStatusCode.NoContent : xhr.status;
         const statusText = xhr.statusText || 'OK';
 
         // Parse headers from XMLHttpRequest - this step is lazy.
@@ -124,7 +122,7 @@ export class HttpXhrBackend implements HttpBackend {
         const url = getResponseUrl(xhr) || req.url;
 
         // Construct the HttpHeaderResponse and memoize it.
-        headerResponse = new HttpHeaderResponse({headers, status, statusText, url});
+        headerResponse = new HttpHeaderResponse({headers, status: xhr.status, statusText, url});
         return headerResponse;
       };
 

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -350,16 +350,6 @@ const XSSI_PREFIX = ')]}\'\n';
       });
     });
     describe('corrects for quirks', () => {
-      it('by normalizing 1223 status to 204', done => {
-        backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
-          expect(events.length).toBe(2);
-          expect(events[1].type).toBe(HttpEventType.Response);
-          const response = events[1] as HttpResponse<string>;
-          expect(response.status).toBe(HttpStatusCode.NoContent);
-          done();
-        });
-        factory.mock.mockFlush(1223, 'IE Special Status', 'Test');
-      });
       it('by normalizing 0 status to 200 if a body is present', done => {
         backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
           expect(events.length).toBe(2);


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)

## What is the current behavior?
Contains a workaround for IE

## What is the new behavior?
Removed IE special Case handling

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No