### PR TITLE
refactor(animations): initialize the WebAnimtionsPlayer's _finalKeyframe field

### DIFF
--- a/packages/animations/browser/src/render/web_animations/web_animations_player.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_player.ts
@@ -22,8 +22,7 @@ export class WebAnimationsPlayer implements AnimationPlayer {
   private _finished = false;
   private _started = false;
   private _destroyed = false;
-  // TODO(issue/24571): remove '!'.
-  private _finalKeyframe!: {[key: string]: string|number};
+  private _finalKeyframe?: {[key: string]: string|number};
 
   // TODO(issue/24571): remove '!'.
   public readonly domPlayer!: DOMAnimation;
@@ -173,10 +172,14 @@ export class WebAnimationsPlayer implements AnimationPlayer {
   beforeDestroy() {
     const styles: {[key: string]: string|number} = {};
     if (this.hasStarted()) {
-      Object.keys(this._finalKeyframe).forEach(prop => {
+      // note: this code is invoked only when the `play` function was called prior to this
+      // (thus `hasStarted` returns true), this implies that the code that initializes
+      // `_finalKeyframe` has also been executed and the non-null assertion can be safely used here
+      const finalKeyframe = this._finalKeyframe!;
+      Object.keys(finalKeyframe).forEach(prop => {
         if (prop != 'offset') {
           styles[prop] =
-              this._finished ? this._finalKeyframe[prop] : computeStyle(this.element, prop);
+              this._finished ? finalKeyframe[prop] : computeStyle(this.element, prop);
         }
       });
     }

--- a/packages/animations/browser/src/render/web_animations/web_animations_player.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_player.ts
@@ -178,8 +178,7 @@ export class WebAnimationsPlayer implements AnimationPlayer {
       const finalKeyframe = this._finalKeyframe!;
       Object.keys(finalKeyframe).forEach(prop => {
         if (prop != 'offset') {
-          styles[prop] =
-              this._finished ? finalKeyframe[prop] : computeStyle(this.element, prop);
+          styles[prop] = this._finished ? finalKeyframe[prop] : computeStyle(this.element, prop);
         }
       });
     }


### PR DESCRIPTION
initialize the _finalKeyframe filed to an empy object instead of using
a non-null assertion on it

relates to #24571

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information

This field is being set here:
https://github.com/angular/angular/blob/a92a89b0eb127a59d7e071502b5850e57618ec2d/packages/animations/browser/src/render/web_animations/web_animations_player.ts#L64

and it is only used here:
https://github.com/angular/angular/blob/a92a89b0eb127a59d7e071502b5850e57618ec2d/packages/animations/browser/src/render/web_animations/web_animations_player.ts#L176-L179

so I think that is can safely be initialized to an empty object 
