### PR TITLE
fix(core): flush delayed scoping queue while setting up TestBed

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -123,6 +123,51 @@ export class HelloWorldModule {
 }
 
 describe('TestBed', () => {
+  // This test is extracted to an individual `describe` block to avoid any extra TestBed
+  // initialization logic that happens in the `beforeEach` functions in other `describe` sections.
+  it('should apply scopes correctly for components in the lazy-loaded module', () => {
+    // Reset TestBed to the initial state, emulating an invocation of a first test.
+    // Check `TestBed.checkGlobalCompilationFinished` for additional info.
+    (getTestBed() as any)._globalCompilationChecked = false;
+
+    @Component({
+      selector: 'root',
+      template: '<div dirA></div>',
+    })
+    class Root {
+    }
+    @Directive({
+      selector: '[dirA]',
+      host: {'title': 'Test title'},
+    })
+    class DirA {
+    }
+
+    // Note: this module is not directly reference in the test intentionally.
+    // Its presence triggers a side-effect of patching correct scopes on the declared components.
+    @NgModule({
+      declarations: [Root, DirA],
+    })
+    class Module {
+    }
+
+    TestBed.configureTestingModule({});
+    // Trigger TestBed initialization.
+    TestBed.inject(Injector);
+
+    // Emulate the end of a test (trigger module scoping queue flush).
+    TestBed.resetTestingModule();
+
+    // Emulate a lazy-loading scenario by creating a component
+    // without importing a module into a TestBed testing module.
+    TestBed.configureTestingModule({});
+    const fixture = TestBed.createComponent(Root);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.firstChild.getAttribute('title')).toEqual('Test title');
+  });
+});
+
+describe('TestBed', () => {
   beforeEach(() => {
     getTestBed().resetTestingModule();
     TestBed.configureTestingModule({imports: [HelloWorldModule]});

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -294,6 +294,13 @@ export class TestBedRender3 implements TestBed {
 
   configureTestingModule(moduleDef: TestModuleMetadata): void {
     this.assertNotInstantiated('R3TestBed.configureTestingModule', 'configure the test module');
+
+    // Trigger module scoping queue flush before executing other TestBed operations in a test.
+    // This is needed for the first test invocation to ensure that globally declared modules have
+    // their components scoped properly. See the `checkGlobalCompilationFinished` function
+    // description for additional info.
+    this.checkGlobalCompilationFinished();
+
     // Always re-assign the teardown options, even if they're undefined.
     // This ensures that we don't carry the options between tests.
     this._instanceTeardownOptions = moduleDef.teardown;


### PR DESCRIPTION
Previously, some NgModules that were added to the delayed scoping queue, never got removed from the queue before unit test execution. That resulted in some components (declared in those NgModules) missing their scope (which components/directives/pipes were matched).

This commit adds the logic to invoke delayed scoping queue flushing before starting a test to avoid missing/incomplete scopes for Components used in a test.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No