### PR TITLE
build(bazel): add bazel build and test targets for aio build

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,9 @@
 workspace(
     name = "angular",
-    managed_directories = {"@npm": ["node_modules"]},
+    managed_directories = {
+        "@npm": ["node_modules"],
+        "@aio_npm": ["aio/node_modules"],
+    },
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -8,8 +11,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch rules_nodejs so we can install our npm dependencies
 http_archive(
     name = "build_bazel_rules_nodejs",
-    sha256 = "ddb78717b802f8dd5d4c01c340ecdc007c8ced5c1df7db421d0df3d642ea0580",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.6.0/rules_nodejs-4.6.0.tar.gz"],
+    sha256 = "2644a66772938db8d8c760334a252f1687455daa7e188073f2d46283f2f6fbb7",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/4.6.2/rules_nodejs-4.6.2.tar.gz"],
 )
 
 # The PKG rules are needed to build tar packages for integration tests. The builtin
@@ -21,6 +24,14 @@ http_archive(
         "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
         "https://github.com/bazelbuild/rules_pkg/releases/download/0.6.0/rules_pkg-0.6.0.tar.gz",
     ],
+)
+
+# Fetch Aspect lib for utilities like write_source_files
+http_archive(
+    name = "aspect_bazel_lib",
+    sha256 = "5f5f1237601d41d61608ad0b9541614935839232940010f9e62163c3e53dc1b7",
+    strip_prefix = "bazel-lib-0.5.0",
+    url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v0.5.0.tar.gz",
 )
 
 # Check the rules_nodejs version and download npm dependencies
@@ -47,6 +58,17 @@ yarn_install(
     package_json = "//:package.json",
     yarn_lock = "//:yarn.lock",
 )
+
+yarn_install(
+    name = "aio_npm",
+    manual_build_file_contents = npm_package_archives(),
+    package_json = "//aio:package.json",
+    yarn_lock = "//aio:yarn.lock",
+)
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies")
+
+aspect_bazel_lib_dependencies()
 
 # Load protractor dependencies
 load("@npm//@bazel/protractor:package.bzl", "npm_bazel_protractor_dependencies")

