### PR TITLE
build: drop dev dependencies in nested zone.js `package.json`

### DIFF
--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -10,17 +10,6 @@
   "dependencies": {
     "tslib": "^2.3.0"
   },
-  "devDependencies": {
-    "@externs/nodejs": "^1.5.0",
-    "@types/node": "^10.9.4",
-    "domino": "2.1.6",
-    "jest": "^26.4",
-    "google-closure-compiler": "^20220104.0.0",
-    "mocha": "^9.0.0",
-    "mock-require": "3.0.3",
-    "promises-aplus-tests": "^2.1.2",
-    "typescript": "~4.5.2"
-  },
   "scripts": {
     "closuretest": "./scripts/closure/closure_compiler.sh",
     "electrontest": "cd test/extra && node electron.js",


### PR DESCRIPTION
This commit removes the `devDependencies` field in the `package.json` for `zone.js`.
This `package.json` file is purely used as NPM entry for the `zone.js` package when
built as release artifact.

The dev dependencies are a leftover from when `zone.js` was in its own repositories.

The removal of the `devDependencies` will help reducing the reviewers
involved when renovate bumps versions (sometimes also dev dependencies
of the `zone.js` package json file).
