### PR TITLE
fix(ngcc): correctly resolve UMD dependencies

### DIFF
--- a/packages/compiler-cli/ngcc/test/helpers/umd_utils.ts
+++ b/packages/compiler-cli/ngcc/test/helpers/umd_utils.ts
@@ -8,16 +8,21 @@
 
 export interface AdditionalFormatOptions {
   /**
-   * The index of the `exports` parameter index in the factory function (and thus the corresponding
-   * argument in the various factory calls). (Only affects the `Rollup` format.)
+   * The index of the `exports` parameter in the factory function (and thus the corresponding
+   * argument in the various factory calls). Passing -1 will cause the `exports` parameter/argument
+   * to be omitted altogether.
+   * (This option only affects the `Rollup` format.)
    *
-   * Defaults to 0 (i.e. `exports` being the first argument).
+   * Defaults to `0` (i.e. `exports` being the first argument).
    */
   exportsParamIndex?: number;
 
   /**
    * Whether to include an initializer for the `global` variable (`global = global || self`) before
-   * the global factory call. (Only affects the `Rollup` format.)
+   * the global factory call.
+   * (This option only affects the `Rollup` format.)
+   *
+   * Defaults to `false` (i.e. not include an initialier for `global`).
    */
   hasGlobalInitializer?: boolean;
 
@@ -26,6 +31,8 @@ export interface AdditionalFormatOptions {
    * function parameters are omitted).
    * Unused dependencies must always follow used ones (if any). In other words, unused dependencies
    * can only appear at the end of the dependency list.
+   *
+   * Defaults to an empty set (i.e. all dependencies are used).
    */
   unusedDependencies?: Set<String>;
 }

--- a/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
@@ -367,7 +367,7 @@ exports.BadIife = BadIife;
                 factoryBody: `
                     var index = '';
                     return index;`,
-                additionalOptions: {omitExports: true},
+                additionalOptions: {exportsParamIndex: -1},
               },
             });
             const {renderer, program} = setup(PROGRAM);


### PR DESCRIPTION
_This is a backport of #44381 to the `12.2.x` branch._

##
Previously, when processing UMD, ngcc assumed that the `exports` argument of the CommonJS factory call (if present) would be the first argument of the call. This is generally true for the supported UMD formats, but can change if ngcc prepends more imports (and thus factory arguments) while processing the module. This could lead to errors when trying to collect dependencies of an already processed module.
(This was accidentally broken in #44245 (commit 2bc3522e167).)

This commit fixes it by not making any assumptions about the position of an `exports` argument in the CommonJS factory call.

Fixes #44380.
