### PR TITLE
Part 2 of Standalone Components

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -12,10 +12,6 @@
     "packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts"
   ],
   [
-    "packages/compiler-cli/src/ngtsc/scope/src/component_scope.ts",
-    "packages/compiler-cli/src/ngtsc/scope/src/local.ts"
-  ],
-  [
     "packages/compiler/src/output/output_ast.ts",
     "packages/compiler/src/render3/view/i18n/meta.ts"
   ],

--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -90,7 +90,8 @@ export class DecorationAnalyzer {
   dtsModuleScopeResolver =
       new MetadataDtsModuleScopeResolver(this.dtsMetaReader, this.aliasingHost);
   scopeRegistry = new LocalModuleScopeRegistry(
-      this.metaRegistry, this.dtsModuleScopeResolver, this.refEmitter, this.aliasingHost);
+      this.metaRegistry, this.fullMetaReader, this.dtsModuleScopeResolver, this.refEmitter,
+      this.aliasingHost);
   fullRegistry = new CompoundMetadataRegistry([this.metaRegistry, this.scopeRegistry]);
   evaluator =
       new PartialEvaluator(this.reflectionHost, this.typeChecker, /* dependencyTracker */ null);

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -51,9 +51,9 @@ function setup(program: ts.Program, options: ts.CompilerOptions, host: ts.Compil
   const metaRegistry = new LocalMetadataRegistry();
   const dtsReader = new DtsMetadataReader(checker, reflectionHost);
   const dtsResolver = new MetadataDtsModuleScopeResolver(dtsReader, null);
-  const scopeRegistry =
-      new LocalModuleScopeRegistry(metaRegistry, dtsResolver, new ReferenceEmitter([]), null);
   const metaReader = new CompoundMetadataReader([metaRegistry, dtsReader]);
+  const scopeRegistry = new LocalModuleScopeRegistry(
+      metaRegistry, metaReader, dtsResolver, new ReferenceEmitter([]), null);
   const refEmitter = new ReferenceEmitter([]);
   const injectableRegistry = new InjectableClassRegistry(reflectionHost);
   const resourceRegistry = new ResourceRegistry();

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/test/directive_spec.ts
@@ -165,8 +165,8 @@ runInEachFileSystem(() => {
     const metaReader = new LocalMetadataRegistry();
     const dtsReader = new DtsMetadataReader(checker, reflectionHost);
     const scopeRegistry = new LocalModuleScopeRegistry(
-        metaReader, new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]),
-        null);
+        metaReader, new CompoundMetadataReader([metaReader, dtsReader]),
+        new MetadataDtsModuleScopeResolver(dtsReader, null), new ReferenceEmitter([]), null);
     const injectableRegistry = new InjectableClassRegistry(reflectionHost);
     const handler = new DirectiveDecoratorHandler(
         reflectionHost, evaluator, scopeRegistry, scopeRegistry, metaReader, injectableRegistry,

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -460,26 +460,7 @@ export class NgModuleDecoratorHandler implements
                 `${refType} ${decl.node.name.text} has no selector, please add it!`);
           }
 
-          if (dirMeta.isStandalone) {
-            diagnostics.push(makeDiagnostic(
-                ErrorCode.NGMODULE_DECLARATION_IS_STANDALONE,
-                decl.getOriginForDiagnostics(analysis.rawDeclarations!),
-                `${refType} ${
-                    decl.node.name
-                        .text} is standalone, and cannot be declared in an NgModule. Did you mean to import it instead?`));
-          }
-
           continue;
-        }
-
-        const pipeMeta = this.metaReader.getPipeMetadata(decl);
-        if (pipeMeta !== null && pipeMeta.isStandalone) {
-          diagnostics.push(makeDiagnostic(
-              ErrorCode.NGMODULE_DECLARATION_IS_STANDALONE,
-              decl.getOriginForDiagnostics(analysis.rawDeclarations!),
-              `Pipe ${
-                  decl.node.name
-                      .text} is standalone, and cannot be declared in an NgModule. Did you mean to import it instead?`));
         }
       }
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -31,7 +31,9 @@ export interface NgModuleAnalysis {
   rawDeclarations: ts.Expression|null;
   schemas: SchemaMetadata[];
   imports: Reference<ClassDeclaration>[];
+  rawImports: ts.Expression|null;
   exports: Reference<ClassDeclaration>[];
+  rawExports: ts.Expression|null;
   id: Expression|null;
   factorySymbolName: string;
   providersRequiringFactory: Set<Reference<ClassDeclaration>>|null;
@@ -211,14 +213,16 @@ export class NgModuleDecoratorHandler implements
     }
 
     let importRefs: Reference<ClassDeclaration>[] = [];
+    let rawImports: ts.Expression|null = null;
     if (ngModule.has('imports')) {
-      const rawImports = ngModule.get('imports')!;
+      rawImports = ngModule.get('imports')!;
       const importsMeta = this.evaluator.evaluate(rawImports, moduleResolvers);
       importRefs = this.resolveTypeList(rawImports, importsMeta, name, 'imports');
     }
     let exportRefs: Reference<ClassDeclaration>[] = [];
