### PR TITLE
refactor(core): the `RuntimeError` class should support more compact syntax

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -5,10 +5,10 @@
 ```ts
 
 // @public
-export function formatRuntimeError<T = RuntimeErrorCode>(code: T, message: null | false | string): string;
+export function formatRuntimeError<T extends number = RuntimeErrorCode>(code: T, message: null | false | string): string;
 
 // @public
-export class RuntimeError<T = RuntimeErrorCode> extends Error {
+export class RuntimeError<T extends number = RuntimeErrorCode> extends Error {
     constructor(code: T, message: null | false | string);
     // (undocumented)
     code: T;

--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -5,11 +5,11 @@
 ```ts
 
 // @public
-export function formatRuntimeError<T = RuntimeErrorCode>(code: T, message: string): string;
+export function formatRuntimeError<T = RuntimeErrorCode>(code: T, message: null | false | string): string;
 
-// @public (undocumented)
+// @public
 export class RuntimeError<T = RuntimeErrorCode> extends Error {
-    constructor(code: T, message: string);
+    constructor(code: T, message: null | false | string);
     // (undocumented)
     code: T;
 }

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -256,10 +256,9 @@ export class R3Injector {
 
   private assertNotDestroyed(): void {
     if (this._destroyed) {
-      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-          'Injector has already been destroyed.' :
-          '';
-      throw new RuntimeError(RuntimeErrorCode.INJECTOR_ALREADY_DESTROYED, errorMessage);
+      throw new RuntimeError(
+          RuntimeErrorCode.INJECTOR_ALREADY_DESTROYED,
+          ngDevMode && 'Injector has already been destroyed.');
     }
   }
 
@@ -450,10 +449,9 @@ function injectableDefOrInjectorDefFactory(token: ProviderToken<any>): FactoryFn
   // InjectionTokens should have an injectable def (ɵprov) and thus should be handled above.
   // If it's missing that, it's an error.
   if (token instanceof InjectionToken) {
-    const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-        `Token ${stringify(token)} is missing a ɵprov definition.` :
-        '';
-    throw new RuntimeError(RuntimeErrorCode.INVALID_INJECTION_TOKEN, errorMessage);
+    throw new RuntimeError(
+        RuntimeErrorCode.INVALID_INJECTION_TOKEN,
+        ngDevMode && `Token ${stringify(token)} is missing a ɵprov definition.`);
   }
 
   // Undecorated types can sometimes be created if they have no constructor arguments.
@@ -462,8 +460,7 @@ function injectableDefOrInjectorDefFactory(token: ProviderToken<any>): FactoryFn
   }
 
   // There was no way to resolve a factory for this token.
