### PR TITLE
feat(compiler): add support for safe calls in templates

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -410,7 +410,7 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
     return true;
   }
   visitSafeCall(ast: SafeCall): boolean {
-    return true;
+    return false;
   }
   visitImplicitReceiver(ast: ImplicitReceiver): boolean {
     return false;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Call, Chain, Conditional, EmptyExpr, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeKeyedRead, SafePropertyRead, ThisReceiver, Unary} from '@angular/compiler';
+import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Call, Chain, Conditional, EmptyExpr, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeCall, SafeKeyedRead, SafePropertyRead, ThisReceiver, Unary} from '@angular/compiler';
 import ts from 'typescript';
 
 import {TypeCheckingConfig} from '../api';
@@ -337,24 +337,39 @@ class AstTranslator implements AstVisitor {
 
     // Safe property/keyed reads will produce a ternary whose value is nullable.
     // We have to generate a similar ternary around the call.
-    if (receiver instanceof SafePropertyRead || receiver instanceof SafeKeyedRead) {
-      if (this.config.strictSafeNavigationTypes) {
-        // "a?.method(...)" becomes (null as any ? a!.method(...) : undefined)
-        const call = ts.createCall(ts.createNonNullExpression(expr), undefined, args);
-        node = ts.createParen(ts.createConditional(NULL_AS_ANY, call, UNDEFINED));
-      } else if (VeSafeLhsInferenceBugDetector.veWillInferAnyFor(ast)) {
-        // "a?.method(...)" becomes (a as any).method(...)
-        node = ts.createCall(tsCastToAny(expr), undefined, args);
-      } else {
-        // "a?.method(...)" becomes (a!.method(...) as any)
-        node = tsCastToAny(ts.createCall(ts.createNonNullExpression(expr), undefined, args));
-      }
+    if (ast.receiver instanceof SafePropertyRead || ast.receiver instanceof SafeKeyedRead) {
+      node = this.convertToSafeCall(ast, expr, args);
     } else {
       node = ts.createCall(expr, undefined, args);
     }
 
     addParseSpanInfo(node, ast.sourceSpan);
     return node;
+  }
+
+  visitSafeCall(ast: SafeCall): ts.Expression {
+    const args = ast.args.map(expr => this.translate(expr));
+    const expr = wrapForDiagnostics(this.translate(ast.receiver));
+    const node = this.convertToSafeCall(ast, expr, args);
+    addParseSpanInfo(node, ast.sourceSpan);
+    return node;
+  }
+
+  private convertToSafeCall(ast: Call|SafeCall, expr: ts.Expression, args: ts.Expression[]):
+      ts.Expression {
+    if (this.config.strictSafeNavigationTypes) {
+      // "a?.method(...)" becomes (null as any ? a!.method(...) : undefined)
+      const call = ts.createCall(ts.createNonNullExpression(expr), undefined, args);
+      return ts.createParen(ts.createConditional(NULL_AS_ANY, call, UNDEFINED));
+    }
+
+    if (VeSafeLhsInferenceBugDetector.veWillInferAnyFor(ast)) {
+      // "a?.method(...)" becomes (a as any).method(...)
+      return ts.createCall(tsCastToAny(expr), undefined, args);
+    }
+
+    // "a?.method(...)" becomes (a!.method(...) as any)
+    return tsCastToAny(ts.createCall(ts.createNonNullExpression(expr), undefined, args));
   }
 }
 
