### PR TITLE
refactor(http): deprecated symbol used

### DIFF
--- a/aio/content/examples/http/src/app/config/config.component.ts
+++ b/aio/content/examples/http/src/app/config/config.component.ts
@@ -69,7 +69,7 @@ export class ConfigComponent {
   }
 // #enddocregion showConfigResponse
   makeError() {
-    this.configService.makeIntentionalError().subscribe(null, error => this.error = error );
+    this.configService.makeIntentionalError().subscribe(null, error => this.error = error.message );
   }
 
   getType(val: any): string {

--- a/aio/content/examples/http/src/app/config/config.service.ts
+++ b/aio/content/examples/http/src/app/config/config.service.ts
@@ -82,9 +82,7 @@ export class ConfigService {
         `Backend returned code ${error.status}, body was: `, error.error);
     }
     // Return an observable with a user-facing error message.
-    return throwError(() => {
-      new Error('Something bad happened; please try again later.');
-    });
+    return throwError(() => new Error('Something bad happened; please try again later.'));
   }
   // #enddocregion handleError
 

--- a/aio/content/examples/http/src/app/config/config.service.ts
+++ b/aio/content/examples/http/src/app/config/config.service.ts
@@ -82,8 +82,9 @@ export class ConfigService {
         `Backend returned code ${error.status}, body was: `, error.error);
     }
     // Return an observable with a user-facing error message.
-    return throwError(
-      'Something bad happened; please try again later.');
+    return throwError(() => {
+      new Error('Something bad happened; please try again later.');
+    });
   }
   // #enddocregion handleError
 


### PR DESCRIPTION
Support for passing an error value to "throwError" method will be removed in v8 of rxjs. More info at https://rxjs.dev/api/index/function/throwError#throwerror

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Deprecated symbol used.

Issue Number: N/A


## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
