### PR TITLE
fix(docs-infra): fix date parsing in a flaky test

### DIFF
--- a/aio/src/app/custom-elements/events/events.component.spec.ts
+++ b/aio/src/app/custom-elements/events/events.component.spec.ts
@@ -31,7 +31,8 @@ describe('EventsComponent', () => {
   describe('ngOnInit()', () => {
     beforeEach(() => {
       jasmine.clock().install();
-      jasmine.clock().mockDate(new Date(2020, 5, 15, 23, 59, 59));
+      // End of day on June 15
+      jasmine.clock().mockDate(new Date(Date.parse('2020-06-16') - 1));
       component.ngOnInit();
     });
 


### PR DESCRIPTION
Mock dates in EventsComponent tests are parsed in inconsistent ways
across platforms/browsers, which makes the comparison to the mocked
UTC "now" date behave differently causing the test to fail. This fix
ensures that the mocked "now" date is parsed in the same way as the
test dates to avoid inconsistencies.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The test `'should treat ongoing events as upcoming'` fails on Ubuntu 20.04.3 LTS running Chrome Headless 93.0.4577.0 (Linux x86_64).


## What is the new behavior?

The test passes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