-  const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ? 'unreachable' : '';
-  throw new RuntimeError(RuntimeErrorCode.INVALID_INJECTION_TOKEN, errorMessage);
+  throw new RuntimeError(RuntimeErrorCode.INVALID_INJECTION_TOKEN, ngDevMode && 'unreachable');
 }
 
 function getUndecoratedInjectableFactory(token: Function) {
@@ -471,10 +468,9 @@ function getUndecoratedInjectableFactory(token: Function) {
   const paramLength = token.length;
   if (paramLength > 0) {
     const args: string[] = newArray(paramLength, '?');
-    const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-        `Can't resolve all parameters for ${stringify(token)}: (${args.join(', ')}).` :
-        '';
-    throw new RuntimeError(RuntimeErrorCode.INVALID_INJECTION_TOKEN, errorMessage);
+    throw new RuntimeError(
+        RuntimeErrorCode.INVALID_INJECTION_TOKEN,
+        ngDevMode && `Can't resolve all parameters for ${stringify(token)}: (${args.join(', ')}).`);
   }
 
   // The constructor function appears to have no parameters.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -65,14 +65,33 @@ export const enum RuntimeErrorCode {
   UNSAFE_VALUE_IN_SCRIPT = 905
 }
 
+/**
+ * Class that represents a runtime error.
+ * Formats and outputs the error message in a consistent way.
+ *
+ * Example:
+ * ```
+ *  throw new RuntimeError(
+ *    RuntimeErrorCode.INJECTOR_ALREADY_DESTROYED,
+ *    ngDevMode && 'Injector has already been destroyed.');
+ * ```
+ *
+ * Note: the `message` argument contains a descriptive error message as a string in development
+ * mode (when the `ngDevMode` is defined). In production mode (after tree-shaking pass), the
+ * `message` argument becomes `false`, thus we account for it in the typings and the runtime logic.
+ */
 export class RuntimeError<T = RuntimeErrorCode> extends Error {
-  constructor(public code: T, message: string) {
+  constructor(public code: T, message: null|false|string) {
     super(formatRuntimeError<T>(code, message));
   }
 }
 
-/** Called to format a runtime error */
-export function formatRuntimeError<T = RuntimeErrorCode>(code: T, message: string): string {
+/**
+ * Called to format a runtime error.
+ * See additional info on the `message` argument type in the `RuntimeError` class description.
+ */
+export function formatRuntimeError<T = RuntimeErrorCode>(
+    code: T, message: null|false|string): string {
   const codeAsNumber = code as unknown as number;
   // Error code might be a negative number, which is a special marker that instructs the logic to
   // generate a link to the error details page on angular.io.

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -80,7 +80,7 @@ export const enum RuntimeErrorCode {
  * mode (when the `ngDevMode` is defined). In production mode (after tree-shaking pass), the
  * `message` argument becomes `false`, thus we account for it in the typings and the runtime logic.
  */
-export class RuntimeError<T = RuntimeErrorCode> extends Error {
+export class RuntimeError<T extends number = RuntimeErrorCode> extends Error {
   constructor(public code: T, message: null|false|string) {
     super(formatRuntimeError<T>(code, message));
   }
@@ -90,16 +90,15 @@ export class RuntimeError<T = RuntimeErrorCode> extends Error {
  * Called to format a runtime error.
  * See additional info on the `message` argument type in the `RuntimeError` class description.
  */
-export function formatRuntimeError<T = RuntimeErrorCode>(
+export function formatRuntimeError<T extends number = RuntimeErrorCode>(
     code: T, message: null|false|string): string {
-  const codeAsNumber = code as unknown as number;
   // Error code might be a negative number, which is a special marker that instructs the logic to
   // generate a link to the error details page on angular.io.
-  const fullCode = `NG0${Math.abs(codeAsNumber)}`;
+  const fullCode = `NG0${Math.abs(code)}`;
 
   let errorMessage = `${fullCode}${message ? ': ' + message : ''}`;
 
-  if (ngDevMode && codeAsNumber < 0) {
+  if (ngDevMode && code < 0) {
     errorMessage = `${errorMessage}. Find more at ${ERROR_DETAILS_PAGE_BASE_URL}/${fullCode}`;
   }
   return errorMessage;

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1417,7 +1417,8 @@ function cacheMatchingLocalNames(
       const index = exportsMap[localRefs[i + 1]];
       if (index == null)
         throw new RuntimeError(
-            RuntimeErrorCode.EXPORT_NOT_FOUND, `Export of name '${localRefs[i + 1]}' not found!`);
+            RuntimeErrorCode.EXPORT_NOT_FOUND,
+            ngDevMode && `Export of name '${localRefs[i + 1]}' not found!`);
       localNames.push(localRefs[i], index);
     }
   }

--- a/packages/core/test/runtime_error_spec.ts
+++ b/packages/core/test/runtime_error_spec.ts
@@ -11,7 +11,7 @@ import {RuntimeError, RuntimeErrorCode} from '../src/errors';
 describe('RuntimeError utils', () => {
   it('should format the error message correctly', () => {
     // Error with a guide, but without an error message.
-    let errorInstance = new RuntimeError(RuntimeErrorCode.EXPORT_NOT_FOUND, '');
+    let errorInstance = new RuntimeError<RuntimeErrorCode>(RuntimeErrorCode.EXPORT_NOT_FOUND, '');
     expect(errorInstance.toString())
         .toBe('Error: NG0301. Find more at https://angular.io/errors/NG0301');
 


### PR DESCRIPTION
This commit refactors the `RuntimeError` class to support a short version of providing error messages:
```
throw new RuntimeError(
  RuntimeErrorCode.INJECTOR_ALREADY_DESTROYED,
  ngDevMode && 'Injector has already been destroyed.');
```
In prod mode, the second argument becomes `false` andn this commit extends the typings to support that.

This commit also contains a couple places were the `RuntimeError` class is used to demostrate the compact form.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No