### PR TITLE
docs: remove unnecessary closing tag in HTTP code example

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -577,7 +577,7 @@ Most interceptors inspect the request on the way in and forward the (perhaps alt
 
 ```javascript
 export abstract class HttpHandler {
-  abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
+  abstract handle(req: HttpRequest<any>): Observable<HttpEvent<any>;
 }
 ```
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is an unnecessary closing tag in an HTTP code example
Issue Number: N/A


## What is the new behavior?
The unnecessary closing tag was removed from the code example

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
