### PR TITLE
ci: group all scorecard action dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -92,6 +92,12 @@
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
       "schedule": ["after 1am on Thursday"]
+    },
+    {
+      "matchPaths": [".github/workflows/scorecard.yml"],
+      "matchPackagePatterns": ["*"],
+      "groupName": "scorecard action dependencies",
+      "groupSlug": "scorecard-action"
     }
   ]
 }


### PR DESCRIPTION
With this change we group all the scorecard action dependencies so that Renovate opens a single PR.
