### PR TITLE
feat(common): support NgModule as an input to the NgComponentOutlet

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -31,12 +31,14 @@ v10 - v13
 v11 - v14
 v12 - v15
 v13 -> v16
+v14 -> v17
 -->
 
 | Area                                | API or Feature                                                                                             | May be removed in     |
 | :---------------------------------- | :--------------------------------------------------------------------------------------------------------- | :-------------------- |
 | `@angular/common`                   | [`ReflectiveInjector`](#reflectiveinjector)                                                                | <!--v8--> v11         |
 | `@angular/common`                   | [`CurrencyPipe` - `DEFAULT_CURRENCY_CODE`](api/common/CurrencyPipe#currency-code-deprecation)              | <!--v9--> v11         |
+| `@angular/common`                   | [`NgComponentOutlet.ngComponentOutletNgModuleFactory`](#common)              | <!--v14--> v17         |
 | `@angular/common/http`              | [`XhrFactory`](api/common/http/XhrFactory)                                                                 | <!--v12--> v15        |
 | `@angular/common/http/testing`      | [`TestRequest` accepting `ErrorEvent` for error simulation](#testrequest-errorevent)                       | <!--v13--> v16        |
 | `@angular/core`                     | [`DefaultIterableDiffer`](#core)                                                                           | <!--v7--> v11         |
@@ -97,6 +99,7 @@ This section contains a complete list all of the currently-deprecated APIs, with
 | API                                                                                           | Replacement                                         | Deprecation announced | Notes                                                                                                     |
 | :-------------------------------------------------------------------------------------------- | :-------------------------------------------------- | :-------------------- | :-------------------------------------------------------------------------------------------------------- |
 | [`CurrencyPipe` - `DEFAULT_CURRENCY_CODE`](api/common/CurrencyPipe#currency-code-deprecation) | `{provide: DEFAULT_CURRENCY_CODE, useValue: 'USD'}` | v9                    | From v11 the default code will be extracted from the locale data given by `LOCALE_ID`, rather than `USD`. |
+| [`NgComponentOutlet.ngComponentOutletNgModuleFactory`](api/common/NgComponentOutlet) | `NgComponentOutlet.ngComponentOutletNgModule` | v14                    | Use the `ngComponentOutletNgModule` input instead. This input doesn't require resolving NgModule factory.  |
 
 {@a common-http}
 

--- a/goldens/public-api/common/common.md
+++ b/goldens/public-api/common/common.md
@@ -412,17 +412,19 @@ export class NgComponentOutlet implements OnChanges, OnDestroy {
     // (undocumented)
     ngComponentOutlet: Type<any>;
     // (undocumented)
-    ngComponentOutletContent: any[][];
+    ngComponentOutletContent?: any[][];
     // (undocumented)
-    ngComponentOutletInjector: Injector;
+    ngComponentOutletInjector?: Injector;
     // (undocumented)
-    ngComponentOutletNgModuleFactory: NgModuleFactory<any>;
+    ngComponentOutletNgModule?: Type<any>;
+    // @deprecated (undocumented)
+    ngComponentOutletNgModuleFactory?: NgModuleFactory<any>;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgComponentOutlet, "[ngComponentOutlet]", never, { "ngComponentOutlet": "ngComponentOutlet"; "ngComponentOutletInjector": "ngComponentOutletInjector"; "ngComponentOutletContent": "ngComponentOutletContent"; "ngComponentOutletNgModuleFactory": "ngComponentOutletNgModuleFactory"; }, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgComponentOutlet, "[ngComponentOutlet]", never, { "ngComponentOutlet": "ngComponentOutlet"; "ngComponentOutletInjector": "ngComponentOutletInjector"; "ngComponentOutletContent": "ngComponentOutletContent"; "ngComponentOutletNgModule": "ngComponentOutletNgModule"; "ngComponentOutletNgModuleFactory": "ngComponentOutletNgModuleFactory"; }, {}, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgComponentOutlet, never>;
 }

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -46,7 +46,7 @@ describe('insert/remove', () => {
        fixture.detectChanges();
        expect(fixture.nativeElement).toHaveText('');
 
-       fixture.componentInstance.cmpRef = null;
+       fixture.componentInstance.cmpRef = undefined;
        fixture.componentInstance.currentComponent = InjectedComponent;
 
        fixture.detectChanges();
@@ -111,7 +111,7 @@ describe('insert/remove', () => {
        let fixture = TestBed.createComponent(TestComponent);
 
        // We are accessing a ViewChild (ngComponentOutlet) before change detection has run
-       fixture.componentInstance.cmpRef = null;
+       fixture.componentInstance.cmpRef = undefined;
        fixture.componentInstance.currentComponent = InjectedComponent;
        fixture.detectChanges();
        let cmpRef: ComponentRef<InjectedComponent> = fixture.componentInstance.cmpRef!;
@@ -144,25 +144,54 @@ describe('insert/remove', () => {
        expect(fixture.nativeElement).toHaveText('projected foo');
      }));
 
-  it('should resolve components from other modules, if supplied', waitForAsync(() => {
+  it('should resolve components from other modules, if supplied as an NgModuleFactory',
+     waitForAsync(() => {
        const compiler = TestBed.inject(Compiler);
        let fixture = TestBed.createComponent(TestComponent);
 
        fixture.detectChanges();
        expect(fixture.nativeElement).toHaveText('');
 
-       fixture.componentInstance.module = compiler.compileModuleSync(TestModule2);
+       fixture.componentInstance.ngModuleFactory = compiler.compileModuleSync(TestModule2);
        fixture.componentInstance.currentComponent = Module2InjectedComponent;
 
        fixture.detectChanges();
        expect(fixture.nativeElement).toHaveText('baz');
      }));
 
-  it('should clean up moduleRef, if supplied', waitForAsync(() => {
-       let destroyed = false;
+  it('should resolve components from other modules, if supplied as an NgModule class reference',
+     waitForAsync(() => {
+       let fixture = TestBed.createComponent(TestComponent);
+
+       fixture.detectChanges();
+       expect(fixture.nativeElement).toHaveText('');
+
+       fixture.componentInstance.ngModule = TestModule2;
+       fixture.componentInstance.currentComponent = Module2InjectedComponent;
+
+       fixture.detectChanges();
+       expect(fixture.nativeElement).toHaveText('baz');
+     }));
+
+
+  it('should clean up moduleRef, if supplied as an NgModuleFactory', waitForAsync(() => {
        const compiler = TestBed.inject(Compiler);
        const fixture = TestBed.createComponent(TestComponent);
-       fixture.componentInstance.module = compiler.compileModuleSync(TestModule2);
+       fixture.componentInstance.ngModuleFactory = compiler.compileModuleSync(TestModule2);
+       fixture.componentInstance.currentComponent = Module2InjectedComponent;
+       fixture.detectChanges();
+
+       const moduleRef = fixture.componentInstance.ngComponentOutlet['_moduleRef']!;
+       spyOn(moduleRef, 'destroy').and.callThrough();
+
+       expect(moduleRef.destroy).not.toHaveBeenCalled();
+       fixture.destroy();
+       expect(moduleRef.destroy).toHaveBeenCalled();
+     }));
+
+  it('should clean up moduleRef, if supplied as an NgModule class reference', waitForAsync(() => {
+       const fixture = TestBed.createComponent(TestComponent);
+       fixture.componentInstance.ngModule = TestModule2;
        fixture.componentInstance.currentComponent = Module2InjectedComponent;
        fixture.detectChanges();
 
@@ -178,7 +207,7 @@ describe('insert/remove', () => {
        const compiler = TestBed.inject(Compiler);
        const fixture = TestBed.createComponent(TestComponent);
 
-       fixture.componentInstance.module = compiler.compileModuleSync(TestModule2);
+       fixture.componentInstance.ngModuleFactory = compiler.compileModuleSync(TestModule2);
        fixture.componentInstance.currentComponent = Module2InjectedComponent;
        fixture.detectChanges();
        expect(fixture.nativeElement).toHaveText('baz');
@@ -191,16 +220,31 @@ describe('insert/remove', () => {
        expect(moduleRef).toBe(fixture.componentInstance.ngComponentOutlet['_moduleRef']);
      }));
 
-  it('should re-create moduleRef when changed', waitForAsync(() => {
+  it('should re-create moduleRef when changed (NgModuleFactory)', waitForAsync(() => {
        const compiler = TestBed.inject(Compiler);
        const fixture = TestBed.createComponent(TestComponent);
-       fixture.componentInstance.module = compiler.compileModuleSync(TestModule2);
+       fixture.componentInstance.ngModuleFactory = compiler.compileModuleSync(TestModule2);
        fixture.componentInstance.currentComponent = Module2InjectedComponent;
        fixture.detectChanges();
 
        expect(fixture.nativeElement).toHaveText('baz');
 
-       fixture.componentInstance.module = compiler.compileModuleSync(TestModule3);
+       fixture.componentInstance.ngModuleFactory = compiler.compileModuleSync(TestModule3);
+       fixture.componentInstance.currentComponent = Module3InjectedComponent;
+       fixture.detectChanges();
+
+       expect(fixture.nativeElement).toHaveText('bat');
+     }));
+
+  it('should re-create moduleRef when changed (NgModule class reference)', waitForAsync(() => {
+       const fixture = TestBed.createComponent(TestComponent);
+       fixture.componentInstance.ngModule = TestModule2;
+       fixture.componentInstance.currentComponent = Module2InjectedComponent;
+       fixture.detectChanges();
+
+       expect(fixture.nativeElement).toHaveText('baz');
+
+       fixture.componentInstance.ngModule = TestModule3;
        fixture.componentInstance.currentComponent = Module3InjectedComponent;
        fixture.detectChanges();
 
@@ -219,23 +263,25 @@ class InjectedComponent {
 class InjectedComponentAgain {
 }
 
-const TEST_CMP_TEMPLATE =
-    `<ng-template *ngComponentOutlet="currentComponent; injector: injector; content: projectables; ngModuleFactory: module;"></ng-template>`;
+const TEST_CMP_TEMPLATE = `<ng-template *ngComponentOutlet="
+      currentComponent;
+      injector: injector;
+      content: projectables;
+      ngModule: ngModule;
+      ngModuleFactory: ngModuleFactory;
+    "></ng-template>`;
 @Component({selector: 'test-cmp', template: TEST_CMP_TEMPLATE})
 class TestComponent {
-  // TODO(issue/24571): remove '!'.
-  currentComponent!: Type<any>|null;
-  // TODO(issue/24571): remove '!'.
-  injector!: Injector;
-  // TODO(issue/24571): remove '!'.
-  projectables!: any[][];
-  // TODO(issue/24571): remove '!'.
-  module!: NgModuleFactory<any>;
+  currentComponent: Type<unknown>|null = null;
+  injector?: Injector;
+  projectables?: any[][];
+  ngModule?: Type<unknown>;
+  ngModuleFactory?: NgModuleFactory<unknown>;
 
-  get cmpRef(): ComponentRef<any>|null {
+  get cmpRef(): ComponentRef<any>|undefined {
     return this.ngComponentOutlet['_componentRef'];
   }
-  set cmpRef(value: ComponentRef<any>|null) {
+  set cmpRef(value: ComponentRef<any>|undefined) {
     this.ngComponentOutlet['_componentRef'] = value;
   }
 


### PR DESCRIPTION
This commit updates the logic of the `NgComponentOutlet` class to allow passing an `NgModule` as an input instead of passing NgModule factory.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No