### PR TITLE
feat(service-worker): add `cacheOpaqueResponses` option for data-groups

### DIFF
--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -247,6 +247,28 @@ This essentially does the following:
 
 </div>
 
+<div class="callout is-important">
+
+  <header>Note on opaque responses</header>
+
+  [Opaque responses][opaque-response] are handled differently depending on the used strategy:
+  Data-groups with the `freshness` strategy cache such responses normally.
+  Data-groups with the `performance` strategy, however, do not cache opaque responses.
+
+  In case you are not familiar, an opaque response is a special type of response returned when requesting a resource that is on a different origin which doesn't return CORS headers.
+  One of the characteristics of an opaque response is that the service worker is not allowed to read its status, meaning it can't check if the request was successful or not.
+  See [Introduction to fetch()][response-types] for more details.
+
+  For data-groups with the `freshness` strategy, it doesn't matter if the service worker caches an error response.
+  The data will be requested anew every time, only falling back to the cached response when offline or on a slow network.
+
+  For data-groups with the `performance` strategy on the other hand, caching an error response would be quite problematic.
+  The service worker would continue to serve the error response until `maxAge` expired, even if the error was due to a temporary network or server issue.
+
+  If you are not able to implement CORS&mdash;for example, if you don't control the origin&mdash;prefer using the `freshness` strategy for resources that result in opaque responses.
+
+</div>
+
 ### `cacheQueryOptions`
 
 See [assetGroups](#assetgroups) for details.
@@ -321,3 +343,7 @@ The `freshness` strategy usually results in more requests sent to the server, wh
 It is recommended that you use the default performance strategy whenever possible.
 
 </div>
+
+
+[opaque-response]: https://fetch.spec.whatwg.org/#concept-filtered-response-opaque
+[response-types]: https://developers.google.com/web/updates/2015/03/introduction-to-fetch#response_types

--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -247,23 +247,28 @@ This essentially does the following:
 
 </div>
 
+#### `cacheOpaqueResponses`
+
+Whether the Angular service worker should cache opaque responses or not.
+
+If not specified, the default value depends on the data group's configured strategy:
+
+- For groups with the `freshness` strategy, the default value is `true` (cache opaque responses).
+  These groups will request the data anew every time, only falling back to the cached response when offline or on a slow network.
+  Therefore, it doesn't matter if the service worker caches an error response.
+
+- For groups with the `performance` strategy, the default value is `false` (do not cache opaque responses).
+  These groups would continue to return a cached response until `maxAge` expires, even if the error was due to a temporary network or server issue.
+  Therefore, it would be problematic for the service worker to cache an error response.
+
 <div class="callout is-important">
 
   <header>Note on opaque responses</header>
 
-  [Opaque responses][opaque-response] are handled differently depending on the used strategy:
-  Data-groups with the `freshness` strategy cache such responses normally.
-  Data-groups with the `performance` strategy, however, do not cache opaque responses.
-
-  In case you are not familiar, an opaque response is a special type of response returned when requesting a resource that is on a different origin which doesn't return CORS headers.
+  In case you are not familiar, an [opaque response][opaque-response] is a special type of response returned when requesting a resource that is on a different origin which doesn't return CORS headers.
   One of the characteristics of an opaque response is that the service worker is not allowed to read its status, meaning it can't check if the request was successful or not.
   See [Introduction to fetch()][response-types] for more details.
 
-  For data-groups with the `freshness` strategy, it doesn't matter if the service worker caches an error response.
-  The data will be requested anew every time, only falling back to the cached response when offline or on a slow network.
-
-  For data-groups with the `performance` strategy on the other hand, caching an error response would be quite problematic.
-  The service worker would continue to serve the error response until `maxAge` expired, even if the error was due to a temporary network or server issue.
 
   If you are not able to implement CORS&mdash;for example, if you don't control the origin&mdash;prefer using the `freshness` strategy for resources that result in opaque responses.
 

--- a/goldens/public-api/service-worker/config/config.md
+++ b/goldens/public-api/service-worker/config/config.md
@@ -45,6 +45,7 @@ export interface DataGroup {
         maxAge: Duration;
         timeout?: Duration;
         strategy?: 'freshness' | 'performance';
+        cacheOpaqueResponses?: boolean;
     };
     // (undocumented)
     cacheQueryOptions?: Pick<CacheQueryOptions, 'ignoreSearch'>;
@@ -78,13 +79,11 @@ class Generator_2 {
     readonly fs: Filesystem;
     // (undocumented)
     process(config: Config): Promise<Object>;
-    }
-
+}
 export { Generator_2 as Generator }
 
 // @public (undocumented)
 export type Glob = string;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/service-worker/config/schema.json
