### PR TITLE
docs: add note about using NG_ASYNC_VALIDATORS

### DIFF
--- a/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
+++ b/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
@@ -19,18 +19,21 @@ export class HeroFormReactiveComponent implements OnInit {
   heroForm: FormGroup;
 
   ngOnInit(): void {
+    // #docregion async-validator-usage
+    const alterEgoControl = new FormControl('', {
+      asyncValidators: [this.alterEgoValidator.validate.bind(this.alterEgoValidator)],
+      updateOn: 'blur'
+    });
+    alterEgoControl.setValue(this.hero.alterEgo);
+    // #enddocregion async-validator-usage
+
     this.heroForm = new FormGroup({
       name: new FormControl(this.hero.name, [
         Validators.required,
         Validators.minLength(4),
         forbiddenNameValidator(/bob/i)
       ]),
-      // #docregion async-validator
-      alterEgo: new FormControl(this.hero.alterEgo, {
-        asyncValidators: [this.alterEgoValidator.validate.bind(this.alterEgoValidator)],
-        updateOn: 'blur'
-      }),
-      // #enddocregion async-validator
+      alterEgo: alterEgoControl,
       power: new FormControl(this.hero.power, Validators.required)
     });
   }
@@ -40,6 +43,8 @@ export class HeroFormReactiveComponent implements OnInit {
   get power() { return this.heroForm.get('power'); }
 
   get alterEgo() { return this.heroForm.get('alterEgo'); }
-
+  
+  // #docregion async-validator-inject
   constructor(private alterEgoValidator: UniqueAlterEgoValidator) {}
+  // #enddocregion async-validator-inject
 }

--- a/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
+++ b/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
@@ -43,7 +43,7 @@ export class HeroFormReactiveComponent implements OnInit {
   get power() { return this.heroForm.get('power'); }
 
   get alterEgo() { return this.heroForm.get('alterEgo'); }
-  
+
   // #docregion async-validator-inject
   constructor(private alterEgoValidator: UniqueAlterEgoValidator) {}
   // #enddocregion async-validator-inject

--- a/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
+++ b/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
@@ -25,10 +25,12 @@ export class HeroFormReactiveComponent implements OnInit {
         Validators.minLength(4),
         forbiddenNameValidator(/bob/i)
       ]),
+      // #docregion async-validator
       alterEgo: new FormControl(this.hero.alterEgo, {
         asyncValidators: [this.alterEgoValidator.validate.bind(this.alterEgoValidator)],
         updateOn: 'blur'
       }),
+      // #enddocregion async-validator
       power: new FormControl(this.hero.power, Validators.required)
     });
   }

--- a/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
+++ b/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
@@ -24,8 +24,8 @@ export class HeroFormReactiveComponent implements OnInit {
       asyncValidators: [this.alterEgoValidator.validate.bind(this.alterEgoValidator)],
       updateOn: 'blur'
     });
-    alterEgoControl.setValue(this.hero.alterEgo);
     // #enddocregion async-validator-usage
