### PR TITLE
docs: fix code sample indentation

### DIFF
--- a/aio/content/examples/rx-library/src/simple-creation.ts
+++ b/aio/content/examples/rx-library/src/simple-creation.ts
@@ -7,12 +7,13 @@
   import { Observable } from 'rxjs';
   import { ajax } from 'rxjs/ajax';
 
-// Create an Observable that will create an AJAX request
 // #enddocregion ajax
+
 export function docRegionAjax<T>(console: Console,
                                  // eslint-disable-next-line @typescript-eslint/no-shadow
                                  ajax: (url: string) => Observable<{status: number, response: T}>) {
   // #docregion ajax
+  // Create an Observable that will create an AJAX request
   const apiData = ajax('/api/data');
   // Subscribe to create the request
   apiData.subscribe(res => console.log(res.status, res.response));


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The motivation for this PR is to correct inconsistent indentation in a code sample in [The RxJS library](https://angular.io/guide/rx-library) page in the docs

## What is the new behavior?
Make the indentation consistent with the other code samples in the docs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->