### PR TITLE
fix(compiler-cli): remove leftover `_extendedTemplateDiagnostics` requirements

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -446,7 +446,7 @@ export class NgCompiler {
     diagnostics.push(
         ...this.getNonTemplateDiagnostics().filter(diag => diag.file === file),
         ...this.getTemplateDiagnosticsForFile(file, optimizeFor));
-    if (this.options._extendedTemplateDiagnostics) {
+    if (this.options.strictTemplates) {
       diagnostics.push(...this.getExtendedTemplateDiagnostics(file));
     }
     return this.addMessageTextDetails(diagnostics);
@@ -460,7 +460,7 @@ export class NgCompiler {
     const ttc = compilation.templateTypeChecker;
     const diagnostics: ts.Diagnostic[] = [];
     diagnostics.push(...ttc.getDiagnosticsForComponent(component));
-    if (this.options._extendedTemplateDiagnostics) {
+    if (this.options.strictTemplates) {
       const extendedTemplateChecker = compilation.extendedTemplateChecker;
       diagnostics.push(...extendedTemplateChecker.getDiagnosticsForComponent(component));
     }

--- a/packages/language-service/test/diagnostic_spec.ts
+++ b/packages/language-service/test/diagnostic_spec.ts
@@ -384,7 +384,7 @@ describe('getSemanticDiagnostics', () => {
     expect(diags[0].category).toEqual(ts.DiagnosticCategory.Warning);
   });
 
-  it('should not produce invalid banana in box warning without the required flags', () => {
+  it('should not produce invalid banana in box warning without `strictTemplates`', () => {
     const files = {
       'app.ts': `
         import {Component} from '@angular/core';
@@ -397,7 +397,9 @@ describe('getSemanticDiagnostics', () => {
         }
     `
     };
-    const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+    const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
+      strictTemplates: false,
+    });
 
     const diags = project.getDiagnosticsForFile('app.ts');
     expect(diags.length).toEqual(0);
@@ -426,7 +428,7 @@ describe('getSemanticDiagnostics', () => {
     expect(diags[0].category).toEqual(ts.DiagnosticCategory.Warning);
   });
 
-  it('should not produce invalid banana in box warning in external html file without the required flags',
+  it('should not produce invalid banana in box warning in external html file without `strictTemplates`',
      () => {
        const files = {
          'app.ts': `
@@ -441,7 +443,9 @@ describe('getSemanticDiagnostics', () => {
     `,
          'app.html': `<div ([foo])="bar"></div>`
        };
-       const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+       const project = createModuleAndProjectWithDeclarations(env, 'test', files, {
+         strictTemplates: false,
+       });
 
        const diags = project.getDiagnosticsForFile('app.html');
        expect(diags.length).toEqual(0);


### PR DESCRIPTION
There were two remaining places where `_extendedTemplateDiagnostics` needed to be set which should have been removed in #44712 but got missed. This updates them to only require `strictTemplates` and not `_extendedTemplateDiagnostics` so the feature is properly enabled in production.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix

## What is the current behavior?

Issue Number: #42966

Extended diagnostics still required the experimental `_extendedTemplateDiagnostics` flag to emit from the compiler / `ng serve`.

## What is the new behavior?

Extended diagnostics are now shown even without `_extendedTemplateDiagnostics`, effectively enabling the feature for production users.

## Does this PR introduce a breaking change?

- [X] No
