### PR TITLE
feat(core): Add a migration for typed forms.

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -16,5 +16,6 @@ pkg_npm(
         "//packages/core/schematics/migrations/entry-components",
         "//packages/core/schematics/migrations/router-link-empty-expression",
         "//packages/core/schematics/migrations/testbed-teardown",
+        "//packages/core/schematics/migrations/typed-forms",
     ],
 )

--- a/packages/core/schematics/migrations/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/google3/BUILD.bazel
@@ -8,6 +8,7 @@ ts_library(
     deps = [
         "//packages/core/schematics/migrations/entry-components",
         "//packages/core/schematics/migrations/testbed-teardown",
+        "//packages/core/schematics/migrations/typed-forms",
         "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tslint",
         "@npm//tslint",

--- a/packages/core/schematics/migrations/google3/typedFormsRule.ts
+++ b/packages/core/schematics/migrations/google3/typedFormsRule.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Replacement, RuleFailure, Rules} from 'tslint';
+import ts from 'typescript';
+
+import {anySymbolName, findControlClassUsages, findFormBuilderCalls, getAnyImport, getControlClassImports, getFormBuilderImport, MigratableNode} from '../typed-forms/util';
+
+/** TSLint rule for Typed Forms migration. */
+export class Rule extends Rules.TypedRule {
+  override applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[] {
+    const typeChecker = program.getTypeChecker();
+
+    const controlClassImports = getControlClassImports(sourceFile);
+    const formBuilderImport = getFormBuilderImport(sourceFile);
+
+    const failures: RuleFailure[] = [];
+
+    // If no relevant classes are imported, we can exit early.
+    if (controlClassImports.length === 0 && formBuilderImport !== null) return failures;
+
+    // For each control class, migrate all of its uses.
+    for (const importSpecifier of controlClassImports) {
+      const usages = findControlClassUsages(sourceFile, typeChecker, importSpecifier);
+      for (const node of usages) {
+        failures.push(this.getNodeFailure(node, sourceFile));
+      }
+    }
+
+    // For each FormBuilder method, migrate all of its uses.
+    const nodes = findFormBuilderCalls(sourceFile, typeChecker, formBuilderImport);
+    for (const n of nodes) {
+      failures.push(this.getNodeFailure(n, sourceFile));
+    }
+
+    // Add the any symbol used by the migrated calls.
+    if (getAnyImport(sourceFile) !== null) {
+      const firstValidFormsImport =
+          [...controlClassImports, formBuilderImport].sort().filter(i => i)[0]!;
+      failures.push(this.getImportFailure(firstValidFormsImport, sourceFile));
+    }
+
+    return failures;
+  }
+
+  private getNodeFailure(node: MigratableNode, sourceFile: ts.SourceFile): RuleFailure {
+    return new RuleFailure(
+        sourceFile, node.node.getStart(), node.node.getEnd(),
+        'Typed Forms requires a generic be provided for this identifier.', this.ruleName,
+        new Replacement(
+            node.node.getStart(), node.node.getWidth(), node.node.getText() + node.generic));
+  }
+
+  private getImportFailure(importd: ts.ImportSpecifier, sourceFile: ts.SourceFile): RuleFailure {
+    return new RuleFailure(
+        sourceFile, importd.getStart(), importd.getEnd(),
+        `Typed Forms requires ${anySymbolName} to be imported.`, this.ruleName,
+        new Replacement(
+            importd.getStart(), importd.getWidth(), `${anySymbolName}, ` + importd.getText()));
+  }
+}

--- a/packages/core/schematics/migrations/typed-forms/BUILD.bazel
+++ b/packages/core/schematics/migrations/typed-forms/BUILD.bazel
@@ -1,0 +1,18 @@
+load("//tools:defaults.bzl", "ts_library")
+
+ts_library(
+    name = "typed-forms",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)

--- a/packages/core/schematics/migrations/typed-forms/README.md
+++ b/packages/core/schematics/migrations/typed-forms/README.md
@@ -1,0 +1,47 @@
+## Typed Forms migration
+
+As of Angular v14, `AbstractControl` and `FormBuilder` classes have a generic type parameter. This migration identifies usage of these classes, and adds `<AnyForUntypedForms>` or `<AnyForUntypedForms[]>` in the appropriate places to preserve the old untyped behavior.
+
+#### Before
+```ts
+import { Component } from '@angular/core';
+import { AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup } from '@angular/forms';
+
+@Component({template: ''})
+export class MyComponent {
+  private _control = new FC(42);
+  private _group = new FormGroup({});
+  private _array = new FormArray([]);
+
+  private fb = new FormBuilder();
+
+  build() {
+    const c = this.fb.control(42);
+    const g = this.fb.group({one: this.fb.control('')});
+    const a = this.fb.array([42]);
+    const fc2 = new FC(0);
+  }
+}
+```
+
+#### After
+```ts
+import { Component } from '@angular/core';
+import { AbstractControl, AnyForUntypedForms, FormArray, FormBuilder, FormControl as FC, FormGroup } from '@angular/forms';
+
+@Component({template: ''})
+export class MyComponent {
+  private _control = new FC<AnyForUntypedForms>(42);
+  private _group = new FormGroup<AnyForUntypedForms>({});
+  private _array = new FormArray<AnyForUntypedForms[]>([]);
+
+  private fb = new FormBuilder();
+
+  build() {
+    const c = this.fb.control<AnyForUntypedForms>(42);
+    const g = this.fb.group<AnyForUntypedForms>({one: this.fb.control<AnyForUntypedForms>('')});
+    const a = this.fb.array<AnyForUntypedForms[]>([42]);
+    const fc2 = new FC<AnyForUntypedForms>(0);
+  }
+}
+```

--- a/packages/core/schematics/migrations/typed-forms/index.ts
+++ b/packages/core/schematics/migrations/typed-forms/index.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicsException, Tree, UpdateRecorder} from '@angular-devkit/schematics';
+import {relative} from 'path';
+import ts from 'typescript';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
+
+import {anySymbolName, findControlClassUsages, findFormBuilderCalls, getAnyImport, getControlClassImports, getFormBuilderImport, MigratableNode} from './util';
+
+export default function(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot migrate to Typed Forms.');
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runTypedFormsMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+function runTypedFormsMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const {program} = createMigrationProgram(tree, tsconfigPath, basePath);
+  const typeChecker = program.getTypeChecker();
+  const sourceFiles =
+      program.getSourceFiles().filter(sourceFile => canMigrateFile(basePath, sourceFile, program));
+
+  for (const sourceFile of sourceFiles) {
+    const controlClassImports = getControlClassImports(sourceFile);
+    const formBuilderImport = getFormBuilderImport(sourceFile);
+
+    // If no relevant classes are imported, we can exit early.
+    if (controlClassImports.length === 0 && formBuilderImport !== null) return;
+
+    const update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
+
+    // For each control class, migrate all of its uses.
+    for (const importSpecifier of controlClassImports) {
+      const usages = findControlClassUsages(sourceFile, typeChecker, importSpecifier);
+      for (const node of usages) {
+        migrateNode(update, node, importSpecifier);
+      }
+    }
+
+    // For each FormBuilder method, migrate all of its uses.
+    const nodes = findFormBuilderCalls(sourceFile, typeChecker, formBuilderImport);
+    for (const n of nodes) {
+      migrateNode(update, n, formBuilderImport);
+    }
+
+    // Add the any symbol used by the migrated calls.
+    if (getAnyImport(sourceFile) !== null) {
+      const firstValidFormsImport =
+          [...controlClassImports, formBuilderImport].sort().filter(i => i !== null)[0]!;
+      insertAnyImport(update, firstValidFormsImport);
+    }
+
+    tree.commitUpdate(update);
+  }
+}
+
+export function migrateNode(
+    update: UpdateRecorder, node: MigratableNode, importd: ts.ImportSpecifier|null) {
+  if (importd === null) return;
+  update.insertRight(node.node.getEnd(), node.generic);
+}
+
+export function insertAnyImport(update: UpdateRecorder, importd: ts.ImportSpecifier) {
+  update.insertLeft(importd.getStart(), `${anySymbolName}, `);
+}

