### PR TITLE
feat(forms): Add an unused symbol `AnyForUntypedForms`.

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -143,6 +143,9 @@ export class AbstractFormGroupDirective extends ControlContainer implements OnIn
 }
 
 // @public
+export type AnyForUntypedForms = any;
+
+// @public
 export interface AsyncValidator extends Validator {
     validate(control: AbstractControl): Promise<ValidationErrors | null> | Observable<ValidationErrors | null>;
 }

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -47,4 +47,20 @@ export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormCon
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';
 export {VERSION} from './version';
 
+/**
+ * `AnyForUntypedForms` is an alias for `any` used as part of the typed forms
+ * migration.
+ *
+ * `AnyForUntypedForms` was inserted into your code automatically as part of a migration. To
+ * continue opting out of strong types, simply replace it with `any`. To opt-in to typed forms,
+ * remove
+ * `<AnyForUntypedForms>` from your call site.
+ *
+ * This symbol is currently unused. Please do not use it. These docs will be updated when this
+ * symbol is in use.
+ *
+ * @publicApi
+ */
+export type AnyForUntypedForms = any;
+
 export * from './form_providers';


### PR DESCRIPTION
Add an unused symbol `AnyForTypedForms`. This symbol will support the typed forms migration in google3. The docs will be updated once the migration begins.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There is no symbol for the typed forms migration.

Issue Number: #13721


## What is the new behavior?

A symbol aliasing `any` has been introduced for the typed forms migration.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
