### PR TITLE
refactor(compiler): remove parsing support for quote expressions

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Call, Chain, Conditional, EmptyExpr, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, SafeCall, SafeKeyedRead, SafePropertyRead, ThisReceiver, Unary} from '@angular/compiler';
+import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Call, Chain, Conditional, EmptyExpr, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, SafeCall, SafeKeyedRead, SafePropertyRead, ThisReceiver, Unary} from '@angular/compiler';
 import ts from 'typescript';
 
 import {TypeCheckingConfig} from '../api';
@@ -252,10 +252,6 @@ class AstTranslator implements AstVisitor {
     return node;
   }
 
-  visitQuote(ast: Quote): ts.Expression {
-    return NULL_AS_ANY;
-  }
-
   visitSafePropertyRead(ast: SafePropertyRead): ts.Expression {
     let node: ts.Expression;
     const receiver = wrapForDiagnostics(this.translate(ast.receiver));
@@ -449,9 +445,6 @@ class VeSafeLhsInferenceBugDetector implements AstVisitor {
     return false;
   }
   visitPropertyWrite(ast: PropertyWrite): boolean {
-    return false;
-  }
-  visitQuote(ast: Quote): boolean {
     return false;
   }
   visitSafePropertyRead(ast: SafePropertyRead): boolean {

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_check_block_spec.ts
@@ -56,11 +56,6 @@ describe('type check blocks', () => {
         .toContain('(((((ctx).a)) ?? (((ctx).b))) + ((((ctx).c)) ?? (((ctx).e))))');
   });
 
-  it('should handle quote expressions as any type', () => {
-    const TEMPLATE = `<span [quote]="sql:expression"></span>`;
-    expect(tcb(TEMPLATE)).toContain('null as any');
-  });
-
   it('should handle attribute values for directive inputs', () => {
     const TEMPLATE = `<div dir inputA="value"></div>`;
     const DIRECTIVES: TestDeclaration[] = [{

--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -518,11 +518,6 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
     return asts.map(ast => this._visit(ast, mode));
   }
 
-  visitQuote(ast: cdAst.Quote, mode: _Mode): any {
-    throw new Error(`Quotes are not supported for evaluation!
-        Statement: ${ast.uninterpretedExpression} located at ${ast.location}`);
-  }
-
   visitCall(ast: cdAst.Call, mode: _Mode): any {
     const leftMostSafe = this.leftMostSafeNode(ast);
     if (leftMostSafe) {
@@ -742,9 +737,6 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
       visitPropertyWrite(ast: cdAst.PropertyWrite) {
         return null;
       },
-      visitQuote(ast: cdAst.Quote) {
-        return null;
-      },
       visitSafePropertyRead(ast: cdAst.SafePropertyRead) {
         return visit(this, ast.receiver) || ast;
       },
@@ -820,9 +812,6 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
         return false;
       },
       visitPropertyWrite(ast: cdAst.PropertyWrite) {
-        return false;
-      },
-      visitQuote(ast: cdAst.Quote) {
         return false;
       },
       visitSafePropertyRead(ast: cdAst.SafePropertyRead) {

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -552,21 +552,8 @@ describe('parser', () => {
         expectBindingError('"Foo"|#privateIdentifier"', 'identifier or keyword');
       });
 
-      it('should parse quoted expressions', () => {
-        checkBinding('a:b', 'a:b');
-      });
-
       it('should not crash when prefix part is not tokenizable', () => {
         checkBinding('"a:b"', '"a:b"');
-      });
-
-      it('should ignore whitespace around quote prefix', () => {
-        checkBinding(' a :b', 'a:b');
-      });
-
-      it('should refuse prefixes that are not single identifiers', () => {
-        expectBindingError('a + b:c', '');
-        expectBindingError('1:c', '');
       });
     });
 
@@ -607,10 +594,6 @@ describe('parser', () => {
 
     it('should retain // in string literals', () => {
       checkBinding(`"http://www.google.com"`, `"http://www.google.com"`);
-    });
-
-    it('should retain // in : microsyntax', () => {
-      checkBinding('one:a//b', 'one:a//b');
     });
   });
 

--- a/packages/compiler/test/expression_parser/utils/unparser.ts
+++ b/packages/compiler/test/expression_parser/utils/unparser.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Call, Chain, Conditional, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeCall, SafeKeyedRead, SafePropertyRead, ThisReceiver, Unary} from '../../../src/expression_parser/ast';
+import {AST, AstVisitor, ASTWithSource, Binary, BindingPipe, Call, Chain, Conditional, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, NonNullAssert, PrefixNot, PropertyRead, PropertyWrite, RecursiveAstVisitor, SafeCall, SafeKeyedRead, SafePropertyRead, ThisReceiver, Unary} from '../../../src/expression_parser/ast';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from '../../../src/ml_parser/interpolation_config';
 
 class Unparser implements AstVisitor {
@@ -175,10 +175,6 @@ class Unparser implements AstVisitor {
   visitSafePropertyRead(ast: SafePropertyRead, context: any) {
     this._visit(ast.receiver);
     this._expression += `?.${ast.name}`;
-  }
-
-  visitQuote(ast: Quote, context: any) {
-    this._expression += `${ast.prefix}:${ast.uninterpretedExpression}`;
   }
 
   visitSafeKeyedRead(ast: SafeKeyedRead, context: any) {

--- a/packages/compiler/test/expression_parser/utils/validator.ts
+++ b/packages/compiler/test/expression_parser/utils/validator.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, Binary, BindingPipe, Call, Chain, Conditional, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, Quote, RecursiveAstVisitor, SafeCall, SafeKeyedRead, SafePropertyRead, Unary} from '../../../src/expression_parser/ast';
+import {AST, Binary, BindingPipe, Call, Chain, Conditional, ImplicitReceiver, Interpolation, KeyedRead, KeyedWrite, LiteralArray, LiteralMap, LiteralPrimitive, ParseSpan, PrefixNot, PropertyRead, PropertyWrite, RecursiveAstVisitor, SafeCall, SafeKeyedRead, SafePropertyRead, Unary} from '../../../src/expression_parser/ast';
 
 import {unparse} from './unparser';
 
@@ -92,10 +92,6 @@ class ASTValidator extends RecursiveAstVisitor {
 
   override visitPropertyWrite(ast: PropertyWrite, context: any): any {
     this.validate(ast, () => super.visitPropertyWrite(ast, context));
-  }
-
-  override visitQuote(ast: Quote, context: any): any {
-    this.validate(ast, () => super.visitQuote(ast, context));
   }
 
   override visitSafePropertyRead(ast: SafePropertyRead, context: any): any {

--- a/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_absolute_span_spec.ts
@@ -344,12 +344,6 @@ describe('expression AST absolute source spans', () => {
     });
   });
 
-  it('should provide absolute offsets of a quote', () => {
-    expect(humanizeExpressionSource(parse('<div [prop]="a:b"></div>').nodes)).toContain([
-      'a:b', new AbsoluteSourceSpan(13, 16)
-    ]);
-  });
-
   describe('absolute offsets for template expressions', () => {
     it('should work for simple cases', () => {
       expect(

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -99,10 +99,6 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
     this.recordAst(ast);
     super.visitSafePropertyRead(ast, null);
   }
-  override visitQuote(ast: e.Quote) {
-    this.recordAst(ast);
-    super.visitQuote(ast, null);
-  }
   override visitSafeKeyedRead(ast: e.SafeKeyedRead) {
     this.recordAst(ast);
     super.visitSafeKeyedRead(ast, null);


### PR DESCRIPTION
So-called "Quote expressions" were added in b6ec2387b31ad1f51b95c8fac8f2a60b2de855f6
to support foreign syntax to be used in Angular templates, requiring a custom
template transform to convert them somehow during compilation. Support for template
transforms was originally implemented in a43ed79ee7d49ec55a0adea9b587ed67780c870c but
has since been dropped. Since the compiler is not public API the quote expressions
should not have any usages anymore. Removing support for them can improve error
reporting for expressions that contain a `:`, e.g. binding to a URL without quotes:

```html
<a [href]="http://google.com">Click me</a>
```

Here, `http` would be parsed as foreign "http" quote expression with `//google.com` as
value, later reporting the error "Quotes are not supported for evaluation!" because
there was no template transform to convert that code.

Closes #40398