--- a/aio/BUILD.bazel
+++ b/aio/BUILD.bazel
@@ -1,0 +1,117 @@
+load("@aio_npm//@angular-devkit/architect-cli:index.bzl", "architect", "architect_test")
+load("@build_bazel_rules_nodejs//:index.bzl", "npm_package_bin")
+
+# The write_source_files macro is used to write bazel outputs to the source tree and test that they are up to date.
+# See: https://docs.aspect.build/aspect-build/bazel-lib/v0.5.0/docs/docs/write_source_files-docgen.html
+load("@aspect_bazel_lib//lib:write_source_files.bzl", generated_files_test = "write_source_files")
+
+exports_files([
+    "firebase.json",
+    "ngsw-config.template.json",
+])
+
+# Generate ngsw-config
+npm_package_bin(
+    name = "ngsw-config",
+    outs = ["ngsw-config_generated.json"],
+    args = ["$@"],
+    tool = "//aio/scripts:build-ngsw-config",
+)
+
+# Write ngsw-config to the source directory and test that it's up to date
+generated_files_test(
+    name = "write-ngsw-config",
+    files = {
+        "ngsw-config.json": ":ngsw-config",
+    },
+)
+
+# All source and configuration files required to build the docs app
+APPLICATION_FILES = [
+    "angular.json",
+    "ngsw-config.json",
+    "package.json",
+    "tsconfig.app.json",
+    "tsconfig.json",
+    "tsconfig.worker.json",
+] + glob(
+    ["src/**/*"],
+    exclude = [
+        "src/**/*.spec.ts",
+        # Temporarily exclude generated sources produced by the non-bazel
+        # build until the whole project is built by bazel and this directory
+        # isn't needed.
+        "src/generated/**/*",
+    ],
+)
+
+# External dependencies from aio/package.json required to build the docs app.
+APPLICATION_DEPS = [
+    "@aio_npm//@angular-devkit/build-angular",
+    "@aio_npm//@angular/animations",
+    "@aio_npm//@angular/cdk",
+    "@aio_npm//@angular/cli",
+    "@aio_npm//@angular/common",
+    "@aio_npm//@angular/compiler",
+    "@aio_npm//@angular/core",
+    "@aio_npm//@angular/elements",
+    "@aio_npm//@angular/forms",
+    "@aio_npm//@angular/material",
+    "@aio_npm//@angular/platform-browser",
+    "@aio_npm//@angular/platform-browser-dynamic",
+    "@aio_npm//@angular/router",
+    "@aio_npm//@angular/service-worker",
+    "@aio_npm//@types/lunr",
+    "@aio_npm//@types/trusted-types",
+    "@aio_npm//lunr",
+    "@aio_npm//rxjs",
+    "@aio_npm//safevalues",
+    "@aio_npm//tslib",
+    "@aio_npm//zone.js",
+]
+
+# All sources, specs, and config files required to test the docs app
+TEST_FILES = APPLICATION_FILES + [
+    "karma.conf.js",
+    "tsconfig.spec.json",
+] + glob(
+    ["src/**/*.spec.ts"],
+)
+
+# External dependencies from aio/package.json required to test the docs app
+TEST_DEPS = APPLICATION_DEPS + [
+    "@aio_npm//@types/jasmine",
+    "@aio_npm//@types/node",
+    "@aio_npm//assert",
+    "@aio_npm//jasmine",
+    "@aio_npm//jasmine-core",
+    "@aio_npm//karma-chrome-launcher",
+    "@aio_npm//karma-coverage",
+    "@aio_npm//karma-jasmine",
+    "@aio_npm//karma-jasmine-html-reporter",
+    "@aio_npm//puppeteer",
+    "@aio_npm//timezone-mock",
+]
+
+architect(
+    name = "build",
+    args = [
+        "site:build:stable",
+        "--outputPath=../$(@D)",
+    ],
+    chdir = package_name(),
+    configuration_env_vars = ["NG_BUILD_CACHE"],
+    data = APPLICATION_FILES + APPLICATION_DEPS,
+    output_dir = True,
+)
+
+architect_test(
+    name = "test",
+    args = [
+        "site:test",
+        "--no-watch",
+    ],
+    chdir = package_name(),
+    configuration_env_vars = ["NG_BUILD_CACHE"],
+    data = TEST_FILES + TEST_DEPS,
+)