+    let rawExports: ts.Expression|null = null;
     if (ngModule.has('exports')) {
-      const rawExports = ngModule.get('exports')!;
+      rawExports = ngModule.get('exports')!;
       const exportsMeta = this.evaluator.evaluate(rawExports, moduleResolvers);
       exportRefs = this.resolveTypeList(rawExports, exportsMeta, name, 'exports');
       this.referencesRegistry.add(node, ...exportRefs);
@@ -371,7 +375,9 @@ export class NgModuleDecoratorHandler implements
         declarations: declarationRefs,
         rawDeclarations,
         imports: importRefs,
+        rawImports,
         exports: exportRefs,
+        rawExports,
         providers: rawProviders,
         providersRequiringFactory: rawProviders ?
             resolveProvidersRequiringFactory(rawProviders, this.reflector, this.evaluator) :
@@ -398,6 +404,8 @@ export class NgModuleDecoratorHandler implements
       imports: analysis.imports,
       exports: analysis.exports,
       rawDeclarations: analysis.rawDeclarations,
+      rawImports: analysis.rawImports,
+      rawExports: analysis.rawExports,
     });
 
     if (this.factoryTracker !== null) {

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/test/ng_module_spec.ts
@@ -64,7 +64,7 @@ runInEachFileSystem(() => {
       const dtsReader = new DtsMetadataReader(checker, reflectionHost);
       const metaReader = new CompoundMetadataReader([metaRegistry, dtsReader]);
       const scopeRegistry = new LocalModuleScopeRegistry(
-          metaRegistry, new MetadataDtsModuleScopeResolver(dtsReader, null),
+          metaRegistry, metaReader, new MetadataDtsModuleScopeResolver(dtsReader, null),
           new ReferenceEmitter([]), null);
       const refEmitter = new ReferenceEmitter([new LocalIdentifierStrategy()]);
       const injectableRegistry = new InjectableClassRegistry(reflectionHost);

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -964,8 +964,8 @@ export class NgCompiler {
     const localMetaReader: MetadataReader = localMetaRegistry;
     const depScopeReader = new MetadataDtsModuleScopeResolver(dtsReader, aliasingHost);
     const metaReader = new CompoundMetadataReader([localMetaReader, dtsReader]);
-    const scopeRegistry =
-        new LocalModuleScopeRegistry(localMetaReader, depScopeReader, refEmitter, aliasingHost);
+    const scopeRegistry = new LocalModuleScopeRegistry(
+        localMetaReader, metaReader, depScopeReader, refEmitter, aliasingHost);
     const scopeReader: ComponentScopeReader = scopeRegistry;
     const semanticDepGraphUpdater = this.incrementalCompilation.semanticDepGraphUpdater;
     const metaRegistry = new CompoundMetadataRegistry([localMetaRegistry, scopeRegistry]);

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -14,7 +14,6 @@ import {ClassDeclaration} from '../../reflection';
 
 import {ClassPropertyMapping, ClassPropertyName} from './property_mapping';
 
-
 /**
  * Metadata collected for an `NgModule`.
  */
@@ -32,6 +31,22 @@ export interface NgModuleMeta {
    * because the module came from a .d.ts file).
    */
   rawDeclarations: ts.Expression|null;
+
+  /**
+   * The raw `ts.Expression` which gave rise to `imports`, if one exists.
+   *
+   * If this is `null`, then either no imports exist, or no expression was available (likely
+   * because the module came from a .d.ts file).
+   */
+  rawImports: ts.Expression|null;
+
+  /**
+   * The raw `ts.Expression` which gave rise to `exports`, if one exists.
+   *
+   * If this is `null`, then either no exports exist, or no expression was available (likely
+   * because the module came from a .d.ts file).
+   */
+  rawExports: ts.Expression|null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -55,6 +55,8 @@ export class DtsMetadataReader implements MetadataReader {
       imports: extractReferencesFromType(this.checker, importMetadata, ref.bestGuessOwningModule),
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     };
   }
 

--- a/packages/compiler-cli/src/ngtsc/scope/index.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/index.ts
@@ -6,8 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {ExportScope, ScopeData} from './src/api';
-export {ComponentScopeReader, CompoundComponentScopeReader} from './src/component_scope';
+export {ComponentScopeReader, ExportScope, LocalModuleScope, ScopeData} from './src/api';
+export {CompoundComponentScopeReader} from './src/component_scope';
 export {DtsModuleScopeResolver, MetadataDtsModuleScopeResolver} from './src/dependency';
-export {DeclarationData, LocalModuleScope, LocalModuleScopeRegistry, LocalNgModuleData} from './src/local';
+export {DeclarationData, LocalModuleScopeRegistry, LocalNgModuleData} from './src/local';
 export {TypeCheckScope, TypeCheckScopeRegistry} from './src/typecheck';
+export {makeNotStandaloneDiagnostic} from './src/util';

--- a/packages/compiler-cli/src/ngtsc/scope/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/api.ts
@@ -26,11 +26,6 @@ export interface ScopeData {
   pipes: PipeMeta[];
 
   /**
-   * NgModules which contributed to the scope of the module.
-   */
-  ngModules: ClassDeclaration[];
-
-  /**
    * Whether some module or component in this scope contains errors and is thus semantically
    * unreliable.
    */

--- a/packages/compiler-cli/src/ngtsc/scope/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/api.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Reference} from '../../imports';
+import {SchemaMetadata} from '@angular/compiler';
+
+import {Reexport, Reference} from '../../imports';
 import {DirectiveMeta, PipeMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
@@ -57,4 +59,27 @@ export interface RemoteScope {
    * Those pipes used by the component that requires this scope to be set remotely.
    */
   pipes: Reference[];
+}
+
+
+export interface LocalModuleScope extends ExportScope {
+  ngModule: ClassDeclaration;
+  compilation: ScopeData;
+  reexports: Reexport[]|null;
+  schemas: SchemaMetadata[];
+}
+
+/**
+ * Read information about the compilation scope of components.
+ */
+export interface ComponentScopeReader {
+  getScopeForComponent(clazz: ClassDeclaration): LocalModuleScope|null;
+
+  /**
+   * Get the `RemoteScope` required for this component, if any.
+   *
+   * If the component requires remote scoping, then retrieve the directives/pipes registered for
+   * that component. If remote scoping is not required (the common case), returns `null`.
+   */
+  getRemoteScope(clazz: ClassDeclaration): RemoteScope|null;
 }

--- a/packages/compiler-cli/src/ngtsc/scope/src/component_scope.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/component_scope.ts
@@ -6,23 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ClassDeclaration} from '../../reflection';
-import {RemoteScope} from './api';
-import {LocalModuleScope} from './local';
 
-/**
- * Read information about the compilation scope of components.
- */
-export interface ComponentScopeReader {
-  getScopeForComponent(clazz: ClassDeclaration): LocalModuleScope|null;
-
-  /**
-   * Get the `RemoteScope` required for this component, if any.
-   *
-   * If the component requires remote scoping, then retrieve the directives/pipes registered for
-   * that component. If remote scoping is not required (the common case), returns `null`.
-   */
-  getRemoteScope(clazz: ClassDeclaration): RemoteScope|null;
-}
+import {ComponentScopeReader, LocalModuleScope, RemoteScope} from './api';
 
 /**
  * A `ComponentScopeReader` that reads from an ordered set of child readers until it obtains the

--- a/packages/compiler-cli/src/ngtsc/scope/src/dependency.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/dependency.ts
@@ -58,7 +58,6 @@ export class MetadataDtsModuleScopeResolver implements DtsModuleScopeResolver {
     // Build up the export scope - those directives and pipes made visible by this module.
     const directives: DirectiveMeta[] = [];
     const pipes: PipeMeta[] = [];
-    const ngModules = new Set<ClassDeclaration>([clazz]);
 
     const meta = this.dtsMetaReader.getNgModuleMetadata(ref);
     if (meta === null) {
@@ -115,9 +114,6 @@ export class MetadataDtsModuleScopeResolver implements DtsModuleScopeResolver {
           for (const pipe of exportScope.exported.pipes) {
             pipes.push(this.maybeAlias(pipe, sourceFile, /* isReExport */ true));
           }
