### PR TITLE
docs: Explain how ngsw.json is generated.

### DIFF
--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -30,7 +30,14 @@ resources, and it changes if any of them change. In practice, the version
 is determined by the contents of the `ngsw.json` file, which includes
 hashes for all known content. If any of the cached files change, the file's
 hash will change in `ngsw.json`, causing the Angular service worker to
-treat the active set of files as a new version.
+treat the active set of files as a new version. 
+
+<div class="alert is-helpful">
+
+`ngsw.json` is the manifest file that is generated at 
+build time based on `ngsw-config.json`. 
+
+</div>
 
 With the versioning behavior of the Angular service worker, an application
 server can ensure that the Angular application always has a consistent set of files.


### PR DESCRIPTION
ngsw.json is the manifest file which is generated at build time ( based on ngsw-config.json ). This explains this a bit clearer.
At first, I thought that it was a wrongly named filename. Not is it explicitly described.

## PR Type
Docs


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Its not explained how ngsw is created and how it differs from ngsw-config




## What is the new behavior?
It explains it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


 

## Other information
Still a proces of my first contribution!