### PR TITLE
refactor(core): make the error messages tree shakable

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -31,9 +31,27 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     EXPRESSION_CHANGED_AFTER_CHECKED = -100,
     // (undocumented)
+    INJECTOR_ALREADY_DESTROYED = 205,
+    // (undocumented)
+    INVALID_DIFFER_INPUT = 900,
+    // (undocumented)
+    INVALID_EVENT_BINDING = 306,
+    // (undocumented)
+    INVALID_FACTORY_DEPENDENCY = 202,
+    // (undocumented)
+    INVALID_I18N_STRUCTURE = 700,
+    // (undocumented)
+    INVALID_INHERITANCE = 903,
+    // (undocumented)
+    INVALID_INJECTION_TOKEN = 204,
+    // (undocumented)
+    MISSING_INJECTION_CONTEXT = 203,
+    // (undocumented)
     MULTIPLE_COMPONENTS_MATCH = -300,
     // (undocumented)
     MULTIPLE_PLATFORMS = 400,
+    // (undocumented)
+    NO_SUPPORTING_DIFFER_FACTORY = 901,
     // (undocumented)
     PIPE_NOT_FOUND = -302,
     // (undocumented)
@@ -47,7 +65,13 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     UNKNOWN_BINDING = 303,
     // (undocumented)
-    UNKNOWN_ELEMENT = 304
+    UNKNOWN_ELEMENT = 304,
+    // (undocumented)
+    UNSAFE_VALUE_IN_RESOURCE_URL = 904,
+    // (undocumented)
+    UNSAFE_VALUE_IN_SCRIPT = 905,
+    // (undocumented)
+    VIEW_ALREADY_ATTACHED = 902
 }
 
 // (No @packageDocumentation comment for this package)

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4330,
-        "main": 458518,
+        "main": 457719,
         "polyfills": 37271,
         "styles": 69863,
         "light-theme": 77232,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,8 +3,8 @@
     "master": {
       "uncompressed": {
         "runtime": 1083,
-        "main": 140067,
-        "polyfills": 36964
+        "main": 139416,
+        "polyfills": 37226
       }
     }
   },
@@ -24,7 +24,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1105,
-        "main": 145783,
+        "main": 145132,
         "polyfills": 37248
       }
     }
@@ -33,7 +33,7 @@
     "master": {
       "uncompressed": {
         "runtime": 929,
-        "main": 138435,
+        "main": 137712,
         "polyfills": 37933
       }
     }
@@ -41,10 +41,10 @@
   "cli-hello-world-lazy": {
     "master": {
       "uncompressed": {
-        "runtime": 2812,
-        "main": 232617,
+        "runtime": 2835,
+        "main": 231989,
         "polyfills": 37244,
-        "src_app_lazy_lazy_module_ts": 796
+        "src_app_lazy_lazy_module_ts": 795
       }
     }
   },
@@ -52,8 +52,8 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 162811,
-        "polyfills": 36975
+        "main": 162121,
+        "polyfills": 37206
       }
     }
   },

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {stringify} from '../../util/stringify';
 import {isListLikeIterable, iterateListLike} from '../change_detection_util';
 
