### PR TITLE
docs: improve try-it-now card focus area

### DIFF
--- a/aio/content/marketing/index.html
+++ b/aio/content/marketing/index.html
@@ -100,7 +100,7 @@
 
     <!-- CTA CARDS -->
     <div layout="row" layout-xs="column" class="home-row">
-      <a href="start">
+      <a href="start" class="card-wrapper">
         <div class="card">
           <img src="generated/images/marketing/home/code-icon.svg" alt="Get Started with Angular" width="70" height="70" loading="lazy">
           <div class="card-text-container">

--- a/aio/content/marketing/index.html
+++ b/aio/content/marketing/index.html
@@ -100,13 +100,11 @@
 
     <!-- CTA CARDS -->
     <div layout="row" layout-xs="column" class="home-row">
-      <a href="start" class="card-wrapper">
-        <div class="card">
-          <img src="generated/images/marketing/home/code-icon.svg" alt="Get Started with Angular" width="70" height="70" loading="lazy">
-          <div class="card-text-container">
-            <div class="text-headline">Try it now</div>
-            <p>Explore Angular's capabilities with a ready-made sample app. No setup required.</p>
-          </div>
+      <a href="start" class="card">
+        <img src="generated/images/marketing/home/code-icon.svg" alt="Get Started with Angular" width="70" height="70" loading="lazy">
+        <div class="card-text-container">
+          <div class="text-headline">Try it now</div>
+          <p>Explore Angular's capabilities with a ready-made sample app. No setup required.</p>
         </div>
       </a>
     </div>

--- a/aio/src/styles/1-layouts/marketing-layout/_marketing-layout.scss
+++ b/aio/src/styles/1-layouts/marketing-layout/_marketing-layout.scss
@@ -171,12 +171,8 @@ section#intro {
 
 // ANGULAR LINE
 
-.home-row .card-wrapper {
-  width: 70%
-}
-
 .home-row .card {
-  @include mixins.card(100%);
+  @include mixins.card(70%);
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/aio/src/styles/1-layouts/marketing-layout/_marketing-layout.scss
+++ b/aio/src/styles/1-layouts/marketing-layout/_marketing-layout.scss
@@ -171,8 +171,12 @@ section#intro {
 
 // ANGULAR LINE
 
+.home-row .card-wrapper {
+  width: 70%
+}
+
 .home-row .card {
-  @include mixins.card(70%);
+  @include mixins.card(100%);
   display: flex;
   flex-direction: row;
   align-items: center;


### PR DESCRIPTION
the focus/interactable area for the try-it-now card is wider than
necessary, reduce such width to the appropriate size

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

![try-it-now-before](https://user-images.githubusercontent.com/61631103/152876738-40f2badf-5f5a-49be-be21-1b4ab3ab213c.gif)

(it is pretty minor, but I just figured why not fixing it :sweat_smile:)

Issue Number: N/A


## What is the new behavior?


![try-it-now-after](https://user-images.githubusercontent.com/61631103/152876805-59866631-bd8f-4bbc-b297-3aa6d29dbed2.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
