### PR TITLE
test(forms): Add more tests for `FormBuilder` method argument shapes.

### DIFF
--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -55,6 +55,59 @@ describe('Form Builder', () => {
     expect(g.controls['login'].asyncValidator).toBe(asyncValidator);
   });
 
+  it('should create controls from FormStates', () => {
+    const c = b.control({value: 'one', disabled: false});
+    expect(c.value).toEqual('one');
+    c.reset();
+    expect(c.value).toEqual(null);
+  });
+
+  it('should work on a directly constructed FormBuilder object', () => {
+    const g = b.group({'login': 'some value'});
+    expect(g.controls['login'].value).toEqual('some value');
+  });
+
+  it('should create homogenous control arrays', () => {
+    const a = b.array(['one', 'two', 'three']);
+    expect(a.value).toEqual(['one', 'two', 'three']);
+  });
+
+  it('should create control arrays with FormStates and ControlConfigs', () => {
+    const a = b.array(['one', 'two', {value: 'three', disabled: false}]);
+    expect(a.value).toEqual(['one', 'two', 'three']);
+  });
+
+  it('should create control arrays with ControlConfigs', () => {
+    const a = b.array([['one', syncValidator, asyncValidator]]);
+    expect(a.value).toEqual(['one']);
+    expect(a.controls[0].validator).toBe(syncValidator);
+    expect(a.controls[0].asyncValidator).toBe(asyncValidator);
+  });
+
+  it('should create nested control arrays with ControlConfigs', () => {
+    const a = b.array(['one', ['two', syncValidator, asyncValidator]]);
+    expect(a.value).toEqual(['one', 'two']);
+    expect(a.controls[1].validator).toBe(syncValidator);
+    expect(a.controls[1].asyncValidator).toBe(asyncValidator);
+  });
+
+  it('should create control arrays with AbstractControls', () => {
+    const ctrl = b.control('one');
+    const a = b.array([ctrl], syncValidator, asyncValidator);
+    expect(a.value).toEqual(['one']);
+    expect(a.validator).toBe(syncValidator);
+    expect(a.asyncValidator).toBe(asyncValidator);
+  });
+
+  it('should create control arrays with mixed value representations', () => {
+    const a = b.array([
+      'one', ['two', syncValidator, asyncValidator], {value: 'three', disabled: false},
+      [{value: 'four', disabled: false}, syncValidator, asyncValidator], ['five'], b.control('six'),
+      b.control({value: 'seven', disabled: false})
+    ]);
+    expect(a.value).toEqual(['one', 'two', 'three', 'four', 'five', 'six', 'seven']);
+  });
+
   it('should support controls with no validators and whose form state is null', () => {
     const g = b.group({'login': b.control(null)});
     expect(g.controls['login'].value).toBeNull();


### PR DESCRIPTION
Add more tests for `FormBuilder` method argument shapes, especially `array`.

It is possible to pass arguments to `FormBuilder` using many different formats. (`control` can take controls, values, boxed values, and control configs; `array` can take all of these plus nested arrays.) Currently, these different methods are not well-tested, especially as they interact, and especially for the `array` method. This PR will add tests for the variety of different argument shapes.

This was originally inspired by typed forms: when `FormBuilder` becomes typed, all these argument shapes should just work, with correct inferred types.

#13721

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: tests


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`FormBuilder` argument shapes are inadequately tested.

Issue Number: N/A


## What is the new behavior?

We have many more tests for `FormBuilder` arguments.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