-          for (const ngModule of exportScope.exported.ngModules) {
-            ngModules.add(ngModule);
-          }
         }
       }
       continue;
@@ -130,7 +126,6 @@ export class MetadataDtsModuleScopeResolver implements DtsModuleScopeResolver {
       exported: {
         directives,
         pipes,
-        ngModules: Array.from(ngModules),
         isPoisoned: false,
       },
     };

--- a/packages/compiler-cli/src/ngtsc/scope/src/local.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/local.ts
@@ -308,11 +308,33 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
       const directive = this.localReader.getDirectiveMetadata(decl);
       const pipe = this.localReader.getPipeMetadata(decl);
       if (directive !== null) {
+        if (directive.isStandalone) {
+          const refType = directive.isComponent ? 'Component' : 'Directive';
+          diagnostics.push(makeDiagnostic(
+              ErrorCode.NGMODULE_DECLARATION_IS_STANDALONE,
+              decl.getOriginForDiagnostics(ngModule.rawDeclarations!),
+              `${refType} ${
+                  decl.node.name
+                      .text} is standalone, and cannot be declared in an NgModule. Did you mean to import it instead?`));
+          isPoisoned = true;
+          continue;
+        }
+
         compilationDirectives.set(decl.node, {...directive, ref: decl});
         if (directive.isPoisoned) {
           isPoisoned = true;
         }
       } else if (pipe !== null) {
+        if (pipe.isStandalone) {
+          diagnostics.push(makeDiagnostic(
+              ErrorCode.NGMODULE_DECLARATION_IS_STANDALONE,
+              decl.getOriginForDiagnostics(ngModule.rawDeclarations!),
+              `Pipe ${
+                  decl.node.name
+                      .text} is standalone, and cannot be declared in an NgModule. Did you mean to import it instead?`));
+          isPoisoned = true;
+          continue;
+        }
         compilationPipes.set(decl.node, {...pipe, ref: decl});
       } else {
         const errorNode = decl.getOriginForDiagnostics(ngModule.rawDeclarations!);

--- a/packages/compiler-cli/src/ngtsc/scope/src/local.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/local.ts
@@ -237,11 +237,6 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
       return null;
     }
 
-    // Modules which contributed to the compilation scope of this module.
-    const compilationModules = new Set<ClassDeclaration>([ngModule.ref.node]);
-    // Modules which contributed to the export scope of this module.
-    const exportedModules = new Set<ClassDeclaration>([ngModule.ref.node]);
-
     // Errors produced during computation of the scope are recorded here. At the end, if this array
     // isn't empty then `undefined` will be cached and returned to indicate this scope is invalid.
     const diagnostics: ts.Diagnostic[] = [];
@@ -306,9 +301,6 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
       for (const pipe of importScope.exported.pipes) {
         compilationPipes.set(pipe.ref.node, pipe);
       }
-      for (const importedModule of importScope.exported.ngModules) {
-        compilationModules.add(importedModule);
-      }
     }
 
     // 2) add declarations.
@@ -366,9 +358,6 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
         for (const pipe of exportScope.exported.pipes) {
           exportPipes.set(pipe.ref.node, pipe);
         }