@@ -152,8 +153,10 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
   diff(collection: NgIterable<V>|null|undefined): DefaultIterableDiffer<V>|null {
     if (collection == null) collection = [];
     if (!isListLikeIterable(collection)) {
-      throw new Error(
-          `Error trying to diff '${stringify(collection)}'. Only arrays and iterables are allowed`);
+      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+          `Error trying to diff '${stringify(collection)}'. Only arrays and iterables are allowed` :
+          '';
+      throw new RuntimeError(RuntimeErrorCode.INVALID_DIFFER_INPUT, errorMessage);
     }
 
     if (this.check(collection)) {

--- a/packages/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/packages/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {stringify} from '../../util/stringify';
 import {isJsObject} from '../change_detection_util';
+
 import {KeyValueChangeRecord, KeyValueChanges, KeyValueDiffer, KeyValueDifferFactory} from './keyvalue_differs';
 
 
@@ -79,8 +81,10 @@ export class DefaultKeyValueDiffer<K, V> implements KeyValueDiffer<K, V>, KeyVal
     if (!map) {
       map = new Map();
     } else if (!(map instanceof Map || isJsObject(map))) {
-      throw new Error(
-          `Error trying to diff '${stringify(map)}'. Only maps and objects are allowed`);
+      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+          `Error trying to diff '${stringify(map)}'. Only maps and objects are allowed` :
+          '';
+      throw new RuntimeError(RuntimeErrorCode.INVALID_DIFFER_INPUT, errorMessage);
     }
 
     return this.check(map) ? this : null;

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -9,6 +9,7 @@
 import {ɵɵdefineInjectable} from '../../di/interface/defs';
 import {StaticProvider} from '../../di/interface/provider';
 import {Optional, SkipSelf} from '../../di/metadata';
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {DefaultIterableDifferFactory} from '../differs/default_iterable_differ';
 
 
@@ -250,8 +251,11 @@ export class IterableDiffers {
     if (factory != null) {
       return factory;
     } else {
-      throw new Error(`Cannot find a differ supporting object '${iterable}' of type '${
-          getTypeNameForDebugging(iterable)}'`);
+      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+          `Cannot find a differ supporting object '${iterable}' of type '${
+              getTypeNameForDebugging(iterable)}'` :
+          '';
+      throw new RuntimeError(RuntimeErrorCode.NO_SUPPORTING_DIFFER_FACTORY, errorMessage);
     }
   }
 }

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -7,6 +7,8 @@
  */
 
 import {Optional, SkipSelf, StaticProvider, ɵɵdefineInjectable} from '../../di';
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
+
 import {DefaultKeyValueDifferFactory} from './default_keyvalue_differ';
 
 
@@ -181,6 +183,9 @@ export class KeyValueDiffers {
     if (factory) {
       return factory;
     }
-    throw new Error(`Cannot find a differ supporting object '${kv}'`);
+    const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+        `Cannot find a differ supporting object '${kv}'` :
+        '';
+    throw new RuntimeError(RuntimeErrorCode.NO_SUPPORTING_DIFFER_FACTORY, errorMessage);
   }
 }

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -8,6 +8,7 @@
 
 import '../util/ng_dev_mode';
 
+import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {Type} from '../interface/type';
 import {getClosureSafeProperty} from '../util/property';
 import {stringify} from '../util/stringify';
