### PR TITLE
build: exclude devtools scope from generated changelogs

### DIFF
--- a/.ng-dev/release.ts
+++ b/.ng-dev/release.ts
@@ -30,7 +30,13 @@ export const release: ReleaseConfig = {
     return buildTargetPackages('dist/release-output', false, 'Release', /* isRelease */ true);
   },
   releaseNotes: {
-    hiddenScopes: ['aio', 'dev-infra', 'docs-infra', 'zone.js'],
+    hiddenScopes: [
+      'aio',
+      'dev-infra',
+      'docs-infra',
+      'zone.js',
+      'devtools',
+    ],
   },
   releasePrLabels: ['comp: build & ci', 'action: merge', 'PullApprove: disable'],
 };


### PR DESCRIPTION
The devtools scoped commits are not included in the repository's CHANGELOG.md file as these commits are not references areas which are included in the
primary released artifacts.
