### PR TITLE
fix(animations): apply setStyles to only rootTimelines

### DIFF
--- a/packages/animations/browser/src/dsl/animation_timeline_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_builder.ts
@@ -130,10 +130,22 @@ export class AnimationTimelineBuilderVisitor implements AstVisitor {
 
     // this checks to see if an actual animation happened
     const timelines = context.timelines.filter(timeline => timeline.containsAnimation());
-    if (timelines.length && Object.keys(finalStyles).length) {
-      const tl = timelines[timelines.length - 1];
-      if (!tl.allowOnlyTimelineStyles()) {
-        tl.setStyles([finalStyles], null, context.errors, options);
+
+    if (Object.keys(finalStyles).length) {
+      // note: we just want to apply the final styles for the rootElement, so we do not
+      //       just apply the styles to the last timeline but the last timeline which
+      //       element is the root one (basically `*`-styles are replaced with the actual
+      //       state style values only for the root element)
+      let lastRootTimeline: TimelineBuilder|undefined;
+      for (let i = timelines.length - 1; i >= 0; i--) {
+        const timeline = timelines[i];
+        if (timeline.element === rootElement) {
+          lastRootTimeline = timeline;
+          break;
+        }
+      }
+      if (lastRootTimeline && !lastRootTimeline.allowOnlyTimelineStyles()) {
+        lastRootTimeline.setStyles([finalStyles], null, context.errors, options);
       }
     }
 


### PR DESCRIPTION
during keyframe building only consider the root element's timelines
for the style setting, so that the states styles (applied with '*')
can be applied correctly

resolves #32133
resolves #28654

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

'*' animation values can be lost based where there are animation's timelines not belonging
to the root element

Issue Number: #32133, #28654


## What is the new behavior?

only  the root element's timelines are considered, this makes sure that '*' get handled correctly

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