+     alterEgoControl.setValue(this.hero.alterEgo);
 
     this.heroForm = new FormGroup({
       name: new FormControl(this.hero.name, [

--- a/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
+++ b/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
@@ -37,15 +37,12 @@ export class UniqueAlterEgoValidator implements AsyncValidator {
   ]
 })
 export class UniqueAlterEgoValidatorDirective implements AsyncValidator {
-  constructor(private heroesService: HeroesService) {}
+  constructor(private validator: UniqueAlterEgoValidator) {}
 
   validate(
     control: AbstractControl
   ): Observable<ValidationErrors | null> {
-    return this.heroesService.isAlterEgoTaken(control.value).pipe(
-      map(isTaken => (isTaken ? { uniqueAlterEgo: true } : null)),
-      catchError(() => of(null))
-    );
+    this.validator.validate(control);
   }
 }
 // #enddocregion async-validator-directive

--- a/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
+++ b/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
@@ -42,7 +42,7 @@ export class UniqueAlterEgoValidatorDirective implements AsyncValidator {
   validate(
     control: AbstractControl
   ): Observable<ValidationErrors | null> {
-    this.validator.validate(control);
+    return this.validator.validate(control);
   }
 }
 // #enddocregion async-validator-directive

--- a/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
+++ b/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
@@ -10,8 +10,19 @@ import { HeroesService } from './heroes.service';
 import { Observable, of } from 'rxjs';
 
 // #docregion async-validator
-@Injectable({ providedIn: 'root' })
-export class UniqueAlterEgoValidator implements AsyncValidator {
+// #docregion async-validator-directive
+@Directive({
+  selector: '[appUniqueAlterEgo]',
+  providers: [
+    {
+      provide: NG_ASYNC_VALIDATORS,
+      useExisting: forwardRef(() => UniqueAlterEgoValidator),
+      multi: true
+    }
+  ]
+})
+// #enddocregion async-validator-directive
+export class UniqueAlterEgoValidatorDirective implements AsyncValidator {
   constructor(private heroesService: HeroesService) {}
 
   validate(
@@ -24,21 +35,3 @@ export class UniqueAlterEgoValidator implements AsyncValidator {
   }
 }
 // #enddocregion async-validator
-
-@Directive({
-  selector: '[appUniqueAlterEgo]',
-  providers: [
-    {
-      provide: NG_ASYNC_VALIDATORS,
-      useExisting: forwardRef(() => UniqueAlterEgoValidator),
-      multi: true
-    }
-  ]
-})
-export class UniqueAlterEgoValidatorDirective {
-  constructor(private validator: UniqueAlterEgoValidator) {}
-
-  validate(control: AbstractControl) {
-    this.validator.validate(control);
-  }
-}

--- a/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
+++ b/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
@@ -16,7 +16,7 @@ import { Observable, of } from 'rxjs';
   providers: [
     {
       provide: NG_ASYNC_VALIDATORS,
-      useExisting: forwardRef(() => UniqueAlterEgoValidator),
+      useExisting: forwardRef(() => UniqueAlterEgoValidatorDirective),
       multi: true
     }
   ]
@@ -26,9 +26,9 @@ export class UniqueAlterEgoValidatorDirective implements AsyncValidator {
   constructor(private heroesService: HeroesService) {}
 
   validate(
-    ctrl: AbstractControl
-  ): Promise<ValidationErrors | null> | Observable<ValidationErrors | null> {
-    return this.heroesService.isAlterEgoTaken(ctrl.value).pipe(
+    control: AbstractControl
+  ): Observable<ValidationErrors | null> {
+    return this.heroesService.isAlterEgoTaken(control.value).pipe(
       map(isTaken => (isTaken ? { uniqueAlterEgo: true } : null)),
       catchError(() => of(null))
     );

--- a/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
+++ b/aio/content/examples/form-validation/src/app/shared/alter-ego.directive.ts
@@ -10,19 +10,8 @@ import { HeroesService } from './heroes.service';
 import { Observable, of } from 'rxjs';
 
 // #docregion async-validator
-// #docregion async-validator-directive
-@Directive({
-  selector: '[appUniqueAlterEgo]',
-  providers: [
-    {
-      provide: NG_ASYNC_VALIDATORS,
-      useExisting: forwardRef(() => UniqueAlterEgoValidatorDirective),
-      multi: true
-    }
-  ]
-})
-// #enddocregion async-validator-directive
-export class UniqueAlterEgoValidatorDirective implements AsyncValidator {
+@Injectable({ providedIn: 'root' })
+export class UniqueAlterEgoValidator implements AsyncValidator {
   constructor(private heroesService: HeroesService) {}
 
   validate(
@@ -35,3 +24,28 @@ export class UniqueAlterEgoValidatorDirective implements AsyncValidator {
   }
 }
 // #enddocregion async-validator
+
+// #docregion async-validator-directive
+@Directive({
+  selector: '[appUniqueAlterEgo]',
+  providers: [
+    {
+      provide: NG_ASYNC_VALIDATORS,
+      useExisting: forwardRef(() => UniqueAlterEgoValidatorDirective),
+      multi: true
+    }
+  ]
+})
+export class UniqueAlterEgoValidatorDirective implements AsyncValidator {
+  constructor(private heroesService: HeroesService) {}
+
+  validate(
+    control: AbstractControl
+  ): Observable<ValidationErrors | null> {
+    return this.heroesService.isAlterEgoTaken(control.value).pipe(
+      map(isTaken => (isTaken ? { uniqueAlterEgo: true } : null)),
+      catchError(() => of(null))
+    );
+  }
+}
+// #enddocregion async-validator-directive

--- a/aio/content/examples/form-validation/src/app/template/hero-form-template.component.html
+++ b/aio/content/examples/form-validation/src/app/template/hero-form-template.component.html
@@ -35,14 +35,15 @@
 
         <div class="form-group">
           <label for="alterEgo">Alter Ego</label>
-          <input type="text"
+        <!-- #docregion alterEgo-input -->
+        <input type="text"
                  id="alterEgo"
                  name="alterEgo"
                  #alterEgo="ngModel"
                  [(ngModel)]="hero.alterEgo"
                  [ngModelOptions]="{ updateOn: 'blur' }"
                  appUniqueAlterEgo>
-
+          <!-- #enddocregion alterEgo-input -->
           <div *ngIf="alterEgo.pending">Validating...</div>
           <div *ngIf="alterEgo.invalid" class="alert alter-ego-errors">
             <div *ngIf="alterEgo.errors?.['uniqueAlterEgo']">

--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -341,7 +341,9 @@ In reactive forms, add an async validator by passing the function directly to th
 
 ### Adding async validators to template-driven forms
 
-To use an async validator in template-driven forms, register it with the `NG_ASYNC_VALIDATORS` provider.
+To use an async validator in template-driven forms, create a new directive and register the `NG_ASYNC_VALIDATORS` provider on it.
+
+In the example below, the directive injects the `UniqueAlterEgoValidator` class that contains the actual validation logic and invokes it in the `validate` function, triggered by Angular when validation should happen.
 
 <code-example path="form-validation/src/app/shared/alter-ego.directive.ts" region="async-validator-directive"></code-example>
 

--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -285,6 +285,7 @@ These are very similar to their synchronous counterparts, with the following dif
 * The `validate()` functions must return a Promise or an observable,
 * The observable returned must be finite, meaning it must complete at some point.
 To convert an infinite observable into a finite one, pipe the observable through a filtering operator such as `first`, `last`, `take`, or `takeUntil`.
+* In template-driven forms, register your validator directive with the `NG_ASYNC_VALIDATORS` provider instead of `NG_VALIDATORS`.
 
 Asynchronous validation happens after the synchronous validation, and is performed only if the synchronous validation is successful.
 This check lets forms avoid potentially expensive async validation processes (such as an HTTP request) if the more basic validation methods have already found invalid input.

--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -341,7 +341,7 @@ To use an async validator in reactive forms, begin by injecting the validator in
 
 Then, pass the validator function directly to the `FormControl` to apply it. 
 
-In the following example, the `validate` function of `UniqueAlterEgoValidator` is applied to `alterEgoControl` by passing it to the control's `asyncValidators` option and binding it to the instance of `UniqueAlterEgoValidator` that was injected into `HeroFormReactiveComponent`. The value of `asyncValidators` can be either a single async validator function, or an array of functions.
+In the following example, the `validate` function of `UniqueAlterEgoValidator` is applied to `alterEgoControl` by passing it to the control's `asyncValidators` option and binding it to the instance of `UniqueAlterEgoValidator` that was injected into `HeroFormReactiveComponent`. The value of `asyncValidators` can be either a single async validator function, or an array of functions. To learn more about `FormControl` options, see the [AbstractControlOptions](/api/forms/AbstractControlOptions) API reference.
 
 <code-example path="form-validation/src/app/reactive/hero-form-reactive.component.2.ts" region="async-validator-usage"></code-example>
 

--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -285,7 +285,6 @@ These are very similar to their synchronous counterparts, with the following dif
 * The `validate()` functions must return a Promise or an observable,
 * The observable returned must be finite, meaning it must complete at some point.
 To convert an infinite observable into a finite one, pipe the observable through a filtering operator such as `first`, `last`, `take`, or `takeUntil`.
-* In template-driven forms, register your validator directive with the `NG_ASYNC_VALIDATORS` provider instead of `NG_VALIDATORS`.
 
 Asynchronous validation happens after the synchronous validation, and is performed only if the synchronous validation is successful.
 This check lets forms avoid potentially expensive async validation processes (such as an HTTP request) if the more basic validation methods have already found invalid input.
@@ -305,7 +304,7 @@ In the following example, an async validator ensures that heroes pick an alter e
 New heroes are constantly enlisting and old heroes are leaving the service, so the list of available alter egos cannot be retrieved ahead of time.
 To validate the potential alter ego entry, the validator must initiate an asynchronous operation to consult a central database of all currently enlisted heroes.
 
-The following code create the validator class, `UniqueAlterEgoValidator`, which implements the `AsyncValidator` interface.
+The following code creates the validator class, `UniqueAlterEgoValidator`, which implements the `AsyncValidator` interface.
 
 <code-example path="form-validation/src/app/shared/alter-ego.directive.ts" region="async-validator"></code-example>
 
@@ -333,6 +332,22 @@ You could handle the error differently and return the `ValidationError` object i
 
 After some time passes, the observable chain completes and the asynchronous validation is done.
 The `pending` flag is set to `false`, and the form validity is updated.
+
+### Adding async validators to reactive forms
+
+In reactive forms, add an async validator by passing the function directly to the `FormControl`.
+
+<code-example path="form-validation/src/app/reactive/hero-form-reactive.component.2.ts" region="async-validator"></code-example>
+
+### Adding async validators to template-driven forms
+
+To use an async validator in template-driven forms, register it with the `NG_ASYNC_VALIDATORS` provider.
+
+<code-example path="form-validation/src/app/shared/alter-ego.directive.ts" region="async-validator-directive"></code-example>
+
+Then, as with synchronous validators, add the directive's selector to an input to activate it.
+
+<code-example path="form-validation/src/app/template/hero-form-template.component.html" region="alterEgo-input" header="template/hero-form-template.component.html (unique-alter-ego-input)"></code-example>
 
 ### Optimizing performance of async validators
 

--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -335,9 +335,15 @@ The `pending` flag is set to `false`, and the form validity is updated.
 
 ### Adding async validators to reactive forms
 
-In reactive forms, add an async validator by passing the function directly to the `FormControl`.
+To use an async validator in reactive forms, begin by injecting the validator into the constructor of the component class.
 
-<code-example path="form-validation/src/app/reactive/hero-form-reactive.component.2.ts" region="async-validator"></code-example>
+<code-example path="form-validation/src/app/reactive/hero-form-reactive.component.2.ts" region="async-validator-inject"></code-example>
+
+Then, pass the validator function directly to the `FormControl` to apply it. 
+
+In the following example, the `validate` function of `UniqueAlterEgoValidator` is applied to `alterEgoControl` by passing it to the control's `asyncValidators` option and binding it to the instance of `UniqueAlterEgoValidator` that was injected into `HeroFormReactiveComponent`. The value of `asyncValidators` can be either a single async validator function, or an array of functions.
+
+<code-example path="form-validation/src/app/reactive/hero-form-reactive.component.2.ts" region="async-validator-usage"></code-example>
 
 ### Adding async validators to template-driven forms
 


### PR DESCRIPTION
When setting up an async validator in a template-driven form, it's necessary to register the directive with NG_ASYNC_VALIDATORS instead of NG_VALIDATORS. This was not mentioned in the docs.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

In the docs for adding async validators to a form, it doesn't mention that the async validator directive needs to register with the `NG_ASYNC_VALIDATORS` provider for use in template-driven forms. This tripped me up until I stumbled on a full example of an async validator on Stack Overflow.

Issue Number: N/A


## What is the new behavior?

I've added a bullet point noting this difference to the intro of the "Creating asynchronous validators" section.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
