### PR TITLE
refactor: enable `useUnknownInCatchVariables` across packages

### DIFF
--- a/packages/animations/browser/test/render/transition_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/transition_animation_engine_spec.ts
@@ -633,7 +633,7 @@ describe('TransitionAnimationEngine', () => {
       try {
         engine.flush();
       } catch (e) {
-        errorMessage = e.toString();
+        errorMessage = (e as Error).toString();
       }
 
       expect(errorMessage).toMatch(/Unable to animate due to the following errors:/);

--- a/packages/common/http/testing/test/request_spec.ts
+++ b/packages/common/http/testing/test/request_spec.ts
@@ -39,7 +39,7 @@ describe('HttpClient TestRequest', () => {
       mock.expectOne('/some-url').flush(null);
       fail();
     } catch (error) {
-      expect(error.message)
+      expect((error as Error).message)
           .toBe(
               'Expected one matching request for criteria "Match URL: /some-url", found none.' +
               ' Requests received are: GET /some-other-url.');
@@ -61,7 +61,7 @@ describe('HttpClient TestRequest', () => {
       mock.expectOne('/some-url?query=world').flush(null);
       fail();
     } catch (error) {
-      expect(error.message)
+      expect((error as Error).message)
           .toBe(
               'Expected one matching request for criteria "Match URL: /some-url?query=world", found none.' +
               ' Requests received are: GET /some-url?query=hello.');
@@ -85,7 +85,7 @@ describe('HttpClient TestRequest', () => {
       mock.expectOne('/some-url').flush(null);
       fail();
     } catch (error) {
-      expect(error.message)
+      expect((error as Error).message)
           .toBe(
               'Expected one matching request for criteria "Match URL: /some-url", found none.' +
               ' Requests received are: GET /some-other-url?query=world, POST /and-another-url.');

--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -7,7 +7,9 @@
  */
 
 import {Inject, InjectionToken, LOCALE_ID, Optional, Pipe, PipeTransform} from '@angular/core';
+
 import {formatDate} from '../i18n/format_date';
+
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 /**
@@ -209,7 +211,7 @@ export class DatePipe implements PipeTransform {
       return formatDate(
           value, format, locale || this.locale, timezone ?? this.defaultTimezone ?? undefined);
     } catch (error) {
-      throw invalidPipeArgumentError(DatePipe, error.message);
+      throw invalidPipeArgumentError(DatePipe, (error as Error).message);
     }
   }
 }

--- a/packages/common/src/pipes/number_pipe.ts
+++ b/packages/common/src/pipes/number_pipe.ts
@@ -7,6 +7,7 @@
  */
 
 import {DEFAULT_CURRENCY_CODE, Inject, LOCALE_ID, Pipe, PipeTransform} from '@angular/core';
+
 import {formatCurrency, formatNumber, formatPercent} from '../i18n/format_number';
 import {getCurrencySymbol} from '../i18n/locale_data_api';
 
@@ -100,7 +101,7 @@ export class DecimalPipe implements PipeTransform {
       const num = strToNumber(value);
       return formatNumber(num, locale, digitsInfo);
     } catch (error) {
-      throw invalidPipeArgumentError(DecimalPipe, error.message);
+      throw invalidPipeArgumentError(DecimalPipe, (error as Error).message);
     }
   }
 }
@@ -156,7 +157,7 @@ export class PercentPipe implements PipeTransform {
       const num = strToNumber(value);
       return formatPercent(num, locale, digitsInfo);
     } catch (error) {
-      throw invalidPipeArgumentError(PercentPipe, error.message);
+      throw invalidPipeArgumentError(PercentPipe, (error as Error).message);
     }
   }
 }
@@ -281,7 +282,7 @@ export class CurrencyPipe implements PipeTransform {
       const num = strToNumber(value);
       return formatCurrency(num, locale, currency, currencyCode, digitsInfo);
     } catch (error) {
-      throw invalidPipeArgumentError(CurrencyPipe, error.message);
+      throw invalidPipeArgumentError(CurrencyPipe, (error as Error).message);
     }
   }
 }

--- a/packages/common/upgrade/src/location_shim.ts
+++ b/packages/common/upgrade/src/location_shim.ts
@@ -360,7 +360,7 @@ export class $locationShim {
       try {
         fn(url, state, oldUrl, oldState);
       } catch (e) {
-        err(e);
+        err(e as Error);
       }
     });
   }

--- a/packages/compiler-cli/linker/babel/src/es2015_linker_plugin.ts
+++ b/packages/compiler-cli/linker/babel/src/es2015_linker_plugin.ts
@@ -92,7 +92,7 @@ export function createEs2015LinkerPlugin({fileSystem, logger, ...options}: Linke
           call.replaceWith(replacement);
         } catch (e) {
           const node = isFatalLinkerError(e) ? e.node as t.Node : call.node;
-          throw buildCodeFrameError(call.hub.file, e.message, node);
+          throw buildCodeFrameError(call.hub.file, (e as Error).message, node);
         }
       }
     }

--- a/packages/compiler-cli/ngcc/main-ngcc.ts
+++ b/packages/compiler-cli/ngcc/main-ngcc.ts
@@ -21,7 +21,7 @@ const options = parseCommandLineOptions(process.argv.slice(2));
       options.logger.debug(`Run ngcc in ${duration}s.`);
     }
     process.exitCode = 0;
-  } catch (e) {
+  } catch (e: any) {
     console.error(e.stack || e.message);
     process.exit(typeof e.code === 'number' ? e.code : 1);
   }

