### PR TITLE
docs: replace deprecated SwUpdate#available/activated with new API

### DIFF
--- a/aio/content/examples/service-worker-getting-started/src/app/log-update.service.ts
+++ b/aio/content/examples/service-worker-getting-started/src/app/log-update.service.ts
@@ -1,18 +1,24 @@
 import { Injectable } from '@angular/core';
-import { SwUpdate } from '@angular/service-worker';
+import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
 
 // #docregion sw-update
 @Injectable()
 export class LogUpdateService {
 
   constructor(updates: SwUpdate) {
-    updates.available.subscribe(event => {
-      console.log('current version is', event.current);
-      console.log('available version is', event.available);
-    });
-    updates.activated.subscribe(event => {
-      console.log('old version was', event.previous);
-      console.log('new version is', event.current);
+    updates.versionUpdates.subscribe(evt => {
+      switch (evt.type) {
+        case 'VERSION_DETECTED':
+          console.log(`Downloading new app version: ${evt.version.hash}`);
+          break;
+        case 'VERSION_READY':
+          console.log(`Current app version: ${evt.currentVersion.hash}`);
+          console.log(`New app version ready for use: ${evt.latestVersion.hash}`);
+          break;
+        case 'VERSION_INSTALLATION_FAILED':
+          console.log(`Failed to install app version '${evt.version.hash}': ${evt.error}`);
+          break;
+      }
     });
   }
 }

--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -10,22 +10,26 @@ A basic understanding of the following:
 
 ## `SwUpdate` service
 
-The `SwUpdate` service gives you access to events that indicate when the service worker discovers an available update for your application or when it activates such an update&mdash;meaning it is now serving content from that update to your application.
+The `SwUpdate` service gives you access to events that indicate when the service worker discovers and installs an available update for your application.
 
-The `SwUpdate` service supports four separate operations:
-* Getting notified of *available* updates. These are new versions of the application to be loaded if the page is refreshed.
-* Getting notified of update *activation*. This is when the service worker starts serving a new version of the application immediately.
+The `SwUpdate` service supports three separate operations:
+* Getting notified when an updated version is *detected* on the server, *installed and ready* to be used locally or when an *installation fails*.
 * Asking the service worker to check the server for new updates.
 * Asking the service worker to activate the latest version of the application for the current tab.
 
-### Available and activated updates
+### Version updates
 
-The two update events, `available` and `activated`, are `Observable` properties of `SwUpdate`:
+The `versionUpdates` is an `Observable` property of `SwUpdate` and emits three event types:
+* `VersionDetectedEvent` is emitted when the service worker has detected a new version of the app on the server and is about to start downloading it.
+* `VersionReadyEvent` is emitted when a new version of the app is available to be activated by clients.
+  It may be used to notify the user of an available update or prompt them to refresh the page.
+* `VersionInstallationFailedEvent` is emitted when the installation of a new version failed.
+  It may be used for logging/monitoring purposes.
+
 
 <code-example path="service-worker-getting-started/src/app/log-update.service.ts" header="log-update.service.ts" region="sw-update"></code-example>
 
 
-Use these events to notify the user of a pending update or to refresh their pages when the code they are running is out of date.
 
 ### Checking for updates
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Deprecated methods `SwUpdate.available` and `SwUpdate.activated` are used in the docs.

Issue Number: #43665


## What is the new behavior?
 The new way to subscribe to version updates is included in the docs instead of the deprecated one.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
