### PR TITLE
docs: correct typo

### DIFF
--- a/aio/content/guide/developer-guide-overview.md
+++ b/aio/content/guide/developer-guide-overview.md
@@ -50,7 +50,7 @@ To get the most out of these developer guides, you should review the following t
   </a>
   <a href="guide/service-worker-intro" class="docs-card" title="Angular service worker developer guide">
     <section>Service Workers and PWA</section>
-    <p>Learn about how to us a service worker to create a progressive web application.</p>
+    <p>Learn about how to use a service worker to create a progressive web application.</p>
     <p class="card-footer">Service workers and PWA</p>
   </a>
   <a href="guide/web-worker" class="docs-card" title="Web Workers">


### PR DESCRIPTION
Service worker card contains typo 'us' when it should be 'use.'

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
