### PR TITLE
fix(animations): don't consume instructions for animateChild

### DIFF
--- a/packages/animations/browser/src/dsl/animation_timeline_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_builder.ts
@@ -154,7 +154,7 @@ export class AnimationTimelineBuilderVisitor implements AstVisitor {
   }
 
   visitAnimateChild(ast: AnimateChildAst, context: AnimationTimelineContext): any {
-    const elementInstructions = context.subInstructions.consume(context.element);
+    const elementInstructions = context.subInstructions.get(context.element);
     if (elementInstructions) {
       const innerContext = context.createSubContext(ast.options);
       const startTime = context.currentTimeline.currentTime;

--- a/packages/animations/browser/src/dsl/element_instruction_map.ts
+++ b/packages/animations/browser/src/dsl/element_instruction_map.ts
@@ -10,14 +10,8 @@ import {AnimationTimelineInstruction} from './animation_timeline_instruction';
 export class ElementInstructionMap {
   private _map = new Map<any, AnimationTimelineInstruction[]>();
 
-  consume(element: any): AnimationTimelineInstruction[] {
-    let instructions = this._map.get(element);
-    if (instructions) {
-      this._map.delete(element);
-    } else {
-      instructions = [];
-    }
-    return instructions;
+  get(element: any): AnimationTimelineInstruction[] {
+    return this._map.get(element) || [];
   }
 
   append(element: any, instructions: AnimationTimelineInstruction[]) {

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -979,9 +979,9 @@ describe('animation tests', function() {
            expect(fixture.nativeElement.children.length).toBe(1);
 
            engine.flush();
-           expect(getLog().length).toBe(1);
+           expect(getLog().length).toBe(2);
 
-           const player = getLog()[0];
+           const player = getLog()[1];
            expect(player.keyframes).toEqual([
              {opacity: '1', offset: 0},
              {opacity: '0', offset: 1},
@@ -3007,8 +3007,8 @@ describe('animation tests', function() {
          cmp.log = [];
 
          const players = getLog();
-         expect(players.length).toEqual(3);
-         const [p1, p2, p3] = players;
+         expect(players.length).toEqual(4);
+         const [, p1, p2, p3] = players;
 
          p1.finish();
          flushMicrotasks();
@@ -3080,10 +3080,9 @@ describe('animation tests', function() {
          cmp.log = [];
 
          const players = getLog();
-         // 1 + 4 + 4 = 9 players
-         expect(players.length).toEqual(9);
+         expect(players.length).toEqual(13);
 
-         const [pA, pq1a, pq1b, pq1c, pq1d, pq2a, pq2b, pq2c, pq2d] = getLog();
+         const [, , , , pA, pq1a, pq1b, pq1c, pq1d, pq2a, pq2b, pq2c, pq2d] = getLog();
          pA.finish();
          pq1a.finish();
          pq1b.finish();
@@ -3100,13 +3099,16 @@ describe('animation tests', function() {
 
          expect(cmp.log).toEqual(['all-done', 'c-0-done', 'c-1-done', 'c-2-done', 'c-3-done']);
 
-         expect(cmp.events['c-0'].totalTime).toEqual(4100);  // 1000 + 1000 + 1800 + 300
+         expect(cmp.events['all'].totalTime).toEqual(4100);  // 1000 + 1000 + 1800 + 300
+         expect(cmp.events['all'].element.innerText.trim().replaceAll('\n', ' '))
+             .toEqual('0 1 2 3');
+         expect(cmp.events['c-0'].totalTime).toEqual(1500);
          expect(cmp.events['c-0'].element.innerText.trim()).toEqual('0');
-         expect(cmp.events['c-1'].totalTime).toEqual(4100);
+         expect(cmp.events['c-1'].totalTime).toEqual(1500);
          expect(cmp.events['c-1'].element.innerText.trim()).toEqual('1');
-         expect(cmp.events['c-2'].totalTime).toEqual(4100);
+         expect(cmp.events['c-2'].totalTime).toEqual(1500);
          expect(cmp.events['c-2'].element.innerText.trim()).toEqual('2');
-         expect(cmp.events['c-3'].totalTime).toEqual(4100);
+         expect(cmp.events['c-3'].totalTime).toEqual(1500);
          expect(cmp.events['c-3'].element.innerText.trim()).toEqual('3');
        }));
   });

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -3008,17 +3008,24 @@ describe('animation tests', function() {
 
          const players = getLog();
          expect(players.length).toEqual(4);
-         const [, p1, p2, p3] = players;
 
-         p1.finish();
+         // players:
+         //  - _scp (skipped child player): player for the child animation
+         //  - pp1 (parent player 1): player for parent animation (from 0px to 100px)
+         //  - pcp (parent child player):
+         //     player for child animation executed by parent via query and animateChild
+         //  - pp2 (parent player 2): player for parent animation (from 100px to 0px)
+         const [_scp, pp1, pcp, pp2] = players;
+
+         pp1.finish();
          flushMicrotasks();
          expect(cmp.log).toEqual([]);
 
-         p2.finish();
+         pcp.finish();
          flushMicrotasks();
          expect(cmp.log).toEqual([]);
 
-         p3.finish();
+         pp2.finish();
          flushMicrotasks();
          expect(cmp.log).toEqual(['parent-done', 'child-done']);
        }));
@@ -3082,19 +3089,29 @@ describe('animation tests', function() {
          const players = getLog();
          expect(players.length).toEqual(13);
 
-         const [, , , , pA, pq1a, pq1b, pq1c, pq1d, pq2a, pq2b, pq2c, pq2d] = getLog();
-         pA.finish();
-         pq1a.finish();
-         pq1b.finish();
-         pq1c.finish();
-         pq1d.finish();
+         // players:
+         //  - _sc1p, _sc2p, _sc3p, _sc4p (skipped child n (1 to 4) players):
+         //     players for the children animations
+         //  - pp1 (parent player 1): player for parent animation (from opacity 0 to opacity 1)
+         //  - pc1p1, pc2p1, pc3p1, pc4p1 (parent child n (1 to 4) player 1):
+         //     players for children animations executed by parent via query and animate
+         //     (from opacity 0 to opacity 1)
+         //  - pc1p2, pc2p2, pc3p2, pc4p2 (parent child n (1 to 4) player 2):
+         //     players for children animations executed by parent via query and animateChild
+         const [_sc1p, _sc2p, _sc3p, _sc4p, pp1, pc1p1, pc2p1, pc3p1, pc4p1, pc1p2, pc2p2, pc3p2, pc4p2] =
+             getLog();
+         pp1.finish();
+         pc1p1.finish();
+         pc2p1.finish();
+         pc3p1.finish();
+         pc4p1.finish();
          flushMicrotasks();
 
          expect(cmp.log).toEqual([]);
-         pq2a.finish();
-         pq2b.finish();
-         pq2c.finish();
-         pq2d.finish();
+         pc1p2.finish();
+         pc2p2.finish();
+         pc3p2.finish();
+         pc4p2.finish();
          flushMicrotasks();
 
          expect(cmp.log).toEqual(['all-done', 'c-0-done', 'c-1-done', 'c-2-done', 'c-3-done']);

--- a/packages/core/test/animation/animation_query_integration_spec.ts
+++ b/packages/core/test/animation/animation_query_integration_spec.ts
@@ -782,8 +782,8 @@ describe('animation query tests', function() {
       engine.flush();
 
       const players = getLog();
-      expect(players.length).toEqual(1);
-      const player = players[0];
+      expect(players.length).toEqual(2);
+      const player = players[1];
 
       expect(player.keyframes).toEqual([{height: '0px', offset: 0}, {height: '444px', offset: 1}]);
       player.finish();
@@ -1868,7 +1868,7 @@ describe('animation query tests', function() {
       const elm1 = cmp.elm1;
       const elm2 = cmp.elm2;
 
-      const [p1, p2] = getLog();
+      const [, p1, p2] = getLog();
       expect(p1.delay).toEqual(0);
       expect(p1.element).toEqual(elm1.nativeElement);
       expect(p1.duration).toEqual(1000);
@@ -1928,8 +1928,8 @@ describe('animation query tests', function() {
          const elements = parent.querySelectorAll('.item');
 
          const players = getLog();
-         expect(players.length).toEqual(7);
-         const [pA, pc1, pc2, pc3, pc4, pc5, pZ] = players;
+         expect(players.length).toEqual(12);
+         const [, , , , , pA, pc1, pc2, pc3, pc4, pc5, pZ] = players;
 
          expect(pA.element).toEqual(parent);
          expect(pA.delay).toEqual(0);
@@ -2110,17 +2110,17 @@ describe('animation query tests', function() {
       engine.flush();
 
       const players = getLog();
-      expect(players.length).toEqual(4);
-      const [pA, pc1, pc2, pZ] = players;
+      expect(players.length).toEqual(6);
+      const [, , , playerChildW, playerChildH, playerParent] = players;
 
-      expect(pc1.delay).toEqual(0);
-      expect(pc1.duration).toEqual(2800);
+      expect(playerChildW.delay).toEqual(0);
+      expect(playerChildW.duration).toEqual(2800);
 
-      expect(pc2.delay).toEqual(0);
-      expect(pc2.duration).toEqual(2500);
+      expect(playerChildH.delay).toEqual(0);
+      expect(playerChildH.duration).toEqual(2500);
 
-      expect(pZ.delay).toEqual(2800);
-      expect(pZ.duration).toEqual(1000);
+      expect(playerParent.delay).toEqual(2800);
+      expect(playerParent.duration).toEqual(1000);
     });
 
     it('should skip a sub animation when a zero duration value is passed in', () => {
@@ -2163,8 +2163,8 @@ describe('animation query tests', function() {
       engine.flush();
 
       const players = getLog();
-      expect(players.length).toEqual(2);
-      const [pA, pZ] = players;
+      expect(players.length).toEqual(3);
+      const [, pA, pZ] = players;
 
       expect(pA.delay).toEqual(0);
       expect(pA.duration).toEqual(1000);
@@ -2215,9 +2215,9 @@ describe('animation query tests', function() {
       engine.flush();
 
       const players = getLog();
-      expect(players.length).toEqual(3);
+      expect(players.length).toEqual(5);
 
-      const [p1, p2, p3] = players;
+      const [, p1, p2, p3] = players;
 
       // parent2 is evaluated first because it is inside of parent1
       expect(p1.element.classList.contains('parent2')).toBeTruthy();
@@ -2363,8 +2363,8 @@ describe('animation query tests', function() {
          fixture.detectChanges();
 
          let players = getLog();
-         expect(players.length).toEqual(1);
-         const [player] = players;
+         expect(players.length).toEqual(2);
+         const [, player] = players;
 
          expect(player.element.classList.contains('inner-div')).toBeTruthy();
          expect(player.keyframes).toEqual([
@@ -3140,10 +3140,10 @@ describe('animation query tests', function() {
          fixture.detectChanges();
          engine.flush();
          const players = getLog();
-         expect(players.length).toEqual(5);
-         const [p1, p2, p3, p4, p5] = players;
+         expect(players.length).toEqual(6);
+         const [, , , , , player] = players;
 
-         expect(p5.keyframes).toEqual([
+         expect(player.keyframes).toEqual([
            {offset: 0, width: '0px'}, {offset: .67, width: '0px'}, {offset: 1, width: '200px'}
          ]);
        });
@@ -3206,9 +3206,9 @@ describe('animation query tests', function() {
       fixture.detectChanges();
 
       const players = getLog();
-      expect(players.length).toEqual(2);
+      expect(players.length).toEqual(3);
 
-      const [p1, p2] = players;
+      const [, p1, p2] = players;
       expect(p1.element.classList.contains('container')).toBeTruthy();
       expect(p2.element.classList.contains('item')).toBeTruthy();
     });
@@ -3272,9 +3272,9 @@ describe('animation query tests', function() {
       fixture.detectChanges();
 
       const players = getLog();
-      expect(players.length).toEqual(2);
+      expect(players.length).toEqual(3);
 
-      const [p1, p2] = players;
+      const [, p1, p2] = players;
       expect(p1.element.classList.contains('container')).toBeTruthy();
       expect(p2.element.classList.contains('item')).toBeTruthy();
     });

--- a/packages/core/test/animation/animation_query_integration_spec.ts
+++ b/packages/core/test/animation/animation_query_integration_spec.ts
@@ -1868,16 +1868,23 @@ describe('animation query tests', function() {
       const elm1 = cmp.elm1;
       const elm2 = cmp.elm2;
 
-      const [, p1, p2] = getLog();
-      expect(p1.delay).toEqual(0);
-      expect(p1.element).toEqual(elm1.nativeElement);
-      expect(p1.duration).toEqual(1000);
-      expect(p1.keyframes).toEqual([{width: '0px', offset: 0}, {width: '100px', offset: 1}]);
+      const players = getLog();
 
-      expect(p2.delay).toEqual(0);
-      expect(p2.element).toEqual(elm2.nativeElement);
-      expect(p2.duration).toEqual(2000);
-      expect(p2.keyframes).toEqual([
+      // players:
+      //  - _scp (skipped child player): player for the child animation
+      //  - pp (parent player): player for parent animation (from 0px to 100px)
+      //  - pcp (parent child player):
+      //      player for child animation executed by parent via query and animateChild
+      const [_scp, pp, pcp] = players;
+      expect(pp.delay).toEqual(0);
+      expect(pp.element).toEqual(elm1.nativeElement);
+      expect(pp.duration).toEqual(1000);
+      expect(pp.keyframes).toEqual([{width: '0px', offset: 0}, {width: '100px', offset: 1}]);
+
+      expect(pcp.delay).toEqual(0);
+      expect(pcp.element).toEqual(elm2.nativeElement);
+      expect(pcp.duration).toEqual(2000);
+      expect(pcp.keyframes).toEqual([
         {height: '0px', offset: 0}, {height: '0px', offset: .5}, {height: '100px', offset: 1}
       ]);
     });
@@ -1929,35 +1936,44 @@ describe('animation query tests', function() {
 
          const players = getLog();
          expect(players.length).toEqual(12);
-         const [, , , , , pA, pc1, pc2, pc3, pc4, pc5, pZ] = players;
 
-         expect(pA.element).toEqual(parent);
-         expect(pA.delay).toEqual(0);
-         expect(pA.duration).toEqual(1000);
+         // players:
+         //  - _sc1p, _sc2p, _sc3p, _sc4p (skipped child n (1 to 4) players):
+         //     players for the children animations
+         //  - pp1 (parent player 1): player for parent animation (from opacity 0 to opacity 1)
+         //  - pc1p, pc2p, pc3p, pc4p, pc5p  (parent child n (1 to 4) player):
+         //     players for children animations executed by parent via query and animateChild
+         //  - pp2 (parent player 2): player for parent animation (from opacity 1 to opacity 0)
+         const [_sc1p, _sc2p, _sc3p, _sc4p, _sc5p, pp1, pc1p, pc2p, pc3p, pc4p, pc5p, pp2] =
+             players;
 
-         expect(pc1.element).toEqual(elements[0]);
-         expect(pc1.delay).toEqual(0);
-         expect(pc1.duration).toEqual(4000);
+         expect(pp1.element).toEqual(parent);
+         expect(pp1.delay).toEqual(0);
+         expect(pp1.duration).toEqual(1000);
 
-         expect(pc2.element).toEqual(elements[1]);
-         expect(pc2.delay).toEqual(0);
-         expect(pc2.duration).toEqual(4000);
+         expect(pc1p.element).toEqual(elements[0]);
+         expect(pc1p.delay).toEqual(0);
+         expect(pc1p.duration).toEqual(4000);
 
-         expect(pc3.element).toEqual(elements[2]);
-         expect(pc3.delay).toEqual(0);
-         expect(pc3.duration).toEqual(4000);
+         expect(pc2p.element).toEqual(elements[1]);
+         expect(pc2p.delay).toEqual(0);
+         expect(pc2p.duration).toEqual(4000);
 
-         expect(pc4.element).toEqual(elements[3]);
-         expect(pc4.delay).toEqual(0);
-         expect(pc4.duration).toEqual(4000);
+         expect(pc3p.element).toEqual(elements[2]);
+         expect(pc3p.delay).toEqual(0);
+         expect(pc3p.duration).toEqual(4000);
 
-         expect(pc5.element).toEqual(elements[4]);
-         expect(pc5.delay).toEqual(0);
-         expect(pc5.duration).toEqual(4000);
+         expect(pc4p.element).toEqual(elements[3]);
+         expect(pc4p.delay).toEqual(0);
+         expect(pc4p.duration).toEqual(4000);
 
-         expect(pZ.element).toEqual(parent);
-         expect(pZ.delay).toEqual(4000);
-         expect(pZ.duration).toEqual(1000);
+         expect(pc5p.element).toEqual(elements[4]);
+         expect(pc5p.delay).toEqual(0);
+         expect(pc5p.duration).toEqual(4000);
+
+         expect(pp2.element).toEqual(parent);
+         expect(pp2.delay).toEqual(4000);
+         expect(pp2.duration).toEqual(1000);
        });
 
     it('should silently continue if a sub trigger is animated that doesn\'t exist', () => {
@@ -2111,16 +2127,26 @@ describe('animation query tests', function() {
 
       const players = getLog();
       expect(players.length).toEqual(6);
-      const [, , , playerChildW, playerChildH, playerParent] = players;
 
-      expect(playerChildW.delay).toEqual(0);
-      expect(playerChildW.duration).toEqual(2800);
+      // players:
+      //  - _scwp (skipped child w player): player for the child animation (trigger w)
+      //  - _schp (skipped child h player): player for the child animation (trigger h)
+      //  - _pp1 (parent player 1): player for parent animation (from opacity 0 to opacity 1)
+      //  - pcwp (parent child w player):
+      //      player for child w animation executed by parent via query and animateChild
+      //  - pchp (parent child h player):
+      //      player for child w animation executed by parent via query and animateChild
+      //  - pp2 (parent player 2): player for parent animation (from opacity 1 to opacity 0)
+      const [_scwp, _schp, _pp1, pcwp, pchp, pp2] = players;
 
-      expect(playerChildH.delay).toEqual(0);
-      expect(playerChildH.duration).toEqual(2500);
+      expect(pcwp.delay).toEqual(0);
+      expect(pcwp.duration).toEqual(2800);
 
-      expect(playerParent.delay).toEqual(2800);
-      expect(playerParent.duration).toEqual(1000);
+      expect(pchp.delay).toEqual(0);
+      expect(pchp.duration).toEqual(2500);
+
+      expect(pp2.delay).toEqual(2800);
+      expect(pp2.duration).toEqual(1000);
     });
 
     it('should skip a sub animation when a zero duration value is passed in', () => {
@@ -2164,13 +2190,20 @@ describe('animation query tests', function() {
 
       const players = getLog();
       expect(players.length).toEqual(3);
-      const [, pA, pZ] = players;
 
-      expect(pA.delay).toEqual(0);
-      expect(pA.duration).toEqual(1000);
+      // players:
+      //  - _scp (skipped child player): player for the child animation
+      //  - pp1 (parent player 1): player for parent animation (from opacity 0 to opacity 1)
+      //  - ( the player for the child animation executed by parent via query
+      //      and animateChild is skipped entirely )
+      //  - pp2 (parent player 2): player for parent animation (from opacity 1 to opacity 0)
+      const [_scp, pp1, pp2] = players;
 
-      expect(pZ.delay).toEqual(1000);
-      expect(pZ.duration).toEqual(1000);
+      expect(pp1.delay).toEqual(0);
+      expect(pp1.duration).toEqual(1000);
+
+      expect(pp2.delay).toEqual(1000);
+      expect(pp2.duration).toEqual(1000);
     });
 
     it('should only allow a sub animation to be used up by a parent trigger once', () => {
@@ -2217,12 +2250,21 @@ describe('animation query tests', function() {
       const players = getLog();
       expect(players.length).toEqual(5);
 
-      const [, p1, p2, p3] = players;
+      // players:
+      //  - _scp (skipped child player): player for the child animation
+      // (note: parent2 is evaluated first because it is inside of parent1)
+      //  - p2p (parent 2 player): player for parent animation (from opacity 0 to opacity 1)
+      //  - p2cp (parent 2 child player):
+      //      player for child animation executed by parent 2 via query and animateChild
+      //  - p1p (parent 1 player): player for parent animation (from opacity 0 to opacity 1)
+      //  - p1cp (parent 1 child player):
+      //      player for child animation executed by parent 1 via query and animateChild
+      const [_scp, p2p, p2cp, p1p, p1cp] = players;
 
-      // parent2 is evaluated first because it is inside of parent1
-      expect(p1.element.classList.contains('parent2')).toBeTruthy();
-      expect(p2.element.classList.contains('child')).toBeTruthy();
-      expect(p3.element.classList.contains('parent1')).toBeTruthy();
+      expect(p2p.element.classList.contains('parent2')).toBeTruthy();
+      expect(p2cp.element.classList.contains('child')).toBeTruthy();
+      expect(p1p.element.classList.contains('parent1')).toBeTruthy();
+      expect(p1cp.element.classList.contains('child')).toBeTruthy();
     });
 
     it('should emulate a leave animation on the nearest sub host elements when a parent is removed',
@@ -2364,10 +2406,15 @@ describe('animation query tests', function() {
 
          let players = getLog();
          expect(players.length).toEqual(2);
-         const [, player] = players;
 
-         expect(player.element.classList.contains('inner-div')).toBeTruthy();
-         expect(player.keyframes).toEqual([
+         // players:
+         //  - _scp (skipped child player): player for the child animation
+         //  - pcp (parent child player):
+         //     player for child animation executed by parent via query and animateChild
+         const [_scp, pcp] = players;
+
+         expect(pcp.element.classList.contains('inner-div')).toBeTruthy();
+         expect(pcp.keyframes).toEqual([
            {opacity: '0', offset: 0},
            {opacity: '1', offset: 1},
          ]);
@@ -3141,9 +3188,22 @@ describe('animation query tests', function() {
          engine.flush();
          const players = getLog();
          expect(players.length).toEqual(6);
-         const [, , , , , player] = players;
 
-         expect(player.keyframes).toEqual([
+         // players:
+         //  - _sgcp (skipped grand child player): player for the grand child animation
+         //  - _psp (parent self player): player for parent self animation (opacity 0)
+         //  - _pgcp1 (parent grand child player 1):
+         //     player for child animation executed by parent via query (opacity 0)
+         //  - _pp1 (parent player 1): player for parent animation (from opacity 0 to opacity 1)
+         //  - _pgcp2 (parent grand child player 2):
+         //     player for child animation executed by parent via query and animate
+         //     (from opacity 0 to opacity 1)
+         //  - pgcp3 (parent grand child player 3):
+         //     player for child animation executed by parent via query and animateChild
+         //     (from 0px to 200px)
+         const [_sgcp, _psp, _pgcp1, _pp1, _pgcp2, pgcp3] = players;
+
+         expect(pgcp3.keyframes).toEqual([
            {offset: 0, width: '0px'}, {offset: .67, width: '0px'}, {offset: 1, width: '200px'}
          ]);
        });
@@ -3208,9 +3268,14 @@ describe('animation query tests', function() {
       const players = getLog();
       expect(players.length).toEqual(3);
 
-      const [, p1, p2] = players;
-      expect(p1.element.classList.contains('container')).toBeTruthy();
-      expect(p2.element.classList.contains('item')).toBeTruthy();
+      // players:
+      //  - _scp (skipped child player): player for the child animation
+      //  - pp (parent player): player for parent animation (from opacity 0 to opacity 1)
+      //  - pcp (parent child player):
+      //      player for child animation executed by parent via query and animateChild
+      const [_scp, pp, pcp] = players;
+      expect(pp.element.classList.contains('container')).toBeTruthy();
+      expect(pcp.element.classList.contains('item')).toBeTruthy();
     });
 
     it('should scope :leave queries between sub animations', () => {
@@ -3274,9 +3339,14 @@ describe('animation query tests', function() {
       const players = getLog();
       expect(players.length).toEqual(3);
 
-      const [, p1, p2] = players;
-      expect(p1.element.classList.contains('container')).toBeTruthy();
-      expect(p2.element.classList.contains('item')).toBeTruthy();
+      // players:
+      //  - _scp (skipped child player): player for the child animation
+      //  - pp (parent player): player for parent animation (from opacity 0 to opacity 1)
+      //  - pcp (parent child player):
+      //      player for child animation executed by parent via query and animateChild
+      const [_scp, pp, pcp] = players;
+      expect(pp.element.classList.contains('container')).toBeTruthy();
+      expect(pcp.element.classList.contains('item')).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
- [ ] TODO: Fill body commit message if PR gets accepted

resolves #41483
resolves #30693

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #41483 (also #30693)

Animations which include `animateChild` calls can fail to remove elements from the DOM as their players are ignored since they are unnecessary for the actual animations

## What is the new behavior?

The aforementioned players are handled as skipped instead of ignoring them, making their callbacks/cleanups take place and removing the issue of not removing elements from the DOM

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