@@ -374,7 +389,7 @@ class AstTranslator implements AstVisitor {
 class VeSafeLhsInferenceBugDetector implements AstVisitor {
   private static SINGLETON = new VeSafeLhsInferenceBugDetector();
 
-  static veWillInferAnyFor(ast: Call|SafePropertyRead|SafeKeyedRead) {
+  static veWillInferAnyFor(ast: Call|SafeCall|SafePropertyRead|SafeKeyedRead) {
     const visitor = VeSafeLhsInferenceBugDetector.SINGLETON;
     return ast instanceof Call ? ast.visit(visitor) : ast.receiver.visit(visitor);
   }
@@ -392,6 +407,9 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
     return ast.condition.visit(this) || ast.trueExp.visit(this) || ast.falseExp.visit(this);
   }
   visitCall(ast: Call): boolean {
+    return true;
+  }
+  visitSafeCall(ast: SafeCall): boolean {
     return true;
   }
   visitImplicitReceiver(ast: ImplicitReceiver): boolean {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, BindingPipe, BindingType, BoundTarget, Call, DYNAMIC_TYPE, ImplicitReceiver, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, SafePropertyRead, SchemaMetadata, ThisReceiver, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstIcu, TmplAstNode, TmplAstReference, TmplAstTemplate, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
+import {AST, BindingPipe, BindingType, BoundTarget, Call, DYNAMIC_TYPE, ImplicitReceiver, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, SafeCall, SafePropertyRead, SchemaMetadata, ThisReceiver, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstIcu, TmplAstNode, TmplAstReference, TmplAstTemplate, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
 import ts from 'typescript';
 
 import {Reference} from '../../imports';
@@ -1727,7 +1727,7 @@ class TcbExpressionTranslator {
       addParseSpanInfo(result, ast.sourceSpan);
       return result;
     } else if (
-        ast instanceof Call &&
+        (ast instanceof Call || ast instanceof SafeCall) &&
         (ast.receiver instanceof PropertyRead || ast.receiver instanceof SafePropertyRead)) {
       // Resolve the special `$any(expr)` syntax to insert a cast of the argument to type `any`.
       // `$any(expr)` -> `expr as any`

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -491,6 +491,35 @@ runInEachFileSystem(() => {
           `TestComponent.html(1, 19): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.`
         ]);
       });
+
+      it('does not produce diagnostic for safe calls', () => {
+        const messages =
+            diagnose(`<div [class.is-hobbit]="person.getName?.() === 'Bilbo'"></div>`, `
+              export class TestComponent {
+                person: {
+                  getName?: () => string;
+                };
+              }`);
+
+        expect(messages).toEqual([]);
+      });
+
+      it('infers a safe call return value as undefined', () => {
+        const messages = diagnose(`<div (click)="log(person.getName?.())"></div>`, `
+          export class TestComponent {
+            person: {
+              getName?: () => string;
+            };
+
+            log(name: string) {
+              console.log(name);
+            }
+          }`);
+
+        expect(messages).toEqual([
+          `TestComponent.html(1, 19): Argument of type 'string | undefined' is not assignable to parameter of type 'string'.`
+        ]);
+      });
     });
 
     it('computes line and column offsets', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/span_comments_spec.ts
@@ -79,6 +79,13 @@ describe('type check blocks diagnostics', () => {
               '(ctx).method /*3,9*/(((ctx).a /*10,11*/) /*10,11*/, ((ctx).b /*13,14*/) /*13,14*/) /*3,15*/');
     });
 
+    it('should annotate safe calls', () => {
+      const TEMPLATE = `{{ method?.(a, b) }}`;
+      expect(tcbWithSpans(TEMPLATE))
+          .toContain(
+              '((null as any ? (((ctx).method /*3,9*/) /*3,9*/)!(((ctx).a /*12,13*/) /*12,13*/, ((ctx).b /*15,16*/) /*15,16*/) : undefined) /*3,17*/)');
+    });
+
     it('should annotate method calls of variables', () => {
       const TEMPLATE = `<ng-template let-method>{{ method(a, b) }}</ng-template>`;
       expect(tcbWithSpans(TEMPLATE))

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1033,7 +1033,7 @@ describe('type check blocks', () => {
             '(null as any ? (null as any ? ((ctx).a())!.method : undefined)!() : undefined)');
         expect(block).toContain('(null as any ? ((((ctx).a)).method())![0] : undefined)');
         expect(block).toContain(
-            '(null as any ? ((null as any ? ((((((ctx).a)).method))())!.otherMethod : undefined))!() : undefined)');
+            '(null as any ? ((null as any ? ((((ctx).a)).method())!.otherMethod : undefined))!() : undefined)');
       });
       it('should not check the presence of a property/method on the receiver when disabled', () => {
         const DISABLED_CONFIG:
@@ -1042,7 +1042,7 @@ describe('type check blocks', () => {
         expect(block).toContain('(((((ctx).a)).method()) as any).b');
         expect(block).toContain('(((((ctx).a()) as any).method as any)())');
         expect(block).toContain('(((((ctx).a)).method()) as any)[0]');
-        expect(block).toContain('(((((((((ctx).a)).method))()) as any).otherMethod)!() as any)');
+        expect(block).toContain('(((((((ctx).a)).method()) as any).otherMethod)!() as any)');
       });
     });
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -1002,7 +1002,7 @@ describe('type check blocks', () => {
     });
 
     describe('config.strictSafeNavigationTypes', () => {
-      const TEMPLATE = `{{a?.b}} {{a?.method()}} {{a?.[0]}}`;
+      const TEMPLATE = `{{a?.b}} {{a?.method()}} {{a?.[0]}} {{a.optionalMethod?.()}}`;
 
       it('should use undefined for safe navigation operations when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
@@ -1010,6 +1010,7 @@ describe('type check blocks', () => {
             '(null as any ? (null as any ? (((ctx).a))!.method : undefined)!() : undefined)');
         expect(block).toContain('(null as any ? (((ctx).a))!.b : undefined)');
         expect(block).toContain('(null as any ? (((ctx).a))![0] : undefined)');
+        expect(block).toContain('(null as any ? (((((ctx).a)).optionalMethod))!() : undefined)');
       });
       it('should use an \'any\' type for safe navigation operations when disabled', () => {
         const DISABLED_CONFIG:
@@ -1018,17 +1019,21 @@ describe('type check blocks', () => {
         expect(block).toContain('((((((ctx).a))!.method as any) as any)())');
         expect(block).toContain('((((ctx).a))!.b as any)');
         expect(block).toContain('(((((ctx).a))![0] as any)');
+        expect(block).toContain('((((((ctx).a)).optionalMethod))!() as any)');
       });
     });
 
     describe('config.strictSafeNavigationTypes (View Engine bug emulation)', () => {
-      const TEMPLATE = `{{a.method()?.b}} {{a()?.method()}} {{a.method()?.[0]}}`;
+      const TEMPLATE =
+          `{{a.method()?.b}} {{a()?.method()}} {{a.method()?.[0]}} {{a.method()?.otherMethod?.()}}`;
       it('should check the presence of a property/method on the receiver when enabled', () => {
         const block = tcb(TEMPLATE, DIRECTIVES);
         expect(block).toContain('(null as any ? ((((ctx).a)).method())!.b : undefined)');
         expect(block).toContain(
             '(null as any ? (null as any ? ((ctx).a())!.method : undefined)!() : undefined)');
         expect(block).toContain('(null as any ? ((((ctx).a)).method())![0] : undefined)');
+        expect(block).toContain(
+            '(null as any ? ((null as any ? ((((((ctx).a)).method))())!.otherMethod : undefined))!() : undefined)');
       });
       it('should not check the presence of a property/method on the receiver when disabled', () => {
         const DISABLED_CONFIG:
@@ -1037,6 +1042,7 @@ describe('type check blocks', () => {
         expect(block).toContain('(((((ctx).a)).method()) as any).b');
         expect(block).toContain('(((((ctx).a()) as any).method as any)())');
         expect(block).toContain('(((((ctx).a)).method()) as any)[0]');
+        expect(block).toContain('(((((((((ctx).a)).method))()) as any).otherMethod)!() as any)');
       });
     });
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
@@ -108,3 +108,60 @@ export declare class MyApp {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: safe_call.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.person = { getName: () => 'Bilbo' };
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <span [title]="'Your last name is ' + (person.getLastName?.() ?? 'unknown')">
+      Hello, {{ person.getName?.() }}!
+      You are a Balrog: {{ person.getSpecies?.()?.()?.()?.()?.() || 'unknown' }}
+    </span>
+`, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <span [title]="'Your last name is ' + (person.getLastName?.() ?? 'unknown')">
+      Hello, {{ person.getName?.() }}!
+      You are a Balrog: {{ person.getSpecies?.()?.()?.()?.()?.() || 'unknown' }}
+    </span>
+`
+                }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [MyApp] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: safe_call.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    person: {
+        getName: () => string;
+        getLastName?: () => string;
+        getSpecies?: () => () => () => () => () => string;
+    };
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
@@ -34,6 +34,23 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should handle safe calls inside templates",
+      "inputFiles": [
+        "safe_call.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "safe_call_template.js",
+              "generated": "safe_call.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_call.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_call.ts
@@ -1,0 +1,21 @@
+import {Component, NgModule} from '@angular/core';
+
+@Component({
+  template: `
+    <span [title]="'Your last name is ' + (person.getLastName?.() ?? 'unknown')">
+      Hello, {{ person.getName?.() }}!
+      You are a Balrog: {{ person.getSpecies?.()?.()?.()?.()?.() || 'unknown' }}
+    </span>
+`
+})
+export class MyApp {
+  person: {
+    getName: () => string,
+    getLastName?: () => string,
+    getSpecies?: () => () => () => () => () => string,
+  } = {getName: () => 'Bilbo'};
+}
+
+@NgModule({declarations: [MyApp]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_call_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_call_template.js
@@ -1,0 +1,17 @@
+template: function MyApp_Template(rf, $ctx$) {
+  if (rf & 1) {
+    $i0$.ɵɵelementStart(0, "span", 0);
+    $i0$.ɵɵtext(1);
+    $i0$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    let $tmp_0_0$;
+    let $tmp_1_0$;
+    let $tmp_1_1$;
+    let $tmp_1_2$;
+    let $tmp_1_3$;
+    $i0$.ɵɵproperty("title", "Your last name is " + (($tmp_0_0$ = $ctx$.person.getLastName == null ? null : $ctx$.person.getLastName()) !== null && $tmp_0_0$ !== undefined ? $tmp_0_0$ : "unknown"));
+    $i0$.ɵɵadvance(1);
+    $i0$.ɵɵtextInterpolate2(" Hello, ", $ctx$.person.getName == null ? null : $ctx$.person.getName(), "! You are a Balrog: ", ($ctx$.person.getSpecies == null ? null : ($tmp_1_0$ = $ctx$.person.getSpecies()) == null ? null : ($tmp_1_1$ = $tmp_1_0$()) == null ? null : ($tmp_1_2$ = $tmp_1_1$()) == null ? null : ($tmp_1_3$ = $tmp_1_2$()) == null ? null : $tmp_1_3$()) || "unknown", " ");
+  }
+}

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -318,7 +318,7 @@ export class NonNullAssert extends AST {
 
 export class Call extends AST {
   constructor(
-      span: ParseSpan, sourceSpan: AbsoluteSourceSpan, public receiver: AST, public args: any[],
+      span: ParseSpan, sourceSpan: AbsoluteSourceSpan, public receiver: AST, public args: AST[],
       public argumentSpan: AbsoluteSourceSpan) {
     super(span, sourceSpan);
   }
@@ -329,7 +329,7 @@ export class Call extends AST {
 
 export class SafeCall extends AST {
   constructor(
-      span: ParseSpan, sourceSpan: AbsoluteSourceSpan, public receiver: AST, public args: any[],
+      span: ParseSpan, sourceSpan: AbsoluteSourceSpan, public receiver: AST, public args: AST[],
       public argumentSpan: AbsoluteSourceSpan) {
     super(span, sourceSpan);
   }

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -327,6 +327,18 @@ export class Call extends AST {
   }
 }
 
+export class SafeCall extends AST {
+  constructor(
+      span: ParseSpan, sourceSpan: AbsoluteSourceSpan, public receiver: AST, public args: any[],
+      public argumentSpan: AbsoluteSourceSpan) {
+    super(span, sourceSpan);
+  }
+  override visit(visitor: AstVisitor, context: any = null): any {
+    return visitor.visitSafeCall(this, context);
+  }
+}
+
+
 /**
  * Records the absolute position of a text span in a source file, where `start` and `end` are the
  * starting and ending byte offsets, respectively, of the text span in a source file.
@@ -439,6 +451,7 @@ export interface AstVisitor {
   visitSafePropertyRead(ast: SafePropertyRead, context: any): any;
   visitSafeKeyedRead(ast: SafeKeyedRead, context: any): any;
   visitCall(ast: Call, context: any): any;
+  visitSafeCall(ast: SafeCall, context: any): any;
   visitASTWithSource?(ast: ASTWithSource, context: any): any;
   /**
    * This function is optionally defined to allow classes that implement this
@@ -517,6 +530,10 @@ export class RecursiveAstVisitor implements AstVisitor {
     this.visit(ast.key, context);
   }
   visitCall(ast: Call, context: any): any {
+    this.visit(ast.receiver, context);
+    this.visitAll(ast.args, context);
+  }
+  visitSafeCall(ast: SafeCall, context: any): any {
     this.visit(ast.receiver, context);
     this.visitAll(ast.args, context);
   }
@@ -618,6 +635,12 @@ export class AstTransformer implements AstVisitor {
 
   visitCall(ast: Call, context: any): AST {
     return new Call(
+        ast.span, ast.sourceSpan, ast.receiver.visit(this), this.visitAll(ast.args),
+        ast.argumentSpan);
+  }
+
+  visitSafeCall(ast: SafeCall, context: any): AST {
+    return new SafeCall(
         ast.span, ast.sourceSpan, ast.receiver.visit(this), this.visitAll(ast.args),
         ast.argumentSpan);
   }
@@ -812,6 +835,15 @@ export class AstMemoryEfficientTransformer implements AstVisitor {
     const args = this.visitAll(ast.args);
     if (receiver !== ast.receiver || args !== ast.args) {
       return new Call(ast.span, ast.sourceSpan, receiver, args, ast.argumentSpan);
+    }
+    return ast;
+  }
+
+  visitSafeCall(ast: SafeCall, context: any): AST {
+    const receiver = ast.receiver.visit(this);
+    const args = this.visitAll(ast.args);
+    if (receiver !== ast.receiver || args !== ast.args) {
+      return new SafeCall(ast.span, ast.sourceSpan, receiver, args, ast.argumentSpan);
     }
     return ast;
   }

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -874,10 +874,8 @@ export class _ParseAST {
       return this.parseLiteralMap();
 
     } else if (this.next.isIdentifier()) {
-      const receiver = new ImplicitReceiver(this.span(start), this.sourceSpan(start));
-      return this.consumeOptionalCharacter(chars.$LPAREN) ?
-          this.parseCall(receiver, start, false) :
-          this.parseAccessMember(receiver, start, false);
+      return this.parseAccessMember(
+          new ImplicitReceiver(this.span(start), this.sourceSpan(start)), start, false);
     } else if (this.next.isNumber()) {
       const value = this.next.toNumber();
       this.advance();

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -9,7 +9,7 @@
 import * as chars from '../chars';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../ml_parser/interpolation_config';
 
-import {AbsoluteSourceSpan, AST, ASTWithSource, Binary, BindingPipe, Call, Chain, Conditional, EmptyExpr, ExpressionBinding, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralMapKey, LiteralPrimitive, NonNullAssert, ParserError, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeKeyedRead, SafePropertyRead, TemplateBinding, TemplateBindingIdentifier, ThisReceiver, Unary, VariableBinding} from './ast';
+import {AbsoluteSourceSpan, AST, ASTWithSource, Binary, BindingPipe, Call, Chain, Conditional, EmptyExpr, ExpressionBinding, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralMapKey, LiteralPrimitive, NonNullAssert, ParserError, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeCall, SafeKeyedRead, SafePropertyRead, TemplateBinding, TemplateBindingIdentifier, ThisReceiver, Unary, VariableBinding} from './ast';
 import {EOF, isIdentifier, Lexer, Token, TokenType} from './lexer';
 
 export interface InterpolationPiece {
@@ -813,23 +813,19 @@ export class _ParseAST {
     let result = this.parsePrimary();
     while (true) {
       if (this.consumeOptionalCharacter(chars.$PERIOD)) {
-        result = this.parseAccessMemberOrCall(result, start, false);
-
+        result = this.parseAccessMember(result, start, false);
       } else if (this.consumeOptionalOperator('?.')) {
-        result = this.consumeOptionalCharacter(chars.$LBRACKET) ?
-            this.parseKeyedReadOrWrite(result, start, true) :
-            this.parseAccessMemberOrCall(result, start, true);
+        if (this.consumeOptionalCharacter(chars.$LPAREN)) {
+          result = this.parseCall(result, start, true);
+        } else {
+          result = this.consumeOptionalCharacter(chars.$LBRACKET) ?
+              this.parseKeyedReadOrWrite(result, start, true) :
+              this.parseAccessMember(result, start, true);
+        }
       } else if (this.consumeOptionalCharacter(chars.$LBRACKET)) {
         result = this.parseKeyedReadOrWrite(result, start, false);
       } else if (this.consumeOptionalCharacter(chars.$LPAREN)) {
-        const argumentStart = this.inputIndex;
-        this.rparensExpected++;
-        const args = this.parseCallArguments();
-        const argumentSpan =
-            this.span(argumentStart, this.inputIndex).toAbsolute(this.absoluteOffset);
-        this.rparensExpected--;
-        this.expectCharacter(chars.$RPAREN);
-        result = new Call(this.span(start), this.sourceSpan(start), result, args, argumentSpan);
+        result = this.parseCall(result, start, false);
       } else if (this.consumeOptionalOperator('!')) {
         result = new NonNullAssert(this.span(start), this.sourceSpan(start), result);
 
@@ -878,9 +874,10 @@ export class _ParseAST {
       return this.parseLiteralMap();
 
     } else if (this.next.isIdentifier()) {
-      return this.parseAccessMemberOrCall(
-          new ImplicitReceiver(this.span(start), this.sourceSpan(start)), start, false);
-
+      const receiver = new ImplicitReceiver(this.span(start), this.sourceSpan(start));
+      return this.consumeOptionalCharacter(chars.$LPAREN) ?
+          this.parseCall(receiver, start, false) :
+          this.parseAccessMember(receiver, start, false);
     } else if (this.next.isNumber()) {
       const value = this.next.toNumber();
       this.advance();
@@ -949,7 +946,7 @@ export class _ParseAST {
     return new LiteralMap(this.span(start), this.sourceSpan(start), keys, values);
   }
 
-  parseAccessMemberOrCall(readReceiver: AST, start: number, isSafe: boolean): AST {
+  parseAccessMember(readReceiver: AST, start: number, isSafe: boolean): AST {
     const nameStart = this.inputIndex;
     const id = this.withContext(ParseContextFlags.Writable, () => {
       const id = this.expectIdentifierOrKeyword() ?? '';
@@ -985,20 +982,20 @@ export class _ParseAST {
       }
     }
 
-    if (this.consumeOptionalCharacter(chars.$LPAREN)) {
-      const argumentStart = this.inputIndex;
-      this.rparensExpected++;
-      const args = this.parseCallArguments();
-      const argumentSpan =
-          this.span(argumentStart, this.inputIndex).toAbsolute(this.absoluteOffset);
-      this.expectCharacter(chars.$RPAREN);
-      this.rparensExpected--;
-      const span = this.span(start);
-      const sourceSpan = this.sourceSpan(start);
-      return new Call(span, sourceSpan, receiver, args, argumentSpan);
-    }
-
     return receiver;
+  }
+
+  parseCall(receiver: AST, start: number, isSafe: boolean): AST {
+    const argumentStart = this.inputIndex;
+    this.rparensExpected++;
+    const args = this.parseCallArguments();
+    const argumentSpan = this.span(argumentStart, this.inputIndex).toAbsolute(this.absoluteOffset);
+    this.expectCharacter(chars.$RPAREN);
+    this.rparensExpected--;
+    const span = this.span(start);
+    const sourceSpan = this.sourceSpan(start);
+    return isSafe ? new SafeCall(span, sourceSpan, receiver, args, argumentSpan) :
+                    new Call(span, sourceSpan, receiver, args, argumentSpan);
   }
 
   parseCallArguments(): BindingPipe[] {

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -256,6 +256,24 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
         expectCharacterToken(tokens[13], 16, 17, ')');
       });
 
+      it('should tokenize safe function invocation', () => {
+        const tokens: Token[] = lex('a?.()');
+        expectIdentifierToken(tokens[0], 0, 1, 'a');
+        expectOperatorToken(tokens[1], 1, 3, '?.');
+        expectCharacterToken(tokens[2], 3, 4, '(');
+        expectCharacterToken(tokens[3], 4, 5, ')');
+      });
+
+      it('should tokenize a safe method invocations', () => {
+        const tokens: Token[] = lex('a.method?.()');
+        expectIdentifierToken(tokens[0], 0, 1, 'a');
+        expectCharacterToken(tokens[1], 1, 2, '.');
+        expectIdentifierToken(tokens[2], 2, 8, 'method');
+        expectOperatorToken(tokens[3], 8, 10, '?.');
+        expectCharacterToken(tokens[4], 10, 11, '(');
+        expectCharacterToken(tokens[5], 11, 12, ')');
+      });
+
       it('should tokenize number', () => {
         expectNumberToken(lex('0.5')[0], 0, 3, 0.5);
       });

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -50,6 +50,8 @@ describe('parser', () => {
       checkAction('true!');
       checkAction('a!.b');
       checkAction('a!!!!.b');
+      checkAction('a!()');
+      checkAction('a.b!()');
     });
 
     it('should parse multiplicative expressions', () => {
@@ -221,6 +223,15 @@ describe('parser', () => {
         expect(ast.args[1]).toBeAnInstanceOf(EmptyExpr);
         const sourceSpan = (ast.args[1] as EmptyExpr).sourceSpan;
         expect([sourceSpan.start, sourceSpan.end]).toEqual([5, 6]);
+      });
+
+      it('should parse safe calls', () => {
+        checkAction('fn?.()');
+        checkAction('add?.(1, 2)');
+        checkAction('a.add?.(1, 2)');
+        checkAction('a?.add?.(1, 2)');
+        checkAction('fn?.().add?.(1, 2)');
+        checkAction('fn?.()?.(1, 2)');
       });
     });
 

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Call, Chain, Conditional, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeKeyedRead, SafePropertyRead, ThisReceiver, Unary} from '../../../src/expression_parser/ast';
+import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Call, Chain, Conditional, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeCall, SafeKeyedRead, SafePropertyRead, ThisReceiver, Unary} from '../../../src/expression_parser/ast';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../src/ml_parser/interpolation_config';
 
 class Unparser implements AstVisitor {
@@ -76,6 +76,18 @@ class Unparser implements AstVisitor {
   visitCall(ast: Call, context: any) {
     this._visit(ast.receiver);
     this._expression += '(';
+    let isFirst = true;
+    ast.args.forEach(arg => {
+      if (!isFirst) this._expression += ', ';
+      isFirst = false;
+      this._visit(arg);
+    });
+    this._expression += ')';
+  }
+
+  visitSafeCall(ast: SafeCall, context: any) {
+    this._visit(ast.receiver);
+    this._expression += '?.(';
     let isFirst = true;
     ast.args.forEach(arg => {
       if (!isFirst) this._expression += ', ';

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, Binary, BindingPipe, Call, Chain, Conditional, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeKeyedRead, SafePropertyRead, Unary} from '../../../src/expression_parser/ast';
+import {AST, Binary, BindingPipe, Call, Chain, Conditional, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeCall, SafeKeyedRead, SafePropertyRead, Unary} from '../../../src/expression_parser/ast';
 
 import {unparse} from './unparser';
 
@@ -108,6 +108,10 @@ class ASTValidator extends RecursiveAstVisitor {
 
   override visitCall(ast: Call, context: any): any {
     this.validate(ast, () => super.visitCall(ast, context));
+  }
+
+  override visitSafeCall(ast: SafeCall, context: any): any {
+    this.validate(ast, () => super.visitSafeCall(ast, context));
   }
 }
 

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -7,6 +7,7 @@
  */
 
 import {AbsoluteSourceSpan} from '@angular/compiler';
+
 import * as e from '../../../src/expression_parser/ast';
 import * as t from '../../../src/render3/r3_ast';
 import {unparse} from '../../expression_parser/utils/unparser';
@@ -109,6 +110,10 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
   override visitCall(ast: e.Call) {
     this.recordAst(ast);
     super.visitCall(ast, null);
+  }
+  override visitSafeCall(ast: e.SafeCall) {
+    this.recordAst(ast);
+    super.visitSafeCall(ast, null);
   }
 
   visitTemplate(ast: t.Template) {

--- a/packages/language-service/src/signature_help.ts
+++ b/packages/language-service/src/signature_help.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Call} from '@angular/compiler';
+import {Call, SafeCall} from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {getSourceFileOrError} from '@angular/compiler-cli/src/ngtsc/file_system';
 import {SymbolKind} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
@@ -48,7 +48,7 @@ export function getSignatureHelp(
   // Additionally, extract the `Call` node for which signature help is being queried, as this
   // is needed to construct the correct span for the results later.
   let shimPosition: number;
-  let expr: Call;
+  let expr: Call|SafeCall;
   switch (targetInfo.context.kind) {
     case TargetNodeKind.RawExpression:
       // For normal expressions, just use the primary TCB position of the expression.
@@ -56,11 +56,11 @@ export function getSignatureHelp(
 
       // Walk up the parents of this expression and try to find a
       // `Call` for which signature information is being fetched.
-      let callExpr: Call|null = null;
+      let callExpr: Call|SafeCall|null = null;
       const parents = targetInfo.context.parents;
       for (let i = parents.length - 1; i >= 0; i--) {
         const parent = parents[i];
-        if (parent instanceof Call) {
+        if (parent instanceof Call || parent instanceof SafeCall) {
           callExpr = parent;
           break;
         }

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -93,7 +93,7 @@ export interface RawExpression {
  */
 export interface CallExpressionInArgContext {
   kind: TargetNodeKind.CallExpressionInArgContext;
-  node: e.Call;
+  node: e.Call|e.SafeCall;
 }
 
 /**
@@ -184,7 +184,8 @@ export function getTargetAtPosition(template: t.Node[], position: number): Templ
 
   // Given the candidate node, determine the full targeted context.
   let nodeInContext: TargetContext;
-  if (candidate instanceof e.Call && isWithin(position, candidate.argumentSpan)) {
+  if ((candidate instanceof e.Call || candidate instanceof e.SafeCall) &&
+      isWithin(position, candidate.argumentSpan)) {
     nodeInContext = {
       kind: TargetNodeKind.CallExpressionInArgContext,
       node: candidate,

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -97,7 +97,6 @@ const NG_FOR_DIR = {
      })
      export class NgFor {
        constructor(ref: TemplateRef<any>) {}
- 
        ngForOf!: any;
      }
    `
@@ -349,16 +348,6 @@ describe('completions', () => {
     it('should return completions in a safe method call context', () => {
       const {templateFile} = setup(`{{name?.f()}}`, `name!: {first: string; full(): string;};`);
       templateFile.moveCursorToText('{{name?.f¦()}}');
-      const completions = templateFile.getCompletionsAtPosition();
-      expectAll(completions, {
-        first: ts.ScriptElementKind.memberVariableElement,
-        full: ts.ScriptElementKind.memberFunctionElement,
-      });
-    });
-
-    it('should return completions in an empty safe method call context', () => {
-      const {templateFile} = setup(`{{name?.()}}`, `name!: {first: string; full(): string;};`);
-      templateFile.moveCursorToText('{{name?.¦()}}');
       const completions = templateFile.getCompletionsAtPosition();
       expectAll(completions, {
         first: ts.ScriptElementKind.memberVariableElement,
@@ -1284,7 +1273,7 @@ function setup(
   const project = env.addProject('test', {
     'test.ts': `
          import {Component, Directive, NgModule, Pipe, TemplateRef} from '@angular/core';
- 
+
          ${functionDeclarations}
 
          @Component({
@@ -1295,9 +1284,9 @@ function setup(
          export class AppCmp {
            ${classContents}
          }
- 
+
          ${otherDirectiveClassDecls}
- 
+
          @NgModule({
            declarations: [${decls.join(', ')}],
          })
@@ -1320,7 +1309,7 @@ function setupInlineTemplate(
   const project = env.addProject('test', {
     'test.ts': `
          import {Component, Directive, NgModule, Pipe, TemplateRef} from '@angular/core';
- 
+
          @Component({
            template: '${template}',
            selector: 'app-cmp',
@@ -1328,9 +1317,9 @@ function setupInlineTemplate(
          export class AppCmp {
            ${classContents}
          }
- 
+
          ${otherDirectiveClassDecls}
- 
+
          @NgModule({
            declarations: [${decls.join(', ')}],
          })

--- a/packages/language-service/test/legacy/template_target_spec.ts
+++ b/packages/language-service/test/legacy/template_target_spec.ts
@@ -558,6 +558,15 @@ describe('getTargetAtPosition for expression AST', () => {
     expect(node).toBeInstanceOf(e.Call);
   });
 
+  it('should locate safe call', () => {
+    const {errors, nodes, position} = parse(`{{ title.toString?.(¦) }}`);
+    expect(errors).toBe(null);
+    const {context} = getTargetAtPosition(nodes, position)!;
+    const {node} = context as SingleNodeTarget;
+    expect(isExpressionNode(node!)).toBe(true);
+    expect(node).toBeInstanceOf(e.SafeCall);
+  });
+
   it('should identify when in the argument position in a no-arg method call', () => {
     const {errors, nodes, position} = parse(`{{ title.toString(¦) }}`);
     expect(errors).toBe(null);


### PR DESCRIPTION
Adds support for safely calling functions that may be undefined inside template expressions. E.g. `maybeUndefined?.()`

Fixes #42298.