### PR TITLE
build: update pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1218,7 +1218,8 @@ groups:
           ])
     reviewers:
       users:
-        - aleksanderbodurri
+        # Temporarily removed while correcting membership and review assignment config.
+        # - aleksanderbodurri
         - devversion
         - josephperrott
         - mgechev


### PR DESCRIPTION
Update pullapprove to temporarily remove aleksanderbodurri from pullapprove configuration while we correct the membership and review assignment's for the account.
