### PR TITLE
test: remove newlines to make a test more stable

### DIFF
--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -25,6 +25,15 @@ describe('ViewContainerRef', () => {
         .replace(/\sng-reflect-\S*="[^"]*"/g, '');
   }
 
+  /**
+   * Helper method to retrieve the text content of the given element. This method also strips all
+   * leading and trailing whitespace and removes all newlines. This makes element content
+   * comparisons easier and less verbose.
+   */
+  function getElementText(element: Element): string {
+    return element.textContent!.trim().replace(/\r?\n/g, ' ');
+  }
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [
@@ -1480,7 +1489,7 @@ describe('ViewContainerRef', () => {
 
           fixture.detectChanges();
 
-          expect(fixture.nativeElement.parentNode.textContent.trim())
+          expect(getElementText(fixture.nativeElement.parentNode))
               .toContain(
                   '[Child Component B] ' +
                   '[Projectable Node] ' +


### PR DESCRIPTION
One of the tests was not taking into account newlines in the text content of an element, thus failing in some browsers. This commit makes the test more stable by removing newlines and comparing the output after that.

This PR resolves an issue in [the "saucelabs" CI job](https://app.circleci.com/pipelines/github/angular/angular/40939/workflows/06cbf675-ce9d-4954-827b-6e88f0378222/jobs/1100069) that we invoke every 24h.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No