### PR TITLE
refactor(compiler): clean up workarounds for TypeScript 4.5

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/host.ts
@@ -67,10 +67,7 @@ export class DelegatingCompilerHost implements
   trace = this.delegateMethod('trace');
   useCaseSensitiveFileNames = this.delegateMethod('useCaseSensitiveFileNames');
   writeFile = this.delegateMethod('writeFile');
-
-  // TODO(crisbeto): the cast to `any` is here since g3 is still on TS 4.4.
-  // Should be cleaned up when g3 has been updated.
-  getModuleResolutionCache = this.delegateMethod('getModuleResolutionCache' as any);
+  getModuleResolutionCache = this.delegateMethod('getModuleResolutionCache');
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/cycles/src/imports.ts
+++ b/packages/compiler-cli/src/ngtsc/cycles/src/imports.ts
@@ -126,9 +126,7 @@ function isTypeOnlyImportClause(node: ts.ImportClause): boolean {
 
   // All the specifiers in the cause are type-only (e.g. `import {type a, type b} from '...'`).
   if (node.namedBindings !== undefined && ts.isNamedImports(node.namedBindings) &&
-      // TODO(crisbeto): the cast to `any` is here since g3 is still on TS 4.4.
-      // Should be cleaned up when g3 has been updated.
-      node.namedBindings.elements.every(specifier => (specifier as any).isTypeOnly)) {
+      node.namedBindings.elements.every(specifier => specifier.isTypeOnly)) {
     return true;
   }
 

--- a/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
+++ b/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
@@ -51,10 +51,7 @@ export class DelegatingCompilerHost implements
   resolveTypeReferenceDirectives = this.delegateMethod('resolveTypeReferenceDirectives');
   trace = this.delegateMethod('trace');
   useCaseSensitiveFileNames = this.delegateMethod('useCaseSensitiveFileNames');
-
-  // TODO(crisbeto): the cast to `any` is here since g3 is still on TS 4.4.
-  // Should be cleaned up when g3 has been updated.
-  getModuleResolutionCache = this.delegateMethod('getModuleResolutionCache' as any);
+  getModuleResolutionCache = this.delegateMethod('getModuleResolutionCache');
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
@@ -72,9 +72,7 @@ export function typeToValue(
       // or
       //   import {Foo as Bar} from 'foo';
 
-      // TODO(crisbeto): the cast to `any` is here since g3 is still on TS 4.4.
-      // Should be cleaned up when g3 has been updated.
-      if ((firstDecl as any).isTypeOnly) {
+      if (firstDecl.isTypeOnly) {
         // The import specifier can't be type-only (e.g. `import {type Foo} from '...')`.
         return typeOnlyImport(typeNode, firstDecl);
       }

--- a/packages/compiler-cli/src/ngtsc/resource/src/loader.ts
+++ b/packages/compiler-cli/src/ngtsc/resource/src/loader.ts
@@ -237,8 +237,6 @@ export class AdapterResourceLoader implements ResourceLoader {
  */
 function createLookupResolutionHost(adapter: NgCompilerAdapter):
     RequiredDelegations<ts.ModuleResolutionHost> {
-  // TODO(crisbeto): the cast to `any` is here since g3 is still on TS 4.4.
-  // Should be cleaned up when g3 has been updated.
   return {
     directoryExists(directoryName: string): boolean {
       if (directoryName.includes(RESOURCE_MARKER)) {
@@ -263,8 +261,8 @@ function createLookupResolutionHost(adapter: NgCompilerAdapter):
     getDirectories: adapter.getDirectories?.bind(adapter),
     realpath: adapter.realpath?.bind(adapter),
     trace: adapter.trace?.bind(adapter),
-    useCaseSensitiveFileNames: typeof (adapter as any).useCaseSensitiveFileNames === 'function' ?
-        (adapter as any).useCaseSensitiveFileNames.bind(adapter) :
-        (adapter as any).useCaseSensitiveFileNames
-  } as any;
+    useCaseSensitiveFileNames: typeof adapter.useCaseSensitiveFileNames === 'function' ?
+        adapter.useCaseSensitiveFileNames.bind(adapter) :
+        adapter.useCaseSensitiveFileNames
+  };
 }

--- a/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
@@ -159,9 +159,7 @@ function transformFactorySourceFile(
       const rewrittenModuleSpecifier =
           importRewriter.rewriteSpecifier('@angular/core', sourceFilePath);
       if (rewrittenModuleSpecifier !== stmt.moduleSpecifier.text) {
-        // TODO(crisbeto): the cast to `any` is here since g3 is still on TS 4.4.
-        // Should be cleaned up when g3 has been updated.
-        transformedStatements.push((ts.updateImportDeclaration as any)(
+        transformedStatements.push(ts.updateImportDeclaration(
             stmt, stmt.decorators, stmt.modifiers, stmt.importClause,
             ts.createStringLiteral(rewrittenModuleSpecifier), undefined));
 

--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -213,28 +213,8 @@ export function toUnredirectedSourceFile(sf: ts.SourceFile): ts.SourceFile {
 export function createExportSpecifier(
     propertyName: string|ts.Identifier|undefined, name: string|ts.Identifier,
     isTypeOnly = false): ts.ExportSpecifier {
-  return PARSED_TS_VERSION > 4.4 ?
-      // TODO(crisbeto): the function is cast to `any` here since g3 is still on TS 4.4.
-      // Should be cleaned up when g3 has been updated.
-      (ts.createExportSpecifier as any)(isTypeOnly, propertyName, name) :
-      // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
-      // Should be cleaned up when we drop support for it.
-      (ts.createExportSpecifier as any)(propertyName, name);
-}
-
-
-/**
- * Backwards-compatible version of `ts.createImportSpecifier`
- * to handle a breaking change between 4.4 and 4.5.
- */
-export function createImportSpecifier(
-    propertyName: string|ts.Identifier|undefined, name: string|ts.Identifier,
-    isTypeOnly = false): ts.ImportSpecifier {
-  return PARSED_TS_VERSION > 4.4 ?
-      // TODO(crisbeto): the function is cast to `any` here since g3 is still on TS 4.4.
-      // Should be cleaned up when g3 has been updated.
-      (ts.createImportSpecifier as any)(isTypeOnly, propertyName, name) :
-      // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
-      // Should be cleaned up when we drop support for it.
-      (ts.createImportSpecifier as any)(propertyName, name);
+  return PARSED_TS_VERSION > 4.4 ? ts.createExportSpecifier(isTypeOnly, propertyName, name) :
+                                   // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
+                                   // Should be cleaned up when we drop support for it.
+                                   (ts.createExportSpecifier as any)(propertyName, name);
 }

--- a/packages/core/schematics/utils/import_manager.ts
+++ b/packages/core/schematics/utils/import_manager.ts
@@ -265,14 +265,11 @@ export class ImportManager {
  * Backwards-compatible version of `ts.createImportSpecifier`
  * to handle a breaking change between 4.4 and 4.5.
  */
-export function createImportSpecifier(
-    propertyName: string|ts.Identifier|undefined, name: string|ts.Identifier,
+function createImportSpecifier(
+    propertyName: ts.Identifier|undefined, name: ts.Identifier,
     isTypeOnly = false): ts.ImportSpecifier {
-  return PARSED_TS_VERSION > 4.4 ?
-      // TODO(crisbeto): the function is cast to `any` here since g3 is still on TS 4.4.
-      // Should be cleaned up when g3 has been updated.
-      (ts.createImportSpecifier as any)(isTypeOnly, propertyName, name) :
-      // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
-      // Should be cleaned up when we drop support for it.
-      (ts.createImportSpecifier as any)(propertyName, name);
+  return PARSED_TS_VERSION > 4.4 ? ts.createImportSpecifier(isTypeOnly, propertyName, name) :
+                                   // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
+                                   // Should be cleaned up when we drop support for it.
+                                   (ts.createImportSpecifier as any)(propertyName, name);
 }

--- a/packages/core/schematics/utils/typescript/imports.ts
+++ b/packages/core/schematics/utils/typescript/imports.ts
@@ -108,13 +108,10 @@ export function replaceImport(
   return ts.updateNamedImports(node, [
     ...node.elements.filter(current => current !== existingImportNode),
     // Create a new import while trying to preserve the alias of the old one.
-    PARSED_TS_VERSION > 4.4 ?
-        // TODO(crisbeto): the function is cast to `any` here since g3 is still on TS 4.4.
-        // Should be cleaned up when g3 has been updated.
-        (ts.createImportSpecifier as any)(false, importPropertyName, importName) :
-        // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
-        // Should be cleaned up when we drop support for it.
-        (ts.createImportSpecifier as any)(importPropertyName, importName)
+    PARSED_TS_VERSION > 4.4 ? ts.createImportSpecifier(false, importPropertyName, importName) :
+                              // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
+                              // Should be cleaned up when we drop support for it.
+                              (ts.createImportSpecifier as any)(importPropertyName, importName)
   ]);
 }
 


### PR DESCRIPTION
Cleans up some of the temporary workarounds that were necessary in order to land support for TypeScript 4.5 since they're no longer required.