### PR TITLE
fix(animations): allow animations with unsupported CSS properties

### DIFF
--- a/packages/animations/browser/src/dsl/animation.ts
+++ b/packages/animations/browser/src/dsl/animation.ts
@@ -10,6 +10,7 @@ import {AnimationMetadata, AnimationMetadataType, AnimationOptions, ɵStyleDataM
 import {buildingFailed, validationFailed} from '../error_helpers';
 import {AnimationDriver} from '../render/animation_driver';
 import {ENTER_CLASSNAME, LEAVE_CLASSNAME, normalizeStyles} from '../util';
+import {warnValidation} from '../warning_helpers';
 
 import {Ast} from './animation_ast';
 import {buildAnimationAst} from './animation_ast_builder';
@@ -21,9 +22,13 @@ export class Animation {
   private _animationAst: Ast<AnimationMetadataType>;
   constructor(private _driver: AnimationDriver, input: AnimationMetadata|AnimationMetadata[]) {
     const errors: Error[] = [];
-    const ast = buildAnimationAst(_driver, input, errors);
+    const warnings: string[] = [];
+    const ast = buildAnimationAst(_driver, input, errors, warnings);
     if (errors.length) {
       throw validationFailed(errors);
+    }
+    if (warnings.length) {
+      warnValidation(warnings);
     }
     this._animationAst = ast;
   }

--- a/packages/animations/browser/src/render/animation_engine_next.ts
+++ b/packages/animations/browser/src/render/animation_engine_next.ts
@@ -12,6 +12,7 @@ import {buildAnimationAst} from '../dsl/animation_ast_builder';
 import {AnimationTrigger, buildTrigger} from '../dsl/animation_trigger';
 import {AnimationStyleNormalizer} from '../dsl/style_normalization/animation_style_normalizer';
 import {triggerBuildFailed} from '../error_helpers';
+import {warnTriggerBuild} from '../warning_helpers';
 
 import {AnimationDriver} from './animation_driver';
 import {parseTimelineCommand} from './shared';
@@ -44,10 +45,14 @@ export class AnimationEngine {
     let trigger = this._triggerCache[cacheKey];
     if (!trigger) {
       const errors: Error[] = [];
-      const ast =
-          buildAnimationAst(this._driver, metadata as AnimationMetadata, errors) as TriggerAst;
+      const warnings: string[] = [];
+      const ast = buildAnimationAst(
+                      this._driver, metadata as AnimationMetadata, errors, warnings) as TriggerAst;
       if (errors.length) {
         throw triggerBuildFailed(name, errors);
+      }
+      if (warnings.length) {
+        warnTriggerBuild(name, warnings);
       }
       trigger = buildTrigger(name, ast, this._normalizer);
       this._triggerCache[cacheKey] = trigger;

--- a/packages/animations/browser/src/render/timeline_animation_engine.ts
+++ b/packages/animations/browser/src/render/timeline_animation_engine.ts
@@ -15,6 +15,7 @@ import {ElementInstructionMap} from '../dsl/element_instruction_map';
 import {AnimationStyleNormalizer} from '../dsl/style_normalization/animation_style_normalizer';
 import {createAnimationFailed, missingOrDestroyedAnimation, missingPlayer, registerFailed} from '../error_helpers';
 import {ENTER_CLASSNAME, LEAVE_CLASSNAME} from '../util';
+import {warnRegister} from '../warning_helpers';
 
 import {AnimationDriver} from './animation_driver';
 import {getOrSetDefaultValue, listenOnPlayer, makeAnimationEvent, normalizeKeyframes, optimizeGroupPlayer} from './shared';
@@ -32,10 +33,14 @@ export class TimelineAnimationEngine {
 
   register(id: string, metadata: AnimationMetadata|AnimationMetadata[]) {
     const errors: Error[] = [];
-    const ast = buildAnimationAst(this._driver, metadata, errors);
+    const warnings: string[] = [];
+    const ast = buildAnimationAst(this._driver, metadata, errors, warnings);
     if (errors.length) {
       throw registerFailed(errors);
     } else {
+      if (warnings.length) {
+        warnRegister(warnings);
+      }
       this._animations.set(id, ast);
     }
   }

--- a/packages/animations/browser/src/warning_helpers.ts
+++ b/packages/animations/browser/src/warning_helpers.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
+
+function createListOfWarnings(warnings: string[]): string {
+  const LINE_START = '\n - ';
+  return `${LINE_START}${warnings.filter(Boolean).map(warning => warning).join(LINE_START)}`;
+}
+
+export function warnValidation(warnings: string[]): void {
+  NG_DEV_MODE && console.warn(`animation validation warnings:${createListOfWarnings(warnings)}`);
+}
+
+export function warnTriggerBuild(name: string, warnings: string[]): void {
+  NG_DEV_MODE &&
+      console.warn(`The animation trigger "${name}" has built with the following warnings:${
+          createListOfWarnings(warnings)}`);
+}
+
+export function warnRegister(warnings: string[]): void {
+  NG_DEV_MODE &&
+      console.warn(`Animation built with the following warnings:${createListOfWarnings(warnings)}`);
+}
+
+export function triggerParsingWarnings(name: string, warnings: string[]): void {
+  NG_DEV_MODE &&
+      console.warn(`Animation parsing for the ${name} trigger presents the following warnings:${
+          createListOfWarnings(warnings)}`);
+}
+
+export function pushUnrecognizedPropertiesWarning(warnings: string[], props: string[]): void {
+  if (ngDevMode && props.length) {
+    warnings.push(
+        `The provided CSS properties are not recognized properties supported for animations: ${
+            props.join(', ')}`);
+  }
+}

--- a/packages/animations/browser/test/render/transition_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/transition_animation_engine_spec.ts
@@ -735,9 +735,11 @@ function registerTrigger(
     element: any, engine: TransitionAnimationEngine, metadata: AnimationTriggerMetadata,
     id: string = DEFAULT_NAMESPACE_ID) {
   const errors: Error[] = [];
+  const warnings: string[] = [];
   const driver = new MockAnimationDriver();
   const name = metadata.name;
-  const ast = buildAnimationAst(driver, metadata as AnimationMetadata, errors) as TriggerAst;
+  const ast =
+      buildAnimationAst(driver, metadata as AnimationMetadata, errors, warnings) as TriggerAst;
   if (errors.length) {
   }
   const trigger = buildTrigger(name, ast, new NoopAnimationStyleNormalizer());

--- a/packages/animations/browser/test/shared.ts
+++ b/packages/animations/browser/test/shared.ts
@@ -13,16 +13,21 @@ import {buildAnimationAst} from '../src/dsl/animation_ast_builder';
 import {AnimationTrigger, buildTrigger} from '../src/dsl/animation_trigger';
 import {NoopAnimationStyleNormalizer} from '../src/dsl/style_normalization/animation_style_normalizer';
 import {triggerParsingFailed} from '../src/error_helpers';
+import {triggerParsingWarnings} from '../src/warning_helpers';
 import {MockAnimationDriver} from '../testing/src/mock_animation_driver';
 
 export function makeTrigger(
     name: string, steps: any, skipErrors: boolean = false): AnimationTrigger {
   const driver = new MockAnimationDriver();
   const errors: Error[] = [];
+  const warnings: string[] = [];
   const triggerData = trigger(name, steps);
-  const triggerAst = buildAnimationAst(driver, triggerData, errors) as TriggerAst;
+  const triggerAst = buildAnimationAst(driver, triggerData, errors, warnings) as TriggerAst;
   if (!skipErrors && errors.length) {
     throw triggerParsingFailed(name, errors);
+  }
+  if (warnings.length) {
+    triggerParsingWarnings(name, warnings);
   }
   return buildTrigger(name, triggerAst, new NoopAnimationStyleNormalizer());
 }


### PR DESCRIPTION
currently animations with unsupported CSS properties cause a hard error
and the crash of the animation itself, instead of this behaviour just
ignore such properties and provide a warning for the developer in
the console (only in dev mode)

resolves #23195

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: #23195



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

I don't think it's a breaking change, unless someone was actually in some circumstances relying on the animations crushing when finding unsupported CSS properties :thinking: 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

You can notice that the warnings I've added are `string`s which is inconsistent with the errors being `any`s, I believe the errors should actually also be strings and I've already opened #44726 to update their type :slightly_smiling_face: 