### PR TITLE
refactor(compiler-cli): remove leftover `_extendedTemplateDiagnostics` flag

### DIFF
--- a/packages/bazel/src/ng_module/ng_module.bzl
+++ b/packages/bazel/src/ng_module/ng_module.bzl
@@ -228,7 +228,6 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
         "generateNgSummaryShims": True if generate_ve_shims else False,
         "fullTemplateTypeCheck": ctx.attr.type_check,
         "strictTemplates": ctx.attr.strict_templates,
-        "_extendedTemplateDiagnostics": ctx.attr.experimental_extended_template_diagnostics,
         "compilationMode": compilation_mode,
         # In Google3 we still want to use the symbol factory re-exports in order to
         # not break existing apps inside Google. Unlike Bazel, Google3 does not only

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -39,12 +39,7 @@ export interface TestOnlyOptions {
 /**
  * Internal only options for compiler.
  */
-export interface InternalOptions {
-  /**
-   * Whether to run all template checks and generate extended template diagnostics.
-   */
-  _extendedTemplateDiagnostics?: boolean;
-}
+export interface InternalOptions {}
 
 /**
  * A merged interface of all of the various Angular compiler options, as well as the standard

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -316,12 +316,6 @@ export class NgCompiler {
       readonly usePoisonedData: boolean,
       private livePerfRecorder: ActivePerfRecorder,
   ) {
-    if (this.options._extendedTemplateDiagnostics === true &&
-        this.options.strictTemplates === false) {
-      throw new Error(
-          'The \'_extendedTemplateDiagnostics\' option requires \'strictTemplates\' to also be enabled.');
-    }
-
     this.constructionDiagnostics.push(
         ...this.adapter.constructionDiagnostics, ...verifyCompatibleTypeCheckOptions(this.options));
 

--- a/packages/compiler-cli/test/ngtsc/extended_template_diagnostics_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/extended_template_diagnostics_spec.ts
@@ -67,27 +67,6 @@ runInEachFileSystem(() => {
       expect(getSourceCodeForDiagnostic(diags[0])).toBe('([notARealThing])="bar"');
     });
 
-    it('should throw error if _extendedTemplateDiagnostics option is enabled and strictTemplates disabled',
-       () => {
-         env.tsconfig({_extendedTemplateDiagnostics: true, strictTemplates: false});
-         env.write('test.ts', `
-              import {Component} from '@angular/core';
-              @Component({
-                selector: 'test',
-                template: '<div ([notARealThing])="bar"></div>',
-              })
-              class TestCmp {
-                bar: string = "text";
-              }
-            `);
-
-         const diags = env.driveDiagnostics();
-         expect(diags.length).toBe(1);
-         expect(diags[0].messageText)
-             .toMatch(
-                 /Error: The '_extendedTemplateDiagnostics' option requires 'strictTemplates' to also be enabled./);
-       });
-
     it(`should produce nullish coalescing not nullable warning`, () => {
       env.write('test.ts', `
               import {Component} from '@angular/core';

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -7634,10 +7634,7 @@ function allTests(os: string) {
        });
 
     it('passes the build when only warnings are emitted', () => {
-      env.tsconfig({
-        strictTemplates: true,
-        _extendedTemplateDiagnostics: true,
-      });
+      env.tsconfig({strictTemplates: true});
 
       env.write('test.ts', `
         import {Component} from '@angular/core';

--- a/packages/language-service/src/language_service.ts
+++ b/packages/language-service/src/language_service.ts
@@ -501,7 +501,6 @@ function parseNgCompilerOptions(
   // regardless of its value in tsconfig.json.
   if (config.forceStrictTemplates === true) {
     options.strictTemplates = true;
-    options._extendedTemplateDiagnostics = true;
   }
 
   return options;

--- a/packages/language-service/test/diagnostic_spec.ts
+++ b/packages/language-service/test/diagnostic_spec.ts
@@ -375,8 +375,8 @@ describe('getSemanticDiagnostics', () => {
         }
     `
     };
-    const project = createModuleAndProjectWithDeclarations(
-        env, 'test', files, {strictTemplates: true, _extendedTemplateDiagnostics: true});
+    const project =
+        createModuleAndProjectWithDeclarations(env, 'test', files, {strictTemplates: true});
 
     const diags = project.getDiagnosticsForFile('app.ts');
     expect(diags.length).toEqual(1);
@@ -419,8 +419,8 @@ describe('getSemanticDiagnostics', () => {
     `,
       'app.html': `<div ([foo])="bar"></div>`
     };
-    const project = createModuleAndProjectWithDeclarations(
-        env, 'test', files, {strictTemplates: true, _extendedTemplateDiagnostics: true});
+    const project =
+        createModuleAndProjectWithDeclarations(env, 'test', files, {strictTemplates: true});
 
     const diags = project.getDiagnosticsForFile('app.html');
     expect(diags.length).toEqual(1);

--- a/packages/language-service/test/legacy/language_service_spec.ts
+++ b/packages/language-service/test/legacy/language_service_spec.ts
@@ -82,7 +82,6 @@ describe('language service adapter', () => {
       // is enabled.
       expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
         strictTemplates: true,
-        _extendedTemplateDiagnostics: true,
       }));
     });
   });


### PR DESCRIPTION
This flag is currently a no-op because extended diagnostics are enabled in production.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Refactoring (no functional changes, no api changes)

## What is the current behavior?

The `_extendedTemplateDiagnostics` flag still litters the codebase, yet is effectively a no-op.

## What is the new behavior?

The `_extendedTemplateDiagnostics` flag is removed entirely.

## Does this PR introduce a breaking change?

- [X] No

## Other information

This was a private, internal-only flag, never exposed publicly, so it should be safe to remove.