### PR TITLE
build: fix formatting in zone.js BUILD file

### DIFF
--- a/packages/zone.js/dist/BUILD.bazel
+++ b/packages/zone.js/dist/BUILD.bazel
@@ -37,8 +37,8 @@ genrule(
 
 js_library(
     name = "zone",
-    srcs = [":zone.js"],
     package_name = "zone.js/dist",
+    srcs = [":zone.js"],
     visibility = ["//modules/benchmarks:__subpackages__"],
 )
 


### PR DESCRIPTION
Fixes formatting in one of the Zone BUILD files.
The lint check on the renovate branch did not check
formatting as it seems. Needs more investigation as
the PR was green.

Seeing the following output:

```
#!/bin/bash -eo pipefail
yarn -s ng-dev format changed $CI_GIT_BASE_REVISION --check
fatal: bad object 1dd6dcd6f8032330fba637921dd2591ab0ddd2a8
No files matched for formatting check.
CircleCI received exit code 0
```