### PR TITLE
docs(localize): fix angular.json syntax error about i18n

### DIFF
--- a/aio/content/examples/i18n/angular.json
+++ b/aio/content/examples/i18n/angular.json
@@ -20,10 +20,12 @@
       "i18n": {
         "sourceLocale": "en-US",
         "locales": {
-          "fr": "src/locale/messages.fr.xlf",
-          // #enddocregion locale-config
-          "baseHref": ""
-          // #docregion locale-config
+          "fr": {
+            "translation": "src/locale/messages.fr.xlf",
+            // #enddocregion locale-config
+            "baseHref": ""
+            // #docregion locale-config
+          }
         }
       },
       // #docregion build-production-french


### PR DESCRIPTION
In chapter internationlization at section "Deploy multiple locales" the
syntax for angular.json is wrong.

Close #45032

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