-        for (const exportedModule of exportScope.exported.ngModules) {
-          exportedModules.add(exportedModule);
-        }
       } else if (compilationDirectives.has(decl.node)) {
         // decl is a directive or component in the compilation scope of this NgModule.
         const directive = compilationDirectives.get(decl.node)!;
@@ -393,7 +382,6 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
     const exported: ScopeData = {
       directives: Array.from(exportDirectives.values()),
       pipes: Array.from(exportPipes.values()),
-      ngModules: Array.from(exportedModules),
       isPoisoned,
     };
 
@@ -406,7 +394,6 @@ export class LocalModuleScopeRegistry implements MetadataRegistry, ComponentScop
       compilation: {
         directives: Array.from(compilationDirectives.values()),
         pipes: Array.from(compilationPipes.values()),
-        ngModules: Array.from(compilationModules),
         isPoisoned,
       },
       exported,

--- a/packages/compiler-cli/src/ngtsc/scope/src/typecheck.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/typecheck.ts
@@ -13,7 +13,7 @@ import {Reference} from '../../imports';
 import {DirectiveMeta, flattenInheritedDirectiveMetadata, MetadataReader} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
-import {ComponentScopeReader} from './component_scope';
+import {ComponentScopeReader} from './api';
 
 /**
  * The scope that is used for type-check code generation of a component template.

--- a/packages/compiler-cli/src/ngtsc/scope/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/util.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {ErrorCode, makeDiagnostic, makeRelatedInformation} from '../../diagnostics';
+import {Reference} from '../../imports';
+import {ClassDeclaration} from '../../reflection';
+
+import {ComponentScopeReader} from './api';
+
+export function getDiagnosticNode(
+    ref: Reference<ClassDeclaration>, rawExpr: ts.Expression|null): ts.Expression {
+  // Show the diagnostic on the node within `rawExpr` which references the declaration
+  // in question. `rawExpr` represents the raw expression from which `ref` was partially evaluated,
+  // so use that to find the right node. Note that by the type system, `rawExpr` might be `null`, so
+  // fall back on the declaration identifier in that case (even though in practice this should never
+  // happen since local NgModules always have associated expressions).
+  return rawExpr !== null ? ref.getOriginForDiagnostics(rawExpr) : ref.node.name;
+}
+
+export function makeNotStandaloneDiagnostic(
+    scopeReader: ComponentScopeReader, ref: Reference<ClassDeclaration>,
+    rawExpr: ts.Expression|null, kind: 'component'|'directive'|'pipe'): ts.Diagnostic {
+  const scope = scopeReader.getScopeForComponent(ref.node);
+
+
+  let message = `The ${kind} '${
+      ref.node.name
+          .text}' appears in 'imports', but is not standalone and cannot be imported directly`;
+  let relatedInformation: ts.DiagnosticRelatedInformation[]|undefined = undefined;
+  if (scope !== null) {
+    // The directive/pipe in question is declared in an NgModule. Check if it's also exported.
+    const isExported = scope.exported.directives.some(exp => exp.ref.node === ref.node) ||
+        scope.exported.pipes.some(exp => exp.ref.node === ref.node);
+    if (isExported) {
+      relatedInformation = [makeRelatedInformation(
+          scope.ngModule.name,
+          `It can be imported using its NgModule '${scope.ngModule.name.text}' instead.`)];
+    } else {
+      relatedInformation = [makeRelatedInformation(
+          scope.ngModule.name,
+          `It's declared in the NgModule '${
+              scope.ngModule.name.text}', but is not exported. Consider exporting it.`)];
+    }
+  } else {
+    // TODO(alxhub): the above case handles directives/pipes in NgModules that are declared in the
+    // current compilation, but not those imported from .d.ts dependencies. We could likely scan the
+    // program here and find NgModules to suggest, to improve the error in that case.
+  }
+  if (relatedInformation === undefined) {
+    // If no contextual pointers can be provided to suggest a specific remedy, then at least tell
+    // the user broadly what they need to do.
+    message += ' It must be imported via an NgModule.';
+  }
+  return makeDiagnostic(
+      ErrorCode.COMPONENT_IMPORT_NOT_STANDALONE, getDiagnosticNode(ref, rawExpr), message,
+      relatedInformation);
+}

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -54,6 +54,8 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [Dir1, Pipe1],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
 
     const scope = scopeRegistry.getScopeOfModule(Module.node) as LocalModuleScope;
@@ -71,6 +73,8 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
@@ -79,6 +83,8 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleC.node),
@@ -87,6 +93,8 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -104,6 +112,8 @@ describe('LocalModuleScopeRegistry', () => {
       declarations: [],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
@@ -112,6 +122,8 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -129,6 +141,8 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [DirA, DirA, DirB, ModuleB],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
@@ -137,6 +151,8 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [DirB],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleC.node),
@@ -145,6 +161,8 @@ describe('LocalModuleScopeRegistry', () => {
       exports: [ModuleB],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
 
     const scope = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -169,6 +187,8 @@ describe('LocalModuleScopeRegistry', () => {
       declarations: [DirInModule],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
 
     const scope = scopeRegistry.getScopeOfModule(Module.node) as LocalModuleScope;
@@ -185,6 +205,8 @@ describe('LocalModuleScopeRegistry', () => {
       declarations: [],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
@@ -193,6 +215,8 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -209,6 +233,8 @@ describe('LocalModuleScopeRegistry', () => {
       declarations: [],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
     metaRegistry.registerNgModuleMetadata({
       ref: new Reference(ModuleB.node),
@@ -217,6 +243,8 @@ describe('LocalModuleScopeRegistry', () => {
       imports: [],
       schemas: [],
       rawDeclarations: null,
+      rawImports: null,
+      rawExports: null,
     });
 
     expect(scopeRegistry.getScopeOfModule(ModuleA.node)!.compilation.isPoisoned).toBeTrue();

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -11,9 +11,9 @@ import ts from 'typescript';
 import {Reference, ReferenceEmitter} from '../../imports';
 import {ClassPropertyMapping, CompoundMetadataRegistry, DirectiveMeta, DtsMetadataReader, LocalMetadataRegistry, MetadataRegistry, MetaType, PipeMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
-import {ScopeData} from '../src/api';
+import {LocalModuleScope, ScopeData} from '../src/api';
 import {DtsModuleScopeResolver} from '../src/dependency';
-import {LocalModuleScope, LocalModuleScopeRegistry} from '../src/local';
+import {LocalModuleScopeRegistry} from '../src/local';
 
 function registerFakeRefs(registry: MetadataRegistry):
     {[name: string]: Reference<ClassDeclaration>} {
@@ -40,7 +40,7 @@ describe('LocalModuleScopeRegistry', () => {
   beforeEach(() => {
     const localRegistry = new LocalMetadataRegistry();
     scopeRegistry = new LocalModuleScopeRegistry(
-        localRegistry, new MockDtsModuleScopeResolver(), refEmitter, null);
+        localRegistry, localRegistry, new MockDtsModuleScopeResolver(), refEmitter, null);
     metaRegistry = new CompoundMetadataRegistry([localRegistry, scopeRegistry]);
   });
 

--- a/packages/compiler-cli/src/ngtsc/testing/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/testing/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/file_system",
         "//packages/compiler-cli/src/ngtsc/file_system/testing",
         "//packages/compiler-cli/src/ngtsc/reflection",
+        "//packages/compiler-cli/src/ngtsc/util",
         "@npm//typescript",
     ],
 )

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -509,7 +509,6 @@ export function setup(targets: TypeCheckingTarget[], overrides: {
               // probably a declaration used in one of them. Return an empty scope.
               const emptyScope: ScopeData = {
                 directives: [],
-                ngModules: [],
                 pipes: [],
                 isPoisoned: false,
               };
@@ -611,7 +610,6 @@ export function getClass(sf: ts.SourceFile, name: string): ClassDeclaration<ts.C
  */
 function makeScope(program: ts.Program, sf: ts.SourceFile, decls: TestDeclaration[]): ScopeData {
   const scope: ScopeData = {
-    ngModules: [],
     directives: [],
     pipes: [],
     isPoisoned: false,

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -5291,7 +5291,10 @@ function allTests(os: string) {
       function verifyThrownError(errorCode: ErrorCode, errorMessage: string) {
         const errors = env.driveDiagnostics();
         expect(errors.length).toBe(1);
-        const {code, messageText} = errors[0];
+        let {code, messageText} = errors[0];
+        if (errors[0].relatedInformation !== undefined) {
+          messageText += errors[0].relatedInformation.map(info => info.messageText).join('\n');
+        }
         expect(code).toBe(ngErrorCode(errorCode));
         expect(trim(messageText as string)).toContain(errorMessage);
       }

--- a/packages/compiler-cli/test/ngtsc/scope_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/scope_spec.ts
@@ -10,8 +10,7 @@ import ts from 'typescript';
 
 import {ErrorCode, ngErrorCode} from '../../src/ngtsc/diagnostics';
 import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
-import {loadStandardTestFiles} from '../../src/ngtsc/testing';
-import {getTokenAtPosition} from '../../src/ngtsc/util/src/typescript';
+import {diagnosticToNode, loadStandardTestFiles} from '../../src/ngtsc/testing';
 
 import {NgtscTestEnvironment} from './env';
 
@@ -382,18 +381,6 @@ runInEachFileSystem(() => {
       });
     });
   });