+++ b/packages/service-worker/config/schema.json
@@ -126,6 +126,10 @@
                 ],
                 "default": "performance",
                 "description": "The Angular service worker can use either of two caching strategies for data resources. 'performance', the default, optimizes for responses that are as fast as possible. If a resource exists in the cache, the cached version is used. This allows for some staleness, depending on the 'maxAge', in exchange for better performance. This is suitable for resources that don't change often; for example, user avatar images. 'freshness' optimizes for currency of data, preferentially fetching requested data from the network. Only if the network times out, according to 'timeout', does the request fall back to the cache. This is useful for resources that change frequently; for example, account balances."
+              },
+              "cacheOpaqueResponses": {
+                "type": "boolean",
+                "description": "Whether to cache opaque responses or not. The default value is 'false' for groups with the 'performance' strategy and 'true' for groups with the 'freshness' strategy. Opaque responses are special in that it is not possible for the service worker to distinguish successful responses from errors. Therefore, be careful with caching opaque responses, especially when combined with a strategy/configuration that could result in a response being retained in the cache for a long time."
               }
             },
             "required": [

--- a/packages/service-worker/config/src/generator.ts
+++ b/packages/service-worker/config/src/generator.ts
@@ -94,6 +94,7 @@ export class Generator {
         maxSize: group.cacheConfig.maxSize,
         maxAge: parseDurationToMs(group.cacheConfig.maxAge),
         timeoutMs: group.cacheConfig.timeout && parseDurationToMs(group.cacheConfig.timeout),
+        cacheOpaqueResponses: group.cacheConfig.cacheOpaqueResponses,
         cacheQueryOptions: buildCacheQueryOptions(group.cacheQueryOptions),
         version: group.version !== undefined ? group.version : 1,
       };

--- a/packages/service-worker/config/src/in.ts
+++ b/packages/service-worker/config/src/in.ts
@@ -56,6 +56,7 @@ export interface DataGroup {
     maxSize: number; maxAge: Duration;
     timeout?: Duration;
     strategy?: 'freshness' | 'performance';
+    cacheOpaqueResponses?: boolean;
   };
   cacheQueryOptions?: Pick<CacheQueryOptions, 'ignoreSearch'>;
 }

--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -106,6 +106,7 @@ describe('Generator', () => {
         maxAge: 259200000,
         timeoutMs: 60000,
         version: 1,
+        cacheOpaqueResponses: undefined,
         cacheQueryOptions: {ignoreVary: true}
       }],
       navigationUrls: [
@@ -282,7 +283,173 @@ describe('Generator', () => {
     }
   });
 
