### PR TITLE
fix(forms): Update the typed forms migration schematic to find all files

### DIFF
--- a/packages/core/schematics/migrations/typed-forms/index.ts
+++ b/packages/core/schematics/migrations/typed-forms/index.ts
@@ -43,7 +43,7 @@ function runTypedFormsMigration(tree: Tree, tsconfigPath: string, basePath: stri
     const formBuilderImport = getFormBuilderImport(sourceFile);
 
     // If no relevant classes are imported, we can exit early.
-    if (controlClassImports.length === 0 && formBuilderImport === null) return;
+    if (controlClassImports.length === 0 && formBuilderImport === null) continue;
 
     const update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
 


### PR DESCRIPTION
We were breaking out of the loop that walks the source tree due to an incorrect return.