### PR TITLE
refactor(compiler-cli): Update where and how the indexed errors are exposed

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -7,6 +7,7 @@
  */
 
 import {ParseSourceFile} from '@angular/compiler';
+
 import {ClassDeclaration, DeclarationNode} from '../../reflection';
 
 /**
@@ -135,4 +136,5 @@ export interface IndexedComponent {
     isInline: boolean,
     file: ParseSourceFile;
   };
+  errors: Error[];
 }

--- a/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/transform.ts
@@ -22,7 +22,6 @@ import {getTemplateIdentifiers} from './template';
  */
 export function generateAnalysis(context: IndexingContext): Map<DeclarationNode, IndexedComponent> {
   const analysis = new Map<DeclarationNode, IndexedComponent>();
-  const analysisErrors: Error[] = [];
 
   context.components.forEach(({declaration, selector, boundTemplate, templateMeta}) => {
     const name = declaration.name.getText();
@@ -47,7 +46,6 @@ export function generateAnalysis(context: IndexingContext): Map<DeclarationNode,
     }
 
     const {identifiers, errors} = getTemplateIdentifiers(boundTemplate);
-    analysisErrors.push(...errors);
     analysis.set(declaration, {
       name,
       selector,
@@ -58,6 +56,7 @@ export function generateAnalysis(context: IndexingContext): Map<DeclarationNode,
         isInline: templateMeta.isInline,
         file: templateFile,
       },
+      errors,
     });
   });
 

--- a/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/transform_spec.ts
@@ -54,7 +54,8 @@ runInEachFileSystem(() => {
           usedComponents: new Set(),
           isInline: false,
           file: new ParseSourceFile('<div>{{foo}}</div>', decl.getSourceFile().fileName),
-        }
+        },
+        errors: [],
       });
     });
 


### PR DESCRIPTION
The initial commit e9124b42d5ac8f570b53a86691aff64d9f6c6ee1 stored the errors rather than
throwing but did not store them in a place that was accessible to consumers. Instead,
the errors should be added to the IndexedComponent so they can be surfaced where the
index results are consumed
