### PR TITLE
refactor(docs-infra): improve aio-footer's layout

### DIFF
--- a/aio/src/styles/1-layouts/footer/_footer.scss
+++ b/aio/src/styles/1-layouts/footer/_footer.scss
@@ -73,8 +73,8 @@ footer {
 
       ul {
         list-style-position: inside;
-        padding: 0px;
-        margin: 0px;
+        padding: 0;
+        margin: 0;
 
         li {
           list-style-type: none;
@@ -92,11 +92,14 @@ footer {
       }
 
       @media (max-width: 25rem) {
-        grid-template-columns: 1fr;
-
         .footer-block {
-          margin-left: 0;
+          margin-left: 5px;
+          margin-right: 5px;
         }
+      }
+
+      @media (max-width: 20rem) {
+        grid-template-columns: 1fr;
       }
     }
   }

--- a/aio/src/styles/1-layouts/footer/_footer.scss
+++ b/aio/src/styles/1-layouts/footer/_footer.scss
@@ -5,21 +5,22 @@ footer {
   position: relative;
   @include mixins.line-height(24);
   flex: 1;
-  padding: 48px;
+  padding: 48px 25px;
   z-index: 0;
   font-weight: 300;
 
   aio-footer {
+    display: block;
     position: relative;
     z-index: 0;
+    overflow: auto;
 
     & > * {
       max-width: 50em;
     }
 
     .footer-block {
-      margin: 0 24px;
-      vertical-align: top;
+      margin: 0;
     }
 
     a {
@@ -63,12 +64,12 @@ footer {
     }
 
     div.grid-fluid {
-      display: -ms-flexbox;
-      display: -webkit-flex;
-      display: flex;
-      justify-content: center;
-      text-align: left;
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      $grid-gap: 24px;
+      gap: $grid-gap;
       margin: 0 auto 40px;
+      justify-content: center;
 
       ul {
         list-style-position: inside;
@@ -82,18 +83,19 @@ footer {
         }
       }
 
-      @media (max-width: 32rem) {
-        flex-direction: column;
+      @media (max-width: 45rem) {
+        grid-template-columns: repeat(2, calc(50% - (#{$grid-gap}/2)));
 
         .footer-block {
-          margin: 8px 24px;
+          margin: 1.5rem 2.4rem 0.8rem 20%;
         }
       }
 
-      @media not all and (min-resolution:.001dpcm) { // hack to detect safari
-        // tweak needed as safari handles rem based media queries differently
-        @media (max-width: 50rem) {
-          flex-direction: column;
+      @media (max-width: 25rem) {
+        grid-template-columns: 1fr;
+
+        .footer-block {
+          margin-left: 0;
         }
       }
     }

--- a/aio/src/styles/1-layouts/footer/_footer.scss
+++ b/aio/src/styles/1-layouts/footer/_footer.scss
@@ -20,7 +20,7 @@ footer {
     }
 
     .footer-block {
-      margin: 0;
+      margin: 0 0.3rem;
     }
 
     a {
@@ -93,8 +93,8 @@ footer {
 
       @media (max-width: 25rem) {
         .footer-block {
-          margin-left: 5px;
-          margin-right: 5px;
+          margin-left: 0.3rem;
+          margin-right: 0.3rem;
         }
       }
 


### PR DESCRIPTION
improve aio-footer's layout by using grid instead of flexbox

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

@gkalpak :slightly_smiling_face::+1: 

- I hope I am not being too bold in dropping a grid in, I just thought you could say it was ok since we said we could drop IE support in AIO :slightly_smiling_face: (https://github.com/angular/angular/pull/44376#discussion_r767934989)

- this is removing the safari hack we had to add in #44266, I have tested this change in chrome and safari and looks good in both with any font-size and width :slightly_smiling_face: (I've also tested this in the xcode iphone simulator, all seems good there too)

- I've used grid so that we have three views, one (large) with the four columns, one (medium) with two and one (small) with one, I thought/tried to use flex-wrap and it worked overall ok but created alignment issues and especially it would have three blocks on one line and just one on the next for some widths, which looked really ugly

- this is an implementation which improves things and removed the safari hack, we could go a step further and do something even more dynamic as for example what [stackoverflow](https://stackoverflow.com/) does for it's footer, as in, it has multiple columns when it has room and then puts all the section's links inline for smaller screens (instead of trying to always keep the blocks vertical) (I did try this solution too, but it didn't look nicely at all given our current styling and the fact that the sections' headers are styled similarly to the links, this would require actual look and feel changes to the footer to work nicely I believe, so I didn't go for it this time around (but I can if we do want to go that route :slightly_smiling_face:) )

