### PR TITLE
Revert "refactor(forms): Temporarily disable the typed forms migration. (#44828)

### DIFF
--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -19,6 +19,11 @@
       "version": "14.0.0-beta",
       "description": "As of Angular version 13, `entryComponents` are no longer necessary.",
       "factory": "./migrations/entry-components/index"
+    },
+    "migration-v14-typed-forms": {
+      "version": "9999.0.0",
+      "description": "Experimental migration that adds <any>s for Typed Forms.",
+      "factory": "./migrations/typed-forms/index"
     }
   }
 }

--- a/packages/core/schematics/test/typed_forms_spec.ts
+++ b/packages/core/schematics/test/typed_forms_spec.ts
@@ -80,214 +80,208 @@ describe('Typed Forms migration', () => {
     shx.rm('-r', tmpDirPath);
   });
 
-  // These tests are disabled because the migration is removed from migration.json, and cannot be
-  // run.
+  describe(`should add ${anySymbolName} to constructors`, () => {
+    it('for FormControl', async () => {
+      writeFile('/index.ts', `
+           import { FormControl } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fc1 = new FormControl();
+             new FormControl(42);
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fc1 = new FormControl<${anySymbolName}>();`);
+      expect(tree.readContent('/index.ts')).toContain(`new FormControl<${anySymbolName}>(42);`);
+    });
 
-  // describe(`should add ${anySymbolName} to constructors`, () => {
-  //   it('for FormControl', async () => {
-  //     writeFile('/index.ts', `
-  //          import { FormControl } from '@angular/forms';
-  //          @Component({template: ''})
-  //          export class MyComp {
-  //            const fc1 = new FormControl();
-  //            new FormControl(42);
-  //            constructor() {}
-  //          }
-  //        `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`const fc1 = new FormControl<${anySymbolName}>();`);
-  //     expect(tree.readContent('/index.ts')).toContain(`new FormControl<${anySymbolName}>(42);`);
-  //   });
+    it('for FormGroup', async () => {
+      writeFile('/index.ts', `
+           import { FormGroup } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fg = new FormGroup({foo: 3});
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fg = new FormGroup<${anySymbolName}>({foo: 3});`);
+    });
 
-  //   it('for FormGroup', async () => {
-  //     writeFile('/index.ts', `
-  //          import { FormGroup } from '@angular/forms';
-  //          @Component({template: ''})
-  //          export class MyComp {
-  //            const fg = new FormGroup({foo: 3});
-  //            constructor() {}
-  //          }
-  //        `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`const fg = new FormGroup<${anySymbolName}>({foo: 3});`);
-  //   });
+    it('for FormArray', async () => {
+      writeFile('/index.ts', `
+           import { FormArray } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fa = new FormArray([null]);
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fa = new FormArray<${anySymbolName}[]>([null]);`);
+    });
 
-  //   it('for FormArray', async () => {
-  //     writeFile('/index.ts', `
-  //          import { FormArray } from '@angular/forms';
-  //          @Component({template: ''})
-  //          export class MyComp {
-  //            const fa = new FormArray([null]);
-  //            constructor() {}
-  //          }
-  //        `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`const fa = new FormArray<${anySymbolName}[]>([null]);`);
-  //   });
+    it('for FormControl with a qualified import', async () => {
+      writeFile('/index.ts', `
+           import { FormControl as FC } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fc = new FC({foo: 3});
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fc = new FC<${anySymbolName}>({foo: 3});`);
+    });
 
-  //   it('for FormControl with a qualified import', async () => {
-  //     writeFile('/index.ts', `
-  //          import { FormControl as FC } from '@angular/forms';
-  //          @Component({template: ''})
-  //          export class MyComp {
-  //            const fc = new FC({foo: 3});
-  //            constructor() {}
-  //          }
-  //        `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`const fc = new FC<${anySymbolName}>({foo: 3});`);
-  //   });
+    it('for FormArray with a qualified import', async () => {
+      writeFile('/index.ts', `
+           import { FormArray as FA } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fa = new FA([null]);
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fa = new FA<${anySymbolName}[]>([null]);`);
+    });
 
-  //   it('for FormArray with a qualified import', async () => {
-  //     writeFile('/index.ts', `
-  //          import { FormArray as FA } from '@angular/forms';
-  //          @Component({template: ''})
-  //          export class MyComp {
-  //            const fa = new FA([null]);
-  //            constructor() {}
-  //          }
-  //        `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`const fa = new FA<${anySymbolName}[]>([null]);`);
-  //   });
+    it('but not for controls that already have type arguments', async () => {
+      writeFile('/index.ts', `
+           import { FormControl } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             const fc1 = new FormControl<${anySymbolName}>();
+             constructor() {}
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fc1 = new FormControl<${anySymbolName}>();`);
+    });
+  });
 
