### PR TITLE
fix: Add back support for namespace URIs in createElement of dom rend…

### DIFF
--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -145,7 +145,16 @@ class DefaultDomRenderer2 implements Renderer2 {
 
   createElement(name: string, namespace?: string): any {
     if (namespace) {
-      return document.createElementNS(NAMESPACE_URIS[namespace], name);
+      // TODO: `|| namespace` was added in
+      // https://github.com/angular/angular/commit/2b9cc8503d48173492c29f5a271b61126104fbdb to
+      // support how Ivy passed around the namespace URI rather than short name at the time. It did
+      // not, however extend the support to other parts of the system (setAttribute, setAttribute,
+      // and the ServerRenderer). We should decide what exactly the semantics for dealing with
+      // namespaces should be and make it consistent.
+      // Related issues:
+      // https://github.com/angular/angular/issues/44028
+      // https://github.com/angular/angular/issues/44883
+      return document.createElementNS(NAMESPACE_URIS[namespace] || namespace, name);
     }
 
     return document.createElement(name);


### PR DESCRIPTION
…erer

Support for namespace URIs rather than short namespace names was added in
https://github.com/angular/angular/commit/2b9cc8503d48173492c29f5a271b61126104fbdb to
support how Ivy passed around the namespace URI rather than short name at the time.
As a side-effect, this meant that namespace URIs were supported by the
default dom renderer as part of the public API (likely unintentionally).

It did not, however extend the support to other parts of the system (setAttribute, setAttribute,
and the ServerRenderer). In the future we should decide what exactly the
semantics for dealing with namespaces should be and make it consistent.

fixes #44028
