### PR TITLE
docs(docs-infra): improve the content of attribute directives

### DIFF
--- a/aio/content/examples/attribute-directives/src/app/highlight.directive.1.ts
+++ b/aio/content/examples/attribute-directives/src/app/highlight.directive.1.ts
@@ -5,7 +5,7 @@ import { Directive, ElementRef } from '@angular/core';
   selector: '[appHighlight]'
 })
 export class HighlightDirective {
-    constructor(el: ElementRef) {
-       el.nativeElement.style.backgroundColor = 'yellow';
+    constructor(private el: ElementRef) {
+       this.el.nativeElement.style.backgroundColor = 'yellow';
     }
 }

--- a/aio/content/examples/attribute-directives/src/app/highlight.directive.3.ts
+++ b/aio/content/examples/attribute-directives/src/app/highlight.directive.3.ts
@@ -13,9 +13,11 @@ export class HighlightDirective {
   @Input() appHighlight = '';
   // #enddocregion input
 
+  // #docregion mouse-enter
   @HostListener('mouseenter') onMouseEnter() {
     this.highlight(this.appHighlight || 'red');
   }
+  // #enddocregion mouse-enter
 
   @HostListener('mouseleave') onMouseLeave() {
     this.highlight('');

--- a/aio/content/examples/attribute-directives/src/app/highlight.directive.ts
+++ b/aio/content/examples/attribute-directives/src/app/highlight.directive.ts
@@ -11,11 +11,11 @@ export class HighlightDirective {
   @Input() defaultColor = '';
   // #enddocregion defaultColor
 
-  @Input('appHighlight') highlightColor = '';
+  @Input() appHighlight = '';
 
   // #docregion mouse-enter
   @HostListener('mouseenter') onMouseEnter() {
-    this.highlight(this.highlightColor || this.defaultColor || 'red');
+    this.highlight(this.appHighlight || this.defaultColor || 'red');
   }
   // #enddocregion mouse-enter
 

--- a/aio/content/guide/attribute-directives.md
+++ b/aio/content/guide/attribute-directives.md
@@ -120,6 +120,10 @@ This section guides you through adding radio buttons to bind your color choice t
 
   <code-example path="attribute-directives/src/app/app.component.ts" header="src/app/app.component.ts (class)" region="class"></code-example>
 
+1. In `highlight.directive.ts`, revise `onMouseEnter` method so that it first tries to highlight with `appHighlight` and falls back to `red` if `appHighlight` is `undefined`.
+
+  <code-example path="attribute-directives/src/app/highlight.directive.3.ts" header="src/app/highlight.directive.ts (mouse-enter)" region="mouse-enter"></code-example>
+
 1. Serve your application to verify that the user can choose the color with the radio buttons.
 
   <div class="lightbox">
@@ -136,7 +140,7 @@ This section guides you through configuring your application so the developer ca
 
   <code-example path="attribute-directives/src/app/highlight.directive.ts" header="src/app/highlight.directive.ts (defaultColor)" region="defaultColor"></code-example>
 
-1. Revise the directive's `onMouseEnter` so that it first tries to highlight with the `highlightColor`, then with the `defaultColor`, and falls back to `red` if both properties are `undefined`.
+1. Revise the directive's `onMouseEnter` so that it first tries to highlight with the `appHighlight`, then with the `defaultColor`, and falls back to `red` if both properties are `undefined`.
 
   <code-example path="attribute-directives/src/app/highlight.directive.ts" header="src/app/highlight.directive.ts (mouse-enter)" region="mouse-enter"></code-example>
 


### PR DESCRIPTION
Improve docs "Understanding Angular-Directives-Attribute Directives"

In `highlight.directive.1.ts`, add the `private` keyword for `el` property
to make it correct and consistent with subsequent examples.

For section "Setting the value with user input", add a step to tell the
reader change the method `onMouseEnter`, thus more readable.

For section "Binding to a secon property", add a step to tell the reader
should add an alias because the docs doesn't mention it at all, thus
more readable.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

https://angular.io/guide/attribute-directives

Issue Number: N/A


## What is the new behavior?

In `highlight.directive.1.ts`, add the `private` keyword for `el` property to make it correct and consistent with subsequent examples.

After:

![image](https://user-images.githubusercontent.com/56911263/148189961-8c5fc602-cac2-4648-beb9-b74d5aa52e41.png)

For section "Setting the value with user input", add a step to tell the reader change the method `onMouseEnter`, thus more readable.

After:

![image](https://user-images.githubusercontent.com/56911263/148199848-ed2d5294-cd0a-45a5-8fce-a488bc27557e.png)


For section "Binding to a second property", add a step to tell the reader should add an alias because the docs doesn't mention it at all, thus more readable

After

![image](https://user-images.githubusercontent.com/56911263/148190231-a62c718f-69d2-4a60-9330-d1c6db22581f.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

