### PR TITLE
fix(common): cleanup URL change listeners when the root view is removed

### DIFF
--- a/goldens/public-api/common/common.md
+++ b/goldens/public-api/common/common.md
@@ -308,7 +308,7 @@ export class KeyValuePipe implements PipeTransform {
 }
 
 // @public
-class Location_2 {
+class Location_2 implements OnDestroy {
     constructor(platformStrategy: LocationStrategy, platformLocation: PlatformLocation);
     back(): void;
     forward(): void;
@@ -317,9 +317,11 @@ class Location_2 {
     historyGo(relativePosition?: number): void;
     isCurrentPathEqualTo(path: string, query?: string): boolean;
     static joinWithSlash: (start: string, end: string) => string;
+    // (undocumented)
+    ngOnDestroy(): void;
     normalize(url: string): string;
     static normalizeQueryParams: (params: string) => string;
-    onUrlChange(fn: (url: string, state: unknown) => void): void;
+    onUrlChange(fn: (url: string, state: unknown) => void): VoidFunction;
     path(includeHash?: boolean): string;
     prepareExternalUrl(url: string): string;
     replaceState(path: string, query?: string, state?: any): void;

--- a/goldens/public-api/common/testing/testing.md
+++ b/goldens/public-api/common/testing/testing.md
@@ -120,9 +120,11 @@ export class SpyLocation implements Location_2 {
     // (undocumented)
     isCurrentPathEqualTo(path: string, query?: string): boolean;
     // (undocumented)
+    ngOnDestroy(): void;
+    // (undocumented)
     normalize(url: string): string;
     // (undocumented)
-    onUrlChange(fn: (url: string, state: unknown) => void): void;
+    onUrlChange(fn: (url: string, state: unknown) => void): VoidFunction;
     // (undocumented)
     path(): string;
     // (undocumented)


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit


## PR Type
- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No