### PR TITLE
fix(zone.js): async-test should only call done once

### DIFF
--- a/packages/zone.js/test/browser/XMLHttpRequest.spec.ts
+++ b/packages/zone.js/test/browser/XMLHttpRequest.spec.ts
@@ -336,14 +336,16 @@ describe('XMLHttpRequest', function() {
          const req = new XMLHttpRequest();
          req.open('get', '/', true);
          req.send();
-         req.addEventListener('readystatechange', function(ev) {
+         const listener = function(ev: any) {
            if (req.readyState >= 2) {
              expect(() => {
                req.abort();
              }).not.toThrow();
+             req.removeEventListener('readystatechange', listener);
              done();
            }
-         });
+         };
+         req.addEventListener('readystatechange', listener);
        });
      });
 

--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -2907,6 +2907,7 @@ describe('Zone', function() {
 
               expect(entries.length).toBe(1);
               expect(entries[0].target).toBe(div);
+              observer.disconnect();
               done();
             });
 

--- a/packages/zone.js/test/extra/cordova.spec.ts
+++ b/packages/zone.js/test/extra/cordova.spec.ts
@@ -19,7 +19,6 @@ describe('cordova test', () => {
       cordova.exec(
           () => {
             expect(Zone.current.name).toEqual('cordova');
-            done();
           },
           () => {
             fail('should not fail');


### PR DESCRIPTION
`AsyncTestZoneSpec` triggers jasmine `done()` function multiple times
and causes warning

```
An asynchronous function called its 'done' callback more than once. This is a bug in the spec, beforeAll, beforeEach, afterAll, or afterEach function in question. This will be treated as an error in a future version. See<https://jasmine.github.io/tutorials/upgrading_to_Jasmine_4.0#deprecations-due-to-calling-done-multiple-times> for more information
```

The reproduce case will be running some `Zone.run()` inside
`waitForAsync()`.

```
it('multiple done', waitForAsync(() => {
  Zone.current.run(() => {});
  Zone.current.run(() => {});
}));
```

The reason the `done()` is called in the `onInvoke()` hook is to handle
the case that the testBody is totally sync, but we should only do this
check for the entry function not for all `Zone.run()` scenario.

Another issue is if we have nested zone inside `waitForAsync()`, the 
`onHasTask()` hook will be triggered multiple times and cause the `done()` 
callback to be triggered multiple times, so we should only trigger it 
when the `zone` is `AsyncTestZone`.

This fix will also fix a lot of flaky errors caused by `done()` is being 
invoked too earlier.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

related to this PR https://github.com/angular/angular/pull/44923
