### PR TITLE
fix(core): handle instrumented constructors during reflection

### DIFF
--- a/packages/core/src/reflection/reflection_capabilities.ts
+++ b/packages/core/src/reflection/reflection_capabilities.ts
@@ -63,7 +63,7 @@ export const ES2015_INHERITED_CLASS_WITH_CTOR =
  * and inherit a constructor.
  */
 export const ES2015_INHERITED_CLASS_WITH_DELEGATE_CTOR =
-    /^class\s+[A-Za-z\d$_]*\s*extends\s+[^{]+{[\s\S]*constructor\s*\(\)\s*{\s*super\(\.\.\.arguments\)/;
+    /^class\s+[A-Za-z\d$_]*\s*extends\s+[^{]+{[\s\S]*constructor\s*\(\)\s*{[\S\s.]*super\(\.\.\.arguments\)/;
 
 /**
  * Determine whether a stringified type is a class which delegates its constructor

--- a/packages/core/test/reflection/reflector_spec.ts
+++ b/packages/core/test/reflection/reflector_spec.ts
@@ -9,7 +9,6 @@
 import {Reflector} from '@angular/core/src/reflection/reflection';
 import {isDelegateCtor, ReflectionCapabilities} from '@angular/core/src/reflection/reflection_capabilities';
 import {makeDecorator, makeParamDecorator, makePropDecorator} from '@angular/core/src/util/decorators';
-import {global} from '@angular/core/src/util/global';
 
 interface ClassDecoratorFactory {
   (data: ClassDecorator): any;
@@ -244,6 +243,17 @@ class TestObj {
         expect(isDelegateCtor(ChildNoCtor)).toBe(true);
         expect(isDelegateCtor(ChildNoCtorPrivateProps)).toBe(true);
         expect(isDelegateCtor(ChildWithCtor)).toBe(false);
+      });
+
+      it('should support instrumented ES2015 extended classes', () => {
+        // These classes are ES2015 instrumented classes by istanbuljs
+        const ChildWithCtorIntsrumented =
+            'class ChildWithCtor extends Parent{constructor(){cov_1wm1ham9dl().s[2]++;cov_1wm1ham9dl().s[1]++;super()cov_1wm1ham9dl().s[1]++;}}';
+        const ChildNoCtorPrivatePropsInstrumented =
+            'class ChildNoCtorPrivateProps extends Parent{constructor(){cov_1wm1ham9dl().s[1]++;cov_1wm1ham9dl().s[2]++;super(...arguments);cov_1wm1ham9dl().s[1]++;this.x=10}}';
+
+        expect(isDelegateCtor(ChildNoCtorPrivatePropsInstrumented)).toBe(true);
+        expect(isDelegateCtor(ChildWithCtorIntsrumented)).toBe(false);
       });
 
       it('should support ES2015 classes when minified', () => {


### PR DESCRIPTION
Currently, the RegExp that detects ES2015 classes which extend from other classes and inherit a constructor doesn't correctly handle instrumented code.

The current RegExp requires that there are no statements prior to the `super` call, but instrumented constructors will contain function calls prior to this.

```js
constructor() {
 cov_1wm1ham9dl().f[0]++;
 cov_1wm1ham9dl().s[1]++;
 super(...arguments);
 cov_1wm1ham9dl().s[2]++;
 this.validation = true;
}
```

Fixes #44781

