### PR TITLE
ci: update payload size limit for the Forms test app

### DIFF
--- a/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
+++ b/aio/content/examples/form-validation/src/app/reactive/hero-form-reactive.component.2.ts
@@ -26,7 +26,7 @@ export class HeroFormReactiveComponent implements OnInit {
       updateOn: 'blur'
     });
     // #enddocregion async-validator-usage
-     alterEgoControl.setValue(this.hero.alterEgo);
+    alterEgoControl.setValue(this.hero.alterEgo);
 
     this.heroForm = new FormGroup({
       name: new FormControl(this.hero.name, [

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -52,7 +52,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 163160,
+        "main": 162641,
         "polyfills": 36975
       }
     }


### PR DESCRIPTION
This commit updates (reduces) the payload size limit for the Forms test app. The increase was made in a previous PR and the limit is different between master and patch branches.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No