### PR TITLE
fix(compiler-cli): skip `ExtendedTemplateCheckerImpl` construction if there were configuration errors

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/src/extended_template_checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/src/extended_template_checker.ts
@@ -86,7 +86,7 @@ export class ExtendedTemplateCheckerImpl implements ExtendedTemplateChecker {
 }
 
 /**
- * Converts a `DiagnosticCategoryLabel` to its equivalent `ts.DiagnosticCategory` or `undefined` if
+ * Converts a `DiagnosticCategoryLabel` to its equivalent `ts.DiagnosticCategory` or `null` if
  * the label is `DiagnosticCategoryLabel.Suppress`.
  */
 function diagnosticLabelToCategory(label: DiagnosticCategoryLabel): ts.DiagnosticCategory|null {

--- a/packages/compiler-cli/test/ngtsc/extended_template_diagnostics_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/extended_template_diagnostics_spec.ts
@@ -233,6 +233,24 @@ runInEachFileSystem(() => {
         const diagnostics = env.driveDiagnostics(0 /* expectedExitCode */);
         expect(diagnostics).toEqual([]);
       });
+
+      it('by throwing an error when given a bad category', () => {
+        env.tsconfig({
+          strictTemplates: true,
+          extendedDiagnostics: {
+            defaultCategory: 'not-a-category',
+          },
+        });
+
+        env.write('test.ts', warningComponent);
+
+        const diagnostics = env.driveDiagnostics(1 /* expectedExitCode */);
+        expect(diagnostics.length).toBe(1);
+        expect(diagnostics[0]).toEqual(jasmine.objectContaining({
+          code: ngErrorCode(ErrorCode.CONFIG_EXTENDED_DIAGNOSTICS_UNKNOWN_CATEGORY_LABEL),
+          category: ts.DiagnosticCategory.Error,
+        }));
+      });
     });
   });
 });


### PR DESCRIPTION
Previously, if a bad extended diagnostic category was given, it would fail with the expected error as well as an unexpected assertion error:

```
$ ng build -c development
✔ Browser application bundle generation complete.

./src/main.ts - Error: Module build failed (from ./node_modules/@ngtools/webpack/src/ivy/index.js):
Error: Unexpected call to 'assertNever()' with value:
test
    at /home/douglasparker/Source/ng-new/node_modules/@ngtools/webpack/src/ivy/loader.js:77:18
    at processTicksAndRejections (internal/process/task_queues.js:95:5)

./src/polyfills.ts - Error: Module build failed (from ./node_modules/@ngtools/webpack/src/ivy/index.js):
Error: Unexpected call to 'assertNever()' with value:
test
    at /home/douglasparker/Source/ng-new/node_modules/@ngtools/webpack/src/ivy/loader.js:77:18
    at processTicksAndRejections (internal/process/task_queues.js:95:5)

Error: error NG4004: Angular compiler option "extendedDiagnostics.checks['invalidBananaInBox']" has an unknown diagnostic category: "test".

Allowed diagnostic categories are:
warning
error
suppress
```

The assertion comes from `ExtendedTemplateCheckerImpl`, which expects a well-formed configuration, yet the compiler would construct it even when errors were found. This commit skips constructing and running extended diagnostics if the configuration had errors, which should avoid triggering these assertion errors.

I'm unfortunately not able to actually test this change. The test passes even before the fix because the `ngc` binary and end-to-end tests [don't request diagnostics unless the configuration is considered valid](https://github.com/angular/angular/blob/ed21f5c75378e1ce717ee3d76d28c8c994209de1/packages/compiler-cli/src/perform_compile.ts#L292-L293). See [Slack](https://angular-team.slack.com/archives/C4WHZQMRA/p1642641305003800) for more details.

I'm pretty sure this is the right fix, but if you have any suggestions for how to test / verify this before releasing it, I'm happy to do what I can.

I listed this as `target: rc` since it would be nice to get it in for `13.2.0`, but functionally it is just a bad error message, so if we can't get it in and need to wait for a patch release, I'm ok with that too.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [X] Bugfix

## What is the current behavior?

Issue Number: #42966

Using a bad diagnostic category in `tsconfig.json` for extended diagnostics throws the expected error and also some assertion errors which clutter the output.

## What is the new behavior?

Using a bad diagnostic category in `tsconfig.json` for extended diagnostics only throws the expected error and no assertion errors.

## Does this PR introduce a breaking change?

- [X] No

## Other information
