### PR TITLE
feat(forms): support negative integers as indices in FormArray

### DIFF
--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -2068,9 +2068,11 @@ export class FormArray extends AbstractControl {
   /**
    * Get the `AbstractControl` at the given `index` in the array.
    *
-   * @param index Index in the array to retrieve the control
+   * @param index Index in the array to retrieve the control. Negative integers count back from the
+   * last item in the array.
    */
   at(index: number): AbstractControl {
+    index = this._adjustIndex(index);
     return this.controls[index];
   }
 
@@ -2094,7 +2096,8 @@ export class FormArray extends AbstractControl {
   /**
    * Insert a new `AbstractControl` at the given `index` in the array.
    *
-   * @param index Index in the array to insert the control
+   * @param index Index in the array to insert the control. Negative integers count back from the
+   *     last item in the array.
    * @param control Form control to be inserted
    * @param options Specifies whether this FormArray instance should emit events after a new
    *     control is inserted.
@@ -2103,6 +2106,7 @@ export class FormArray extends AbstractControl {
    * inserted. When false, no events are emitted.
    */
   insert(index: number, control: AbstractControl, options: {emitEvent?: boolean} = {}): void {
+    index = this._adjustIndex(index);
     this.controls.splice(index, 0, control);
 
     this._registerControl(control);
@@ -2112,7 +2116,8 @@ export class FormArray extends AbstractControl {
   /**
    * Remove the control at the given `index` in the array.
    *
-   * @param index Index in the array to remove the control
+   * @param index Index in the array to remove the control. Negative integers count back from the
+   *     last item in the array.
    * @param options Specifies whether this FormArray instance should emit events after a
    *     control is removed.
    * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
@@ -2120,6 +2125,7 @@ export class FormArray extends AbstractControl {
    * removed. When false, no events are emitted.
    */
   removeAt(index: number, options: {emitEvent?: boolean} = {}): void {
+    let adjustedIndex = this._adjustIndex(index);
     if (this.controls[index]) this.controls[index]._registerOnCollectionChange(() => {});
     this.controls.splice(index, 1);
     this.updateValueAndValidity({emitEvent: options.emitEvent});
@@ -2128,7 +2134,8 @@ export class FormArray extends AbstractControl {
   /**
    * Replace an existing control.
    *
-   * @param index Index in the array to replace the control
+   * @param index Index in the array to replace the control. Negative integers count back from the
+   *     last item in the array.
    * @param control The `AbstractControl` control to replace the existing control
    * @param options Specifies whether this FormArray instance should emit events after an
    *     existing control is replaced with a new one.
@@ -2137,6 +2144,7 @@ export class FormArray extends AbstractControl {
    * replaced with a new one. When false, no events are emitted.
    */
   setControl(index: number, control: AbstractControl, options: {emitEvent?: boolean} = {}): void {
+    index = this._adjustIndex(index);
     if (this.controls[index]) this.controls[index]._registerOnCollectionChange(() => {});
     this.controls.splice(index, 1);
 
@@ -2147,6 +2155,14 @@ export class FormArray extends AbstractControl {
 
     this.updateValueAndValidity({emitEvent: options.emitEvent});
     this._onCollectionChange();
+  }
+
+  /**
+   * Converts negative indices to a corresponding positive number that represents a position of
+   * an element in an array.
+   */
+  private _adjustIndex(index: number): number {
+    return index >= 0 ? index : index + this.length;
   }
 
   /**


### PR DESCRIPTION
This new feature allows negative integers to wrap around when used as FormArray indices. Rebased from #44631. Please see that PR for original context.

Co-authored-by: Amit Beckenstein <amitbeck@gmail.com>
