### PR TITLE
build: bump version for `@angular/benchpress` to v0.2.2

### DIFF
--- a/packages/benchpress/package.json
+++ b/packages/benchpress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@angular/benchpress",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Benchpress - a framework for e2e performance tests",
   "main": "index.js",
   "typings": "./index.d.ts",


### PR DESCRIPTION
Bumps the version for benchpress to v0.2.2 so that a new version
is available on NPM with Angular v13 support. This would be needed
for dev-infra which exposes tooling for benchmarks relying on the
Angular benchpress NPM package.