### PR TITLE
build: enable `noPropertyAccessFromIndexSignature`

### DIFF
--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -18,6 +18,7 @@
     "noImplicitOverride": true,
     "useUnknownInCatchVariables": false,
     "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true,
     "paths": {
       "selenium-webdriver": [
         "./node_modules/@types/selenium-webdriver/index.d.ts"


### PR DESCRIPTION
This flag makes TypeScript throw an error when using `foo.bar` syntax to resolve an index signature type (`{[prop: string]: T}`). This avoids accidentally using the index signature type when a more explict type was intended, catching many typos. For example, it would catch:

```typescript
interface Foo {
  bar: string;
  [prop: string]: any;
}

const foo: Foo = /* ... */;
foo.bar; // string
foo.abr; // Error...
foo['abr']; // any
```

Motivation for this is an upcoming `CompilerOptions` change for extended template diagnostics which will require adding `{[prop: string]: any}` to remain compatible with TypeScript's existing types while having a more flexible `tsconfig.json` structure.

It's only really needed in the `compiler-cli` package, but I put this in `packages/tsconfig.json` to be consistent across the whole repository. If that's too broad, I can narrow it down to `packages/compiler-cli/tsconfig.json`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Build related changes