### PR TITLE
feat(common): add BehaviorSubject overload to AsyncPipe

### DIFF
--- a/goldens/public-api/common/common.md
+++ b/goldens/public-api/common/common.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { BehaviorSubject } from 'rxjs';
 import { ChangeDetectorRef } from '@angular/core';
 import { DoCheck } from '@angular/core';
 import { ElementRef } from '@angular/core';
@@ -36,6 +37,8 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     constructor(_ref: ChangeDetectorRef);
     // (undocumented)
     ngOnDestroy(): void;
+    // (undocumented)
+    transform<T>(obj: BehaviorSubject<T>): T;
     // (undocumented)
     transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T>): T | null;
     // (undocumented)

--- a/packages/common/src/pipes/async_pipe.ts
+++ b/packages/common/src/pipes/async_pipe.ts
@@ -7,7 +7,7 @@
  */
 
 import {ChangeDetectorRef, EventEmitter, OnDestroy, Pipe, PipeTransform, ɵisPromise, ɵisSubscribable} from '@angular/core';
-import {Observable, Subscribable, Unsubscribable} from 'rxjs';
+import {BehaviorSubject, Observable, Subscribable, Unsubscribable} from 'rxjs';
 
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
@@ -100,6 +100,7 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
   // TypeScript has a hard time matching Observable to Subscribable, for more information
   // see https://github.com/microsoft/TypeScript/issues/43643
 
+  transform<T>(obj: BehaviorSubject<T>): T;
   transform<T>(obj: Observable<T>|Subscribable<T>|Promise<T>): T|null;
   transform<T>(obj: null|undefined): null;
   transform<T>(obj: Observable<T>|Subscribable<T>|Promise<T>|null|undefined): T|null;

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -9,7 +9,7 @@
 import {AsyncPipe, ɵgetDOM as getDOM} from '@angular/common';
 import {ChangeDetectorRef, EventEmitter} from '@angular/core';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
-import {Subscribable, Unsubscribable} from 'rxjs';
+import {BehaviorSubject, Subscribable, Unsubscribable} from 'rxjs';
 
 {
   describe('AsyncPipe', () => {
@@ -133,6 +133,16 @@ import {Subscribable, Unsubscribable} from 'rxjs';
         const emitter = new EventEmitter<{name: 'T'}>();
         // The following line will fail to compile if the type cannot be inferred.
         const name = pipe.transform(emitter)?.name;
+      });
+    });
+
+    describe('BehaviorSubject', () => {
+      it('should use the BehaviorSubject overload and not return null', () => {
+        const ref = getChangeDetectorRefSpy();
+        const pipe = new AsyncPipe(ref);
+        const behaviorSubject = new BehaviorSubject<number>(1);
+        // The following line will only compile using the BehaviorSubject overload.
+        const value: number = pipe.transform(behaviorSubject);
       });
     });
 

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -144,6 +144,14 @@ import {BehaviorSubject, Subscribable, Unsubscribable} from 'rxjs';
         // The following line will only compile using the BehaviorSubject overload.
         const value: number = pipe.transform(behaviorSubject);
       });
+
+      it('should return the stored value', () => {
+        const ref = getChangeDetectorRefSpy();
+        const pipe = new AsyncPipe(ref);
+        const behaviorSubject = new BehaviorSubject<number>(1);
+        const value = pipe.transform(behaviorSubject);
+        expect(value).toBe(1);
+      });
     });
 
     describe('Promise', () => {


### PR DESCRIPTION
An AsyncPipe applied to a BehaviorSubject always has a non-null value to return.
Add an overload that reflects that fact.
Resolves false reports by Angular Ivy with strict template checking about `behaviorSubject | async` possibly being null.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Angular Ivy with strict template checking warns that a `behaviorSubject | async` may be null.
This is a false alarm, since a BehaviorSubject always has a value, so the AsyncPipe will have a value to output.


## What is the new behavior?

Applying an AsyncPipe on a BehaviorSubject will choose the BehaviorSubject overload, thus preventing the false alarm.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
