### PR TITLE
refactor(core): strict templates type-checking compatibility for perf tests

### DIFF
--- a/modules/benchmarks/src/change_detection/transplanted_views/transplanted_views.ts
+++ b/modules/benchmarks/src/change_detection/transplanted_views/transplanted_views.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {NgForOfContext} from '@angular/common';
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, NgModule, TemplateRef, ViewChild} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
@@ -19,7 +20,7 @@ import {newArray} from '../util';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class InsertionComponent {
-  @Input() template !: TemplateRef<{}>;
+  @Input() template!: TemplateRef<NgForOfContext<any, any[]>>;
   views: any[] = [];
   @Input()
   set viewCount(n: number) {


### PR DESCRIPTION
This commit updates a type used in the transplanted views perf tests, to make the test compatible with strict template type-checking.

Currently, compiling the perf test results in the following TS error:
```
error TS2322: Type 'TemplateRef<{}>' is not assignable to type 'TemplateRef<NgForOfContext<any, any[]>>'.

17     <ng-container *ngFor="let n of views; template: template; trackBy: trackByIndex"></ng-container>
                                             ~~~~~~~~
```

Note: using the `refactor` commit type (instead of a `fix`) to avoid referencing this change in the CHANGELOG (as the change is minor and doesn't affect apps).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No