### PR TITLE
fix(compiler-cli): incorrectly interpreting $any calls with a property read

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -1728,11 +1728,12 @@ class TcbExpressionTranslator {
       return result;
     } else if (
         ast instanceof Call &&
-        (ast.receiver instanceof PropertyRead || ast.receiver instanceof SafePropertyRead) &&
-        !(ast.receiver.receiver instanceof ThisReceiver)) {
+        (ast.receiver instanceof PropertyRead || ast.receiver instanceof SafePropertyRead)) {
       // Resolve the special `$any(expr)` syntax to insert a cast of the argument to type `any`.
       // `$any(expr)` -> `expr as any`
-      if (ast.receiver.name === '$any' && ast.args.length === 1) {
+      if (ast.receiver.receiver instanceof ImplicitReceiver &&
+          !(ast.receiver.receiver instanceof ThisReceiver) && ast.receiver.name === '$any' &&
+          ast.args.length === 1) {
         const expr = this.translate(ast.args[0]);
         const exprAsAny =
             ts.createAsExpression(expr, ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -8,7 +8,6 @@
 
 import {initMockFileSystem} from '../../file_system/testing';
 import {TypeCheckingConfig} from '../api';
-
 import {ALL_ENABLED_CONFIG, tcb, TestDeclaration, TestDirective} from '../testing';
 
 
@@ -611,6 +610,12 @@ describe('type check blocks', () => {
     const TEMPLATE = `{{this.$any(a)}}`;
     const block = tcb(TEMPLATE);
     expect(block).toContain('((((ctx).$any))(((ctx).a)))');
+  });
+
+  it('should handle $any accessed through a property read', () => {
+    const TEMPLATE = `{{foo.$any(a)}}`;
+    const block = tcb(TEMPLATE);
+    expect(block).toContain('((((((ctx).foo)).$any))(((ctx).a)))');
   });
 
   describe('experimental DOM checking via lib.dom.d.ts', () => {


### PR DESCRIPTION
This was flagged during the code review of #44580. When generating a type check block, we were interpreting any call to `$any` as an `as any` cast, even if it's part of a `PropertyRead` (e.g. `foo.$any(1)`). This is handled correctly in other parts of the compiler, but it looks like it was missed in the type checker.