### PR TITLE
feat(forms): Allow a FormControl to use initial value as default.

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -276,7 +276,7 @@ export class FormArrayName extends ControlContainer implements OnInit, OnDestroy
 // @public
 export class FormBuilder {
     array(controlsConfig: any[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormArray;
-    control(formState: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl;
+    control(formState: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl;
     group(controlsConfig: {
         [key: string]: any;
     }, options?: AbstractControlOptions | null): FormGroup;
@@ -294,7 +294,8 @@ export class FormBuilder {
 
 // @public
 export class FormControl extends AbstractControl {
-    constructor(formState?: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
+    constructor(formState?: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
+    readonly defaultValue: any;
     patchValue(value: any, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
@@ -359,6 +360,11 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
     static ɵdir: i0.ɵɵDirectiveDeclaration<FormControlName, "[formControlName]", never, { "name": "formControlName"; "isDisabled": "disabled"; "model": "ngModel"; }, { "update": "ngModelChange"; }, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FormControlName, [{ optional: true; host: true; skipSelf: true; }, { optional: true; self: true; }, { optional: true; self: true; }, { optional: true; self: true; }, { optional: true; }]>;
+}
+
+// @public
+export interface FormControlOptions extends AbstractControlOptions {
+    initialValueIsDefault?: boolean;
 }
 
 // @public

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -10,7 +10,7 @@ import {Injectable} from '@angular/core';
 
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
 import {ReactiveFormsModule} from './form_providers';
-import {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormGroup, FormHooks} from './model';
+import {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlOptions, FormGroup, FormHooks} from './model';
 
 function isAbstractControlOptions(options: AbstractControlOptions|
                                   {[key: string]: any}): options is AbstractControlOptions {
@@ -127,7 +127,7 @@ export class FormBuilder {
    * </code-example>
    */
   control(
-      formState: any, validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      formState: any, validatorOrOpts?: ValidatorFn|ValidatorFn[]|FormControlOptions|null,
       asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): FormControl {
     return new FormControl(formState, validatorOrOpts, asyncValidator);
   }

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -43,7 +43,7 @@ export {NgSelectOption, SelectControlValueAccessor} from './directives/select_co
 export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlStatus, FormGroup} from './model';
+export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlOptions, FormControlStatus, FormGroup} from './model';
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';
 export {VERSION} from './version';
 

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -817,6 +817,62 @@ describe('FormControl', () => {
       expect(c.value).toBe(null);
     });
 
+    it('should reset to the initial value if specified in FormControlOptions', () => {
+      const c2 = new FormControl('foo', {initialValueIsDefault: true});
+      expect(c2.value).toBe('foo');
+      expect(c2.defaultValue).toBe('foo');
+
+      c2.setValue('bar');
+      expect(c2.value).toBe('bar');
+      expect(c2.defaultValue).toBe('foo');
+
+      c2.reset();
+      expect(c2.value).toBe('foo');
+      expect(c2.defaultValue).toBe('foo');
+
+      const c3 = new FormControl('foo', {initialValueIsDefault: false});
+      expect(c3.value).toBe('foo');
+      expect(c3.defaultValue).toBe(null);
+
+      c3.setValue('bar');
+      expect(c3.value).toBe('bar');
+      expect(c3.defaultValue).toBe(null);
+
+      c3.reset();
+      expect(c3.value).toBe(null);
+      expect(c3.defaultValue).toBe(null);
+    });
+
+    it('should look inside FormState objects for a default value', () => {
+      const c2 = new FormControl({value: 'foo', disabled: false}, {initialValueIsDefault: true});
+      expect(c2.value).toBe('foo');
+      expect(c2.defaultValue).toBe('foo');
+
+      c2.setValue('bar');
+      expect(c2.value).toBe('bar');
+      expect(c2.defaultValue).toBe('foo');
+
+      c2.reset();
+      expect(c2.value).toBe('foo');
+      expect(c2.defaultValue).toBe('foo');
+    });
+
+    it('should not alter the disabled state when resetting, even if a default value is provided',
+       () => {
+         const c2 = new FormControl({value: 'foo', disabled: true}, {initialValueIsDefault: true});
+         expect(c2.value).toBe('foo');
+         expect(c2.defaultValue).toBe('foo');
+         expect(c2.disabled).toBe(true);
+
+         c2.setValue('bar');
+         c2.enable();
+
+         c2.reset();
+         expect(c2.value).toBe('foo');
+         expect(c2.defaultValue).toBe('foo');
+         expect(c2.disabled).toBe(false);
+       });
+
     it('should update the value of any parent controls with passed value', () => {
       const g = new FormGroup({'one': c});
       c.setValue('new value');


### PR DESCRIPTION
Allow a FormControl to be reset to its initial value. Provide this feature via a new option in a FormControlOptions interface, based on AbstractControlOptions.

Also, expose the default value as part of the public API. This is part of a feature that has been requested elsewhere (e.g. in #19747).

This was originally proposed as part of typed forms. As discussed in the GDE session (and after with akushnir/alxhub), it is likely better to just reuse the initial value rather than accepting an additional default.

It is desirable to land this separately in order to reduce the scope of the typed forms PR, and make it a types-only change.

Edit: This change will also help us in a long-term shift to reduce the use of `null` in Forms, and adopt safer defaults.

Pertains to issue #13721.
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
It is impossible to specify the value to which a control will reset ahead of time.

Issue Number: #13721


## What is the new behavior?
It is now possible to cause a control to reset to its initial value. This will be useful for simplifying the types in strongly typed reactive forms.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
