### PR TITLE
Chain elementStart/elementEnd instructions

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/array_literals_null_vs_empty.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/array_literals_null_vs_empty.js
@@ -10,8 +10,7 @@ MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   consts: [[__AttributeMarker.Bindings__, "dir"]],
   template:  function MyApp_Template(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵelement(0, "div", 0);
-      $r3$.ɵɵelement(1, "div", 0);
+      $r3$.ɵɵelement(0, "div", 0)(1, "div", 0);
     }
     if (rf & 2) {
       $r3$.ɵɵproperty("dir", $r3$.ɵɵpureFunction0(2, $c0$));

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/lifecycle_hooks/lifecycle_hooks_simple_layout_def.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/lifecycle_hooks/lifecycle_hooks_simple_layout_def.js
@@ -6,8 +6,7 @@ SimpleLayout.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   consts: [[__AttributeMarker.Bindings__, "name"]],
   template:  function SimpleLayout_Template(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵelement(0, "lifecycle-comp", 0);
-      $r3$.ɵɵelement(1, "lifecycle-comp", 0);
+      $r3$.ɵɵelement(0, "lifecycle-comp", 0)(1, "lifecycle-comp", 0);
     }
     if (rf & 2) {
       $r3$.ɵɵproperty("name", ctx.name1);

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_empty.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_empty.js
@@ -10,8 +10,7 @@ MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   consts: [[__AttributeMarker.Bindings__, "dir"]],
   template:  function MyApp_Template(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵelement(0, "div", 0);
-      $r3$.ɵɵelement(1, "div", 0);
+      $r3$.ɵɵelement(0, "div", 0)(1, "div", 0);
     }
     if (rf & 2) {
       $r3$.ɵɵproperty("dir", $r3$.ɵɵpureFunction0(2, $c0$));

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_function.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/object_literals_null_vs_function.js
@@ -9,8 +9,7 @@ MyApp.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   consts: [[__AttributeMarker.Bindings__, "dir"]],
   template:  function MyApp_Template(rf, ctx) {
     if (rf & 1) {
-      $r3$.ɵɵelement(0, "div", 0);
-      $r3$.ɵɵelement(1, "div", 0);
+      $r3$.ɵɵelement(0, "div", 0)(1, "div", 0);
     }
     if (rf & 2) {
       $r3$.ɵɵproperty("dir", $r3$.ɵɵpureFunction0(2, $c0$));

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/template_variables/parent_template_variable.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/template_variables/parent_template_variable.js
@@ -14,14 +14,12 @@ function MyComponent_li_1_li_4_Template(rf, ctx) {
 
 function MyComponent_li_1_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵelementStart(0, "li");
-    $r3$.ɵɵelementStart(1, "div");
+    $r3$.ɵɵelementStart(0, "li")(1, "div");
     $r3$.ɵɵtext(2);
     $r3$.ɵɵelementEnd();
     $r3$.ɵɵelementStart(3, "ul");
     $r3$.ɵɵtemplate(4, MyComponent_li_1_li_4_Template, 2, 2, "li", 0);
-    $r3$.ɵɵelementEnd();
-    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd()();
   }
   if (rf & 2) {
     const $item$ = ctx.$implicit;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/deduplicate_attributes.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/deduplicate_attributes.js
@@ -1,8 +1,7 @@
 consts: [["title", "hi"]],
 template: function MyComponent_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵelement(0, "div", 0);
-    $r3$.ɵɵelement(1, "span", 0);
+    $r3$.ɵɵelement(0, "div", 0)(1, "span", 0);
   }
   …
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/mathml_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/mathml_template.js
@@ -10,7 +10,6 @@ template: function MyComponent_Template(rf, ctx) {
     $r3$.ɵɵnamespaceHTML();
     $r3$.ɵɵelementStart(3, "p");
     $r3$.ɵɵtext(4, "test");
-    $r3$.ɵɵelementEnd();
-    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd()();
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/security_sensitive_constant_attributes.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/security_sensitive_constant_attributes.js
@@ -6,11 +6,7 @@ consts: [
 ],
 template: function MyComponent_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵelement(0, "embed", 0);
-    $r3$.ɵɵelement(1, "iframe", 1);
-    $r3$.ɵɵelement(2, "object", 2);
-    $r3$.ɵɵelement(3, "embed", 0);
-    $r3$.ɵɵelement(4, "img", 3);
+    $r3$.ɵɵelement(0, "embed", 0)(1, "iframe", 1)(2, "object", 2)(3, "embed", 0)(4, "img", 3);
   }
   …
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/svg_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/svg_template.js
@@ -9,7 +9,6 @@ consts: [["title", "Hello", 1, "my-app"], ["cx", "20", "cy", "30", "r", "50"]],
         $r3$.ɵɵnamespaceHTML();
         $r3$.ɵɵelementStart(3, "p");
         $r3$.ɵɵtext(4, "test");
-        $r3$.ɵɵelementEnd();
-        $r3$.ɵɵelementEnd();
+        $r3$.ɵɵelementEnd()();
       }
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/nullish_coalescing/nullish_coalescing_property_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/nullish_coalescing/nullish_coalescing_property_template.js
@@ -1,7 +1,6 @@
 template: function MyApp_Template(rf, ctx) {
   if (rf & 1) {
-    i0.ɵɵelement(0, "div", 0);
-    i0.ɵɵelement(1, "span", 0);
+    i0.ɵɵelement(0, "div", 0)(1, "span", 0);
   }
   if (rf & 2) {
     let $tmp_0_0$;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolation_nested_context.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/interpolation_nested_context.js
@@ -1,11 +1,9 @@
 function MyComponent_div_0_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵelementStart(0, "div");
-    $r3$.ɵɵelementStart(1, "div", 1);
+    $r3$.ɵɵelementStart(0, "div")(1, "div", 1);
     $r3$.ɵɵpipe(2, "uppercase");
     $r3$.ɵɵi18nAttributes(3, 2);
-    $r3$.ɵɵelementEnd();
-    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd()();
   }
   if (rf & 2) {
     const $outer_r1$ = ctx.$implicit;

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/namespaces/foreign_object.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/namespaces/foreign_object.js
@@ -25,15 +25,13 @@ consts: function() {
 template: function MyComponent_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵnamespaceSVG();
-    $r3$.ɵɵelementStart(0, "svg", 0);
-    $r3$.ɵɵelementStart(1, "foreignObject");
+    $r3$.ɵɵelementStart(0, "svg", 0)(1, "foreignObject");
     $r3$.ɵɵi18nStart(2, 1);
     $r3$.ɵɵnamespaceHTML();
     $r3$.ɵɵelementStart(3, "div", 2);
     $r3$.ɵɵelement(4, "span");
     $r3$.ɵɵelementEnd();
     $r3$.ɵɵi18nEnd();
-    $r3$.ɵɵelementEnd();
-    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd()();
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/namespaces/namespaced_div.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/namespaces/namespaced_div.js
@@ -22,15 +22,12 @@ consts: function() {
 template: function MyComponent_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵnamespaceSVG();
-    $r3$.ɵɵelementStart(0, "svg", 0);
-    $r3$.ɵɵelementStart(1, "foreignObject");
+    $r3$.ɵɵelementStart(0, "svg", 0)(1, "foreignObject");
     $r3$.ɵɵnamespaceHTML();
     $r3$.ɵɵelementStart(2, "div", 1);
     $r3$.ɵɵi18nStart(3, 2);
     $r3$.ɵɵelement(4, "span");
     $r3$.ɵɵi18nEnd();
-    $r3$.ɵɵelementEnd();
-    $r3$.ɵɵelementEnd();
-    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd()()();
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/empty_content.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/empty_content.js
@@ -1,7 +1,5 @@
 template: function MyComponent_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵelement(0, "div");
-    $r3$.ɵɵelement(1, "div");
-    $r3$.ɵɵelement(2, "div");
+    $r3$.ɵɵelement(0, "div")(1, "div")(2, "div");
   }
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/nested_elements.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/nested_elements.js
@@ -18,11 +18,9 @@ template: function MyComponent_Template(rf, ctx) {
     $r3$.ɵɵelementStart(3, "div");
     $r3$.ɵɵi18nStart(4, 1);
     $r3$.ɵɵpipe(5, "uppercase");
-    $r3$.ɵɵelementStart(6, "div");
-    $r3$.ɵɵelementStart(7, "div");
+    $r3$.ɵɵelementStart(6, "div")(7, "div");
     $r3$.ɵɵelement(8, "span");
-    $r3$.ɵɵelementEnd();
-    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd()();
     $r3$.ɵɵi18nEnd();
     $r3$.ɵɵelementEnd();
   }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/nested_templates.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/nested_templates.js
@@ -1,13 +1,11 @@
 function MyComponent_div_2_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵelementStart(0, "div");
-    $r3$.ɵɵelementStart(1, "div");
+    $r3$.ɵɵelementStart(0, "div")(1, "div");
     $r3$.ɵɵi18nStart(2, 1);
     $r3$.ɵɵelement(3, "div");
     $r3$.ɵɵpipe(4, "uppercase");
     $r3$.ɵɵi18nEnd();
-    $r3$.ɵɵelementEnd();
-    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd()();
   }
   if (rf & 2) {
     const $ctx_r0$ = $r3$.ɵɵnextContext();

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/nested_templates_context.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/nested_templates_context.js
@@ -16,12 +16,10 @@ function MyComponent_div_2_div_4_Template(rf, ctx) {
 function MyComponent_div_2_Template(rf, ctx) {
   if (rf & 1) {
     $r3$.ɵɵi18nStart(0, 0, 1);
-    $r3$.ɵɵelementStart(1, "div");
-    $r3$.ɵɵelementStart(2, "div");
+    $r3$.ɵɵelementStart(1, "div")(2, "div");
     $r3$.ɵɵpipe(3, "uppercase");
     $r3$.ɵɵtemplate(4, MyComponent_div_2_div_4_Template, 3, 2, "div", 1);
-    $r3$.ɵɵelementEnd();
-    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd()();
     $r3$.ɵɵi18nEnd();
   }
   if (rf & 2) {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/shared_snapshot_listeners_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/shared_snapshot_listeners_template.js
@@ -1,8 +1,7 @@
 function MyComponent_div_0_Template(rf, ctx) {
   if (rf & 1) {
     const $s$ = $r3$.ɵɵgetCurrentView();
-    $r3$.ɵɵelementStart(0, "div");
-    $r3$.ɵɵelementStart(1, "div", 1);
+    $r3$.ɵɵelementStart(0, "div")(1, "div", 1);
     $r3$.ɵɵlistener("click", function MyComponent_div_0_Template_div_click_1_listener() {
       $r3$.ɵɵrestoreView($s$);
       const $comp$ = $r3$.ɵɵnextContext();
@@ -15,8 +14,7 @@ function MyComponent_div_0_Template(rf, ctx) {
       const $comp2$ = $r3$.ɵɵnextContext();
       return $comp2$.onClick2($comp2$.bar);
     });
-    $r3$.ɵɵelementEnd();
-    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵelementEnd()();
   }
 }
 // ...

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_animations/animation_property_bindings.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_animations/animation_property_bindings.js
@@ -5,9 +5,7 @@ MyComponent.ɵcmp = /*@__PURE__*/ $r3$.ɵɵdefineComponent({
   vars: 3,
   template:  function MyComponent_Template(rf, $ctx$) {
     if (rf & 1) {
-      $r3$.ɵɵelement(0, "div");
-      $r3$.ɵɵelement(1, "div");
-      $r3$.ɵɵelement(2, "div");
+      $r3$.ɵɵelement(0, "div")(1, "div")(2, "div");
     }
     if (rf & 2) {
       $r3$.ɵɵproperty("@foo", ctx.exp);

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -23,7 +23,7 @@ import {prepareSyntheticListenerFunctionName, prepareSyntheticPropertyName, R3Co
 import {DeclarationListEmitMode, R3ComponentMetadata, R3DirectiveMetadata, R3HostMetadata, R3QueryMetadata} from './api';
 import {MIN_STYLING_BINDING_SLOTS_REQUIRED, StylingBuilder, StylingInstructionCall} from './styling_builder';
 import {BindingScope, makeBindingParser, prepareEventListenerParameters, renderFlagCheckIfStmt, resolveSanitizationFn, TemplateDefinitionBuilder, ValueConverter} from './template';
-import {asLiteral, chainedInstruction, conditionallyCreateMapObjectLiteral, CONTEXT_NAME, DefinitionMap, getQueryPredicate, RENDER_FLAGS, TEMPORARY_NAME, temporaryAllocator} from './util';
+import {asLiteral, conditionallyCreateMapObjectLiteral, CONTEXT_NAME, DefinitionMap, getInstructionStatements, getQueryPredicate, Instruction, RENDER_FLAGS, TEMPORARY_NAME, temporaryAllocator} from './util';
 
 
 // This regex matches any binding names that contain the "attr." prefix, e.g. "attr.required"
@@ -468,8 +468,9 @@ function createHostBindingsFunction(
     styleBuilder.registerClassAttr(classAttr);
   }
 
-  const createStatements: o.Statement[] = [];
-  const updateStatements: o.Statement[] = [];
+  const createInstructions: Instruction[] = [];
+  const updateInstructions: Instruction[] = [];
+  const updateVariables: o.Statement[] = [];
 
   const hostBindingSourceSpan = typeSourceSpan;
 
@@ -477,8 +478,7 @@ function createHostBindingsFunction(
   const eventBindings = bindingParser.createDirectiveHostEventAsts(
       hostBindingsMetadata.listeners, hostBindingSourceSpan);
   if (eventBindings && eventBindings.length) {
-    const listeners = createHostListeners(eventBindings, name);
-    createStatements.push(...listeners);
+    createInstructions.push(...createHostListeners(eventBindings, name));
   }
 
   // Calculate the host property bindings
@@ -522,7 +522,8 @@ function createHostBindingsFunction(
   const propertyBindings: o.Expression[][] = [];
   const attributeBindings: o.Expression[][] = [];
   const syntheticHostBindings: o.Expression[][] = [];
-  allOtherBindings.forEach((binding: ParsedProperty) => {
+
+  for (const binding of allOtherBindings) {
     // resolve literal arrays and literal objects
     const value = binding.expression.visit(getValueConverter());
     const bindingExpr = bindingFn(bindingContext, value);
@@ -552,7 +553,7 @@ function createHostBindingsFunction(
       instructionParams.push(sanitizerFn);
     }
 
-    updateStatements.push(...bindingExpr.stmts);
+    updateVariables.push(...bindingExpr.stmts);
 
     if (instruction === R3.hostProperty) {
       propertyBindings.push(instructionParams);
@@ -561,21 +562,21 @@ function createHostBindingsFunction(
     } else if (instruction === R3.syntheticHostProperty) {
       syntheticHostBindings.push(instructionParams);
     } else {
-      updateStatements.push(o.importExpr(instruction).callFn(instructionParams).toStmt());
+      updateInstructions.push({reference: instruction, paramsOrFn: instructionParams, span: null});
     }
-  });
-
-  if (propertyBindings.length > 0) {
-    updateStatements.push(chainedInstruction(R3.hostProperty, propertyBindings).toStmt());
   }
 
-  if (attributeBindings.length > 0) {
-    updateStatements.push(chainedInstruction(R3.attribute, attributeBindings).toStmt());
+  for (const bindingParams of propertyBindings) {
+    updateInstructions.push({reference: R3.hostProperty, paramsOrFn: bindingParams, span: null});
   }
 
-  if (syntheticHostBindings.length > 0) {
-    updateStatements.push(
-        chainedInstruction(R3.syntheticHostProperty, syntheticHostBindings).toStmt());
+  for (const bindingParams of attributeBindings) {
+    updateInstructions.push({reference: R3.attribute, paramsOrFn: bindingParams, span: null});
+  }
+
+  for (const bindingParams of syntheticHostBindings) {
+    updateInstructions.push(
+        {reference: R3.syntheticHostProperty, paramsOrFn: bindingParams, span: null});
   }
 
   // since we're dealing with directives/components and both have hostBinding
@@ -593,18 +594,17 @@ function createHostBindingsFunction(
     // the update block of a component/directive templateFn/hostBindingsFn so that the bindings
     // are evaluated and updated for the element.
     styleBuilder.buildUpdateLevelInstructions(getValueConverter()).forEach(instruction => {
-      if (instruction.calls.length > 0) {
-        const calls: o.Expression[][] = [];
+      for (const call of instruction.calls) {
+        // we subtract a value of `1` here because the binding slot was already allocated
+        // at the top of this method when all the input bindings were counted.
+        totalHostVarsCount +=
+            Math.max(call.allocateBindingSlots - MIN_STYLING_BINDING_SLOTS_REQUIRED, 0);
 
-        instruction.calls.forEach(call => {
-          // we subtract a value of `1` here because the binding slot was already allocated
-          // at the top of this method when all the input bindings were counted.
-          totalHostVarsCount +=
-              Math.max(call.allocateBindingSlots - MIN_STYLING_BINDING_SLOTS_REQUIRED, 0);
-          calls.push(convertStylingCall(call, bindingContext, bindingFn));
+        updateInstructions.push({
+          reference: instruction.reference,
+          paramsOrFn: convertStylingCall(call, bindingContext, bindingFn),
+          span: null
         });
-
-        updateStatements.push(chainedInstruction(instruction.reference, calls).toStmt());
       }
     });
   }
@@ -613,14 +613,17 @@ function createHostBindingsFunction(
     definitionMap.set('hostVars', o.literal(totalHostVarsCount));
   }
 
-  if (createStatements.length > 0 || updateStatements.length > 0) {
+  if (createInstructions.length > 0 || updateInstructions.length > 0) {
     const hostBindingsFnName = name ? `${name}_HostBindings` : null;
     const statements: o.Statement[] = [];
-    if (createStatements.length > 0) {
-      statements.push(renderFlagCheckIfStmt(core.RenderFlags.Create, createStatements));
+    if (createInstructions.length > 0) {
+      statements.push(renderFlagCheckIfStmt(
+          core.RenderFlags.Create, getInstructionStatements(createInstructions)));
     }
-    if (updateStatements.length > 0) {
-      statements.push(renderFlagCheckIfStmt(core.RenderFlags.Update, updateStatements));
+    if (updateInstructions.length > 0) {
+      statements.push(renderFlagCheckIfStmt(
+          core.RenderFlags.Update,
+          updateVariables.concat(getInstructionStatements(updateInstructions))));
     }
     return o.fn(
         [new o.FnParam(RENDER_FLAGS, o.NUMBER_TYPE), new o.FnParam(CONTEXT_NAME, null)], statements,
@@ -664,12 +667,12 @@ function getBindingNameAndInstruction(binding: ParsedProperty):
   return {bindingName, instruction, isAttribute: !!attrMatches};
 }
 
-function createHostListeners(eventBindings: ParsedEvent[], name?: string): o.Statement[] {
-  const listeners: o.Expression[][] = [];
-  const syntheticListeners: o.Expression[][] = [];
-  const instructions: o.Statement[] = [];
+function createHostListeners(eventBindings: ParsedEvent[], name?: string): Instruction[] {
+  const listenerParams: o.Expression[][] = [];
+  const syntheticListenerParams: o.Expression[][] = [];
+  const instructions: Instruction[] = [];
 
-  eventBindings.forEach(binding => {
+  for (const binding of eventBindings) {
     let bindingName = binding.name && sanitizeIdentifier(binding.name);
     const bindingFnName = binding.type === ParsedEventType.Animation ?
         prepareSyntheticListenerFunctionName(bindingName, binding.targetOrPhase) :
@@ -678,18 +681,18 @@ function createHostListeners(eventBindings: ParsedEvent[], name?: string): o.Sta
     const params = prepareEventListenerParameters(BoundEvent.fromParsedEvent(binding), handlerName);
 
     if (binding.type == ParsedEventType.Animation) {
-      syntheticListeners.push(params);
+      syntheticListenerParams.push(params);
     } else {
-      listeners.push(params);
+      listenerParams.push(params);
     }
-  });
-
-  if (syntheticListeners.length > 0) {
-    instructions.push(chainedInstruction(R3.syntheticHostListener, syntheticListeners).toStmt());
   }
 
-  if (listeners.length > 0) {
-    instructions.push(chainedInstruction(R3.listener, listeners).toStmt());
+  for (const params of syntheticListenerParams) {
+    instructions.push({reference: R3.syntheticHostListener, paramsOrFn: params, span: null});
+  }
+
+  for (const params of listenerParams) {
+    instructions.push({reference: R3.listener, paramsOrFn: params, span: null});
   }
 
   return instructions;

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -38,7 +38,7 @@ import {createLocalizeStatements} from './i18n/localize_utils';
 import {I18nMetaVisitor} from './i18n/meta';
 import {assembleBoundTextPlaceholders, assembleI18nBoundString, declareI18nVariable, getTranslationConstPrefix, hasI18nMeta, I18N_ICU_MAPPING_PREFIX, i18nFormatPlaceholderNames, icuFromI18nMessage, isI18nRootNode, isSingleI18nIcu, placeholdersToParams, TRANSLATION_VAR_PREFIX, wrapI18nPlaceholder} from './i18n/util';
 import {StylingBuilder, StylingInstruction} from './styling_builder';
-import {asLiteral, chainedInstruction, CONTEXT_NAME, getInterpolationArgsLength, IMPLICIT_REFERENCE, invalid, NON_BINDABLE_ATTR, REFERENCE_PREFIX, RENDER_FLAGS, RESTORED_VIEW_CONTEXT_NAME, trimTrailingNulls} from './util';
+import {asLiteral, CONTEXT_NAME, getInstructionStatements, getInterpolationArgsLength, IMPLICIT_REFERENCE, Instruction, InstructionParams, invalid, invokeInstruction, NON_BINDABLE_ATTR, REFERENCE_PREFIX, RENDER_FLAGS, RESTORED_VIEW_CONTEXT_NAME, trimTrailingNulls} from './util';
 
 
 
@@ -145,13 +145,13 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
    * the template so bindings in listeners are resolved only once all nodes have been visited.
    * This ensures all local refs and context variables are available for matching.
    */
-  private _creationCodeFns: (() => o.Statement)[] = [];
+  private _creationCodeFns: Instruction[] = [];
   /**
    * List of callbacks to generate update mode instructions. We store them here as we process
    * the template so bindings are resolved only once all nodes have been visited. This ensures
    * all local refs and context variables are available for matching.
    */
-  private _updateCodeFns: (() => o.Statement)[] = [];
+  private _updateCodeFns: Instruction[] = [];
 
   /** Index of the currently-selected node. */
   private _currentIndex: number = 0;
@@ -287,10 +287,10 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     }
 
     // Generate all the creation mode instructions (e.g. resolve bindings in listeners)
-    const creationStatements = this._creationCodeFns.map((fn: () => o.Statement) => fn());
+    const creationStatements = getInstructionStatements(this._creationCodeFns);
 
     // Generate all the update mode instructions (e.g. resolve property or text bindings)
-    const updateStatements = this._updateCodeFns.map((fn: () => o.Statement) => fn());
+    const updateStatements = getInstructionStatements(this._updateCodeFns);
 
     //  Variable declaration must occur after binding resolution so we can generate context
     //  instructions that build on each other.
@@ -463,7 +463,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
           if (Object.keys(icuMapping).length) {
             args.push(mapLiteral(icuMapping, true));
           }
-          return instruction(null, R3.i18nPostprocess, args);
+          return invokeInstruction(null, R3.i18nPostprocess, args);
         };
       }
       this.i18nTranslate(meta as i18n.Message, params, context.ref, transformFn);
@@ -503,14 +503,14 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     // setup accumulated bindings
     const {index, bindings} = this.i18n;
     if (bindings.size) {
-      const chainBindings: ChainableBindingInstruction[] = [];
-      bindings.forEach(binding => {
-        chainBindings.push({sourceSpan: span, value: () => this.convertPropertyBinding(binding)});
-      });
-      // for i18n block, advance to the most recent element index (by taking the current number of
-      // elements and subtracting one) before invoking `i18nExp` instructions, to make sure the
-      // necessary lifecycle hooks of components/directives are properly flushed.
-      this.updateInstructionChainWithAdvance(this.getConstCount() - 1, R3.i18nExp, chainBindings);
+      for (const binding of bindings) {
+        // for i18n block, advance to the most recent element index (by taking the current number of
+        // elements and subtracting one) before invoking `i18nExp` instructions, to make sure the
+        // necessary lifecycle hooks of components/directives are properly flushed.
+        this.updateInstructionWithAdvance(
+            this.getConstCount() - 1, span, R3.i18nExp, () => this.convertPropertyBinding(binding));
+      }
+
       this.updateInstruction(span, R3.i18nApply, [o.literal(index)]);
     }
     if (!selfClosing) {
@@ -521,9 +521,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
   private i18nAttributesInstruction(
       nodeIndex: number, attrs: t.BoundAttribute[], sourceSpan: ParseSourceSpan): void {
-    let hasBindings: boolean = false;
+    let hasBindings = false;
     const i18nAttrArgs: o.Expression[] = [];
-    const bindings: ChainableBindingInstruction[] = [];
     attrs.forEach(attr => {
       const message = attr.i18n! as i18n.Message;
       const converted = attr.value.visit(this._valueConverter);
@@ -534,16 +533,11 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         i18nAttrArgs.push(o.literal(attr.name), this.i18nTranslate(message, params));
         converted.expressions.forEach(expression => {
           hasBindings = true;
-          bindings.push({
-            sourceSpan,
-            value: () => this.convertPropertyBinding(expression),
-          });
+          this.updateInstructionWithAdvance(
+              nodeIndex, sourceSpan, R3.i18nExp, () => this.convertPropertyBinding(expression));
         });
       }
     });
-    if (bindings.length > 0) {
-      this.updateInstructionChainWithAdvance(nodeIndex, R3.i18nExp, bindings);
-    }
     if (i18nAttrArgs.length > 0) {
       const index: o.Expression = o.literal(this.allocateDataSlot());
       const constIndex = this.addToConsts(o.literalArr(i18nAttrArgs));
@@ -706,12 +700,11 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
       // Generate Listeners (outputs)
       if (element.outputs.length > 0) {
-        const listeners = element.outputs.map(
-            (outputAst: t.BoundEvent) => ({
-              sourceSpan: outputAst.sourceSpan,
-              params: this.prepareListenerParameter(element.name, outputAst, elementIndex)
-            }));
-        this.creationInstructionChain(R3.listener, listeners);
+        for (const outputAst of element.outputs) {
+          this.creationInstruction(
+              outputAst.sourceSpan, R3.listener,
+              this.prepareListenerParameter(element.name, outputAst, elementIndex));
+        }
       }
 
       // Note: it's important to keep i18n/i18nStart instructions after i18nAttributes and
@@ -736,8 +729,8 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     // special value to symbolize that there is no RHS to this binding
     // TODO (matsko): revisit this once FW-959 is approached
     const emptyValueBindInstruction = o.literal(undefined);
-    const propertyBindings: ChainableBindingInstruction[] = [];
-    const attributeBindings: ChainableBindingInstruction[] = [];
+    const propertyBindings: Omit<Instruction, 'reference'>[] = [];
+    const attributeBindings: Omit<Instruction, 'reference'>[] = [];
 
     // Generate element input bindings
     allOtherInputs.forEach(input => {
@@ -757,9 +750,10 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
         this.allocateBindingSlots(value);
 
         propertyBindings.push({
-          name: prepareSyntheticPropertyName(input.name),
-          sourceSpan: input.sourceSpan,
-          value: () => hasValue ? this.convertPropertyBinding(value) : emptyValueBindInstruction
+          span: input.sourceSpan,
+          paramsOrFn: getBindingFunctionParams(
+              () => hasValue ? this.convertPropertyBinding(value) : emptyValueBindInstruction,
+              prepareSyntheticPropertyName(input.name))
         });
       } else {
         // we must skip attributes with associated i18n context, since these attributes are handled
@@ -796,10 +790,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
               // [prop]="value"
               // Collect all the properties so that we can chain into a single function at the end.
               propertyBindings.push({
-                name: attrName,
-                sourceSpan: input.sourceSpan,
-                value: () => this.convertPropertyBinding(value),
-                params
+                span: input.sourceSpan,
+                paramsOrFn: getBindingFunctionParams(
+                    () => this.convertPropertyBinding(value), attrName, params)
               });
             }
           } else if (inputType === BindingType.Attribute) {
@@ -813,10 +806,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
               // [attr.name]="value" or attr.name="{{value}}"
               // Collect the attribute bindings so that they can be chained at the end.
               attributeBindings.push({
-                name: attrName,
-                sourceSpan: input.sourceSpan,
-                value: () => this.convertPropertyBinding(boundValue),
-                params
+                span: input.sourceSpan,
+                paramsOrFn: getBindingFunctionParams(
+                    () => this.convertPropertyBinding(boundValue), attrName, params)
               });
             }
           } else {
@@ -832,12 +824,14 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       }
     });
 
-    if (propertyBindings.length > 0) {
-      this.updateInstructionChainWithAdvance(elementIndex, R3.property, propertyBindings);
+    for (const propertyBinding of propertyBindings) {
+      this.updateInstructionWithAdvance(
+          elementIndex, propertyBinding.span, R3.property, propertyBinding.paramsOrFn);
     }
 
-    if (attributeBindings.length > 0) {
-      this.updateInstructionChainWithAdvance(elementIndex, R3.attribute, attributeBindings);
+    for (const attributeBinding of attributeBindings) {
+      this.updateInstructionWithAdvance(
+          elementIndex, attributeBinding.span, R3.attribute, attributeBinding.paramsOrFn);
     }
 
     // Traverse element child nodes
@@ -946,13 +940,10 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       }
 
       // Generate listeners for directive output
-      if (template.outputs.length > 0) {
-        const listeners = template.outputs.map(
-            (outputAst: t.BoundEvent) => ({
-              sourceSpan: outputAst.sourceSpan,
-              params: this.prepareListenerParameter('ng_template', outputAst, templateIndex)
-            }));
-        this.creationInstructionChain(R3.listener, listeners);
+      for (const outputAst of template.outputs) {
+        this.creationInstruction(
+            outputAst.sourceSpan, R3.listener,
+            this.prepareListenerParameter('ng_template', outputAst, templateIndex));
       }
     }
   }
@@ -1027,7 +1018,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     const transformFn = (raw: o.ReadVarExpr) => {
       const params = {...vars, ...placeholders};
       const formatted = i18nFormatPlaceholderNames(params, /* useCamelCase */ false);
-      return instruction(null, R3.i18nPostprocess, [raw, mapLiteral(formatted, true)]);
+      return invokeInstruction(null, R3.i18nPostprocess, [raw, mapLiteral(formatted, true)]);
     };
 
     // in case the whole i18n message is a single ICU - we do not need to
@@ -1078,37 +1069,41 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
   private templatePropertyBindings(
       templateIndex: number, attrs: (t.BoundAttribute|t.TextAttribute)[]) {
-    const propertyBindings: ChainableBindingInstruction[] = [];
-    attrs.forEach(input => {
-      if (input instanceof t.BoundAttribute) {
-        const value = input.value.visit(this._valueConverter);
+    const propertyBindings: Omit<Instruction, 'reference'>[] = [];
 
-        if (value !== undefined) {
-          this.allocateBindingSlots(value);
-          if (value instanceof Interpolation) {
-            // Params typically contain attribute namespace and value sanitizer, which is applicable
-            // for regular HTML elements, but not applicable for <ng-template> (since props act as
-            // inputs to directives), so keep params array empty.
-            const params: any[] = [];
-
-            // prop="{{value}}" case
-            this.interpolatedUpdateInstruction(
-                getPropertyInterpolationExpression(value), templateIndex, input.name, input, value,
-                params);
-          } else {
-            // [prop]="value" case
-            propertyBindings.push({
-              name: input.name,
-              sourceSpan: input.sourceSpan,
-              value: () => this.convertPropertyBinding(value)
-            });
-          }
-        }
+    for (const input of attrs) {
+      if (!(input instanceof t.BoundAttribute)) {
+        continue;
       }
-    });
 
-    if (propertyBindings.length > 0) {
-      this.updateInstructionChainWithAdvance(templateIndex, R3.property, propertyBindings);
+      const value = input.value.visit(this._valueConverter);
+      if (value === undefined) {
+        continue;
+      }
+
+      this.allocateBindingSlots(value);
+      if (value instanceof Interpolation) {
+        // Params typically contain attribute namespace and value sanitizer, which is applicable
+        // for regular HTML elements, but not applicable for <ng-template> (since props act as
+        // inputs to directives), so keep params array empty.
+        const params: any[] = [];
+
+        // prop="{{value}}" case
+        this.interpolatedUpdateInstruction(
+            getPropertyInterpolationExpression(value), templateIndex, input.name, input, value,
+            params);
+      } else {
+        // [prop]="value" case
+        propertyBindings.push({
+          span: input.sourceSpan,
+          paramsOrFn: getBindingFunctionParams(() => this.convertPropertyBinding(value), input.name)
+        });
+      }
+    }
+
+    for (const propertyBinding of propertyBindings) {
+      this.updateInstructionWithAdvance(
+          templateIndex, propertyBinding.span, R3.property, propertyBinding.paramsOrFn);
     }
   }
 
@@ -1117,95 +1112,44 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
   // Otherwise, we wouldn't be able to support local refs that are defined after their
   // bindings. e.g. {{ foo }} <div #foo></div>
   private instructionFn(
-      fns: (() => o.Statement)[], span: ParseSourceSpan|null, reference: o.ExternalReference,
-      paramsOrFn: o.Expression[]|(() => o.Expression[]), prepend: boolean = false): void {
-    fns[prepend ? 'unshift' : 'push'](() => {
-      const params = Array.isArray(paramsOrFn) ? paramsOrFn : paramsOrFn();
-      return instruction(span, reference, params).toStmt();
-    });
+      fns: Instruction[], span: ParseSourceSpan|null, reference: o.ExternalReference,
+      paramsOrFn: InstructionParams, prepend: boolean = false): void {
+    fns[prepend ? 'unshift' : 'push']({span, reference, paramsOrFn});
   }
 
   private processStylingUpdateInstruction(
       elementIndex: number, instruction: StylingInstruction|null) {
     let allocateBindingSlots = 0;
     if (instruction) {
-      const calls: ChainableBindingInstruction[] = [];
-
-      instruction.calls.forEach(call => {
+      for (const call of instruction.calls) {
         allocateBindingSlots += call.allocateBindingSlots;
-        calls.push({
-          sourceSpan: call.sourceSpan,
-          value: () => {
-            return call.params(
-                       value => (call.supportsInterpolation && value instanceof Interpolation) ?
-                           this.getUpdateInstructionArguments(value) :
-                           this.convertPropertyBinding(value)) as o.Expression[];
-          }
-        });
-      });
-
-      this.updateInstructionChainWithAdvance(elementIndex, instruction.reference, calls);
+        this.updateInstructionWithAdvance(
+            elementIndex, call.sourceSpan, instruction.reference,
+            () => call.params(
+                      value => (call.supportsInterpolation && value instanceof Interpolation) ?
+                          this.getUpdateInstructionArguments(value) :
+                          this.convertPropertyBinding(value)) as o.Expression[]);
+      }
     }
-
     return allocateBindingSlots;
   }
 
   private creationInstruction(
-      span: ParseSourceSpan|null, reference: o.ExternalReference,
-      paramsOrFn?: o.Expression[]|(() => o.Expression[]), prepend?: boolean) {
+      span: ParseSourceSpan|null, reference: o.ExternalReference, paramsOrFn?: InstructionParams,
+      prepend?: boolean) {
     this.instructionFn(this._creationCodeFns, span, reference, paramsOrFn || [], prepend);
-  }
-
-  private creationInstructionChain(reference: o.ExternalReference, calls: {
-    sourceSpan: ParseSourceSpan|null,
-    params: () => o.Expression[]
-  }[]) {
-    const span = calls.length ? calls[0].sourceSpan : null;
-    this._creationCodeFns.push(() => {
-      return chainedInstruction(reference, calls.map(call => call.params()), span).toStmt();
-    });
   }
 
   private updateInstructionWithAdvance(
       nodeIndex: number, span: ParseSourceSpan|null, reference: o.ExternalReference,
-      paramsOrFn?: o.Expression[]|(() => o.Expression[])) {
+      paramsOrFn?: InstructionParams) {
     this.addAdvanceInstructionIfNecessary(nodeIndex, span);
     this.updateInstruction(span, reference, paramsOrFn);
   }
 
   private updateInstruction(
-      span: ParseSourceSpan|null, reference: o.ExternalReference,
-      paramsOrFn?: o.Expression[]|(() => o.Expression[])) {
+      span: ParseSourceSpan|null, reference: o.ExternalReference, paramsOrFn?: InstructionParams) {
     this.instructionFn(this._updateCodeFns, span, reference, paramsOrFn || []);
-  }
-
-  private updateInstructionChain(
-      reference: o.ExternalReference, bindings: ChainableBindingInstruction[]) {
-    const span = bindings.length ? bindings[0].sourceSpan : null;
-
-    this._updateCodeFns.push(() => {
-      const calls = bindings.map(property => {
-        const value = property.value();
-        const fnParams = Array.isArray(value) ? value : [value];
-        if (property.params) {
-          fnParams.push(...property.params);
-        }
-        if (property.name) {
-          // We want the property name to always be the first function parameter.
-          fnParams.unshift(o.literal(property.name));
-        }
-        return fnParams;
-      });
-
-      return chainedInstruction(reference, calls, span).toStmt();
-    });
-  }
-
-  private updateInstructionChainWithAdvance(
-      nodeIndex: number, reference: o.ExternalReference, bindings: ChainableBindingInstruction[]) {
-    this.addAdvanceInstructionIfNecessary(
-        nodeIndex, bindings.length ? bindings[0].sourceSpan : null);
-    this.updateInstructionChain(reference, bindings);
   }
 
   private addAdvanceInstructionIfNecessary(nodeIndex: number, span: ParseSourceSpan|null) {
@@ -1553,12 +1497,6 @@ function pureFunctionCallInfo(args: o.Expression[]) {
   };
 }
 
-function instruction(
-    span: ParseSourceSpan|null, reference: o.ExternalReference,
-    params: o.Expression[]): o.Expression {
-  return o.importExpr(reference, null, span).callFn(params, span);
-}
-
 // e.g. x(2);
 function generateNextContextExpr(relativeLevelDiff: number): o.Expression {
   return o.importExpr(R3.nextContext)
@@ -1825,7 +1763,7 @@ export class BindingScope implements LocalResolver {
   restoreViewStatement(): o.Statement[] {
     const statements: o.Statement[] = [];
     if (this.restoreViewVariable) {
-      const restoreCall = instruction(null, R3.restoreView, [this.restoreViewVariable]);
+      const restoreCall = invokeInstruction(null, R3.restoreView, [this.restoreViewVariable]);
       // Either `const restoredCtx = restoreView($state$);` or `restoreView($state$);`
       // depending on whether it is being used.
       statements.push(
@@ -1839,7 +1777,9 @@ export class BindingScope implements LocalResolver {
   viewSnapshotStatements(): o.Statement[] {
     // const $state$ = getCurrentView();
     return this.restoreViewVariable ?
-        [this.restoreViewVariable.set(instruction(null, R3.getCurrentView, [])).toConstDecl()] :
+        [
+          this.restoreViewVariable.set(invokeInstruction(null, R3.getCurrentView, [])).toConstDecl()
+        ] :
         [];
   }
 
@@ -2259,11 +2199,21 @@ function hasTextChildrenOnly(children: t.Node[]): boolean {
   return children.every(isTextNode);
 }
 
-interface ChainableBindingInstruction {
-  name?: string;
-  sourceSpan: ParseSourceSpan|null;
-  value: () => o.Expression | o.Expression[];
-  params?: any[];
+function getBindingFunctionParams(
+    deferredParams: () => (o.Expression | o.Expression[]), name?: string,
+    eagerParams?: o.Expression[]) {
+  return () => {
+    const value = deferredParams();
+    const fnParams = Array.isArray(value) ? value : [value];
+    if (eagerParams) {
+      fnParams.push(...eagerParams);
+    }
+    if (name) {
+      // We want the property name to always be the first function parameter.
+      fnParams.unshift(o.literal(name));
+    }
+    return fnParams;
+  };
 }
 
 /** Name of the global variable that is used to determine if we use Closure translations or not */

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -52,6 +52,12 @@ export const RESTORED_VIEW_CONTEXT_NAME = 'restoredCtx';
 
 /** Instructions that support chaining. */
 const CHAINABLE_INSTRUCTIONS = new Set([
+  R3.element,
+  R3.elementStart,
+  R3.elementEnd,
+  R3.elementContainer,
+  R3.elementContainerStart,
+  R3.elementContainerEnd,
   R3.i18nExp,
   R3.listener,
   R3.classProp,

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -63,6 +63,7 @@ function elementStartFirstCreatePass(
  * @param name Name of the DOM Node
  * @param attrsIndex Index of the element's attributes in the `consts` array.
  * @param localRefsIndex Index of the element's local references in the `consts` array.
+ * @returns This function returns itself so that it may be chained.
  *
  * Attributes and localRefs are passed as an array of strings where elements with an even index
  * hold an attribute name and elements with an odd index hold an attribute value, ex.:
@@ -71,7 +72,8 @@ function elementStartFirstCreatePass(
  * @codeGenApi
  */
 export function ɵɵelementStart(
-    index: number, name: string, attrsIndex?: number|null, localRefsIndex?: number): void {
+    index: number, name: string, attrsIndex?: number|null,
+    localRefsIndex?: number): typeof ɵɵelementStart {
   const lView = getLView();
   const tView = getTView();
   const adjustedIndex = HEADER_OFFSET + index;
@@ -125,14 +127,16 @@ export function ɵɵelementStart(
   if (localRefsIndex !== null) {
     saveResolvedLocalsInData(lView, tNode);
   }
+  return ɵɵelementStart;
 }
 
 /**
  * Mark the end of the element.
+ * @returns This function returns itself so that it may be chained.
  *
  * @codeGenApi
  */
-export function ɵɵelementEnd(): void {
+export function ɵɵelementEnd(): typeof ɵɵelementEnd {
   let currentTNode = getCurrentTNode()!;
   ngDevMode && assertDefined(currentTNode, 'No parent node to close.');
   if (isCurrentTNodeParent()) {
@@ -164,6 +168,7 @@ export function ɵɵelementEnd(): void {
   if (tNode.stylesWithoutHost != null && hasStyleInput(tNode)) {
     setDirectiveInputsWhichShadowsStyling(tView, tNode, getLView(), tNode.stylesWithoutHost, false);
   }
+  return ɵɵelementEnd;
 }
 
 /**
@@ -173,13 +178,16 @@ export function ɵɵelementEnd(): void {
  * @param name Name of the DOM Node
  * @param attrsIndex Index of the element's attributes in the `consts` array.
  * @param localRefsIndex Index of the element's local references in the `consts` array.
+ * @returns This function returns itself so that it may be chained.
  *
  * @codeGenApi
  */
 export function ɵɵelement(
-    index: number, name: string, attrsIndex?: number|null, localRefsIndex?: number): void {
+    index: number, name: string, attrsIndex?: number|null,
+    localRefsIndex?: number): typeof ɵɵelement {
   ɵɵelementStart(index, name, attrsIndex, localRefsIndex);
   ɵɵelementEnd();
+  return ɵɵelement;
 }
 
 function logUnknownElementError(

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -11,7 +11,7 @@ import {attachPatchData} from '../context_discovery';
 import {registerPostOrderHooks} from '../hooks';
 import {TAttributes, TElementContainerNode, TNodeType} from '../interfaces/node';
 import {isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
-import {HEADER_OFFSET, LView, RENDERER, T_HOST, TView} from '../interfaces/view';
+import {HEADER_OFFSET, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
 import {appendChild} from '../node_manipulation';
 import {getBindingIndex, getCurrentTNode, getLView, getTView, isCurrentTNodeParent, setCurrentTNode, setCurrentTNodeAsNotParent} from '../state';
@@ -52,6 +52,7 @@ function elementContainerStartFirstCreatePass(
  * @param index Index of the element in the LView array
  * @param attrsIndex Index of the container attributes in the `consts` array.
  * @param localRefsIndex Index of the container's local references in the `consts` array.
+ * @returns This function returns itself so that it may be chained.
  *
  * Even if this instruction accepts a set of attributes no actual attribute values are propagated to
  * the DOM (as a comment node can't have attributes). Attributes are here only for directive
@@ -60,7 +61,8 @@ function elementContainerStartFirstCreatePass(
  * @codeGenApi
  */
 export function ɵɵelementContainerStart(
-    index: number, attrsIndex?: number|null, localRefsIndex?: number): void {
+    index: number, attrsIndex?: number|null,
+    localRefsIndex?: number): typeof ɵɵelementContainerStart {
   const lView = getLView();
   const tView = getTView();
   const adjustedIndex = index + HEADER_OFFSET;
@@ -91,14 +93,17 @@ export function ɵɵelementContainerStart(
   if (localRefsIndex != null) {
     saveResolvedLocalsInData(lView, tNode);
   }
+
+  return ɵɵelementContainerStart;
 }
 
 /**
  * Mark the end of the <ng-container>.
+ * @returns This function returns itself so that it may be chained.
  *
  * @codeGenApi
  */
-export function ɵɵelementContainerEnd(): void {
+export function ɵɵelementContainerEnd(): typeof ɵɵelementContainerEnd {
   let currentTNode = getCurrentTNode()!;
   const tView = getTView();
   if (isCurrentTNodeParent()) {
@@ -117,6 +122,7 @@ export function ɵɵelementContainerEnd(): void {
       tView.queries!.elementEnd(currentTNode);
     }
   }
+  return ɵɵelementContainerEnd;
 }
 
 /**
@@ -126,11 +132,13 @@ export function ɵɵelementContainerEnd(): void {
  * @param index Index of the element in the LView array
  * @param attrsIndex Index of the container attributes in the `consts` array.
  * @param localRefsIndex Index of the container's local references in the `consts` array.
+ * @returns This function returns itself so that it may be chained.
  *
  * @codeGenApi
  */
 export function ɵɵelementContainer(
-    index: number, attrsIndex?: number|null, localRefsIndex?: number): void {
+    index: number, attrsIndex?: number|null, localRefsIndex?: number): typeof ɵɵelementContainer {
   ɵɵelementContainerStart(index, attrsIndex, localRefsIndex);
   ɵɵelementContainerEnd();
+  return ɵɵelementContainer;
 }

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1476,6 +1476,9 @@
     "name": "ɵɵelement"
   },
   {
+    "name": "ɵɵelementEnd"
+  },
+  {
     "name": "ɵɵelementStart"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -363,6 +363,12 @@
     "name": "ɵɵdefineComponent"
   },
   {
+    "name": "ɵɵelement"
+  },
+  {
+    "name": "ɵɵelementEnd"
+  },
+  {
     "name": "ɵɵelementStart"
   }
 ]

--- a/packages/core/test/linker/source_map_integration_node_only_spec.ts
+++ b/packages/core/test/linker/source_map_integration_node_only_spec.ts
@@ -121,7 +121,7 @@ describe('jit source mapping', () => {
          }));
 
       it('should report di errors with multiple elements and directives', fakeAsync(() => {
-           const template = `<div someDir></div><div someDir="throw"></div>`;
+           const template = `<div someDir></div>|<div someDir="throw"></div>`;
 
            @Component({...templateDecorator(template)})
            class MyComp {
@@ -146,7 +146,7 @@ describe('jit source mapping', () => {
            // The error should be logged from the 2nd-element
            expect(jitEvaluator.getSourcePositionForStack(error.stack, generatedUrl)).toEqual({
              line: 1,
-             column: 19,
+             column: 20,
              source: ngUrl,
            });
          }));


### PR DESCRIPTION
Split up into two commits to make it easier to review:

1. **refactor(compiler): rework instruction generation logic for improved flexibility**
Previously the logic for generating chained instructions was somewhat rigid, because we had to collect all of the calls ahead of time and then call one of the chained instruction helpers. This doesn't work for something like `elementStart`, because we have to descend into other elements that could add to the chain.

These changes refactor the code so that we collect the list of instructions in a flat array and we do the chaining only once at the end when we have the entire instruction set for the code block.

The new approach has the advantage of being (almost) entirely configuration-based via the `CHAINABLE_INSTRUCTIONS` array and being more flexible in allowing us to chain instructions that span across elements.

2. **perf(compiler): chain element start/end instructions** 

In templates with several levels of nested nodes, it's common for several `elementStart`/`elementEnd` instructions to show up in a row which can be optimized away.

These changes add chaining support for `elementStart`, `elementEnd`, `elementContainerStart` and `elementContainerEnd` to shave off some bytes when possible.
