### PR TITLE
[12.2.x] ci: bump the cache key version for components unit tests CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,8 @@ var_4_win: &cache_key_win_fallback v1-angular-win-node-14-{{ checksum "month.txt
 
 # Cache key for the `components-repo-unit-tests` job. **Note** when updating the SHA in the
 # cache keys also update the SHA for the "COMPONENTS_REPO_COMMIT" environment variable.
-var_5: &components_repo_unit_tests_cache_key v1-angular-components-{{ checksum "month.txt" }}-d090617912da8e70aa336aa5b4d804b1b535402e
-var_6: &components_repo_unit_tests_cache_key_fallback v1-angular-components-{{ checksum "month.txt" }}
+var_5: &components_repo_unit_tests_cache_key v2-angular-components-{{ checksum "month.txt" }}-d090617912da8e70aa336aa5b4d804b1b535402e
+var_6: &components_repo_unit_tests_cache_key_fallback v2-angular-components-{{ checksum "month.txt" }}
 
 # Workspace initially persisted by the `setup` job, and then enhanced by `build-npm-packages` and
 # `build-ivy-npm-packages`.


### PR DESCRIPTION
Yarn 1.x sometimes does not clean up unneeded nested node modules, and this breaks some strict assumption in the Bazel NodeJS yarn install. This commit bumps the version in the cache key to make sure there is no stale cache that is used in CI jobs (that is causing issues with that CI job).


## PR Type
What kind of change does this PR introduce?
- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No