### PR TITLE
docs(upgrade glossary): fix ngOnChange description issue in glossary.md 

### DIFF
--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -572,7 +572,7 @@ For example, the `OnInit` interface has a hook method named `ngOnInit`.
 
 Angular calls these hook methods in the following order:
 
-* `ngOnChanges`: When an [input](#input)/[output](#output) binding value changes.
+* `ngOnChanges`: When an [input](#input) binding value changes.
 * `ngOnInit`: After the first `ngOnChanges`.
 * `ngDoCheck`: Developer's custom change detection.
 * `ngAfterContentInit`: After component content initialized.


### PR DESCRIPTION
ngOnChange respond when Angular sets or resets data-bound @input properties and description of the ngOnChanges should be `When an [input](#input) binding value changes` instead of `When an [input](#input)/[output](#output) binding value changes`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