-
-  function diagnosticToNode<T extends ts.Node>(
-      diagnostic: ts.Diagnostic|ts.DiagnosticRelatedInformation,
-      guard: (node: ts.Node) => node is T): T {
-    const diag = diagnostic as ts.Diagnostic | ts.DiagnosticRelatedInformation;
-    if (diag.file === undefined) {
-      throw new Error(`Expected ts.Diagnostic to have a file source`);
-    }
-    const node = getTokenAtPosition(diag.file, diag.start!);
-    expect(guard(node)).toBe(true);
-    return node as T;
-  }
 });
 
 function findContainingClass(node: ts.Node): ts.ClassDeclaration {

--- a/packages/compiler-cli/test/ngtsc/scope_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/scope_spec.ts
@@ -187,10 +187,9 @@ runInEachFileSystem(() => {
         `);
           const [error] = env.driveDiagnostics();
           expect(error).not.toBeUndefined();
-          expect(error.messageText).toContain('IsAModule');
-          expect(error.messageText).toContain('NgModule.imports');
           expect(error.code).toEqual(ngErrorCode(ErrorCode.NGMODULE_INVALID_IMPORT));
-          expect(diagnosticToNode(error, ts.isIdentifier).text).toEqual('NotAModule');
+          expect(diagnosticToNode(error, ts.isIdentifier).parent.parent.getText())
+              .toEqual('imports: [NotAModule]');
         });
 
         it('should produce an error when a non-class is imported from a .d.ts dependency', () => {
@@ -250,10 +249,9 @@ runInEachFileSystem(() => {
         `);
           const [error] = env.driveDiagnostics();
           expect(error).not.toBeUndefined();
-          expect(error.messageText).toContain('IsAModule');
-          expect(error.messageText).toContain('NgModule.exports');
           expect(error.code).toEqual(ngErrorCode(ErrorCode.NGMODULE_INVALID_EXPORT));
-          expect(diagnosticToNode(error, ts.isIdentifier).text).toEqual('NotAModule');
+          expect(diagnosticToNode(error, ts.isIdentifier).parent.parent.getText())
+              .toEqual('exports: [NotAModule]');
         });
 
         it('should produce a transitive error when an invalid NgModule is exported', () => {
@@ -277,9 +275,9 @@ runInEachFileSystem(() => {
           if (error === undefined) {
             return fail('Expected to find a diagnostic referencing InvalidModule');
           }
-          expect(error.messageText).toContain('IsAModule');
-          expect(error.messageText).toContain('NgModule.exports');
           expect(error.code).toEqual(ngErrorCode(ErrorCode.NGMODULE_INVALID_EXPORT));
+          expect(diagnosticToNode(error, ts.isIdentifier).parent.parent.getText())
+              .toEqual('exports: [InvalidModule]');
         });
       });
 
@@ -296,10 +294,9 @@ runInEachFileSystem(() => {
         `);
           const [error] = env.driveDiagnostics();
           expect(error).not.toBeUndefined();
-          expect(error.messageText).toContain('IsAModule');
-          expect(error.messageText).toContain('NgModule.exports');
           expect(error.code).toEqual(ngErrorCode(ErrorCode.NGMODULE_INVALID_REEXPORT));
-          expect(diagnosticToNode(error, ts.isIdentifier).text).toEqual('Dir');
+          expect(diagnosticToNode(error, ts.isIdentifier).parent.parent.getText())
+              .toEqual('exports: [Dir]');
         });
       });
 

--- a/packages/compiler-cli/test/ngtsc/standalone_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/standalone_spec.ts
@@ -45,7 +45,9 @@ runInEachFileSystem(() => {
               export class TestCmp {}
             `);
         env.driveMain();
-        expect(env.getContents('test.js')).toContain('directives: [TestDir]');
+        const jsCode = env.getContents('test.js');
+        expect(jsCode).toContain('directives: [TestDir]');
+        expect(jsCode).toContain('standalone: true');
       });
 
       it('should error when a non-standalone component tries to use imports', () => {
@@ -395,6 +397,36 @@ runInEachFileSystem(() => {
         expect(diags[0].messageText).toContain('is not standalone');
         expect(diagnosticToNode(diags[0], ts.isIdentifier).parent.parent.getText())
             .toEqual('imports: [TestDir]');
+      });
+    });
+
+    describe('other types', () => {
+      it('should compile a basic standalone directive', () => {
+        env.write('test.ts', `
+              import {Directive} from '@angular/core';
+        
+              @Directive({
+                selector: '[dir]',
+                standalone: true,
+              })
+              export class TestDir {}
+            `);
+        env.driveMain();
+        expect(env.getContents('test.js')).toContain('standalone: true');
+      });
+
+      it('should compile a basic standalone pipe', () => {
+        env.write('test.ts', `
+              import {Pipe} from '@angular/core';
+        
+              @Pipe({
+                name: 'testpipe',
+                standalone: true,
+              })
+              export class TestPipe {}
+            `);
+        env.driveMain();
+        expect(env.getContents('test.js')).toContain('standalone: true');
       });
     });
   });