@@ -58,7 +59,10 @@ export function injectInjectorOnly<T>(token: ProviderToken<T>, flags?: InjectFla
 export function injectInjectorOnly<T>(token: ProviderToken<T>, flags = InjectFlags.Default): T|
     null {
   if (_currentInjector === undefined) {
-    throw new Error(`inject() must be called from an injection context`);
+    const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+        `inject() must be called from an injection context` :
+        '';
+    throw new RuntimeError(RuntimeErrorCode.MISSING_INJECTION_CONTEXT, errorMessage);
   } else if (_currentInjector === null) {
     return injectRootLimpMode(token, undefined, flags);
   } else {
@@ -141,7 +145,10 @@ export function injectArgs(types: (ProviderToken<any>|any[])[]): any[] {
     const arg = resolveForwardRef(types[i]);
     if (Array.isArray(arg)) {
       if (arg.length === 0) {
-        throw new Error('Arguments array must have arguments.');
+        const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+            'Arguments array must have arguments.' :
+            '';
+        throw new RuntimeError(RuntimeErrorCode.INVALID_DIFFER_INPUT, errorMessage);
       }
       let type: Type<any>|undefined = undefined;
       let flags: InjectFlags = InjectFlags.Default;

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -8,6 +8,7 @@
 
 import '../util/ng_dev_mode';
 
+import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {OnDestroy} from '../interface/lifecycle_hooks';
 import {Type} from '../interface/type';
 import {FactoryFn, getFactoryDef} from '../render3/definition_factory';
@@ -255,7 +256,10 @@ export class R3Injector {
 
   private assertNotDestroyed(): void {
     if (this._destroyed) {
-      throw new Error('Injector has already been destroyed.');
+      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+          'Injector has already been destroyed.' :
+          '';
+      throw new RuntimeError(RuntimeErrorCode.INJECTOR_ALREADY_DESTROYED, errorMessage);
     }
   }
 
@@ -446,7 +450,10 @@ function injectableDefOrInjectorDefFactory(token: ProviderToken<any>): FactoryFn
   // InjectionTokens should have an injectable def (ɵprov) and thus should be handled above.
   // If it's missing that, it's an error.
   if (token instanceof InjectionToken) {
-    throw new Error(`Token ${stringify(token)} is missing a ɵprov definition.`);
+    const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+        `Token ${stringify(token)} is missing a ɵprov definition.` :
+        '';
+    throw new RuntimeError(RuntimeErrorCode.INVALID_INJECTION_TOKEN, errorMessage);
   }
 
   // Undecorated types can sometimes be created if they have no constructor arguments.
@@ -455,7 +462,8 @@ function injectableDefOrInjectorDefFactory(token: ProviderToken<any>): FactoryFn
   }
 
   // There was no way to resolve a factory for this token.
-  throw new Error('unreachable');
+  const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ? 'unreachable' : '';
+  throw new RuntimeError(RuntimeErrorCode.INVALID_INJECTION_TOKEN, errorMessage);
 }
 
 function getUndecoratedInjectableFactory(token: Function) {
@@ -463,7 +471,10 @@ function getUndecoratedInjectableFactory(token: Function) {
   const paramLength = token.length;
   if (paramLength > 0) {
     const args: string[] = newArray(paramLength, '?');
-    throw new Error(`Can't resolve all parameters for ${stringify(token)}: (${args.join(', ')}).`);
+    const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+        `Can't resolve all parameters for ${stringify(token)}: (${args.join(', ')}).` :
+        '';
+    throw new RuntimeError(RuntimeErrorCode.INVALID_INJECTION_TOKEN, errorMessage);
   }
 
   // The constructor function appears to have no parameters.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -26,6 +26,10 @@ export const enum RuntimeErrorCode {
   // Dependency Injection Errors
   CYCLIC_DI_DEPENDENCY = -200,
   PROVIDER_NOT_FOUND = -201,
+  INVALID_FACTORY_DEPENDENCY = 202,
+  MISSING_INJECTION_CONTEXT = 203,
+  INVALID_INJECTION_TOKEN = 204,
+  INJECTOR_ALREADY_DESTROYED = 205,
 
   // Template Errors
   MULTIPLE_COMPONENTS_MATCH = -300,
@@ -34,6 +38,7 @@ export const enum RuntimeErrorCode {
   UNKNOWN_BINDING = 303,
   UNKNOWN_ELEMENT = 304,
   TEMPLATE_STRUCTURE_ERROR = 305,
+  INVALID_EVENT_BINDING = 306,
 
   // Bootstrap Errors
   MULTIPLE_PLATFORMS = 400,
@@ -48,8 +53,16 @@ export const enum RuntimeErrorCode {
   // Declarations Errors
 
   // i18n Errors
+  INVALID_I18N_STRUCTURE = 700,
 
   // JIT Compilation Errors
+  // Other
+  INVALID_DIFFER_INPUT = 900,
+  NO_SUPPORTING_DIFFER_FACTORY = 901,
+  VIEW_ALREADY_ATTACHED = 902,
+  INVALID_INHERITANCE = 903,
+  UNSAFE_VALUE_IN_RESOURCE_URL = 904,
+  UNSAFE_VALUE_IN_SCRIPT = 905
 }
 
 export class RuntimeError<T = RuntimeErrorCode> extends Error {

--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {Type, Writable} from '../../interface/type';
 import {EMPTY_ARRAY, EMPTY_OBJ} from '../../util/empty';
 import {fillProperties} from '../../util/property';
@@ -39,7 +40,10 @@ export function ɵɵInheritDefinitionFeature(definition: DirectiveDef<any>|Compo
       superDef = superType.ɵcmp || superType.ɵdir;
     } else {
       if (superType.ɵcmp) {
-        throw new Error('Directives cannot inherit Components');
+        const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+            'Directives cannot inherit Components' :
+            '';
+        throw new RuntimeError(RuntimeErrorCode.INVALID_INHERITANCE, errorMessage);
       }
       // Don't use getComponentDef/getDirectiveDef. This logic relies on inheritance.
       superDef = superType.ɵdir;

--- a/packages/core/src/render3/i18n/i18n_apply.ts
+++ b/packages/core/src/render3/i18n/i18n_apply.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {getPluralCase} from '../../i18n/localization';
 import {assertDefined, assertDomNode, assertEqual, assertGreaterThan, assertIndexInRange, throwError} from '../../util/assert';
 import {assertIndexInExpandoRange, assertTIcu} from '../assert';
@@ -20,6 +21,7 @@ import {createCommentNode, createElementNode, createTextNode, nativeInsertBefore
 import {getBindingIndex} from '../state';
 import {renderStringify} from '../util/stringify_utils';
 import {getNativeByIndex, unwrapRNode} from '../util/view_utils';
+
 import {getLocaleId} from './i18n_locale_id';
 import {getCurrentICUCaseIndex, getParentFromIcuCreateOpCode, getRefFromIcuCreateOpCode, getTIcu} from './i18n_util';
 
@@ -198,7 +200,11 @@ export function applyMutableOpCodes(
               attrValue, null);
           break;
         default:
-          throw new Error(`Unable to determine the type of mutate operation for "${opCode}"`);
+          if (ngDevMode) {
+            throw new RuntimeError(
+                RuntimeErrorCode.INVALID_I18N_STRUCTURE,
+                `Unable to determine the type of mutate operation for "${opCode}"`);
+          }
       }
     } else {
       switch (opCode) {

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -7,9 +7,11 @@
  */
 
 import {ChangeDetectorRef as viewEngine_ChangeDetectorRef} from '../change_detection/change_detector_ref';
+import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, InternalViewRef as viewEngine_InternalViewRef, ViewRefTracker} from '../linker/view_ref';
 import {removeFromArray} from '../util/array_utils';
 import {assertEqual} from '../util/assert';
+
 import {collectNativeNodes} from './collect_native_nodes';
 import {checkNoChangesInRootView, checkNoChangesInternal, detectChangesInRootView, detectChangesInternal, markViewDirty, storeCleanupWithContext} from './instructions/shared';
 import {CONTAINER_HEADER_OFFSET, VIEW_REFS} from './interfaces/container';
@@ -284,7 +286,9 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
 
   attachToViewContainerRef() {
     if (this._appRef) {
-      throw new Error('This view is already attached directly to the ApplicationRef!');
+      const errorMessage =
+          ngDevMode ? 'This view is already attached directly to the ApplicationRef!' : '';
+      throw new RuntimeError(RuntimeErrorCode.VIEW_ALREADY_ATTACHED, errorMessage);
     }
     this._attachedToViewContainer = true;
   }
@@ -296,7 +300,8 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
 
   attachToAppRef(appRef: ViewRefTracker) {
     if (this._attachedToViewContainer) {
-      throw new Error('This view is already attached to a ViewContainer!');
+      const errorMessage = ngDevMode ? 'This view is already attached to a ViewContainer!' : '';
+      throw new RuntimeError(RuntimeErrorCode.VIEW_ALREADY_ATTACHED, errorMessage);
     }
     this._appRef = appRef;
   }

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {getDocument} from '../render3/interfaces/document';
 import {SANITIZER} from '../render3/interfaces/view';
 import {getLView} from '../render3/state';
@@ -117,7 +118,10 @@ export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): TrustedScriptUR
   if (allowSanitizationBypassAndThrow(unsafeResourceUrl, BypassType.ResourceUrl)) {
     return trustedScriptURLFromStringBypass(unwrapSafeValue(unsafeResourceUrl));
   }
-  throw new Error('unsafe value used in a resource URL context (see https://g.co/ng/security#xss)');
+  const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+      'unsafe value used in a resource URL context (see https://g.co/ng/security#xss)' :
+      '';
+  throw new RuntimeError(RuntimeErrorCode.UNSAFE_VALUE_IN_RESOURCE_URL, errorMessage);
 }
 
 /**
@@ -141,7 +145,10 @@ export function ɵɵsanitizeScript(unsafeScript: any): TrustedScript|string {
   if (allowSanitizationBypassAndThrow(unsafeScript, BypassType.Script)) {
     return trustedScriptFromStringBypass(unwrapSafeValue(unsafeScript));
   }
-  throw new Error('unsafe value used in a script context');
+  const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+      'unsafe value used in a script context' :
+      '';
+  throw new RuntimeError(RuntimeErrorCode.UNSAFE_VALUE_IN_SCRIPT, errorMessage);
 }
 
 /**
@@ -234,19 +241,21 @@ export function ɵɵsanitizeUrlOrResourceUrl(unsafeUrl: any, tag: string, prop: 
 
 export function validateAgainstEventProperties(name: string) {
   if (name.toLowerCase().startsWith('on')) {
-    const msg = `Binding to event property '${name}' is disallowed for security reasons, ` +
+    const errorMessage =
+        `Binding to event property '${name}' is disallowed for security reasons, ` +
         `please use (${name.slice(2)})=...` +
         `\nIf '${name}' is a directive input, make sure the directive is imported by the` +
         ` current module.`;
-    throw new Error(msg);
+    throw new RuntimeError(RuntimeErrorCode.INVALID_EVENT_BINDING, errorMessage);
   }
 }
 
 export function validateAgainstEventAttributes(name: string) {
   if (name.toLowerCase().startsWith('on')) {
-    const msg = `Binding to event attribute '${name}' is disallowed for security reasons, ` +
+    const errorMessage =
+        `Binding to event attribute '${name}' is disallowed for security reasons, ` +
         `please use (${name.slice(2)})=...`;
-    throw new Error(msg);
+    throw new RuntimeError(RuntimeErrorCode.INVALID_EVENT_BINDING, errorMessage);
   }
 }
 

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -40,7 +40,7 @@ describe('inheritance', () => {
 
     expect(() => {
       TestBed.createComponent(App);
-    }).toThrowError('Directives cannot inherit Components');
+    }).toThrowError('NG0903: Directives cannot inherit Components');
   });
 
   describe('multiple children', () => {

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -516,12 +516,13 @@ class SomeComponent {
 
            vc.insert(hostView);
            expect(() => appRef.attachView(hostView))
-               .toThrowError('This view is already attached to a ViewContainer!');
+               .toThrowError('NG0902: This view is already attached to a ViewContainer!');
            hostView = vc.detach(0)!;
 
            appRef.attachView(hostView);
            expect(() => vc.insert(hostView))
-               .toThrowError('This view is already attached directly to the ApplicationRef!');
+               .toThrowError(
+                   'NG0902: This view is already attached directly to the ApplicationRef!');
          });
     });
   });

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1878,7 +1878,7 @@
     "name": "stringify"
   },
   {
-    "name": "stringify7"
+    "name": "stringify8"
   },
   {
     "name": "stringifyCSSSelector"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1878,7 +1878,7 @@
     "name": "stringify"
   },
   {
-    "name": "stringify8"
+    "name": "stringify9"
   },
   {
     "name": "stringifyCSSSelector"

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -447,13 +447,14 @@ describe('InjectorDef-based createInjector()', () => {
 
   it('does not allow injection after destroy', () => {
     (injector as R3Injector).destroy();
-    expect(() => injector.get(DeepService)).toThrowError('Injector has already been destroyed.');
+    expect(() => injector.get(DeepService))
+        .toThrowError('NG0205: Injector has already been destroyed.');
   });
 
   it('does not allow double destroy', () => {
     (injector as R3Injector).destroy();
     expect(() => (injector as R3Injector).destroy())
-        .toThrowError('Injector has already been destroyed.');
+        .toThrowError('NG0205: Injector has already been destroyed.');
   });
 
   it('should not crash when importing something that has no ɵinj', () => {
@@ -490,7 +491,7 @@ describe('InjectorDef-based createInjector()', () => {
         static ɵinj = ɵɵdefineInjector({providers: [MissingArgumentType]});
       }
       expect(() => createInjector(ErrorModule).get(MissingArgumentType))
-          .toThrowError('Can\'t resolve all parameters for MissingArgumentType: (?).');
+          .toThrowError('NG0204: Can\'t resolve all parameters for MissingArgumentType: (?).');
     });
   });
 });

--- a/packages/core/test/linker/inheritance_integration_spec.ts
+++ b/packages/core/test/linker/inheritance_integration_spec.ts
@@ -72,6 +72,7 @@ describe('Inheritance logic', () => {
     TestBed.configureTestingModule({declarations: [DirectiveExtendsComponent, App]});
     const template = '<div directiveExtendsComponent>Some content</div>';
     TestBed.overrideComponent(App, {set: {template}});
-    expect(() => TestBed.createComponent(App)).toThrowError('Directives cannot inherit Components');
+    expect(() => TestBed.createComponent(App))
+        .toThrowError('NG0903: Directives cannot inherit Components');
   });
 });

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -644,7 +644,7 @@ describe('NgModule', () => {
 
     it('should throw when no type and not @Inject (class case)', () => {
       expect(() => createInjector([NoAnnotations]))
-          .toThrowError('Can\'t resolve all parameters for NoAnnotations: (?).');
+          .toThrowError('NG0204: Can\'t resolve all parameters for NoAnnotations: (?).');
     });
 
     it('should cache instances', () => {

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -52,7 +52,8 @@ describe('sanitization', () => {
   });
 
   it('should sanitize resourceUrl', () => {
-    const ERROR = 'unsafe value used in a resource URL context (see https://g.co/ng/security#xss)';
+    const ERROR =
+        'NG0904: unsafe value used in a resource URL context (see https://g.co/ng/security#xss)';
     expect(() => ɵɵsanitizeResourceUrl('http://server')).toThrowError(ERROR);
     expect(() => ɵɵsanitizeResourceUrl('javascript:true')).toThrowError(ERROR);
     expect(() => ɵɵsanitizeResourceUrl(bypassSanitizationTrustHtml('javascript:true')))
@@ -73,7 +74,7 @@ describe('sanitization', () => {
   });
 
   it('should sanitize script', () => {
-    const ERROR = 'unsafe value used in a script context';
+    const ERROR = 'NG0905: unsafe value used in a script context';
     expect(() => ɵɵsanitizeScript('true')).toThrowError(ERROR);
     expect(() => ɵɵsanitizeScript('true')).toThrowError(ERROR);
     expect(() => ɵɵsanitizeScript(bypassSanitizationTrustHtml('true')))
@@ -105,7 +106,8 @@ describe('sanitization', () => {
   });
 
   it('should sanitize resourceUrls via sanitizeUrlOrResourceUrl', () => {
-    const ERROR = 'unsafe value used in a resource URL context (see https://g.co/ng/security#xss)';
+    const ERROR =
+        'NG0904: unsafe value used in a resource URL context (see https://g.co/ng/security#xss)';
     expect(() => ɵɵsanitizeUrlOrResourceUrl('http://server', 'iframe', 'src')).toThrowError(ERROR);
     expect(() => ɵɵsanitizeUrlOrResourceUrl('javascript:true', 'iframe', 'src'))
         .toThrowError(ERROR);


### PR DESCRIPTION
Long error messages can be tree-shaken in the production build and replaced with error codes.

See: https://github.com/angular/angular/pull/44219#issuecomment-983216374

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Long error messages are not tree-shakable in the production build.

Issue Number: N/A


## What is the new behavior?
Long error messages are tree-shaken in the production build and replaced with error codes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
