### PR TITLE
fix(animations): add preventDefault to leaving form elements

### DIFF
--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -759,6 +759,17 @@ export class TransitionAnimationEngine {
     this.collectedLeaveElements.push(element);
     element[REMOVAL_FLAG] =
         {namespaceId, setForRemoval: context, hasAnimation, removedBeforeQueried: false};
+
+    // if a form (or an element containing a form) is leaving and the user attempts
+    // to submit the form (for example by clicking on a submit button inside of it)
+    // we do not want the native submit event to cause a page refresh so we need
+    // to prevent the event's default behavior
+    // Note: this does not remove existing native listeners from the form element,
+    //       if present they will still be executed as well
+    const formChildElems = element.querySelectorAll('form');
+    for (let i = 0; i < formChildElems.length; i++) {
+      formChildElems[i].addEventListener('submit', (event: any) => event.preventDefault());
+    }
   }
 
   listen(


### PR DESCRIPTION
form elements leaving the dom can still trigger submit events
which cause a page refresh, so add a preventDefault call to
any form element as soon as they or their parent is being
marked as removed

resolves #42850

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #42850


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