--- a/packages/compiler-cli/test/ngtsc/standalone_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/standalone_spec.ts
@@ -23,219 +23,139 @@ runInEachFileSystem(() => {
       env.tsconfig();
     });
 
-    it('should compile a basic standalone component', () => {
-      env.write('test.ts', `
-        import {Component, Directive} from '@angular/core';
-  
-        @Directive({
-          selector: '[dir]',
-          standalone: true,
-        })
-        export class TestDir {}
-  
-        @Component({
-          selector: 'test-cmp',
-          template: '<div dir></div>',
-          standalone: true,
-          imports: [TestDir],
-        })
-        export class TestCmp {}
-      `);
-      env.driveMain();
-      expect(env.getContents('test.js')).toContain('directives: [TestDir]');
-    });
+    describe('component-side', () => {
+      it('should compile a basic standalone component', () => {
+        env.write('test.ts', `
+              import {Component, Directive} from '@angular/core';
+        
+              @Directive({
+                selector: '[dir]',
+                standalone: true,
+              })
+              export class TestDir {}
+        
+              @Component({
+                selector: 'test-cmp',
+                template: '<div dir></div>',
+                standalone: true,
+                imports: [TestDir],
+              })
+              export class TestCmp {}
+            `);
+        env.driveMain();
+        expect(env.getContents('test.js')).toContain('directives: [TestDir]');
+      });
 
-    it('should error when a non-standalone component tries to use imports', () => {
-      env.write('test.ts', `
-        import {Component, Directive} from '@angular/core';
-  
-        @Directive({
-          selector: '[dir]',
-          standalone: true,
-        })
-        export class TestDir {}
-  
-        @Component({
-          selector: 'test-cmp',
-          template: '<div dir></div>',
-          imports: [TestDir],
-        })
-        export class TestCmp {}
-      `);
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.COMPONENT_NOT_STANDALONE));
-      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('[TestDir]');
-    });
+      it('should error when a non-standalone component tries to use imports', () => {
+        env.write('test.ts', `
+              import {Component, Directive} from '@angular/core';
+        
+              @Directive({
+                selector: '[dir]',
+                standalone: true,
+              })
+              export class TestDir {}
+        
+              @Component({
+                selector: 'test-cmp',
+                template: '<div dir></div>',
+                imports: [TestDir],
+              })
+              export class TestCmp {}
+            `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].code).toBe(ngErrorCode(ErrorCode.COMPONENT_NOT_STANDALONE));
+        expect(getSourceCodeForDiagnostic(diags[0])).toEqual('[TestDir]');
+      });
 
-    it('should compile a standalone component that imports an NgModule', () => {
-      env.write('test.ts', `
-        import {Component, Directive, NgModule} from '@angular/core';
-  
-        @Directive({
-          selector: '[dir]',
-        })
-        export class TestDir {}
+      it('should compile a standalone component that imports an NgModule', () => {
+        env.write('test.ts', `
+              import {Component, Directive, NgModule} from '@angular/core';
+        
+              @Directive({
+                selector: '[dir]',
+              })
+              export class TestDir {}
+      
+              @NgModule({
+                declarations: [TestDir],
+                exports: [TestDir],
+              })
+              export class TestModule {}
+        
+              @Component({
+                selector: 'test-cmp',
+                template: '<div dir></div>',
+                standalone: true,
+                imports: [TestModule],
+              })
+              export class TestCmp {}
+            `);
+        env.driveMain();
+        expect(env.getContents('test.js')).toContain('directives: [TestDir]');
+      });
 
-        @NgModule({
-          declarations: [TestDir],
-          exports: [TestDir],
-        })
-        export class TestModule {}
-  
-        @Component({
-          selector: 'test-cmp',
-          template: '<div dir></div>',
-          standalone: true,
-          imports: [TestModule],
-        })
-        export class TestCmp {}
-      `);
-      env.driveMain();
-      expect(env.getContents('test.js')).toContain('directives: [TestDir]');
-    });
+      it('should allow nested arrays in standalone component imports', () => {
+        env.write('test.ts', `
+              import {Component, Directive} from '@angular/core';
+        
+              @Directive({
+                selector: '[dir]',
+                standalone: true,
+              })
+              export class TestDir {}
+      
+              export const DIRECTIVES = [TestDir];
+        
+              @Component({
+                selector: 'test-cmp',
+                template: '<div dir></div>',
+                standalone: true,
+                imports: [DIRECTIVES],
+              })
+              export class TestCmp {}
+            `);
+        env.driveMain();
+        expect(env.getContents('test.js')).toContain('directives: [TestDir]');
+      });
 
