### PR TITLE
docs: update deprecated form of the tap operator in http example

### DIFF
--- a/aio/content/examples/http/src/app/downloader/downloader.service.ts
+++ b/aio/content/examples/http/src/app/downloader/downloader.service.ts
@@ -19,8 +19,10 @@ export class DownloaderService {
     return this.http.get(filename, {responseType: 'text'})
       .pipe(
         tap( // Log the result or error
-          data => this.log(filename, data),
-          error => this.logError(filename, error)
+        {
+          next: (data) => this.log(filename, data),
+          error: (error) => this.logError(filename, error)
+        }
         )
       );
   }

--- a/aio/content/examples/http/src/app/http-interceptors/logging-interceptor.ts
+++ b/aio/content/examples/http/src/app/http-interceptors/logging-interceptor.ts
@@ -19,12 +19,12 @@ export class LoggingInterceptor implements HttpInterceptor {
     // extend server response observable with logging
     return next.handle(req)
       .pipe(
-        tap(
+        tap({
           // Succeeds when there is a response; ignore other events
-          event => ok = event instanceof HttpResponse ? 'succeeded' : '',
+          next: (event) => (ok = event instanceof HttpResponse ? 'succeeded' : ''),
           // Operation failed; error is an HttpErrorResponse
-          error => ok = 'failed'
-        ),
+          error: (error) => (ok = 'failed')
+        }),
         // Log when response observable either completes or errors
         finalize(() => {
           const elapsed = Date.now() - started;

--- a/aio/content/examples/http/src/app/http-interceptors/retry-interceptor.ts
+++ b/aio/content/examples/http/src/app/http-interceptors/retry-interceptor.ts
@@ -44,10 +44,9 @@ export class RetryInterceptor implements HttpInterceptor {
 
     return next.handle(req).pipe(
         // #enddocregion reading-context
-        tap(null,
-            () => {
+        tap({
               // An error has occurred, so increment this request's ERROR_COUNT.
-              req.context.set(ERROR_COUNT, req.context.get(ERROR_COUNT) + 1);
+             error: () => req.context.set(ERROR_COUNT, req.context.get(ERROR_COUNT) + 1)
             }),
         // #docregion reading-context
         // Retry the request a configurable number of times.


### PR DESCRIPTION
update deprecated form of the tap operator. Instead of passing separate callback arguments, use an observer argument. Signatures taking separate callback arguments will be removed in v8. Details: https://rxjs.dev/deprecations/subscribe-arguments

DEPRECATED: tap operator subscribe signature is deprecated

Instead of passing separate callback arguments, use an observer argument. Signatures taking separate callback arguments will be removed in v8. Details: https://rxjs.dev/deprecations/subscribe-arguments

Closes #44708

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #44708 


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
