### PR TITLE
docs(animations): fix filter-animations docregion

### DIFF
--- a/aio/content/examples/animations/src/app/hero-list-page.component.html
+++ b/aio/content/examples/animations/src/app/hero-list-page.component.html
@@ -8,13 +8,11 @@
        placeholder="Search heroes">
 
 <ul class="heroes" [@filterAnimation]="heroesTotal">
-<!-- #enddocregion filter-animations -->
   <li *ngFor="let hero of heroes" class="hero">
     <div class="inner">
       <span class="badge">{{ hero.id }}</span>
       <span>{{ hero.name }}</span>
     </div>
   </li>
-<!-- #docregion filter-animations -->
 </ul>
 <!-- #enddocregion filter-animations -->


### PR DESCRIPTION
the filter animation example in the complex-animation-sequences guide
talks about entering and leaving elements, but the presented html
snipped exluded the *ngFor which actually adds and removes the elements,
so add the *ngFor section to make the example complete and
understandable

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No




## Other information
This PR refers to [this example](https://angular.io/guide/complex-animation-sequences#filter-animation-example)

This is how it looks before the change:
![Screenshot at 2021-12-21 22-23-10](https://user-images.githubusercontent.com/61631103/147000028-53773848-81e5-4f0b-b1a4-60db666317d1.png)
and this is after:
![Screenshot at 2021-12-21 22-22-49](https://user-images.githubusercontent.com/61631103/147000080-4a0387aa-51fd-4f62-a26d-92a50c8d9d9a.png)

I think it makes much more sense to include the `*ngFor` section since the guide does talk about entering and leaving elements, but the presented html doesn't really have anything suggesting that elements are entering/leaving
