### PR TITLE
build(docs-infra): upgrade cli command docs sources to e7881e40b

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 481eb4544",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js e7881e40b",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint && yarn security-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#13.1.x](https://github.com/angular/angular/tree/13.1.x) from [cli-builds#13.0.x](https://github.com/angular/cli-builds/tree/13.0.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/481eb4544...e7881e40b):

**Modified**
- help/new.json