--- a/packages/core/schematics/migrations/typed-forms/util.ts
+++ b/packages/core/schematics/migrations/typed-forms/util.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {getImportSpecifier} from '../../utils/typescript/imports';
+import {isReferenceToImport} from '../../utils/typescript/symbol';
+
+export const controlClassNames = ['AbstractControl', 'FormArray', 'FormControl', 'FormGroup'];
+export const builderMethodNames = ['control', 'group', 'array'];
+export const anySymbolName = 'AnyForUntypedForms';
+
+export interface MigratableNode {
+  node: ts.Expression;
+  generic: string;
+}
+
+export function getControlClassImports(sourceFile: ts.SourceFile) {
+  return controlClassNames.map(cclass => getImportSpecifier(sourceFile, '@angular/forms', cclass))
+      .filter(v => v != null);
+}
+
+export function getFormBuilderImport(sourceFile: ts.SourceFile) {
+  return getImportSpecifier(sourceFile, '@angular/forms', 'FormBuilder');
+}
+
+export function getAnyImport(sourceFile: ts.SourceFile) {
+  return getImportSpecifier(sourceFile, '@angular/forms', anySymbolName);
+}
+
+export function findControlClassUsages(
+    sourceFile: ts.SourceFile, typeChecker: ts.TypeChecker,
+    importSpecifier: ts.ImportSpecifier|null): MigratableNode[] {
+  if (importSpecifier === null) return [];
+  let generic = `<${anySymbolName}>`;
+  if (importSpecifier.name.getText() === 'FormArray' ||
+      importSpecifier.propertyName?.getText() === 'FormArray') {
+    generic = `<${anySymbolName}[]>`;
+  }
+  const usages: MigratableNode[] = [];
+  const visitNode = (node: ts.Node) => {
+    // Look for a `new` expression with no type arguments which references an import we care about:
+    // `new FormControl()`
+    if (ts.isNewExpression(node) && !node.typeArguments &&
+        isReferenceToImport(typeChecker, node.expression, importSpecifier)) {
+      usages.push({node: node.expression, generic});
+    }
+    ts.forEachChild(node, visitNode);
+  };
+  ts.forEachChild(sourceFile, visitNode);
+  return usages;
+}
+
+export function findFormBuilderCalls(
+    sourceFile: ts.SourceFile, typeChecker: ts.TypeChecker,
+    importSpecifier: ts.ImportSpecifier|null): MigratableNode[] {
+  if (!importSpecifier) return [];
+  const usages = new Array<MigratableNode>();
+  ts.forEachChild(sourceFile, function visitNode(node: ts.Node) {
+    // Look for calls that look like `foo.<method to migrate>`.
+    if (ts.isCallExpression(node) && !node.typeArguments &&
+        ts.isPropertyAccessExpression(node.expression) && ts.isIdentifier(node.expression.name) &&
+        builderMethodNames.includes(node.expression.name.text)) {
+      const generic =
+          node.expression.name.text === 'array' ? `<${anySymbolName}[]>` : `<${anySymbolName}>`;
+      // Check whether the type of the object on which the function is called refers to the
+      // provided import.
+      if (isReferenceToImport(typeChecker, node.expression.expression, importSpecifier)) {
+        usages.push({node: node.expression, generic});
+      }
+    }
+    ts.forEachChild(node, visitNode);
+  });
+  return usages;
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -11,6 +11,7 @@ ts_library(
         "//packages/core/schematics/migrations/entry-components",
         "//packages/core/schematics/migrations/router-link-empty-expression",
         "//packages/core/schematics/migrations/testbed-teardown",
+        "//packages/core/schematics/migrations/typed-forms",
         "//packages/core/schematics/utils",
         "@npm//@angular-devkit/core",
         "@npm//@angular-devkit/schematics",

--- a/packages/core/schematics/test/google3/typed_forms_spec.ts
+++ b/packages/core/schematics/test/google3/typed_forms_spec.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {readFileSync, writeFileSync} from 'fs';
+import {dirname, join} from 'path';
+import * as shx from 'shelljs';
+import {Configuration, Linter} from 'tslint';
+
+const anySymbolName = 'AnyForUntypedForms';
+
+// Tests disabled, as the migration is currently disabled in package.json.
+/*
+
+describe('Google3 typedForms TSLint rule', () => {
+  const rulesDirectory = dirname(require.resolve('../../migrations/google3/typedFormsRule'));
+
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(process.env['TEST_TMPDIR']!, 'google3-test');
+    shx.mkdir('-p', tmpDir);
+
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('testing.d.ts', `
+        export type ${anySymbolName} = any;
+        export declare class FormControl {}
+        export declare class FormGroup {}
+        export declare class FormArray {}
+        export declare class AbstractControl {}
+        export declare class FormBuilder {
+          constructor();
+          control(
+            formState: any, validatorOrOpts?: any,
+            asyncValidator?: any): FormControl;
+          group(
+            controlsConfig: {[key: string]: any},
+            options?: any,
+            ): FormGroup;
+          group(
+            controlsConfig: {[key: string]: any},
+            options: {[key: string]: any},
+            ): FormGroup;
+          group(
+            controlsConfig: {[key: string]: any},
+            options: any): FormGroup;
+          array(
+            controlsConfig: any[],
+            validatorOrOpts?: any,
+            asyncValidator?: any): FormArray;
+        }
+     `);
+
+    writeFile('tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        module: 'es2015',
+        baseUrl: './',
+        paths: {
+          '@angular/forms': ['testing.d.ts'],
+        }
+      },
+    }));
+  });
+
+  afterEach(() => shx.rm('-r', tmpDir));
+
+  function runTSLint(fix: boolean) {
+    const program = Linter.createProgram(join(tmpDir, 'tsconfig.json'));
+    const linter = new Linter({fix, rulesDirectory: [rulesDirectory]}, program);
+    const config = Configuration.parseConfigFile({rules: {'typedForms': true}});
+
+    program.getRootFileNames().forEach(fileName => {
+      linter.lint(fileName, program.getSourceFile(fileName)!.getFullText(), config);
+    });
+
+    return linter;
+  }
+
+  function writeFile(fileName: string, content: string) {
+    writeFileSync(join(tmpDir, fileName), content);
+  }
+
+  function getFile(fileName: string) {
+    return readFileSync(join(tmpDir, fileName), 'utf8');
+  }
+
+  it('should migrate a complete example', () => {
+    writeFile('/index.ts', `
+      import { Component } from '@angular/core';
+      import { AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup } from
+'@angular/forms';
+
+      @Component({template: ''})
+      export class MyComponent {
+        private _control = new FC(42);
+        private _group = new FormGroup({});
+        private _array = new FormArray([]);
+
+        private fb = new FormBuilder();
+
+        build() {
+          const c = this.fb.control(42);
+          const g = this.fb.group({one: this.fb.control('')});
+          const a = this.fb.array([42]);
+          const fc2 = new FC(0);
+        }
+      }
+    `);
+
+    const linter = runTSLint(true);
+
+    [`import { ${
+         anySymbolName}, AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup }
+from '@angular/forms';`, `private _control = new FC<${anySymbolName}>(42)`, `private _group = new
+FormGroup<${anySymbolName}>({})`, `private _array = new FormArray<${anySymbolName}[]>([])`, `const
+fc2 = new FC<${anySymbolName}>(0)`, `const c = this.fb.control<${anySymbolName}>(42)`, `const g =
+this.fb.group<${anySymbolName}>({one: this.fb.control<${anySymbolName}>('')})`, `const a =
+this.fb.array<${anySymbolName}[]>([42])`] .forEach(t => expect(getFile(`/index.ts`)).toContain(t));
+  });
+});
+
+*/

--- a/packages/core/schematics/test/typed_forms_spec.ts
+++ b/packages/core/schematics/test/typed_forms_spec.ts
@@ -1,0 +1,298 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import * as shx from 'shelljs';
+
+const anySymbolName = 'AnyForUntypedForms';
+
+// Tests disabled, as the migration is currently disabled in package.json.
+/*
+
+describe('Typed Forms migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', require.resolve('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+        strictNullChecks: true,
+      },
+    }));
+
+    writeFile('/angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('/node_modules/@angular/forms/index.d.ts', `
+       export type ${anySymbolName} = any;
+       export declare class FormControl {}
+       export declare class FormGroup {}
+       export declare class FormArray {}
+       export declare class AbstractControl {}
+       export declare class FormBuilder {
+         constructor();
+         control(
+           formState: any, validatorOrOpts?: any,
+           asyncValidator?: any): FormControl;
+         group(
+           controlsConfig: {[key: string]: any},
+           options?: any,
+           ): FormGroup;
+         group(
+           controlsConfig: {[key: string]: any},
+           options: {[key: string]: any},
+           ): FormGroup;
+         group(
+           controlsConfig: {[key: string]: any},
+           options: any): FormGroup;
+         array(
+           controlsConfig: any[],
+           validatorOrOpts?: any,
+           asyncValidator?: any): FormArray;
+       }
+      `);
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  describe(`should add ${anySymbolName} to constructors`, () => {
+    it('for FormControl', async () => {
+      writeFile('/index.ts', `
+           import { FormControl } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fc1 = new FormControl();
+             new FormControl(42);
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fc1 = new FormControl<${anySymbolName}>();`);
+      expect(tree.readContent('/index.ts')).toContain(`new FormControl<${anySymbolName}>(42);`);
+    });
+
+    it('for FormGroup', async () => {
+      writeFile('/index.ts', `
+           import { FormGroup } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fg = new FormGroup({foo: 3});
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fg = new FormGroup<${anySymbolName}>({foo: 3});`);
+    });
+
+    it('for FormArray', async () => {
+      writeFile('/index.ts', `
+           import { FormArray } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fa = new FormArray([null]);
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fa = new FormArray<${anySymbolName}[]>([null]);`);
+    });
+
+    it('for FormControl with a qualified import', async () => {
+      writeFile('/index.ts', `
+           import { FormControl as FC } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fc = new FC({foo: 3});
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fc = new FC<${anySymbolName}>({foo: 3});`);
+    });
+
+    it('for FormArray with a qualified import', async () => {
+      writeFile('/index.ts', `
+           import { FormArray as FA } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fa = new FA([null]);
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fa = new FA<${anySymbolName}[]>([null]);`);
+    });
+
+    it('but not for controls that already have type arguments', async () => {
+      writeFile('/index.ts', `
+           import { FormControl } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fc1 = new FormControl<${anySymbolName}>();
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fc1 = new FormControl<${anySymbolName}>();`);
+    });
+  });
+
+  describe(`should add ${anySymbolName} to FormBuilder method`, () => {
+    it('control', async () => {
+      writeFile('/index.ts', `
+           import { FormBuilder } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             constructor() {
+               const fb = new FormBuilder();
+               const fc = fb.control(43);
+               const fd = new FormBuilder().control(42);
+             }
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts')).toContain(`.control<${anySymbolName}>(43);`);
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fd = new FormBuilder().control<${anySymbolName}>(42)`);
+    });
+
+    it('group', async () => {
+      writeFile('/index.ts', `
+           import { FormBuilder } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             constructor() {
+               const fb = new FormBuilder();
+               const fc = fb.group({});
+               const fd = new FormBuilder().group({});
+             }
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts')).toContain(`fb.group<${anySymbolName}>({});`);
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fd = new FormBuilder().group<${anySymbolName}>({})`);
+    });
+
+    it('array', async () => {
+      writeFile('/index.ts', `
+           import { FormBuilder } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             constructor() {
+               const fb = new FormBuilder();
+               const fc = fb.array([0]);
+               const fd = new FormBuilder().array([0]);
+             }
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts')).toContain(`fb.array<${anySymbolName}[]>([0]);`);
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fd = new FormBuilder().array<${anySymbolName}[]>([0])`);
+    });
+  });
+
+  describe('should add import', () => {
+    it('any when not already imported', async () => {
+      writeFile('/index.ts', `
+        import { FormBuilder } from '@angular/forms';
+        @Component({template: ''})
+        export class MyComp { }
+      `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`import { ${anySymbolName}, FormBuilder } from '@angular/forms';`);
+    });
+
+    it('exclusively when not already imported', async () => {
+      writeFile('/index.ts', `
+        import { ${anySymbolName}, FormBuilder } from '@angular/forms';
+        @Component({template: ''})
+        export class MyComp { }
+      `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`import { ${anySymbolName}, FormBuilder } from '@angular/forms';`);
+    });
+  });
+
+  describe('should handle', () => {
+    it('an integrated example', async () => {
+      writeFile('/index.ts', `
+           import { Component } from '@angular/core';
+           import { AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup } from
+'@angular/forms';
+
+           @Component({template: ''})
+           export class MyComponent {
+             private _control = new FC(42);
+             private _group = new FormGroup({});
+             private _array = new FormArray([]);
+
+             private fb = new FormBuilder();
+
+             build() {
+               const c = this.fb.control(42);
+               const g = this.fb.group({one: this.fb.control('')});
+               const a = this.fb.array([42]);
+               const fc2 = new FC(0);
+             }
+           }
+         `);
+      await runMigration();
+      [`import { ${
+           anySymbolName}, AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup }
+from '@angular/forms';`, `private _control = new FC<${anySymbolName}>(42)`, `private _group = new
+FormGroup<${anySymbolName}>({})`, `private _array = new FormArray<${anySymbolName}[]>([])`, `const
+fc2 = new FC<${anySymbolName}>(0)`, `const c = this.fb.control<${anySymbolName}>(42)`, `const g =
+this.fb.group<${anySymbolName}>({one: this.fb.control<${anySymbolName}>('')})`, `const a =
+this.fb.array<${anySymbolName}[]>([42])`] .forEach(t =>
+expect(tree.readContent('/index.ts')).toContain(t));
+    });
+  });
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematicAsync('migration-v14-typed-forms', {}, tree).toPromise();
+  }
+});
+
+*/


### PR DESCRIPTION
Add a migration for typed forms. This migration will insert `<AnyForUntypedForms>` or `<AnyForUntypedForms[]>` at existing uses of `AbstractControl` classes, as well as calls to `FormBuilder` methods.

We need to submit this ahead of time in order to get started with the migration in google3.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

There is no migration to support typed forms.
Issue Number: #13721


## What is the new behavior?

A migration has been added to insert `any`s in the appropriate places. This migration will be used inside google3 before the typed forms PR is merged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
