### PR TITLE
refactor(animations): change errors type from any to string

### DIFF
--- a/packages/animations/browser/src/dsl/animation.ts
+++ b/packages/animations/browser/src/dsl/animation.ts
@@ -19,7 +19,7 @@ import {ElementInstructionMap} from './element_instruction_map';
 export class Animation {
   private _animationAst: Ast<AnimationMetadataType>;
   constructor(private _driver: AnimationDriver, input: AnimationMetadata|AnimationMetadata[]) {
-    const errors: any[] = [];
+    const errors: string[] = [];
     const ast = buildAnimationAst(_driver, input, errors);
     if (errors.length) {
       const errorMessage = `animation validation failed:\n${errors.join('\n')}`;

--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -56,7 +56,7 @@ const SELF_TOKEN_REGEX = new RegExp(`\s*${SELF_TOKEN}\s*,?`, 'g');
  */
 export function buildAnimationAst(
     driver: AnimationDriver, metadata: AnimationMetadata|AnimationMetadata[],
-    errors: any[]): Ast<AnimationMetadataType> {
+    errors: string[]): Ast<AnimationMetadataType> {
   return new AnimationAstBuilderVisitor(driver).build(metadata, errors);
 }
 
@@ -65,7 +65,7 @@ const ROOT_SELECTOR = '';
 export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
   constructor(private _driver: AnimationDriver) {}
 
-  build(metadata: AnimationMetadata|AnimationMetadata[], errors: any[]):
+  build(metadata: AnimationMetadata|AnimationMetadata[], errors: string[]):
       Ast<AnimationMetadataType> {
     const context = new AnimationAstBuilderContext(errors);
     this._resetContextStyleTimingState(context);
@@ -515,7 +515,7 @@ export class AnimationAstBuilderContext {
   public currentTime: number = 0;
   public collectedStyles: {[selectorName: string]: {[propName: string]: StyleTimeTuple}} = {};
   public options: AnimationOptions|null = null;
-  constructor(public errors: any[]) {}
+  constructor(public errors: string[]) {}
 }
 
 function consumeOffset(styles: ɵStyleData|string|(ɵStyleData | string)[]): number|null {
@@ -543,7 +543,7 @@ function isObject(value: any): boolean {
   return !Array.isArray(value) && typeof value == 'object';
 }
 
-function constructTimingAst(value: string|number|AnimateTimings, errors: any[]) {
+function constructTimingAst(value: string|number|AnimateTimings, errors: string[]) {
   let timings: AnimateTimings|null = null;
   if (value.hasOwnProperty('duration')) {
     timings = value as AnimateTimings;

--- a/packages/animations/browser/src/dsl/animation_timeline_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_builder.ts
@@ -108,7 +108,8 @@ export function buildAnimationTimelines(
     driver: AnimationDriver, rootElement: any, ast: Ast<AnimationMetadataType>,
     enterClassName: string, leaveClassName: string, startingStyles: ɵStyleData = {},
     finalStyles: ɵStyleData = {}, options: AnimationOptions,
-    subInstructions?: ElementInstructionMap, errors: any[] = []): AnimationTimelineInstruction[] {
+    subInstructions?: ElementInstructionMap,
+    errors: string[] = []): AnimationTimelineInstruction[] {
   return new AnimationTimelineBuilderVisitor().buildKeyframes(
       driver, rootElement, ast, enterClassName, leaveClassName, startingStyles, finalStyles,
       options, subInstructions, errors);
@@ -119,7 +120,7 @@ export class AnimationTimelineBuilderVisitor implements AstVisitor {
       driver: AnimationDriver, rootElement: any, ast: Ast<AnimationMetadataType>,
       enterClassName: string, leaveClassName: string, startingStyles: ɵStyleData,
       finalStyles: ɵStyleData, options: AnimationOptions, subInstructions?: ElementInstructionMap,
-      errors: any[] = []): AnimationTimelineInstruction[] {
+      errors: string[] = []): AnimationTimelineInstruction[] {
     subInstructions = subInstructions || new ElementInstructionMap();
     const context = new AnimationTimelineContext(
         driver, rootElement, subInstructions, enterClassName, leaveClassName, errors, []);
@@ -466,7 +467,7 @@ export class AnimationTimelineContext {
   constructor(
       private _driver: AnimationDriver, public element: any,
       public subInstructions: ElementInstructionMap, private _enterClassName: string,
-      private _leaveClassName: string, public errors: any[], public timelines: TimelineBuilder[],
+      private _leaveClassName: string, public errors: string[], public timelines: TimelineBuilder[],
       initialTimeline?: TimelineBuilder) {
     this.currentTimeline = initialTimeline || new TimelineBuilder(this._driver, element, 0);
     timelines.push(this.currentTimeline);
@@ -574,7 +575,7 @@ export class AnimationTimelineContext {
 
   invokeQuery(
       selector: string, originalSelector: string, limit: number, includeSelf: boolean,
-      optional: boolean, errors: any[]): any[] {
+      optional: boolean, errors: string[]): any[] {
     let results: any[] = [];
     if (includeSelf) {
       results.push(this.element);
@@ -723,7 +724,7 @@ export class TimelineBuilder {
   }
 
   setStyles(
-      input: (ɵStyleData|string)[], easing: string|null, errors: any[],
+      input: (ɵStyleData|string)[], easing: string|null, errors: string[],
       options?: AnimationOptions) {
     if (easing) {
       this._previousKeyframe['easing'] = easing;

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -29,7 +29,7 @@ export class AnimationTransitionFactory {
     return oneOrMoreTransitionsMatch(this.ast.matchers, currentState, nextState, element, params);
   }
 
-  buildStyles(stateName: string, params: {[key: string]: any}, errors: any[]) {
+  buildStyles(stateName: string, params: {[key: string]: any}, errors: string[]) {
     const backupStateStyler = this._stateStyles['*'];
     const stateStyler = this._stateStyles[stateName];
     const backupStyles = backupStateStyler ? backupStateStyler.buildStyles(params, errors) : {};
@@ -41,7 +41,7 @@ export class AnimationTransitionFactory {
       enterClassName: string, leaveClassName: string, currentOptions?: AnimationOptions,
       nextOptions?: AnimationOptions, subInstructions?: ElementInstructionMap,
       skipAstBuild?: boolean): AnimationTransitionInstruction {
-    const errors: any[] = [];
+    const errors: string[] = [];
 
     const transitionAnimationParams = this.ast.options && this.ast.options.params || EMPTY_OBJECT;
     const currentAnimationParams = currentOptions && currentOptions.params || EMPTY_OBJECT;

--- a/packages/animations/browser/src/dsl/animation_transition_instruction.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_instruction.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵStyleData} from '@angular/animations';
+
 import {AnimationEngineInstruction, AnimationTransitionInstructionType} from '../render/animation_engine_instruction';
+
 import {AnimationTimelineInstruction} from './animation_timeline_instruction';
 
 export interface AnimationTransitionInstruction extends AnimationEngineInstruction {
@@ -22,7 +24,7 @@ export interface AnimationTransitionInstruction extends AnimationEngineInstructi
   preStyleProps: Map<any, {[prop: string]: boolean}>;
   postStyleProps: Map<any, {[prop: string]: boolean}>;
   totalTime: number;
-  errors?: any[];
+  errors?: string[];
 }
 
 export function createTransitionInstruction(
@@ -31,7 +33,7 @@ export function createTransitionInstruction(
     timelines: AnimationTimelineInstruction[], queriedElements: any[],
     preStyleProps: Map<any, {[prop: string]: boolean}>,
     postStyleProps: Map<any, {[prop: string]: boolean}>, totalTime: number,
-    errors?: any[]): AnimationTransitionInstruction {
+    errors?: string[]): AnimationTransitionInstruction {
   return {
     type: AnimationTransitionInstructionType.TransitionAnimation,
     element,

--- a/packages/animations/browser/src/dsl/animation_trigger.ts
+++ b/packages/animations/browser/src/dsl/animation_trigger.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AnimationMetadataType, ɵStyleData} from '@angular/animations';
+
 import {SequenceAst, TransitionAst, TriggerAst} from './animation_ast';
 import {AnimationStateStyles, AnimationTransitionFactory} from './animation_transition_factory';
 import {AnimationStyleNormalizer} from './style_normalization/animation_style_normalizer';
@@ -50,7 +51,7 @@ export class AnimationTrigger {
     return entry || null;
   }
 
-  matchStyles(currentState: any, params: {[key: string]: any}, errors: any[]): ɵStyleData {
+  matchStyles(currentState: any, params: {[key: string]: any}, errors: string[]): ɵStyleData {
     return this.fallbackTransition.buildStyles(currentState, params, errors);
   }
 }

--- a/packages/animations/browser/src/render/animation_engine_next.ts
+++ b/packages/animations/browser/src/render/animation_engine_next.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AnimationMetadata, AnimationPlayer, AnimationTriggerMetadata} from '@angular/animations';
+
 import {TriggerAst} from '../dsl/animation_ast';
 import {buildAnimationAst} from '../dsl/animation_ast_builder';
 import {AnimationTrigger, buildTrigger} from '../dsl/animation_trigger';
@@ -41,7 +42,7 @@ export class AnimationEngine {
     const cacheKey = componentId + '-' + name;
     let trigger = this._triggerCache[cacheKey];
     if (!trigger) {
-      const errors: any[] = [];
+      const errors: string[] = [];
       const ast =
           buildAnimationAst(this._driver, metadata as AnimationMetadata, errors) as TriggerAst;
       if (errors.length) {

--- a/packages/animations/browser/src/render/timeline_animation_engine.ts
+++ b/packages/animations/browser/src/render/timeline_animation_engine.ts
@@ -30,7 +30,7 @@ export class TimelineAnimationEngine {
       private _normalizer: AnimationStyleNormalizer) {}
 
   register(id: string, metadata: AnimationMetadata|AnimationMetadata[]) {
-    const errors: any[] = [];
+    const errors: string[] = [];
     const ast = buildAnimationAst(this._driver, metadata, errors);
     if (errors.length) {
       throw new Error(
@@ -50,7 +50,7 @@ export class TimelineAnimationEngine {
   }
 
   create(id: string, element: any, options: AnimationOptions = {}): AnimationPlayer {
-    const errors: any[] = [];
+    const errors: string[] = [];
     const ast = this._animations[id];
     let instructions: AnimationTimelineInstruction[];
 

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -224,7 +224,7 @@ export class AnimationTransitionNamespace {
       // this means that despite the value not changing, some inner params
       // have changed which means that the animation final styles need to be applied
       if (!objEquals(fromState.params, toState.params)) {
-        const errors: any[] = [];
+        const errors: string[] = [];
         const fromStyles = trigger.matchStyles(fromState.value, fromState.params, errors);
         const toStyles = trigger.matchStyles(toState.value, toState.params, errors);
         if (errors.length) {

--- a/packages/animations/browser/src/util.ts
+++ b/packages/animations/browser/src/util.ts
@@ -41,7 +41,7 @@ function _convertTimeValueToMS(value: number, unit: string): number {
 }
 
 export function resolveTiming(
-    timings: string|number|AnimateTimings, errors: any[], allowNegativeValues?: boolean) {
+    timings: string|number|AnimateTimings, errors: string[], allowNegativeValues?: boolean) {
   return timings.hasOwnProperty('duration') ?
       <AnimateTimings>timings :
       parseTimeExpression(<string|number>timings, errors, allowNegativeValues);
@@ -197,7 +197,7 @@ export function normalizeAnimationEntry(steps: AnimationMetadata|
 }
 
 export function validateStyleParams(
-    value: string|number, options: AnimationOptions, errors: any[]) {
+    value: string|number, options: AnimationOptions, errors: string[]) {
   const params = options.params || {};
   const matches = extractStyleParams(value);
   if (matches.length) {
@@ -225,7 +225,7 @@ export function extractStyleParams(value: string|number): string[] {
 }
 
 export function interpolateParams(
-    value: string|number, params: {[name: string]: any}, errors: any[]): string|number {
+    value: string|number, params: {[name: string]: any}, errors: string[]): string|number {
   const original = value.toString();
   const str = original.replace(PARAM_REGEX, (_, varName) => {
     let localVal = params[varName];

--- a/packages/animations/browser/test/dsl/animation_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_spec.ts
@@ -1069,7 +1069,7 @@ function invokeAnimationSequence(
 
 function validateAndThrowAnimationSequence(steps: AnimationMetadata|AnimationMetadata[]) {
   const driver = new MockAnimationDriver();
-  const errors: any[] = [];
+  const errors: string[] = [];
   const ast = buildAnimationAst(driver, steps, errors);
   if (errors.length) {
     throw new Error(errors.join('\n'));

--- a/packages/animations/browser/test/render/transition_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/transition_animation_engine_spec.ts
@@ -730,7 +730,7 @@ class ExactCssValueNormalizer extends AnimationStyleNormalizer {
 function registerTrigger(
     element: any, engine: TransitionAnimationEngine, metadata: AnimationTriggerMetadata,
     id: string = DEFAULT_NAMESPACE_ID) {
-  const errors: any[] = [];
+  const errors: string[] = [];
   const driver = new MockAnimationDriver();
   const name = metadata.name;
   const ast = buildAnimationAst(driver, metadata as AnimationMetadata, errors) as TriggerAst;

--- a/packages/animations/browser/test/shared.ts
+++ b/packages/animations/browser/test/shared.ts
@@ -17,7 +17,7 @@ import {MockAnimationDriver} from '../testing/src/mock_animation_driver';
 export function makeTrigger(
     name: string, steps: any, skipErrors: boolean = false): AnimationTrigger {
   const driver = new MockAnimationDriver();
-  const errors: any[] = [];
+  const errors: string[] = [];
   const triggerData = trigger(name, steps);
   const triggerAst = buildAnimationAst(driver, triggerData, errors) as TriggerAst;
   if (!skipErrors && errors.length) {


### PR DESCRIPTION
errors in the animations code are of type `any` but are consistently
used as if there were `string`s, change `any` to `string` to make
typing more accurate

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I am not completely sure why they were `any`s in the first place, I'd imagine it was done in order to make the code more flexible :thinking: 

Anyways as far I can tell all errors are just strings in the animations code and there are also parts in which getting something different from a string would likely create undesirable results, mainly when combining them together for the generation of an error message, for example like so:

https://github.com/angular/angular/blob/a92a89b0eb127a59d7e071502b5850e57618ec2d/packages/animations/browser/src/render/timeline_animation_engine.ts#L37

here if errors could be more complex data structures such as objects, when converted to strings by `join` (unless they implement their own `toString`) would just produce `"[object Object]"` which of course would produce a pretty bad error message

Also I don't think this is part of any public api so it should be a safe change to make :slightly_smiling_face: 