### PR TITLE
docs: fix incorrect title and tooltip in navigation

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -415,8 +415,8 @@
                 },
                 {
                   "url": "guide/i18n-common-prepare",
-                  "title": "Prepare templates for translations",
-                  "tooltip": "Prepare content for translation"
+                  "title": "Prepare component for translations",
+                  "tooltip": "Prepare component for translation"
                 },
                 {
                   "url": "guide/i18n-common-translation-files",

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -415,7 +415,7 @@
                 },
                 {
                   "url": "guide/i18n-common-prepare",
-                  "title": "Prepare component for translations",
+                  "title": "Prepare component for translation",
                   "tooltip": "Prepare component for translation"
                 },
                 {


### PR DESCRIPTION
Fixes #44589

In the navigation pane, the title and tooltip for the page,
Preparing component for translation, are incorrect. This PR
fixes this issue.