### PR TITLE
feat(forms): support negative indices in FormArray methods.

### DIFF
--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -1361,5 +1361,170 @@ describe('FormArray', () => {
       });
     });
   });
+
+  describe('out of bounds positive indices', () => {
+    let c1: FormControl = new FormControl(1);
+    let c2: FormControl = new FormControl(2);
+    let c3: FormControl = new FormControl(3);
+    let c4: FormControl = new FormControl(4);
+    let c99: FormControl = new FormControl(99);
+
+    let fa: FormArray;
+
+    beforeEach(() => {
+      fa = new FormArray([c1, c2, c3, c4]);
+    });
+
+    // This spec checks the behavior is identical to `Array.prototype.at(index)`
+    it('should work with at', () => {
+      expect(fa.at(4)).toBeUndefined();
+    });
+
+    // This spec checks the behavior is identical to `Array.prototype.splice(index, 1, ...)`
+    it('should work with setControl', () => {
+      fa.setControl(4, c99);
+      expect(fa.value).toEqual([1, 2, 3, 4, 99]);
+    });
+
+    // This spec checks the behavior is identical to `Array.prototype.splice(index, 1)`
+    it('should work with removeAt', () => {
+      fa.removeAt(4);
+      expect(fa.value).toEqual([1, 2, 3, 4]);
+    });
+
+    // This spec checks the behavior is identical to `Array.prototype.splice(index, 0, ...)`
+    it('should work with insert', () => {
+      fa.insert(4, c99);
+      expect(fa.value).toEqual([1, 2, 3, 4, 99]);
+    });
+  });
+
+  describe('negative indices', () => {
+    let c1: FormControl = new FormControl(1);
+    let c2: FormControl = new FormControl(2);
+    let c3: FormControl = new FormControl(3);
+    let c4: FormControl = new FormControl(4);
+    let c99: FormControl = new FormControl(99);
+
+    let fa: FormArray;
+
+    beforeEach(() => {
+      fa = new FormArray([c1, c2, c3, c4]);
+    });
+
+    // This spec checks the behavior is identical to `Array.prototype.at(index)`
+    describe('should work with at', () => {
+      it('wrapping from the back between [-length, 0)', () => {
+        expect(fa.at(-1)).toBe(c4);
+        expect(fa.at(-2)).toBe(c3);
+        expect(fa.at(-3)).toBe(c2);
+        expect(fa.at(-4)).toBe(c1);
+      });
+
+      it('becoming undefined when less than -length', () => {
+        expect(fa.at(-5)).toBeUndefined();
+        expect(fa.at(-10)).toBeUndefined();
+      });
+    });
+
+    // This spec checks the behavior is identical to `Array.prototype.splice(index, 1, ...)`
+    describe('should work with setControl', () => {
+      describe('wrapping from the back between [-length, 0)', () => {
+        it('at -1', () => {
+          fa.setControl(-1, c99);
+          expect(fa.value).toEqual([1, 2, 3, 99]);
+        });
+        it('at -2', () => {
+          fa.setControl(-2, c99);
+          expect(fa.value).toEqual([1, 2, 99, 4]);
+        });
+        it('at -3', () => {
+          fa.setControl(-3, c99);
+          expect(fa.value).toEqual([1, 99, 3, 4]);
+        });
+        it('at -4', () => {
+          fa.setControl(-4, c99);
+          expect(fa.value).toEqual([99, 2, 3, 4]);
+        });
+      });
+
+      describe('replacing the first item when less than -length', () => {
+        it('at -5', () => {
+          fa.setControl(-5, c99);
+          expect(fa.value).toEqual([99, 2, 3, 4]);
+        });
+        it('at -10', () => {
+          fa.setControl(-10, c99);
+          expect(fa.value).toEqual([99, 2, 3, 4]);
+        });
+      });
+    });
+
+    // This spec checks the behavior is identical to `Array.prototype.splice(index, 1)`
+    describe('should work with removeAt', () => {
+      describe('wrapping from the back between [-length, 0)', () => {
+        it('at -1', () => {
+          fa.removeAt(-1);
+          expect(fa.value).toEqual([1, 2, 3]);
+        });
+        it('at -2', () => {
+          fa.removeAt(-2);
+          expect(fa.value).toEqual([1, 2, 4]);
+        });
+        it('at -3', () => {
+          fa.removeAt(-3);
+          expect(fa.value).toEqual([1, 3, 4]);
+        });
+        it('at -4', () => {
+          fa.removeAt(-4);
+          expect(fa.value).toEqual([2, 3, 4]);
+        });
+      });
+
+      describe('removing the first item when less than -length', () => {
+        it('at -5', () => {
+          fa.removeAt(-5);
+          expect(fa.value).toEqual([2, 3, 4]);
+        });
+        it('at -10', () => {
+          fa.removeAt(-10);
+          expect(fa.value).toEqual([2, 3, 4]);
+        });
+      });
+    });
+
+    // This spec checks the behavior is identical to `Array.prototype.splice(index, 0, ...)`
+    describe('should work with insert', () => {
+      describe('wrapping from the back between [-length, 0)', () => {
+        it('at -1', () => {
+          fa.insert(-1, c99);
+          expect(fa.value).toEqual([1, 2, 3, 99, 4]);
+        });
+        it('at -2', () => {
+          fa.insert(-2, c99);
+          expect(fa.value).toEqual([1, 2, 99, 3, 4]);
+        });
+        it('at -3', () => {
+          fa.insert(-3, c99);
+          expect(fa.value).toEqual([1, 99, 2, 3, 4]);
+        });
+        it('at -4', () => {
+          fa.insert(-4, c99);
+          expect(fa.value).toEqual([99, 1, 2, 3, 4]);
+        });
+      });
+
+      describe('prepending when less than -length', () => {
+        it('at -5', () => {
+          fa.insert(-5, c99);
+          expect(fa.value).toEqual([99, 1, 2, 3, 4]);
+        });
+        it('at -10', () => {
+          fa.insert(-10, c99);
+          expect(fa.value).toEqual([99, 1, 2, 3, 4]);
+        });
+      });
+    });
+  });
 });
 })();


### PR DESCRIPTION
This new feature allows negative indices to wrap around from the back, just like ES2021 `Array.at`. In particular, the following methods accept negative indices, and behave like corresponding Array methods:
* `FormArray.at(index)`: behaves the same as `Array.at(index)`
* `FormArray.insert(index, control)`: behaves the same as `Array.splice(index, 0, control)`
* `FormArray.setControl(index, control)`: behaves the same as `Array.splice(index, 1, control)`
* `FormArray.removeAt(index, control)`: behaves the same as `Array.splice(index, 1)`

Previous work in #44746 and #44631 (by @amitbeck).

Issue #44642.

Co-authored-by: Amit Beckenstein <amitbeck@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

`FormArray` has various unpredictable behaviors with negative indices:

- `at` returns undefined
- `insert` works correctly
- `removeAt` works in trivial cases, but fails to call `_registerOnCollectionChange`
- `setControl` performs a nonsense transformation


## What is the new behavior?

`FormArray` accepts negative indices, and treats them according to comparable basic `Array` methods. 

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

Yes, this is technically a breaking change. However, the current behavior of `FormArray` with negative indices is not reliable (e.g. `setControl` produces garbage results), so I'd be surprised if many people are relying on it. I will run a TGP in google3 to determine the extent of breakage.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
