### PR TITLE
docs: fix typo in tutorial

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -141,7 +141,7 @@ To get information from a route:
     <code-example path="router/src/app/heroes/hero-detail/hero-detail.component.ts" region="activated-route" header="In the component class (excerpt)">
     </code-example>
 
-  1. Update the `ngOnInit()` method to access the `ActivatedRoute` and track the `id` parameter:
+  1. Update the `ngOnInit()` method to access the `ActivatedRoute` and track the `name` parameter:
 
       <code-example header="In the component (excerpt)">
         ngOnInit() {


### PR DESCRIPTION
`name` instead of `id`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ]  Tests for the changes have been added (for bug fixes / features)
- [ ]  Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
`name` instead of `id`

Issue Number: N/A


## What is the new behavior?
change `id` to `name`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
