### PR TITLE
refactor(docs-infra): replace deprecated subscribe usages

### DIFF
--- a/aio/content/examples/http/src/app/config/config.component.ts
+++ b/aio/content/examples/http/src/app/config/config.component.ts
@@ -28,10 +28,10 @@ export class ConfigComponent {
   showConfig() {
     this.configService.getConfig()
   // #enddocregion v1, v2
-      .subscribe(
-        (data: Config) => this.config = { ...data }, // success path
-        error => this.error = error // error path
-      );
+      .subscribe({
+        next: (data: Config) => this.config = { ...data }, // success path
+        error: error => this.error = error, // error path
+      });
   }
 
   showConfig_v1() {
@@ -69,7 +69,7 @@ export class ConfigComponent {
   }
 // #enddocregion showConfigResponse
   makeError() {
-    this.configService.makeIntentionalError().subscribe(null, error => this.error = error.message );
+    this.configService.makeIntentionalError().subscribe({ error: error => this.error = error.message });
   }
 
   getType(val: any): string {

--- a/aio/content/examples/http/src/app/heroes/heroes.service.spec.ts
+++ b/aio/content/examples/http/src/app/heroes/heroes.service.spec.ts
@@ -53,10 +53,10 @@ describe('HeroesService', () => {
 
     it('should return expected heroes (called once)', () => {
 
-      heroService.getHeroes().subscribe(
-        heroes => expect(heroes).toEqual(expectedHeroes, 'should return expected heroes'),
-        fail
-      );
+      heroService.getHeroes().subscribe({
+        next: heroes => expect(heroes).toEqual(expectedHeroes, 'should return expected heroes'),
+        error: fail,
+      });
 
       // HeroService should have made one request to GET heroes from expected URL
       const req = httpTestingController.expectOne(heroService.heroesUrl);
@@ -68,10 +68,10 @@ describe('HeroesService', () => {
 
     it('should be OK returning no heroes', () => {
 
-      heroService.getHeroes().subscribe(
-        heroes => expect(heroes.length).toEqual(0, 'should have empty heroes array'),
-        fail
-      );
+      heroService.getHeroes().subscribe({
+        next: heroes => expect(heroes.length).toEqual(0, 'should have empty heroes array'),
+        error: fail,
+      });
 
       const req = httpTestingController.expectOne(heroService.heroesUrl);
       req.flush([]); // Respond with no heroes
@@ -80,10 +80,10 @@ describe('HeroesService', () => {
     // This service reports the error but finds a way to let the app keep going.
     it('should turn 404 into an empty heroes result', () => {
 
-      heroService.getHeroes().subscribe(
-        heroes => expect(heroes.length).toEqual(0, 'should return empty heroes array'),
-        fail
-      );
+      heroService.getHeroes().subscribe({
+        next: heroes => expect(heroes.length).toEqual(0, 'should return empty heroes array'),
+        error: fail,
+      });
 
       const req = httpTestingController.expectOne(heroService.heroesUrl);
 
@@ -96,10 +96,10 @@ describe('HeroesService', () => {
 
       heroService.getHeroes().subscribe();
       heroService.getHeroes().subscribe();
-      heroService.getHeroes().subscribe(
-        heroes => expect(heroes).toEqual(expectedHeroes, 'should return expected heroes'),
-        fail
-      );
+      heroService.getHeroes().subscribe({
+        next: heroes => expect(heroes).toEqual(expectedHeroes, 'should return expected heroes'),
+        error: fail,
+      });
 
       const requests = httpTestingController.match(heroService.heroesUrl);
       expect(requests.length).toEqual(3, 'calls to getHeroes()');
@@ -119,10 +119,10 @@ describe('HeroesService', () => {
 
       const updateHero: Hero = { id: 1, name: 'A' };
 
-      heroService.updateHero(updateHero).subscribe(
-        data => expect(data).toEqual(updateHero, 'should return the hero'),
-        fail
-      );
+      heroService.updateHero(updateHero).subscribe({
+        next: data => expect(data).toEqual(updateHero, 'should return the hero'),
+        error: fail,
+      });
 
       // HeroService should have made one request to PUT hero
       const req = httpTestingController.expectOne(heroService.heroesUrl);
@@ -139,10 +139,10 @@ describe('HeroesService', () => {
     it('should turn 404 error into return of the update hero', () => {
       const updateHero: Hero = { id: 1, name: 'A' };
 
-      heroService.updateHero(updateHero).subscribe(
-        data => expect(data).toEqual(updateHero, 'should return the update hero'),
-        fail
-      );
+      heroService.updateHero(updateHero).subscribe({
+        next: data => expect(data).toEqual(updateHero, 'should return the update hero'),
+        error: fail,
+      });
 
       const req = httpTestingController.expectOne(heroService.heroesUrl);
 

--- a/aio/content/examples/http/src/testing/http-client.spec.ts
+++ b/aio/content/examples/http/src/testing/http-client.spec.ts
@@ -121,13 +121,13 @@ describe('HttpClient testing', () => {
   it('can test for 404 error', () => {
     const emsg = 'deliberate 404 error';
 
-    httpClient.get<Data[]>(testUrl).subscribe(
-      data => fail('should have failed with the 404 error'),
-      (error: HttpErrorResponse) => {
+    httpClient.get<Data[]>(testUrl).subscribe({
+      next: () => fail('should have failed with the 404 error'),
+      error: (error: HttpErrorResponse) => {
         expect(error.status).toEqual(404, 'status');
         expect(error.error).toEqual(emsg, 'message');
-      }
-    );
+      },
+    });
 
     const req = httpTestingController.expectOne(testUrl);
 
@@ -142,13 +142,13 @@ describe('HttpClient testing', () => {
     // at network level. e.g. Connection timeout, DNS error, offline, etc.
     const mockError = new ProgressEvent('error');
 
-    httpClient.get<Data[]>(testUrl).subscribe(
-      data => fail('should have failed with the network error'),
-      (error: HttpErrorResponse) => {
+    httpClient.get<Data[]>(testUrl).subscribe({
+      next: () => fail('should have failed with the network error'),
+      error: (error: HttpErrorResponse) => {
         expect(error.error).toBe(mockError);
         done();
-      }
-    );
+      },
+    });
 
     const req = httpTestingController.expectOne(testUrl);
 

--- a/aio/src/app/custom-elements/api/api.service.ts
+++ b/aio/src/app/custom-elements/api/api.service.ts
@@ -77,13 +77,13 @@ export class ApiService implements OnDestroy {
         takeUntil(this.onDestroy),
         tap(() => this.logger.log(`Got API sections from ${url}`)),
       )
-      .subscribe(
-        sections => this.sectionsSubject.next(sections),
-        (err: HttpErrorResponse) => {
+      .subscribe({
+        next: sections => this.sectionsSubject.next(sections),
+        error: (err: HttpErrorResponse) => {
           // TODO: handle error
           this.logger.error(err);
           throw err; // rethrow for now.
-        }
-      );
+        },
+      });
   }
 }

--- a/aio/src/app/custom-elements/code/code.component.ts
+++ b/aio/src/app/custom-elements/code/code.component.ts
@@ -129,7 +129,10 @@ export class CodeComponent implements OnChanges {
     }
 
     ((this.language === 'none' ? skipPrettify : prettifyCode) as Observable<unknown>)
-        .subscribe(() => this.codeFormatted.emit(), () => { /* ignore failure to format */ });
+        .subscribe({
+          next: () => this.codeFormatted.emit(),
+          error: () => { /* ignore failure to format */ },
+        });
   }
 
   /** Sets the message showing that the code could not be found. */

--- a/aio/src/app/custom-elements/elements-loader.spec.ts
+++ b/aio/src/app/custom-elements/elements-loader.spec.ts
@@ -78,11 +78,11 @@ describe('ElementsLoader', () => {
       `;
 
       const log: any[] = [];
-      elementsLoader.loadContainedCustomElements(hostEl).subscribe(
-        v => log.push(`emitted: ${v}`),
-        e => log.push(`errored: ${e}`),
-        () => log.push('completed'),
-      );
+      elementsLoader.loadContainedCustomElements(hostEl).subscribe({
+        next: v => log.push(`emitted: ${v}`),
+        error: e => log.push(`errored: ${e}`),
+        complete: () => log.push('completed'),
+      });
 
       flushMicrotasks();
       expect(log).toEqual([]);
@@ -106,11 +106,11 @@ describe('ElementsLoader', () => {
       `;
 
       const log: any[] = [];
-      elementsLoader.loadContainedCustomElements(hostEl).subscribe(
-        v => log.push(`emitted: ${v}`),
-        e => log.push(`errored: ${e}`),
-        () => log.push('completed'),
-      );
+      elementsLoader.loadContainedCustomElements(hostEl).subscribe({
+        next: v => log.push(`emitted: ${v}`),
+        error: e => log.push(`errored: ${e}`),
+        complete: () => log.push('completed'),
+      });
 
       flushMicrotasks();
       expect(log).toEqual([]);

--- a/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
+++ b/aio/src/app/layout/doc-viewer/doc-viewer.component.spec.ts
@@ -598,7 +598,7 @@ describe('DocViewerComponent', () => {
         beforeEach(() => docViewerEl.classList[animationsEnabled ? 'remove' : 'add'](NO_ANIMATIONS));
 
         it('should return an observable', done => {
-          docViewer.swapViews().subscribe(done, done.fail);
+          docViewer.swapViews().subscribe({ next: done, error: done.fail });
         });
 
         it('should swap the views', async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Replaced deprecated `observable$.subscribe(next, error, complete)` signature with `observable$.subscribe({ next, error, complete })`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
