### PR TITLE
build: Update 13.2.x for useUnknownInCatch

### DIFF
--- a/packages/core/schematics/migrations/router-link-empty-expression/index.ts
+++ b/packages/core/schematics/migrations/router-link-empty-expression/index.ts
@@ -53,7 +53,7 @@ export default function(): Rule {
       compilerModule = await loadEsmModule<typeof import('@angular/compiler')>('@angular/compiler');
     } catch (e) {
       throw new SchematicsException(
-          `Unable to load the '@angular/compiler' package. Details: ${e.message}`);
+          `Unable to load the '@angular/compiler' package. Details: ${(e as Error).message}`);
     }
 
     for (const tsconfigPath of [...buildPaths, ...testPaths]) {


### PR DESCRIPTION
36b16e667a99a69bbee8979e4f0517ed26f8d69c enabled `useUnknownInCatchVariables`
but broke the build becaue the migration does not exist on the main
branch.
