### PR TITLE
refactor(common): make the error messages tree shakable

### DIFF
--- a/goldens/public-api/common/errors.md
+++ b/goldens/public-api/common/errors.md
@@ -7,6 +7,8 @@
 // @public
 export const enum RuntimeErrorCode {
     // (undocumented)
+    INVALID_PIPE_ARGUMENT = 2100,
+    // (undocumented)
     PARENT_NG_SWITCH_NOT_FOUND = 2000
 }
 

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -13,4 +13,6 @@
 export const enum RuntimeErrorCode {
   // NgSwitch errors
   PARENT_NG_SWITCH_NOT_FOUND = 2000,
+  // Pipe errors
+  INVALID_PIPE_ARGUMENT = 2100
 }

--- a/packages/common/src/pipes/invalid_pipe_argument_error.ts
+++ b/packages/common/src/pipes/invalid_pipe_argument_error.ts
@@ -6,8 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type, ɵstringify as stringify} from '@angular/core';
+import {Type, ɵRuntimeError as RuntimeError, ɵstringify as stringify} from '@angular/core';
+
+import {RuntimeErrorCode} from '../errors';
 
 export function invalidPipeArgumentError(type: Type<any>, value: Object) {
-  return Error(`InvalidPipeArgument: '${value}' for pipe '${stringify(type)}'`);
+  const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
+      `InvalidPipeArgument: '${value}' for pipe '${stringify(type)}'` :
+      '';
+  return new RuntimeError(RuntimeErrorCode.INVALID_PIPE_ARGUMENT, errorMessage);
 }

--- a/packages/common/test/pipes/number_pipe_spec.ts
+++ b/packages/common/test/pipes/number_pipe_spec.ts
@@ -64,9 +64,10 @@ import {ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
         it('should not support other objects', () => {
           expect(() => pipe.transform({} as any))
               .toThrowError(
-                  `InvalidPipeArgument: '[object Object] is not a number' for pipe 'DecimalPipe'`);
+                  `NG02100: InvalidPipeArgument: '[object Object] is not a number' for pipe 'DecimalPipe'`);
           expect(() => pipe.transform('123abc'))
-              .toThrowError(`InvalidPipeArgument: '123abc is not a number' for pipe 'DecimalPipe'`);
+              .toThrowError(
+                  `NG02100: InvalidPipeArgument: '123abc is not a number' for pipe 'DecimalPipe'`);
         });
       });
 
@@ -108,7 +109,7 @@ import {ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
         it('should not support other objects', () => {
           expect(() => pipe.transform({} as any))
               .toThrowError(
-                  `InvalidPipeArgument: '[object Object] is not a number' for pipe 'PercentPipe'`);
+                  `NG02100: InvalidPipeArgument: '[object Object] is not a number' for pipe 'PercentPipe'`);
         });
       });
     });
@@ -168,7 +169,7 @@ import {ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
         it('should not support other objects', () => {
           expect(() => pipe.transform({} as any))
               .toThrowError(
-                  `InvalidPipeArgument: '[object Object] is not a number' for pipe 'CurrencyPipe'`);
+                  `NG02100: InvalidPipeArgument: '[object Object] is not a number' for pipe 'CurrencyPipe'`);
         });
 
         it('should warn if you are using the v4 signature', () => {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1878,7 +1878,7 @@
     "name": "stringify"
   },
   {
-    "name": "stringify6"
+    "name": "stringify7"
   },
   {
     "name": "stringifyCSSSelector"


### PR DESCRIPTION
Make Long error messages tree-shakable in the production build with error codes.

fixes #40096

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Invalid argument errors in the pipes are not tree-shakable in the production build.

Issue Number: 40096


## What is the new behavior?
Make the invalid argument errors in the pipes tree-shakable in the production build.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
