### PR TITLE
fix(forms): Update the typed forms migration to use `FormArray<T>` instead of `FormArray<T[]>`.

### DIFF
--- a/packages/core/schematics/migrations/typed-forms/README.md
+++ b/packages/core/schematics/migrations/typed-forms/README.md
@@ -1,6 +1,6 @@
 ## Typed Forms migration
 
-As of Angular v14, `AbstractControl` and `FormBuilder` classes have a generic type parameter. This migration identifies usage of these classes, and adds `<AnyForUntypedForms>` or `<AnyForUntypedForms[]>` in the appropriate places to preserve the old untyped behavior.
+As of Angular v14, `AbstractControl` and `FormBuilder` classes have a generic type parameter. This migration identifies usage of these classes, and adds `<AnyForUntypedForms>` in the appropriate places to preserve the old untyped behavior.
 
 #### Before
 ```ts
@@ -33,14 +33,14 @@ import { AbstractControl, AnyForUntypedForms, FormArray, FormBuilder, FormContro
 export class MyComponent {
   private _control = new FC<AnyForUntypedForms>(42);
   private _group = new FormGroup<AnyForUntypedForms>({});
-  private _array = new FormArray<AnyForUntypedForms[]>([]);
+  private _array = new FormArray<AnyForUntypedForms>([]);
 
   private fb = new FormBuilder();
 
   build() {
     const c = this.fb.control<AnyForUntypedForms>(42);
     const g = this.fb.group<AnyForUntypedForms>({one: this.fb.control<AnyForUntypedForms>('')});
-    const a = this.fb.array<AnyForUntypedForms[]>([42]);
+    const a = this.fb.array<AnyForUntypedForms>([42]);
     const fc2 = new FC<AnyForUntypedForms>(0);
   }
 }

--- a/packages/core/schematics/migrations/typed-forms/util.ts
+++ b/packages/core/schematics/migrations/typed-forms/util.ts
@@ -37,11 +37,7 @@ export function findControlClassUsages(
     sourceFile: ts.SourceFile, typeChecker: ts.TypeChecker,
     importSpecifier: ts.ImportSpecifier|null): MigratableNode[] {
   if (importSpecifier === null) return [];
-  let generic = `<${anySymbolName}>`;
-  if (importSpecifier.name.getText() === 'FormArray' ||
-      importSpecifier.propertyName?.getText() === 'FormArray') {
-    generic = `<${anySymbolName}[]>`;
-  }
+  const generic = `<${anySymbolName}>`;
   const usages: MigratableNode[] = [];
   const visitNode = (node: ts.Node) => {
     // Look for a `new` expression with no type arguments which references an import we care about:
@@ -66,8 +62,7 @@ export function findFormBuilderCalls(
     if (ts.isCallExpression(node) && !node.typeArguments &&
         ts.isPropertyAccessExpression(node.expression) && ts.isIdentifier(node.expression.name) &&
         builderMethodNames.includes(node.expression.name.text)) {
-      const generic =
-          node.expression.name.text === 'array' ? `<${anySymbolName}[]>` : `<${anySymbolName}>`;
+      const generic = `<${anySymbolName}>`;
       // Check whether the type of the object on which the function is called refers to the
       // provided import.
       if (isReferenceToImport(typeChecker, node.expression.expression, importSpecifier)) {

--- a/packages/core/schematics/test/google3/typed_forms_spec.ts
+++ b/packages/core/schematics/test/google3/typed_forms_spec.ts
@@ -113,10 +113,10 @@ describe('Google3 typedForms TSLint rule', () => {
          anySymbolName}, AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup } from '@angular/forms';`,
      `private _control = new FC<${anySymbolName}>(42)`,
      `private _group = new FormGroup<${anySymbolName}>({})`,
-     `private _array = new FormArray<${anySymbolName}[]>([])`,
+     `private _array = new FormArray<${anySymbolName}>([])`,
      `const fc2 = new FC<${anySymbolName}>(0)`, `const c = this.fb.control<${anySymbolName}>(42)`,
      `const g = this.fb.group<${anySymbolName}>({one: this.fb.control<${anySymbolName}>('')})`,
-     `const a = this.fb.array<${anySymbolName}[]>([42])`]
+     `const a = this.fb.array<${anySymbolName}>([42])`]
         .forEach(t => expect(getFile(`/index.ts`)).toContain(t));
   });
 });

--- a/packages/core/schematics/test/typed_forms_spec.ts
+++ b/packages/core/schematics/test/typed_forms_spec.ts
@@ -122,7 +122,7 @@ describe('Typed Forms migration', () => {
          `);
       await runMigration();
       expect(tree.readContent('/index.ts'))
-          .toContain(`const fa = new FormArray<${anySymbolName}[]>([null]);`);
+          .toContain(`const fa = new FormArray<${anySymbolName}>([null]);`);
     });
 
     it('for FormControl with a qualified import', async () => {
@@ -150,7 +150,7 @@ describe('Typed Forms migration', () => {
          `);
       await runMigration();
       expect(tree.readContent('/index.ts'))
-          .toContain(`const fa = new FA<${anySymbolName}[]>([null]);`);
+          .toContain(`const fa = new FA<${anySymbolName}>([null]);`);
     });
 
     it('but not for controls that already have type arguments', async () => {
@@ -218,9 +218,9 @@ describe('Typed Forms migration', () => {
            }
          `);
       await runMigration();
-      expect(tree.readContent('/index.ts')).toContain(`fb.array<${anySymbolName}[]>([0]);`);
+      expect(tree.readContent('/index.ts')).toContain(`fb.array<${anySymbolName}>([0]);`);
       expect(tree.readContent('/index.ts'))
-          .toContain(`const fd = new FormBuilder().array<${anySymbolName}[]>([0])`);
+          .toContain(`const fd = new FormBuilder().array<${anySymbolName}>([0])`);
     });
   });
 
@@ -275,10 +275,10 @@ describe('Typed Forms migration', () => {
            anySymbolName}, AbstractControl, FormArray, FormBuilder, FormControl as FC, FormGroup } from '@angular/forms';`,
        `private _control = new FC<${anySymbolName}>(42)`,
        `private _group = new FormGroup<${anySymbolName}>({})`,
-       `private _array = new FormArray<${anySymbolName}[]>([])`,
+       `private _array = new FormArray<${anySymbolName}>([])`,
        `const fc2 = new FC<${anySymbolName}>(0)`, `const c = this.fb.control<${anySymbolName}>(42)`,
        `const g = this.fb.group<${anySymbolName}>({one: this.fb.control<${anySymbolName}>('')})`,
-       `const a = this.fb.array<${anySymbolName}[]>([42])`]
+       `const a = this.fb.array<${anySymbolName}>([42])`]
           .forEach(t => expect(tree.readContent('/index.ts')).toContain(t));
     });
   });


### PR DESCRIPTION
Previously, `FormArray` accepted an array generic. With the most up-to-date prototype, it accepts the element type, so the migration must be updated accordingly.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

