### PR TITLE
feat(docs-infra): Add a new processor for `@overriddenImplementation`.

### DIFF
--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -44,6 +44,7 @@ module.exports =
         .processor(require('./processors/processNgModuleDocs'))
         .processor(require('./processors/fixupRealProjectRelativePath'))
         .processor(require('./processors/processAliasDocs'))
+        .processor(require('./processors/mergeOverriddenImplementation'))
 
 
         /**

--- a/aio/tools/transforms/angular-api-package/processors/mergeOverriddenImplementation.js
+++ b/aio/tools/transforms/angular-api-package/processors/mergeOverriddenImplementation.js
@@ -1,0 +1,103 @@
+/**
+ * In some cases it is desirable to override the exported implementation and constructor for a symbol.
+ * This is useful for a few reasons:
+ * - A symbol could have multiple constructors
+ * - It is possible to disambiguate multiple different signatures from a single polymorphic constructor
+ * - The return type of the overridden constructor can differ (e.g. `Foo<T|null>` vs `Foo<T>`)
+ * 
+ * This looks like the following:
+ * 
+ * ```
+ * export interface Foo {
+ *   bar();
+ * }
+ * 
+ * export class FooImpl {
+ *   bar() {}
+ * }
+ * 
+ * export interface FooCtor {
+ *   new(): Foo;
+ * }
+ * 
+ * export const Foo: FooCtor = FooImpl as FooCtor;
+ * ```
+ * 
+ * This processor will correct the docs for symbol `Foo` by copying them over from `FooImpl`
+ * to the exported symbol `Foo`. The processor will also copy all documented constructor overrides from `FooCtor`.
+ * 
+ * In order to use this processor, annotate the exported constant with `@overriddenImplementation`,
+ * and mark the implementation and constructor types as `@internal`. Place the desired
+ * documentation on the implementation class.
+ */
+ module.exports = function mergeOverriddenImplementation(getDocFromAlias, log) {
+  return {
+    $runAfter: ['tags-extracted', 'ids-computed'],
+    $runBefore: ['filterPrivateDocs'],
+    propertiesToKeep: [
+      'name', 'id', 'aliases', 'fileInfo', 'startingLine', 'endingLine',
+      'path', 'originalModule', 'outputPath', 'privateExport', 'moduleDoc'
+    ],
+    $process(docs) {
+      docs.forEach(doc => {
+        if (doc.overriddenImplementation) {          
+          // Check the AST is of the expected expression shape, and extract the identifiers.
+          const symbolAstObjects = [doc.declaration?.name, doc.declaration?.type, doc.declaration?.initializer?.expression];
+          if (symbolAstObjects.some(symbol => symbol === undefined)) {
+            throw new Error('@overriddenImplementation must have format `export const Foo: FooCtor = FooImpl as FooCtor;`');
+          }
+
+          // Convert the AST nodes into docs.
+          const symbolNames = symbolAstObjects.map(s => s.getText());
+          const symbolDocArrays = symbolNames.map(symbol => getDocFromAlias(symbol));
+          for (let i = 0; i < symbolDocArrays.length; i++) {
+            if (symbolDocArrays[i].length === 0) {
+              throw new Error(`@overriddenImplementation failed to find a doc for ${symbolNames[i]}. Are you sure this symbol is documented and exported?`);
+            }
+            if (symbolDocArrays[i].length >= 2) {
+              throw new Error(`@overriddenImplementation found multiple docs for ${symbolNames[i]}. You may only have one documented symbol for each.`);
+            }
+          }
+          const symbolDocs = symbolDocArrays.map(a => a[0]);
+          const exportedNameDoc = symbolDocs[0];
+          const ctorDoc = symbolDocs[1];
+          const implDoc = symbolDocs[2];
+
+          // Clean out the unwanted properties from the exported doc.
+          Object.keys(doc).forEach(key => {
+            if (!this.propertiesToKeep.includes(key)) {
+              delete doc[key];
+            }
+          });
+
+          // Copy over all the properties from the implementation doc.
+          Object.keys(implDoc).forEach(key => {
+            if (!this.propertiesToKeep.includes(key)) {
+              exportedNameDoc[key] = implDoc[key];
+            }
+          });
+
+          // Copy the constructor overrides from the constructor doc, if any are present.
+          if (!ctorDoc.members || ctorDoc.members.length !== 1 || !ctorDoc.members[0].name.includes('new')) {
+            throw new Error(`@overriddenImplementation requires that the provided constructor ${symbolNames[1]} have exactly one member called "new", possibly with multiple overrides.`);
+          }
+          exportedNameDoc.constructorDoc = ctorDoc.members[0];
+
+          // Mark symbols other than the exported name as internal.
+          if (!ctorDoc.internal) {
+            log.warn(`Constructor doc ${symbolNames[1]} was not marked '@internal'; adding this annotation.`);
+            ctorDoc.internal = true;
+          }
+          if (!implDoc.internal) {
+            log.warn(`Implementation doc ${symbolNames[2]} was not marked '@internal'; adding this annotation.`);
+            implDoc.internal = true;
+          }
+
+          // The exported doc should not be private, unlike the implementation doc.
+          exportedNameDoc.privateExport = false;
+          exportedNameDoc.internal = false;
+        }
+      });
+    }
+  };
+};