-  it('generates a correct config with cacheQueryOptions', async () => {
+  it('generates a correct config with `cacheOpaqueResponses`', async () => {
+    const fs = new MockFilesystem({
+      '/index.html': 'This is a test',
+    });
+    const gen = new Generator(fs, '/');
+    const config = await gen.process({
+      index: '/index.html',
+      dataGroups: [
+        {
+          name: 'freshness-undefined',
+          urls: ['/api/1/**'],
+          cacheConfig: {
+            maxAge: '3d',
+            maxSize: 100,
+            strategy: 'freshness',
+          },
+        },
+        {
+          name: 'freshness-false',
+          urls: ['/api/2/**'],
+          cacheConfig: {
+            cacheOpaqueResponses: false,
+            maxAge: '3d',
+            maxSize: 100,
+            strategy: 'freshness',
+          },
+        },
+        {
+          name: 'freshness-true',
+          urls: ['/api/3/**'],
+          cacheConfig: {
+            cacheOpaqueResponses: true,
+            maxAge: '3d',
+            maxSize: 100,
+            strategy: 'freshness',
+          },
+        },
+        {
+          name: 'performance-undefined',
+          urls: ['/api/4/**'],
+          cacheConfig: {
+            maxAge: '3d',
+            maxSize: 100,
+            strategy: 'performance',
+          },
+        },
+        {
+          name: 'performance-false',
+          urls: ['/api/5/**'],
+          cacheConfig: {
+            cacheOpaqueResponses: false,
+            maxAge: '3d',
+            maxSize: 100,
+            strategy: 'performance',
+          },
+        },
+        {
+          name: 'performance-true',
+          urls: ['/api/6/**'],
+          cacheConfig: {
+            cacheOpaqueResponses: true,
+            maxAge: '3d',
+            maxSize: 100,
+            strategy: 'performance',
+          },
+        },
+      ],
+    });
+
+    expect(config).toEqual({
+      configVersion: 1,
+      appData: undefined,
+      timestamp: 1234567890123,
+      index: '/index.html',
+      assetGroups: [],
+      dataGroups: [
+        {
+          name: 'freshness-undefined',
+          patterns: [
+            '\\/api\\/1\\/.*',
+          ],
+          strategy: 'freshness',
+          maxSize: 100,
+          maxAge: 259200000,
+          timeoutMs: undefined,
+          version: 1,
+          cacheOpaqueResponses: undefined,
+          cacheQueryOptions: {ignoreVary: true},
+        },
+        {
+          name: 'freshness-false',
+          patterns: [
+            '\\/api\\/2\\/.*',
+          ],
+          strategy: 'freshness',
+          maxSize: 100,
+          maxAge: 259200000,
+          timeoutMs: undefined,
+          version: 1,
+          cacheOpaqueResponses: false,
+          cacheQueryOptions: {ignoreVary: true},
+        },
+        {
+          name: 'freshness-true',
+          patterns: [
+            '\\/api\\/3\\/.*',
+          ],
+          strategy: 'freshness',
+          maxSize: 100,
+          maxAge: 259200000,
+          timeoutMs: undefined,
+          version: 1,
+          cacheOpaqueResponses: true,
+          cacheQueryOptions: {ignoreVary: true},
+        },
+        {
+          name: 'performance-undefined',
+          patterns: [
+            '\\/api\\/4\\/.*',
+          ],
+          strategy: 'performance',
+          maxSize: 100,
+          maxAge: 259200000,
+          timeoutMs: undefined,
+          version: 1,
+          cacheOpaqueResponses: undefined,
+          cacheQueryOptions: {ignoreVary: true},
+        },
+        {
+          name: 'performance-false',
+          patterns: [
+            '\\/api\\/5\\/.*',
+          ],
+          strategy: 'performance',
+          maxSize: 100,
+          maxAge: 259200000,
+          timeoutMs: undefined,
+          version: 1,
+          cacheOpaqueResponses: false,
+          cacheQueryOptions: {ignoreVary: true},
+        },
+        {
+          name: 'performance-true',
+          patterns: [
+            '\\/api\\/6\\/.*',
+          ],
+          strategy: 'performance',
+          maxSize: 100,
+          maxAge: 259200000,
+          timeoutMs: undefined,
+          version: 1,
+          cacheOpaqueResponses: true,
+          cacheQueryOptions: {ignoreVary: true},
+        },
+      ],
+      navigationUrls: [
+        {positive: true, regex: '^\\/.*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*\\.[^/]*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*$'},
+        {positive: false, regex: '^\\/(?:.+\\/)?[^/]*__[^/]*\\/.*$'},
+      ],
+      navigationRequestStrategy: 'performance',
+      hashTable: {},
+    });
+  });
+
+  it('generates a correct config with `cacheQueryOptions`', async () => {
     const fs = new MockFilesystem({
       '/index.html': 'This is a test',
       '/main.js': 'This is a JS file',
@@ -339,6 +506,7 @@ describe('Generator', () => {
         maxAge: 259200000,
         timeoutMs: 60000,
         version: 1,
+        cacheOpaqueResponses: undefined,
         cacheQueryOptions: {ignoreSearch: false, ignoreVary: true}
       }],
       navigationUrls: [

--- a/packages/service-worker/worker/src/manifest.ts
+++ b/packages/service-worker/worker/src/manifest.ts
@@ -37,9 +37,10 @@ export interface DataGroupConfig {
   strategy: 'freshness'|'performance';
   patterns: string[];
   maxSize: number;
+  maxAge: number;
   timeoutMs?: number;
   refreshAheadMs?: number;
-  maxAge: number;
+  cacheOpaqueResponses?: boolean;
   cacheQueryOptions?: CacheQueryOptions;
 }
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -362,6 +362,7 @@ describe('Driver', () => {
     server.assertSawRequestFor('/foo.txt');
     server.assertSawRequestFor('/bar.txt');
     server.assertSawRequestFor('/redirected.txt');
+    server.assertSawRequestFor('/redirect-target.txt');
     expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
     expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
     server.assertNoOtherRequests();
@@ -374,6 +375,7 @@ describe('Driver', () => {
     server.assertSawRequestFor('/foo.txt');
     server.assertSawRequestFor('/bar.txt');
     server.assertSawRequestFor('/redirected.txt');
+    server.assertSawRequestFor('/redirect-target.txt');
     expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
     expect(await makeRequest(scope, '/bar.txt')).toEqual('this is bar');
     server.assertNoOtherRequests();
@@ -391,6 +393,7 @@ describe('Driver', () => {
     server.assertSawRequestFor('/foo.txt');
     server.assertSawRequestFor('/bar.txt');
     server.assertSawRequestFor('/redirected.txt');
+    server.assertSawRequestFor('/redirect-target.txt');
 
     // Once initialized, cached resources are served without network requests.
     expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
@@ -411,6 +414,7 @@ describe('Driver', () => {
     server.assertSawRequestFor('/foo.txt');
     server.assertSawRequestFor('/bar.txt');
     server.assertSawRequestFor('/redirected.txt');
+    server.assertSawRequestFor('/redirect-target.txt');
 
     // Once initialized, pushed messages are handled without re-initializing.
     await scope.handleMessage({action: 'bar'}, 'someClient');
@@ -476,6 +480,7 @@ describe('Driver', () => {
     serverUpdate.assertSawRequestFor('/ngsw.json');
     serverUpdate.assertSawRequestFor('/foo.txt');
     serverUpdate.assertSawRequestFor('/redirected.txt');
+    serverUpdate.assertSawRequestFor('/redirect-target.txt');
     serverUpdate.assertNoOtherRequests();
 
     expect(client.messages).toEqual([
@@ -577,6 +582,7 @@ describe('Driver', () => {
     serverUpdate.assertSawRequestFor('/ngsw.json');
     serverUpdate.assertSawRequestFor('/foo.txt');
     serverUpdate.assertSawRequestFor('/redirected.txt');
+    serverUpdate.assertSawRequestFor('/redirect-target.txt');
     serverUpdate.assertNoOtherRequests();
   });
 

--- a/packages/service-worker/worker/testing/fetch.ts
+++ b/packages/service-worker/worker/testing/fetch.ts
@@ -171,7 +171,7 @@ export class MockResponse extends MockBody implements Response {
       init: ResponseInit&{type?: ResponseType, redirected?: boolean, url?: string} = {}) {
     super(typeof body === 'string' ? body : null);
     this.status = (init.status !== undefined) ? init.status : 200;
-    this.statusText = init.statusText || 'OK';
+    this.statusText = (init.statusText !== undefined) ? init.statusText : 'OK';
     const headers = init.headers as {[key: string]: string};
     if (headers !== undefined) {
       if (headers instanceof MockHeaders) {
@@ -197,7 +197,13 @@ export class MockResponse extends MockBody implements Response {
     if (this.bodyUsed) {
       throw 'Body already consumed';
     }
-    return new MockResponse(
-        this._body, {status: this.status, statusText: this.statusText, headers: this.headers});
+    return new MockResponse(this._body, {
+      status: this.status,
+      statusText: this.statusText,
+      headers: this.headers,
+      type: this.type,
+      redirected: this.redirected,
+      url: this.url,
+    });
   }
 }


### PR DESCRIPTION
Add a new option for configuring data-groups, `cacheOpaqueResponses`, that determines whether opaque responses are cached or not. This allows greater flexibility in configuring the behavior of data-groups, while still keeping the current defaults as fallbacks.

Fixes #44246.