### PR TITLE
fix(core): consistently use namespace short name rather than URI 

### DIFF
--- a/packages/core/src/render3/namespaces.ts
+++ b/packages/core/src/render3/namespaces.ts
@@ -6,5 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export const SVG_NAMESPACE = 'http://www.w3.org/2000/svg';
-export const MATH_ML_NAMESPACE = 'http://www.w3.org/1998/MathML/';
+export const SVG_NAMESPACE = 'svg';
+export const SVG_NAMESPACE_URI = 'http://www.w3.org/2000/svg';
+export const MATH_ML_NAMESPACE = 'math';
+export const MATH_ML_NAMESPACE_URI = 'http://www.w3.org/1998/MathML/';
+
+export function getNamespaceUri(namespace: string): string|null {
+  const name = namespace.toLowerCase();
+  return name === SVG_NAMESPACE ? SVG_NAMESPACE_URI :
+                                  (name === MATH_ML_NAMESPACE ? MATH_ML_NAMESPACE_URI : null);
+}

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -25,6 +25,7 @@ import {isProceduralRenderer, ProceduralRenderer3, Renderer3, unusedValueExportT
 import {RComment, RElement, RNode, RText} from './interfaces/renderer_dom';
 import {isLContainer, isLView} from './interfaces/type_checks';
 import {CHILD_HEAD, CLEANUP, DECLARATION_COMPONENT_VIEW, DECLARATION_LCONTAINER, DestroyHookData, FLAGS, HookData, HookFn, HOST, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, T_HOST, TVIEW, TView, TViewType, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
+import {getNamespaceUri} from './namespaces';
 import {assertTNodeType} from './node_assert';
 import {profiler, ProfilerEvent} from './profiler';
 import {getLViewParent} from './util/view_traversal_utils';
@@ -132,8 +133,9 @@ export function createElementNode(
   if (isProceduralRenderer(renderer)) {
     return renderer.createElement(name, namespace);
   } else {
-    return namespace === null ? renderer.createElement(name) :
-                                renderer.createElementNS(namespace, name);
+    const namespaceUri = namespace !== null ? getNamespaceUri(namespace) : null;
+    return namespaceUri === null ? renderer.createElement(name) :
+                                   renderer.createElementNS(namespaceUri, name);
   }
 }
 

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -542,10 +542,6 @@ describe('runtime i18n', () => {
       TestBed.configureTestingModule({
         providers: [
           {provide: DOCUMENT, useFactory: _document, deps: []},
-          // TODO(FW-811): switch back to default server renderer (i.e. remove the line
-          // below) once it starts to support Ivy namespace format (URIs) correctly. For
-          // now, use `DomRenderer` that supports Ivy namespace format.
-          {provide: RendererFactory2, useClass: DomRendererFactory2}
         ],
       });
     });

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -197,10 +197,6 @@ describe('ViewContainerRef', () => {
             declarations: [TestComp, SvgComp, MathMLComp],
             providers: [
               {provide: DOCUMENT, useFactory: _document, deps: []},
-              // TODO(FW-811): switch back to default server renderer (i.e. remove the line below)
-              // once it starts to support Ivy namespace format (URIs) correctly. For now, use
-              // `DomRenderer` that supports Ivy namespace format.
-              {provide: RendererFactory2, useClass: DomRendererFactory2}
             ],
           });
           const fixture = TestBed.createComponent(TestComp);

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -17,6 +17,7 @@ export const NAMESPACE_URIS: {[ns: string]: string} = {
   'xlink': 'http://www.w3.org/1999/xlink',
   'xml': 'http://www.w3.org/XML/1998/namespace',
   'xmlns': 'http://www.w3.org/2000/xmlns/',
+  'math': 'http://www.w3.org/1998/MathML/',
 };
 
 const COMPONENT_REGEX = /%COMP%/g;
@@ -144,9 +145,7 @@ class DefaultDomRenderer2 implements Renderer2 {
 
   createElement(name: string, namespace?: string): any {
     if (namespace) {
-      // In cases where Ivy (not ViewEngine) is giving us the actual namespace, the look up by key
-      // will result in undefined, so we just return the namespace here.
-      return document.createElementNS(NAMESPACE_URIS[namespace] || namespace, name);
+      return document.createElementNS(NAMESPACE_URIS[namespace], name);
     }
 
     return document.createElement(name);
@@ -199,8 +198,6 @@ class DefaultDomRenderer2 implements Renderer2 {
   setAttribute(el: any, name: string, value: string, namespace?: string): void {
     if (namespace) {
       name = namespace + ':' + name;
-      // TODO(FW-811): Ivy may cause issues here because it's passing around
-      // full URIs for namespaces, therefore this lookup will fail.
       const namespaceUri = NAMESPACE_URIS[namespace];
       if (namespaceUri) {
         el.setAttributeNS(namespaceUri, name, value);
@@ -214,15 +211,10 @@ class DefaultDomRenderer2 implements Renderer2 {
 
   removeAttribute(el: any, name: string, namespace?: string): void {
     if (namespace) {
-      // TODO(FW-811): Ivy may cause issues here because it's passing around
-      // full URIs for namespaces, therefore this lookup will fail.
       const namespaceUri = NAMESPACE_URIS[namespace];
       if (namespaceUri) {
         el.removeAttributeNS(namespaceUri, name);
       } else {
-        // TODO(FW-811): Since ivy is passing around full URIs for namespaces
-        // this could result in properties like `http://www.w3.org/2000/svg:cx="123"`,
-        // which is wrong.
         el.removeAttribute(`${namespace}:${name}`);
       }
     } else {

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -72,8 +72,6 @@ class DefaultServerRenderer2 implements Renderer2 {
   createElement(name: string, namespace?: string, debugInfo?: any): any {
     if (namespace) {
       const doc = this.document || getDOM().getDefaultDocument();
-      // TODO(FW-811): Ivy may cause issues here because it's passing around
-      // full URIs for namespaces, therefore this lookup will fail.
       return doc.createElementNS(NAMESPACE_URIS[namespace], name);
     }
 
@@ -131,8 +129,6 @@ class DefaultServerRenderer2 implements Renderer2 {
 
   setAttribute(el: any, name: string, value: string, namespace?: string): void {
     if (namespace) {
-      // TODO(FW-811): Ivy may cause issues here because it's passing around
-      // full URIs for namespaces, therefore this lookup will fail.
       el.setAttributeNS(NAMESPACE_URIS[namespace], namespace + ':' + name, value);
     } else {
       el.setAttribute(name, value);
@@ -141,8 +137,6 @@ class DefaultServerRenderer2 implements Renderer2 {
 
   removeAttribute(el: any, name: string, namespace?: string): void {
     if (namespace) {
-      // TODO(FW-811): Ivy may cause issues here because it's passing around
-      // full URIs for namespaces, therefore this lookup will fail.
       el.removeAttributeNS(NAMESPACE_URIS[namespace], name);
     } else {
       el.removeAttribute(name);

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -10,7 +10,7 @@ import {animate, AnimationBuilder, state, style, transition, trigger} from '@ang
 import {DOCUMENT, isPlatformServer, PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
 import {HTTP_INTERCEPTORS, HttpClient, HttpClientModule, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
-import {ApplicationRef, CompilerFactory, Component, destroyPlatform, getPlatform, HostListener, Inject, Injectable, Input, NgModule, NgZone, PLATFORM_ID, PlatformRef, ViewEncapsulation} from '@angular/core';
+import {ApplicationRef, CompilerFactory, Component, destroyPlatform, getPlatform, HostBinding, HostListener, Inject, Injectable, Input, NgModule, NgZone, OnInit, PLATFORM_ID, PlatformRef, ViewEncapsulation} from '@angular/core';
 import {inject, waitForAsync} from '@angular/core/testing';
 import {BrowserModule, makeStateKey, Title, TransferState} from '@angular/platform-browser';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformDynamicServer, PlatformState, renderModule, renderModuleFactory, ServerModule, ServerTransferStateModule} from '@angular/platform-server';
@@ -20,11 +20,16 @@ import {first} from 'rxjs/operators';
 @Component({selector: 'app', template: `Works!`})
 class MyServerApp {
 }
+@NgModule({
+  declarations: [MyServerApp],
+  exports: [MyServerApp],
+})
+export class MyServerAppModule {
+}
 
 @NgModule({
   bootstrap: [MyServerApp],
-  declarations: [MyServerApp],
-  imports: [ServerModule],
+  imports: [MyServerAppModule, ServerModule],
 })
 class ExampleModule {
 }
@@ -73,8 +78,8 @@ function asyncRejectRenderHook() {
 
 @NgModule({
   bootstrap: [MyServerApp],
-  declarations: [MyServerApp],
-  imports: [BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
+  imports:
+      [MyServerAppModule, BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
   providers: [
     {provide: BEFORE_APP_SERIALIZED, useFactory: getTitleRenderHook, multi: true, deps: [DOCUMENT]},
   ]
@@ -84,8 +89,8 @@ class RenderHookModule {
 
 @NgModule({
   bootstrap: [MyServerApp],
-  declarations: [MyServerApp],
-  imports: [BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
+  imports:
+      [MyServerAppModule, BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
   providers: [
     {provide: BEFORE_APP_SERIALIZED, useFactory: getTitleRenderHook, multi: true, deps: [DOCUMENT]},
     {provide: BEFORE_APP_SERIALIZED, useValue: exceptionRenderHook, multi: true},
@@ -97,8 +102,8 @@ class MultiRenderHookModule {
 
 @NgModule({
   bootstrap: [MyServerApp],
-  declarations: [MyServerApp],
-  imports: [BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
+  imports:
+      [MyServerAppModule, BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
   providers: [
     {
       provide: BEFORE_APP_SERIALIZED,
@@ -112,8 +117,8 @@ class AsyncRenderHookModule {
 }
 @NgModule({
   bootstrap: [MyServerApp],
-  declarations: [MyServerApp],
-  imports: [BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
+  imports:
+      [MyServerAppModule, BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
   providers: [
     {provide: BEFORE_APP_SERIALIZED, useFactory: getMetaRenderHook, multi: true, deps: [DOCUMENT]},
     {
@@ -235,8 +240,7 @@ class ExampleStylesModule {
 
 @NgModule({
   bootstrap: [MyServerApp],
-  declarations: [MyServerApp],
-  imports: [ServerModule, HttpClientModule, HttpClientTestingModule],
+  imports: [MyServerAppModule, ServerModule, HttpClientModule, HttpClientTestingModule],
 })
 export class HttpClientExampleModule {
 }
@@ -252,8 +256,7 @@ export class MyHttpInterceptor implements HttpInterceptor {
 
 @NgModule({
   bootstrap: [MyServerApp],
-  declarations: [MyServerApp],
-  imports: [ServerModule, HttpClientModule, HttpClientTestingModule],
+  imports: [MyServerAppModule, ServerModule, HttpClientModule, HttpClientTestingModule],
   providers: [
     {provide: HTTP_INTERCEPTORS, multi: true, useClass: MyHttpInterceptor},
   ],

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -193,7 +193,11 @@ class SVGServerModule {
 
 @Component({
   selector: 'app',
-  template: `<div [@myAnimation]="state">{{text}}</div>`,
+  template: `
+  <div [@myAnimation]="state">
+    <svg *ngIf="true"></svg>
+    {{text}}
+  </div>`,
   animations: [trigger(
       'myAnimation',
       [


### PR DESCRIPTION
This issue was discovered when debugging #44028. The root cause ended up being the TODO
here which points out a change in the namespaces between Ivy and VE. As a result,
the server renderer was always passing `undefined` as the namespace.

The effect of this for #44028 was that the SVG element was being created
as just an element rather than an SVGElement. [Here][1] is the code reference
for what happens in Domino. Finally, when the animation attempts to
apply to the SVG element, it fails to because the element doesn't have a
`style` property.

Resolves #44028

[1]: https://github.com/fgnass/domino/blob/12a5f67136a0ac10e3fa1649b8787ba3b309e9a7/lib/Document.js#L232-L239