### PR TITLE
fix(docs-infra): implement focus trap for aio search results

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -9,7 +9,7 @@
 </div>
 
 <header>
-  <mat-toolbar color="primary" class="app-toolbar no-print" [class.transitioning]="isTransitioning">
+  <mat-toolbar #appToolbar color="primary" class="app-toolbar no-print" [class.transitioning]="isTransitioning">
     <mat-toolbar-row class="notification-container">
       <aio-notification notificationId="war-ukraine" expirationDate="null" [dismissOnContentClick]="false" (dismissed)="notificationDismissed()">
         <a class="link" target="_blank" rel="noopener" href="https://www.google.org/ukraine-relief/">
@@ -33,9 +33,9 @@
         <img *ngSwitchDefault src="assets/images/logos/angular/shield-large.svg" width="37" height="40" title="Home" alt="Home">
       </a>
       <aio-top-menu *ngIf="showTopMenu" [nodes]="topMenuNodes" [currentNode]="currentNodes?.TopBar"></aio-top-menu>
-      <aio-search-box class="search-container" #searchBox (onSearch)="doSearch($event)" (onFocus)="doSearch($event)"></aio-search-box>
-      <aio-theme-toggle></aio-theme-toggle>
-      <div class="toolbar-external-icons-container">
+      <aio-search-box class="search-container" #searchBox (onSearch)="doSearch($event)" (onFocus)="doSearch($event, true)"></aio-search-box>
+      <aio-theme-toggle #themeToggle></aio-theme-toggle>
+      <div #externalIcons class="toolbar-external-icons-container">
         <a mat-icon-button href="https://twitter.com/angular" title="Twitter" aria-label="Angular on twitter">
           <mat-icon svgIcon="logos:twitter"></mat-icon>
         </a>

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -756,6 +756,8 @@ describe('AppComponent', () => {
         it('should clear "only" the search query param from the URL', () => {
           // Mock out the current state of the URL query params
           locationService.search.and.returnValue({ a: 'some-A', b: 'some-B', search: 'some-C'});
+          // the clearing only happens when some results are actually being shown
+          component.showSearchResults = true;
           // docViewer is a commonly-clicked, non-search element
           docViewer.click();
           // Check that the query params were updated correctly
@@ -847,11 +849,20 @@ describe('AppComponent', () => {
           expect(component.showSearchResults).toBe(false);
         });
 
-        it('should re-run the search when the search box regains focus', () => {
-          const doSearchSpy = spyOn(component, 'doSearch');
+        it('should re-run the search when the search box regains focus and there are no results being shown', () => {
+          const searchService = TestBed.inject(SearchService) as Partial<SearchService> as MockSearchService;
+          component.showSearchResults = false;
           const searchBox = fixture.debugElement.query(By.directive(SearchBoxComponent));
           searchBox.triggerEventHandler('onFocus', 'some query');
-          expect(doSearchSpy).toHaveBeenCalledWith('some query');
+          expect(searchService.search).toHaveBeenCalledWith('some query');
+        });
+
+        it('should not re-run the search when the search box regains focus and there are results being shown', () => {
+          const searchService = TestBed.inject(SearchService) as Partial<SearchService> as MockSearchService;
+          component.showSearchResults = true;
+          const searchBox = fixture.debugElement.query(By.directive(SearchBoxComponent));
+          searchBox.triggerEventHandler('onFocus', 'some query');
+          expect(searchService.search).not.toHaveBeenCalled();
         });
       });
     });

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 449905,
+        "main": 450884,
         "polyfills": 33869,
         "styles": 70515,
         "light-theme": 77708,
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 450969,
+        "main": 451472,
         "polyfills": 33980,
         "styles": 70515,
         "light-theme": 77708,


### PR DESCRIPTION
currently if a user tries to navigate via keyboard, once the are
presented with search results, the search results panel remains
present and can potentially hide most of the content on the page,
in such case keyboard navigation will be severly hindered and
the only option for the user would be to go back to the seach input
text and clear its value, fix such inconvenience by looping the
focus in the header area close to the search results and the
results panel itself

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

- before
   ![before](https://user-images.githubusercontent.com/61631103/152695256-6cd3f6a8-00ef-457b-a0aa-43f25987a2ff.gif)

- after:
   ![after](https://user-images.githubusercontent.com/61631103/152695259-43ecd677-ccce-4e20-ae30-8b4781cd6947.gif)

- as you can notice from the gifs (especially the second one) there is also an issue with the elements in the sidenav being in the tab order even when they are not on screen, since it is unrelated I'll address it in a separate PR :slightly_smiling_face: 
 