### PR TITLE
refactor: convert nullish coalescing operator to plain javascript

### DIFF
--- a/tools/postinstall-patches.js
+++ b/tools/postinstall-patches.js
@@ -68,7 +68,8 @@ const captureNgDevPatches = (files, patches) =>
     patches.forEach(p => _captureNgDevPatch(p[0], p[1], files));
 const _captureNgDevPatch = (search, replace, files) => {
   for (const fileName of files) {
-    const currentPatches = ngDevPatches.get(fileName) ?? [];
+    const patches = ngDevPatches.get(fileName);
+    const currentPatches = (patches !== null && patches !== undefined) ? patches : [];
     ngDevPatches.set(fileName, [...currentPatches, [search, replace]]);
   }
 };


### PR DESCRIPTION
the node engines requirement is described in package.json as below:
```
 "engines": {
    "node": "^12.20.0 || ^14.15.0 || >=16.10.0" 
 },
```
It seems low version nodejs (such as v12.22.8) doesn't support nullish coalescing operator.