--- a/aio/angular.json
+++ b/aio/angular.json
@@ -32,7 +32,7 @@
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
-            "ngswConfigPath": "src/generated/ngsw-config.json",
+            "ngswConfigPath": "ngsw-config.json",
             "tsConfig": "tsconfig.app.json",
             "webWorkerTsConfig": "tsconfig.worker.json",
             "optimization": {
@@ -53,10 +53,7 @@
               {
                 "input": "src/generated",
                 "output": "generated",
-                "glob": "**",
-                "ignore": [
-                  "ngsw-config.json"
-                ]
+                "glob": "**"
               }
             ],
             "styles": [

--- a/aio/ngsw-config.json
+++ b/aio/ngsw-config.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "./node_modules/@angular/service-worker/config/schema.json",
+  "index": "/index.html",
+  "assetGroups": [
+    {
+      "name": "app-shell",
+      "installMode": "prefetch",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/index.html",
+          "/pwa-manifest.json",
+          "/assets/images/favicons/favicon.ico",
+          "/assets/js/*.js",
+          "/*.css",
+          "/*.js"
+        ],
+        "urls": [
+          "https://fonts.googleapis.com/**",
+          "https://fonts.gstatic.com/s/**"
+        ]
+      }
+    },
+    {
+      "name": "assets-eager",
+      "installMode": "prefetch",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/assets/images/**",
+          "/generated/images/marketing/**",
+          "!/assets/images/favicons/**",
+          "!/**/_unused/**"
+        ]
+      }
+    },
+    {
+      "name": "assets-lazy",
+      "installMode": "lazy",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/assets/images/favicons/**",
+          "!/**/_unused/**"
+        ]
+      }
+    },
+    {
+      "name": "docs-index",
+      "installMode": "prefetch",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/generated/*.json",
+          "/generated/docs/*.json",
+          "/generated/docs/api/api-list.json",
+          "/generated/docs/app/search-data.json"
+        ]
+      }
+    },
+    {
+      "name": "docs-lazy",
+      "installMode": "lazy",
+      "updateMode": "lazy",
+      "resources": {
+        "files": [
+          "/generated/docs/**/*.json",
+          "/generated/images/**",
+          "!/**/_unused/**"
+        ]
+      }
+    }
+  ],
+  "navigationUrls": [
+    "/**",
+    "!/**/*.*",
+    "!/**/*__*",
+    "!/**/*__*/**",
+    "!/**/stackblitz/{0,1}",
+    "!/**/AnimationStateDeclarationMetadata*",
+    "!/**/CORE_DIRECTIVES*",
+    "!/**/DirectiveMetadata-*",
+    "!/**/HTTP_PROVIDERS*",
+    "!/**/NgFor-*",
+    "!/**/OptionalMetadata-*",
+    "!/**/PLATFORM_PIPES*",
+    "!/**/api/common/Control*",
+    "!/**/api/common/ControlGroup*",
+    "!/**/api/common/NgModel/{0,1}",
+    "!/**/api/common/SelectControlValueAccessor-*",
+    "!/**/api/common/index/MaxLengthValidator-*",
+    "!/**/cookbook/ts-to-js*",
+    "!/apf/{0,1}",
+    "!/api/*/*-(class|decorator|directive|function|interface|let|pipe|type|type-alias|var)",
+    "!/api/*/testing/*-(class|decorator|directive|function|interface|let|pipe|type|type-alias|var)",
+    "!/api/*/testing/index/*",
+    "!/api/animate/**",
+    "!/api/api/**",
+    "!/api/http/**",
+    "!/api/http/{0,1}",
+    "!/api/platform-browser/AnimationDriver/{0,1}",
+    "!/api/testing/*-*",
+    "!/api/upgrade/*/*-(class|decorator|directive|function|interface|let|pipe|type|type-alias|var)",
+    "!/api/upgrade/*/index/*",
+    "!/config/app-package-json/{0,1}",
+    "!/config/solution-tsconfig/{0,1}",
+    "!/config/tsconfig/{0,1}",
+    "!/devtools/{0,1}",
+    "!/docs/*/latest/**",
+    "!/docs/*/latest/{0,1}",
+    "!/docs/latest/**",
+    "!/docs/styleguide*",
+    "!/docs/styleguide/{0,1}",
+    "!/getting-started/**",
+    "!/getting-started/{0,1}",
+    "!/guide/bazel/{0,1}",
+    "!/guide/change-log/{0,1}",
+    "!/guide/cli-quickstart/{0,1}",
+    "!/guide/displaying-data/{0,1}",
+    "!/guide/i18n/{0,1}",
+    "!/guide/learning-angular*",
+    "!/guide/metadata/{0,1}",
+    "!/guide/ngmodule/{0,1}",
+    "!/guide/quickstart/{0,1}",
+    "!/guide/service-worker-comm/{0,1}",
+    "!/guide/service-worker-configref/{0,1}",
+    "!/guide/service-worker-getstart/{0,1}",
+    "!/guide/setup-systemjs-anatomy/{0,1}",
+    "!/guide/setup/{0,1}",
+    "!/guide/updating-to-version-10/{0,1}",
+    "!/guide/updating-to-version-11/{0,1}",
+    "!/guide/updating-to-version-12/{0,1}",
+    "!/guide/webpack/{0,1}",
+    "!/guide/{0,1}",
+    "!/news*",
+    "!/start/data/{0,1}",
+    "!/start/deployment/{0,1}",
+    "!/start/forms/{0,1}",
+    "!/start/routing/{0,1}",
+    "!/strict/{0,1}",
+    "!/styleguide/{0,1}",
+    "!/testing/**",
+    "!/testing/{0,1}"
+  ]
+}

