### PR TITLE
feat(compiler-cli): enable extended diagnostics by default

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -430,7 +430,7 @@ export class NgCompiler {
   getDiagnostics(): ts.Diagnostic[] {
     const diagnostics: ts.Diagnostic[] = [];
     diagnostics.push(...this.getNonTemplateDiagnostics(), ...this.getTemplateDiagnostics());
-    if (this.options._extendedTemplateDiagnostics) {
+    if (this.options.strictTemplates) {
       diagnostics.push(...this.getExtendedTemplateDiagnostics());
     }
     return this.addMessageTextDetails(diagnostics);


### PR DESCRIPTION
This is just a flag flip to enable extended diagnostics in production for v13.2. It swaps out `_extendedTemplateDiagnostics` for `strictTemplates`, since strict templates are required anyways. The commit message includes a deeper discussion of the feature just to give users something useful in release notes.

Extended template diagnostics provide additional analysis about Angular templates by emitting warnings for specific patterns known to be error prone or cause developer confusion. Currently, there are two such diagnostics which are enabled by default:

* `invalidBananaInBox` emits a warning if a user writes a two-way binding backwards like `([foo])="bar"`, when they actually wanted `[(foo)]="bar"`.
* `nullishCoalescingNotNullable` emits a warning if a binding attempts to perform nullish coalescing (`??`) on a type which does not include `null` or `undefined`, such as `{{ foo ?? 'bar' }}` where `foo` is defined as `string` instead of `string | null`.

These diagnostics are enabled as warnings by default, but this can be configured in the `tsconfig.json` like so:

```jsonc
{
  "angularCompilerOptions": {
    "extendedDiagnostics": {
      // The categories to use for specific diagnostics.
      "checks": {
        // Maps check name to its category.
        "invalidBananaInBox": "suppress"
      },

      // The category to use for any diagnostics not listed in `checks` above.
      "defaultCategory": "error"
    }
  }
}
```

Allowed categories for a diagnostic are `warning` (default), `error`, or `suppress`. `warning` emits the diagnostic but allows the compilation to succeed, `error` *will* fail the compilation, while `suppress` will ignore the diagnostic altogether.

The initial release has two diagnostics, and we are hoping to expand this longer term to add more diagnostics and provide additional insight into Angular templates to detect and surface developer mistakes *before* hours of debugging are wasted.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

Docs are included in #44704.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Feature

## What is the current behavior?

Extended diagnostics are gated on a private `_extendedTemplateDiagnostics` flag in `tsconfig.json`.

Issue Number: #42966.

## What is the new behavior?

Extended diagnostics are now enabled by default. This includes two existing diagnostics: `invalidBananaInBox` and `nullishCoalescingNotNullable`.

## Does this PR introduce a breaking change?

- [X] No

This will enable two new extended diagnostics as warnings. Existing users may see new warnings as a result, but no builds should fail as a result, so this is not considered a breaking change. Users may disable specific (or all) diagnostics via the above `tsconfig.json` configuration.

## Other information

Special thanks to @danieltre23 for designing and implementing extended diagnostics. Awesome work! :tada: