### PR TITLE
build(docs-infra): upgrade cli command docs sources to db5e7c82e

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 9ac3df5d1",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js db5e7c82e",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint && yarn security-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/9ac3df5d1...db5e7c82e):

**Modified**
- help/build.json
- help/e2e.json
- help/extract-i18n.json
- help/serve.json
- help/test.json
- help/update.json