### PR TITLE
fix(docs-infra): fix sidenav elements being focusable off screen

### DIFF
--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -54,7 +54,7 @@ export class AppComponent implements OnInit {
    */
   pageId: string;
   /**
-   * An HTML friendly identifer for the "folder" of the currently displayed page.
+   * An HTML friendly identifier for the "folder" of the currently displayed page.
    * This is computed by taking everything up to the first `/` in the `currentDocument.id`
    */
   folderId: string;

--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -101,7 +101,6 @@ aio-nav-menu {
 
     .heading-children {
       &.expanded {
-        visibility: visible;
         opacity: 1;
         padding-left: 0;
         max-height: 4000px; // Arbitrary max-height. Can increase if needed. Must have measurement to transition height.


### PR DESCRIPTION
some elements in the aio sidenav (especially anchors) are still
included in the tab order even though they are not visible, fix
such behavior by applying `display: none` to the closed sidenav
so that its elements become non-interactable

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

In the aio sidevan elements off screen are still present in the tab order which is not correct

For example:
![sidenav-before](https://user-images.githubusercontent.com/61631103/152705189-66cb79c3-d316-48b7-98b5-1f35d3ac3a9e.gif)
(notice the urls at the bottom of the page appearing as I am pressing `tab`)


Issue Number: N/A


## What is the new behavior?

I've added a display none to the sidenav so that its elements cannot get focus anymore:
![sidenav-after](https://user-images.githubusercontent.com/61631103/152705243-01a430cb-f916-417d-b131-b66162293b96.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
