### PR TITLE
devtools: Fix highlighter content

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -106,7 +106,8 @@ Fixes #<issue number>
 #   │       └─⫸ Commit Scope: animations|bazel|benchpress|common|compiler|compiler-cli|core|
 #   │                          elements|forms|http|language-service|localize|platform-browser|
 #   │                          platform-browser-dynamic|platform-server|router|service-worker|
-#   │                          upgrade|zone.js|packaging|changelog|docs-infra|migrations|ngcc|ve
+#   │                          upgrade|zone.js|packaging|changelog|docs-infra|migrations|ngcc|ve|
+#   │                          devtools
 #   │                          https://github.com/angular/angular/blob/master/CONTRIBUTING.md#scope
 #   │
 #   └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|style|test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,7 +246,8 @@ The `footer` is optional. The [Commit Message Footer](#commit-footer) format des
   │       └─⫸ Commit Scope: animations|bazel|benchpress|common|compiler|compiler-cli|core|
   │                          elements|forms|http|language-service|localize|platform-browser|
   │                          platform-browser-dynamic|platform-server|router|service-worker|
-  │                          upgrade|zone.js|packaging|changelog|docs-infra|migrations|ngcc|ve
+  │                          upgrade|zone.js|packaging|changelog|docs-infra|migrations|ngcc|ve|
+  │                          devtools
   │
   └─⫸ Commit Type: build|ci|docs|feat|fix|perf|refactor|test
 ```
@@ -308,6 +309,8 @@ There are currently a few exceptions to the "use package name" rule:
 * `ngcc`: used for changes to the [Angular Compatibility Compiler](./packages/compiler-cli/ngcc/README.md)
 
 * `ve`: used for changes specific to ViewEngine (legacy compiler/renderer).
+
+* `devtools`: used for changes in the browser extension
 
 * none/empty string: useful for `test` and `refactor` changes that are done across all packages (e.g. `test: add missing unit tests`) and for docs changes that are not related to a specific package (e.g. `docs: fix typo in tutorial`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,7 +310,7 @@ There are currently a few exceptions to the "use package name" rule:
 
 * `ve`: used for changes specific to ViewEngine (legacy compiler/renderer).
 
-* `devtools`: used for changes in the browser extension
+* `devtools`: used for changes in the [browser extension](./devtools/README.md).
 
 * none/empty string: useful for `test` and `refactor` changes that are done across all packages (e.g. `test: add missing unit tests`) and for docs changes that are not related to a specific package (e.g. `docs: fix typo in tutorial`).
 

--- a/devtools/CONTRIBUTING.md
+++ b/devtools/CONTRIBUTING.md
@@ -63,7 +63,7 @@ You can file new issues by filling out our [new issue form](https://github.com/r
 
 Before you submit your Pull Request (PR) consider the following guidelines:
 
-- Search [GitHub](https://github.com/rangle/angular-devtools/pulls) for an open or closed PR
+- Search [GitHub](https://github.com/angular/angular) for an open or closed PR
   that relates to your submission. You don't want to duplicate effort.
 - [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the rangle/angular-devtools repo.
 - In your forked repository, make your changes in a new git branch:
@@ -224,6 +224,6 @@ reference GitHub issues that this commit **Closes**.
 
 A detailed explanation can be found in this [document][commit-message-format].
 
-[github]: https://github.com/rangle/angular-devtools
+[github]: https://github.com/angular/angular
 [gitter]: https://gitter.im/angular/angular
 [stackoverflow]: http://stackoverflow.com/questions/tagged/angular-devtools

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -36,10 +36,10 @@ Angular DevTools supports Angular v9 and above, with Ivy enabled.
 To setup your local development environment for Angular DevTools, perform the following steps:
 
 ```bash
-git clone git://github.com/rangle/angular-devtools
-cd angular-devtools
+git clone git://github.com/angular/angular
+cd angular
 yarn
-yarn start
+yarn run devtools:devserver
 ```
 
 ### Build and Install on Chrome locally

--- a/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/highlighter.ts
@@ -131,10 +131,7 @@ function showOverlay(
   overlay.style.top = ~~top + 'px';
   overlay.style.left = ~~left + 'px';
 
-  while (overlayContent.children.length) {
-    const {children} = overlayContent;
-    overlayContent.removeChild(children[children.length - 1]);
-  }
+  overlayContent.replaceChildren();
 
   content.forEach((child) => overlayContent.appendChild(child));
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: Devtools is now part of the angular monorepo, guidelines are now reflect these changes


## What is the current behavior?

Highlight overlay content is not cleard correctly, and the more element we hover over the bigger the overlay content will be (see the original PR screenshots)

## What is the new behavior?

We correctly empty the overlay content (see the original PR screenshots).

Also updated the repo documentations to reflect it is possible now to contribute to the devtools.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

This is a follow-up PR that i opened in the old repo: https://github.com/rangle/angular-devtools/pull/977