-  //   it('but not for controls that already have type arguments', async () => {
-  //     writeFile('/index.ts', `
-  //          import { FormControl } from '@angular/forms';
-  //          @Component({template: ''})
-  //          export class MyComp {
-  //            const fc1 = new FormControl<${anySymbolName}>();
-  //            constructor() {}
-  //          }
-  //        `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`const fc1 = new FormControl<${anySymbolName}>();`);
-  //   });
-  // });
+  describe(`should add ${anySymbolName} to FormBuilder method`, () => {
+    it('control', async () => {
+      writeFile('/index.ts', `
+           import { FormBuilder } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             constructor() {
+               const fb = new FormBuilder();
+               const fc = fb.control(43);
+               const fd = new FormBuilder().control(42);
+             }
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts')).toContain(`.control<${anySymbolName}>(43);`);
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fd = new FormBuilder().control<${anySymbolName}>(42)`);
+    });
 
-  // describe(`should add ${anySymbolName} to FormBuilder method`, () => {
-  //   it('control', async () => {
-  //     writeFile('/index.ts', `
-  //          import { FormBuilder } from '@angular/forms';
-  //          @Component({template: ''})
-  //          export class MyComp {
-  //            constructor() {
-  //              const fb = new FormBuilder();
-  //              const fc = fb.control(43);
-  //              const fd = new FormBuilder().control(42);
-  //            }
-  //          }
-  //        `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts')).toContain(`.control<${anySymbolName}>(43);`);
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`const fd = new FormBuilder().control<${anySymbolName}>(42)`);
-  //   });
+    it('group', async () => {
+      writeFile('/index.ts', `
+           import { FormBuilder } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             constructor() {
+               const fb = new FormBuilder();
+               const fc = fb.group({});
+               const fd = new FormBuilder().group({});
+             }
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts')).toContain(`fb.group<${anySymbolName}>({});`);
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fd = new FormBuilder().group<${anySymbolName}>({})`);
+    });
 
-  //   it('group', async () => {
-  //     writeFile('/index.ts', `
-  //          import { FormBuilder } from '@angular/forms';
-  //          @Component({template: ''})
-  //          export class MyComp {
-  //            constructor() {
-  //              const fb = new FormBuilder();
-  //              const fc = fb.group({});
-  //              const fd = new FormBuilder().group({});
-  //            }
-  //          }
-  //        `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts')).toContain(`fb.group<${anySymbolName}>({});`);
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`const fd = new FormBuilder().group<${anySymbolName}>({})`);
-  //   });
+    it('array', async () => {
+      writeFile('/index.ts', `
+           import { FormBuilder } from '@angular/forms';
+           @Component({template: ''})
+           export class MyComp {
+             constructor() {
+               const fb = new FormBuilder();
+               const fc = fb.array([0]);
+               const fd = new FormBuilder().array([0]);
+             }
+           }
+         `);
+      await runMigration();
+      expect(tree.readContent('/index.ts')).toContain(`fb.array<${anySymbolName}[]>([0]);`);
+      expect(tree.readContent('/index.ts'))
+          .toContain(`const fd = new FormBuilder().array<${anySymbolName}[]>([0])`);
+    });
+  });
 
-  //   it('array', async () => {
-  //     writeFile('/index.ts', `
-  //          import { FormBuilder } from '@angular/forms';
-  //          @Component({template: ''})
-  //          export class MyComp {
-  //            constructor() {
-  //              const fb = new FormBuilder();
-  //              const fc = fb.array([0]);
-  //              const fd = new FormBuilder().array([0]);
-  //            }
-  //          }
-  //        `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts')).toContain(`fb.array<${anySymbolName}[]>([0]);`);
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`const fd = new FormBuilder().array<${anySymbolName}[]>([0])`);
-  //   });
-  // });
+  describe('should add import', () => {
+    it('any when not already imported', async () => {
+      writeFile('/index.ts', `
+        import { FormBuilder } from '@angular/forms';
+        @Component({template: ''})
+        export class MyComp { }
+      `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`import { ${anySymbolName}, FormBuilder } from '@angular/forms';`);
+    });
 
-  // describe('should add import', () => {
-  //   it('any when not already imported', async () => {
-  //     writeFile('/index.ts', `
-  //       import { FormBuilder } from '@angular/forms';
-  //       @Component({template: ''})
-  //       export class MyComp { }
-  //     `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`import { ${anySymbolName}, FormBuilder } from '@angular/forms';`);
-  //   });
+    it('exclusively when not already imported', async () => {
+      writeFile('/index.ts', `
+        import { ${anySymbolName}, FormBuilder } from '@angular/forms';
+        @Component({template: ''})
+        export class MyComp { }
+      `);
+      await runMigration();
+      expect(tree.readContent('/index.ts'))
+          .toContain(`import { ${anySymbolName}, FormBuilder } from '@angular/forms';`);
+    });
+  });
 
