### PR TITLE
fix(common): stricter type for http methods

### DIFF
--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -1553,7 +1553,7 @@ export class HttpClient {
         withCredentials?: boolean;
     }): Observable<T>;
     request<R>(req: HttpRequest<any>): Observable<HttpEvent<R>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1570,7 +1570,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<ArrayBuffer>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1587,7 +1587,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<Blob>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1604,7 +1604,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<string>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1621,7 +1621,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1638,7 +1638,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<HttpEvent<Blob>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1655,7 +1655,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<HttpEvent<string>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1672,7 +1672,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<HttpEvent<any>>;
-    request<R>(method: string, url: string, options: {
+    request<R>(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1689,7 +1689,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<HttpEvent<R>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1706,7 +1706,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1723,7 +1723,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<HttpResponse<Blob>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1740,7 +1740,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<HttpResponse<string>>;
-    request(method: string, url: string, options: {
+    request(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1754,7 +1754,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
-    request<R>(method: string, url: string, options: {
+    request<R>(method: HttpMethod | string, url: string, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1771,7 +1771,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<HttpResponse<R>>;
-    request(method: string, url: string, options?: {
+    request(method: HttpMethod | string, url: string, options?: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1788,7 +1788,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<Object>;
-    request<R>(method: string, url: string, options?: {
+    request<R>(method: HttpMethod | string, url: string, options?: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1805,7 +1805,7 @@ export class HttpClient {
             includeHeaders?: string[];
         } | boolean;
     }): Observable<R>;
-    request(method: string, url: string, options?: {
+    request(method: HttpMethod | string, url: string, options?: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1994,6 +1994,9 @@ export interface HttpInterceptor {
 export type HttpInterceptorFn = (req: HttpRequest<unknown>, next: HttpHandlerFn) => Observable<HttpEvent<unknown>>;
 
 // @public
+export type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH' | 'JSONP' | 'get' | 'head' | 'post' | 'put' | 'delete' | 'connect' | 'options' | 'trace' | 'patch' | 'jsonp';
+
+// @public
 export interface HttpParameterCodec {
     // (undocumented)
     decodeKey(key: string): string;
@@ -2077,7 +2080,7 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
     });
-    constructor(method: string, url: string, body: T | null, init?: {
+    constructor(method: HttpMethod | string, url: string, body: T | null, init?: {
         headers?: HttpHeaders;
         context?: HttpContext;
         reportProgress?: boolean;
@@ -2100,7 +2103,7 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
         body?: T | null;
-        method?: string;
+        method?: HttpMethod;
         url?: string;
         setHeaders?: {
             [name: string]: string | string[];
@@ -2118,7 +2121,7 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
         body?: V | null;
-        method?: string;
+        method?: HttpMethod;
         url?: string;
         setHeaders?: {
             [name: string]: string | string[];
@@ -2130,7 +2133,7 @@ export class HttpRequest<T> {
     readonly context: HttpContext;
     detectContentTypeHeader(): string | null;
     readonly headers: HttpHeaders;
-    readonly method: string;
+    readonly method: HttpMethod;
     readonly params: HttpParams;
     readonly reportProgress: boolean;
     readonly responseType: 'arraybuffer' | 'blob' | 'json' | 'text';

--- a/goldens/public-api/common/http/testing/index.md
+++ b/goldens/public-api/common/http/testing/index.md
@@ -6,6 +6,7 @@
 
 import { HttpEvent } from '@angular/common/http';
 import { HttpHeaders } from '@angular/common/http';
+import { HttpMethod } from '@angular/common/http';
 import { HttpRequest } from '@angular/common/http';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/common/http';
@@ -44,7 +45,7 @@ export function provideHttpClientTesting(): Provider[];
 // @public
 export interface RequestMatch {
     // (undocumented)
-    method?: string;
+    method?: HttpMethod | string;
     // (undocumented)
     url?: string;
 }

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -13,6 +13,7 @@ export {FetchBackend} from './src/fetch';
 export {HttpHeaders} from './src/headers';
 export {HTTP_INTERCEPTORS, HttpHandlerFn, HttpInterceptor, HttpInterceptorFn, HttpInterceptorHandler as ɵHttpInterceptorHandler, HttpInterceptorHandler as ɵHttpInterceptingHandler} from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
+export {HttpMethod} from './src/method';
 export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule} from './src/module';
 export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec} from './src/params';
 export {HttpFeature, HttpFeatureKind, provideHttpClient, withFetch, withInterceptors, withInterceptorsFromDi, withJsonpSupport, withNoXsrfProtection, withRequestsMadeViaParent, withXsrfConfiguration} from './src/provider';

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -13,6 +13,7 @@ import {concatMap, filter, map} from 'rxjs/operators';
 import {HttpHandler} from './backend';
 import {HttpContext} from './context';
 import {HttpHeaders} from './headers';
+import {HttpMethod} from './method';
 import {HttpParams, HttpParamsOptions} from './params';
 import {HttpRequest} from './request';
 import {HttpEvent, HttpResponse} from './response';
@@ -131,7 +132,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as an `ArrayBuffer`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -153,7 +154,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type `Blob`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -175,7 +176,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type string.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -198,7 +199,7 @@ export class HttpClient {
    * @return An `Observable` of the response, with the response body as an array of `HttpEvent`s for
    * the request.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -221,7 +222,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type `Blob`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
@@ -243,7 +244,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type string.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
@@ -265,7 +266,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type `Object`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -288,7 +289,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type `R`.
    */
-  request<R>(method: string, url: string, options: {
+  request<R>(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -310,7 +311,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body as an `ArrayBuffer`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
@@ -330,7 +331,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of type `Blob`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
@@ -351,7 +352,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the HTTP response, with the response body of type string.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
@@ -373,7 +374,7 @@ export class HttpClient {
    * @return An `Observable` of the full `HttpResponse`,
    * with the response body of type `Object`.
    */
-  request(method: string, url: string, options: {
+  request(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -394,7 +395,7 @@ export class HttpClient {
    *
    * @return  An `Observable` of the full `HttpResponse`, with the response body of type `R`.
    */
-  request<R>(method: string, url: string, options: {
+  request<R>(method: HttpMethod|string, url: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -416,7 +417,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of type `Object`.
    */
-  request(method: string, url: string, options?: {
+  request(method: HttpMethod|string, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -439,7 +440,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of type `R`.
    */
-  request<R>(method: string, url: string, options?: {
+  request<R>(method: HttpMethod|string, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -461,7 +462,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the requested response, with body of type `any`.
    */
-  request(method: string, url: string, options?: {
+  request(method: HttpMethod|string, url: string, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -500,7 +501,7 @@ export class HttpClient {
    *   * An `observe` value of body returns an observable of `<T>` with the same `T` body type.
    *
    */
-  request(first: string|HttpRequest<any>, url?: string, options: {
+  request(first: HttpMethod|string|HttpRequest<any>, url?: string, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,

--- a/packages/common/http/src/method.ts
+++ b/packages/common/http/src/method.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Common HTTP methods that can be used, both in lowercase or uppercase.
+ *
+ * Based on:
+ * - https://datatracker.ietf.org/doc/html/rfc7231#section-4 for
+ * `'GET'|'HEAD'|'POST'|'PUT'|'DELETE'|'CONNECT'|'OPTIONS'|'TRACE'`
+ * - https://datatracker.ietf.org/doc/html/rfc5789#section-2 for `'PATCH`'
+ * - `'JSONP'` as a special one for jsonp support.
+ */
+export type HttpMethod = 'GET'|'HEAD'|'POST'|'PUT'|'DELETE'|'CONNECT'|'OPTIONS'|'TRACE'|'PATCH'|
+    'JSONP'|'get'|'head'|'post'|'put'|'delete'|'connect'|'options'|'trace'|'patch'|'jsonp';

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -8,6 +8,7 @@
 
 import {HttpContext} from './context';
 import {HttpHeaders} from './headers';
+import {HttpMethod} from './method';
 import {HttpParams} from './params';
 
 /**
@@ -134,7 +135,7 @@ export class HttpRequest<T> {
   /**
    * The outgoing HTTP request method.
    */
-  readonly method: string;
+  readonly method: HttpMethod;
 
   /**
    * Outgoing URL parameters.
@@ -209,7 +210,7 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
   });
-  constructor(method: string, url: string, body: T|null, init?: {
+  constructor(method: HttpMethod|string, url: string, body: T|null, init?: {
     headers?: HttpHeaders,
     context?: HttpContext,
     reportProgress?: boolean,
@@ -245,7 +246,7 @@ export class HttpRequest<T> {
         withCredentials?: boolean,
         transferCache?: {includeHeaders?: string[]}|boolean
       }) {
-    this.method = method.toUpperCase();
+    this.method = method.toUpperCase() as HttpMethod;
     // Next, need to figure out which argument holds the HttpRequestInit
     // options, if any.
     let options: HttpRequestInit|undefined;
@@ -404,7 +405,7 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
     body?: T|null,
-    method?: string,
+    method?: HttpMethod,
     url?: string,
     setHeaders?: {[name: string]: string|string[]},
     setParams?: {[param: string]: string},
@@ -417,7 +418,7 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
     body?: V|null,
-    method?: string,
+    method?: HttpMethod,
     url?: string,
     setHeaders?: {[name: string]: string|string[]},
     setParams?: {[param: string]: string},
@@ -430,7 +431,7 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
     body?: any|null,
-    method?: string,
+    method?: HttpMethod,
     url?: string,
     setHeaders?: {[name: string]: string|string[]},
     setParams?: {[param: string]: string};

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -17,7 +17,7 @@ const TEST_STRING = `I'm a body!`;
 describe('HttpRequest', () => {
   describe('constructor', () => {
     it('initializes url', () => {
-      const req = new HttpRequest('', TEST_URL, null);
+      const req = new HttpRequest('TEST', TEST_URL, null);
       expect(req.url).toBe(TEST_URL);
     });
     it('doesn\'t require a body for body-less methods', () => {

--- a/packages/common/http/testing/src/api.ts
+++ b/packages/common/http/testing/src/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpRequest} from '@angular/common/http';
+import {HttpMethod, HttpRequest} from '@angular/common/http';
 
 import {TestRequest} from './request';
 
@@ -16,7 +16,7 @@ import {TestRequest} from './request';
  * @publicApi
  */
 export interface RequestMatch {
-  method?: string;
+  method?: HttpMethod|string;
   url?: string;
 }
 

--- a/packages/common/http/testing/test/request_spec.ts
+++ b/packages/common/http/testing/test/request_spec.ts
@@ -25,6 +25,36 @@ describe('HttpClient TestRequest', () => {
     expect(resp).toBeNull();
   });
 
+  it('accepts a request match', () => {
+    const mock = new HttpClientTestingBackend();
+    const client = new HttpClient(mock);
+
+    let resp: any;
+    client.delete('/some-url').subscribe(body => {
+      resp = body;
+    });
+
+    const req = mock.expectOne({method: 'DELETE', url: '/some-url'});
+    req.flush(null);
+
+    expect(resp).toBeNull();
+  });
+
+  it('accepts a custom HTTP method', () => {
+    const mock = new HttpClientTestingBackend();
+    const client = new HttpClient(mock);
+
+    let resp: any;
+    client.request('TEST', '/some-url').subscribe(body => {
+      resp = body;
+    });
+
+    const req = mock.expectOne({method: 'TEST', url: '/some-url'});
+    req.flush(null);
+
+    expect(resp).toBeNull();
+  });
+
   it('throws if no request matches', () => {
     const mock = new HttpClientTestingBackend();
     const client = new HttpClient(mock);


### PR DESCRIPTION
(Less breaky) alternative to #44328 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The current API accepts `string` for the HTTP method.


## What is the new behavior?

This commit tightens the API to accept both one of the common  HTTP verb (either in lowercase or in uppercase to preserve the existing behavior), or a `string` to be as less breaking as possible.

The common HTTP methods picked are `'GET'|'HEAD'|'POST'|'PUT'|'DELETE'|'CONNECT'|'OPTIONS'|'TRACE'|'PATCH'|'JSONP'` (or one of these in lowercase), based on:

- https://datatracker.ietf.org/doc/html/rfc7231#section-4 for `'GET'|'HEAD'|'POST'|'PUT'|'DELETE'|'CONNECT'|'OPTIONS'|'TRACE'`
- https://datatracker.ietf.org/doc/html/rfc5789#section-2 for `'PATCH`'
- `'JSONP'` as a special one for jsonp support.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
