### PR TITLE
test: spy on console.error in configureTestingModule reset test

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -1242,10 +1242,15 @@ describe('TestBed', () => {
 
          TestBed.resetTestingModule();
 
+         const spy = spyOn(console, 'error');
+
          // Case #2: the `TestBed.configureTestingModule` was not invoked, thus the `ChildCmp`
          // should not be available in the `RootCmp` scope and no child content should be
          // rendered.
          fixture = TestBed.createComponent(RootCmp);
+         // also an error should be logged to the user informing them that
+         // the child component is not part of the module
+         expect(spy).toHaveBeenCalledTimes(1);
          fixture.detectChanges();
 
          childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp));


### PR DESCRIPTION
improve the configureTestingModule reset test by also spying on
console.error and making sure that an error is logged to the user
when it should be

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When running the web karma unit tests (https://github.com/angular/angular/blob/master/docs/BAZEL.md#debugging-a-karma-test) one test always shows a console error:
![Screenshot at 2021-12-04 14-50-05](https://user-images.githubusercontent.com/61631103/144714765-882de6fe-5ae0-4326-8ed0-e07f7a750808.png)

That is not a real issue/error as it the expected behavior in the test, but it does always appear and can lead to devs not familiar with it to think that something is going wrong (/is broken) somewhere

## What is the new behavior?

A spy has been added on console.error so that
 - the error is not shown anymore in the tests results
 - we actually also check that the error is being shown to the user, which is the expected behavior

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


