### PR TITLE
refactor(compiler-cli): remove unused `canonical-path` dependency

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -45,7 +45,6 @@ esbuild(
         "tsickle",
         "@babel/core",
         "reflect-metadata",
-        "canonical-path",
         "chokidar",
         "convert-source-map",
         "dependency-graph",

--- a/packages/compiler-cli/ngcc/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/BUILD.bazel
@@ -35,7 +35,6 @@ ts_library(
         "@npm//@types/node",
         "@npm//@types/semver",
         "@npm//@types/yargs",
-        "@npm//canonical-path",
         "@npm//dependency-graph",
         "@npm//magic-string",
         "@npm//semver",

--- a/packages/compiler-cli/ngcc/test/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/test/BUILD.bazel
@@ -106,7 +106,6 @@ jasmine_node_test(
     ],
     deps = [
         ":integration_lib",
-        "@npm//canonical-path",
         "@npm//convert-source-map",
     ],
 )

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -55,7 +55,6 @@
   "dependencies": {
     "@babel/core": "^7.8.6",
     "reflect-metadata": "^0.1.2",
-    "canonical-path": "1.0.0",
     "chokidar": "^3.0.0",
     "convert-source-map": "^1.5.1",
     "dependency-graph": "^0.11.0",


### PR DESCRIPTION
This package is no longer used within `compiler-cli` so is being removed as a dependency.