### PR TITLE
fix(devtools): show date type property value in preview

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -62,7 +62,12 @@ const typeToDescriptorPreview: Formatter<string> = {
   [PropType.Object]: (prop: any) => (getKeys(prop).length > 0 ? '{...}' : '{}'),
   [PropType.Symbol]: (_: any) => 'Symbol()',
   [PropType.Undefined]: (_: any) => 'undefined',
-  [PropType.Date]: (_: any) => 'Date()',
+  [PropType.Date]: (prop: any) => {
+    if (prop instanceof Date) {
+      return `Date(${new Date(prop).toISOString()})`;
+    }
+    return prop;
+  },
   [PropType.Unknown]: (_: any) => 'unknown',
 };
 
@@ -87,7 +92,7 @@ const shallowPropTypeToTreeMetaData = {
     expandable: false,
   },
   [PropType.Date]: {
-    editable: true,
+    editable: false,
     expandable: false,
   },
   [PropType.Null]: {


### PR DESCRIPTION
Values of Date properties were not shown in the preview. It was formatted to a simple string thus not giving valuable info to the developer.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/rangle/angular-devtools/issues/880

![image](https://user-images.githubusercontent.com/506946/151440542-186d1b80-1f59-4379-8682-a55491f6b3bd.png)


## What is the new behavior?

We show the Date value inside `Date()`.

Instead of showing the property's value, Date values are just formatted to a simple text.

![image](https://user-images.githubusercontent.com/506946/151441098-a6e1a04d-c0e3-43ff-b2cc-0bc93bf6f055.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a follow-up PR from the old one: https://github.com/rangle/angular-devtools/pull/976

As i mention in the PR this would be a quick win, we could improve this in the long run.

I believe we could further improve the UX and DX later on, by:

- Updating the demo app, so there would be a page, with all kinds of inputs, to test it out while developing the devtools
- Instead of just showing the property in an editable, it would be nice if a little icon would show up telling us it is indeed a Date type property. Just looking at the current solution, one might think it's a simple string ([like in the vue devtools](https://github.com/vuejs/devtools/raw/main/media/screenshot-shadow.png))
- I feel like devtool panel components should be refactord to be OnPush components. It's clear, that it has Inputs/Outputs, so tweaking it a little so changes are always immutable we could improve perf
