### PR TITLE
feat(core): move ANIMATION_MODULE_TYPE injection token into core

### DIFF
--- a/goldens/public-api/core/core.md
+++ b/goldens/public-api/core/core.md
@@ -38,6 +38,9 @@ export interface AfterViewInit {
 export const ANALYZE_FOR_ENTRY_COMPONENTS: InjectionToken<any>;
 
 // @public
+export const ANIMATION_MODULE_TYPE: InjectionToken<"NoopAnimations" | "BrowserAnimations">;
+
+// @public
 export const APP_BOOTSTRAP_LISTENER: InjectionToken<((compRef: ComponentRef<any>) => void)[]>;
 
 // @public

--- a/goldens/public-api/platform-browser/animations/animations.md
+++ b/goldens/public-api/platform-browser/animations/animations.md
@@ -4,13 +4,12 @@
 
 ```ts
 
+import { ANIMATION_MODULE_TYPE } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/platform-browser';
-import { InjectionToken } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
 
-// @public (undocumented)
-export const ANIMATION_MODULE_TYPE: InjectionToken<"NoopAnimations" | "BrowserAnimations">;
+export { ANIMATION_MODULE_TYPE }
 
 // @public
 export class BrowserAnimationsModule {

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 451244,
+        "main": 449957,
         "polyfills": 37297,
         "styles": 70379,
         "light-theme": 77582,

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -72,3 +72,15 @@ export const APP_BOOTSTRAP_LISTENER =
  * @publicApi
  */
 export const PACKAGE_ROOT_URL = new InjectionToken<string>('Application Packages Root URL');
+
+// We keep this token here, rather than the animations package, so that modules that only care
+// about which animations module is loaded (e.g. the CDK) can retrieve it without having to
+// include extra dependencies. See #44970 for more context.
+
+/**
+ * A [DI token](guide/glossary#di-token "DI token definition") that indicates which animations
+ * module has been loaded.
+ * @publicApi
+ */
+export const ANIMATION_MODULE_TYPE =
+    new InjectionToken<'NoopAnimations'|'BrowserAnimations'>('AnimationModuleType');

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -17,7 +17,7 @@ export {TypeDecorator} from './util/decorators';
 export * from './di';
 export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, createPlatformFactory, NgProbeToken} from './application_ref';
 export {enableProdMode, isDevMode} from './util/is_dev_mode';
-export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, PLATFORM_ID, APP_BOOTSTRAP_LISTENER} from './application_tokens';
+export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, PLATFORM_ID, APP_BOOTSTRAP_LISTENER, ANIMATION_MODULE_TYPE} from './application_tokens';
 export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 export * from './zone';
 export * from './render';

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -255,9 +255,6 @@
     "name": "InjectFlags"
   },
   {
-    "name": "InjectableAnimationEngine"
-  },
-  {
     "name": "InjectionToken"
   },
   {

--- a/packages/platform-browser/animations/src/animations.ts
+++ b/packages/platform-browser/animations/src/animations.ts
@@ -11,8 +11,7 @@
  * @description
  * Entry point for all animation APIs of the animation browser package.
  */
+export {ANIMATION_MODULE_TYPE} from '@angular/core';
 export {BrowserAnimationsModule, BrowserAnimationsModuleConfig, NoopAnimationsModule} from './module';
-
-export {ANIMATION_MODULE_TYPE} from './providers';
 
 export * from './private_export';

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -9,7 +9,7 @@
 import {AnimationBuilder} from '@angular/animations';
 import {AnimationDriver, ɵAnimationEngine as AnimationEngine, ɵAnimationStyleNormalizer as AnimationStyleNormalizer, ɵNoopAnimationDriver as NoopAnimationDriver, ɵWebAnimationsDriver as WebAnimationsDriver, ɵWebAnimationsStyleNormalizer as WebAnimationsStyleNormalizer} from '@angular/animations/browser';
 import {DOCUMENT} from '@angular/common';
-import {Inject, Injectable, InjectionToken, NgZone, OnDestroy, Provider, RendererFactory2} from '@angular/core';
+import {ANIMATION_MODULE_TYPE, Inject, Injectable, InjectionToken, NgZone, OnDestroy, Provider, RendererFactory2} from '@angular/core';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 
 import {BrowserAnimationBuilder} from './animation_builder';
@@ -35,12 +35,6 @@ export function instantiateRendererFactory(
     renderer: DomRendererFactory2, engine: AnimationEngine, zone: NgZone) {
   return new AnimationRendererFactory(renderer, engine, zone);
 }
-
-/**
- * @publicApi
- */
-export const ANIMATION_MODULE_TYPE =
-    new InjectionToken<'NoopAnimations'|'BrowserAnimations'>('AnimationModuleType');
 
 const SHARED_ANIMATION_PROVIDERS: Provider[] = [
   {provide: AnimationBuilder, useClass: BrowserAnimationBuilder},


### PR DESCRIPTION
Moves the `ANIMATION_MODULE_TYPE` DI token into core so that libraries like Material don't have to introduce a dependency to animations only to figure out whether animations are disabled.