### PR TITLE
ci: re-enable components repo unit tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ var_4_win: &cache_key_win_fallback v6-angular-win-node-14-{{ checksum "month.txt
 
 # Cache key for the `components-repo-unit-tests` job. **Note** when updating the SHA in the
 # cache keys also update the SHA for the "COMPONENTS_REPO_COMMIT" environment variable.
-var_5: &components_repo_unit_tests_cache_key v1-angular-components-{{ checksum "month.txt" }}-a931de54a786597b34259e461c2cf3ab6edc590a
+var_5: &components_repo_unit_tests_cache_key v1-angular-components-{{ checksum "month.txt" }}-d1cd928714c2d6e3de75f9469ce58b06aad6353c
 var_6: &components_repo_unit_tests_cache_key_fallback v1-angular-components-{{ checksum "month.txt" }}
 
 # Workspace initially persisted by the `setup` job, and then enhanced by `build-npm-packages`.
@@ -797,10 +797,9 @@ workflows:
             # since the publishing script expects the legacy outputs layout.
             - build-npm-packages
             - legacy-unit-tests-saucelabs
-      # TODO(devversion): re-enable once the components repo has accounted for the `ng_module` devmode target changes.
-      #- components-repo-unit-tests:
-      #    requires:
-      #      - build-npm-packages
+      - components-repo-unit-tests:
+          requires:
+            - build-npm-packages
       - test_zonejs:
           requires:
             - setup

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -74,7 +74,7 @@ setPublicVar COMPONENTS_REPO_TMP_DIR "/tmp/angular-components-repo"
 setPublicVar COMPONENTS_REPO_URL "https://github.com/angular/components.git"
 setPublicVar COMPONENTS_REPO_BRANCH "master"
 # **NOTE**: When updating the commit SHA, also update the cache key in the CircleCI `config.yml`.
-setPublicVar COMPONENTS_REPO_COMMIT "a931de54a786597b34259e461c2cf3ab6edc590a"
+setPublicVar COMPONENTS_REPO_COMMIT "d1cd928714c2d6e3de75f9469ce58b06aad6353c"
 
 
 ####################################################################################################

--- a/scripts/ci/run_angular_components_unit_tests.sh
+++ b/scripts/ci/run_angular_components_unit_tests.sh
@@ -14,4 +14,8 @@ cd ${COMPONENTS_REPO_TMP_DIR}
 ./scripts/circleci/setup_bazel_binary.sh
 
 # Now actually run the tests.
-bazel test --build_tag_filters=-docs-package,-e2e,-browser:firefox-local --test_tag_filters=-e2e,-browser:firefox-local -- src/...
+bazel test \
+  --build_tag_filters=-docs-package,-e2e,-browser:firefox-local \
+  --test_tag_filters=-e2e,-browser:firefox-local \
+  --build_tests_only \
+  -- src/...


### PR DESCRIPTION
Re-enables the components-repo unit tests job that we previously
disabled due to the devmode target change that caused conflicts
with `angular/components` patching `ng_module.bzl` of `@angular/bazel`.