### PR TITLE
docs: update survey id

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -10,7 +10,7 @@
 
 <mat-toolbar color="primary" class="app-toolbar no-print" [class.transitioning]="isTransitioning">
   <mat-toolbar-row class="notification-container">
-    <aio-notification notificationId="survey-october-2021" expirationDate="2022-02-01" [dismissOnContentClick]="true" (dismissed)="notificationDismissed()">
+    <aio-notification notificationId="survey-january-2022" expirationDate="2022-02-01" [dismissOnContentClick]="true" (dismissed)="notificationDismissed()">
       <a href="https://stateofjs.com">
         <mat-icon class="icon" svgIcon="insert_comment" aria-label="Announcement"></mat-icon>
         <span class="message">Share your experience with Angular in <b>The State of JavaScript</b></span>


### PR DESCRIPTION
The survey id is used as a key in the local storage to keep the state (don't show the message again). Reusing this survey id will make the message invisible to some users who already have that key in local storage.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No