### PR TITLE
refactor(elements): remove the createCustomEvent function

### DIFF
--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -11,7 +11,7 @@ import {Subscription} from 'rxjs';
 
 import {ComponentNgElementStrategyFactory} from './component-factory-strategy';
 import {NgElementStrategy, NgElementStrategyFactory} from './element-strategy';
-import {createCustomEvent, getComponentInputs, getDefaultAttributeToPropertyInputs} from './utils';
+import {getComponentInputs, getDefaultAttributeToPropertyInputs} from './utils';
 
 /**
  * Prototype for a class constructor based on an Angular component
@@ -223,7 +223,7 @@ export function createCustomElement<P>(
     private subscribeToEvents(): void {
       // Listen for events from the strategy and dispatch them as custom events.
       this.ngElementEventsSubscription = this.ngElementStrategy.events.subscribe(e => {
-        const customEvent = createCustomEvent(this.ownerDocument!, e.name, e.value);
+        const customEvent = new CustomEvent(e.name, {detail: e.value});
         this.dispatchEvent(customEvent);
       });
     }

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -53,23 +53,6 @@ export function camelToDashCase(input: string): string {
 }
 
 /**
- * Create a `CustomEvent` (even on browsers where `CustomEvent` is not a constructor).
- */
-export function createCustomEvent(doc: Document, name: string, detail: any): CustomEvent {
-  const bubbles = false;
-  const cancelable = false;
-
-  // On IE11, `CustomEvent` is not a constructor.
-  if (typeof CustomEvent !== 'function') {
-    const event = doc.createEvent('CustomEvent');
-    event.initCustomEvent(name, bubbles, cancelable, detail);
-    return event;
-  }
-
-  return new CustomEvent(name, {bubbles, cancelable, detail});
-}
-
-/**
  * Check whether the input is an `Element`.
  */
 export function isElement(node: Node|null): node is Element {

--- a/packages/elements/test/utils_spec.ts
+++ b/packages/elements/test/utils_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {camelToDashCase, createCustomEvent, isElement, isFunction, kebabToCamelCase, matchesSelector, scheduler, strictEquals} from '../src/utils';
+import {camelToDashCase, isElement, isFunction, kebabToCamelCase, matchesSelector, scheduler, strictEquals} from '../src/utils';
 
 describe('utils', () => {
   describe('scheduler', () => {
@@ -86,20 +86,6 @@ describe('utils', () => {
 
     it('should keep existing dashes', () => {
       expect(camelToDashCase('fooBar-baz-Qux')).toBe('foo-bar-baz--qux');
-    });
-  });
-
-  describe('createCustomEvent()', () => {
-    it('should create a custom event (with appropriate properties)', () => {
-      const value = {bar: 'baz'};
-      const event = createCustomEvent(document, 'foo', value);
-
-      expect(event).toEqual(jasmine.any(CustomEvent));
-      expect(event).toEqual(jasmine.any(Event));
-      expect(event.type).toBe('foo');
-      expect(event.bubbles).toBe(false);
-      expect(event.cancelable).toBe(false);
-      expect(event.detail).toEqual(value);
     });
   });
 


### PR DESCRIPTION
the createCustomEvent function's pupose is to create customEvents
even on browsers where `CustomEvent` is not a constructor,
`CustomEvent` is currently available in all supported browsers (since
IE11 support has ended), so remove the function as it is no longer
needed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
- [caniuse CustomEvent](https://caniuse.com/customevent)
- I am pretty sure `bubbles` and `cancellable` are false by default (as you can see from the legacy initCustomEvent here: https://dom.spec.whatwg.org/#interface-customevent)