-    it('should allow nested arrays in standalone component imports', () => {
-      env.write('test.ts', `
-        import {Component, Directive} from '@angular/core';
-  
-        @Directive({
-          selector: '[dir]',
-          standalone: true,
-        })
-        export class TestDir {}
+      it('should deduplicate standalone component imports', () => {
+        env.write('test.ts', `
+              import {Component, Directive} from '@angular/core';
+        
+              @Directive({
+                selector: '[dir]',
+                standalone: true,
+              })
+              export class TestDir {}
+      
+              export const DIRECTIVES = [TestDir];
+        
+              @Component({
+                selector: 'test-cmp',
+                template: '<div dir></div>',
+                standalone: true,
+                imports: [TestDir, DIRECTIVES],
+              })
+              export class TestCmp {}
+            `);
+        env.driveMain();
+        expect(env.getContents('test.js')).toContain('directives: [TestDir]');
+      });
 
-        export const DIRECTIVES = [TestDir];
-  
-        @Component({
-          selector: 'test-cmp',
-          template: '<div dir></div>',
-          standalone: true,
-          imports: [DIRECTIVES],
-        })
-        export class TestCmp {}
-      `);
-      env.driveMain();
-      expect(env.getContents('test.js')).toContain('directives: [TestDir]');
-    });
-
-    it('should deduplicate standalone component imports', () => {
-      env.write('test.ts', `
-        import {Component, Directive} from '@angular/core';
-  
-        @Directive({
-          selector: '[dir]',
-          standalone: true,
-        })
-        export class TestDir {}
-
-        export const DIRECTIVES = [TestDir];
-  
-        @Component({
-          selector: 'test-cmp',
-          template: '<div dir></div>',
-          standalone: true,
-          imports: [TestDir, DIRECTIVES],
-        })
-        export class TestCmp {}
-      `);
-      env.driveMain();
-      expect(env.getContents('test.js')).toContain('directives: [TestDir]');
-    });
-
-    it('should not allow a standalone component to be declared in an NgModule', () => {
-      env.write('test.ts', `
-        import {Component, NgModule} from '@angular/core';
-  
-        @Component({
-          selector: 'test-cmp',
-          template: 'Test',
-          standalone: true,
-        })
-        export class TestCmp {}
-
-        @NgModule({
-          declarations: [TestCmp],
-        })
-        export class TestModule {}
-      `);
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.NGMODULE_DECLARATION_IS_STANDALONE));
-      expect(diags[0].messageText).toContain('Component TestCmp is standalone');
-      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('TestCmp');
-    });
-
-    it('should not allow a standalone pipe to be declared in an NgModule', () => {
-      env.write('test.ts', `
-        import {Pipe, NgModule} from '@angular/core';
-  
-        @Pipe({
-          name: 'test',
-          standalone: true,
-        })
-        export class TestPipe {}
-
-        @NgModule({
-          declarations: [TestPipe],
-        })
-        export class TestModule {}
-      `);
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.NGMODULE_DECLARATION_IS_STANDALONE));
-      expect(diags[0].messageText).toContain('Pipe TestPipe is standalone');
-      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('TestPipe');
-    });
-
-    it('should error when a standalone component imports a non-standalone entity', () => {
-      env.write('test.ts', `
-        import {Component, Directive, NgModule} from '@angular/core';
-  
-        @Directive({
-          selector: '[dir]',
-        })
-        export class TestDir {}
-
-        @NgModule({
-          declarations: [TestDir],
-          exports: [TestDir],
-        })
-        export class TestModule {}
-  
-        @Component({
-          selector: 'test-cmp',
-          template: '<div dir></div>',
-          standalone: true,
-          imports: [TestDir],
-        })
-        export class TestCmp {}
-      `);
-      const diags = env.driveDiagnostics();
-      expect(diags.length).toBe(1);
-      expect(diags[0].code).toBe(ngErrorCode(ErrorCode.COMPONENT_IMPORT_NOT_STANDALONE));
-      expect(getSourceCodeForDiagnostic(diags[0])).toEqual('TestDir');
-
-      // The diagnostic produced here should suggest that the directive be imported via its NgModule
-      // instead.
-      expect(diags[0].relatedInformation).not.toBeUndefined();
-      expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0])).toEqual('TestModule');
-      expect(diags[0].relatedInformation![0].messageText)
-          .toContain('It can be imported using its NgModule');
-    });
-
-    it('should error when a standalone component imports a non-standalone entity, with a specific error when that entity is not exported',
-       () => {
-         env.write('test.ts', `
+      it('should error when a standalone component imports a non-standalone entity', () => {
+        env.write('test.ts', `
           import {Component, Directive, NgModule} from '@angular/core';
     
           @Directive({
             selector: '[dir]',
           })
           export class TestDir {}
-
+  
           @NgModule({
             declarations: [TestDir],
+            exports: [TestDir],
           })
           export class TestModule {}
     
@@ -247,18 +167,103 @@ runInEachFileSystem(() => {
           })
           export class TestCmp {}
         `);
-         const diags = env.driveDiagnostics();
-         expect(diags.length).toBe(1);
-         expect(diags[0].code).toBe(ngErrorCode(ErrorCode.COMPONENT_IMPORT_NOT_STANDALONE));
-         expect(getSourceCodeForDiagnostic(diags[0])).toEqual('TestDir');
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].code).toBe(ngErrorCode(ErrorCode.COMPONENT_IMPORT_NOT_STANDALONE));
+        expect(getSourceCodeForDiagnostic(diags[0])).toEqual('TestDir');
 
-         // The diagnostic produced here should suggest that the directive be imported via its
-         // NgModule instead.
-         expect(diags[0].relatedInformation).not.toBeUndefined();
-         expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0])).toEqual('TestModule');
-         expect(diags[0].relatedInformation![0].messageText)
-             .toEqual(
-                 `It's declared in the NgModule 'TestModule', but is not exported. Consider exporting it.`);
-       });
+        // The diagnostic produced here should suggest that the directive be imported via its
+        // NgModule instead.
+        expect(diags[0].relatedInformation).not.toBeUndefined();
+        expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0])).toEqual('TestModule');
+        expect(diags[0].relatedInformation![0].messageText)
+            .toContain('It can be imported using its NgModule');
+      });
+
+      it('should error when a standalone component imports a non-standalone entity, with a specific error when that entity is not exported',
+         () => {
+           env.write('test.ts', `
+            import {Component, Directive, NgModule} from '@angular/core';
+      
+            @Directive({
+              selector: '[dir]',
+            })
+            export class TestDir {}
+  
+            @NgModule({
+              declarations: [TestDir],
+            })
+            export class TestModule {}
+      
+            @Component({
+              selector: 'test-cmp',
+              template: '<div dir></div>',
+              standalone: true,
+              imports: [TestDir],
+            })
+            export class TestCmp {}
+          `);
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(1);
+           expect(diags[0].code).toBe(ngErrorCode(ErrorCode.COMPONENT_IMPORT_NOT_STANDALONE));
+           expect(getSourceCodeForDiagnostic(diags[0])).toEqual('TestDir');
+
+           // The diagnostic produced here should suggest that the directive be imported via its
+           // NgModule instead.
+           expect(diags[0].relatedInformation).not.toBeUndefined();
+           expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0]))
+               .toEqual('TestModule');
+           expect(diags[0].relatedInformation![0].messageText)
+               .toEqual(
+                   `It's declared in the NgModule 'TestModule', but is not exported. Consider exporting it.`);
+         });
+    });
+
+    describe('NgModule-side', () => {
+      it('should not allow a standalone component to be declared in an NgModule', () => {
+        env.write('test.ts', `
+              import {Component, NgModule} from '@angular/core';
+        
+              @Component({
+                selector: 'test-cmp',
+                template: 'Test',
+                standalone: true,
+              })
+              export class TestCmp {}
+      
+              @NgModule({
+                declarations: [TestCmp],
+              })
+              export class TestModule {}
+            `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].code).toBe(ngErrorCode(ErrorCode.NGMODULE_DECLARATION_IS_STANDALONE));
+        expect(diags[0].messageText).toContain('Component TestCmp is standalone');
+        expect(getSourceCodeForDiagnostic(diags[0])).toEqual('TestCmp');
+      });
+
+      it('should not allow a standalone pipe to be declared in an NgModule', () => {
+        env.write('test.ts', `
+              import {Pipe, NgModule} from '@angular/core';
+        
+              @Pipe({
+                name: 'test',
+                standalone: true,
+              })
+              export class TestPipe {}
+      
+              @NgModule({
+                declarations: [TestPipe],
+              })
+              export class TestModule {}
+            `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].code).toBe(ngErrorCode(ErrorCode.NGMODULE_DECLARATION_IS_STANDALONE));
+        expect(diags[0].messageText).toContain('Pipe TestPipe is standalone');
+        expect(getSourceCodeForDiagnostic(diags[0])).toEqual('TestPipe');
+      });
+    });
   });
 });