--- a/aio/tools/transforms/angular-api-package/processors/mergeOverriddenImplementation.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/mergeOverriddenImplementation.spec.js
@@ -1,0 +1,82 @@
+const testPackage = require('../../helpers/test-package');
+const processorFactory = require('./mergeOverriddenImplementation');
+const Dgeni = require('dgeni');
+const mockLogFactory = require('dgeni/lib/mocks/log');
+const createDocMessageFactory = require('dgeni-packages/base/services/createDocMessage');
+
+describe('mergeOverriddenImplementation processor', () => {
+
+  let getDocFromAlias, log, createDocMessage, processor;
+
+  beforeEach(() => {
+    getDocFromAlias = jasmine.createSpy('getDocFromAlias');
+    log = mockLogFactory(false);
+    createDocMessage = createDocMessageFactory();
+    processor = processorFactory(getDocFromAlias, log, createDocMessage);
+  });
+
+  it('should be available on the injector', () => {
+    const dgeni = new Dgeni([testPackage('angular-api-package')]);
+    const injector = dgeni.configureInjector();
+    const processor = injector.get('mergeOverriddenImplementation');
+    expect(processor.$process).toBeDefined();
+  });
+
+  it('should run before the correct processor', () => {
+    expect(processor.$runBefore).toEqual(['filterPrivateDocs']);
+  });
+
+  it('should run after the correct processor', () => {
+    expect(processor.$runAfter).toEqual(['tags-extracted', 'ids-computed']);
+  });
+
+  it('should ignore docs that do not have a `@overriddenImplementation` tag', () => {
+    const docs = [{}];
+    getDocFromAlias.and.returnValue([{ prop1: 'prop-1', prop2: 'prop-2', prop3: 'prop-3' }]);
+    processor.$process(docs);
+    expect(docs).toEqual([{}]);
+  });
+
+  it('should replace properties with those from the implementation and constructor docs', () => {
+    const exportedNameDoc = {
+      overriddenImplementation: 'Foo has an overridden implementation.', // This processor should apply
+      declaration: { // Imitate a valid AST
+        name: {getText: () => 'Foo'},
+        type: {getText: () => 'FooCtor'},
+        initializer: {
+          expression: {getText: () => 'FooImpl'},
+        },
+      },
+      exportedProp: true, // This prop will be removed
+    };
+    const docs = [exportedNameDoc];
+
+    const fakeGetDocs = (docName) => {
+      switch(docName) {
+        case 'Foo': return [exportedNameDoc];
+        case 'FooCtor': return [{ctorProp: true, members: [{name: 'new'}]}];
+        case 'FooImpl': return [{implProp: true}];
+      }
+    };
+
+    getDocFromAlias.and.callFake(fakeGetDocs);
+    processor.$process(docs);
+
+    expect(docs).toEqual([{
+      // Property copied from the implementation
+      implProp: true,
+      // Constructor signature property
+      constructorDoc: {name: 'new'},
+      // The exported symbol should be explicitly marked non-internal
+      internal: false,
+      privateExport: false,
+    }]);
+  });
+
+  it('should have default properties to keep', () => {
+    expect(processor.propertiesToKeep).toEqual([
+      'name', 'id', 'aliases', 'fileInfo', 'startingLine', 'endingLine',
+      'path', 'originalModule', 'outputPath', 'privateExport', 'moduleDoc'
+    ]);
+  });
+});

--- a/aio/tools/transforms/angular-api-package/tag-defs/overriddenImplementation.js
+++ b/aio/tools/transforms/angular-api-package/tag-defs/overriddenImplementation.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+  return {
+    name: 'overriddenImplementation',
+  };
+};


### PR DESCRIPTION
This new processor, `mergeOverriddenImplementation`, allows Dgeni to produce correct documentation for symbols with overridden exported constructors. For example, in the following example, the implementation documentation will be used, including the constructor signature:

```
export const Foo: FooCtor = FooImpl as FooCtor;
```

This is a major improvement over the current situation, in which no constructor signature is documented whatsoever.

This processor will collect all constructor overrides from `FooCtor` as well, listing multiple constructors if provided.

Landing this should unblock #44316.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It is not possible to merge documentation when the exported constructor is overridden.

Issue Number: N/A


## What is the new behavior?

Using `@ overriddenImplementation` will copy documentation from the implementation symbol.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
