### PR TITLE
build: use correct target name

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/testing/test/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/file_system/testing/test/BUILD.bazel
@@ -16,7 +16,7 @@ ts_library(
 
 jasmine_node_test(
     name = "test",
-    bootstrap = ["//tools/testing:node_no_angular_es5"],
+    bootstrap = ["//tools/testing:node_no_angular_es2015"],
     deps = [
         ":test_lib",
     ],


### PR DESCRIPTION
Dev mode output was switched from ES5 -> ES2015 recently and as a part of those changes, some target names that contained `_es5` postfixes were changes to `_es2015` instead. This commit fixes the issue with one of the recently merged BUILD files that contained the old (`_es5`) postfix.

## PR Type
What kind of change does this PR introduce?

- [x] Build related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No