### PR TITLE
ci: reenable CI checks for commit message validation and rebasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,21 +237,19 @@ jobs:
       - checkout
       - save_month_to_file
       - init_environment
-
-      # TODO(aleksanderbodurri): renable this as soon as angular-devtools is tranfered into angular/angular
-      # - run:
-      #     name: Rebase PR on target branch
-      #     # After checkout, rebase on top of target branch.
-      #     command: >
-      #       if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
-      #         # User is required for rebase.
-      #         git config user.name "angular-ci"
-      #         git config user.email "angular-ci"
-      #         # Rebase PR on top of target branch.
-      #         node .circleci/rebase-pr.js
-      #       else
-      #         echo "This build is not over a PR, nothing to do."
-      #       fi
+      - run:
+          name: Rebase PR on target branch
+          # After checkout, rebase on top of target branch.
+          command: >
+            if [[ -n "${CIRCLE_PR_NUMBER}" ]]; then
+              # User is required for rebase.
+              git config user.name "angular-ci"
+              git config user.email "angular-ci"
+              # Rebase PR on top of target branch.
+              node .circleci/rebase-pr.js
+            else
+              echo "This build is not over a PR, nothing to do."
+            fi
       # This cache is saved in the build-npm-packages so that Bazel cache is also included.
       - restore_cache:
           keys:
@@ -289,11 +287,7 @@ jobs:
       - run: yarn -s ts-circular-deps:check
       - run: yarn -s ng-dev pullapprove verify
       - run: yarn -s ng-dev ngbot verify
-
-      # temporarily disable commit message validation because commits from angular devtools don't have commit bodies
-      # todo(aleksanderbodurri): renable
-      # - run: yarn -s ng-dev commit-message validate-range $CI_GIT_BASE_REVISION $CI_GIT_REVISION
-
+      - run: yarn -s ng-dev commit-message validate-range $CI_GIT_BASE_REVISION $CI_GIT_REVISION
       - run: yarn -s check-tooling-setup
 
   test:


### PR DESCRIPTION
These checks were temporarily disabled in order to support the angular devtools migration to the angular/angular repo. Now that devtools was merged, we can safely enable these checks again.