### PR TITLE
docs(docs-infra): Replace OnInit with AfterViewInit

### DIFF
--- a/aio/content/examples/dynamic-component-loader/src/app/ad-banner.component.ts
+++ b/aio/content/examples/dynamic-component-loader/src/app/ad-banner.component.ts
@@ -1,5 +1,5 @@
 // #docregion
-import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, Input, OnDestroy, AfterViewInit, ViewChild } from '@angular/core';
 
 import { AdDirective } from './ad.directive';
 import { AdItem } from './ad-item';
@@ -17,7 +17,7 @@ import { AdComponent } from './ad.component';
   // #enddocregion ad-host
 })
 // #docregion class
-export class AdBannerComponent implements OnInit, OnDestroy {
+export class AdBannerComponent implements AfterViewInit, OnDestroy {
   @Input() ads: AdItem[] = [];
 
   currentAdIndex = -1;
@@ -25,7 +25,7 @@ export class AdBannerComponent implements OnInit, OnDestroy {
   @ViewChild(AdDirective, {static: true}) adHost!: AdDirective;
   interval: number|undefined;
 
-  ngOnInit() {
+  ngAfterViewInit() {
     this.loadComponent();
     this.getAds();
   }


### PR DESCRIPTION
`this.adHost` is `undefined`  if  `loadComponent`  is called in `OnInit`.
So replace `OnInit` with `AfterViewInit`!

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
