### PR TITLE
refactor(compiler-cli): use relative imports into dts files as fallback in type-check files

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/src/logical.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/logical.ts
@@ -83,9 +83,9 @@ export class LogicalFileSystem {
    * of the TS project's root directories.
    */
   logicalPathOfFile(physicalFile: AbsoluteFsPath): LogicalProjectPath|null {
-    const canonicalFilePath =
-        this.compilerHost.getCanonicalFileName(physicalFile) as AbsoluteFsPath;
-    if (!this.cache.has(canonicalFilePath)) {
+    if (!this.cache.has(physicalFile)) {
+      const canonicalFilePath =
+          this.compilerHost.getCanonicalFileName(physicalFile) as AbsoluteFsPath;
       let logicalFile: LogicalProjectPath|null = null;
       for (let i = 0; i < this.rootDirs.length; i++) {
         const rootDir = this.rootDirs[i];
@@ -102,9 +102,9 @@ export class LogicalFileSystem {
           }
         }
       }
-      this.cache.set(canonicalFilePath, logicalFile);
+      this.cache.set(physicalFile, logicalFile);
     }
-    return this.cache.get(canonicalFilePath)!;
+    return this.cache.get(physicalFile)!;
   }
 
   private createLogicalProjectPath(file: AbsoluteFsPath, rootDir: AbsoluteFsPath):

--- a/packages/compiler-cli/src/ngtsc/file_system/test/logical_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/test/logical_spec.ts
@@ -57,6 +57,8 @@ runInEachFileSystem(() => {
         const fs = new LogicalFileSystem([_('/Test')], host);
         expect(fs.logicalPathOfFile(_('/Test/foo/Foo.ts')))
             .toEqual('/foo/Foo' as LogicalProjectPath);
+        expect(fs.logicalPathOfFile(_('/Test/foo/foo.ts')))
+            .toEqual('/foo/foo' as LogicalProjectPath);
         expect(fs.logicalPathOfFile(_('/Test/bar/bAR.ts')))
             .toEqual('/bar/bAR' as LogicalProjectPath);
       });

--- a/packages/compiler-cli/src/ngtsc/imports/test/emitter_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/test/emitter_spec.ts
@@ -203,7 +203,7 @@ runInEachFileSystem(() => {
       const strategy = new LogicalProjectStrategy(new TestHost(checker), logicalFs);
       const decl = getDeclaration(program, _('/index.ts'), 'Foo', ts.isClassDeclaration);
       const context = program.getSourceFile(_('/context.ts'))!;
-      const ref = strategy.emit(new Reference(decl), context);
+      const ref = strategy.emit(new Reference(decl), context, ImportFlags.None);
       if (ref === null || ref.kind !== ReferenceEmitKind.Success) {
         return fail('Reference should be emitted');
       }
@@ -233,7 +233,7 @@ runInEachFileSystem(() => {
       const strategy = new LogicalProjectStrategy(new TypeScriptReflectionHost(checker), logicalFs);
       const decl = getDeclaration(program, _('/index.ts'), 'Foo', ts.isClassDeclaration);
       const context = program.getSourceFile(_('/context.ts'))!;
-      const emitted = strategy.emit(new Reference(decl), context);
+      const emitted = strategy.emit(new Reference(decl), context, ImportFlags.None);
       if (emitted === null || emitted.kind !== ReferenceEmitKind.Success) {
         return fail('Reference should be emitted');
       }
@@ -243,6 +243,97 @@ runInEachFileSystem(() => {
       expect(emitted.expression.value.name).toEqual('Foo');
       expect(emitted.expression.value.moduleName).toEqual('./index');
     });
+
+    it('should never use relative imports outside of the logical filesystem for source files',
+       () => {
+         const {program, host} = makeProgram([
+           {
+             name: _('/app/context.ts'),
+             contents: `
+             export {};
+           `,
+           },
+           {
+             name: _('/foo.ts'),
+             contents: 'export declare class Foo {}',
+           }
+         ]);
+         const checker = program.getTypeChecker();
+         const logicalFs = new LogicalFileSystem([_('/app')], host);
+         const strategy =
+             new LogicalProjectStrategy(new TypeScriptReflectionHost(checker), logicalFs);
+         const decl = getDeclaration(program, _('/foo.ts'), 'Foo', ts.isClassDeclaration);
+         const context = program.getSourceFile(_('/app/context.ts'))!;
+         const emitted =
+             strategy.emit(new Reference(decl), context, ImportFlags.AllowRelativeDtsImports);
+         if (emitted === null || emitted.kind !== ReferenceEmitKind.Failed) {
+           return fail('Reference emit should have failed');
+         }
+         expect(emitted.reason)
+             .toEqual(`The file ${
+                 decl.getSourceFile().fileName} is outside of the configured 'rootDir'.`);
+       });
+
+    it('should use relative imports outside of the logical filesystem for declaration files if allowed',
+       () => {
+         const {program, host} = makeProgram([
+           {
+             name: _('/app/context.ts'),
+             contents: `
+             export {};
+           `,
+           },
+           {
+             name: _('/foo.d.ts'),
+             contents: 'export declare class Foo {}',
+           }
+         ]);
+         const checker = program.getTypeChecker();
+         const logicalFs = new LogicalFileSystem([_('/app')], host);
+         const strategy =
+             new LogicalProjectStrategy(new TypeScriptReflectionHost(checker), logicalFs);
+         const decl = getDeclaration(program, _('/foo.d.ts'), 'Foo', ts.isClassDeclaration);
+         const context = program.getSourceFile(_('/app/context.ts'))!;
+         const emitted =
+             strategy.emit(new Reference(decl), context, ImportFlags.AllowRelativeDtsImports);
+         if (emitted === null || emitted.kind !== ReferenceEmitKind.Success) {
+           return fail('Reference should be emitted');
+         }
+         if (!(emitted.expression instanceof ExternalExpr)) {
+           return fail('Reference should be emitted as ExternalExpr');
+         }
+         expect(emitted.expression.value.name).toEqual('Foo');
+         expect(emitted.expression.value.moduleName).toEqual('../foo');
+       });
+
+    it('should not use relative imports outside of the logical filesystem for declaration files if not allowed',
+       () => {
+         const {program, host} = makeProgram([
+           {
+             name: _('/app/context.ts'),
+             contents: `
+             export {};
+           `,
+           },
+           {
+             name: _('/foo.d.ts'),
+             contents: 'export declare class Foo {}',
+           }
+         ]);
+         const checker = program.getTypeChecker();
+         const logicalFs = new LogicalFileSystem([_('/app')], host);
+         const strategy =
+             new LogicalProjectStrategy(new TypeScriptReflectionHost(checker), logicalFs);
+         const decl = getDeclaration(program, _('/foo.d.ts'), 'Foo', ts.isClassDeclaration);
+         const context = program.getSourceFile(_('/app/context.ts'))!;
+         const emitted = strategy.emit(new Reference(decl), context, ImportFlags.None);
+         if (emitted === null || emitted.kind !== ReferenceEmitKind.Failed) {
+           return fail('Reference emit should have failed');
+         }
+         expect(emitted.reason)
+             .toEqual(`The file ${
+                 decl.getSourceFile().fileName} is outside of the configured 'rootDir'.`);
+       });
   });
 
   describe('RelativePathStrategy', () => {

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -129,7 +129,9 @@ export class Environment implements ReferenceEmitEnvironment {
 
   canReferenceType(ref: Reference): boolean {
     const result = this.refEmitter.emit(
-        ref, this.contextFile, ImportFlags.NoAliasing | ImportFlags.AllowTypeImports);
+        ref, this.contextFile,
+        ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
+            ImportFlags.AllowRelativeDtsImports);
     return result.kind === ReferenceEmitKind.Success;
   }
 
@@ -140,7 +142,9 @@ export class Environment implements ReferenceEmitEnvironment {
    */
   referenceType(ref: Reference): ts.TypeNode {
     const ngExpr = this.refEmitter.emit(
-        ref, this.contextFile, ImportFlags.NoAliasing | ImportFlags.AllowTypeImports);
+        ref, this.contextFile,
+        ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
+            ImportFlags.AllowRelativeDtsImports);
     assertSuccessfulReferenceEmit(ngExpr, this.contextFile, 'symbol');
 
     // Create an `ExpressionType` from the `Expression` and translate it via `translateType`.


### PR DESCRIPTION
The generated imports should normally use module specifiers that are valid for
use in production code, where arbitrary relative imports into e.g. node_modules
are not allowed. For template type-checking code it is however acceptable to
use relative imports, as such files are never emitted to JS code. It is
desirable to allow a filesystem relative import as fallback if an import would
otherwise fail to be generated, as doing so allows fewer situations from
needing an inline type constructor.

--- 

**fix(compiler-cli): ensure casing of logical paths is preserved**

The logical filesystem would store a cached result based on the canonical path,
where the cached value contains the physical path that was originally provided.
This meant that other physical paths with an identical canonical path would use
a cached result derived from another physical path.

This inconsistency is not known to result in actual issues but is primarily
being made as a performance improvement, as using the provided physical paths
as cache key avoids the need to canonicalize the path if its result is already
cached.