### PR TITLE
fix(core): error if NgZone.isInAngularZone is called with a noop zone

### DIFF
--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -153,7 +153,8 @@ export class NgZone {
   }
 
   static isInAngularZone(): boolean {
-    return Zone.current.get('isAngularZone') === true;
+    // Zone needs to be checked, because this method might be called even when NoopNgZone is used.
+    return typeof Zone !== 'undefined' && Zone.current.get('isAngularZone') === true;
   }
 
   static assertInAngularZone(): void {


### PR DESCRIPTION
When the user opts into the noop `NgZone`, they usually still interact with the static methods on the non-noop class. This change adds a check to handle the case where zone.js hasn't been loaded.

Fixes #44784.