-  //   it('exclusively when not already imported', async () => {
-  //     writeFile('/index.ts', `
-  //       import { ${anySymbolName}, FormBuilder } from '@angular/forms';
-  //       @Component({template: ''})
-  //       export class MyComp { }
-  //     `);
-  //     await runMigration();
-  //     expect(tree.readContent('/index.ts'))
-  //         .toContain(`import { ${anySymbolName}, FormBuilder } from '@angular/forms';`);
-  //   });
-  // });
+  describe('should handle', () => {
+    it('an integrated example', async () => {
+      writeFile('/index.ts', `
+           import { Component } from '@angular/core';
+           import { AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup } from '@angular/forms';
 
-  // describe('should handle', () => {
-  //   it('an integrated example', async () => {
-  //     writeFile('/index.ts', `
-  //          import { Component } from '@angular/core';
-  //          import { AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup } from
-  //          '@angular/forms';
+           @Component({template: ''})
+           export class MyComponent {
+             private _control = new FC(42);
+             private _group = new FormGroup({});
+             private _array = new FormArray([]);
 
-  //          @Component({template: ''})
-  //          export class MyComponent {
-  //            private _control = new FC(42);
-  //            private _group = new FormGroup({});
-  //            private _array = new FormArray([]);
+             private fb = new FormBuilder();
 
-  //            private fb = new FormBuilder();
-
-  //            build() {
-  //              const c = this.fb.control(42);
-  //              const g = this.fb.group({one: this.fb.control('')});
-  //              const a = this.fb.array([42]);
-  //              const fc2 = new FC(0);
-  //            }
-  //          }
-  //        `);
-  //     await runMigration();
-  //     [`import { ${
-  //          anySymbolName}, AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup
-  //          } from '@angular/forms';`,
-  //      `private _control = new FC<${anySymbolName}>(42)`,
-  //      `private _group = new FormGroup<${anySymbolName}>({})`,
-  //      `private _array = new FormArray<${anySymbolName}[]>([])`,
-  //      `const fc2 = new FC<${anySymbolName}>(0)`, `const c =
-  //      this.fb.control<${anySymbolName}>(42)`, `const g = this.fb.group<${anySymbolName}>({one:
-  //      this.fb.control<${anySymbolName}>('')})`, `const a =
-  //      this.fb.array<${anySymbolName}[]>([42])`]
-  //         .forEach(t => expect(tree.readContent('/index.ts')).toContain(t));
-  //   });
-  // });
+             build() {
+               const c = this.fb.control(42);
+               const g = this.fb.group({one: this.fb.control('')});
+               const a = this.fb.array([42]);
+               const fc2 = new FC(0);
+             }
+           }
+         `);
+      await runMigration();
+      [`import { ${
+           anySymbolName}, AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup } from '@angular/forms';`,
+       `private _control = new FC<${anySymbolName}>(42)`,
+       `private _group = new FormGroup<${anySymbolName}>({})`,
+       `private _array = new FormArray<${anySymbolName}[]>([])`,
+       `const fc2 = new FC<${anySymbolName}>(0)`, `const c = this.fb.control<${anySymbolName}>(42)`,
+       `const g = this.fb.group<${anySymbolName}>({one: this.fb.control<${anySymbolName}>('')})`,
+       `const a = this.fb.array<${anySymbolName}[]>([42])`]
+          .forEach(t => expect(tree.readContent('/index.ts')).toContain(t));
+    });
+  });
 
   function writeFile(filePath: string, contents: string) {
     host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));


### PR DESCRIPTION
This reverts commit 894fa759f1eba6de1960b08d511ce4332a423ae5. In that commit, the migration was completely disabled in order to prevent users from selecting it for the 13.2 release. This revert commit restores the migration to its previous (fully optional) state, in order to continue migration-focused work.