### PR TITLE
refactor(compiler-cli): Tolerate source span errors in indexer

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
@@ -7,7 +7,9 @@
  */
 
 import {ParseSourceFile} from '@angular/compiler';
+
 import {DeclarationNode} from '../../reflection';
+
 import {IndexedComponent} from './api';
 import {IndexingContext} from './context';
 import {getTemplateIdentifiers} from './template';
@@ -20,6 +22,7 @@ import {getTemplateIdentifiers} from './template';
  */
 export function generateAnalysis(context: IndexingContext): Map<DeclarationNode, IndexedComponent> {
   const analysis = new Map<DeclarationNode, IndexedComponent>();
+  const analysisErrors: Error[] = [];
 
   context.components.forEach(({declaration, selector, boundTemplate, templateMeta}) => {
     const name = declaration.name.getText();
@@ -43,12 +46,14 @@ export function generateAnalysis(context: IndexingContext): Map<DeclarationNode,
       templateFile = templateMeta.file;
     }
 
+    const {identifiers, errors} = getTemplateIdentifiers(boundTemplate);
+    analysisErrors.push(...errors);
     analysis.set(declaration, {
       name,
       selector,
       file: componentFile,
       template: {
-        identifiers: getTemplateIdentifiers(boundTemplate),
+        identifiers,
         usedComponents,
         isInline: templateMeta.isInline,
         file: templateFile,

--- a/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/template_spec.ts
@@ -6,9 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {BoundTarget} from '@angular/compiler';
+
 import {AbsoluteSourceSpan, AttributeIdentifier, ElementIdentifier, IdentifierKind, ReferenceIdentifier, TemplateNodeIdentifier, TopLevelIdentifier, VariableIdentifier} from '..';
 import {runInEachFileSystem} from '../../file_system/testing';
-import {getTemplateIdentifiers} from '../src/template';
+import {ComponentMeta} from '../src/context';
+import {getTemplateIdentifiers as getTemplateIdentifiersAndErrors} from '../src/template';
 
 import * as util from './util';
 
@@ -17,6 +20,10 @@ function bind(template: string) {
     preserveWhitespaces: true,
     leadingTriviaChars: [],
   });
+}
+
+function getTemplateIdentifiers(boundTemplate: BoundTarget<ComponentMeta>) {
+  return getTemplateIdentifiersAndErrors(boundTemplate).identifiers;
 }
 
 runInEachFileSystem(() => {

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -6,11 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {BoundTarget, ParseSourceFile} from '@angular/compiler';
+
 import {runInEachFileSystem} from '../../file_system/testing';
 import {ClassDeclaration} from '../../reflection';
 import {ComponentMeta, IndexingContext} from '../src/context';
 import {getTemplateIdentifiers} from '../src/template';
 import {generateAnalysis} from '../src/transform';
+
 import * as util from './util';
 
 /**
@@ -47,7 +49,8 @@ runInEachFileSystem(() => {
         selector: 'c-selector',
         file: new ParseSourceFile('class C {}', decl.getSourceFile().fileName),
         template: {
-          identifiers: getTemplateIdentifiers(util.getBoundTemplate('<div>{{foo}}</div>')),
+          identifiers:
+              getTemplateIdentifiers(util.getBoundTemplate('<div>{{foo}}</div>')).identifiers,
           usedComponents: new Set(),
           isInline: false,
           file: new ParseSourceFile('<div>{{foo}}</div>', decl.getSourceFile().fileName),


### PR DESCRIPTION
When the indexer encounters a location where the source span doesn't
match up with the expected identifier, the current visitor code throws
an error. Instead, this change creates an error and moves on to the next
template item. This allows the indexer to continue analysis even when
there are errors in the source mapping. In addition, it still allows callers
to surface those errors in their own way while still providing as much indexed
information as possible about a node.

After this is merged, we can update the internal indexing code to iterate and
log these errors after the `getIndexedComponents` call.