--- a/packages/compiler-cli/ngcc/src/execution/cluster/ngcc_cluster_worker.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/ngcc_cluster_worker.ts
@@ -40,7 +40,7 @@ import {startWorker} from './worker';
     await startWorker(logger, createCompileFn);
     process.exitCode = 0;
   } catch (e) {
-    console.error(e.stack || e.message);
+    console.error((e as Error).stack || (e as Error).message);
     process.exit(1);
   }
 })();

--- a/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/worker.ts
@@ -40,7 +40,7 @@ export async function startWorker(logger: Logger, createCompileFn: CreateCompile
           throw new Error(
               `[Worker #${cluster.worker.id}] Invalid message received: ${JSON.stringify(msg)}`);
       }
-    } catch (err) {
+    } catch (err: any) {
       switch (err && err.code) {
         case 'ENOMEM':
           // Not being able to allocate enough memory is not necessarily a problem with processing

--- a/packages/compiler-cli/ngcc/src/locking/async_locker.ts
+++ b/packages/compiler-cli/ngcc/src/locking/async_locker.ts
@@ -49,7 +49,7 @@ export class AsyncLocker {
     for (let attempts = 0; attempts < this.retryAttempts; attempts++) {
       try {
         return this.lockFile.write();
-      } catch (e) {
+      } catch (e: any) {
         if (e.code !== 'EEXIST') {
           throw e;
         }

--- a/packages/compiler-cli/ngcc/src/locking/lock_file_with_child_process/util.ts
+++ b/packages/compiler-cli/ngcc/src/locking/lock_file_with_child_process/util.ts
@@ -26,7 +26,7 @@ export function removeLockFile(
       logger.debug(
           `PIDs do not match (${pid} and ${lockFilePid}), so not removing ${lockFilePath}.`);
     }
-  } catch (e) {
+  } catch (e: any) {
     if (e.code === 'ENOENT') {
       logger.debug(`The lock-file at ${lockFilePath} was already removed.`);
       // File already removed so quietly exit

--- a/packages/compiler-cli/ngcc/src/locking/sync_locker.ts
+++ b/packages/compiler-cli/ngcc/src/locking/sync_locker.ts
@@ -39,7 +39,7 @@ export class SyncLocker {
   protected create(): void {
     try {
       this.lockFile.write();
-    } catch (e) {
+    } catch (e: any) {
       if (e.code !== 'EEXIST') {
         throw e;
       }

--- a/packages/compiler-cli/ngcc/src/packages/configuration.ts
+++ b/packages/compiler-cli/ngcc/src/packages/configuration.ts
@@ -415,7 +415,8 @@ export class NgccConfiguration {
       try {
         return this.evalSrcFile(configFilePath);
       } catch (e) {
-        throw new Error(`Invalid project configuration file at "${configFilePath}": ` + e.message);
+        throw new Error(
+            `Invalid project configuration file at "${configFilePath}": ` + (e as Error).message);
       }
     } else {
       return {packages: {}};
@@ -433,7 +434,8 @@ export class NgccConfiguration {
           versionRange: version || '*',
         };
       } catch (e) {
-        throw new Error(`Invalid package configuration file at "${configFilePath}": ` + e.message);
+        throw new Error(
+            `Invalid package configuration file at "${configFilePath}": ` + (e as Error).message);
       }
     } else {
       return null;

--- a/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
+++ b/packages/compiler-cli/ngcc/src/packages/entry_point_manifest.ts
@@ -95,7 +95,8 @@ export class EntryPointManifest {
       return entryPoints;
     } catch (e) {
       this.logger.warn(
-          `Unable to read the entry-point manifest for ${basePath}:\n`, e.stack || e.toString());
+          `Unable to read the entry-point manifest for ${basePath}:\n`,
+          (e as Error).stack || (e as Error).toString());
       return null;
     }
   }

--- a/packages/compiler-cli/ngcc/src/rendering/source_maps.ts
+++ b/packages/compiler-cli/ngcc/src/rendering/source_maps.ts
@@ -64,7 +64,7 @@ export function renderSourceAndMap(
     ];
   } catch (e) {
     logger.error(`Error when flattening the source-map "${sourceMapPath}" for "${
-        sourceFilePath}": ${e.toString()}`);
+        sourceFilePath}": ${(e as Error).toString()}`);
     return [
       {path: sourceFilePath, contents: generatedContent},
       {path: sourceMapPath, contents: mapHelpers.fromObject(generatedMap).toJSON()},

--- a/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
+++ b/packages/compiler-cli/ngcc/src/writing/new_entry_point_file_writer.ts
@@ -113,7 +113,7 @@ export class NewEntryPointFileWriter extends InPlaceFileWriter {
         this.fs.writeFile(newSourceMapPath, JSON.stringify(sourceMap));
       } catch (e) {
         this.logger.warn(`Failed to process source-map at ${sourceMapPath}`);
-        this.logger.warn(e.message ?? e);
+        this.logger.warn((e as Error).message ?? e);
       }
     }
   }

--- a/packages/compiler-cli/ngcc/test/execution/cluster/executor_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/executor_spec.ts
@@ -86,7 +86,7 @@ runInEachFileSystem(() => {
         try {
           await executor.execute(analyzeEntryPointsSpy, createCompilerFnSpy);
         } catch (e) {
-          error = e.message;
+          error = (e as Error).message;
         }
         expect(analyzeEntryPointsSpy).toHaveBeenCalledWith();
         expect(createCompilerFnSpy).not.toHaveBeenCalled();
@@ -101,7 +101,7 @@ runInEachFileSystem(() => {
         try {
           await executor.execute(anyFn, anyFn);
         } catch (e) {
-          error = e.message;
+          error = (e as Error).message;
         }
         expect(error).toEqual('master runner error');
         expect(lockFileLog).toEqual(['write()', 'remove()']);
@@ -121,7 +121,7 @@ runInEachFileSystem(() => {
         try {
           await executor.execute(anyFn, anyFn);
         } catch (e) {
-          error = e.message;
+          error = (e as Error).message;
         }
         expect(error).toEqual('LockFile.write() error');
         expect(masterRunSpy).not.toHaveBeenCalled();
@@ -141,7 +141,7 @@ runInEachFileSystem(() => {
         try {
           await executor.execute(anyFn, anyFn);
         } catch (e) {
-          error = e.message;
+          error = (e as Error).message;
         }
         expect(error).toEqual('LockFile.remove() error');
         expect(lockFileLog).toEqual(['write()', 'remove()']);

--- a/packages/compiler-cli/ngcc/test/execution/single_processor_executor_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/single_processor_executor_spec.ts
@@ -65,7 +65,7 @@ describe('SingleProcessExecutor', () => {
       try {
         executor.execute(errorFn, createCompileFn);
       } catch (e) {
-        error = e.message;
+        error = (e as Error).message;
       }
       expect(error).toEqual('analyze error');
       expect(lockFileLog).toEqual(['write()', 'remove()']);
@@ -79,7 +79,7 @@ describe('SingleProcessExecutor', () => {
       try {
         executor.execute(oneTask, createErrorCompileFn);
       } catch (e) {
-        error = e.message;
+        error = (e as Error).message;
       }
       expect(error).toEqual('compile error');
       expect(lockFileLog).toEqual(['write()', 'remove()']);
@@ -100,7 +100,7 @@ describe('SingleProcessExecutor', () => {
       try {
         executor.execute(analyzeFn, anyFn);
       } catch (e) {
-        error = e.message;
+        error = (e as Error).message;
       }
       expect(error).toEqual('LockFile.write() error');
       expect(lockFileLog).toEqual(['write()']);
@@ -118,7 +118,7 @@ describe('SingleProcessExecutor', () => {
       try {
         executor.execute(noTasks, anyFn);
       } catch (e) {
-        error = e.message;
+        error = (e as Error).message;
       }
       expect(error).toEqual('LockFile.remove() error');
       expect(lockFileLog).toEqual(['write()', 'remove()']);

--- a/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
+++ b/packages/compiler-cli/ngcc/test/integration/ngcc_spec.ts
@@ -1525,10 +1525,11 @@ runInEachFileSystem(() => {
            });
            fail('should have thrown');
          } catch (e) {
-           expect(e.message).toContain(
-               'Failed to compile entry-point test-package (`esm2015` as esm2015) due to compilation errors:');
-           expect(e.message).toContain('NG1010');
-           expect(e.message).toContain('selector must be a string');
+           expect((e as Error).message)
+               .toContain(
+                   'Failed to compile entry-point test-package (`esm2015` as esm2015) due to compilation errors:');
+           expect((e as Error).message).toContain('NG1010');
+           expect((e as Error).message).toContain('selector must be a string');
          }
        });
 
@@ -2827,10 +2828,11 @@ runInEachFileSystem(() => {
              });
              fail('should have thrown');
            } catch (e) {
-             expect(e.message).toContain(
-                 'Failed to compile entry-point fatal-error (`es2015` as esm2015) due to compilation errors:');
-             expect(e.message).toContain('NG2001');
-             expect(e.message).toContain('component is missing a template');
+             expect((e as Error).message)
+                 .toContain(
+                     'Failed to compile entry-point fatal-error (`es2015` as esm2015) due to compilation errors:');
+             expect((e as Error).message).toContain('NG2001');
+             expect((e as Error).message).toContain('component is missing a template');
            }
          });
 

--- a/packages/compiler-cli/ngcc/test/locking/async_locker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/locking/async_locker_spec.ts
@@ -44,7 +44,7 @@ runInEachFileSystem(() => {
                throw new Error('ERROR');
              });
            } catch (e) {
-             error = e.message;
+             error = (e as Error).message;
            }
            expect(error).toEqual('ERROR');
            expect(log).toEqual(['write()', 'fn()', 'remove()']);

--- a/packages/compiler-cli/ngcc/test/locking/sync_locker_spec.ts
+++ b/packages/compiler-cli/ngcc/test/locking/sync_locker_spec.ts
@@ -38,7 +38,7 @@ runInEachFileSystem(() => {
                throw new Error('ERROR');
              });
            } catch (e) {
-             error = e.message;
+             error = (e as Error).message;
            }
            expect(error).toEqual('ERROR');
            expect(log).toEqual(['write()', 'fn()', 'remove()']);

--- a/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
+++ b/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
@@ -111,7 +111,7 @@ export class SourceFileLoader {
       return new SourceFile(sourcePath, contents, sourceMapInfo, sources, this.fs);
     } catch (e) {
       this.logger.warn(
-          `Unable to fully load ${sourcePath} for source-map flattening: ${e.message}`);
+          `Unable to fully load ${sourcePath} for source-map flattening: ${(e as Error).message}`);
       return null;
     } finally {
       // We are finished with this recursion so revert the paths being tracked
@@ -166,8 +166,8 @@ export class SourceFileLoader {
           origin: ContentOrigin.FileSystem,
         };
       } catch (e) {
-        this.logger.warn(
-            `Unable to fully load ${sourcePath} for source-map flattening: ${e.message}`);
+        this.logger.warn(`Unable to fully load ${sourcePath} for source-map flattening: ${
+            (e as Error).message}`);
         return null;
       }
     }

--- a/packages/compiler-cli/src/ngtsc/testing/src/mock_file_loading.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/mock_file_loading.ts
@@ -12,6 +12,7 @@ import {resolve} from 'path';
 
 import {AbsoluteFsPath, FileSystem, getFileSystem} from '../../file_system';
 import {Folder, MockFileSystemPosix, TestFile} from '../../file_system/testing';
+
 import {getAngularPackagesFromRunfiles, resolveNpmTreeArtifact} from './runfile_helpers';
 
 export function loadTestFiles(files: TestFile[]) {
@@ -132,7 +133,7 @@ export function loadTestDirectory(
         fs.writeFile(targetPath, readFileSync(srcPath, 'utf-8'));
       }
     } catch (e) {
-      console.warn(`Failed to add ${srcPath} to the mock file-system: ${e.message}`);
+      console.warn(`Failed to add ${srcPath} to the mock file-system: ${(e as Error).message}`);
     }
   });
 }

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -133,7 +133,7 @@ export function readConfiguration(
   } catch (e) {
     const errors: ts.Diagnostic[] = [{
       category: ts.DiagnosticCategory.Error,
-      messageText: e.stack,
+      messageText: (e as Error).stack!,
       file: undefined,
       start: undefined,
       length: undefined,
@@ -267,7 +267,7 @@ export function performCompilation({
     program = undefined;
     allDiagnostics.push({
       category: ts.DiagnosticCategory.Error,
-      messageText: e.stack,
+      messageText: (e as Error).stack!,
       code: api.UNKNOWN_ERROR_CODE,
       file: undefined,
       start: undefined,

--- a/packages/compiler-cli/test/compliance/test_helpers/get_compliance_tests.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/get_compliance_tests.ts
@@ -59,8 +59,8 @@ function loadTestCasesFile(
   try {
     return JSON.parse(fs.readFile(testCasesPath)) as {cases: TestCaseJson | TestCaseJson[]};
   } catch (e) {
-    throw new Error(
-        `Failed to load test-cases at "${fs.relative(basePath, testCasesPath)}":\n ${e.message}`);
+    throw new Error(`Failed to load test-cases at "${fs.relative(basePath, testCasesPath)}":\n ${
+        (e as Error).message}`);
   }
 }
 

--- a/packages/compiler-cli/test/test_support.ts
+++ b/packages/compiler-cli/test/test_support.ts
@@ -142,7 +142,7 @@ export function setupBazelTo(tmpDirPath: string) {
     const rxjsSource = resolveNpmTreeArtifact('rxjs', 'index.js');
     const rxjsDest = path.join(nodeModulesPath, 'rxjs');
     fs.symlinkSync(rxjsSource, rxjsDest, 'junction');
-  } catch (e) {
+  } catch (e: any) {
     if (e.code !== 'MODULE_NOT_FOUND') throw e;
   }
 }

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -221,7 +221,7 @@ export class R3Injector {
           null :
           notFoundValue;
       return nextInjector.get(token, notFoundValue);
-    } catch (e) {
+    } catch (e: any) {
       if (e.name === 'NullInjectorError') {
         const path: any[] = e[NG_TEMP_TOKEN_PATH] = e[NG_TEMP_TOKEN_PATH] || [];
         path.unshift(stringify(token));

--- a/packages/core/src/di/reflective_injector.ts
+++ b/packages/core/src/di/reflective_injector.ts
@@ -362,7 +362,7 @@ export class ReflectiveInjector_ implements ReflectiveInjector {
     try {
       deps =
           ResolvedReflectiveFactory.dependencies.map(dep => this._getByReflectiveDependency(dep));
-    } catch (e) {
+    } catch (e: any) {
       if (e.addKey) {
         e.addKey(this, provider.key);
       }
@@ -373,7 +373,7 @@ export class ReflectiveInjector_ implements ReflectiveInjector {
     try {
       obj = factory(...deps);
     } catch (e) {
-      throw instantiationError(this, e, e.stack, provider.key);
+      throw instantiationError(this, e, (e as Error).stack!, provider.key);
     }
 
     return obj;

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -3811,7 +3811,7 @@ describe('animation tests', function() {
        try {
          fixture.detectChanges();
        } catch (e) {
-         errorMsg = e.message;
+         errorMsg = (e as Error).message;
        }
 
        expect(errorMsg).toMatch(/@foo has failed due to:/);

--- a/packages/core/test/compiler/compiler_facade_spec.ts
+++ b/packages/core/test/compiler/compiler_facade_spec.ts
@@ -20,8 +20,9 @@ describe('getCompilerFacade', () => {
         getCompilerFacade({usage: JitCompilerUsage.Decorator, kind: 'directive', type: TestClass});
         fail('Error expected as compiler facade is not available');
       } catch (e) {
-        expect(e.message).toEqual(
-            `The directive 'TestClass' needs to be compiled using the JIT compiler, but '@angular/compiler' is not available.
+        expect((e as Error).message)
+            .toEqual(
+                `The directive 'TestClass' needs to be compiled using the JIT compiler, but '@angular/compiler' is not available.
 
 JIT compilation is discouraged for production use-cases! Consider using AOT mode instead.
 Alternatively, the JIT compiler should be loaded by bootstrapping using '@angular/platform-browser-dynamic' or '@angular/platform-server',
@@ -35,8 +36,9 @@ or manually provide the compiler with 'import "@angular/compiler";' before boots
             {usage: JitCompilerUsage.PartialDeclaration, kind: 'directive', type: TestClass});
         fail('Error expected as compiler facade is not available');
       } catch (e) {
-        expect(e.message).toEqual(
-            `The directive 'TestClass' needs to be compiled using the JIT compiler, but '@angular/compiler' is not available.
+        expect((e as Error).message)
+            .toEqual(
+                `The directive 'TestClass' needs to be compiled using the JIT compiler, but '@angular/compiler' is not available.
 
 The directive is part of a library that has been partially compiled.
 However, the Angular Linker has not processed the library such that JIT compilation is used as fallback.

--- a/packages/core/test/di/reflective_injector_spec.ts
+++ b/packages/core/test/di/reflective_injector_spec.ts
@@ -300,7 +300,7 @@ describe(`injector`, () => {
     try {
       injector.get(Car);
       throw 'Must throw';
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).toContain(
           `Error during instantiation of Engine! (${stringify(Car)} -> Engine)`);
       expect(getOriginalError(e) instanceof Error).toBeTruthy();

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -748,7 +748,7 @@ describe(`ChangeDetection`, () => {
            try {
              ctx.detectChanges(false);
            } catch (e) {
-             expect(e.message).toBe('Boom!');
+             expect((e as Error).message).toBe('Boom!');
              errored = true;
            }
            expect(errored).toBe(true);
@@ -760,7 +760,7 @@ describe(`ChangeDetection`, () => {
            try {
              ctx.detectChanges(false);
            } catch (e) {
-             expect(e.message).toBe('Boom!');
+             expect((e as Error).message).toBe('Boom!');
              throw new Error('Second detectChanges() should not have called ngOnInit.');
            }
            expect(directiveLog.filter(['ngOnInit'])).toEqual([]);

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -1426,8 +1426,8 @@ describe('integration tests', function() {
       try {
         TestBed.createComponent(ComponentWithoutView);
       } catch (e) {
-        expect(e.message).toContain(
-            `No template specified for component ${stringify(ComponentWithoutView)}`);
+        expect((e as Error).message)
+            .toContain(`No template specified for component ${stringify(ComponentWithoutView)}`);
       }
     });
   });

--- a/packages/localize/src/translate.ts
+++ b/packages/localize/src/translate.ts
@@ -93,7 +93,7 @@ export function translate(messageParts: TemplateStringsArray, substitutions: rea
   try {
     return _translate($localize.TRANSLATIONS, messageParts, substitutions);
   } catch (e) {
-    console.warn(e.message);
+    console.warn((e as Error).message);
     return [messageParts, substitutions];
   }
 }

--- a/packages/localize/tools/src/source_file_utils.ts
+++ b/packages/localize/tools/src/source_file_utils.ts
@@ -383,7 +383,7 @@ export function translate(
         substitutions
       ];
     } else {
-      diagnostics.error(e.message);
+      diagnostics.error((e as Error).message);
       return [messageParts, substitutions];
     }
   }

--- a/packages/localize/tools/src/translate/asset_files/asset_translation_handler.ts
+++ b/packages/localize/tools/src/translate/asset_files/asset_translation_handler.ts
@@ -42,7 +42,7 @@ export class AssetTranslationHandler implements TranslationHandler {
       this.fs.ensureDir(this.fs.dirname(outputPath));
       this.fs.writeFile(outputPath, contents);
     } catch (e) {
-      diagnostics.error(e.message);
+      diagnostics.error((e as Error).message);
     }
   }
 }

--- a/packages/localize/tools/src/translate/source_files/source_file_translation_handler.ts
+++ b/packages/localize/tools/src/translate/source_files/source_file_translation_handler.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {absoluteFrom, AbsoluteFsPath, FileSystem, PathSegment} from '@angular/compiler-cli/private/localize';
-import {parseSync, transformFromAstSync, types as t} from '../../babel_core';
 
+import {parseSync, transformFromAstSync, types as t} from '../../babel_core';
 import {Diagnostics} from '../../diagnostics';
 import {TranslatePluginOptions} from '../../source_file_utils';
 import {OutputPathFn} from '../output_path';
@@ -103,7 +103,7 @@ export class SourceFileTranslationHandler implements TranslationHandler {
       this.fs.ensureDir(this.fs.dirname(outputPath));
       this.fs.writeFile(outputPath, contents);
     } catch (e) {
-      diagnostics.error(e.message);
+      diagnostics.error((e as Error).message);
     }
   }
 }

--- a/packages/localize/tools/src/translate/translation_files/translation_parsers/serialize_translation_message.ts
+++ b/packages/localize/tools/src/translate/translation_files/translation_parsers/serialize_translation_message.ts
@@ -27,6 +27,6 @@ export function serializeTranslationMessage(element: Element, config: MessageSer
     const translation = serializer.serialize(rootNodes);
     return {translation, parseErrors, serializeErrors: []};
   } catch (e) {
-    return {translation: null, parseErrors, serializeErrors: [e]};
+    return {translation: null, parseErrors, serializeErrors: [e as ParseError]};
   }
 }

--- a/packages/misc/angular-in-memory-web-api/src/backend-service.ts
+++ b/packages/misc/angular-in-memory-web-api/src/backend-service.ts
@@ -320,7 +320,7 @@ export abstract class BackendService {
       try {
         resOptions = resOptionsFactory();
       } catch (error) {
-        const err = error.message || error;
+        const err = (error as Error).message || error;
         resOptions = this.createErrorResponseOptions('', STATUS.INTERNAL_SERVER_ERROR, `${err}`);
       }
 
@@ -550,7 +550,7 @@ export abstract class BackendService {
       const resourceUrl = urlRoot + apiBase + collectionName + '/';
       return {apiBase, collectionName, id, query, resourceUrl};
     } catch (err) {
-      const msg = `unable to parse url '${url}'; original error: ${err.message}`;
+      const msg = `unable to parse url '${url}'; original error: ${(err as Error).message}`;
       throw new Error(msg);
     }
   }
@@ -565,7 +565,7 @@ export abstract class BackendService {
       try {
         item.id = id || this.genId(collection, collectionName);
       } catch (err) {
-        const emsg: string = err.message || '';
+        const emsg: string = (err as Error).message || '';
         if (/id type is non-numeric/.test(emsg)) {
           return this.createErrorResponseOptions(url, STATUS.UNPROCESSABLE_ENTRY, emsg);
         } else {
@@ -597,7 +597,7 @@ export abstract class BackendService {
     } else {
       collection[existingIx] = item;
       return this.config.post204 ? {headers, status: STATUS.NO_CONTENT} :  // successful; no content
-          {headers, body, status: STATUS.OK};  // successful; return entity
+                                   {headers, body, status: STATUS.OK};  // successful; return entity
     }
   }
 
@@ -621,7 +621,7 @@ export abstract class BackendService {
     if (existingIx > -1) {
       collection[existingIx] = item;
       return this.config.put204 ? {headers, status: STATUS.NO_CONTENT} :  // successful; no content
-          {headers, body, status: STATUS.OK};  // successful; return entity
+                                  {headers, body, status: STATUS.OK};  // successful; return entity
     } else if (this.config.put404) {
       // item to update not found; use POST to create new item for this id.
       return this.createErrorResponseOptions(
@@ -651,9 +651,9 @@ export abstract class BackendService {
   protected resetDb(reqInfo?: RequestInfo): Observable<boolean> {
     this.dbReadySubject && this.dbReadySubject.next(false);
     const db = this.inMemDbService.createDb(reqInfo);
-    const db$ = db instanceof Observable ?
-        db :
-        typeof (db as any).then === 'function' ? from(db as Promise<any>) : of(db);
+    const db$ = db instanceof Observable       ? db :
+        typeof (db as any).then === 'function' ? from(db as Promise<any>) :
+                                                 of(db);
     db$.pipe(first()).subscribe((d: {}) => {
       this.db = d;
       this.dbReadySubject && this.dbReadySubject.next(true);

--- a/packages/misc/angular-in-memory-web-api/src/http-client-backend-service.ts
+++ b/packages/misc/angular-in-memory-web-api/src/http-client-backend-service.ts
@@ -57,7 +57,7 @@ export class HttpClientBackendService extends BackendService implements HttpBack
       return this.handleRequest(req);
 
     } catch (error) {
-      const err = error.message || error;
+      const err = (error as Error).message || error;
       const resOptions =
           this.createErrorResponseOptions(req.url, STATUS.INTERNAL_SERVER_ERROR, `${err}`);
       return this.createResponse$(() => resOptions);
@@ -94,7 +94,7 @@ export class HttpClientBackendService extends BackendService implements HttpBack
     try {
       return new HttpXhrBackend(this.xhrFactory);
     } catch (ex) {
-      ex.message = 'Cannot create passThru404 backend; ' + (ex.message || '');
+      (ex as Error).message = 'Cannot create passThru404 backend; ' + ((ex as Error).message || '');
       throw ex;
     }
   }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1279,7 +1279,7 @@ export class Router {
     try {
       urlTree = this.urlSerializer.parse(url);
     } catch (e) {
-      urlTree = this.malformedUriErrorHandler(e, this.urlSerializer, url);
+      urlTree = this.malformedUriErrorHandler(e as URIError, this.urlSerializer, url);
     }
     return urlTree;
   }

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -213,7 +213,7 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
             await push.unsubscribe();
             throw new Error('`unsubscribe()` should fail');
           } catch (err) {
-            expect(err.message).toBe('Not subscribed to push notifications.');
+            expect((err as Error).message).toBe('Not subscribed to push notifications.');
           }
         });
 
@@ -234,7 +234,7 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
             await push.unsubscribe();
             throw new Error('`unsubscribe()` should fail');
           } catch (err) {
-            expect(err.message).toBe('foo');
+            expect((err as Error).message).toBe('foo');
           }
         });
 
@@ -246,7 +246,7 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
             await push.unsubscribe();
             throw new Error('`unsubscribe()` should fail');
           } catch (err) {
-            expect(err.message).toBe('Unsubscribe failed!');
+            expect((err as Error).message).toBe('Unsubscribe failed!');
           }
         });
 

--- a/packages/service-worker/worker/src/data.ts
+++ b/packages/service-worker/worker/src/data.ts
@@ -284,7 +284,8 @@ export class DataGroup {
     } catch (err) {
       // Writing lru cache table failed. This could be a result of a full storage.
       // Continue serving clients as usual.
-      this.debugHandler.log(err, `DataGroup(${this.config.name}@${this.config.version}).syncLru()`);
+      this.debugHandler.log(
+          err as Error, `DataGroup(${this.config.name}@${this.config.version}).syncLru()`);
       // TODO: Better detect/handle full storage; e.g. using
       // [navigator.storage](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorStorage/storage).
     }
@@ -457,7 +458,7 @@ export class DataGroup {
         // Saving the API response failed. This could be a result of a full storage.
         // Since this data is cached lazily and temporarily, continue serving clients as usual.
         this.debugHandler.log(
-            err,
+            err as Error,
             `DataGroup(${this.config.name}@${this.config.version}).safeCacheResponse(${
                 req.url}, status: ${res.status})`);
 

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -142,7 +142,7 @@ export class Driver implements Debuggable, UpdateSource {
             await this.cleanupOldSwCaches();
           } catch (err) {
             // Nothing to do - cleanup failed. Just log it.
-            this.debugger.log(err, 'cleanupOldSwCaches @ activate: cleanup-old-sw-caches');
+            this.debugger.log(err as Error, 'cleanupOldSwCaches @ activate: cleanup-old-sw-caches');
           }
         });
       })());
@@ -409,7 +409,7 @@ export class Driver implements Debuggable, UpdateSource {
     } catch (e) {
       client.postMessage({
         ...response,
-        error: e.toString(),
+        error: (e as Error).toString(),
       });
     }
   }
@@ -479,7 +479,7 @@ export class Driver implements Debuggable, UpdateSource {
           // Handle the request. First try the AppVersion. If that doesn't work, fall back on the
           // network.
           res = await appVersion.handleFetch(event.request, event);
-        } catch (err) {
+        } catch (err: any) {
           if (err.isUnrecoverableState) {
             await this.notifyClientsAboutUnrecoverableState(appVersion, err.message);
           }
@@ -632,7 +632,7 @@ export class Driver implements Debuggable, UpdateSource {
         // it fails, then full initialization was attempted and failed.
         await this.scheduleInitialization(this.versions.get(hash)!);
       } catch (err) {
-        this.debugger.log(err, `initialize: schedule init of ${hash}`);
+        this.debugger.log(err as Error, `initialize: schedule init of ${hash}`);
         return false;
       }
     }));
@@ -782,8 +782,8 @@ export class Driver implements Debuggable, UpdateSource {
       try {
         await appVersion.initializeFully();
       } catch (err) {
-        this.debugger.log(err, `initializeFully for ${appVersion.manifestHash}`);
-        await this.versionFailed(appVersion, err);
+        this.debugger.log(err as Error, `initializeFully for ${appVersion.manifestHash}`);
+        await this.versionFailed(appVersion, err as Error);
       }
     };
     // TODO: better logic for detecting localhost.
@@ -887,7 +887,7 @@ export class Driver implements Debuggable, UpdateSource {
 
       return true;
     } catch (err) {
-      this.debugger.log(err, `Error occurred while updating to manifest ${hash}`);
+      this.debugger.log(err as Error, `Error occurred while updating to manifest ${hash}`);
 
       this.state = DriverReadyState.EXISTING_CLIENTS_ONLY;
       this.stateMessage = `Degraded due to failed initialization: ${errorToString(err)}`;
@@ -966,7 +966,7 @@ export class Driver implements Debuggable, UpdateSource {
     } catch (err) {
       // Oh well? Not much that can be done here. These caches will be removed on the next attempt
       // or when the SW revs its format version, which happens from time to time.
-      this.debugger.log(err, 'cleanupCaches');
+      this.debugger.log(err as Error, 'cleanupCaches');
     }
   }
 
@@ -1167,7 +1167,7 @@ export class Driver implements Debuggable, UpdateSource {
     try {
       return await this.scope.fetch(req);
     } catch (err) {
-      this.debugger.log(err, `Driver.fetch(${req.url})`);
+      this.debugger.log(err as Error, `Driver.fetch(${req.url})`);
       return this.adapter.newResponse(null, {
         status: 504,
         statusText: 'Gateway Timeout',

--- a/packages/service-worker/worker/src/idle.ts
+++ b/packages/service-worker/worker/src/idle.ts
@@ -73,7 +73,7 @@ export class IdleScheduler {
         try {
           await task.run();
         } catch (err) {
-          this.debug.log(err, `while running idle task ${task.desc}`);
+          this.debug.log(err as Error, `while running idle task ${task.desc}`);
         }
       }, Promise.resolve());
     }

--- a/packages/tsconfig-build.json
+++ b/packages/tsconfig-build.json
@@ -11,14 +11,17 @@
     "noImplicitOverride": true,
     "strictNullChecks": true,
     "esModuleInterop": true,
-    "useUnknownInCatchVariables": false,
+    "useUnknownInCatchVariables": true,
     "strict": true,
     "strictPropertyInitialization": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "module": "es2020",
     "target": "es2020",
-    "lib": ["es2020", "dom"],
+    "lib": [
+      "es2020",
+      "dom"
+    ],
     "skipLibCheck": true,
     // don't auto-discover @types/node, it results in a ///<reference in the .d.ts output
     "types": [],

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -17,7 +17,7 @@
     "outDir": "../dist/all/@angular",
     "noImplicitAny": true,
     "noImplicitOverride": true,
-    "useUnknownInCatchVariables": false,
+    "useUnknownInCatchVariables": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
       "selenium-webdriver": [

--- a/packages/upgrade/src/common/src/downgrade_injectable.ts
+++ b/packages/upgrade/src/common/src/downgrade_injectable.ts
@@ -7,6 +7,7 @@
  */
 
 import {Injector} from '@angular/core';
+
 import {IInjectorService} from './angular1';
 import {$INJECTOR, INJECTOR_KEY} from './constants';
 import {getTypeName, isFunction, validateInjectionKey} from './util';
@@ -83,7 +84,7 @@ export function downgradeInjectable(token: any, downgradedModule: string = ''): 
       const injector: Injector = $injector.get(injectorKey);
       return injector.get(token);
     } catch (err) {
-      throw new Error(`Error while ${attemptedAction}: ${err.message || err}`);
+      throw new Error(`Error while ${attemptedAction}: ${(err as Error).message || err}`);
     }
   };
   (factory as any)['$inject'] = [$INJECTOR];

--- a/packages/zone.js/lib/common/events.ts
+++ b/packages/zone.js/lib/common/events.ts
@@ -120,7 +120,7 @@ export function patchEventTarget(
     // need to try/catch error here, otherwise, the error in one event listener
     // will break the executions of the other event listeners. Also error will
     // not remove the event listener when `once` options is true.
-    let error;
+    let error: any;
     try {
       task.invoke(task, target, [event]);
     } catch (err) {

--- a/packages/zone.js/lib/extra/bluebird.ts
+++ b/packages/zone.js/lib/extra/bluebird.ts
@@ -74,8 +74,8 @@ Zone.__load_patch('bluebird', (global: any, Zone: ZoneType, api: _ZonePrivate) =
           throw e;
         });
       } catch (err) {
-        err.isHandledByZone = false;
-        api.onUnhandledError(err);
+        (err as any).isHandledByZone = false;
+        api.onUnhandledError(err as Error);
       }
     });
 

--- a/packages/zone.js/lib/zone-spec/long-stack-trace.ts
+++ b/packages/zone.js/lib/zone-spec/long-stack-trace.ts
@@ -30,7 +30,7 @@ function getStacktraceWithCaughtError(): Error {
   try {
     throw getStacktraceWithUncaughtError();
   } catch (err) {
-    return err;
+    return err as Error;
   }
 }
 

--- a/packages/zone.js/lib/zone.ts
+++ b/packages/zone.js/lib/zone.ts
@@ -1380,7 +1380,7 @@ const Zone: ZoneType = (function(global: any) {
           try {
             task.zone.runTask(task, null, null);
           } catch (error) {
-            _api.onUnhandledError(error);
+            _api.onUnhandledError(error as Error);
           }
         }
       }

--- a/packages/zone.js/test/browser/XMLHttpRequest.spec.ts
+++ b/packages/zone.js/test/browser/XMLHttpRequest.spec.ts
@@ -280,7 +280,7 @@ describe('XMLHttpRequest', function() {
       expect(req.responseType).toBe('document');
     } catch (e) {
       // Android browser: using this setter throws, this should be preserved
-      expect(e.message).toBe('INVALID_STATE_ERR: DOM Exception 11');
+      expect((e as Error).message).toBe('INVALID_STATE_ERR: DOM Exception 11');
     }
   });
 

--- a/packages/zone.js/test/common/zone.spec.ts
+++ b/packages/zone.js/test/common/zone.spec.ts
@@ -185,8 +185,9 @@ describe('Zone', function() {
       try {
         zone.cancelTask(task);
       } catch (e) {
-        expect(e.message).toContain(
-            'macroTask \'test\': can not transition to \'canceling\', expecting state \'scheduled\' or \'running\', was \'notScheduled\'.');
+        expect((e as Error).message)
+            .toContain(
+                'macroTask \'test\': can not transition to \'canceling\', expecting state \'scheduled\' or \'running\', was \'notScheduled\'.');
       }
     });
 

--- a/packages/zone.js/test/test-util.ts
+++ b/packages/zone.js/test/test-util.ts
@@ -79,8 +79,8 @@ export function isSupportSetErrorStack() {
     throw new Error('test');
   } catch (err) {
     try {
-      err.stack = 'new stack';
-      supportSetErrorStack = err.stack === 'new stack';
+      (err as Error).stack = 'new stack';
+      supportSetErrorStack = (err as Error).stack === 'new stack';
     } catch (error) {
       supportSetErrorStack = false;
     }

--- a/packages/zone.js/tsconfig.json
+++ b/packages/zone.js/tsconfig.json
@@ -10,7 +10,7 @@
     "stripInternal": false,
     "strict": true,
     "noImplicitOverride": true,
-    "useUnknownInCatchVariables": false,
+    "useUnknownInCatchVariables": true,
     "lib": [
       "es5",
       "dom",
@@ -19,7 +19,9 @@
       "es2015.symbol",
       "es2015.symbol.wellknown"
     ],
-    "typeRoots": ["node_modules/@types"],
+    "typeRoots": [
+      "node_modules/@types"
+    ],
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This commit enables the TypeScript flag `useUnknownInCatchVariables`, which
uses `unknown` instead of `any` as the default type of the error in a
`catch` block. This flag is being enabled in g3, and so these changes are
necessary in the upstream repo.

The primary strategy taken in this commit is to cast the error to an
appropriate type when necessary. This was applied mechanically, which for
several files results in multiple casts for a single `catch` block. There is
no cost here other than the repetition, and this can be cleaned up easily if
needed.

Occasionally, the error was expected to conform to some interface beyond
`Error`. In these cases, the type of the error variable was declared as
`any` explicitly.
