### PR TITLE
fix(docs-infra): fix links to CLI commands source code

### DIFF
--- a/aio/tools/transforms/cli-docs-package/index.js
+++ b/aio/tools/transforms/cli-docs-package/index.js
@@ -50,7 +50,7 @@ module.exports =
 
           const cliPackage = require(resolve(CLI_SOURCE_PATH, 'package.json'));
           const repoUrlParts = cliPackage.repository.url.replace(/\.git$/, '').split('/');
-          const version = `v${semver.clean(cliPackage.version)}`;
+          const version = semver.clean(cliPackage.version);
           const repo = repoUrlParts.pop();
           const owner = repoUrlParts.pop();
           const cliVersionInfo = {gitRepoInfo: {owner, repo}, currentVersion: {raw: version}};


### PR DESCRIPTION
Recently, the [CLI repository][1] switched to not prefixing tag names with a `v`. Update the `versionInfo` generated for CLI commands docs, so that the links to the source code (which include the tag name) are correct.

Fixes #44822.