--- a/aio/package.json
+++ b/aio/package.json
@@ -14,6 +14,7 @@
     "start": "yarn check-env && ng serve",
     "prebuild": "yarn setup",
     "build": "yarn ~~build",
+    "build:bazel": "bazelisk build //aio:build",
     "prebuild-local": "yarn setup-local",
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
@@ -21,6 +22,7 @@
     "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 9aa2eb03f",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint && yarn security-lint",
     "test": "yarn check-env && ng test",
+    "test:bazel": "bazelisk test //aio:test",
     "pree2e": "yarn check-env && yarn update-webdriver",
     "e2e": "ng e2e --no-webdriver-update",
     "presetup": "yarn --cwd .. install && yarn install --frozen-lockfile && yarn ~~check-env && yarn ~~clean-generated && yarn boilerplate:remove",
@@ -103,6 +105,7 @@
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
+    "@angular-devkit/architect-cli": "0.1302.5",
     "@angular-devkit/build-angular": "13.2.5",
     "@angular-eslint/builder": "^13.0.0",
     "@angular-eslint/eslint-plugin": "^13.0.0",
@@ -110,6 +113,7 @@
     "@angular-eslint/template-parser": "^13.0.0",
     "@angular/cli": "13.2.5",
     "@angular/compiler-cli": "13.2.4",
+    "@bazel/bazelisk": "^1.7.5",
     "@types/jasmine": "~3.10.0",
     "@types/lunr": "^2.3.3",
     "@types/node": "^12.7.9",

--- a/aio/scripts/BUILD.bazel
+++ b/aio/scripts/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+nodejs_binary(
+    name = "build-ngsw-config",
+    data = [
+        "//aio:firebase.json",
+        "//aio:ngsw-config.template.json",
+        "@aio_npm//canonical-path",
+        "@aio_npm//json5",
+    ],
+    entry_point = "build-ngsw-config.js",
+)

--- a/aio/scripts/build-ngsw-config.js
+++ b/aio/scripts/build-ngsw-config.js
@@ -7,13 +7,18 @@ const {parse: parseJson} = require('json5');
 // Constants
 const FIREBASE_CONFIG_PATH = resolvePath(__dirname, '../firebase.json');
 const NGSW_CONFIG_TEMPLATE_PATH = resolvePath(__dirname, '../ngsw-config.template.json');