--- a/packages/compiler/src/render3/r3_pipe_compiler.ts
+++ b/packages/compiler/src/render3/r3_pipe_compiler.ts
@@ -69,6 +69,10 @@ export function compilePipeFromMetadata(metadata: R3PipeMetadata): R3CompiledExp
   // e.g. `pure: true`
   definitionMapValues.push({key: 'pure', value: o.literal(metadata.pure), quoted: false});
 
+  if (metadata.isStandalone) {
+    definitionMapValues.push({key: 'standalone', value: o.literal(true), quoted: false});
+  }
+
   const expression =
       o.importExpr(R3.definePipe).callFn([o.literalMap(definitionMapValues)], undefined, true);
   const type = createPipeType(metadata);

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -77,6 +77,10 @@ function baseDirectiveFields(
     definitionMap.set('exportAs', o.literalArr(meta.exportAs.map(e => o.literal(e))));
   }
 
+  if (meta.isStandalone) {
+    definitionMap.set('standalone', o.literal(true));
+  }
+
   return definitionMap;
 }
 

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -284,6 +284,11 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
    * The set of schemas that declare elements to be allowed in the component's template.
    */
   schemas?: SchemaMetadata[] | null;
+
+  /**
+   * Whether this directive/component is standalone.
+   */
+  standalone?: boolean;
 }): unknown {
   return noSideEffects(() => {
     // Initialize ngDevMode. This must be the first statement in ɵɵdefineComponent.
@@ -312,6 +317,7 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
       onPush: componentDefinition.changeDetection === ChangeDetectionStrategy.OnPush,
       directiveDefs: null!,  // assigned in noSideEffects
       pipeDefs: null!,       // assigned in noSideEffects
+      standalone: componentDefinition.standalone === true,
       selectors: componentDefinition.selectors || EMPTY_ARRAY,
       viewQuery: componentDefinition.viewQuery || null,
       features: componentDefinition.features as DirectiveDefFeature[] || null,
@@ -709,13 +715,19 @@ export function ɵɵdefinePipe<T>(pipeDef: {
   type: Type<T>,
 
   /** Whether the pipe is pure. */
-  pure?: boolean
+  pure?: boolean,
+
+  /**
+   * Whether the pipe is standalone.
+   */
+  standalone?: boolean,
 }): unknown {
   return (<PipeDef<T>>{
     type: pipeDef.type,
     name: pipeDef.name,
     factory: null,
     pure: pipeDef.pure !== false,
+    standalone: pipeDef.standalone === true,
     onDestroy: pipeDef.type.prototype.ngOnDestroy || null
   });
 }

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -190,6 +190,11 @@ export interface DirectiveDef<T> {
   readonly exportAs: string[]|null;
 
   /**
+   * Whether this directive (or component) is standalone.
+   */
+  readonly standalone: boolean;
+
+  /**
    * Factory function used to create a new directive instance. Will be null initially.
    * Populated when the factory is first requested by directive instantiation logic.
    */
@@ -354,6 +359,11 @@ export interface PipeDef<T> {
    * state of the pipe.
    */
   readonly pure: boolean;
+
+  /**
+   * Whether this pipe is standalone.
+   */
+  readonly standalone: boolean;
 
   /* The following are lifecycle hooks for this pipe */
   onDestroy: (() => void)|null;


### PR DESCRIPTION
Part 1 implemented the `standalone` flag in components/directives/pipes, and `imports` for components. In this PR, NgModules gain support for importing standalone types.