### PR TITLE
refactor(docs-infra): fix template eslint issues in aio examples

### DIFF
--- a/aio/content/examples/.eslintrc.json
+++ b/aio/content/examples/.eslintrc.json
@@ -13,12 +13,12 @@
         "plugin:@angular-eslint/template/recommended"
       ],
       "rules": {
-        "@angular-eslint/template/accessibility-alt-text": "off", // TODO: Fix the code violating this rule and enable it.
-        "@angular-eslint/template/accessibility-elements-content": "off", // TODO: Fix the code violating this rule and enable it.
-        "@angular-eslint/template/accessibility-label-has-associated-control": "off", // TODO: Fix the code violating this rule and enable it.
+        "@angular-eslint/template/accessibility-alt-text": "error",
+        "@angular-eslint/template/accessibility-elements-content": "error",
+        "@angular-eslint/template/accessibility-label-has-associated-control": "error",
         "@angular-eslint/template/accessibility-table-scope": "error",
         "@angular-eslint/template/accessibility-valid-aria": "error",
-        "@angular-eslint/template/click-events-have-key-events": "off", // TODO: Fix the code violating this rule and enable it.
+        "@angular-eslint/template/click-events-have-key-events": "error",
         "@angular-eslint/template/eqeqeq": "off",
         "@angular-eslint/template/mouse-events-have-key-events": "error",
         "@angular-eslint/template/no-autofocus": "error",

--- a/aio/content/examples/ajs-quick-reference/src/app/app.component.html
+++ b/aio/content/examples/ajs-quick-reference/src/app/app.component.html
@@ -51,7 +51,7 @@
 <p></p>
 <div *ngIf="showImage">
   <!-- #docregion src -->
-  <img [src]="movie.imageurl">
+  <img [src]="movie.imageurl" [alt]="movie.title">
   <!-- #enddocregion src -->
 </div>
 

--- a/aio/content/examples/ajs-quick-reference/src/app/app.component.html
+++ b/aio/content/examples/ajs-quick-reference/src/app/app.component.html
@@ -38,11 +38,11 @@
 <p></p>
 <div>
   <!-- #docregion event-binding -->
-  <button (click)="toggleImage()">
+  <button type="button" (click)="toggleImage()">
   <!-- #enddocregion event-binding -->
   Image Toggle #1</button>
   <!-- #docregion event-binding -->
-  <button (click)="toggleImage($event)">
+  <button type="button" (click)="toggleImage($event)">
   <!-- #enddocregion event-binding -->
   Image Toggle #2</button>
   <p>Image toggle event type was {{eventType}}</p>

--- a/aio/content/examples/ajs-quick-reference/src/app/movie-list.component.html
+++ b/aio/content/examples/ajs-quick-reference/src/app/movie-list.component.html
@@ -61,6 +61,7 @@
                 [style.height.px]="50"
                 [style.margin.px]="2"
                 [src]="movie.imageurl"
+                [alt]="movie.title"
                 [title]="movie.title">
         </td>
         <td>{{movie.title}}</td>

--- a/aio/content/examples/ajs-quick-reference/src/app/movie-list.component.html
+++ b/aio/content/examples/ajs-quick-reference/src/app/movie-list.component.html
@@ -39,7 +39,7 @@
     <thead>
       <tr>
         <th>
-          <button (click)="toggleImage()">
+          <button type="button" (click)="toggleImage()">
             {{showImage ? "Hide" : "Show"}} Poster
           </button>
         </th>

--- a/aio/content/examples/animations/src/app/hero-list-auto.component.html
+++ b/aio/content/examples/animations/src/app/hero-list-auto.component.html
@@ -1,7 +1,7 @@
 <ul class="heroes">
   <li *ngFor="let hero of heroes"
       [@shrinkOut]="'in'">
-      <button class="inner" (click)="removeHero(hero.id)">
+      <button class="inner" type="button" (click)="removeHero(hero.id)">
         <span class="badge">{{ hero.id }}</span>
         <span class="name">{{ hero.name }}</span>
       </button>

--- a/aio/content/examples/animations/src/app/hero-list-auto.component.html
+++ b/aio/content/examples/animations/src/app/hero-list-auto.component.html
@@ -1,9 +1,9 @@
 <ul class="heroes">
   <li *ngFor="let hero of heroes"
-      [@shrinkOut]="'in'" (click)="removeHero(hero.id)">
-      <div class="inner">
+      [@shrinkOut]="'in'">
+      <button class="inner" (click)="removeHero(hero.id)">
         <span class="badge">{{ hero.id }}</span>
-        <span>{{ hero.name }}</span>
-      </div>
+        <span class="name">{{ hero.name }}</span>
+      </button>
   </li>
 </ul>

--- a/aio/content/examples/animations/src/app/hero-list-enter-leave.component.ts
+++ b/aio/content/examples/animations/src/app/hero-list-enter-leave.component.ts
@@ -19,11 +19,11 @@ import { Hero } from './hero';
   template: `
     <ul class="heroes">
       <li *ngFor="let hero of heroes"
-          [@flyInOut]="'in'" (click)="removeHero(hero.id)">
-          <div class="inner">
+          [@flyInOut]="'in'">
+          <button class="inner" (click)="removeHero(hero.id)">
             <span class="badge">{{ hero.id }}</span>
-            <span>{{ hero.name }}</span>
-          </div>
+            <span class="name">{{ hero.name }}</span>
+          </button>
       </li>
     </ul>
   `,

--- a/aio/content/examples/animations/src/app/hero-list-enter-leave.component.ts
+++ b/aio/content/examples/animations/src/app/hero-list-enter-leave.component.ts
@@ -20,7 +20,7 @@ import { Hero } from './hero';
     <ul class="heroes">
       <li *ngFor="let hero of heroes"
           [@flyInOut]="'in'">
-          <button class="inner" (click)="removeHero(hero.id)">
+          <button class="inner" type="button" (click)="removeHero(hero.id)">
             <span class="badge">{{ hero.id }}</span>
             <span class="name">{{ hero.name }}</span>
           </button>

--- a/aio/content/examples/animations/src/app/hero-list-groups.component.ts
+++ b/aio/content/examples/animations/src/app/hero-list-groups.component.ts
@@ -19,12 +19,11 @@ import { Hero } from './hero';
   selector: 'app-hero-list-groups',
   template: `
     <ul class="heroes">
-      <li *ngFor="let hero of heroes"
-          [@flyInOut]="'in'" (click)="removeHero(hero.id)">
-          <div class="inner">
+      <li *ngFor="let hero of heroes" [@flyInOut]="'in'">
+          <button class="inner" (click)="removeHero(hero.id)">
             <span class="badge">{{ hero.id }}</span>
-            <span>{{ hero.name }}</span>
-          </div>
+            <span class="name">{{ hero.name }}</span>
+          </button>
       </li>
     </ul>
   `,
@@ -33,7 +32,7 @@ import { Hero } from './hero';
   animations: [
     trigger('flyInOut', [
       state('in', style({
-        width: 120,
+        width: '*',
         transform: 'translateX(0)', opacity: 1
       })),
       transition(':enter', [
@@ -41,7 +40,7 @@ import { Hero } from './hero';
         group([
           animate('0.3s 0.1s ease', style({
             transform: 'translateX(0)',
-            width: 120
+            width: '*'
           })),
           animate('0.3s ease', style({
             opacity: 1

--- a/aio/content/examples/animations/src/app/hero-list-groups.component.ts
+++ b/aio/content/examples/animations/src/app/hero-list-groups.component.ts
@@ -20,7 +20,7 @@ import { Hero } from './hero';
   template: `
     <ul class="heroes">
       <li *ngFor="let hero of heroes" [@flyInOut]="'in'">
-          <button class="inner" (click)="removeHero(hero.id)">
+          <button class="inner" type="button" (click)="removeHero(hero.id)">
             <span class="badge">{{ hero.id }}</span>
             <span class="name">{{ hero.name }}</span>
           </button>

--- a/aio/content/examples/animations/src/app/hero-list-page.component.css
+++ b/aio/content/examples/animations/src/app/hero-list-page.component.css
@@ -1,25 +1,56 @@
 .heroes {
+  margin: 0 0 2em 0;
   list-style-type: none;
   padding: 0;
+  width: 15em;
 }
 
 .heroes li {
-  overflow:hidden;
-  margin: .5em 0;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  overflow: hidden;
 }
 
-.heroes li > .inner {
-  cursor: pointer;
+.heroes .inner {
+  flex: 1;
   background-color: #EEE;
-  padding: .3rem 0;
-  height: 1.6rem;
+  margin: .5em;
+  padding: 0;
   border-radius: 4px;
+  display: flex;
+  align-items: stretch;
 }
 
-.heroes li:hover > .inner {
-  color: black;
-  background-color: #DDD;
-  transform: translateX(.1em);
+.heroes button.inner {
+  cursor: pointer;
+  font-size: inherit;
+}
+
+.heroes button.inner:hover {
+  color: #2c3a41;
+  background-color: #e6e6e6;
+  left: .1em;
+}
+
+.heroes button.inner:active {
+  background-color: #525252;
+  color: #fafafa;
+}
+
+.heroes button.inner.selected {
+  background-color: black;
+  color: white;
+}
+
+.heroes button.inner.selected:hover {
+  background-color: #505050;
+  color: white;
+}
+
+.heroes button.inner.selected:active {
+  background-color: black;
+  color: white;
 }
 
 .heroes .badge {
@@ -27,15 +58,15 @@
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color: #3d5157;
-  position: relative;
-  left: -1px;
-  top: -4px;
-  height: 1.8em;
-  min-width: 16px;
-  text-align: right;
+  background-color: #405061;
+  line-height: 1em;
   margin-right: .8em;
   border-radius: 4px 0 0 4px;
+}
+
+.heroes .name {
+  min-width: max-content;
+  padding: 0.5rem 0;
 }
 
 label {

--- a/aio/content/examples/animations/src/app/hero-list-page.component.html
+++ b/aio/content/examples/animations/src/app/hero-list-page.component.html
@@ -11,7 +11,7 @@
   <li *ngFor="let hero of heroes" class="hero">
     <div class="inner">
       <span class="badge">{{ hero.id }}</span>
-      <span>{{ hero.name }}</span>
+      <span class="name">{{ hero.name }}</span>
     </div>
   </li>
 </ul>

--- a/aio/content/examples/animations/src/app/insert-remove.component.html
+++ b/aio/content/examples/animations/src/app/insert-remove.component.html
@@ -3,7 +3,7 @@
 <h2>Insert/Remove</h2>
 
 <nav>
-  <button (click)="toggle()">Toggle Insert/Remove</button>
+  <button type="button" (click)="toggle()">Toggle Insert/Remove</button>
 </nav>
 
 <!-- #docregion insert-remove-->

--- a/aio/content/examples/animations/src/app/open-close.component.1.html
+++ b/aio/content/examples/animations/src/app/open-close.component.1.html
@@ -1,7 +1,7 @@
 <!-- #docplaster -->
 <!-- #docregion trigger -->
 <nav>
-  <button (click)="toggle()">Toggle Open/Close</button>
+  <button type="button" (click)="toggle()">Toggle Open/Close</button>
 </nav>
 
 <div [@openClose]="isOpen ? 'open' : 'closed'" class="open-close-container">

--- a/aio/content/examples/animations/src/app/open-close.component.2.html
+++ b/aio/content/examples/animations/src/app/open-close.component.2.html
@@ -1,6 +1,6 @@
 <!-- #docplaster -->
 <nav>
-  <button (click)="toggle()">Toggle Boolean/Close</button>
+  <button type="button" (click)="toggle()">Toggle Boolean/Close</button>
 </nav>
 
 <!-- #docregion trigger-boolean -->

--- a/aio/content/examples/animations/src/app/open-close.component.3.html
+++ b/aio/content/examples/animations/src/app/open-close.component.3.html
@@ -1,6 +1,6 @@
 <!-- #docplaster -->
 <nav>
-  <button (click)="toggle()">Toggle Open/Close</button>
+  <button type="button" (click)="toggle()">Toggle Open/Close</button>
 </nav>
 
 <!-- #docregion callbacks -->

--- a/aio/content/examples/animations/src/app/open-close.component.4.html
+++ b/aio/content/examples/animations/src/app/open-close.component.4.html
@@ -1,6 +1,6 @@
 <nav>
-  <button (click)="toggleAnimations()">Toggle Animations</button>
-  <button (click)="toggle()">Toggle Open/Closed</button>
+  <button type="button" (click)="toggleAnimations()">Toggle Animations</button>
+  <button type="button" (click)="toggle()">Toggle Open/Closed</button>
 </nav>
 <!-- #docregion toggle-animation -->
 <div [@.disabled]="isDisabled">

--- a/aio/content/examples/animations/src/app/open-close.component.html
+++ b/aio/content/examples/animations/src/app/open-close.component.html
@@ -1,4 +1,4 @@
-<button (click)="toggle()">Toggle Open/Close</button>
+<button type="button" (click)="toggle()">Toggle Open/Close</button>
 
 <div [@openClose]="isOpen ? 'open' : 'closed'"
   (@openClose.start)="onAnimationEvent($event)"

--- a/aio/content/examples/animations/src/app/status-slider.component.html
+++ b/aio/content/examples/animations/src/app/status-slider.component.html
@@ -1,5 +1,5 @@
 <nav>
-  <button (click)="toggle()">Toggle Status</button>
+  <button type="button" (click)="toggle()">Toggle Status</button>
 </nav>
 
 <div [@slideStatus]="status" class="box">

--- a/aio/content/examples/architecture/src/app/hero-list.component.1.html
+++ b/aio/content/examples/architecture/src/app/hero-list.component.1.html
@@ -1,6 +1,6 @@
 <!--#docregion binding  -->
 <app-hero-detail [hero]="selectedHero"></app-hero-detail>
-<button (click)="selectHero(hero)">
+<button type="button" (click)="selectHero(hero)">
   {{hero.name}}
 </button>
 <!--#enddocregion binding -->

--- a/aio/content/examples/architecture/src/app/hero-list.component.1.html
+++ b/aio/content/examples/architecture/src/app/hero-list.component.1.html
@@ -1,8 +1,8 @@
 <!--#docregion binding  -->
-<li>{{hero.name}}</li>
 <app-hero-detail [hero]="selectedHero"></app-hero-detail>
-<!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
-<li (click)="selectHero(hero)"></li>
+<button (click)="selectHero(hero)">
+  {{hero.name}}
+</button>
 <!--#enddocregion binding -->
 
 <!--#docregion structural  -->

--- a/aio/content/examples/architecture/src/app/hero-list.component.1.html
+++ b/aio/content/examples/architecture/src/app/hero-list.component.1.html
@@ -1,6 +1,7 @@
 <!--#docregion binding  -->
 <li>{{hero.name}}</li>
 <app-hero-detail [hero]="selectedHero"></app-hero-detail>
+<!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
 <li (click)="selectHero(hero)"></li>
 <!--#enddocregion binding -->
 

--- a/aio/content/examples/architecture/src/app/hero-list.component.html
+++ b/aio/content/examples/architecture/src/app/hero-list.component.html
@@ -3,8 +3,10 @@
 
 <p><em>Select a hero from the list to see details.</em></p>
 <ul>
-  <li *ngFor="let hero of heroes" (click)="selectHero(hero)">
-    {{hero.name}}
+  <li *ngFor="let hero of heroes">
+    <button (click)="selectHero(hero)">
+      {{hero.name}}
+    </button>
   </li>
 </ul>
 

--- a/aio/content/examples/architecture/src/app/hero-list.component.html
+++ b/aio/content/examples/architecture/src/app/hero-list.component.html
@@ -4,7 +4,7 @@
 <p><em>Select a hero from the list to see details.</em></p>
 <ul>
   <li *ngFor="let hero of heroes">
-    <button (click)="selectHero(hero)">
+    <button type="button" (click)="selectHero(hero)">
       {{hero.name}}
     </button>
   </li>

--- a/aio/content/examples/architecture/src/assets/architecture.css
+++ b/aio/content/examples/architecture/src/assets/architecture.css
@@ -15,6 +15,7 @@ li button {
   padding: 1rem;
   margin: 0;
   text-align: left;
+  border-radius: 0;
 }
 
 li button:hover, li button:active {

--- a/aio/content/examples/architecture/src/assets/architecture.css
+++ b/aio/content/examples/architecture/src/assets/architecture.css
@@ -4,13 +4,20 @@ ul {
 
 li {
   list-style-type: none;
-  padding: 1rem;
-  background-color: aliceblue;
   border: 1px solid #444;
   margin-bottom: .5rem;
+  display: flex;
 }
 
-li:hover {
+li button {
+  background-color: aliceblue;
+  flex: 1;
+  padding: 1rem;
+  margin: 0;
+  text-align: left;
+}
+
+li button:hover, li button:active {
   background-color: #444;
   color: white;
   cursor: pointer;

--- a/aio/content/examples/attribute-binding/src/app/app.component.html
+++ b/aio/content/examples/attribute-binding/src/app/app.component.html
@@ -21,7 +21,7 @@
 <div>
   <!-- #docregion attrib-binding-aria -->
   <!-- create and set an aria attribute for assistive technology -->
-  <button [attr.aria-label]="actionName">{{actionName}} with Aria</button>
+  <button type="button" [attr.aria-label]="actionName">{{actionName}} with Aria</button>
   <!-- #enddocregion attrib-binding-aria -->
 </div>
 

--- a/aio/content/examples/binding-syntax/src/app/app.component.html
+++ b/aio/content/examples/binding-syntax/src/app/app.component.html
@@ -7,7 +7,7 @@
     <h2>Button disabled state bound to isUnchanged property</h2>
     <!-- #docregion disabled-button -->
     <!-- Bind button disabled state to `isUnchanged` property -->
-    <button [disabled]="isUnchanged">Save</button>
+    <button type="button" [disabled]="isUnchanged">Save</button>
     <!-- #enddocregion disabled-button -->
   </div>
 
@@ -20,11 +20,11 @@
     <label>HTML Attribute Initializes to "Sarah":
     <input type="text" value="Sarah" #bindingInput></label>
     <div>
-    <button (click)="getHTMLAttributeValue()">Get HTML attribute value</button> Won't change.
+    <button type="button" (click)="getHTMLAttributeValue()">Get HTML attribute value</button> Won't change.
     </div>
 
     <div>
-        <button (click)="getDOMPropertyValue()">Get DOM property value</button> Changeable. Angular works with these.
+        <button type="button" (click)="getDOMPropertyValue()">Get DOM property value</button> Changeable. Angular works with these.
     </div>
 
     <p>2. Change the name in the input and click the buttons again.</p>
@@ -36,10 +36,10 @@
     <h3>Disabled property vs. attribute</h3>
     <p>Use the inspector to see the Test Button work and its disabled property toggle.</p>
     <div>
-    <button id="testButton" (click)="working()">Test Button</button>
+    <button type="button" id="testButton" (click)="working()">Test Button</button>
     </div>
     <div>
-    <button (click)="toggleDisabled()">Toggle disabled property for Test Button</button>
+    <button type="button" (click)="toggleDisabled()">Toggle disabled property for Test Button</button>
   </div>
 
 </div>

--- a/aio/content/examples/built-in-directives/src/app/app.component.html
+++ b/aio/content/examples/built-in-directives/src/app/app.component.html
@@ -50,7 +50,7 @@
     <label for="special">special: <input type="checkbox" [(ngModel)]="isSpecial" id="special"></label>
 </li>
 </ul>
-<button (click)="setCurrentClasses()">Refresh currentClasses</button>
+<button type="button" (click)="setCurrentClasses()">Refresh currentClasses</button>
 
 <div [ngClass]="currentClasses">
   This div should be {{ canSave ? "": "not"}} saveable,
@@ -86,7 +86,7 @@
 <label>italic: <input type="checkbox" [(ngModel)]="canSave"></label> |
 <label>normal: <input type="checkbox" [(ngModel)]="isUnchanged"></label> |
 <label>xlarge: <input type="checkbox" [(ngModel)]="isSpecial"></label>
-<button (click)="setCurrentStyles()">Refresh currentStyles</button>
+<button type="button" (click)="setCurrentStyles()">Refresh currentStyles</button>
 <br><br>
 <div [ngStyle]="currentStyles">
   This div should be {{ canSave ? "italic": "plain"}},
@@ -102,7 +102,7 @@
   <app-item-detail *ngIf="isActive" [item]="item"></app-item-detail>
   <!-- #enddocregion NgIf-1 -->
 
-  <button (click)="isActiveToggle()">Toggle app-item-detail</button>
+  <button type="button" (click)="isActiveToggle()">Toggle app-item-detail</button>
 </div>
 <p>If currentCustomer isn't null, say hello to Laura:</p>
 <!-- #docregion NgIf-2 -->
@@ -112,7 +112,7 @@
 <!-- #docregion NgIf-2b -->
 <div *ngIf="nullCustomer">Hello, <span>{{nullCustomer}}</span></div>
 <!-- #enddocregion NgIf-2b -->
-<button (click)="giveNullCustomerValue()">Give nullCustomer a value</button>
+<button type="button" (click)="giveNullCustomerValue()">Give nullCustomer a value</button>
 
 
 <h4>NgIf binding with template (no *)</h4>
@@ -163,9 +163,9 @@
 </div>
 
 <h4 id="ngFor-trackBy">*ngFor trackBy</h4>
-<button (click)="resetList()">Reset items</button>
-<button (click)="changeIds()">Change ids</button>
-<button (click)="clearTrackByCounts()">Clear counts</button>
+<button type="button" (click)="resetList()">Reset items</button>
+<button type="button" (click)="changeIds()">Change ids</button>
+<button type="button" (click)="clearTrackByCounts()">Clear counts</button>
 
 <p><i>without</i> trackBy</p>
 <div class="box">

--- a/aio/content/examples/component-interaction/src/app/astronaut.component.ts
+++ b/aio/content/examples/component-interaction/src/app/astronaut.component.ts
@@ -10,6 +10,7 @@ import { Subscription } from 'rxjs';
     <p>
       {{astronaut}}: <strong>{{mission}}</strong>
       <button
+        type="button"
         (click)="confirm()"
         [disabled]="!announced || confirmed">
         Confirm

--- a/aio/content/examples/component-interaction/src/app/countdown-parent.component.ts
+++ b/aio/content/examples/component-interaction/src/app/countdown-parent.component.ts
@@ -14,8 +14,8 @@ import { CountdownTimerComponent } from './countdown-timer.component';
   selector: 'app-countdown-parent-lv',
   template: `
     <h3>Countdown to Liftoff (via local variable)</h3>
-    <button (click)="timer.start()">Start</button>
-    <button (click)="timer.stop()">Stop</button>
+    <button type="button" (click)="timer.start()">Start</button>
+    <button type="button" (click)="timer.stop()">Stop</button>
     <div class="seconds">{{timer.seconds}}</div>
     <app-countdown-timer #timer></app-countdown-timer>
   `,
@@ -30,8 +30,8 @@ export class CountdownLocalVarParentComponent { }
   selector: 'app-countdown-parent-vc',
   template: `
     <h3>Countdown to Liftoff (via ViewChild)</h3>
-    <button (click)="start()">Start</button>
-    <button (click)="stop()">Stop</button>
+    <button type="button" (click)="start()">Start</button>
+    <button type="button" (click)="stop()">Stop</button>
     <div class="seconds">{{ seconds() }}</div>
     <app-countdown-timer></app-countdown-timer>
   `,

--- a/aio/content/examples/component-interaction/src/app/missioncontrol.component.ts
+++ b/aio/content/examples/component-interaction/src/app/missioncontrol.component.ts
@@ -7,7 +7,7 @@ import { MissionService } from './mission.service';
   selector: 'app-mission-control',
   template: `
     <h2>Mission Control</h2>
-    <button (click)="announce()">Announce mission</button>
+    <button type="button" (click)="announce()">Announce mission</button>
 
     <app-astronaut
       *ngFor="let astronaut of astronauts"

--- a/aio/content/examples/component-interaction/src/app/version-parent.component.ts
+++ b/aio/content/examples/component-interaction/src/app/version-parent.component.ts
@@ -5,8 +5,8 @@ import { Component } from '@angular/core';
   selector: 'app-version-parent',
   template: `
     <h2>Source code version</h2>
-    <button (click)="newMinor()">New minor version</button>
-    <button (click)="newMajor()">New major version</button>
+    <button type="button" (click)="newMinor()">New minor version</button>
+    <button type="button" (click)="newMajor()">New major version</button>
     <app-version-child [major]="major" [minor]="minor"></app-version-child>
   `
 })

--- a/aio/content/examples/component-interaction/src/app/voter.component.ts
+++ b/aio/content/examples/component-interaction/src/app/voter.component.ts
@@ -5,8 +5,8 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   selector: 'app-voter',
   template: `
     <h4>{{name}}</h4>
-    <button (click)="vote(true)"  [disabled]="didVote">Agree</button>
-    <button (click)="vote(false)" [disabled]="didVote">Disagree</button>
+    <button type="button" (click)="vote(true)"  [disabled]="didVote">Agree</button>
+    <button type="button" (click)="vote(false)" [disabled]="didVote">Disagree</button>
   `
 })
 export class VoterComponent {

--- a/aio/content/examples/component-styles/src/app/hero-controls.component.ts
+++ b/aio/content/examples/component-styles/src/app/hero-controls.component.ts
@@ -12,7 +12,7 @@ import { Hero } from './hero';
       }
     </style>
     <h3>Controls</h3>
-    <button (click)="activate()">Activate</button>
+    <button type="button" (click)="activate()">Activate</button>
   `
 })
 // #enddocregion inlinestyles

--- a/aio/content/examples/component-styles/src/index.html
+++ b/aio/content/examples/component-styles/src/index.html
@@ -10,7 +10,7 @@
   <body>
     <h1 style="visibility: hidden;">External H1 Title for E2E test</h1>
     <app-root></app-root>
-    <button style="visibility: hidden;">External button for E2E test</button>
+    <button type="button" style="visibility: hidden;">External button for E2E test</button>
     <ul style="visibility: hidden;">
       <li>External list for E2E test</li>
     </ul>

--- a/aio/content/examples/content-projection/src/app/app.component.html
+++ b/aio/content/examples/content-projection/src/app/app.component.html
@@ -22,7 +22,7 @@
 <h2>Here's a zippy</h2>
 
 <app-example-zippy>
-  <button appExampleZippyToggle>Is content project cool?</button>
+  <button type="button" appExampleZippyToggle>Is content project cool?</button>
   <!-- #docregion ng-template-->
   <ng-template appExampleZippyContent>
     It depends on what you do with it.

--- a/aio/content/examples/dependency-injection-in-action/src/app/storage.component.ts
+++ b/aio/content/examples/dependency-injection-in-action/src/app/storage.component.ts
@@ -8,10 +8,10 @@ import { BROWSER_STORAGE, BrowserStorageService } from './storage.service';
     Open the inspector to see the local/session storage keys:
 
     <h3>Session Storage</h3>
-    <button (click)="setSession()">Set Session Storage</button>
+    <button type="button" (click)="setSession()">Set Session Storage</button>
 
     <h3>Local Storage</h3>
-    <button (click)="setLocal()">Set Local Storage</button>
+    <button type="button" (click)="setLocal()">Set Local Storage</button>
   `,
   providers: [
     BrowserStorageService,

--- a/aio/content/examples/dependency-injection/src/app/app.component.ts
+++ b/aio/content/examples/dependency-injection/src/app/app.component.ts
@@ -13,7 +13,7 @@ import { UserService } from './user.service';
     <h2>User</h2>
     <p id="user">
       {{userInfo}}
-      <button (click)="nextUser()">Next User</button>
+      <button type="button" (click)="nextUser()">Next User</button>
     <p>
     <app-heroes id="authorized" *ngIf="isAuthorized"></app-heroes>
     <app-heroes id="unauthorized" *ngIf="!isAuthorized"></app-heroes>

--- a/aio/content/examples/docs-style-guide/src/app/app.component.css
+++ b/aio/content/examples/docs-style-guide/src/app/app.component.css
@@ -7,45 +7,68 @@
 }
 /* #enddocregion heroes */
 
+.heroes {
+  margin: 0 0 2em 0;
+  list-style-type: none;
+  padding: 0;
+  width: 15em;
+}
 .heroes li {
+  display: flex;
+}
+
+.heroes button {
+  flex: 1;
   cursor: pointer;
   position: relative;
   left: 0;
   background-color: #EEE;
   margin: .5em;
-  padding: .3em 0;
+  padding: 0;
   height: 1.6em;
   border-radius: 4px;
+  display: flex;
+  align-items: stretch;
+  height: 1.8em;
 }
-.heroes li.selected:hover {
-  background-color: #BBD8DC !important;
-  color: white;
-}
-.heroes li:hover {
-  color: #607D8B;
-  background-color: #DDD;
+
+.heroes button:hover {
+  color: #2c3a41;
+  background-color: #e6e6e6;
   left: .1em;
 }
-.heroes .text {
-  position: relative;
-  top: -3px;
+
+.heroes button:active {
+  background-color: #525252;
+  color: #fafafa;
 }
+
+.heroes button.selected {
+  background-color: black;
+  color: white;
+}
+
+.heroes button.selected:hover {
+  background-color: #505050;
+  color: white;
+}
+
+.heroes button.selected:active {
+  background-color: black;
+  color: white;
+}
+
 .heroes .badge {
   display: inline-block;
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color: #607D8B;
+  background-color: #405061;
   line-height: 1em;
-  position: relative;
-  left: -1px;
-  top: -4px;
-  height: 1.8em;
   margin-right: .8em;
   border-radius: 4px 0 0 4px;
 }
 
-.selected {
-  background-color: #CFD8DC !important;
-  color: white;
+.heroes .name {
+  align-self: center;
 }

--- a/aio/content/examples/docs-style-guide/src/app/app.component.html
+++ b/aio/content/examples/docs-style-guide/src/app/app.component.html
@@ -2,7 +2,7 @@
 <h2>My Heroes</h2>
 <ul class="heroes">
   <li *ngFor="let hero of heroes">
-    <button [class.selected]="hero === selectedHero" (click)="onSelect(hero)">
+    <button [class.selected]="hero === selectedHero" type="button" (click)="onSelect(hero)">
       <span class="badge">{{hero.id}}</span>
       <span class="name">{{hero.name}}</span>
     </button>

--- a/aio/content/examples/docs-style-guide/src/app/app.component.html
+++ b/aio/content/examples/docs-style-guide/src/app/app.component.html
@@ -1,17 +1,18 @@
 <h1>{{title}}</h1>
 <h2>My Heroes</h2>
 <ul class="heroes">
-  <li *ngFor="let hero of heroes"
-    [class.selected]="hero === selectedHero"
-    (click)="onSelect(hero)">
-    <span class="badge">{{hero.id}}</span> {{hero.name}}
+  <li *ngFor="let hero of heroes">
+    <button [class.selected]="hero === selectedHero" (click)="onSelect(hero)">
+      <span class="badge">{{hero.id}}</span>
+      <span class="name">{{hero.name}}</span>
+    </button>
   </li>
 </ul>
 <div *ngIf="selectedHero">
   <h2>{{selectedHero.name}} details!</h2>
-  <div><label>id: </label>{{selectedHero.id}}</div>
+  <div><span>id: </span>{{selectedHero.id}}</div>
   <div>
-    <label>name: </label>
+    <span>name: </span>
     <input [(ngModel)]="selectedHero.name" placeholder="name"/>
   </div>
 </div>

--- a/aio/content/examples/docs-style-guide/src/app/app.component.html
+++ b/aio/content/examples/docs-style-guide/src/app/app.component.html
@@ -10,9 +10,10 @@
 </ul>
 <div *ngIf="selectedHero">
   <h2>{{selectedHero.name}} details!</h2>
-  <div><span>id: </span>{{selectedHero.id}}</div>
+  <div>id: {{selectedHero.id}}</div>
   <div>
-    <span>name: </span>
-    <input [(ngModel)]="selectedHero.name" placeholder="name"/>
+    <label>
+      name: <input [(ngModel)]="selectedHero.name" placeholder="name"/>
+    </label>
   </div>
 </div>

--- a/aio/content/examples/elements/src/app/app.component.ts
+++ b/aio/content/examples/elements/src/app/app.component.ts
@@ -7,8 +7,8 @@ import { PopupComponent } from './popup.component';
   selector: 'app-root',
   template: `
     <input #input value="Message">
-    <button (click)="popup.showAsComponent(input.value)">Show as component</button>
-    <button (click)="popup.showAsElement(input.value)">Show as element</button>
+    <button type="button" (click)="popup.showAsComponent(input.value)">Show as component</button>
+    <button type="button" (click)="popup.showAsElement(input.value)">Show as element</button>
   `,
 })
 export class AppComponent {

--- a/aio/content/examples/elements/src/app/popup.component.ts
+++ b/aio/content/examples/elements/src/app/popup.component.ts
@@ -6,7 +6,7 @@ import { animate, state, style, transition, trigger } from '@angular/animations'
   selector: 'my-popup',
   template: `
     <span>Popup: {{message}}</span>
-    <button (click)="closed.next()">&#x2716;</button>
+    <button type="button" (click)="closed.next()">&#x2716;</button>
   `,
   animations: [
     trigger('state', [

--- a/aio/content/examples/event-binding/src/app/app.component.html
+++ b/aio/content/examples/event-binding/src/app/app.component.html
@@ -2,13 +2,13 @@
 
 <div class="group">
   <h3>Target event</h3>
-  <button (click)="onSave($event)">Save</button>
+  <button type="button" (click)="onSave($event)">Save</button>
 
-  <button on-click="onSave($event)">on-click Save</button>
+  <button type="button" on-enter="onSave()">on-click Save</button>
 
   <!-- #docregion custom-directive -->
   <h4>myClick is an event on the custom ClickDirective:</h4>
-  <button (myClick)="clickMessage=$event" clickable>click with myClick</button>
+  <button type="button" (myClick)="clickMessage=$event" clickable>click with myClick</button>
   {{clickMessage}}
   <!-- #enddocregion custom-directive -->
 
@@ -43,12 +43,12 @@
 
 <h3>Saves only once:</h3>
 <div (click)="onSave()" clickable>
-  <button (click)="onSave($event)">Save, no propagation</button>
+  <button type="button" (click)="onSave($event)">Save, no propagation</button>
 </div>
 
 <h3>Saves twice:</h3>
 <div (click)="onSave()" clickable>
-  <button (click)="onSave()">Save with propagation</button>
+  <button type="button" (click)="onSave()">Save with propagation</button>
 </div>
 
 <!-- eslint-enable @angular-eslint/template/click-events-have-key-events -->

--- a/aio/content/examples/event-binding/src/app/app.component.html
+++ b/aio/content/examples/event-binding/src/app/app.component.html
@@ -34,6 +34,9 @@
 
 
   <h4>Click to see event target class:</h4>
+
+<!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
+
 <div class="parent-div" (click)="onClickMe($event)" clickable>Click me (parent)
   <div class="child-div">Click me too! (child) </div>
 </div>
@@ -47,3 +50,5 @@
 <div (click)="onSave()" clickable>
   <button (click)="onSave()">Save with propagation</button>
 </div>
+
+<!-- eslint-enable @angular-eslint/template/click-events-have-key-events -->

--- a/aio/content/examples/event-binding/src/app/item-detail/item-detail.component.html
+++ b/aio/content/examples/event-binding/src/app/item-detail/item-detail.component.html
@@ -4,6 +4,6 @@
   <img src="{{itemImageUrl}}" alt="{{item.name}}" [style.display]="displayNone">
   <span [style.text-decoration]="lineThrough">{{ item.name }}
   </span>
-  <button (click)="delete()">Delete</button>
+  <button type="button" (click)="delete()">Delete</button>
   <!-- #enddocregion line-through -->
 </div>

--- a/aio/content/examples/event-binding/src/app/item-detail/item-detail.component.html
+++ b/aio/content/examples/event-binding/src/app/item-detail/item-detail.component.html
@@ -1,7 +1,7 @@
 <div class="detail">
   <p>This is the ItemDetailComponent</p>
   <!-- #docregion line-through -->
-  <img src="{{itemImageUrl}}" [style.display]="displayNone">
+  <img src="{{itemImageUrl}}" alt="{{item.name}}" [style.display]="displayNone">
   <span [style.text-decoration]="lineThrough">{{ item.name }}
   </span>
   <button (click)="delete()">Delete</button>

--- a/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.html
+++ b/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.html
@@ -74,6 +74,6 @@
 
   <div class="submitted-message" *ngIf="formDir.submitted">
     <p>You've submitted your hero, {{ heroForm.value.name }}!</p>
-    <button (click)="formDir.resetForm({})">Add new hero</button>
+    <button type="button" (click)="formDir.resetForm({})">Add new hero</button>
   </div>
 </div>

--- a/aio/content/examples/form-validation/src/app/template/hero-form-template.component.html
+++ b/aio/content/examples/form-validation/src/app/template/hero-form-template.component.html
@@ -81,7 +81,7 @@
 
     <div class="submitted-message" *ngIf="heroForm.submitted">
       <p>You've submitted your hero, {{ heroForm.value.name }}!</p>
-      <button (click)="heroForm.resetForm({})">Add new hero</button>
+      <button type="button" (click)="heroForm.resetForm({})">Add new hero</button>
     </div>
   </form>
 </div>

--- a/aio/content/examples/forms/src/app/hero-form/hero-form.component.html
+++ b/aio/content/examples/forms/src/app/hero-form/hero-form.component.html
@@ -83,7 +83,7 @@
       <div class="col-xs-9">{{ model.power }}</div>
     </div>
     <br>
-    <button class="btn btn-primary" (click)="submitted=false">Edit</button>
+    <button type="button" class="btn btn-primary" (click)="submitted=false">Edit</button>
   </div>
   <!-- #enddocregion submitted -->
 </div>

--- a/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.1.html
+++ b/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.1.html
@@ -1,3 +1,3 @@
 <p *ngIf="product && product.price > 700">
-  <button>Notify Me</button>
+  <button type="button">Notify Me</button>
 </p>

--- a/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.html
+++ b/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.html
@@ -1,3 +1,3 @@
 <p *ngIf="product && product.price > 700">
-  <button (click)="notify.emit()">Notify Me</button>
+  <button type="button" (click)="notify.emit()">Notify Me</button>
 </p>

--- a/aio/content/examples/getting-started/src/app/product-details/product-details.component.html
+++ b/aio/content/examples/getting-started/src/app/product-details/product-details.component.html
@@ -7,6 +7,6 @@
   <h4>{{ product.price | currency }}</h4>
   <p>{{ product.description }}</p>
 <!-- #enddocregion details -->
-  <button (click)="addToCart(product)">Buy</button>
+  <button type="button" (click)="addToCart(product)">Buy</button>
 <!-- #docregion details -->
 </div>

--- a/aio/content/examples/getting-started/src/app/product-list/product-list.component.4.html
+++ b/aio/content/examples/getting-started/src/app/product-list/product-list.component.4.html
@@ -12,7 +12,7 @@
     Description: {{ product.description }}
   </p>
 
-  <button (click)="share()">
+  <button type="button" (click)="share()">
     Share
   </button>
 

--- a/aio/content/examples/getting-started/src/app/product-list/product-list.component.5.html
+++ b/aio/content/examples/getting-started/src/app/product-list/product-list.component.5.html
@@ -13,7 +13,7 @@
   </p>
 
 <!-- #docregion app-product-alerts -->
-  <button (click)="share()">
+  <button type="button" (click)="share()">
     Share
   </button>
 

--- a/aio/content/examples/getting-started/src/app/product-list/product-list.component.6.html
+++ b/aio/content/examples/getting-started/src/app/product-list/product-list.component.6.html
@@ -13,7 +13,7 @@
   </p>
 
 <!-- #docregion on-notify -->
-  <button (click)="share()">
+  <button type="button" (click)="share()">
     Share
   </button>
 

--- a/aio/content/examples/getting-started/src/app/product-list/product-list.component.html
+++ b/aio/content/examples/getting-started/src/app/product-list/product-list.component.html
@@ -16,7 +16,7 @@
     Description: {{ product.description }}
   </p>
 
-  <button (click)="share()">
+  <button type="button" (click)="share()">
     Share
   </button>
 

--- a/aio/content/examples/hierarchical-dependency-injection/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/hierarchical-dependency-injection/e2e/src/app.e2e-spec.ts
@@ -10,7 +10,7 @@ describe('Hierarchical dependency injection', () => {
       income: '',
 
       // queries
-      heroEl: element.all(by.css('app-heroes-list li')).get(0), // first hero
+      heroEl: element.all(by.css('app-heroes-list li button')).get(0), // first hero
       heroCardEl: element(by.css('app-heroes-list app-hero-tax-return')), // first hero tax-return
       taxReturnNameEl: element.all(by.css('app-heroes-list app-hero-tax-return #name')).get(0),
       incomeInputEl: element.all(by.css('app-heroes-list app-hero-tax-return input')).get(0),

--- a/aio/content/examples/hierarchical-dependency-injection/src/app/hero-tax-return.component.html
+++ b/aio/content/examples/hierarchical-dependency-injection/src/app/hero-tax-return.component.html
@@ -13,8 +13,8 @@
     <span>Tax: {{taxReturn.tax}}</span>
   </fieldset>
   <fieldset>
-    <button (click)="onSaved()">Save</button>
-    <button (click)="onCanceled()">Cancel</button>
-    <button (click)="onClose()">Close</button>
+    <button type="button" (click)="onSaved()">Save</button>
+    <button type="button" (click)="onCanceled()">Cancel</button>
+    <button type="button" (click)="onClose()">Close</button>
   </fieldset>
 </div>

--- a/aio/content/examples/hierarchical-dependency-injection/src/app/hero-tax-return.component.html
+++ b/aio/content/examples/hierarchical-dependency-injection/src/app/hero-tax-return.component.html
@@ -5,9 +5,9 @@
     <span id=tid>TID: {{taxReturn.tid}}</span>
   </fieldset>
   <fieldset>
-    <span>
+    <label>
       Income: <input [(ngModel)]="taxReturn.income" class="num">
-    </span>
+    </label>
   </fieldset>
   <fieldset>
     <span>Tax: {{taxReturn.tax}}</span>

--- a/aio/content/examples/hierarchical-dependency-injection/src/app/hero-tax-return.component.html
+++ b/aio/content/examples/hierarchical-dependency-injection/src/app/hero-tax-return.component.html
@@ -2,15 +2,15 @@
   <div class="msg" [class.canceled]="message==='Canceled'">{{message}}</div>
   <fieldset>
     <span  id=name>{{taxReturn.name}}</span>
-    <label id=tid>TID: {{taxReturn.tid}}</label>
+    <span id=tid>TID: {{taxReturn.tid}}</span>
   </fieldset>
   <fieldset>
-    <label>
+    <span>
       Income: <input [(ngModel)]="taxReturn.income" class="num">
-    </label>
+    </span>
   </fieldset>
   <fieldset>
-    <label>Tax: {{taxReturn.tax}}</label>
+    <span>Tax: {{taxReturn.tax}}</span>
   </fieldset>
   <fieldset>
     <button (click)="onSaved()">Save</button>

--- a/aio/content/examples/hierarchical-dependency-injection/src/app/heroes-list.component.ts
+++ b/aio/content/examples/hierarchical-dependency-injection/src/app/heroes-list.component.ts
@@ -12,7 +12,7 @@ import { HeroesService } from './heroes.service';
       <h3>Hero Tax Returns</h3>
       <ul>
         <li *ngFor="let hero of heroes | async">
-          <button (click)="showTaxReturn(hero)">{{hero.name}}</button>
+          <button type="button" (click)="showTaxReturn(hero)">{{hero.name}}</button>
         </li>
       </ul>
       <app-hero-tax-return

--- a/aio/content/examples/hierarchical-dependency-injection/src/app/heroes-list.component.ts
+++ b/aio/content/examples/hierarchical-dependency-injection/src/app/heroes-list.component.ts
@@ -11,8 +11,8 @@ import { HeroesService } from './heroes.service';
     <div>
       <h3>Hero Tax Returns</h3>
       <ul>
-        <li *ngFor="let hero of heroes | async"
-            (click)="showTaxReturn(hero)">{{hero.name}}
+        <li *ngFor="let hero of heroes | async">
+            <button (click)="showTaxReturn(hero)">{{hero.name}}</button>
         </li>
       </ul>
       <app-hero-tax-return
@@ -22,7 +22,13 @@ import { HeroesService } from './heroes.service';
       </app-hero-tax-return>
     </div>
     `,
-  styles: [ 'li {cursor: pointer;}' ]
+  styles: [`
+    li button {
+      font-size: inherit;
+      margin: 0.3rem;
+      padding: 0.5rem;
+    }
+  `]
 })
 export class HeroesListComponent {
   heroes: Observable<Hero[]>;

--- a/aio/content/examples/hierarchical-dependency-injection/src/app/heroes-list.component.ts
+++ b/aio/content/examples/hierarchical-dependency-injection/src/app/heroes-list.component.ts
@@ -12,7 +12,7 @@ import { HeroesService } from './heroes.service';
       <h3>Hero Tax Returns</h3>
       <ul>
         <li *ngFor="let hero of heroes | async">
-            <button (click)="showTaxReturn(hero)">{{hero.name}}</button>
+          <button (click)="showTaxReturn(hero)">{{hero.name}}</button>
         </li>
       </ul>
       <app-hero-tax-return

--- a/aio/content/examples/http/src/app/config/config.component.html
+++ b/aio/content/examples/http/src/app/config/config.component.html
@@ -1,9 +1,9 @@
 <h3>Get configuration from JSON file</h3>
 <div>
-  <button (click)="clear(); showConfig()">get</button>
-  <button (click)="clear(); showConfigResponse()">getResponse</button>
-  <button (click)="clear()">clear</button>
-  <button (click)="clear(); makeError()">error</button>
+  <button type="button" (click)="clear(); showConfig()">get</button>
+  <button type="button" (click)="clear(); showConfigResponse()">getResponse</button>
+  <button type="button" (click)="clear()">clear</button>
+  <button type="button" (click)="clear(); makeError()">error</button>
   <span *ngIf="config">
     <p>Heroes API URL is "{{config.heroesUrl}}"</p>
     <p>Textfile URL is "{{config.textfile}}"</p>

--- a/aio/content/examples/http/src/app/downloader/downloader.component.html
+++ b/aio/content/examples/http/src/app/downloader/downloader.component.html
@@ -1,4 +1,4 @@
 <h2>Download the text file</h2>
-<button (click)="download()">Download</button>
-<button (click)="clear()">clear</button>
+<button type="button" (click)="download()">Download</button>
+<button type="button" (click)="clear()">clear</button>
 <p *ngIf="contents">Contents: "{{contents}}"</p>

--- a/aio/content/examples/http/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/http/src/app/heroes/heroes.component.css
@@ -9,21 +9,20 @@
 }
 
 .heroes li {
-  position: relative;
+  display: flex;
+  width: 100%;
 }
 
 .heroes li:hover {
   left: .1em;
 }
 
-.heroes a {
+.heroes button.delete {
   color: black;
   display: block;
   font-size: 1.2rem;
   background-color: #eee;
-  margin: .5em 0;
-  padding: .5em 0;
-  border-radius: 4px;
+  border-radius: 0 4px 4px 0;
 }
 
 .heroes a:hover {
@@ -40,8 +39,18 @@
   border-radius: 4px 0 0 4px;
 }
 
+.heroes button.edit {
+  flex: 1;
+  text-align: left;
+  padding: 0;
+  margin-right: 0;
+  display: flex;
+  align-items: center;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
 button.delete {
-  position: absolute;
   right: -8px;
   top: 5px;
   background-color: gray;
@@ -53,6 +62,4 @@ button.delete {
 .heroes input {
   max-width: 12rem;
   padding: .25rem;
-  position: absolute;
-  top: 8px;
 }

--- a/aio/content/examples/http/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/http/src/app/heroes/heroes.component.html
@@ -14,7 +14,7 @@
 
 <ul class="heroes">
   <li *ngFor="let hero of heroes">
-    <a (click)="edit(hero)">
+    <button class="edit" (click)="edit(hero)">
       <span class="badge">{{ hero.id || -1 }}</span>
       <span *ngIf="hero!==editHero">{{hero.name}}</span>
       <input type="text"
@@ -22,7 +22,7 @@
              [(ngModel)]="hero.name"
              (blur)="update()"
              (keyup.enter)="update()">
-    </a>
+    </button>
     <button class="delete" title="delete hero"
     (click)="delete(hero)">x</button>
   </li>

--- a/aio/content/examples/http/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/http/src/app/heroes/heroes.component.html
@@ -4,17 +4,17 @@
   <input type="text" #heroName id="hero-name">
 
   <!-- (click) passes input value to add() and then clears the input -->
-  <button (click)="add(heroName.value); heroName.value=''">
+  <button type="button" (click)="add(heroName.value); heroName.value=''">
     Add hero
   </button>
-  <button (click)="search(heroName.value)">
+  <button type="button" (click)="search(heroName.value)">
     Search
   </button>
 </div>
 
 <ul class="heroes">
   <li *ngFor="let hero of heroes">
-    <button class="edit" (click)="edit(hero)">
+    <button type="button" class="edit" (click)="edit(hero)">
       <span class="badge">{{ hero.id || -1 }}</span>
       <span *ngIf="hero!==editHero">{{hero.name}}</span>
       <input type="text"
@@ -23,7 +23,7 @@
              (blur)="update()"
              (keyup.enter)="update()">
     </button>
-    <button class="delete" title="delete hero"
+    <button type="button" class="delete" title="delete hero"
     (click)="delete(hero)">x</button>
   </li>
 </ul>

--- a/aio/content/examples/http/src/app/messages/messages.component.html
+++ b/aio/content/examples/http/src/app/messages/messages.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="messageService.messages.length">
   <h2>Messages</h2>
-  <button class="clear" (click)="messageService.clear()">clear</button>
+  <button type="button" class="clear" (click)="messageService.clear()">clear</button>
   <br>
   <ol>
     <li *ngFor='let message of messageService.messages'> {{message}} </li>

--- a/aio/content/examples/i18n/doc-files/app.component.html
+++ b/aio/content/examples/i18n/doc-files/app.component.html
@@ -27,7 +27,7 @@
 <!--#enddocregion i18n-attribute-solo-id-->
 
 <!--#docregion i18n-title-->
-<img [src]="logo" title="Angular logo">
+<img [src]="logo" title="Angular logo" alt="Angular logo">
 <!--#enddocregion i18n-title-->
 
 <!--#docregion i18n-duplicate-custom-id-->

--- a/aio/content/examples/i18n/src/app/app.component.html
+++ b/aio/content/examples/i18n/src/app/app.component.html
@@ -13,13 +13,13 @@
 <img [src]="logo" i18n-title title="Angular logo" alt="Angular logo"/>
 <!--#enddocregion i18n-title-translate-->
 <br>
-<button (click)="inc(1)">+</button> <button (click)="inc(-1)">-</button>
+<button type="button" (click)="inc(1)">+</button> <button type="button" (click)="inc(-1)">-</button>
 <!--#docregion i18n-plural-->
 <span i18n>Updated {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</span>
 <!--#enddocregion i18n-plural-->
 ({{minutes}})
 <br><br>
-<button (click)="male()">&#9794;</button> <button (click)="female()">&#9792;</button> <button (click)="other()">&#9895;</button>
+<button type="button" (click)="male()">&#9794;</button> <button type="button" (click)="female()">&#9792;</button> <button type="button" (click)="other()">&#9895;</button>
 <!--#docregion i18n-select-->
 <span i18n>The author is {gender, select, male {male} female {female} other {other}}</span>
 <!--#enddocregion i18n-select-->

--- a/aio/content/examples/i18n/src/app/app.component.html
+++ b/aio/content/examples/i18n/src/app/app.component.html
@@ -10,7 +10,7 @@
 <br />
 
 <!--#docregion i18n-title-translate-->
-<img [src]="logo" i18n-title title="Angular logo" />
+<img [src]="logo" i18n-title title="Angular logo" alt="Angular logo"/>
 <!--#enddocregion i18n-title-translate-->
 <br>
 <button (click)="inc(1)">+</button> <button (click)="inc(-1)">-</button>

--- a/aio/content/examples/inputs-outputs/src/app/aliasing/aliasing.component.html
+++ b/aio/content/examples/inputs-outputs/src/app/aliasing/aliasing.component.html
@@ -1,6 +1,6 @@
 <p>Save for later item: {{input1}}</p>
-<button (click)="saveIt()"> Save for later</button>
+<button type="button" (click)="saveIt()"> Save for later</button>
 
 <p>Item for wishlist: {{input2}}</p>
-<button (click)="wishForIt()"> Add to wishlist</button>
+<button type="button" (click)="wishForIt()"> Add to wishlist</button>
 

--- a/aio/content/examples/inputs-outputs/src/app/in-the-metadata/in-the-metadata.component.html
+++ b/aio/content/examples/inputs-outputs/src/app/in-the-metadata/in-the-metadata.component.html
@@ -1,3 +1,3 @@
 <p>Latest clearance item: {{clearanceItem}}</p>
 
-<button (click)="buyIt()"> Buy it with an Output!</button>
+<button type="button" (click)="buyIt()"> Buy it with an Output!</button>

--- a/aio/content/examples/inputs-outputs/src/app/input-output/input-output.component.html
+++ b/aio/content/examples/inputs-outputs/src/app/input-output/input-output.component.html
@@ -1,2 +1,2 @@
 <p [style.text-decoration]="lineThrough">Item: {{item}}</p>
-<button (click)="delete()">Delete item with an Output!</button>
+<button type="button" (click)="delete()">Delete item with an Output!</button>

--- a/aio/content/examples/inputs-outputs/src/app/item-output/item-output.component.html
+++ b/aio/content/examples/inputs-outputs/src/app/item-output/item-output.component.html
@@ -3,5 +3,5 @@
 <!-- #docregion child-output -->
 <label for="item-input">Add an item:</label>
 <input type="text" id="item-input" #newItem>
-<button (click)="addNewItem(newItem.value)">Add to parent's list</button>
+<button type="button" (click)="addNewItem(newItem.value)">Add to parent's list</button>
 <!-- #enddocregion child-output -->

--- a/aio/content/examples/interpolation/src/app/app.component.html
+++ b/aio/content/examples/interpolation/src/app/app.component.html
@@ -11,7 +11,7 @@
 
     <!-- #docregion component-property -->
     <p>{{title}}</p>
-    <div><img src="{{itemImageUrl}}"></div>
+    <div><img alt="item" src="{{itemImageUrl}}"></div>
     <!-- #enddocregion component-property -->
 
     <h3>Evaluating template expressions </h3>
@@ -35,7 +35,7 @@
   <h3>Component context, properties of app.component.ts:</h3>
   <!-- #docregion component-context -->
   <h4>{{recommended}}</h4>
-  <img [src]="itemImageUrl2">
+  <img alt="item" [src]="itemImageUrl2">
   <!-- #enddocregion component-context -->
 </div>
 

--- a/aio/content/examples/interpolation/src/app/app.component.html
+++ b/aio/content/examples/interpolation/src/app/app.component.html
@@ -35,7 +35,7 @@
   <h3>Component context, properties of app.component.ts:</h3>
   <!-- #docregion component-context -->
   <h4>{{recommended}}</h4>
-  <img alt="item" [src]="itemImageUrl2">
+  <img alt="item 2" [src]="itemImageUrl2">
   <!-- #enddocregion component-context -->
 </div>
 

--- a/aio/content/examples/lazy-loading-ngmodules/src/app/app.component.html
+++ b/aio/content/examples/lazy-loading-ngmodules/src/app/app.component.html
@@ -4,9 +4,9 @@
   {{title}}
 </h1>
 
-<button routerLink="/customers">Customers</button>
-<button routerLink="/orders">Orders</button>
-<button routerLink="">Home</button>
+<button type="button" routerLink="/customers">Customers</button>
+<button type="button" routerLink="/orders">Orders</button>
+<button type="button" routerLink="">Home</button>
 
 <router-outlet></router-outlet>
 

--- a/aio/content/examples/lifecycle-hooks/src/app/after-content-parent.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/after-content-parent.component.ts
@@ -18,7 +18,7 @@ import { LoggerService } from './logger.service';
 
     <div class="info">
       <h3>AfterContent Logs</h3>
-      <button (click)="reset()">Reset</button>
+      <button type="button" (click)="reset()">Reset</button>
       <div *ngFor="let msg of logger.logs" class="log">{{msg}}</div>
     </div>
   </div>

--- a/aio/content/examples/lifecycle-hooks/src/app/after-view-parent.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/after-view-parent.component.ts
@@ -11,7 +11,7 @@ import { LoggerService } from './logger.service';
 
   <div class="info">
     <h3>AfterView Logs</h3>
-    <button (click)="reset()">Reset</button>
+    <button type="button" (click)="reset()">Reset</button>
     <div *ngFor="let msg of logger.logs" class="log">{{msg}}</div>
   </div>
   `,

--- a/aio/content/examples/lifecycle-hooks/src/app/app.component.html
+++ b/aio/content/examples/lifecycle-hooks/src/app/app.component.html
@@ -1,5 +1,4 @@
-<a id="top"></a>
-<h1>Lifecycle Hooks</h1>
+<h1 id="top">Lifecycle Hooks</h1>
 <a href="#hooks">Peek-a-boo: (most) lifecycle hooks</a>
 <a href="#spy">Spy: directive with OnInit & OnDestroy</a>
 <a href="#onchanges">OnChanges</a>
@@ -8,36 +7,29 @@
 <a href="#after-content">AfterContentInit & AfterContentChecked</a>
 <a href="#counter">Counter: OnChanges + Spy directive</a>
 
-<a id="hooks"></a>
-<peek-a-boo-parent></peek-a-boo-parent>
+<peek-a-boo-parent id="hooks"></peek-a-boo-parent>
 <a href="#top">back to top</a>
 <hr />
 
-<a id="spy"></a>
-<spy-parent></spy-parent>
+<spy-parent id="spy"></spy-parent>
 <a href="#top">back to top</a>
 <hr />
 
-<a id="onchanges"></a>
-<on-changes-parent></on-changes-parent>
+<on-changes-parent id="onchanges"></on-changes-parent>
 <a href="#top">back to top</a>
 <hr />
 
-<a id="docheck"></a>
-<do-check-parent></do-check-parent>
+<do-check-parent id="docheck"></do-check-parent>
 <a href="#top">back to top</a>
 <hr />
 
-<a id="after-view"></a>
-<after-view-parent></after-view-parent>
+<after-view-parent id="after-view"></after-view-parent>
 <a href="#top">back to top</a>
 <hr />
 
-<a id="after-content"></a>
-<after-content-parent></after-content-parent>
+<after-content-parent id="after-content"></after-content-parent>
 <a href="#top">back to top</a>
 <hr />
 
-<a id="counter"></a>
-<counter-parent></counter-parent>
+<counter-parent id="counter"></counter-parent>
 <a href="#top">back to top</a>

--- a/aio/content/examples/lifecycle-hooks/src/app/counter-parent.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/counter-parent.component.ts
@@ -7,8 +7,8 @@ import { LoggerService } from './logger.service';
   template: `
   <h2>Counter Spy</h2>
 
-  <button (click)="updateCounter()">Update counter</button>
-  <button (click)="reset()">Reset Counter</button>
+  <button type="button" (click)="updateCounter()">Update counter</button>
+  <button type="button" (click)="reset()">Reset Counter</button>
 
   <app-counter [counter]="value"></app-counter>
 

--- a/aio/content/examples/lifecycle-hooks/src/app/do-check-parent.component.html
+++ b/aio/content/examples/lifecycle-hooks/src/app/do-check-parent.component.html
@@ -1,5 +1,5 @@
 <h2>{{title}}</h2>
-<label for="power-input"><label>Power: </label>
+<label for="power-input">Power: </label>
 <input type="text" id="power-input" [(ngModel)]="power">
 <label for="hero-name">Hero.name: </label>
 <input type="text" id="hero-name" [(ngModel)]="hero.name">

--- a/aio/content/examples/lifecycle-hooks/src/app/do-check-parent.component.html
+++ b/aio/content/examples/lifecycle-hooks/src/app/do-check-parent.component.html
@@ -3,7 +3,7 @@
 <input type="text" id="power-input" [(ngModel)]="power">
 <label for="hero-name">Hero.name: </label>
 <input type="text" id="hero-name" [(ngModel)]="hero.name">
-<button (click)="reset()">Reset Log</button>
+<button type="button" (click)="reset()">Reset Log</button>
 
 <do-check [hero]="hero" [power]="power"></do-check>
 

--- a/aio/content/examples/lifecycle-hooks/src/app/on-changes-parent.component.html
+++ b/aio/content/examples/lifecycle-hooks/src/app/on-changes-parent.component.html
@@ -4,7 +4,7 @@
 <label for="hero-name"> Hero.name: </label>
 <input type="text" id="hero-name" [(ngModel)]="hero.name">
 
-<button (click)="reset()">Reset Log</button>
+<button type="button" (click)="reset()">Reset Log</button>
 
 <!-- #docregion on-changes -->
 <on-changes [hero]="hero" [power]="power"></on-changes>

--- a/aio/content/examples/lifecycle-hooks/src/app/peek-a-boo-parent.component.ts
+++ b/aio/content/examples/lifecycle-hooks/src/app/peek-a-boo-parent.component.ts
@@ -10,10 +10,10 @@ import { LoggerService } from './logger.service';
   <div class="parent">
     <h2>Peek-A-Boo</h2>
 
-    <button (click)="toggleChild()">
+    <button type="button" (click)="toggleChild()">
       {{hasChild ? 'Destroy' : 'Create'}} PeekABooComponent
     </button>
-    <button (click)="updateHero()" [hidden]="!hasChild">Update Hero</button>
+    <button type="button" (click)="updateHero()" [hidden]="!hasChild">Update Hero</button>
 
     <div class="info">
       <peek-a-boo *ngIf="hasChild" [name]="heroName"></peek-a-boo>

--- a/aio/content/examples/lifecycle-hooks/src/app/spy.component.html
+++ b/aio/content/examples/lifecycle-hooks/src/app/spy.component.html
@@ -3,8 +3,8 @@
 
   <label for="hero-name">Hero name: </label>
   <input type="text" id="hero-name" [(ngModel)]="newName" (keyup.enter)="addHero()">
-  <button (click)="addHero()">Add Hero</button>
-  <button (click)="reset()">Reset Heroes</button>
+  <button type="button" (click)="addHero()">Add Hero</button>
+  <button type="button" (click)="reset()">Reset Heroes</button>
 
   <div class="info">
     <!-- #docregion template -->

--- a/aio/content/examples/ngcontainer/src/app/app.component.html
+++ b/aio/content/examples/ngcontainer/src/app/app.component.html
@@ -9,7 +9,7 @@
 <h3>&lt;ng-container&gt; and CSS</h3>
 <p>Examples demonstrating issues with rigid CSS styles.</p>
 
-<button (click)="hero = hero ? null : heroes[0]">Toggle hero</button>
+<button type="button" (click)="hero = hero ? null : heroes[0]">Toggle hero</button>
 
 <h4>#1 &lt;ng-container&gt; and &lt;p&gt;</h4>
 <p>

--- a/aio/content/examples/observables-in-angular/src/main.ts
+++ b/aio/content/examples/observables-in-angular/src/main.ts
@@ -11,7 +11,7 @@ import { Observable } from 'rxjs';
   selector: 'app-zippy',
   template: `
     <div class="zippy">
-      <button (click)="toggle()">Toggle</button>
+      <button type="button" (click)="toggle()">Toggle</button>
       <div [hidden]="!visible">
         <ng-content></ng-content>
       </div>

--- a/aio/content/examples/observables-in-angular/src/main.ts
+++ b/aio/content/examples/observables-in-angular/src/main.ts
@@ -11,7 +11,7 @@ import { Observable } from 'rxjs';
   selector: 'app-zippy',
   template: `
     <div class="zippy">
-      <div (click)="toggle()">Toggle</div>
+      <button (click)="toggle()">Toggle</button>
       <div [hidden]="!visible">
         <ng-content></ng-content>
       </div>

--- a/aio/content/examples/pipes/src/app/app.component.html
+++ b/aio/content/examples/pipes/src/app/app.component.html
@@ -1,5 +1,4 @@
-<a id="toc"></a>
-<h1>Pipes</h1>
+<h1 id="toc">Pipes</h1>
 <a href="#happy-birthday1">Happy Birthday v1</a>
 <a href="#birthday-date-pipe">Birthday DatePipe</a>
 <a href="#happy-birthday2">Happy Birthday v2</a>
@@ -14,13 +13,11 @@
 
 
 <hr>
-<a id="happy-birthday1"></a>
-<h2>Hero Birthday v1</h2>
+<h2 id="happy-birthday1">Hero Birthday v1</h2>
 <app-hero-birthday></app-hero-birthday>
 
 <hr>
-<a id="birthday-date-pipe"></a>
-<h2>Birthday DatePipe</h2>
+<h2 id="birthday-date-pipe">Birthday DatePipe</h2>
 <!-- #docregion hero-birthday-template -->
 <p>The hero's birthday is {{ birthday | date }}</p>
 <!-- #enddocregion hero-birthday-template-->
@@ -30,13 +27,11 @@
 <!-- #enddocregion format-birthday-->
 
 <hr>
-<a id="happy-birthday2"></a>
-<h2>Hero Birthday v2</h2>
+<h2 id="happy-birthday2">Hero Birthday v2</h2>
 <app-hero-birthday2></app-hero-birthday2>
 
 <hr>
-<a id="birthday-pipe-chaining"></a>
-<h2>Birthday Pipe Chaining</h2>
+<h2 id="birthday-pipe-chaining">Birthday Pipe Chaining</h2>
 <p>
 <!-- #docregion chained-birthday -->
   The chained hero's birthday is
@@ -55,31 +50,24 @@
   {{ ( birthday | date:'fullDate' ) | uppercase}}
 </p>
 <hr>
-<a id="power-booster"></a>
-<app-power-booster></app-power-booster>
+<app-power-booster id="power-booster"></app-power-booster>
 
 <hr>
-<a id="power-boost-calc"></a>
-<app-power-boost-calculator>loading</app-power-boost-calculator>
+<app-power-boost-calculator id="power-boost-calc">loading</app-power-boost-calculator>
 
 <hr>
-<a id="flying-heroes"></a>
-<app-flying-heroes></app-flying-heroes>
+<app-flying-heroes id="flying-heroes"></app-flying-heroes>
 
 <hr>
-<a id="flying-heroes-impure"></a>
-<app-flying-heroes-impure></app-flying-heroes-impure>
+<app-flying-heroes-impure id="flying-heroes-impure"></app-flying-heroes-impure>
 
 <hr>
-<a id="hero-message"></a>
 <!-- async examples at the top so can see them in action -->
-<app-hero-async-message></app-hero-async-message>
+<app-hero-async-message id="hero-message"></app-hero-async-message>
 
 <hr>
-<a id="hero-list"></a>
-<app-hero-list></app-hero-list>
+<app-hero-list id="hero-list"></app-hero-list>
 
 <hr>
-<a id="pipe-precedence"></a>
-<app-precedence></app-precedence>
+<app-precedence id="pipe-precedence"></app-precedence>
 <hr>

--- a/aio/content/examples/pipes/src/app/flying-heroes-impure.component.html
+++ b/aio/content/examples/pipes/src/app/flying-heroes-impure.component.html
@@ -15,7 +15,7 @@
 
 <div>
   <input id="mutate" type="checkbox" [(ngModel)]="mutate">Mutate array
-  <button (click)="reset()">Reset</button>
+  <button type="button" (click)="reset()">Reset</button>
 </div>
 
 <h3>Heroes who fly (piped)</h3>

--- a/aio/content/examples/pipes/src/app/flying-heroes.component.html
+++ b/aio/content/examples/pipes/src/app/flying-heroes.component.html
@@ -17,7 +17,7 @@
 <input id="mutate" type="checkbox" [(ngModel)]="mutate">
 <label for="mutate">Mutate array</label>
 <!-- #docregion template-1 -->
-<button (click)="reset()">Reset list of heroes</button>
+<button type="button" (click)="reset()">Reset list of heroes</button>
 <!-- #enddocregion template-1 -->
 </div>
 

--- a/aio/content/examples/pipes/src/app/hero-async-message.component.ts
+++ b/aio/content/examples/pipes/src/app/hero-async-message.component.ts
@@ -9,7 +9,7 @@ import { map, take } from 'rxjs/operators';
   template: `
     <h2>Async Hero Message and AsyncPipe</h2>
     <p>Message: {{ message$ | async }}</p>
-    <button (click)="resend()">Resend</button>`,
+    <button type="button" (click)="resend()">Resend</button>`,
 })
 export class HeroAsyncMessageComponent {
   message$: Observable<string>;

--- a/aio/content/examples/pipes/src/app/hero-birthday2.component.ts
+++ b/aio/content/examples/pipes/src/app/hero-birthday2.component.ts
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
   // #docregion template
   template: `
     <p>The hero's birthday is {{ birthday | date:format }}</p>
-    <button (click)="toggleFormat()">Toggle Format</button>
+    <button type="button" (click)="toggleFormat()">Toggle Format</button>
   `
   // #enddocregion template
 })

--- a/aio/content/examples/property-binding/src/app/app.component.html
+++ b/aio/content/examples/property-binding/src/app/app.component.html
@@ -20,7 +20,7 @@
   <h2>Button disabled state bound to isUnchanged property:</h2>
   <!-- #docregion disabled-button -->
   <!-- Bind button disabled state to `isUnchanged` property -->
-  <button [disabled]="isUnchanged">Disabled Button</button>
+  <button type="button" [disabled]="isUnchanged">Disabled Button</button>
   <!-- #enddocregion disabled-button -->
   <hr />
 

--- a/aio/content/examples/property-binding/src/app/app.component.html
+++ b/aio/content/examples/property-binding/src/app/app.component.html
@@ -4,7 +4,7 @@
   <h1>Property Binding with Angular</h1>
   <h2>Binding the src property of an image:</h2>
   <!-- #docregion property-binding -->
-  <img [src]="itemImageUrl">
+  <img alt="item" [src]="itemImageUrl">
   <!-- #enddocregion property-binding -->
   <hr />
 
@@ -47,8 +47,8 @@
 
   <h2>Property binding and interpolation</h2>
   <!-- #docregion property-binding-interpolation -->
-  <p><img src="{{itemImageUrl}}"> is the <i>interpolated</i> image.</p>
-  <p><img [src]="itemImageUrl"> is the <i>property bound</i> image.</p>
+  <p><img alt="item" src="{{itemImageUrl}}"> is the <i>interpolated</i> image.</p>
+  <p><img alt="item" [src]="itemImageUrl"> is the <i>property bound</i> image.</p>
 
   <p><span>"{{interpolationTitle}}" is the <i>interpolated</i> title.</span></p>
   <p>"<span [innerHTML]="propertyTitle"></span>" is the <i>property bound</i> title.</p>

--- a/aio/content/examples/property-binding/src/app/app.component.html
+++ b/aio/content/examples/property-binding/src/app/app.component.html
@@ -47,8 +47,8 @@
 
   <h2>Property binding and interpolation</h2>
   <!-- #docregion property-binding-interpolation -->
-  <p><img alt="item" src="{{itemImageUrl}}"> is the <i>interpolated</i> image.</p>
-  <p><img alt="item" [src]="itemImageUrl"> is the <i>property bound</i> image.</p>
+  <p><img alt="Interpolated item" src="{{itemImageUrl}}"> is the <i>interpolated</i> image.</p>
+  <p><img alt="Property Bound item" [src]="itemImageUrl"> is the <i>property bound</i> image.</p>
 
   <p><span>"{{interpolationTitle}}" is the <i>interpolated</i> title.</span></p>
   <p>"<span [innerHTML]="propertyTitle"></span>" is the <i>property bound</i> title.</p>

--- a/aio/content/examples/reactive-forms/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/reactive-forms/e2e/src/app.e2e-spec.ts
@@ -3,8 +3,8 @@ import { browser, element, by } from 'protractor';
 describe('Reactive forms', () => {
   const nameEditor = element(by.css('app-name-editor'));
   const profileEditor = element(by.css('app-profile-editor'));
-  const nameEditorLink = element(by.cssContainingText('app-root > nav > a', 'Name Editor'));
-  const profileEditorLink = element(by.cssContainingText('app-root > nav > a', 'Profile Editor'));
+  const nameEditorButton = element(by.cssContainingText('app-root > nav > button', 'Name Editor'));
+  const profileEditorButton = element(by.cssContainingText('app-root > nav > button', 'Profile Editor'));
 
   beforeAll(() => browser.get(''));
 
@@ -14,7 +14,7 @@ describe('Reactive forms', () => {
     const nameText = 'John Smith';
 
     beforeAll(async () => {
-      await nameEditorLink.click();
+      await nameEditorButton.click();
     });
 
     beforeEach(async () => {
@@ -66,12 +66,12 @@ describe('Reactive forms', () => {
     };
 
     beforeAll(async () => {
-      await profileEditorLink.click();
+      await profileEditorButton.click();
     });
 
     beforeEach(async () => {
       await browser.get('');
-      await profileEditorLink.click();
+      await profileEditorButton.click();
     });
 
     it('should be invalid by default', async () => {

--- a/aio/content/examples/reactive-forms/src/app/app.component.css
+++ b/aio/content/examples/reactive-forms/src/app/app.component.css
@@ -1,3 +1,4 @@
-nav a {
+nav button {
   padding: 1rem;
+  font-size: inherit;
 }

--- a/aio/content/examples/reactive-forms/src/app/app.component.html
+++ b/aio/content/examples/reactive-forms/src/app/app.component.html
@@ -1,8 +1,8 @@
 <h1>Reactive Forms</h1>
 
 <nav>
-  <button (click)="toggleEditor('name')">Name Editor</button>
-  <button (click)="toggleEditor('profile')">Profile Editor</button>
+  <button type="button" (click)="toggleEditor('name')">Name Editor</button>
+  <button type="button" (click)="toggleEditor('profile')">Profile Editor</button>
 </nav>
 
 <app-name-editor *ngIf="showNameEditor"></app-name-editor>

--- a/aio/content/examples/reactive-forms/src/app/app.component.html
+++ b/aio/content/examples/reactive-forms/src/app/app.component.html
@@ -1,8 +1,8 @@
 <h1>Reactive Forms</h1>
 
 <nav>
-  <a (click)="toggleEditor('name')">Name Editor</a>
-  <a (click)="toggleEditor('profile')">Profile Editor</a>
+  <button (click)="toggleEditor('name')">Name Editor</button>
+  <button (click)="toggleEditor('profile')">Profile Editor</button>
 </nav>
 
 <app-name-editor *ngIf="showNameEditor"></app-name-editor>

--- a/aio/content/examples/reactive-forms/src/app/name-editor/name-editor.component.html
+++ b/aio/content/examples/reactive-forms/src/app/name-editor/name-editor.component.html
@@ -8,5 +8,5 @@
 <!-- #enddocregion display-value -->
 
 <!-- #docregion update-value -->
-<button (click)="updateName()">Update Name</button>
+<button type="button" (click)="updateName()">Update Name</button>
 <!-- #enddocregion update-value -->

--- a/aio/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.1.html
+++ b/aio/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.1.html
@@ -29,7 +29,7 @@
 
   <div formArrayName="aliases">
     <h2>Aliases</h2>
-    <button (click)="addAlias()">+ Add another alias</button>
+    <button type="button" (click)="addAlias()">+ Add another alias</button>
 
     <div *ngFor="let address of aliases.controls; let i=index">
       <!-- The repeated alias template -->
@@ -44,5 +44,5 @@
 <p>Form Value: {{ profileForm.value | json }}</p>
 
 <!-- #docregion patch-value -->
-<button (click)="updateProfile()">Update Profile</button>
+<button type="button" (click)="updateProfile()">Update Profile</button>
 <!-- #enddocregion patch-value -->

--- a/aio/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.html
+++ b/aio/content/examples/reactive-forms/src/app/profile-editor/profile-editor.component.html
@@ -27,7 +27,7 @@
   <!-- #docregion formarrayname -->
   <div formArrayName="aliases">
     <h2>Aliases</h2>
-    <button (click)="addAlias()" type="button">+ Add another alias</button>
+    <button type="button" (click)="addAlias()" type="button">+ Add another alias</button>
 
     <div *ngFor="let alias of aliases.controls; let i=index">
       <!-- The repeated alias template -->
@@ -52,4 +52,4 @@
 <p>Form Status: {{ profileForm.status }}</p>
 <!-- #enddocregion display-status -->
 
-<button (click)="updateProfile()">Update Profile</button>
+<button type="button" (click)="updateProfile()">Update Profile</button>

--- a/aio/content/examples/router/src/app/admin/admin-dashboard/admin-dashboard.component.2.html
+++ b/aio/content/examples/router/src/app/admin/admin-dashboard/admin-dashboard.component.2.html
@@ -1,5 +1,4 @@
 <h3>Dashboard</h3>
 
 <p>Session ID: {{ sessionId | async }}</p>
-<a id="anchor"></a>
 <p>Token: {{ token | async }}</p>

--- a/aio/content/examples/router/src/app/admin/admin-dashboard/admin-dashboard.component.2.html
+++ b/aio/content/examples/router/src/app/admin/admin-dashboard/admin-dashboard.component.2.html
@@ -1,5 +1,0 @@
-<h3>Dashboard</h3>
-
-<p>Session ID: {{ sessionId | async }}</p>
-<div id="anchor"></div>
-<p>Token: {{ token | async }}</p>

--- a/aio/content/examples/router/src/app/admin/admin-dashboard/admin-dashboard.component.2.html
+++ b/aio/content/examples/router/src/app/admin/admin-dashboard/admin-dashboard.component.2.html
@@ -1,4 +1,5 @@
 <h3>Dashboard</h3>
 
 <p>Session ID: {{ sessionId | async }}</p>
+<div id="anchor"></div>
 <p>Token: {{ token | async }}</p>

--- a/aio/content/examples/router/src/app/admin/admin-dashboard/admin-dashboard.component.html
+++ b/aio/content/examples/router/src/app/admin/admin-dashboard/admin-dashboard.component.html
@@ -1,6 +1,7 @@
 <h3>Dashboard</h3>
 
 <p>Session ID: {{ sessionId | async }}</p>
+<div id="anchor"></div>
 <p>Token: {{ token | async }}</p>
 
 Preloaded Modules

--- a/aio/content/examples/router/src/app/admin/admin-dashboard/admin-dashboard.component.html
+++ b/aio/content/examples/router/src/app/admin/admin-dashboard/admin-dashboard.component.html
@@ -1,7 +1,6 @@
 <h3>Dashboard</h3>
 
 <p>Session ID: {{ sessionId | async }}</p>
-<a id="anchor"></a>
 <p>Token: {{ token | async }}</p>
 
 Preloaded Modules

--- a/aio/content/examples/router/src/app/auth/login/login.component.html
+++ b/aio/content/examples/router/src/app/auth/login/login.component.html
@@ -1,6 +1,6 @@
 <h2>Login</h2>
 <p>{{message}}</p>
 <p>
-  <button (click)="login()"  *ngIf="!authService.isLoggedIn">Login</button>
-  <button (click)="logout()" *ngIf="authService.isLoggedIn">Logout</button>
+  <button type="button" (click)="login()"  *ngIf="!authService.isLoggedIn">Login</button>
+  <button type="button" (click)="logout()" *ngIf="authService.isLoggedIn">Logout</button>
 </p>

--- a/aio/content/examples/router/src/app/compose-message/compose-message.component.html
+++ b/aio/content/examples/router/src/app/compose-message/compose-message.component.html
@@ -12,6 +12,6 @@
   </div>
 </div>
 <p *ngIf="!sending">
-  <button (click)="send()">Send</button>
-  <button (click)="cancel()">Cancel</button>
+  <button type="button" (click)="send()">Send</button>
+  <button type="button" (click)="cancel()">Cancel</button>
 </p>

--- a/aio/content/examples/router/src/app/crisis-center/crisis-detail/crisis-detail.component.html
+++ b/aio/content/examples/router/src/app/crisis-center/crisis-detail/crisis-detail.component.html
@@ -4,7 +4,7 @@
   <label for="crisis-name">Crisis name: </label>
   <input type="text" id="crisis-name" [(ngModel)]="editName" placeholder="name"/>
   <div>
-    <button (click)="save()">Save</button>
-    <button (click)="cancel()">Cancel</button>
+    <button type="button" (click)="save()">Save</button>
+    <button type="button" (click)="cancel()">Cancel</button>
   </div>
 </div>

--- a/aio/content/examples/router/src/app/hero-list/hero-list.component.1.html
+++ b/aio/content/examples/router/src/app/hero-list/hero-list.component.1.html
@@ -3,4 +3,4 @@
 <p>Get your heroes here</p>
 
 <!-- #enddocregion template-->
-<button routerLink="/sidekicks">Go to sidekicks</button>
+<button type="button" routerLink="/sidekicks">Go to sidekicks</button>

--- a/aio/content/examples/router/src/app/heroes/hero-detail/hero-detail.component.html
+++ b/aio/content/examples/router/src/app/heroes/hero-detail/hero-detail.component.html
@@ -4,5 +4,5 @@
   <p>Id: {{ hero.id }}</p>
   <label for="hero-name">Hero name: </label>
   <input type="text" id="hero-name" [(ngModel)]="hero.name" placeholder="name"/>
-  <button (click)="gotoHeroes(hero)">Back</button>
+  <button type="button" (click)="gotoHeroes(hero)">Back</button>
 </div>

--- a/aio/content/examples/router/src/app/heroes/hero-list/hero-list.component.1.html
+++ b/aio/content/examples/router/src/app/heroes/hero-list/hero-list.component.1.html
@@ -11,4 +11,4 @@
   </li>
 </ul>
 
-<button routerLink="/sidekicks">Go to sidekicks</button>
+<button type="button" routerLink="/sidekicks">Go to sidekicks</button>

--- a/aio/content/examples/router/src/app/heroes/hero-list/hero-list.component.html
+++ b/aio/content/examples/router/src/app/heroes/hero-list/hero-list.component.html
@@ -7,4 +7,4 @@
   </li>
 </ul>
 
-<button routerLink="/sidekicks">Go to sidekicks</button>
+<button type="button" routerLink="/sidekicks">Go to sidekicks</button>

--- a/aio/content/examples/service-worker-getting-started/src/app/app.component.html
+++ b/aio/content/examples/service-worker-getting-started/src/app/app.component.html
@@ -6,7 +6,7 @@
   <img width="300" alt="Angular Logo" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTAgMjUwIj4KICAgIDxwYXRoIGZpbGw9IiNERDAwMzEiIGQ9Ik0xMjUgMzBMMzEuOSA2My4ybDE0LjIgMTIzLjFMMTI1IDIzMGw3OC45LTQzLjcgMTQuMi0xMjMuMXoiIC8+CiAgICA8cGF0aCBmaWxsPSIjQzMwMDJGIiBkPSJNMTI1IDMwdjIyLjItLjFWMjMwbDc4LjktNDMuNyAxNC4yLTEyMy4xTDEyNSAzMHoiIC8+CiAgICA8cGF0aCAgZmlsbD0iI0ZGRkZGRiIgZD0iTTEyNSA1Mi4xTDY2LjggMTgyLjZoMjEuN2wxMS43LTI5LjJoNDkuNGwxMS43IDI5LjJIMTgzTDEyNSA1Mi4xem0xNyA4My4zaC0zNGwxNy00MC45IDE3IDQwLjl6IiAvPgogIDwvc3ZnPg==">
 </div>
 
-<button id="check" (click)="updateCheck()">Check for Update</button>
+<button type="button" id="check" (click)="updateCheck()">Check for Update</button>
 <p id="checkResult">{{updateCheckText}}</p>
 
 <h2>Here are some links to help you start: </h2>

--- a/aio/content/examples/set-document-title/src/app/app.component.ts
+++ b/aio/content/examples/set-document-title/src/app/app.component.ts
@@ -12,9 +12,9 @@ import { Title } from '@angular/platform-browser';
     </p>
 
     <ul>
-      <li><button (click)="setTitle('Good morning!')">Good morning</button></li>
-      <li><button (click)="setTitle('Good afternoon!')">Good afternoon</button></li>
-      <li><button (click)="setTitle('Good evening!')">Good evening</button></li>
+      <li><button type="button" (click)="setTitle('Good morning!')">Good morning</button></li>
+      <li><button type="button" (click)="setTitle('Good afternoon!')">Good afternoon</button></li>
+      <li><button type="button" (click)="setTitle('Good evening!')">Good evening</button></li>
     </ul>
   `,
 })

--- a/aio/content/examples/set-document-title/src/app/app.component.ts
+++ b/aio/content/examples/set-document-title/src/app/app.component.ts
@@ -12,9 +12,9 @@ import { Title } from '@angular/platform-browser';
     </p>
 
     <ul>
-      <li><a (click)="setTitle('Good morning!')">Good morning</a>.</li>
-      <li><a (click)="setTitle('Good afternoon!')">Good afternoon</a>.</li>
-      <li><a (click)="setTitle('Good evening!')">Good evening</a>.</li>
+      <li><button (click)="setTitle('Good morning!')">Good morning</button></li>
+      <li><button (click)="setTitle('Good afternoon!')">Good afternoon</button></li>
+      <li><button (click)="setTitle('Good evening!')">Good evening</button></li>
     </ul>
   `,
 })

--- a/aio/content/examples/structural-directives/src/app/app.component.html
+++ b/aio/content/examples/structural-directives/src/app/app.component.html
@@ -52,7 +52,7 @@
 
 <h4>*ngIf with a &lt;ng-container&gt;</h4>
 
-<button (click)="hero = hero ? null : heroes[0]">Toggle hero</button>
+<button type="button" (click)="hero = hero ? null : heroes[0]">Toggle hero</button>
 
 <!-- #docregion ngif-ngcontainer -->
 <p>
@@ -179,6 +179,7 @@
   The condition is currently
   <span [ngClass]="{ 'a': !condition, 'b': condition, 'unless': true }">{{condition}}</span>.
   <button
+    type="button"
     (click)="condition = !condition"
     [ngClass] = "{ 'a': condition, 'b': !condition }" >
     Toggle condition to {{condition ? 'false' : 'true'}}

--- a/aio/content/examples/styleguide/src/04-11/app/heroes/heroes.component.html
+++ b/aio/content/examples/styleguide/src/04-11/app/heroes/heroes.component.html
@@ -1,7 +1,7 @@
 <!--#docregion-->
 <div>
 
-	<button (click)="getHeroes()">Get Heroes</button>
+	<button type="button" (click)="getHeroes()">Get Heroes</button>
 
 	<ul>
 		<li *ngFor="let hero of heroes">

--- a/aio/content/examples/styleguide/src/04-12/app/heroes/heroes.component.html
+++ b/aio/content/examples/styleguide/src/04-12/app/heroes/heroes.component.html
@@ -1,7 +1,7 @@
 <!--#docregion-->
 <div>
 
-	<button (click)="getHeroes()">Get Heroes</button>
+	<button type="button" (click)="getHeroes()">Get Heroes</button>
 
 	<ul>
 		<li *ngFor="let hero of heroes">

--- a/aio/content/examples/styleguide/src/05-02/app/heroes/shared/hero-button/hero-button.component.html
+++ b/aio/content/examples/styleguide/src/05-02/app/heroes/shared/hero-button/hero-button.component.html
@@ -1,1 +1,1 @@
-<button class="hero-button">Hero button</button>
+<button type="button" class="hero-button">Hero button</button>

--- a/aio/content/examples/styleguide/src/05-03/app/heroes/shared/hero-button/hero-button.component.html
+++ b/aio/content/examples/styleguide/src/05-03/app/heroes/shared/hero-button/hero-button.component.html
@@ -1,1 +1,1 @@
-<button class="hero-button">Hero button</button>
+<button type="button" class="hero-button">Hero button</button>

--- a/aio/content/examples/styleguide/src/05-04/app/heroes/heroes.component.css
+++ b/aio/content/examples/styleguide/src/05-04/app/heroes/heroes.component.css
@@ -5,27 +5,63 @@
   padding: 0;
   width: 15em;
 }
+
 .heroes li {
+  display: flex;
+}
+
+.heroes button {
+  flex: 1;
   cursor: pointer;
   position: relative;
   left: 0;
   background-color: #EEE;
   margin: .5em;
-  padding: .3em 0;
+  padding: 0;
   height: 1.6em;
   border-radius: 4px;
+  display: flex;
+  align-items: stretch;
+  height: 1.8em;
 }
+
+.heroes button:hover {
+  color: #2c3a41;
+  background-color: #e6e6e6;
+  left: .1em;
+}
+
+.heroes button:active {
+  background-color: #525252;
+  color: #fafafa;
+}
+
+.heroes button.selected {
+  background-color: black;
+  color: white;
+}
+
+.heroes button.selected:hover {
+  background-color: #505050;
+  color: white;
+}
+
+.heroes button.selected:active {
+  background-color: black;
+  color: white;
+}
+
 .heroes .badge {
   display: inline-block;
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color: #607D8B;
+  background-color: #405061;
   line-height: 1em;
-  position: relative;
-  left: -1px;
-  top: -4px;
-  height: 1.8em;
   margin-right: .8em;
   border-radius: 4px 0 0 4px;
+}
+
+.heroes .name {
+  align-self: center;
 }

--- a/aio/content/examples/styleguide/src/05-04/app/heroes/heroes.component.html
+++ b/aio/content/examples/styleguide/src/05-04/app/heroes/heroes.component.html
@@ -3,7 +3,7 @@
   <h2>My Heroes</h2>
   <ul class="heroes">
     <li *ngFor="let hero of heroes | async">
-      <button (click)="selectedHero=hero">
+      <button type="button" (click)="selectedHero=hero">
         <span class="badge">{{hero.id}}</span>
         <span class="name">{{hero.name}}</span>
       </button>

--- a/aio/content/examples/styleguide/src/05-04/app/heroes/heroes.component.html
+++ b/aio/content/examples/styleguide/src/05-04/app/heroes/heroes.component.html
@@ -2,8 +2,11 @@
 <div>
   <h2>My Heroes</h2>
   <ul class="heroes">
-    <li *ngFor="let hero of heroes | async" (click)="selectedHero=hero">
-      <span class="badge">{{hero.id}}</span> {{hero.name}}
+    <li *ngFor="let hero of heroes | async">
+      <button (click)="selectedHero=hero">
+        <span class="badge">{{hero.id}}</span>
+        <span class="name">{{hero.name}}</span>
+      </button>
     </li>
   </ul>
   <div *ngIf="selectedHero">

--- a/aio/content/examples/styleguide/src/05-12/app/heroes/shared/hero-button/hero-button.component.avoid.ts
+++ b/aio/content/examples/styleguide/src/05-12/app/heroes/shared/hero-button/hero-button.component.avoid.ts
@@ -5,7 +5,7 @@ import { Component, EventEmitter } from '@angular/core';
 
 @Component({
   selector: 'toh-hero-button',
-  template: `<button></button>`,
+  template: `<button type="button"></button>`,
   inputs: [
     'label'
   ],

--- a/aio/content/examples/styleguide/src/05-12/app/heroes/shared/hero-button/hero-button.component.ts
+++ b/aio/content/examples/styleguide/src/05-12/app/heroes/shared/hero-button/hero-button.component.ts
@@ -4,7 +4,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 // #docregion example
 @Component({
   selector: 'toh-hero-button',
-  template: `<button>{{label}}</button>`
+  template: `<button type="button">{{label}}</button>`
 })
 export class HeroButtonComponent {
   @Output() heroChange = new EventEmitter<any>();

--- a/aio/content/examples/styleguide/src/05-13/app/heroes/shared/hero-button/hero-button.component.avoid.ts
+++ b/aio/content/examples/styleguide/src/05-13/app/heroes/shared/hero-button/hero-button.component.avoid.ts
@@ -4,7 +4,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 @Component({
   selector: 'toh-hero-button',
-  template: `<button>{{label}}</button>`
+  template: `<button type="button">{{label}}</button>`
 })
 export class HeroButtonComponent {
   // Pointless aliases

--- a/aio/content/examples/styleguide/src/05-13/app/heroes/shared/hero-button/hero-button.component.ts
+++ b/aio/content/examples/styleguide/src/05-13/app/heroes/shared/hero-button/hero-button.component.ts
@@ -4,7 +4,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 // #docregion example
 @Component({
   selector: 'toh-hero-button',
-  template: `<button>{{label}}</button>`
+  template: `<button type="button" >{{label}}</button>`
 })
 export class HeroButtonComponent {
   // No aliases

--- a/aio/content/examples/styleguide/src/09-01/app/heroes/shared/hero-button/hero-button.component.avoid.ts
+++ b/aio/content/examples/styleguide/src/09-01/app/heroes/shared/hero-button/hero-button.component.avoid.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'toh-hero-button',
-  template: `<button>OK<button>`
+  template: `<button type="button">OK</button>`
 })
 export class HeroButtonComponent {
   onInit() { // misspelled

--- a/aio/content/examples/styleguide/src/09-01/app/heroes/shared/hero-button/hero-button.component.ts
+++ b/aio/content/examples/styleguide/src/09-01/app/heroes/shared/hero-button/hero-button.component.ts
@@ -4,7 +4,7 @@ import { Component, OnInit } from '@angular/core';
 // #docregion example
 @Component({
   selector: 'toh-hero-button',
-  template: `<button>OK</button>`
+  template: `<button type="button">OK</button>`
 })
 export class HeroButtonComponent implements OnInit {
   ngOnInit() {

--- a/aio/content/examples/template-reference-variables/src/app/app.component.html
+++ b/aio/content/examples/template-reference-variables/src/app/app.component.html
@@ -11,7 +11,7 @@
   <!-- lots of other elements -->
 
   <!-- phone refers to the input element; pass its `value` to an event handler -->
-  <button (click)="callPhone(phone.value)">Call</button>
+  <button type="button" (click)="callPhone(phone.value)">Call</button>
   <!-- #enddocregion ref-phone -->
 </div>
 
@@ -21,6 +21,7 @@
   <h2>Template reference variable with disabled button</h2>
   <p>btn refers to the button element.</p>
   <button
+    type="button"
     #btn
     disabled
     [innerHTML]="'disabled by attribute: ' + btn.disabled"
@@ -98,5 +99,5 @@ See the console output to see that when you declare the variable on an <code>ng-
 
 <!-- #docregion template-ref -->
 <ng-template #ref3></ng-template>
-<button (click)="log(ref3)">Log type of #ref</button>
+<button type="button" (click)="log(ref3)">Log type of #ref</button>
 <!-- #enddocregion template-ref -->

--- a/aio/content/examples/template-syntax/src/app/app.component.html
+++ b/aio/content/examples/template-syntax/src/app/app.component.html
@@ -85,14 +85,14 @@
 <p>Component statement context ( (click)="onSave() )
 <div class="context">
   <!-- #docregion context-component-statement -->
-  <button (click)="deleteHero()">Delete hero</button>
+  <button type="button" (click)="deleteHero()">Delete hero</button>
   <!-- #enddocregion context-component-statement -->
 </div>
 
 <p>Template $event statement context</p>
 <div class="context">
   <!-- #docregion context-var-statement -->
-  <button (click)="onSave($event)">Save</button>
+  <button type="button" (click)="onSave($event)">Save</button>
   <!-- #enddocregion context-var-statement -->
 </div>
 
@@ -100,7 +100,7 @@
 <!-- template hides the following; plenty of examples later -->
 <div class="context">
   <!-- #docregion context-var-statement -->
-  <button *ngFor="let hero of heroes" (click)="deleteHero(hero)">{{hero.name}}</button>
+  <button type="button" *ngFor="let hero of heroes" (click)="deleteHero(hero)">{{hero.name}}</button>
   <!-- #enddocregion context-var-statement -->
 </div>
 
@@ -120,7 +120,7 @@
 <!-- Public Domain terms of use: https://wpclipart.com/terms.html -->
 <div class="special">Mental Model</div>
 <img [alt]="hero.name" src="assets/images/hero.png">
-<button disabled>Save</button>
+<button type="button" disabled>Save</button>
 <br><br>
 
 <div>
@@ -133,7 +133,7 @@
 
 <div>
   <!-- Bind button disabled state to `isUnchanged` property -->
-  <button [disabled]="isUnchanged">Save</button>
+  <button type="button" [disabled]="isUnchanged">Save</button>
 </div>
 <br><br>
 
@@ -147,7 +147,7 @@
 <br><br>
 
 <!-- #docregion event-binding-syntax-1 -->
-<button (click)="onSave()">Save</button>
+<button type="button" (click)="onSave()">Save</button>
 <app-hero-detail (deleteRequest)="deleteHero()"></app-hero-detail>
 <div (myClick)="clicked=$event" clickable>click me</div>
 <!-- #enddocregion event-binding-syntax-1 -->
@@ -164,7 +164,7 @@
 <br><br>
 
 <!-- #docregion attribute-binding-syntax-1 -->
-<button [attr.aria-label]="help">help</button>
+<button type="button" [attr.aria-label]="help">help</button>
 <!-- #enddocregion attribute-binding-syntax-1 -->
 <br><br>
 
@@ -174,7 +174,7 @@
 <br><br>
 
 <!-- #docregion style-binding-syntax-1 -->
-<button [style.color]="isSpecial ? 'red' : 'green'">
+<button type="button" [style.color]="isSpecial ? 'red' : 'green'">
 <!-- #enddocregion style-binding-syntax-1 -->
 button</button>
 
@@ -198,13 +198,13 @@ button</button>
 <hr><h2 id="buttons">Buttons</h2>
 
 <button>Enabled (but does nothing)</button>
-<button disabled>Disabled</button>
-<button disabled=false>Still disabled</button>
+<button type="button" disabled>Disabled</button>
+<button type="button" disabled=false>Still disabled</button>
 <br><br>
-<button disabled>disabled by attribute</button>
-<button [disabled]="isUnchanged">disabled by property binding</button>
+<button type="button" disabled>disabled by attribute</button>
+<button type="button" [disabled]="isUnchanged">disabled by property binding</button>
 <br><br>
-<button [disabled]="!canSave" (click)="onSave($event)">Enabled Save</button>
+<button type="button" [disabled]="!canSave" (click)="onSave($event)">Enabled Save</button>
 
 <a class="to-toc" href="#toc">top</a>
 
@@ -212,7 +212,7 @@ button</button>
 <hr><h2 id="property-binding">Property Binding</h2>
 
 <img [alt]="hero.name" [src]="heroImageUrl">
-<button [disabled]="isUnchanged">Cancel is disabled</button>
+<button type="button" [disabled]="isUnchanged">Cancel is disabled</button>
 <div [ngClass]="classes">[ngClass] binding to the classes property</div>
 <app-hero-detail [hero]="currentHero"></app-hero-detail>
 
@@ -259,18 +259,18 @@ button</button>
 
 <br>
 <!-- create and set an aria attribute for assistive technology -->
-<button [attr.aria-label]="actionName">{{actionName}} with Aria</button>
+<button type="button" [attr.aria-label]="actionName">{{actionName}} with Aria</button>
 <br><br>
 
 <!-- The following effects are not discussed in the chapter -->
 <div>
   <!-- any use of [attr.disabled] creates the disabled attribute -->
-  <button [attr.disabled]="isUnchanged">Disabled</button>
+  <button type="button" [attr.disabled]="isUnchanged">Disabled</button>
 
-  <button [attr.disabled]="!isUnchanged">Disabled as well</button>
+  <button type="button" [attr.disabled]="!isUnchanged">Disabled as well</button>
 
   <!-- we'd have to remove it with property binding -->
-  <button disabled [disabled]="false">Enabled (but inert)</button>
+  <button type="button" disabled [disabled]="false">Enabled (but inert)</button>
 </div>
 
 <a class="to-toc" href="#toc">top</a>
@@ -297,18 +297,18 @@ button</button>
 <!--style binding -->
 <hr><h2 id="style-binding">Style Binding</h2>
 
-<button [style.color]="isSpecial ? 'red': 'green'">Red</button>
-<button [style.background-color]="canSave ? 'cyan': 'grey'" >Save</button>
+<button type="button" [style.color]="isSpecial ? 'red': 'green'">Red</button>
+<button type="button" [style.background-color]="canSave ? 'cyan': 'grey'" >Save</button>
 
-<button [style.font-size.em]="isSpecial ? 3 : 1" >Big</button>
-<button [style.font-size.%]="!isSpecial ? 150 : 50" >Small</button>
+<button type="button" [style.font-size.em]="isSpecial ? 3 : 1" >Big</button>
+<button type="button" [style.font-size.%]="!isSpecial ? 150 : 50" >Small</button>
 
 <a class="to-toc" href="#toc">top</a>
 
 <!-- event binding -->
 <hr><h2 id="event-binding">Event Binding</h2>
 
-<button (click)="onSave()">Save</button>
+<button type="button" (click)="onSave()">Save</button>
 
 <div>
 <!-- `myClick` is an event on the custom `ClickDirective` -->
@@ -334,12 +334,12 @@ button</button>
 
 <!-- Will save only once -->
 <div (click)="onSave()" clickable>
-  <button (click)="onSave($event)">Save, no propagation</button>
+  <button type="button" (click)="onSave($event)">Save, no propagation</button>
 </div>
 
 <!-- Will save twice -->
 <div (click)="onSave()" clickable>
-  <button (click)="onSave()">Save w/ propagation</button>
+  <button type="button" (click)="onSave()">Save w/ propagation</button>
 </div>
 
 <!-- eslint-enable @angular-eslint/template/click-events-have-key-events -->
@@ -396,7 +396,7 @@ without NgModel
 <label>saveable   <input type="checkbox" [(ngModel)]="canSave"></label> |
 <label>modified:  <input type="checkbox" [value]="!isUnchanged" (change)="isUnchanged=!isUnchanged"></label> |
 <label>special:   <input type="checkbox" [(ngModel)]="isSpecial"></label>
-<button (click)="setCurrentClasses()">Refresh currentClasses</button>
+<button type="button" (click)="setCurrentClasses()">Refresh currentClasses</button>
 <br><br>
 <div [ngClass]="currentClasses">
   This div should be {{ canSave ? "": "not"}} saveable,
@@ -429,7 +429,7 @@ without NgModel
 <label>italic: <input type="checkbox" [(ngModel)]="canSave"></label> |
 <label>normal: <input type="checkbox" [(ngModel)]="isUnchanged"></label> |
 <label>xlarge: <input type="checkbox" [(ngModel)]="isSpecial"></label>
-<button (click)="setCurrentStyles()">Refresh currentStyles</button>
+<button type="button" (click)="setCurrentStyles()">Refresh currentStyles</button>
 <br><br>
 <div [ngStyle]="currentStyles">
   This div should be {{ canSave ? "italic": "plain"}},
@@ -498,9 +498,9 @@ without NgModel
 <a class="to-toc" href="#toc">top</a>
 
 <h4 id="ngFor-trackBy">*ngFor trackBy</h4>
-<button (click)="resetHeroes()">Reset heroes</button>
-<button (click)="changeIds()">Change ids</button>
-<button (click)="clearTrackByCounts()">Clear counts</button>
+<button type="button" (click)="resetHeroes()">Reset heroes</button>
+<button type="button" (click)="changeIds()">Change ids</button>
+<button type="button" (click)="clearTrackByCounts()">Clear counts</button>
 
 <p><i>without</i> trackBy</p>
 <div class="box">
@@ -574,10 +574,10 @@ without NgModel
 <!-- lots of other elements -->
 
 <!-- phone refers to the input element; pass its `value` to an event handler -->
-<button (click)="callPhone(phone.value)">Call</button>
+<button type="button" (click)="callPhone(phone.value)">Call</button>
 
 <!-- btn refers to the button element; show its disabled state -->
-<button #btn disabled [innerHTML]="'disabled by attribute: '+btn.disabled"></button>
+<button type="button" #btn disabled [innerHTML]="'disabled by attribute: '+btn.disabled"></button>
 
 <h4>Example Form</h4>
 <app-hero-form [hero]="currentHero"></app-hero-form>
@@ -588,7 +588,7 @@ without NgModel
 <hr><h2 id="inputs-and-outputs">Inputs and Outputs</h2>
 
 <img alt="icon" [src]="iconUrl"/>
-<button (click)="onSave()">Save</button>
+<button type="button" (click)="onSave()">Save</button>
 
 <app-hero-detail [hero]="currentHero" (deleteRequest)="deleteHero($event)">
 </app-hero-detail>
@@ -699,7 +699,7 @@ The null hero's name is {{nullHero && nullHero.name}}
 <p>
   The name of the Color.Red enum is {{Color[Color.Red]}}.<br>
   The current color is {{Color[color]}} and its number is {{color}}.<br>
-  <button [style.color]="Color[color]" (click)="colorToggle()">Enum Toggle</button>
+  <button type="button" [style.color]="Color[color]" (click)="colorToggle()">Enum Toggle</button>
 </p>
 
 <a class="to-toc" href="#toc">top</a>

--- a/aio/content/examples/template-syntax/src/app/app.component.html
+++ b/aio/content/examples/template-syntax/src/app/app.component.html
@@ -221,10 +221,14 @@ button</button>
 
 <app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
 
-<!-- eslint-disable @angular-eslint/template/accessibility-alt-text -->
-<p><img src="{{heroImageUrl}}"> is the <i>interpolated</i> image.</p>
-<p><img [src]="heroImageUrl"> is the <i>property bound</i> image.</p>
-<!-- eslint-enable @angular-eslint/template/accessibility-alt-text -->
+<p>
+  <img src="{{heroImageUrl}}" alt="interpolated image of {{currentHero.name}}">
+  is the <i>interpolated</i> image.
+</p>
+<p>
+  <img [src]="heroImageUrl" [alt]="'property bounded image of ' + currentHero.name">
+  is the <i>property bound</i> image.
+</p>
 
 <p><span>"{{title}}" is the <i>interpolated</i> title.</span></p>
 <p>"<span [innerHTML]="title"></span>" is the <i>property bound</i> title.</p>

--- a/aio/content/examples/template-syntax/src/app/app.component.html
+++ b/aio/content/examples/template-syntax/src/app/app.component.html
@@ -1,6 +1,5 @@
 <!-- #docplaster -->
-<a id="toc"></a>
-<h1>Template Syntax</h1>
+<h1 id="toc">Template Syntax</h1>
 <a href="#interpolation">Interpolation</a><br>
 <a href="#expression-context">Expression context</a><br>
 <a href="#statement-context">Statement context</a><br>
@@ -47,7 +46,7 @@
 
 <h3>
   {{title}}
-  <img src="{{heroImageUrl}}" style="height:30px">
+  <img alt="{{hero.name}}" src="{{heroImageUrl}}" style="height:30px">
 </h3>
 
 <!-- "The sum of 1 + 1 is 2" -->
@@ -120,7 +119,7 @@
 <!--<img src="https://wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png">-->
 <!-- Public Domain terms of use: https://wpclipart.com/terms.html -->
 <div class="special">Mental Model</div>
-<img src="assets/images/hero.png">
+<img [alt]="hero.name" src="assets/images/hero.png">
 <button disabled>Save</button>
 <br><br>
 
@@ -140,7 +139,7 @@
 
 <div>
   <!-- #docregion property-binding-syntax-1 -->
-  <img [src]="heroImageUrl">
+  <img [alt]="hero.name" [src]="heroImageUrl">
   <app-hero-detail [hero]="currentHero"></app-hero-detail>
   <div [ngClass]="{'special': isSpecial}"></div>
   <!-- #enddocregion property-binding-syntax-1 -->
@@ -181,6 +180,7 @@ button</button>
 
 <a class="to-toc" href="#toc">top</a>
 
+<!-- eslint-disable @angular-eslint/template/accessibility-alt-text -->
 <!-- property vs. attribute -->
 <hr><h2 id="prop-vs-attrib">Property vs. Attribute (img examples)</h2>
 <!-- examine the following <img> tag in the browser tools -->
@@ -191,7 +191,7 @@ button</button>
 
 <img [src]="iconUrl"/>
 <img [attr.src]="villainImageUrl"/>
-
+<!-- eslint-enable @angular-eslint/template/accessibility-alt-text -->
 <a class="to-toc" href="#toc">top</a>
 
 <!-- buttons -->
@@ -211,7 +211,7 @@ button</button>
 <!-- property binding -->
 <hr><h2 id="property-binding">Property Binding</h2>
 
-<img [src]="heroImageUrl">
+<img [alt]="hero.name" [src]="heroImageUrl">
 <button [disabled]="isUnchanged">Cancel is disabled</button>
 <div [ngClass]="classes">[ngClass] binding to the classes property</div>
 <app-hero-detail [hero]="currentHero"></app-hero-detail>
@@ -221,8 +221,10 @@ button</button>
 
 <app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
 
+<!-- eslint-disable @angular-eslint/template/accessibility-alt-text -->
 <p><img src="{{heroImageUrl}}"> is the <i>interpolated</i> image.</p>
 <p><img [src]="heroImageUrl"> is the <i>property bound</i> image.</p>
+<!-- eslint-enable @angular-eslint/template/accessibility-alt-text -->
 
 <p><span>"{{title}}" is the <i>interpolated</i> title.</span></p>
 <p>"<span [innerHTML]="title"></span>" is the <i>property bound</i> title.</p>
@@ -320,6 +322,8 @@ button</button>
     [hero]="currentHero">
 </app-big-hero-detail>
 
+<!-- eslint-disable @angular-eslint/template/click-events-have-key-events -->
+
 <div class="parent-div" (click)="onClickMe($event)" clickable>Click me
   <div class="child-div">Click me too!</div>
 </div>
@@ -333,6 +337,8 @@ button</button>
 <div (click)="onSave()" clickable>
   <button (click)="onSave()">Save w/ propagation</button>
 </div>
+
+<!-- eslint-enable @angular-eslint/template/click-events-have-key-events -->
 
 <a class="to-toc" href="#toc">top</a>
 
@@ -577,7 +583,7 @@ without NgModel
 <!-- inputs and output -->
 <hr><h2 id="inputs-and-outputs">Inputs and Outputs</h2>
 
-<img [src]="iconUrl"/>
+<img alt="icon" [src]="iconUrl"/>
 <button (click)="onSave()">Save</button>
 
 <app-hero-detail [hero]="currentHero" (deleteRequest)="deleteHero($event)">
@@ -608,7 +614,7 @@ without NgModel
 
 <div>
   <!-- pipe price to USD and display the $ symbol -->
-  <label>Price: </label>{{product.price | currency:'USD':'symbol'}}
+  <span>Price: </span>{{product.price | currency:'USD':'symbol'}}
 </div>
 
 <a class="to-toc" href="#toc">top</a>

--- a/aio/content/examples/template-syntax/src/app/hero-detail.component.ts
+++ b/aio/content/examples/template-syntax/src/app/hero-detail.component.ts
@@ -14,7 +14,7 @@ import { Hero } from './hero';
     <span [style.text-decoration]="lineThrough">
       {{prefix}} {{hero.name}}
     </span>
-    <button (click)="delete()">Delete</button>
+    <button type="button" (click)="delete()">Delete</button>
   </div>`
 })
 export class HeroDetailComponent {
@@ -46,7 +46,7 @@ export class HeroDetailComponent {
     <div>Web: <a href="{{hero.url}}" target="_blank">{{hero.url}}</a></div>
     <div>Rate/hr: {{hero.rate | currency:'EUR'}}</div>
     <br clear="all">
-    <button (click)="delete()">Delete</button>
+    <button type="button" (click)="delete()">Delete</button>
   </div>
   `,
   styles: [`

--- a/aio/content/examples/template-syntax/src/app/hero-detail.component.ts
+++ b/aio/content/examples/template-syntax/src/app/hero-detail.component.ts
@@ -10,7 +10,7 @@ import { Hero } from './hero';
   styles: ['button {margin-left: 8px} div {margin: 8px 0} img {height:24px}'],
   template: `
   <div>
-    <img src="{{heroImageUrl}}">
+    <img src="{{heroImageUrl}}" alt="{{hero.name}}">
     <span [style.text-decoration]="lineThrough">
       {{prefix}} {{hero.name}}
     </span>
@@ -38,7 +38,7 @@ export class HeroDetailComponent {
   selector: 'app-big-hero-detail',
   template: `
   <div class="detail">
-    <img src="{{heroImageUrl}}">
+    <img src="{{heroImageUrl}}" alt="{{hero.name}}">
     <div><b>{{hero.name}}</b></div>
     <div>Name: {{hero.name}}</div>
     <div>Emotion: {{hero.emotion}}</div>

--- a/aio/content/examples/template-syntax/src/app/sizer.component.ts
+++ b/aio/content/examples/template-syntax/src/app/sizer.component.ts
@@ -5,8 +5,8 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   selector: 'app-sizer',
   template: `
   <div>
-    <button (click)="dec()" title="smaller">-</button>
-    <button (click)="inc()" title="bigger">+</button>
+    <button type="button" (click)="dec()" title="smaller">-</button>
+    <button type="button" (click)="inc()" title="bigger">+</button>
     <span [style.font-size.px]="size">FontSize: {{size}}px</span>
   </div>`
 })

--- a/aio/content/examples/template-syntax/src/app/sizer.component.ts
+++ b/aio/content/examples/template-syntax/src/app/sizer.component.ts
@@ -7,7 +7,7 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
   <div>
     <button (click)="dec()" title="smaller">-</button>
     <button (click)="inc()" title="bigger">+</button>
-    <label [style.font-size.px]="size">FontSize: {{size}}px</label>
+    <span [style.font-size.px]="size">FontSize: {{size}}px</span>
   </div>`
 })
 export class SizerComponent {

--- a/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.css
+++ b/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.css
@@ -4,6 +4,7 @@
 	text-align: center;
 	color: #eee;
 	max-height: 120px;
+	width: 100%;
 	min-width: 120px;
 	background-color: #607D8B;
 	border-radius: 2px;

--- a/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.ts
+++ b/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.ts
@@ -7,9 +7,9 @@ import { Hero } from '../model/hero';
 @Component({
   selector: 'dashboard-hero',
   template: `
-    <div (click)="click()" class="hero">
+    <button (click)="click()" class="hero">
       {{hero.name | uppercase}}
-    </div>
+    </button>
   `,
   styleUrls: [ './dashboard-hero.component.css' ]
 })

--- a/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.ts
+++ b/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.ts
@@ -7,7 +7,7 @@ import { Hero } from '../model/hero';
 @Component({
   selector: 'dashboard-hero',
   template: `
-    <button (click)="click()" class="hero">
+    <button type="button" (click)="click()" class="hero">
       {{hero.name | uppercase}}
     </button>
   `,

--- a/aio/content/examples/testing/src/app/demo/demo.testbed.spec.ts
+++ b/aio/content/examples/testing/src/app/demo/demo.testbed.spec.ts
@@ -288,8 +288,6 @@ describe('demo (with TestBed):', () => {
 
         // Dispatch a DOM event so that Angular learns of input value change.
         // then wait while ngModel pushes input.box value to comp.name
-        // In older browsers, such as IE, you might need a CustomEvent instead. See
-        // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
         input.dispatchEvent(new Event('input'));
         return fixture.whenStable();
       })
@@ -332,8 +330,6 @@ describe('demo (with TestBed):', () => {
 
       // Dispatch a DOM event so that Angular learns of input value change.
       // then wait a tick while ngModel pushes input.box value to comp.name
-      // In older browsers, such as IE, you might need a CustomEvent instead. See
-      // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
       input.dispatchEvent(new Event('input'));
       tick();
       expect(comp.name)
@@ -358,8 +354,6 @@ describe('demo (with TestBed):', () => {
       // Dispatch a DOM event so that Angular learns of input value change.
       // then wait a tick while ngModel pushes input.box value to comp.text
       // and Angular updates the output span
-      // In older browsers, such as IE, you might need a CustomEvent instead. See
-      // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
       input.dispatchEvent(new Event('input'));
       tick();
       fixture.detectChanges();

--- a/aio/content/examples/testing/src/app/demo/demo.ts
+++ b/aio/content/examples/testing/src/app/demo/demo.ts
@@ -184,7 +184,7 @@ export class ParentComponent { }
 
 @Component({
   selector: 'io-comp',
-  template: '<div class="hero" (click)="click()">Original {{hero.name}}</div>'
+  template: '<button class="hero" (click)="click()">Original {{hero.name}}</button>'
 })
 export class IoComponent {
   @Input() hero!: Hero;

--- a/aio/content/examples/testing/src/app/demo/demo.ts
+++ b/aio/content/examples/testing/src/app/demo/demo.ts
@@ -95,7 +95,7 @@ export class BankAccountParentComponent {
 @Component({
   selector: 'lightswitch-comp',
   template: `
-    <button (click)="clicked()">Click me!</button>
+    <button type="button" (click)="clicked()">Click me!</button>
     <span>{{message}}</span>`
 })
 export class LightswitchComponent {
@@ -184,7 +184,7 @@ export class ParentComponent { }
 
 @Component({
   selector: 'io-comp',
-  template: '<button class="hero" (click)="click()">Original {{hero.name}}</button>'
+  template: '<button type="button" class="hero" (click)="click()">Original {{hero.name}}</button>'
 })
 export class IoComponent {
   @Input() hero!: Hero;
@@ -325,7 +325,7 @@ export class MyIfChildComponent implements OnInit, OnChanges, OnDestroy {
     <label>Parent value:
       <input [(ngModel)]="parentValue">
     </label>
-    <button (click)="clicked()">{{toggleLabel}} Child</button><br>
+    <button type="button" (click)="clicked()">{{toggleLabel}} Child</button><br>
     <div *ngIf="showChild"
          style="margin: 4px; padding: 4px; background-color: aliceblue;">
       <my-if-child-1  [(value)]="parentValue"></my-if-child-1>

--- a/aio/content/examples/testing/src/app/hero/hero-detail.component.html
+++ b/aio/content/examples/testing/src/app/hero/hero-detail.component.html
@@ -7,6 +7,6 @@
     <label for="name">name: </label>
     <input id="name" [(ngModel)]="hero.name" placeholder="name" />
   </div>
-  <button (click)="save()">Save</button>
-  <button (click)="cancel()">Cancel</button>
+  <button type="button" (click)="save()">Save</button>
+  <button type="button" (click)="cancel()">Cancel</button>
 </div>

--- a/aio/content/examples/testing/src/app/hero/hero-detail.component.html
+++ b/aio/content/examples/testing/src/app/hero/hero-detail.component.html
@@ -2,7 +2,7 @@
 <div *ngIf="hero">
   <h2><span>{{hero.name | titlecase}}</span> Details</h2>
   <div>
-    <label>id: </label>{{hero.id}}</div>
+    <span>id: </span>{{hero.id}}</div>
   <div>
     <label for="name">name: </label>
     <input id="name" [(ngModel)]="hero.name" placeholder="name" />

--- a/aio/content/examples/testing/src/app/hero/hero-detail.component.spec.ts
+++ b/aio/content/examples/testing/src/app/hero/hero-detail.component.spec.ts
@@ -102,8 +102,6 @@ function overrideSetup() {
 
        page.nameInput.value = newName;
 
-       // In older browsers, such as IE, you might need a CustomEvent instead. See
-       // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
        page.nameInput.dispatchEvent(new Event('input')); // tell Angular
 
        expect(component.hero.name)
@@ -223,8 +221,6 @@ function heroModuleSetup() {
       nameInput.value = 'quick BROWN  fOx';
 
       // Dispatch a DOM event so that Angular learns of input value change.
-      // In older browsers, such as IE, you might need a CustomEvent instead. See
-      // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
       nameInput.dispatchEvent(new Event('input'));
 
       // Tell Angular to update the display binding through the title pipe

--- a/aio/content/examples/testing/src/app/hero/hero-list.component.css
+++ b/aio/content/examples/testing/src/app/hero/hero-list.component.css
@@ -2,57 +2,70 @@
   background-color: #CFD8DC !important;
   color: white;
 }
+
 .heroes {
   margin: 0 0 2em 0;
   list-style-type: none;
   padding: 0;
   width: 15em;
 }
+
 .heroes li {
+  display: flex;
+}
+
+.heroes button {
+  flex: 1;
   cursor: pointer;
   position: relative;
   left: 0;
   background-color: #EEE;
   margin: .5em;
-  padding: .3em 0;
+  padding: 0;
   height: 1.6em;
   border-radius: 4px;
+  display: flex;
+  align-items: stretch;
+  height: 1.8em;
 }
-.heroes li:hover {
-  color: #607D8B;
-  background-color: #DDD;
+
+.heroes button:hover {
+  color: #2c3a41;
+  background-color: #e6e6e6;
   left: .1em;
 }
-.heroes li.selected:hover {
-  background-color: #BBD8DC !important;
+
+.heroes button:active {
+  background-color: #525252;
+  color: #fafafa;
+}
+
+.heroes button.selected {
+  background-color: black;
   color: white;
 }
-.heroes .text {
-  position: relative;
-  top: -3px;
+
+.heroes button.selected:hover {
+  background-color: #505050;
+  color: white;
 }
+
+.heroes button.selected:active {
+  background-color: black;
+  color: white;
+}
+
 .heroes .badge {
   display: inline-block;
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color: #607D8B;
+  background-color: #405061;
   line-height: 1em;
-  position: relative;
-  left: -1px;
-  top: -4px;
-  height: 1.8em;
   margin-right: .8em;
   border-radius: 4px 0 0 4px;
 }
-button {
-  font-family: Arial, sans-serif;
-  background-color: #eee;
-  border: none;
-  padding: 5px 10px;
-  border-radius: 4px;
-  cursor: pointer;
-}
-button:hover {
-  background-color: #cfd8dc;
+
+.heroes .name {
+  align-self: center;
 }

--- a/aio/content/examples/testing/src/app/hero/hero-list.component.html
+++ b/aio/content/examples/testing/src/app/hero/hero-list.component.html
@@ -1,8 +1,9 @@
 <h2 highlight="gold">My Heroes</h2>
 <ul class="heroes">
-  <li *ngFor="let hero of heroes | async "
-    [class.selected]="hero === selectedHero"
-    (click)="onSelect(hero)">
-    <span class="badge">{{hero.id}}</span> {{hero.name}}
+  <li *ngFor="let hero of heroes | async ">
+    <button [class.selected]="hero === selectedHero" (click)="onSelect(hero)">
+      <span class="badge">{{hero.id}}</span>
+      <span class="name">{{hero.name}}</span>
+    </button>
   </li>
 </ul>

--- a/aio/content/examples/testing/src/app/hero/hero-list.component.html
+++ b/aio/content/examples/testing/src/app/hero/hero-list.component.html
@@ -1,7 +1,7 @@
 <h2 highlight="gold">My Heroes</h2>
 <ul class="heroes">
   <li *ngFor="let hero of heroes | async ">
-    <button [class.selected]="hero === selectedHero" (click)="onSelect(hero)">
+    <button [class.selected]="hero === selectedHero" type="button" (click)="onSelect(hero)">
       <span class="badge">{{hero.id}}</span>
       <span class="name">{{hero.name}}</span>
     </button>

--- a/aio/content/examples/testing/src/app/hero/hero-list.component.spec.ts
+++ b/aio/content/examples/testing/src/app/hero/hero-list.component.spec.ts
@@ -58,8 +58,6 @@ describe('HeroListComponent', () => {
        const expectedHero = HEROES[1];
        const btn = page.heroRows[1].querySelector('button');
 
-       // In older browsers, such as IE, you might need a CustomEvent instead. See
-       // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
        btn!.dispatchEvent(new Event('click'));
        tick();
        // `.toEqual` because selectedHero is clone of expectedHero; see FakeHeroService
@@ -70,8 +68,6 @@ describe('HeroListComponent', () => {
        const expectedHero = HEROES[1];
        const btn = page.heroRows[1].querySelector('button');
 
-       // In older browsers, such as IE, you might need a CustomEvent instead. See
-       // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
        btn!.dispatchEvent(new Event('click'));
        tick();
 

--- a/aio/content/examples/testing/src/app/hero/hero-list.component.spec.ts
+++ b/aio/content/examples/testing/src/app/hero/hero-list.component.spec.ts
@@ -60,7 +60,7 @@ describe('HeroListComponent', () => {
 
        // In older browsers, such as IE, you might need a CustomEvent instead. See
        // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
-       li.dispatchEvent(new Event('click'));
+       li.firstChild!.dispatchEvent(new Event('click'));
        tick();
        // `.toEqual` because selectedHero is clone of expectedHero; see FakeHeroService
        expect(comp.selectedHero).toEqual(expectedHero);
@@ -72,7 +72,7 @@ describe('HeroListComponent', () => {
 
        // In older browsers, such as IE, you might need a CustomEvent instead. See
        // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
-       li.dispatchEvent(new Event('click'));
+       li.firstChild!.dispatchEvent(new Event('click'));
        tick();
 
        // should have navigated

--- a/aio/content/examples/testing/src/app/hero/hero-list.component.spec.ts
+++ b/aio/content/examples/testing/src/app/hero/hero-list.component.spec.ts
@@ -56,11 +56,11 @@ describe('HeroListComponent', () => {
 
   it('should select hero on click', fakeAsync(() => {
        const expectedHero = HEROES[1];
-       const li = page.heroRows[1];
+       const btn = page.heroRows[1].querySelector('button');
 
        // In older browsers, such as IE, you might need a CustomEvent instead. See
        // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
-       li.firstChild!.dispatchEvent(new Event('click'));
+       btn!.dispatchEvent(new Event('click'));
        tick();
        // `.toEqual` because selectedHero is clone of expectedHero; see FakeHeroService
        expect(comp.selectedHero).toEqual(expectedHero);
@@ -68,11 +68,11 @@ describe('HeroListComponent', () => {
 
   it('should navigate to selected hero detail on click', fakeAsync(() => {
        const expectedHero = HEROES[1];
-       const li = page.heroRows[1];
+       const btn = page.heroRows[1].querySelector('button');
 
        // In older browsers, such as IE, you might need a CustomEvent instead. See
        // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
-       li.firstChild!.dispatchEvent(new Event('click'));
+       btn!.dispatchEvent(new Event('click'));
        tick();
 
        // should have navigated

--- a/aio/content/examples/testing/src/app/shared/highlight.directive.spec.ts
+++ b/aio/content/examples/testing/src/app/shared/highlight.directive.spec.ts
@@ -63,8 +63,6 @@ describe('HighlightDirective', () => {
     input.value = 'green';
 
     // Dispatch a DOM event so that Angular responds to the input value change.
-    // In older browsers, such as IE, you might need a CustomEvent instead. See
-    // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill
     input.dispatchEvent(new Event('input'));
     fixture.detectChanges();
 

--- a/aio/content/examples/testing/src/app/twain/twain.component.ts
+++ b/aio/content/examples/testing/src/app/twain/twain.component.ts
@@ -11,7 +11,7 @@ import { TwainService } from './twain.service';
   // #docregion template
   template: `
     <p class="twain"><i>{{quote | async}}</i></p>
-    <button (click)="getQuote()">Next quote</button>
+    <button type="button" (click)="getQuote()">Next quote</button>
     <p class="error" *ngIf="errorMessage">{{ errorMessage }}</p>`,
   // #enddocregion template
   styles: [

--- a/aio/content/examples/toh-pt2/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/toh-pt2/e2e/src/app.e2e-spec.ts
@@ -66,7 +66,7 @@ function initialPageTests() {
 
 function selectHeroTests() {
   it(`selects ${targetHero.name} from hero list`, async () => {
-    const hero = element(by.cssContainingText('li span.badge', targetHero.id.toString()));
+    const hero = element(by.cssContainingText('button span.badge', targetHero.id.toString()));
     await hero.click();
     // Nothing specific to expect other than lack of exceptions.
   });
@@ -74,7 +74,7 @@ function selectHeroTests() {
   it(`has selected ${targetHero.name}`, async () => {
     const page = getPageElts();
     const expectedText = `${targetHero.id} ${targetHero.name}`;
-    expect(await page.selected.getText()).toBe(expectedText);
+    expect((await page.selected.getText()).replace('\n', ' ')).toBe(expectedText);
   });
 
   it('shows selected hero details', async () => {
@@ -101,7 +101,7 @@ function updateHeroTests() {
 
   it(`shows updated hero name in list`, async () => {
     const page = getPageElts();
-    const hero = Hero.fromString(await page.selected.getText());
+    const hero = Hero.fromString((await page.selected.getText()).replace('\n', ' '));
     const newName = targetHero.name + nameSuffix;
     expect(hero.id).toEqual(targetHero.id);
     expect(hero.name).toEqual(newName);
@@ -122,8 +122,8 @@ async function expectHeading(hLevel: number, expectedText: string): Promise<void
 
 function getPageElts() {
   return {
-    heroes: element.all(by.css('app-root li')),
-    selected: element(by.css('app-root li.selected')),
+    heroes: element.all(by.css('app-root li button')),
+    selected: element(by.css('app-root li button.selected')),
     heroDetail: element(by.css('app-root > div, app-root > app-heroes > div'))
   };
 }

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.1.html
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.1.html
@@ -13,7 +13,7 @@
 
 <!-- #docregion selectedHero-click -->
 <li *ngFor="let hero of heroes">
-  <button (click)="onSelect(hero)">
+  <button type="button" (click)="onSelect(hero)">
 <!-- #enddocregion selectedHero-click -->
 
 <!-- #docregion class-selected -->

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.1.html
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.1.html
@@ -12,6 +12,7 @@
 <!-- #enddocregion li -->
 
 <!-- #docregion selectedHero-click -->
+<!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
 <li *ngFor="let hero of heroes" (click)="onSelect(hero)">
 <!-- #enddocregion selectedHero-click -->
 

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.1.html
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.1.html
@@ -12,8 +12,8 @@
 <!-- #enddocregion li -->
 
 <!-- #docregion selectedHero-click -->
-<!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
-<li *ngFor="let hero of heroes" (click)="onSelect(hero)">
+<li *ngFor="let hero of heroes">
+  <button (click)="onSelect(hero)">
 <!-- #enddocregion selectedHero-click -->
 
 <!-- #docregion class-selected -->

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.css
@@ -5,48 +5,63 @@
   padding: 0;
   width: 15em;
 }
+
 .heroes li {
+  display: flex;
+}
+
+.heroes button {
+  flex: 1;
   cursor: pointer;
   position: relative;
   left: 0;
   background-color: #EEE;
   margin: .5em;
-  padding: .3em 0;
+  padding: 0;
   height: 1.6em;
   border-radius: 4px;
+  display: flex;
+  align-items: stretch;
+  height: 1.8em;
 }
-.heroes li:hover {
+
+.heroes button:hover {
   color: #2c3a41;
   background-color: #e6e6e6;
   left: .1em;
 }
-.heroes li.selected {
+
+.heroes button:active {
+  background-color: #525252;
+  color: #fafafa;
+}
+
+.heroes button.selected {
   background-color: black;
   color: white;
 }
-.heroes li.selected:hover {
+
+.heroes button.selected:hover {
   background-color: #505050;
   color: white;
 }
-.heroes li.selected:active {
+
+.heroes button.selected:active {
   background-color: black;
   color: white;
 }
+
 .heroes .badge {
   display: inline-block;
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color:#405061;
+  background-color: #405061;
   line-height: 1em;
-  position: relative;
-  left: -1px;
-  top: -4px;
-  height: 1.8em;
   margin-right: .8em;
   border-radius: 4px 0 0 4px;
 }
 
-input {
-  padding: .5rem;
+.heroes .name {
+  align-self: center;
 }

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.html
@@ -3,7 +3,7 @@
 <ul class="heroes">
   <!-- #docregion li -->
   <li *ngFor="let hero of heroes">
-    <button [class.selected]="hero === selectedHero" (click)="onSelect(hero)">
+    <button [class.selected]="hero === selectedHero" type="button" (click)="onSelect(hero)">
       <span class="badge">{{hero.id}}</span>
       <span class="name">{{hero.name}}</span>
     </button>

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.html
@@ -16,7 +16,7 @@
 
   <!-- #docregion selectedHero-details -->
   <h2>{{selectedHero.name | uppercase}} Details</h2>
-  <div><span>id: </span>{{selectedHero.id}}</div>
+  <div>id: {{selectedHero.id}}</div>
   <div>
     <label for="hero-name">Hero name: </label>
     <input id="hero-name" [(ngModel)]="selectedHero.name" placeholder="name">

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.html
@@ -2,10 +2,11 @@
 <h2>My Heroes</h2>
 <ul class="heroes">
   <!-- #docregion li -->
-  <li *ngFor="let hero of heroes"
-    [class.selected]="hero === selectedHero"
-    (click)="onSelect(hero)">
-    <span class="badge">{{hero.id}}</span> {{hero.name}}
+  <li *ngFor="let hero of heroes">
+    <button [class.selected]="hero === selectedHero" (click)="onSelect(hero)">
+      <span class="badge">{{hero.id}}</span>
+      <span class="name">{{hero.name}}</span>
+    </button>
   </li>
   <!-- #enddocregion li -->
 </ul>

--- a/aio/content/examples/toh-pt3/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/toh-pt3/e2e/src/app.e2e-spec.ts
@@ -66,7 +66,7 @@ function initialPageTests() {
 
 function selectHeroTests() {
   it(`selects ${targetHero.name} from hero list`, async () => {
-    const hero = element(by.cssContainingText('li span.badge', targetHero.id.toString()));
+    const hero = element(by.cssContainingText('li button', targetHero.id.toString() + targetHero.name.toString()));
     await hero.click();
     // Nothing specific to expect other than lack of exceptions.
   });
@@ -74,7 +74,7 @@ function selectHeroTests() {
   it(`has selected ${targetHero.name}`, async () => {
     const page = getPageElts();
     const expectedText = `${targetHero.id} ${targetHero.name}`;
-    expect(await page.selected.getText()).toBe(expectedText);
+    expect((await page.selected.getText()).replace('\n', ' ')).toBe(expectedText);
   });
 
   it('shows selected hero details', async () => {
@@ -101,7 +101,7 @@ function updateHeroTests() {
 
   it(`shows updated hero name in list`, async () => {
     const page = getPageElts();
-    const hero = Hero.fromString(await page.selected.getText());
+    const hero = Hero.fromString(await (await page.selected.getText()).replace('\n', ' '));
     const newName = targetHero.name + nameSuffix;
     expect(hero.id).toEqual(targetHero.id);
     expect(hero.name).toEqual(newName);
@@ -122,8 +122,8 @@ async function expectHeading(hLevel: number, expectedText: string): Promise<void
 
 function getPageElts() {
   return {
-    heroes: element.all(by.css('app-root li')),
-    selected: element(by.css('app-root li.selected')),
+    heroes: element.all(by.css('app-root li button')),
+    selected: element(by.css('app-root li button.selected')),
     heroDetail: element(by.css('app-root > div, app-root > app-heroes > app-hero-detail > div'))
   };
 }

--- a/aio/content/examples/toh-pt3/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt3/src/app/heroes/heroes.component.css
@@ -6,43 +6,61 @@
   width: 15em;
 }
 .heroes li {
+  display: flex;
+}
+
+.heroes button {
+  flex: 1;
   cursor: pointer;
   position: relative;
   left: 0;
   background-color: #EEE;
   margin: .5em;
-  padding: .3em 0;
+  padding: 0;
   height: 1.6em;
   border-radius: 4px;
+  display: flex;
+  align-items: stretch;
+  height: 1.8em;
 }
-.heroes li:hover {
+
+.heroes button:hover {
   color: #2c3a41;
   background-color: #e6e6e6;
   left: .1em;
 }
-.heroes li.selected {
+
+.heroes button:active {
+  background-color: #525252;
+  color: #fafafa;
+}
+
+.heroes button.selected {
   background-color: black;
   color: white;
 }
-.heroes li.selected:hover {
+
+.heroes button.selected:hover {
   background-color: #505050;
   color: white;
 }
-.heroes li.selected:active {
+
+.heroes button.selected:active {
   background-color: black;
   color: white;
 }
+
 .heroes .badge {
   display: inline-block;
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color:#405061;
+  background-color: #405061;
   line-height: 1em;
-  position: relative;
-  left: -1px;
-  top: -4px;
-  height: 1.8em;
   margin-right: .8em;
   border-radius: 4px 0 0 4px;
+}
+
+.heroes .name {
+  align-self: center;
 }

--- a/aio/content/examples/toh-pt3/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/toh-pt3/src/app/heroes/heroes.component.html
@@ -1,10 +1,11 @@
 <h2>My Heroes</h2>
 
 <ul class="heroes">
-  <li *ngFor="let hero of heroes"
-    [class.selected]="hero === selectedHero"
-    (click)="onSelect(hero)">
-    <span class="badge">{{hero.id}}</span> {{hero.name}}
+  <li *ngFor="let hero of heroes">
+    <button [class.selected]="hero === selectedHero" (click)="onSelect(hero)">
+      <span class="badge">{{hero.id}}</span>
+      <span class="name">{{hero.name}}</span>
+    </button>
   </li>
 </ul>
 

--- a/aio/content/examples/toh-pt3/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/toh-pt3/src/app/heroes/heroes.component.html
@@ -2,7 +2,7 @@
 
 <ul class="heroes">
   <li *ngFor="let hero of heroes">
-    <button [class.selected]="hero === selectedHero" (click)="onSelect(hero)">
+    <button [class.selected]="hero === selectedHero" type="button" (click)="onSelect(hero)">
       <span class="badge">{{hero.id}}</span>
       <span class="name">{{hero.name}}</span>
     </button>

--- a/aio/content/examples/toh-pt4/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/toh-pt4/e2e/src/app.e2e-spec.ts
@@ -74,7 +74,7 @@ function selectHeroTests() {
   it(`has selected ${targetHero.name}`, async () => {
     const page = getPageElts();
     const expectedText = `${targetHero.id} ${targetHero.name}`;
-    expect(await page.selected.getText()).toBe(expectedText);
+    expect((await page.selected.getText()).replace('\n', ' ')).toBe(expectedText);
   });
 
   it('shows selected hero details', async () => {
@@ -106,7 +106,7 @@ function updateHeroTests() {
 
   it(`shows updated hero name in list`, async () => {
     const page = getPageElts();
-    const hero = Hero.fromString(await page.selected.getText());
+    const hero = Hero.fromString((await page.selected.getText()).replace('\n', ' '));
     const newName = targetHero.name + nameSuffix;
     expect(hero.id).toEqual(targetHero.id);
     expect(hero.name).toEqual(newName);
@@ -127,8 +127,8 @@ async function expectHeading(hLevel: number, expectedText: string): Promise<void
 
 function getPageElts() {
   return {
-    heroes: element.all(by.css('app-root li')),
-    selected: element(by.css('app-root li.selected')),
+    heroes: element.all(by.css('app-root li button')),
+    selected: element(by.css('app-root li button.selected')),
     heroDetail: element(by.css('app-root > div, app-root > app-heroes > app-hero-detail > div'))
   };
 }

--- a/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.css
@@ -5,49 +5,63 @@
   padding: 0;
   width: 15em;
 }
+
 .heroes li {
+  display: flex;
+}
+
+.heroes button {
+  flex: 1;
   cursor: pointer;
   position: relative;
   left: 0;
   background-color: #EEE;
   margin: .5em;
-  padding: .3em 0;
+  padding: 0;
   height: 1.6em;
   border-radius: 4px;
+  display: flex;
+  align-items: stretch;
+  height: 1.8em;
 }
-.heroes li:hover {
+
+.heroes button:hover {
   color: #2c3a41;
   background-color: #e6e6e6;
   left: .1em;
 }
-.heroes li:active {
+
+.heroes button:active {
   background-color: #525252;
   color: #fafafa;
 }
-.heroes li.selected {
+
+.heroes button.selected {
   background-color: black;
   color: white;
 }
-.heroes li.selected:hover {
+
+.heroes button.selected:hover {
   background-color: #505050;
   color: white;
 }
-.heroes li.selected:active {
+
+.heroes button.selected:active {
   background-color: black;
   color: white;
 }
+
 .heroes .badge {
   display: inline-block;
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color:#405061;
+  background-color: #405061;
   line-height: 1em;
-  position: relative;
-  left: -1px;
-  top: -4px;
-  height: 1.8em;
   margin-right: .8em;
   border-radius: 4px 0 0 4px;
 }
 
+.heroes .name {
+  align-self: center;
+}

--- a/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.html
@@ -1,10 +1,11 @@
 <h2>My Heroes</h2>
 <!-- #docregion list -->
 <ul class="heroes">
-  <li *ngFor="let hero of heroes"
-    [class.selected]="hero === selectedHero"
-    (click)="onSelect(hero)">
-    <span class="badge">{{hero.id}}</span> {{hero.name}}
+  <li *ngFor="let hero of heroes">
+    <button (click)="onSelect(hero)" [class.selected]="hero === selectedHero">
+      <span class="badge">{{hero.id}}</span>
+      <span class="name">{{hero.name}}</span>
+    </button>
   </li>
 </ul>
 <!-- #enddocregion list -->

--- a/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/toh-pt4/src/app/heroes/heroes.component.html
@@ -2,7 +2,7 @@
 <!-- #docregion list -->
 <ul class="heroes">
   <li *ngFor="let hero of heroes">
-    <button (click)="onSelect(hero)" [class.selected]="hero === selectedHero">
+    <button type="button" (click)="onSelect(hero)" [class.selected]="hero === selectedHero">
       <span class="badge">{{hero.id}}</span>
       <span class="name">{{hero.name}}</span>
     </button>

--- a/aio/content/examples/toh-pt4/src/app/messages/messages.component.html
+++ b/aio/content/examples/toh-pt4/src/app/messages/messages.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="messageService.messages.length">
 
   <h2>Messages</h2>
-  <button class="clear"
+  <button type="button" class="clear"
           (click)="messageService.clear()">Clear messages</button>
   <div *ngFor='let message of messageService.messages'> {{message}} </div>
 

--- a/aio/content/examples/toh-pt5/src/app/hero-detail/hero-detail.component.html
+++ b/aio/content/examples/toh-pt5/src/app/hero-detail/hero-detail.component.html
@@ -6,6 +6,6 @@
     <input id="hero-name" [(ngModel)]="hero.name" placeholder="Hero name"/>
   </div>
   <!-- #docregion back-button -->
-  <button (click)="goBack()">go back</button>
+  <button type="button" (click)="goBack()">go back</button>
   <!-- #enddocregion back-button -->
 </div>

--- a/aio/content/examples/toh-pt5/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt5/src/app/heroes/heroes.component.css
@@ -41,7 +41,7 @@
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color:#405061;
+  background-color: #405061;
   line-height: 1em;
   position: relative;
   left: -1px;

--- a/aio/content/examples/toh-pt5/src/app/messages/messages.component.html
+++ b/aio/content/examples/toh-pt5/src/app/messages/messages.component.html
@@ -1,7 +1,8 @@
 <div *ngIf="messageService.messages.length">
 
   <h2>Messages</h2>
-  <button class="clear"
+  <button type="button"
+          class="clear"
           (click)="messageService.clear()">Clear messages</button>
   <div *ngFor="let message of messageService.messages"> {{message}} </div>
 

--- a/aio/content/examples/toh-pt6/src/app/hero-detail/hero-detail.component.html
+++ b/aio/content/examples/toh-pt6/src/app/hero-detail/hero-detail.component.html
@@ -5,8 +5,8 @@
     <label for="hero-name">Hero name: </label>
     <input id="hero-name" [(ngModel)]="hero.name" placeholder="Hero name"/>
   </div>
-  <button (click)="goBack()">go back</button>
+  <button type="button" (click)="goBack()">go back</button>
   <!-- #docregion save -->
-  <button (click)="save()">save</button>
+  <button type="button" (click)="save()">save</button>
   <!-- #enddocregion save -->
 </div>

--- a/aio/content/examples/toh-pt6/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/toh-pt6/src/app/heroes/heroes.component.css
@@ -50,7 +50,7 @@ input {
   font-size: small;
   color: white;
   padding: 0.8em 0.7em 0 0.7em;
-  background-color:#405061;
+  background-color: #405061;
   line-height: 1em;
   position: relative;
   left: -1px;
@@ -80,6 +80,7 @@ button.delete {
   background-color: white;
   color:  #525252;
   font-size: 1.1rem;
+  margin: 0;
   padding: 1px 10px 3px 10px;
 }
 

--- a/aio/content/examples/toh-pt6/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/toh-pt6/src/app/heroes/heroes.component.html
@@ -6,7 +6,7 @@
   <input id="new-hero" #heroName />
 
   <!-- (click) passes input value to add() and then clears the input -->
-  <button class="add-button" (click)="add(heroName.value); heroName.value=''">
+  <button type="button" class="add-button" (click)="add(heroName.value); heroName.value=''">
     Add hero
   </button>
 </div>
@@ -19,7 +19,7 @@
       <span class="badge">{{hero.id}}</span> {{hero.name}}
     </a>
     <!-- #docregion delete -->
-    <button class="delete" title="delete hero"
+    <button type="button" class="delete" title="delete hero"
       (click)="delete(hero)">x</button>
     <!-- #enddocregion delete -->
   </li>

--- a/aio/content/examples/toh-pt6/src/app/messages/messages.component.html
+++ b/aio/content/examples/toh-pt6/src/app/messages/messages.component.html
@@ -1,7 +1,8 @@
 <div *ngIf="messageService.messages.length">
 
   <h2>Messages</h2>
-  <button class="clear"
+  <button type="button"
+          class="clear"
           (click)="messageService.clear()">Clear messages</button>
   <div *ngFor='let message of messageService.messages'> {{message}} </div>
 

--- a/aio/content/examples/two-way-binding/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/two-way-binding/e2e/src/app.e2e-spec.ts
@@ -20,17 +20,17 @@ describe('Two-way binding e2e tests', () => {
     expect(await plus2Button.getText()).toBe('+');
   });
 
-  it('should change font size labels', async () => {
+  it('should change font size texts', async () => {
     await minusButton.click();
-    expect(await element.all(by.css('label')).get(0).getText()).toEqual('FontSize: 15px');
+    expect(await element.all(by.css('span')).get(0).getText()).toEqual('FontSize: 15px');
     expect(await element.all(by.css('input')).get(0).getAttribute('value')).toEqual('15');
 
     await plusButton.click();
-    expect(await element.all(by.css('label')).get(0).getText()).toEqual('FontSize: 16px');
+    expect(await element.all(by.css('span')).get(0).getText()).toEqual('FontSize: 16px');
     expect(await element.all(by.css('input')).get(0).getAttribute('value')).toEqual('16');
 
     await minus2Button.click();
-    expect(await element.all(by.css('label')).get(2).getText()).toEqual('FontSize: 15px');
+    expect(await element.all(by.css('span')).get(1).getText()).toEqual('FontSize: 15px');
   });
 
   it('should display De-sugared two-way binding', async () => {

--- a/aio/content/examples/two-way-binding/src/app/sizer/sizer.component.html
+++ b/aio/content/examples/two-way-binding/src/app/sizer/sizer.component.html
@@ -1,5 +1,5 @@
 <div>
   <button (click)="dec()" title="smaller">-</button>
   <button (click)="inc()" title="bigger">+</button>
-  <label [style.font-size.px]="size">FontSize: {{size}}px</label>
+  <span [style.font-size.px]="size">FontSize: {{size}}px</span>
 </div>

--- a/aio/content/examples/two-way-binding/src/app/sizer/sizer.component.html
+++ b/aio/content/examples/two-way-binding/src/app/sizer/sizer.component.html
@@ -1,5 +1,5 @@
 <div>
-  <button (click)="dec()" title="smaller">-</button>
-  <button (click)="inc()" title="bigger">+</button>
+  <button type="button" (click)="dec()" title="smaller">-</button>
+  <button type="button" (click)="inc()" title="bigger">+</button>
   <span [style.font-size.px]="size">FontSize: {{size}}px</span>
 </div>

--- a/aio/content/examples/universal/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/universal/e2e/src/app.e2e-spec.ts
@@ -176,8 +176,9 @@ describe('Universal', () => {
         expect(await button.getCssValue('padding')).toBe('5px 10px');
         expect(await button.getCssValue('border-radius')).toBe('4px');
         // Styles defined in heroes.component.css
-        expect(await button.getCssValue('left')).toBe('194px');
-        expect(await button.getCssValue('top')).toBe('-32px');
+        expect(await button.getCssValue('right')).toBe('0px');
+        expect(await button.getCssValue('top')).toBe('0px');
+        expect(await button.getCssValue('bottom')).toBe('0px');
       }
 
       const addButton = element(by.buttonText('add'));

--- a/aio/content/examples/universal/src/app/hero-detail/hero-detail.component.html
+++ b/aio/content/examples/universal/src/app/hero-detail/hero-detail.component.html
@@ -6,6 +6,6 @@
       <input [(ngModel)]="hero.name" placeholder="name"/>
     </label>
   </div>
-  <button (click)="goBack()">go back</button>
-  <button (click)="save()">save</button>
+  <button type="button" (click)="goBack()">go back</button>
+  <button type="button" (click)="save()">save</button>
 </div>

--- a/aio/content/examples/universal/src/app/heroes/heroes.component.css
+++ b/aio/content/examples/universal/src/app/heroes/heroes.component.css
@@ -5,6 +5,7 @@
   padding: 0;
   width: 15em;
 }
+
 .heroes li {
   position: relative;
   cursor: pointer;
@@ -64,10 +65,12 @@ button:hover {
 }
 
 button.delete {
-  position: relative;
-  left: 194px;
-  top: -32px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
   background-color: gray !important;
   color: white;
+  margin: 0;
 }
 

--- a/aio/content/examples/universal/src/app/heroes/heroes.component.html
+++ b/aio/content/examples/universal/src/app/heroes/heroes.component.html
@@ -5,7 +5,7 @@
     <input #heroName />
   </label>
   <!-- (click) passes input value to add() and then clears the input -->
-  <button (click)="add(heroName.value); heroName.value=''">
+  <button type="button" (click)="add(heroName.value); heroName.value=''">
     add
   </button>
 </div>
@@ -15,7 +15,7 @@
     <a routerLink="/detail/{{hero.id}}">
       <span class="badge">{{hero.id}}</span> {{hero.name}}
     </a>
-    <button class="delete" title="delete hero"
+    <button type="button" class="delete" title="delete hero"
       (click)="delete(hero)">x</button>
   </li>
 </ul>

--- a/aio/content/examples/universal/src/app/messages/messages.component.html
+++ b/aio/content/examples/universal/src/app/messages/messages.component.html
@@ -1,7 +1,8 @@
 <div *ngIf="messageService.messages.length">
 
   <h2>Messages</h2>
-  <button class="clear"
+  <button type="button"
+          class="clear"
           (click)="messageService.clear()">clear</button>
   <div *ngFor='let message of messageService.messages'> {{message}} </div>
 

--- a/aio/content/examples/upgrade-module/src/app/downgrade-io/hero-detail.component.ts
+++ b/aio/content/examples/upgrade-module/src/app/downgrade-io/hero-detail.component.ts
@@ -6,7 +6,7 @@ import { Hero } from '../hero';
   selector: 'hero-detail',
   template: `
     <h2>{{hero.name}} details!</h2>
-    <div><label>id: </label>{{hero.id}}</div>
+    <div>id: {{hero.id}}</div>
     <button (click)="onDelete()">Delete</button>
   `
 })

--- a/aio/content/examples/upgrade-module/src/app/downgrade-io/hero-detail.component.ts
+++ b/aio/content/examples/upgrade-module/src/app/downgrade-io/hero-detail.component.ts
@@ -7,7 +7,7 @@ import { Hero } from '../hero';
   template: `
     <h2>{{hero.name}} details!</h2>
     <div>id: {{hero.id}}</div>
-    <button (click)="onDelete()">Delete</button>
+    <button type="button" (click)="onDelete()">Delete</button>
   `
 })
 export class HeroDetailComponent {

--- a/aio/content/examples/upgrade-module/src/app/downgrade-static/hero-detail.component.ts
+++ b/aio/content/examples/upgrade-module/src/app/downgrade-static/hero-detail.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
   selector: 'hero-detail',
   template: `
     <h2>Windstorm details!</h2>
-    <div><label>id: </label>1</div>
+    <div>id: 1</div>
   `
 })
 export class HeroDetailComponent { }

--- a/aio/content/examples/upgrade-module/src/app/hero-detail.directive.ts
+++ b/aio/content/examples/upgrade-module/src/app/hero-detail.directive.ts
@@ -10,7 +10,7 @@ export function heroDetailDirective() {
     template: `
       <h2>{{$ctrl.hero.name}} details!</h2>
       <div><label>id: </label>{{$ctrl.hero.id}}</div>
-      <button ng-click="$ctrl.onDelete()">Delete</button>
+      <button type="button" ng-click="$ctrl.onDelete()">Delete</button>
     `,
     controller: function HeroDetailController() {
       this.onDelete = () => {

--- a/aio/content/examples/upgrade-module/src/app/upgrade-io/hero-detail.component.ts
+++ b/aio/content/examples/upgrade-module/src/app/upgrade-io/hero-detail.component.ts
@@ -8,7 +8,7 @@ export const heroDetail = {
   template: `
     <h2>{{$ctrl.hero.name}} details!</h2>
     <div><label>id: </label>{{$ctrl.hero.id}}</div>
-    <button ng-click="$ctrl.onDelete()">Delete</button>
+    <button type="button" ng-click="$ctrl.onDelete()">Delete</button>
   `,
   controller: function HeroDetailController() {
     this.onDelete = () => {

--- a/aio/content/examples/upgrade-phonecat-1-typescript/app/phone-detail/phone-detail.template.html
+++ b/aio/content/examples/upgrade-phonecat-1-typescript/app/phone-detail/phone-detail.template.html
@@ -1,5 +1,5 @@
 <div class="phone-images">
-  <img ng-src="{{img}}" class="phone"
+  <img ng-src="{{img}}" class="phone" alt="phone {{$index}}"
       ng-class="{selected: img === $ctrl.mainImageUrl}"
       ng-repeat="img in $ctrl.phone.images" />
 </div>
@@ -10,7 +10,7 @@
 
 <ul class="phone-thumbs">
   <li ng-repeat="img in $ctrl.phone.images">
-    <img ng-src="{{img}}" ng-click="$ctrl.setImage(img)" />
+    <img ng-src="{{img}}" ng-click="$ctrl.setImage(img)" alt="phone thumb {{$index}}"/>
   </li>
 </ul>
 

--- a/aio/content/examples/upgrade-phonecat-1-typescript/app/phone-detail/phone-detail.template.html
+++ b/aio/content/examples/upgrade-phonecat-1-typescript/app/phone-detail/phone-detail.template.html
@@ -1,5 +1,5 @@
 <div class="phone-images">
-  <img ng-src="{{img}}" class="phone" alt="phone {{$index}}"
+  <img ng-src="{{img}}" class="phone" alt="Phone {{$ctrl.phone.name}} - thumbnail {{$index}}"
       ng-class="{selected: img === $ctrl.mainImageUrl}"
       ng-repeat="img in $ctrl.phone.images" />
 </div>
@@ -10,7 +10,7 @@
 
 <ul class="phone-thumbs">
   <li ng-repeat="img in $ctrl.phone.images">
-    <img ng-src="{{img}}" ng-click="$ctrl.setImage(img)" alt="phone thumb {{$index}}"/>
+    <img ng-src="{{img}}" ng-click="$ctrl.setImage(img)" alt="Phone {{$ctrl.phone.name}} - thumbnail {{$index}}"/>
   </li>
 </ul>
 

--- a/aio/content/examples/upgrade-phonecat-2-hybrid/app/phone-detail/phone-detail.template.html
+++ b/aio/content/examples/upgrade-phonecat-2-hybrid/app/phone-detail/phone-detail.template.html
@@ -1,7 +1,7 @@
 <!-- #docregion -->
 <div *ngIf="phone">
   <div class="phone-images">
-    <img [src]="img" class="phone" [alt]="'phone ' + index"
+    <img [src]="img" class="phone" [alt]="'Phone ' + phone.name + ' - thumbnail ' + index"
         [ngClass]="{'selected': img === mainImageUrl}"
         *ngFor="let img of phone.images; let index = index;" />
   </div>
@@ -13,7 +13,7 @@
   <ul class="phone-thumbs">
     <li *ngFor="let img of phone.images; let index = index">
       <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
-      <img [src]="img" (click)="setImage(img)" [alt]="'phone thumb ' + index"/>
+      <img [src]="img" (click)="setImage(img)" [alt]="'Phone ' + phone.name + ' - thumbnail ' + index"/>
     </li>
   </ul>
 

--- a/aio/content/examples/upgrade-phonecat-2-hybrid/app/phone-detail/phone-detail.template.html
+++ b/aio/content/examples/upgrade-phonecat-2-hybrid/app/phone-detail/phone-detail.template.html
@@ -1,9 +1,9 @@
 <!-- #docregion -->
 <div *ngIf="phone">
   <div class="phone-images">
-    <img [src]="img" class="phone"
+    <img [src]="img" class="phone" [alt]="'phone ' + index"
         [ngClass]="{'selected': img === mainImageUrl}"
-        *ngFor="let img of phone.images" />
+        *ngFor="let img of phone.images; let index = index;" />
   </div>
 
   <h1>{{phone.name}}</h1>
@@ -11,8 +11,9 @@
   <p>{{phone.description}}</p>
 
   <ul class="phone-thumbs">
-    <li *ngFor="let img of phone.images">
-      <img [src]="img" (click)="setImage(img)" />
+    <li *ngFor="let img of phone.images; let index = index">
+      <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
+      <img [src]="img" (click)="setImage(img)" [alt]="'phone thumb ' + index"/>
     </li>
   </ul>
 

--- a/aio/content/examples/upgrade-phonecat-2-hybrid/app/phone-detail/phone-detail.template.html
+++ b/aio/content/examples/upgrade-phonecat-2-hybrid/app/phone-detail/phone-detail.template.html
@@ -1,7 +1,7 @@
 <!-- #docregion -->
 <div *ngIf="phone">
   <div class="phone-images">
-    <img [src]="img" class="phone" [alt]="'Phone ' + phone.name + ' - thumbnail ' + index"
+    <img [src]="img" class="phone" alt="Phone {{ phone.name }} - thumbnail {{ index }}"
         [ngClass]="{'selected': img === mainImageUrl}"
         *ngFor="let img of phone.images; let index = index;" />
   </div>
@@ -13,7 +13,7 @@
   <ul class="phone-thumbs">
     <li *ngFor="let img of phone.images; let index = index">
       <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
-      <img [src]="img" (click)="setImage(img)" [alt]="'Phone ' + phone.name + ' - thumbnail ' + index"/>
+      <img [src]="img" (click)="setImage(img)" alt="Phone {{ phone.name }} - thumbnail {{ index }}"/>
     </li>
   </ul>
 

--- a/aio/content/examples/upgrade-phonecat-3-final/app/phone-detail/phone-detail.template.html
+++ b/aio/content/examples/upgrade-phonecat-3-final/app/phone-detail/phone-detail.template.html
@@ -1,9 +1,9 @@
 <!-- #docregion -->
 <div *ngIf="phone">
   <div class="phone-images">
-    <img [src]="img" class="phone"
+    <img [src]="img" class="phone" [alt]="'phone' + index"
         [ngClass]="{'selected': img === mainImageUrl}"
-        *ngFor="let img of phone.images" />
+        *ngFor="let img of phone.images; let index = index" />
   </div>
 
   <h1>{{phone.name}}</h1>
@@ -11,8 +11,9 @@
   <p>{{phone.description}}</p>
 
   <ul class="phone-thumbs">
-    <li *ngFor="let img of phone.images">
-      <img [src]="img" (click)="setImage(img)" />
+    <li *ngFor="let img of phone.images let index = index">
+      <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
+      <img [src]="img" [alt]="'phone thumb' + index" (click)="setImage(img)" />
     </li>
   </ul>
 

--- a/aio/content/examples/user-input/src/app/click-me.component.ts
+++ b/aio/content/examples/user-input/src/app/click-me.component.ts
@@ -1,6 +1,6 @@
 /* FOR DOCS ... MUST MATCH ClickMeComponent template
 // #docregion click-me-button
-  <button (click)="onClickMe()">Click me!</button>
+  <button type="button" (click)="onClickMe()">Click me!</button>
 // #enddocregion click-me-button
 */
 
@@ -11,7 +11,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-click-me',
   template: `
-    <button (click)="onClickMe()">Click me!</button>
+    <button type="button" (click)="onClickMe()">Click me!</button>
     {{clickMessage}}`
 })
 export class ClickMeComponent {

--- a/aio/content/examples/user-input/src/app/click-me2.component.ts
+++ b/aio/content/examples/user-input/src/app/click-me2.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-click-me2',
   template: `
-    <button (click)="onClickMe2($event)">No! .. Click me!</button>
+    <button type="button" (click)="onClickMe2($event)">No! .. Click me!</button>
     {{clickMessage}}`
 })
 export class ClickMe2Component {

--- a/aio/content/examples/user-input/src/app/little-tour.component.ts
+++ b/aio/content/examples/user-input/src/app/little-tour.component.ts
@@ -9,7 +9,7 @@ import { Component } from '@angular/core';
       (keyup.enter)="addHero(newHero.value)"
       (blur)="addHero(newHero.value); newHero.value='' ">
 
-    <button (click)="addHero(newHero.value)">Add</button>
+    <button type="button" (click)="addHero(newHero.value)">Add</button>
 
     <ul><li *ngFor="let hero of heroes">{{hero}}</li></ul>
   `

--- a/aio/content/examples/what-is-angular/src/app/hello-world-bindings/hello-world-bindings.component.html
+++ b/aio/content/examples/what-is-angular/src/app/hello-world-bindings/hello-world-bindings.component.html
@@ -1,5 +1,6 @@
 <!-- #docregion event-binding -->
 <button
+  type="button"
   [disabled]="canClick"
   (click)="sayMessage()">
   Trigger alert message

--- a/aio/content/examples/what-is-angular/src/app/hello-world-di/hello-world-di.component.html
+++ b/aio/content/examples/what-is-angular/src/app/hello-world-di/hello-world-di.component.html
@@ -1,5 +1,5 @@
 <h2>Hello World: Dependency Injection</h2>
 
-<button (click)="onLogMe()">Log me!</button>
+<button type="button" (click)="onLogMe()">Log me!</button>
 
 <p>Be sure to open the console to view the output!</p>

--- a/aio/content/examples/what-is-angular/src/app/hello-world-ngif/hello-world-ngif.component.html
+++ b/aio/content/examples/what-is-angular/src/app/hello-world-ngif/hello-world-ngif.component.html
@@ -1,6 +1,6 @@
 <h2>Hello World: ngIf!</h2>
 
-<button (click)="onEditClick()">Make text editable!</button>
+<button type="button" (click)="onEditClick()">Make text editable!</button>
 
 <div *ngIf="canEdit; else noEdit">
     <p>You can edit the following paragraph.</p>

--- a/aio/content/examples/what-is-angular/src/app/hello-world-template.component.ts
+++ b/aio/content/examples/what-is-angular/src/app/hello-world-template.component.ts
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
     selector: 'hello-world-template',
     template: `
         <h2>Hello World Template</h2>
-        <button (click)="onEditClick()">Make text editable!</button>
+        <button type="button" (click)="onEditClick()">Make text editable!</button>
         <p [contentEditable]="canEdit">{{ message }}</p>
         `
   })

--- a/aio/content/guide/architecture-components.md
+++ b/aio/content/guide/architecture-components.md
@@ -89,13 +89,13 @@ This example from the `HeroListComponent` template uses three of these forms.
 
 <code-example path="architecture/src/app/hero-list.component.1.html" header="src/app/hero-list.component.html (binding)" region="binding"></code-example>
 
-* The `{{hero.name}}` [*interpolation*](guide/interpolation)
-displays the component's `hero.name` property value within the `<li>` element.
-
 * The `[hero]` [*property binding*](guide/property-binding) passes the value of
 `selectedHero` from the parent `HeroListComponent` to the `hero` property of the child `HeroDetailComponent`.
 
 * The `(click)` [*event binding*](guide/user-input#binding-to-user-input-events) calls the component's `selectHero` method when the user clicks a hero's name.
+
+* The `{{hero.name}}` [*interpolation*](guide/interpolation)
+displays the component's `hero.name` property value within the `<button>` element.
 
 Two-way data binding (used mainly in [template-driven forms](guide/forms))
 combines property and event binding in a single notation.

--- a/aio/content/guide/binding-syntax.md
+++ b/aio/content/guide/binding-syntax.md
@@ -237,7 +237,7 @@ The following table summarizes the targets for the different binding types.
       Directive&nbsp;property
     </td>
     <td>
-      <code>src</code>, <code>hero</code>, and <code>ngClass</code> in the following:
+      <code>alt</code>, <code>src</code>, <code>hero</code>, and <code>ngClass</code> in the following:
       <code-example path="template-syntax/src/app/app.component.html" region="property-binding-syntax-1"></code-example>
       <!-- For more information, see [Property Binding](guide/property-binding). -->
     </td>

--- a/aio/content/tutorial/toh-pt2.md
+++ b/aio/content/tutorial/toh-pt2.md
@@ -117,14 +117,14 @@ and update the hero detail.
 
 ### Add a click event binding
 
-Add a click event binding to the `<li>` like this:
+Add a `<button>` with a click event binding in the `<li>` like this:
 
 <code-example path="toh-pt2/src/app/heroes/heroes.component.1.html" region="selectedHero-click" header="heroes.component.html (template excerpt)"></code-example>
 
 This is an example of Angular's [event binding](guide/event-binding) syntax.
 
-The parentheses around `click` tell Angular to listen for the `<li>` element's  `click` event.
-When the user clicks in the `<li>`, Angular executes the `onSelect(hero)` expression.
+The parentheses around `click` tell Angular to listen for the `<button>` element's  `click` event.
+When the user clicks in the `<button>`, Angular executes the `onSelect(hero)` expression.
 
 
 In the next section, define an `onSelect()` method in `HeroesComponent` to
@@ -207,7 +207,7 @@ To apply the `.selected` class to the `<li>` when the user clicks it, use class 
 Angular's [class binding](guide/attribute-binding#class-binding) can add and remove a CSS class conditionally.
 Add `[class.some-css-class]="some-condition"` to the element you want to style.
 
-Add the following `[class.selected]` binding to the `<li>` in the `HeroesComponent` template:
+Add the following `[class.selected]` binding to the `<button>` in the `HeroesComponent` template:
 
 <code-example path="toh-pt2/src/app/heroes/heroes.component.1.html" region="class-selected" header="heroes.component.html (toggle the 'selected' CSS class)"></code-example>
 

--- a/aio/content/tutorial/toh-pt2.md
+++ b/aio/content/tutorial/toh-pt2.md
@@ -128,11 +128,12 @@ When the user clicks in the `<button>`, Angular executes the `onSelect(hero)` ex
 
 <div class="callout is-helpful">
 
-<header>Clickable Elements</header>
+  <header>Clickable elements</header>
 
   Note that we added the click event binding on a new `<button>` element. While we could have added
   the event binding on the `<li>` element directly, it is better for accessibility purposes to use
   the native `<button>` element to handle clicks.
+
   For more details on accessibility, see [Accessibility in Angular](guide/accessibility).
 
 </div>

--- a/aio/content/tutorial/toh-pt2.md
+++ b/aio/content/tutorial/toh-pt2.md
@@ -130,16 +130,10 @@ When the user clicks in the `<button>`, Angular executes the `onSelect(hero)` ex
 
 <header>Clickable Elements</header>
 
-  In order to add a click event binding we've added a `<button>` element to our `<li>`, note that this
-  is not the only option, and we could have just as easily added the click event binding directly to the
-  `<li>` element.
-
-  We can add the click event binding to any possible element, but this is generally not advised as doing
-  so hinders assistive technologies and prevents automatic keyboard behaviors (e.g. the click being emitted
-  also when the user presses the enter key).
-
-  These problems can still be overcome by adding additional event bindings and ARIA attributes, but by using
-  `<button>` elements we get all the desired behaviors for free.
+  Note that we added the click event binding on a new `<button>` element. While we could have added
+  the event binding on the `<li>` element directly, it is better for accessibility purposes to use
+  the native `<button>` element to handle clicks.
+  For more details on accessibility, see [Accessibility in Angular](guide/accessibility).
 
 </div>
 

--- a/aio/content/tutorial/toh-pt2.md
+++ b/aio/content/tutorial/toh-pt2.md
@@ -123,9 +123,25 @@ Add a `<button>` with a click event binding in the `<li>` like this:
 
 This is an example of Angular's [event binding](guide/event-binding) syntax.
 
-The parentheses around `click` tell Angular to listen for the `<button>` element's  `click` event.
+The parentheses around `click` tell Angular to listen for the `<button>` element's `click` event.
 When the user clicks in the `<button>`, Angular executes the `onSelect(hero)` expression.
 
+<div class="callout is-helpful">
+
+<header>Clickable Elements</header>
+
+  In order to add a click event binding we've added a `<button>` element to our `<li>`, note that this
+  is not the only option, and we could have just as easily added the click event binding directly to the
+  `<li>` element.
+
+  We can add the click event binding to any possible element, but this is generally not advised as doing
+  so hinders assistive technologies and prevents automatic keyboard behaviors (e.g. the click being emitted
+  also when the user presses the enter key).
+
+  These problems can still be overcome by adding additional event bindings and ARIA attributes, but by using
+  `<button>` elements we get all the desired behaviors for free.
+
+</div>
 
 In the next section, define an `onSelect()` method in `HeroesComponent` to
 display the hero that was defined in the `*ngFor` expression.


### PR DESCRIPTION
the aio examples have various eslint issues regarding template rules, those
are currently turned off and TODO comments have been added to them in the
examples eslintrc, fix such issues and remove the respective TODO comments

this also includes examples refactoring to use buttons for better accessibility,
this change tries to make the smallest amound of changes to the examples' behaviors
and designs/UI

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue
Issue Number: N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
@gkalpak 😃 👍 