### PR TITLE
refactor(forms): update email validator to inherit abstractValidator

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -203,10 +203,12 @@ export class DefaultValueAccessor extends BaseControlValueAccessor implements Co
 }
 
 // @public
-export class EmailValidator implements Validator {
-    set email(value: boolean | string);
-    registerOnValidatorChange(fn: () => void): void;
-    validate(control: AbstractControl): ValidationErrors | null;
+export class EmailValidator extends AbstractValidatorDirective {
+    email: boolean | string;
+
+    // (undocumented)
+    enabled(input: boolean): boolean;
+    
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<EmailValidator, "[email][formControlName],[email][formControl],[email][ngModel]", never, { "email": "email"; }, {}, never>;
     // (undocumented)

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -482,7 +482,10 @@ export class EmailValidator extends AbstractValidatorDirective {
 
   /** @internal */
   override normalizeInput = (input: unknown): boolean =>
-      input === '' || input === true || input === 'true';
+      // Avoid TSLint requirement to omit semicolon, see
+      // https://github.com/palantir/tslint/issues/1476
+      // tslint:disable-next-line:semicolon
+      (input === '' || input === true || input === 'true');
 
   /** @internal */
   override createValidator = (input: number): ValidatorFn => emailValidator;

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -482,7 +482,7 @@ export class EmailValidator extends AbstractValidatorDirective {
 
   /** @internal */
   override normalizeInput = (input: unknown): boolean =>
-      input === '' || input === true || input === 'true'
+      input === '' || input === true || input === 'true';
 
   /** @internal */
   override createValidator = (input: number): ValidatorFn => emailValidator;

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -470,35 +470,26 @@ export const EMAIL_VALIDATOR: any = {
   selector: '[email][formControlName],[email][formControl],[email][ngModel]',
   providers: [EMAIL_VALIDATOR]
 })
-export class EmailValidator implements Validator {
-  private _enabled = false;
-  private _onChange?: () => void;
-
+export class EmailValidator extends AbstractValidatorDirective {
   /**
    * @description
    * Tracks changes to the email attribute bound to this directive.
    */
-  @Input()
-  set email(value: boolean|string) {
-    this._enabled = value === '' || value === true || value === 'true';
-    if (this._onChange) this._onChange();
-  }
+  @Input() email!: boolean|string;
 
-  /**
-   * Method that validates whether an email address is valid.
-   * Returns the validation result if enabled, otherwise null.
-   * @nodoc
-   */
-  validate(control: AbstractControl): ValidationErrors|null {
-    return this._enabled ? emailValidator(control) : null;
-  }
+  /** @internal */
+  override inputName = 'email';
 
-  /**
-   * Registers a callback function to call when the validator inputs change.
-   * @nodoc
-   */
-  registerOnValidatorChange(fn: () => void): void {
-    this._onChange = fn;
+  /** @internal */
+  override normalizeInput = (input: unknown): boolean =>
+      input === '' || input === true || input === 'true'
+
+  /** @internal */
+  override createValidator = (input: number): ValidatorFn => emailValidator;
+
+  /** @nodoc */
+  override enabled(input: boolean): boolean {
+    return input;
   }
 }
 


### PR DESCRIPTION
Modified email validator to inherit abstractValidator.

For every validato type different PR will be raised as discussed in #42378.

Closes #42267

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #42378


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