-const NGSW_CONFIG_OUTPUT_PATH = resolvePath(__dirname, '../src/generated/ngsw-config.json');
+const NGSW_CONFIG_OUTPUT_PATH = resolvePath(__dirname, '../ngsw-config.json');
 
 // Run
 _main();
 
 // Helpers
 function _main() {
+  // Allow an alternative output path (used by bazel to output to output dir)
+  const ngswConfigOutputPath = process.argv.length > 2
+    ? process.argv[2]
+    : NGSW_CONFIG_OUTPUT_PATH;
+
   const firebaseConfig = readJson(FIREBASE_CONFIG_PATH);
   const ngswConfig = readJson(NGSW_CONFIG_TEMPLATE_PATH);
 
@@ -56,8 +61,8 @@ function _main() {
   // Add the additional `navigationUrls` globs and save the config.
   ngswConfig.navigationUrls.push(...additionalNavigationUrls);
 
-  mkdirSync(dirname(NGSW_CONFIG_OUTPUT_PATH), {recursive: true});
-  writeJson(NGSW_CONFIG_OUTPUT_PATH, ngswConfig);
+  mkdirSync(dirname(ngswConfigOutputPath), {recursive: true});
+  writeJson(ngswConfigOutputPath, ngswConfig);
 }
 
 function isGlobRedundant(glob, globs) {

--- a/aio/tests/deployment/shared/helpers.ts
+++ b/aio/tests/deployment/shared/helpers.ts
@@ -19,7 +19,7 @@ export function getRedirector() {
 }
 
 export function getSwNavigationUrlChecker() {
-  const config = loadJson(`${AIO_DIR}/src/generated/ngsw-config.json`);
+  const config = loadJson(`${AIO_DIR}/ngsw-config.json`);
   const navigationUrlSpecs = processNavigationUrls('', config.navigationUrls);
 
   const includePatterns = navigationUrlSpecs

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -17,6 +17,19 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
+"@angular-devkit/architect-cli@0.1302.5":
+  version "0.1302.5"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/architect-cli/-/architect-cli-0.1302.5.tgz#0f4d8bf5bc3902ebe9177c681f8cfe117a1fbf01"
+  integrity sha512-jJ06hOaR/nXLbXrhIv9tzbxbNinrpiqAWE8KkEKRSR8fI4lS/40qRHdJxevnZ9i7t11TFKvsF8aPVfQEapRO+A==
+  dependencies:
+    "@angular-devkit/architect" "0.1302.5"
+    "@angular-devkit/core" "13.2.5"
+    ansi-colors "4.1.1"
+    minimist "1.2.5"
+    progress "2.0.3"
+    rxjs "6.6.7"
+    symbol-observable "4.0.0"
+
 "@angular-devkit/architect@0.1302.5":
   version "0.1302.5"
   resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1302.5.tgz#24284a44dcfcfd6bd5ee00a086f10f8d58316ad3"
@@ -1275,6 +1288,11 @@
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
+
+"@bazel/bazelisk@^1.7.5":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@bazel/bazelisk/-/bazelisk-1.11.0.tgz#f98d8438b4c14e3328126618b96775d271caa5f8"
+  integrity sha512-lxiQzVqSGDG0PIDQGJdVDjp7T+50p5NnM4EnRJa76mkZp6u5ul19GJNKhPKi81TZQALZEZDxAgxVqQKkWTUOxA==
 
 "@colors/colors@1.5.0":
   version "1.5.0"
@@ -8490,7 +8508,7 @@ minimatch@~3.0.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.5:
+minimist@1.2.5, minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -9812,7 +9830,7 @@ progress@2.0.1:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
   integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
 
-progress@^2.0.0, progress@^2.0.3:
+progress@2.0.3, progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "postinstall": "node scripts/webdriver-manager-update.js && node --preserve-symlinks --preserve-symlinks-main ./tools/postinstall-patches.js",
     "prepare": "husky install",
     "test": "bazelisk test",
-    "test:ci": "bazelisk test -- //... -//devtools/...",
+    "test:ci": "bazelisk test -- //... -//devtools/... -//aio/...",
     "test-tsec": "bazelisk test //... --build_tag_filters=tsec --test_tag_filters=tsec",
     "lint": "yarn -s tslint && yarn -s ng-dev format changed --check",
     "tslint": "tslint -c tslint.json --project tsconfig-tslint.json",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Added a target for the aio project to be built by bazel. It does not yet include the generated content and is not used by the ci.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Since architect requires the generated ngsw-config.json to be in the source root, I added a rule that will write to it and ensure it exists and is up to date (see [write_source_files](https://docs.aspect.build/aspect-build/bazel-lib/v0.4.3/docs/docs/write_source_files-docgen.html)). I chose to commit that file here, and that will be required once aio is fully built with bazel, but if you prefer I can leave it uncommitted for now---running the bazel build on aio will just pop out an error with a command to generate it.

Another decision I made was to move the ngsw-config.json out of `src/generated` to the root. This is because on each regular build the `generated` folder is deleted, and since I would need a `BUILD.bazel` file in there to stamp the `write_source_files`, it would be deleted and someone developing using the regular build would see the file missing in their git diff. Another option I could do is to make that deletion script a bit more picky about what it deletes.

Overall this is a first partial step in the migration.