### PR TITLE
refactor(compiler-cli): update template typechecking link to latest angular.io version

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1160,7 +1160,7 @@ One of the following actions is required:
 2. Remove "strictTemplates" or set it to 'false'.
 
 More information about the template type checking compiler options can be found in the documentation:
-https://v9.angular.io/guide/template-typecheck#template-type-checking`,
+https://angular.io/guide/template-typecheck`,
     };
   }
 


### PR DESCRIPTION
This page exists in the most recent angular.io version (v13 currently), so there's no need to link to an old version. The hash also refers to the title section of the page, which isn't necessary and is now dropped.

This was originally added in https://github.com/angular/angular/pull/34887, and doesn't appear to actually require the v9 version, so I don't see any reason not to update the link.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Refactoring (no functional changes, no api changes)

## What is the current behavior?

Error message links to old v9 documentation.

## What is the new behavior?

Error message now links to the most current documentation.

## Does this PR introduce a breaking change?

- [X] No

## Other information

Identified in https://github.com/angular/angular/pull/44391#discussion_r779779154, but pulled into its own PR to be more obvious about the change.