### PR TITLE
fix(docs-infra): content overflow in mobile

### DIFF
--- a/aio/src/styles/2-modules/table/_table.scss
+++ b/aio/src/styles/2-modules/table/_table.scss
@@ -3,6 +3,8 @@
 table {
   margin: 24px 0px;
   border-radius: 2px;
+  display: block;
+  overflow-x: auto;
 
   &.is-full-width {
     width: 100%;


### PR DESCRIPTION
When reading the docs page on mobile, some page tend to scroll in horizontal direction quite a lot which is unpleasant.

Fixes #44850

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
https://github.com/angular/angular/issues/44850

Issue Number: #44850 


## What is the new behavior?
Page contents in mobile browser will not overflow in horizontal direction and table(s) can be scrolled in horizontal direction. 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
