### PR TITLE
fix(docs-infra): eslint parsing-error

### DIFF
--- a/aio/content/examples/.eslintrc.json
+++ b/aio/content/examples/.eslintrc.json
@@ -37,7 +37,7 @@
       ],
       "parserOptions": {
         "createDefaultProgram": false,
-        "project": "content/examples/tsconfig.eslint.json"
+        "project": "tsconfig.eslint.json"
       },
       "rules": {
         "@typescript-eslint/ban-types": "error",


### PR DESCRIPTION
Fixed can not read tsconfig.eslint.json file.
At "parserOptions -> project" file path name was wrong.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

![image](https://user-images.githubusercontent.com/28996115/152666648-f421ff52-8850-4e64-af05-1e8867ccba82.png)

Issue Number: N/A


## What is the new behavior?

Error is fixed by changing the wrong path value in tsconfig.eslint.json file. Eslint doesn't complain no more.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
