### PR TITLE
test(docs-infra): Correct an invalid assumption regarding `FormControl` in aio tests.

### DIFF
--- a/aio/tests/e2e/src/api-pages.e2e-spec.ts
+++ b/aio/tests/e2e/src/api-pages.e2e-spec.ts
@@ -58,7 +58,7 @@ describe('Api pages', () => {
   });
 
   it('should not show a "Properties" section if there are only internal properties', async () => {
-    await page.navigateTo('api/forms/FormControl');
+    await page.navigateTo('api/forms/AsyncValidator');
     expect(await page.getSection('instance-properties').isPresent()).toBe(false);
   });
 


### PR DESCRIPTION
The aio application expects `FormControl` to have no properties for the purposes of its own internal tests, but this is no longer true after #44434.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: Test fix


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

a.io expects `FormControl` will have no properties as part of its own internal tests.

Issue Number: N/A


## What is the new behavior?

a.io uses `AsyncValidator` instead, which actually has no properties.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
