### PR TITLE
Fix 3 "Illegal State" bugs in the Angular Indexer

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AST, ASTWithSource, BoundTarget, ImplicitReceiver, ParseSourceSpan, PropertyRead, PropertyWrite, RecursiveAstVisitor, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstBoundText, TmplAstElement, TmplAstNode, TmplAstRecursiveVisitor, TmplAstReference, TmplAstTemplate, TmplAstVariable} from '@angular/compiler';
+
 import {AbsoluteSourceSpan, AttributeIdentifier, ElementIdentifier, IdentifierKind, MethodIdentifier, PropertyIdentifier, ReferenceIdentifier, TemplateNodeIdentifier, TopLevelIdentifier, VariableIdentifier} from './api';
 import {ComponentMeta} from './context';
 
@@ -93,7 +94,14 @@ class ExpressionVisitor extends RecursiveAstVisitor {
     }
 
     // The source span of the requested AST starts at a location that is offset from the expression.
-    const identifierStart = ast.sourceSpan.start - this.absoluteOffset;
+    let identifierStart = ast.sourceSpan.start - this.absoluteOffset;
+
+    if (ast instanceof PropertyRead || ast instanceof PropertyWrite) {
+      // For `PropertyRead` and `PropertyWrite`, the identifier starts at the `nameSpan`, not
+      // necessarily the `sourceSpan`.
+      identifierStart = ast.nameSpan.start - this.absoluteOffset;
+    }
+
     if (!this.expressionStr.substring(identifierStart).startsWith(ast.name)) {
       throw new Error(`Impossible state: "${ast.name}" not found in "${
           this.expressionStr}" at location ${identifierStart}`);

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -232,7 +232,15 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
       name = node.tagName;
       kind = IdentifierKind.Template;
     } else {
-      name = node.name;
+      // Namespaced elements have a particular format for `node.name` that needs to be handled.
+      // For example, an `<svg>` element has a `node.name` of `':svg:svg'`.
+
+      // TODO(alxhub): properly handle namespaced elements
+      if (node.name.startsWith(':')) {
+        name = node.name.split(':').pop()!;
+      } else {
+        name = node.name;
+      }
       kind = IdentifierKind.Element;
     }
     const sourceSpan = node.startSourceSpan;

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -21,6 +21,20 @@ function bind(template: string) {
 
 runInEachFileSystem(() => {
   describe('getTemplateIdentifiers', () => {
+    it('should handle svg elements', () => {
+      const template = '<svg></svg>';
+      const refs = getTemplateIdentifiers(bind(template));
+
+      const [ref] = Array.from(refs);
+      expect(ref).toEqual({
+        kind: IdentifierKind.Element,
+        name: 'svg',
+        span: new AbsoluteSourceSpan(1, 4),
+        usedDirectives: new Set(),
+        attributes: new Set(),
+      });
+    });
+
     it('should handle comments in interpolations', () => {
       const template = '{{foo // comment}}';
       const refs = getTemplateIdentifiers(bind(template));

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -21,6 +21,19 @@ function bind(template: string) {
 
 runInEachFileSystem(() => {
   describe('getTemplateIdentifiers', () => {
+    it('should handle comments in interpolations', () => {
+      const template = '{{foo // comment}}';
+      const refs = getTemplateIdentifiers(bind(template));
+
+      const [ref] = Array.from(refs);
+      expect(ref).toEqual({
+        name: 'foo',
+        kind: IdentifierKind.Property,
+        span: new AbsoluteSourceSpan(2, 5),
+        target: null,
+      });
+    });
+
     it('should generate nothing in empty template', () => {
       const template = '';
       const refs = getTemplateIdentifiers(bind(template));

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -9,6 +9,7 @@
 import {AbsoluteSourceSpan, AttributeIdentifier, ElementIdentifier, IdentifierKind, ReferenceIdentifier, TemplateNodeIdentifier, TopLevelIdentifier, VariableIdentifier} from '..';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {getTemplateIdentifiers} from '../src/template';
+
 import * as util from './util';
 
 function bind(template: string) {
@@ -85,6 +86,20 @@ runInEachFileSystem(() => {
           name: 'foo',
           kind: IdentifierKind.Property,
           span: new AbsoluteSourceSpan(2, 5),
+          target: null,
+        });
+      });
+
+      it('should discover component properties read using "this" as a receiver', () => {
+        const template = '{{this.foo}}';
+        const refs = getTemplateIdentifiers(bind(template));
+        expect(refs.size).toBe(1);
+
+        const [ref] = Array.from(refs);
+        expect(ref).toEqual({
+          name: 'foo',
+          kind: IdentifierKind.Property,
+          span: new AbsoluteSourceSpan(7, 10),
           target: null,
         });
       });

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -39,11 +39,11 @@ export class Parser {
       interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): ASTWithSource {
     this._checkNoInterpolation(input, location, interpolationConfig);
     const sourceToLex = this._stripComments(input);
-    const tokens = this._lexer.tokenize(this._stripComments(input));
-    const ast = new _ParseAST(
-                    input, location, absoluteOffset, tokens, sourceToLex.length, true, this.errors,
-                    input.length - sourceToLex.length)
-                    .parseChain();
+    const tokens = this._lexer.tokenize(sourceToLex);
+    const ast =
+        new _ParseAST(
+            input, location, absoluteOffset, tokens, sourceToLex.length, true, this.errors, 0)
+            .parseChain();
     return new ASTWithSource(ast, input, location, absoluteOffset, this.errors);
   }
 
@@ -91,8 +91,7 @@ export class Parser {
     const sourceToLex = this._stripComments(input);
     const tokens = this._lexer.tokenize(sourceToLex);
     return new _ParseAST(
-               input, location, absoluteOffset, tokens, sourceToLex.length, false, this.errors,
-               input.length - sourceToLex.length)
+               input, location, absoluteOffset, tokens, sourceToLex.length, false, this.errors, 0)
         .parseChain();
   }
 
@@ -162,7 +161,7 @@ export class Parser {
       const tokens = this._lexer.tokenize(sourceToLex);
       const ast = new _ParseAST(
                       input, location, absoluteOffset, tokens, sourceToLex.length, false,
-                      this.errors, offsets[i] + (expressionText.length - sourceToLex.length))
+                      this.errors, offsets[i])
                       .parseChain();
       expressionNodes.push(ast);
     }

--- a/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
@@ -7,10 +7,23 @@
  */
 
 import {AbsoluteSourceSpan} from '@angular/compiler';
+
 import {humanizeExpressionSource} from './util/expression';
 import {parseR3 as parse} from './view/util';
 
 describe('expression AST absolute source spans', () => {
+  it('should handle comment in interpolation', () => {
+    expect(humanizeExpressionSource(parse('{{foo // comment}}', {preserveWhitespaces: true}).nodes))
+        .toContain(['foo', new AbsoluteSourceSpan(2, 5)]);
+  });
+
+  it('should handle comment in an action binding', () => {
+    expect(humanizeExpressionSource(parse('<button (click)="foo = true // comment">Save</button>', {
+                                      preserveWhitespaces: true
+                                    }).nodes))
+        .toContain(['foo = true', new AbsoluteSourceSpan(17, 27)]);
+  });
+
   // TODO(ayazhafiz): duplicate this test without `preserveWhitespaces` once whitespace rewriting is
   // moved to post-R3AST generation.
   it('should provide absolute offsets with arbitrary whitespace', () => {


### PR DESCRIPTION
This PR contains 3 commits, each of which fixes a separate crash in the Angular Indexer:

* Bindings to component properties using `this` as a receiver: `{{this.foo}}`
* Expressions that contain a comment: `{{foo // comment}}`
* SVG and other namespaced elements: `<svg></svg>`

Each of these templates would previously crash the indexer.