### PR TITLE
Revert "fix(docs-infra): content overflow in mobile (#44851)"

### DIFF
--- a/aio/src/styles/2-modules/table/_table.scss
+++ b/aio/src/styles/2-modules/table/_table.scss
@@ -3,8 +3,6 @@
 table {
   margin: 24px 0px;
   border-radius: 2px;
-  display: block;
-  overflow-x: auto;
 
   &.is-full-width {
     width: 100%;


### PR DESCRIPTION
This reverts commit c2e09e09114977fcdc93cd60db57e4c863a12d9a, because it messes up the table layouts on some resolutions/pages. See #44891 for details.

Fixes #44891.
