### PR TITLE
feat(router): Allow symbol keys for `Route` `data` and `resolve` prop…

### DIFF
--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -165,7 +165,7 @@ export function convertToParamMap(params: Params): ParamMap;
 
 // @public
 export type Data = {
-    [name: string]: any;
+    [key: string | symbol]: any;
 };
 
 // @public
@@ -390,7 +390,7 @@ export interface Resolve<T> {
 
 // @public
 export type ResolveData = {
-    [name: string]: any;
+    [key: string | symbol]: any;
 };
 
 // @public

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1218,6 +1218,9 @@
     "name": "getData"
   },
   {
+    "name": "getDataKeys"
+  },
+  {
     "name": "getDeclarationTNode"
   },
   {

--- a/packages/router/src/config.ts
+++ b/packages/router/src/config.ts
@@ -73,7 +73,7 @@ export type UrlMatcher = (segments: UrlSegment[], group: UrlSegmentGroup, route:
  * @publicApi
  */
 export type Data = {
-  [name: string]: any
+  [key: string|symbol]: any
 };
 
 /**
@@ -85,7 +85,7 @@ export type Data = {
  * @publicApi
  */
 export type ResolveData = {
-  [name: string]: any
+  [key: string|symbol]: any
 };
 
 /**

--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -56,27 +56,31 @@ function runResolve(
 function resolveNode(
     resolve: ResolveData, futureARS: ActivatedRouteSnapshot, futureRSS: RouterStateSnapshot,
     moduleInjector: Injector): Observable<any> {
-  const keys = Object.keys(resolve);
+  const keys = getDataKeys(resolve);
   if (keys.length === 0) {
     return of({});
   }
-  const data: {[k: string]: any} = {};
+  const data: {[k: string|symbol]: any} = {};
   return from(keys).pipe(
       mergeMap(
-          (key: string) => getResolver(resolve[key], futureARS, futureRSS, moduleInjector)
-                               .pipe(tap((value: any) => {
-                                 data[key] = value;
-                               }))),
+          key => getResolver(resolve[key], futureARS, futureRSS, moduleInjector)
+                     .pipe(tap((value: any) => {
+                       data[key] = value;
+                     }))),
       takeLast(1),
       mergeMap(() => {
         // Ensure all resolvers returned values, otherwise don't emit any "next" and just complete
         // the chain which will cancel navigation
-        if (Object.keys(data).length === keys.length) {
+        if (getDataKeys(data).length === keys.length) {
           return of(data);
         }
         return EMPTY;
       }),
   );
+}
+
+function getDataKeys(obj: Object): Array<string|symbol> {
+  return [...Object.keys(obj), ...Object.getOwnPropertySymbols(obj)];
 }
 
 function getResolver(

--- a/packages/router/test/computed_state_restoration.spec.ts
+++ b/packages/router/test/computed_state_restoration.spec.ts
@@ -89,21 +89,21 @@ describe('`restoredState#ɵrouterPageId`', () => {
         component: SimpleCmp,
         canDeactivate: [MyCanDeactivateGuard],
         canActivate: [MyCanActivateGuard, ThrowingCanActivateGuard],
-        resolve: [MyResolve]
+        resolve: {x: MyResolve}
       },
       {
         path: 'second',
         component: SimpleCmp,
         canDeactivate: [MyCanDeactivateGuard],
         canActivate: [MyCanActivateGuard, ThrowingCanActivateGuard],
-        resolve: [MyResolve]
+        resolve: {x: MyResolve}
       },
       {
         path: 'third',
         component: SimpleCmp,
         canDeactivate: [MyCanDeactivateGuard],
         canActivate: [MyCanActivateGuard, ThrowingCanActivateGuard],
-        resolve: [MyResolve]
+        resolve: {x: MyResolve}
       },
       {
         path: 'unguarded',

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2334,6 +2334,20 @@ describe('Integration', () => {
            expect(log).toEqual(['resolver2', 'resolver1']);
          })));
     });
+
+    it('can resolve symbol keys', fakeAsync(() => {
+         const router = TestBed.inject(Router);
+         const fixture = createRoot(router, RootCmp);
+         const symbolKey = Symbol('key');
+
+         router.resetConfig(
+             [{path: 'simple', component: SimpleCmp, resolve: {[symbolKey]: 'resolveFour'}}]);
+
+         router.navigateByUrl('/simple');
+         advance(fixture);
+
+         expect(router.routerState.root.snapshot.firstChild!.data[symbolKey]).toEqual(4);
+       }));
   });
 
   describe('router links', () => {


### PR DESCRIPTION
…erties

This commit adds the ability to use a symbol as the key for the `data` and `resolve` objects
in a `Route` config.

reviewer note: This unlocks a proposal to quietly use a private symbol in https://github.com/angular/angular/pull/43307 to store the `title` property without needing a type cast. Additionally, it may be more desirable for certain teams to use symbols rather than string keys so they can enforce keys that are safe for property renaming without additional rule enforcements (i.e. ensuring that `Route.data` properties are always defined with string keys `{data: {'user': 123}}`.