### PR TITLE
build: fix `update_all_goldens.js` to use ESM.

### DIFF
--- a/packages/compiler-cli/test/compliance/update_all_goldens.js
+++ b/packages/compiler-cli/test/compliance/update_all_goldens.js
@@ -8,7 +8,8 @@
  */
 
 // tslint:disable:no-console
-const {exec} = require('shelljs');
+import shelljs from 'shelljs';
+const {exec} = shelljs;
 
 process.stdout.write('Gathering all partial golden update targets');
 const queryCommand =


### PR DESCRIPTION
Attempting to run as is fails because we have `"type": "module"`. `shelljs` is a CommonJS module however, so we need to do a default import and destructure.

```
$ node packages/compiler-cli/test/compliance/update_all_goldens.js
const {exec} = require('shelljs');
               ^

ReferenceError: require is not defined in ES module scope, you can use import instead
This file is being treated as an ES module because it has a '.js' file extension and '/home/douglasparker/Source/ng/packages/compiler-cli/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.
    at file:///home/douglasparker/Source/ng/packages/compiler-cli/test/compliance/update_all_goldens.js:11:16
    at ModuleJob.run (node:internal/modules/esm/module_job:183:25)
    at async Loader.import (node:internal/modules/esm/loader:178:24)
    at async Object.loadESM (node:internal/process/esm_loader:68:5)
    at async handleMainPromise (node:internal/modules/run_main:63:12)
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Build related changes

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`update_all_goldens.js` script fails to run due to using `require()` in an ES module.


## What is the new behavior?

`update_all_goldens.js` now imports its dependencies via ES modules.

## Does this PR introduce a breaking change?

- [X] No