### PR TITLE
fix(compiler-cli): enable narrowing of using type guard methods

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -11,7 +11,7 @@ import ts from 'typescript';
 import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem, TestFile} from '../../file_system/testing';
 import {OptimizeFor, TypeCheckingConfig} from '../api';
-import {ngForDeclaration, ngForDts, setup, TestDeclaration} from '../testing';
+import {ngForDeclaration, ngForDts, ngIfDeclaration, ngIfDts, setup, TestDeclaration} from '../testing';
 
 runInEachFileSystem(() => {
   describe('template diagnostics', () => {
@@ -337,6 +337,17 @@ runInEachFileSystem(() => {
       expect(messages).toEqual([
         `TestComponent.html(1, 31): Argument of type '-2' is not assignable to parameter of type '1 | -1'.`,
       ]);
+    });
+
+    it('should support type-narrowing for methods with type guards', () => {
+      const messages = diagnose(
+          `<div *ngIf="hasSuccess()">{{ success }}</div>`, `
+          class TestComponent {
+            hasSuccess(): this is { success: boolean };
+          }`,
+          [ngIfDeclaration()], [ngIfDts()]);
+
+      expect(messages).toEqual([]);
     });
 
     describe('outputs', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -39,7 +39,7 @@ describe('type check blocks diagnostics', () => {
       const TEMPLATE = '{{ m({foo: a, bar: b}) }}';
       expect(tcbWithSpans(TEMPLATE))
           .toContain(
-              '((((ctx).m /*3,4*/) /*3,4*/)({ "foo": ((ctx).a /*11,12*/) /*11,12*/, "bar": ((ctx).b /*19,20*/) /*19,20*/ } /*5,21*/) /*3,22*/)');
+              '(ctx).m /*3,4*/({ "foo": ((ctx).a /*11,12*/) /*11,12*/, "bar": ((ctx).b /*19,20*/) /*19,20*/ } /*5,21*/) /*3,22*/');
     });
 
     it('should annotate literal map expressions with shorthand declarations', () => {
@@ -48,7 +48,7 @@ describe('type check blocks diagnostics', () => {
       const TEMPLATE = '{{ m({a, b}) }}';
       expect(tcbWithSpans(TEMPLATE))
           .toContain(
-              '((((ctx).m /*3,4*/) /*3,4*/)({ "a": ((ctx).a /*6,7*/) /*6,7*/, "b": ((ctx).b /*9,10*/) /*9,10*/ } /*5,11*/) /*3,12*/)');
+              '((ctx).m /*3,4*/({ "a": ((ctx).a /*6,7*/) /*6,7*/, "b": ((ctx).b /*9,10*/) /*9,10*/ } /*5,11*/) /*3,12*/)');
     });
 
     it('should annotate literal array expressions', () => {
@@ -76,21 +76,21 @@ describe('type check blocks diagnostics', () => {
       const TEMPLATE = `{{ method(a, b) }}`;
       expect(tcbWithSpans(TEMPLATE))
           .toContain(
-              '((((ctx).method /*3,9*/) /*3,9*/)(((ctx).a /*10,11*/) /*10,11*/, ((ctx).b /*13,14*/) /*13,14*/) /*3,15*/)');
+              '(ctx).method /*3,9*/(((ctx).a /*10,11*/) /*10,11*/, ((ctx).b /*13,14*/) /*13,14*/) /*3,15*/');
     });
 
     it('should annotate method calls of variables', () => {
       const TEMPLATE = `<ng-template let-method>{{ method(a, b) }}</ng-template>`;
       expect(tcbWithSpans(TEMPLATE))
           .toContain(
-              '((_t2 /*27,33*/)(((ctx).a /*34,35*/) /*34,35*/, ((ctx).b /*37,38*/) /*37,38*/) /*27,39*/)');
+              '_t2 /*27,33*/(((ctx).a /*34,35*/) /*34,35*/, ((ctx).b /*37,38*/) /*37,38*/) /*27,39*/');
     });
 
     it('should annotate function calls', () => {
       const TEMPLATE = `{{ method(a)(b, c) }}`;
       expect(tcbWithSpans(TEMPLATE))
           .toContain(
-              '(((((ctx).method /*3,9*/) /*3,9*/)(((ctx).a /*10,11*/) /*10,11*/) /*3,12*/)(((ctx).b /*13,14*/) /*13,14*/, ((ctx).c /*16,17*/) /*16,17*/) /*3,18*/)');
+              '(ctx).method /*3,9*/(((ctx).a /*10,11*/) /*10,11*/) /*3,12*/(((ctx).b /*13,14*/) /*13,14*/, ((ctx).c /*16,17*/) /*16,17*/) /*3,18*/');
     });
 
     it('should annotate property access', () => {
@@ -135,7 +135,7 @@ describe('type check blocks diagnostics', () => {
       const TEMPLATE = `{{ a?.method(b) }}`;
       expect(tcbWithSpans(TEMPLATE))
           .toContain(
-              '((null as any ? ((null as any ? (((ctx).a /*3,4*/) /*3,4*/)!.method /*6,12*/ : undefined) /*3,12*/)!(((ctx).b /*13,14*/) /*13,14*/) : undefined) /*3,15*/)');
+              '((null as any ? (null as any ? (((ctx).a /*3,4*/) /*3,4*/)!.method /*6,12*/ : undefined) /*3,12*/!(((ctx).b /*13,14*/) /*13,14*/) : undefined) /*3,15*/)');
     });
 
     it('should annotate safe keyed reads', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -20,12 +20,12 @@ describe('type check blocks', () => {
 
   it('should generate literal map expressions', () => {
     const TEMPLATE = '{{ method({foo: a, bar: b}) }}';
-    expect(tcb(TEMPLATE)).toContain('(((ctx).method))({ "foo": ((ctx).a), "bar": ((ctx).b) })');
+    expect(tcb(TEMPLATE)).toContain('(ctx).method({ "foo": ((ctx).a), "bar": ((ctx).b) })');
   });
 
   it('should generate literal array expressions', () => {
     const TEMPLATE = '{{ method([a, b]) }}';
-    expect(tcb(TEMPLATE)).toContain('(((ctx).method))([((ctx).a), ((ctx).b)])');
+    expect(tcb(TEMPLATE)).toContain('(ctx).method([((ctx).a), ((ctx).b)])');
   });
 
   it('should handle non-null assertions', () => {
@@ -115,7 +115,7 @@ describe('type check blocks', () => {
   it('should handle method calls of template variables', () => {
     const TEMPLATE = `<ng-template let-a>{{a(1)}}</ng-template>`;
     expect(tcb(TEMPLATE)).toContain('var _t2 = _t1.$implicit;');
-    expect(tcb(TEMPLATE)).toContain('(_t2)(1)');
+    expect(tcb(TEMPLATE)).toContain('_t2(1)');
   });
 
   it('should handle implicit vars when using microsyntax', () => {
@@ -126,7 +126,7 @@ describe('type check blocks', () => {
   it('should handle direct calls of an implicit template variable', () => {
     const TEMPLATE = `<div *ngFor="let a of letters">{{a(1)}}</div>`;
     expect(tcb(TEMPLATE)).toContain('var _t2 = _t1.$implicit;');
-    expect(tcb(TEMPLATE)).toContain('(_t2)(1)');
+    expect(tcb(TEMPLATE)).toContain('_t2(1)');
   });
 
   describe('type constructors', () => {
@@ -609,13 +609,13 @@ describe('type check blocks', () => {
   it('should handle $any accessed through `this`', () => {
     const TEMPLATE = `{{this.$any(a)}}`;
     const block = tcb(TEMPLATE);
-    expect(block).toContain('((((ctx).$any))(((ctx).a)))');
+    expect(block).toContain('((ctx).$any(((ctx).a)))');
   });
 
   it('should handle $any accessed through a property read', () => {
     const TEMPLATE = `{{foo.$any(a)}}`;
     const block = tcb(TEMPLATE);
-    expect(block).toContain('((((((ctx).foo)).$any))(((ctx).a)))');
+    expect(block).toContain('((((ctx).foo)).$any(((ctx).a)))');
   });
 
   describe('experimental DOM checking via lib.dom.d.ts', () => {
@@ -688,28 +688,27 @@ describe('type check blocks', () => {
       const TEMPLATE = `<div dir (dirOutput)="foo($event)"></div>`;
       const block = tcb(TEMPLATE, DIRECTIVES);
       expect(block).toContain(
-          '_t1["outputField"].subscribe(function ($event): any { (((ctx).foo))($event); });');
+          '_t1["outputField"].subscribe(function ($event): any { (ctx).foo($event); });');
     });
 
     it('should emit a listener function with AnimationEvent for animation events', () => {
       const TEMPLATE = `<div (@animation.done)="foo($event)"></div>`;
       const block = tcb(TEMPLATE);
-      expect(block).toContain(
-          'function ($event: i1.AnimationEvent): any { (((ctx).foo))($event); }');
+      expect(block).toContain('function ($event: i1.AnimationEvent): any { (ctx).foo($event); }');
     });
 
     it('should emit addEventListener calls for unclaimed outputs', () => {
       const TEMPLATE = `<div (event)="foo($event)"></div>`;
       const block = tcb(TEMPLATE);
       expect(block).toContain(
-          '_t1.addEventListener("event", function ($event): any { (((ctx).foo))($event); });');
+          '_t1.addEventListener("event", function ($event): any { (ctx).foo($event); });');
     });
 
     it('should allow to cast $event using $any', () => {
       const TEMPLATE = `<div (event)="foo($any($event))"></div>`;
       const block = tcb(TEMPLATE);
       expect(block).toContain(
-          '_t1.addEventListener("event", function ($event): any { (((ctx).foo))(($event as any)); });');
+          '_t1.addEventListener("event", function ($event): any { (ctx).foo(($event as any)); });');
     });
 
     it('should detect writes to template variables', () => {
@@ -724,7 +723,7 @@ describe('type check blocks', () => {
       const block = tcb(TEMPLATE);
 
       expect(block).toContain(
-          '_t1.addEventListener("event", function ($event): any { (((ctx).foo))(((ctx).$event)); });');
+          '_t1.addEventListener("event", function ($event): any { (ctx).foo(((ctx).$event)); });');
     });
   });
 
@@ -852,18 +851,18 @@ describe('type check blocks', () => {
       it('should check types of directive outputs when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain(
-            '_t1["outputField"].subscribe(function ($event): any { (((ctx).foo))($event); });');
+            '_t1["outputField"].subscribe(function ($event): any { (ctx).foo($event); });');
         expect(block).toContain(
-            '_t2.addEventListener("nonDirOutput", function ($event): any { (((ctx).foo))($event); });');
+            '_t2.addEventListener("nonDirOutput", function ($event): any { (ctx).foo($event); });');
       });
       it('should not check types of directive outputs when disabled', () => {
         const DISABLED_CONFIG:
             TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfOutputEvents: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('function ($event: any): any { (((ctx).foo))($event); }');
+        expect(block).toContain('function ($event: any): any { (ctx).foo($event); }');
         // Note that DOM events are still checked, that is controlled by `checkTypeOfDomEvents`
         expect(block).toContain(
-            'addEventListener("nonDirOutput", function ($event): any { (((ctx).foo))($event); });');
+            'addEventListener("nonDirOutput", function ($event): any { (ctx).foo($event); });');
       });
     });
 
@@ -872,14 +871,13 @@ describe('type check blocks', () => {
 
       it('should check types of animation events when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain(
-            'function ($event: i1.AnimationEvent): any { (((ctx).foo))($event); }');
+        expect(block).toContain('function ($event: i1.AnimationEvent): any { (ctx).foo($event); }');
       });
       it('should not check types of animation events when disabled', () => {
         const DISABLED_CONFIG:
             TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfAnimationEvents: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('function ($event: any): any { (((ctx).foo))($event); }');
+        expect(block).toContain('function ($event: any): any { (ctx).foo($event); }');
       });
     });
 
@@ -889,9 +887,9 @@ describe('type check blocks', () => {
       it('should check types of DOM events when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain(
-            '_t1["outputField"].subscribe(function ($event): any { (((ctx).foo))($event); });');
+            '_t1["outputField"].subscribe(function ($event): any { (ctx).foo($event); });');
         expect(block).toContain(
-            '_t2.addEventListener("nonDirOutput", function ($event): any { (((ctx).foo))($event); });');
+            '_t2.addEventListener("nonDirOutput", function ($event): any { (ctx).foo($event); });');
       });
       it('should not check types of DOM events when disabled', () => {
         const DISABLED_CONFIG: TypeCheckingConfig = {...BASE_CONFIG, checkTypeOfDomEvents: false};
@@ -899,8 +897,8 @@ describe('type check blocks', () => {
         // Note that directive outputs are still checked, that is controlled by
         // `checkTypeOfOutputEvents`
         expect(block).toContain(
-            '_t1["outputField"].subscribe(function ($event): any { (((ctx).foo))($event); });');
-        expect(block).toContain('function ($event: any): any { (((ctx).foo))($event); }');
+            '_t1["outputField"].subscribe(function ($event): any { (ctx).foo($event); });');
+        expect(block).toContain('function ($event: any): any { (ctx).foo($event); }');
       });
     });
 
@@ -1009,7 +1007,7 @@ describe('type check blocks', () => {
       it('should use undefined for safe navigation operations when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain(
-            '(null as any ? ((null as any ? (((ctx).a))!.method : undefined))!() : undefined)');
+            '(null as any ? (null as any ? (((ctx).a))!.method : undefined)!() : undefined)');
         expect(block).toContain('(null as any ? (((ctx).a))!.b : undefined)');
         expect(block).toContain('(null as any ? (((ctx).a))![0] : undefined)');
       });
@@ -1017,7 +1015,7 @@ describe('type check blocks', () => {
         const DISABLED_CONFIG:
             TypeCheckingConfig = {...BASE_CONFIG, strictSafeNavigationTypes: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('(((((((ctx).a))!.method as any)) as any)())');
+        expect(block).toContain('((((((ctx).a))!.method as any) as any)())');
         expect(block).toContain('((((ctx).a))!.b as any)');
         expect(block).toContain('(((((ctx).a))![0] as any)');
       });
@@ -1027,18 +1025,18 @@ describe('type check blocks', () => {
       const TEMPLATE = `{{a.method()?.b}} {{a()?.method()}} {{a.method()?.[0]}}`;
       it('should check the presence of a property/method on the receiver when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
-        expect(block).toContain('(null as any ? ((((((ctx).a)).method))())!.b : undefined)');
+        expect(block).toContain('(null as any ? ((((ctx).a)).method())!.b : undefined)');
         expect(block).toContain(
-            '(null as any ? ((null as any ? ((((ctx).a))())!.method : undefined))!() : undefined)');
-        expect(block).toContain('(null as any ? ((((((ctx).a)).method))())![0] : undefined)');
+            '(null as any ? (null as any ? ((ctx).a())!.method : undefined)!() : undefined)');
+        expect(block).toContain('(null as any ? ((((ctx).a)).method())![0] : undefined)');
       });
       it('should not check the presence of a property/method on the receiver when disabled', () => {
         const DISABLED_CONFIG:
             TypeCheckingConfig = {...BASE_CONFIG, strictSafeNavigationTypes: false};
         const block = tcb(TEMPLATE, DIRECTIVES, DISABLED_CONFIG);
-        expect(block).toContain('((((((((ctx).a)).method))()) as any).b)');
-        expect(block).toContain('((((((((ctx).a))()) as any).method) as any)())');
-        expect(block).toContain('((((((((ctx).a)).method))()) as any)[0])');
+        expect(block).toContain('(((((ctx).a)).method()) as any).b');
+        expect(block).toContain('(((((ctx).a()) as any).method as any)())');
+        expect(block).toContain('(((((ctx).a)).method()) as any)[0]');
       });
     });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -120,6 +120,35 @@ export function angularAnimationsDts(): TestFile {
   };
 }
 
+export function ngIfDeclaration(): TestDeclaration {
+  return {
+    type: 'directive',
+    file: absoluteFrom('/ngif.d.ts'),
+    selector: '[ngIf]',
+    name: 'NgIf',
+    inputs: {ngIf: 'ngIf'},
+    ngTemplateGuards: [{type: 'binding', inputName: 'ngIf'}],
+    hasNgTemplateContextGuard: true,
+    isGeneric: true,
+  };
+}
+
+export function ngIfDts(): TestFile {
+  return {
+    name: absoluteFrom('/ngif.d.ts'),
+    contents: `
+    export declare class NgIf<T> {
+      ngIf: T;
+      static ngTemplateContextGuard<T>(dir: NgIf<T>, ctx: any): ctx is NgIfContext<Exclude<T, false|0|''|null|undefined>>
+    }
+
+    export declare class NgIfContext<T> {
+      $implicit: T;
+      ngIf: T;
+    }`,
+  };
+}
+
 export function ngForDeclaration(): TestDeclaration {
   return {
     type: 'directive',


### PR DESCRIPTION
The changes in 2028c3933f7fe2961999da475febde5a03bb694d caused method
calls to be emitted using additional parenthesis into the TCB, which in
turn prevented proper type narrowing when the method acts as a type
guard. This commit special-cases method calls from property reads to
avoid the additional parenthesis.

Fixes #44353