### PR TITLE
perf(core): avoid storing LView in __ngContext__

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -131,9 +131,10 @@ export class DebugElement extends DebugNode {
    * The element tag name, if it is an element.
    */
   get name(): string {
-    const context = getLContext(this.nativeNode);
-    if (context !== null) {
-      const lView = context.lView;
+    const context = getLContext(this.nativeNode)!;
+    const lView = context ? context.lView : null;
+
+    if (lView !== null) {
       const tData = lView[TVIEW].data;
       const tNode = tData[context.nodeIndex] as TNode;
       return tNode.value!;
@@ -154,13 +155,14 @@ export class DebugElement extends DebugNode {
    *  - input property bindings (e.g. `[myCustomInput]="value"`)
    *  - attribute bindings (e.g. `[attr.role]="menu"`)
    */
-  get properties(): {[key: string]: any} {
-    const context = getLContext(this.nativeNode);
-    if (context === null) {
+  get properties(): {[key: string]: any;} {
+    const context = getLContext(this.nativeNode)!;
+    const lView = context ? context.lView : null;
+
+    if (lView === null) {
       return {};
     }
 
-    const lView = context.lView;
     const tData = lView[TVIEW].data;
     const tNode = tData[context.nodeIndex] as TNode;
 
@@ -184,12 +186,13 @@ export class DebugElement extends DebugNode {
       return attributes;
     }
 
-    const context = getLContext(element);
-    if (context === null) {
+    const context = getLContext(element)!;
+    const lView = context ? context.lView : null;
+
+    if (lView === null) {
       return {};
     }
 
-    const lView = context.lView;
     const tNodeAttrs = (lView[TVIEW].data[context.nodeIndex] as TNode).attrs;
     const lowercaseTNodeAttrs: string[] = [];
 
@@ -420,11 +423,12 @@ function _queryAll(
 function _queryAll(
     parentElement: DebugElement, predicate: Predicate<DebugElement>|Predicate<DebugNode>,
     matches: DebugElement[]|DebugNode[], elementsOnly: boolean) {
-  const context = getLContext(parentElement.nativeNode);
-  if (context !== null) {
-    const parentTNode = context.lView[TVIEW].data[context.nodeIndex] as TNode;
+  const context = getLContext(parentElement.nativeNode)!;
+  const lView = context ? context.lView : null;
+  if (lView !== null) {
+    const parentTNode = lView[TVIEW].data[context.nodeIndex] as TNode;
     _queryNodeChildren(
-        parentTNode, context.lView, predicate, matches, elementsOnly, parentElement.nativeNode);
+        parentTNode, lView, predicate, matches, elementsOnly, parentElement.nativeNode);
   } else {
     // If the context is null, then `parentElement` was either created with Renderer2 or native DOM
     // APIs.

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -24,7 +24,7 @@ import {LQueries, TQueries} from '../interfaces/query';
 import {Renderer3, RendererFactory3} from '../interfaces/renderer';
 import {RComment, RElement, RNode} from '../interfaces/renderer_dom';
 import {getTStylingRangeNext, getTStylingRangeNextDuplicate, getTStylingRangePrev, getTStylingRangePrevDuplicate, TStylingKey, TStylingRange} from '../interfaces/styling';
-import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DebugNode, DECLARATION_VIEW, DestroyHookData, FLAGS, HEADER_OFFSET, HookData, HOST, HostBindingOpCodes, INJECTOR, LContainerDebug as ILContainerDebug, LView, LViewDebug as ILViewDebug, LViewDebugRange, LViewDebugRangeContent, LViewFlags, NEXT, NodeInjectorDebug, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, T_HOST, TData, TView as ITView, TVIEW, TView, TViewType, TViewTypeAsString} from '../interfaces/view';
+import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DebugNode, DECLARATION_VIEW, DestroyHookData, FLAGS, HEADER_OFFSET, HookData, HOST, HostBindingOpCodes, ID, INJECTOR, LContainerDebug as ILContainerDebug, LView, LViewDebug as ILViewDebug, LViewDebugRange, LViewDebugRangeContent, LViewFlags, NEXT, NodeInjectorDebug, PARENT, QUERIES, RENDERER, RENDERER_FACTORY, SANITIZER, T_HOST, TData, TView as ITView, TVIEW, TView, TViewType, TViewTypeAsString} from '../interfaces/view';
 import {attachDebugObject} from '../util/debug_utils';
 import {getParentInjectorIndex, getParentInjectorView} from '../util/injector_utils';
 import {unwrapRNode} from '../util/view_utils';
@@ -512,6 +512,9 @@ export class LViewDebug implements ILViewDebug {
   }
   get tHost(): ITNode|null {
     return this._raw_lView[T_HOST];
+  }
+  get id(): number {
+    return this._raw_lView[ID];
   }
 
   get decls(): LViewDebugRange {

--- a/packages/core/src/render3/interfaces/context.ts
+++ b/packages/core/src/render3/interfaces/context.ts
@@ -7,6 +7,7 @@
  */
 
 
+import {getLViewById} from './lview_tracking';
 import {RNode} from './renderer_dom';
 import {LView} from './view';
 
@@ -21,35 +22,41 @@ import {LView} from './view';
  * function. The component, element and each directive instance will share the same instance
  * of the context.
  */
-export interface LContext {
-  /**
-   * The component's parent view data.
-   */
-  lView: LView;
-
-  /**
-   * The index instance of the node.
-   */
-  nodeIndex: number;
-
-  /**
-   * The instance of the DOM node that is attached to the lNode.
-   */
-  native: RNode;
-
+export class LContext {
   /**
    * The instance of the Component node.
    */
-  component: {}|null|undefined;
+  public component: {}|null|undefined;
 
   /**
    * The list of active directives that exist on this element.
    */
-  directives: any[]|null|undefined;
+  public directives: any[]|null|undefined;
 
   /**
-   * The map of local references (local reference name => element or directive instance) that exist
-   * on this element.
+   * The map of local references (local reference name => element or directive instance) that
+   * exist on this element.
    */
-  localRefs: {[key: string]: any}|null|undefined;
+  public localRefs: {[key: string]: any}|null|undefined;
+
+  /** Component's parent view data. */
+  get lView(): LView|null {
+    return getLViewById(this.lViewId);
+  }
+
+  constructor(
+      /**
+       * ID of the component's parent view data.
+       */
+      private lViewId: number,
+
+      /**
+       * The index instance of the node.
+       */
+      public nodeIndex: number,
+
+      /**
+       * The instance of the DOM node that is attached to the lNode.
+       */
+      public native: RNode) {}
 }

--- a/packages/core/src/render3/interfaces/lview_tracking.ts
+++ b/packages/core/src/render3/interfaces/lview_tracking.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {assertNumber} from '../../util/assert';
+
+import {ID, LView} from './view';
+
+// Keeps track of the currently-active LViews.
+const TRACKED_LVIEWS = new Map<number, LView>();
+
+// Used for generating unique IDs for LViews.
+let uniqueIdCounter = 0;
+
+/** Starts tracking an LView and returns a unique ID that can be used for future lookups. */
+export function registerLView(lView: LView): number {
+  const id = uniqueIdCounter++;
+  TRACKED_LVIEWS.set(id, lView);
+  return id;
+}
+
+/** Gets an LView by its unique ID. */
+export function getLViewById(id: number): LView|null {
+  ngDevMode && assertNumber(id, 'ID used for LView lookup must be a number');
+  return TRACKED_LVIEWS.get(id) || null;
+}
+
+/** Stops tracking an LView. */
+export function unregisterLView(lView: LView): void {
+  ngDevMode && assertNumber(lView[ID], 'Cannot stop tracking an LView that does not have an ID');
+  TRACKED_LVIEWS.delete(lView[ID]);
+}

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -11,6 +11,7 @@ import {ProviderToken} from '../../di/provider_token';
 import {Type} from '../../interface/type';
 import {SchemaMetadata} from '../../metadata/schema';
 import {Sanitizer} from '../../sanitization/sanitizer';
+
 import {LContainer} from './container';
 import {ComponentDef, ComponentTemplate, DirectiveDef, DirectiveDefList, HostBindingsFunction, PipeDef, PipeDefList, ViewQueriesFunction} from './definition';
 import {I18nUpdateOpCodes, TI18n, TIcu} from './i18n';
@@ -47,6 +48,7 @@ export const DECLARATION_COMPONENT_VIEW = 16;
 export const DECLARATION_LCONTAINER = 17;
 export const PREORDER_HOOK_FLAGS = 18;
 export const QUERIES = 19;
+export const ID = 20;
 /**
  * Size of LView's header. Necessary to adjust for it when setting slots.
  *
@@ -54,7 +56,7 @@ export const QUERIES = 19;
  * instruction index into `LView` index. All other indexes should be in the `LView` index space and
  * there should be no need to refer to `HEADER_OFFSET` anywhere else.
  */
-export const HEADER_OFFSET = 20;
+export const HEADER_OFFSET = 21;
 
 
 // This interface replaces the real LView interface if it is an arg or a
@@ -326,6 +328,9 @@ export interface LView extends Array<any> {
    * are not `Dirty`/`CheckAlways`.
    */
   [TRANSPLANTED_VIEWS_TO_REFRESH]: number;
+
+  /** Unique ID of the view. Used for `__ngContext__` lookups in the `LView` registry. */
+  [ID]: number;
 }
 
 /** Flags associated with an LView (saved in LView[FLAGS]) */

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -19,6 +19,7 @@ import {icuContainerIterate} from './i18n/i18n_tree_shaking';
 import {CONTAINER_HEADER_OFFSET, HAS_TRANSPLANTED_VIEWS, LContainer, MOVED_VIEWS, NATIVE, unusedValueExportToPlacateAjd as unused1} from './interfaces/container';
 import {ComponentDef} from './interfaces/definition';
 import {NodeInjectorFactory} from './interfaces/injector';
+import {unregisterLView} from './interfaces/lview_tracking';
 import {TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeType, TProjectionNode, unusedValueExportToPlacateAjd as unused2} from './interfaces/node';
 import {unusedValueExportToPlacateAjd as unused3} from './interfaces/projection';
 import {isProceduralRenderer, ProceduralRenderer3, Renderer3, unusedValueExportToPlacateAjd as unused4} from './interfaces/renderer';
@@ -444,6 +445,9 @@ function cleanUpView(tView: TView, lView: LView): void {
         lQueries.detachView(tView);
       }
     }
+
+    // Unregister the view once everything else has been cleaned up.
+    unregisterLView(lView);
   }
 }
 

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -11,7 +11,7 @@ import {Injector} from '../../di/injector';
 import {ViewEncapsulation} from '../../metadata/view';
 import {assertEqual} from '../../util/assert';
 import {assertLView} from '../assert';
-import {discoverLocalRefs, getComponentAtNodeIndex, getDirectivesAtNodeIndex, getLContext} from '../context_discovery';
+import {discoverLocalRefs, getComponentAtNodeIndex, getDirectivesAtNodeIndex, getLContext, readPatchedLView} from '../context_discovery';
 import {getComponentDef, getDirectiveDef} from '../definition';
 import {NodeInjector} from '../di';
 import {buildDebugNode} from '../instructions/lview_debug';
@@ -20,6 +20,7 @@ import {DirectiveDef} from '../interfaces/definition';
 import {TElementNode, TNode, TNodeProviderIndexes} from '../interfaces/node';
 import {isLView} from '../interfaces/type_checks';
 import {CLEANUP, CONTEXT, DebugNode, FLAGS, LView, LViewFlags, T_HOST, TVIEW, TViewType} from '../interfaces/view';
+
 import {stringifyForError} from './stringify_utils';
 import {getLViewParent, getRootContext} from './view_traversal_utils';
 import {getTNode, unwrapRNode} from './view_utils';
@@ -54,12 +55,16 @@ import {getTNode, unwrapRNode} from './view_utils';
  * @globalApi ng
  */
 export function getComponent<T>(element: Element): T|null {
-  assertDomElement(element);
+  ngDevMode && assertDomElement(element);
   const context = getLContext(element);
   if (context === null) return null;
 
   if (context.component === undefined) {
-    context.component = getComponentAtNodeIndex(context.nodeIndex, context.lView);
+    const lView = context.lView;
+    if (lView === null) {
+      return null;
+    }
+    context.component = getComponentAtNodeIndex(context.nodeIndex, lView);
   }
 
   return context.component as T;
@@ -80,8 +85,9 @@ export function getComponent<T>(element: Element): T|null {
  */
 export function getContext<T>(element: Element): T|null {
   assertDomElement(element);
-  const context = getLContext(element);
-  return context === null ? null : context.lView[CONTEXT] as T;
+  const context = getLContext(element)!;
+  const lView = context ? context.lView : null;
+  return lView === null ? null : lView[CONTEXT] as T;
 }
 
 /**
@@ -100,12 +106,11 @@ export function getContext<T>(element: Element): T|null {
  * @globalApi ng
  */
 export function getOwningComponent<T>(elementOrDir: Element|{}): T|null {
-  const context = getLContext(elementOrDir);
-  if (context === null) return null;
+  const context = getLContext(elementOrDir)!;
+  let lView = context ? context.lView : null;
+  if (lView === null) return null;
 
-  let lView = context.lView;
   let parent: LView|null;
-  ngDevMode && assertLView(lView);
   while (lView[TVIEW].type === TViewType.Embedded && (parent = getLViewParent(lView)!)) {
     lView = parent;
   }
@@ -124,7 +129,8 @@ export function getOwningComponent<T>(elementOrDir: Element|{}): T|null {
  * @globalApi ng
  */
 export function getRootComponents(elementOrDir: Element|{}): {}[] {
-  return [...getRootContext(elementOrDir).components];
+  const lView = readPatchedLView(elementOrDir);
+  return lView !== null ? [...getRootContext(lView).components] : [];
 }
 
 /**
@@ -138,11 +144,12 @@ export function getRootComponents(elementOrDir: Element|{}): {}[] {
  * @globalApi ng
  */
 export function getInjector(elementOrDir: Element|{}): Injector {
-  const context = getLContext(elementOrDir);
-  if (context === null) return Injector.NULL;
+  const context = getLContext(elementOrDir)!;
+  const lView = context ? context.lView : null;
+  if (lView === null) return Injector.NULL;
 
-  const tNode = context.lView[TVIEW].data[context.nodeIndex] as TElementNode;
-  return new NodeInjector(tNode, context.lView);
+  const tNode = lView[TVIEW].data[context.nodeIndex] as TElementNode;
+  return new NodeInjector(tNode, lView);
 }
 
 /**
@@ -151,9 +158,9 @@ export function getInjector(elementOrDir: Element|{}): Injector {
  * @param element Element for which the injection tokens should be retrieved.
  */
 export function getInjectionTokens(element: Element): any[] {
-  const context = getLContext(element);
-  if (context === null) return [];
-  const lView = context.lView;
+  const context = getLContext(element)!;
+  const lView = context ? context.lView : null;
+  if (lView === null) return [];
   const tView = lView[TVIEW];
   const tNode = tView.data[context.nodeIndex] as TNode;
   const providerTokens: any[] = [];
@@ -204,12 +211,12 @@ export function getDirectives(node: Node): {}[] {
     return [];
   }
 
-  const context = getLContext(node);
-  if (context === null) {
+  const context = getLContext(node)!;
+  const lView = context ? context.lView : null;
+  if (lView === null) {
     return [];
   }
 
-  const lView = context.lView;
   const tView = lView[TVIEW];
   const nodeIndex = context.nodeIndex;
   if (!tView?.data[nodeIndex]) {
@@ -301,7 +308,11 @@ export function getLocalRefs(target: {}): {[key: string]: any} {
   if (context === null) return {};
 
   if (context.localRefs === undefined) {
-    context.localRefs = discoverLocalRefs(context.lView, context.nodeIndex);
+    const lView = context.lView;
+    if (lView === null) {
+      return {};
+    }
+    context.localRefs = discoverLocalRefs(lView, context.nodeIndex);
   }
 
   return context.localRefs || {};
@@ -389,11 +400,11 @@ export interface Listener {
  * @globalApi ng
  */
 export function getListeners(element: Element): Listener[] {
-  assertDomElement(element);
+  ngDevMode && assertDomElement(element);
   const lContext = getLContext(element);
-  if (lContext === null) return [];
+  const lView = lContext === null ? null : lContext.lView;
+  if (lView === null) return [];
 
-  const lView = lContext.lView;
   const tView = lView[TVIEW];
   const lCleanup = lView[CLEANUP];
   const tCleanup = tView.cleanup;
@@ -447,12 +458,13 @@ export function getDebugNode(element: Element): DebugNode|null {
     throw new Error('Expecting instance of DOM Element');
   }
 
-  const lContext = getLContext(element);
-  if (lContext === null) {
+  const lContext = getLContext(element)!;
+  const lView = lContext ? lContext.lView : null;
+
+  if (lView === null) {
     return null;
   }
 
-  const lView = lContext.lView;
   const nodeIndex = lContext.nodeIndex;
   if (nodeIndex !== -1) {
     const valueInLView = lView[nodeIndex];
@@ -479,7 +491,8 @@ export function getDebugNode(element: Element): DebugNode|null {
 export function getComponentLView(target: any): LView {
   const lContext = getLContext(target)!;
   const nodeIndx = lContext.nodeIndex;
-  const lView = lContext.lView;
+  const lView = lContext.lView!;
+  ngDevMode && assertLView(lView);
   const componentLView = lView[nodeIndx];
   ngDevMode && assertLView(componentLView);
   return componentLView;

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -91,6 +91,31 @@ describe('component', () => {
        expect(fixture.nativeElement.textContent.trim()).toBe('hello');
      });
 
+  it('should not throw when calling `detectChanges` on the ChangeDetectorRef of a destroyed view',
+     () => {
+       @Component({template: 'hello'})
+       class HelloComponent {
+       }
+
+       @Component({template: `<div #insertionPoint></div>`})
+       class App {
+         @ViewChild('insertionPoint', {read: ViewContainerRef}) viewContainerRef!: ViewContainerRef;
+       }
+
+       TestBed.configureTestingModule({declarations: [App, HelloComponent]});
+       const fixture = TestBed.createComponent(App);
+       fixture.detectChanges();
+
+       const componentRef =
+           fixture.componentInstance.viewContainerRef.createComponent(HelloComponent);
+       fixture.detectChanges();
+
+       expect(() => {
+         componentRef.destroy();
+         componentRef.changeDetectorRef.detectChanges();
+       }).not.toThrow();
+     });
+
   // TODO: add tests with Native once tests run in real browser (domino doesn't support shadow root)
   describe('encapsulation', () => {
     @Component({

--- a/packages/core/test/acceptance/debug_spec.ts
+++ b/packages/core/test/acceptance/debug_spec.ts
@@ -26,7 +26,7 @@ describe('Debug Representation', () => {
     const fixture = TestBed.createComponent(MyComponent);
     fixture.detectChanges();
 
-    const hostView = getLContext(fixture.componentInstance)!.lView.debug!;
+    const hostView = getLContext(fixture.componentInstance)!.lView!.debug!;
     expect(hostView.hostHTML).toEqual(null);
     const myCompView = hostView.childViews[0] as LViewDebug;
     expect(myCompView.hostHTML).toContain('<div id="123">Hello World</div>');
@@ -46,7 +46,7 @@ describe('Debug Representation', () => {
         const fixture = TestBed.createComponent(MyComponent);
         fixture.detectChanges();
 
-        const hostView = getLContext(fixture.componentInstance)!.lView.debug!;
+        const hostView = getLContext(fixture.componentInstance)!.lView!.debug!;
         const myComponentView = hostView.childViews[0] as LViewDebug;
         expect(myComponentView.decls).toEqual({
           start: HEADER_OFFSET,

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -65,16 +65,19 @@ describe('discovery utils', () => {
   @Component({
     selector: 'my-app',
     template: `
-      <span (click)="log($event)">{{text}}</span>
+      <span (click)="log($event)" *ngIf="spanVisible">{{text}}</span>
       <div dirA #div #foo="dirA"></div>
       <child></child>
       <child dirA #child></child>
-      <child dirA *ngIf="true"></child>
+      <child dirA *ngIf="conditionalChildVisible"></child>
       <ng-container><p></p></ng-container>
+      <b *ngIf="visible">Bold</b>
     `
   })
   class MyApp {
     text: string = 'INIT';
+    spanVisible = true;
+    conditionalChildVisible = true;
     @Input('a') b = 2;
     @Output('c') d = new EventEmitter();
     constructor() {
@@ -100,6 +103,15 @@ describe('discovery utils', () => {
       expect(getComponent<MyApp>(fixture.nativeElement)).toEqual(myApp);
       expect(getComponent<Child>(child[0])).toEqual(childComponent[0]);
       expect(getComponent<Child>(child[1])).toEqual(childComponent[1]);
+    });
+    it('should not throw when called on a destroyed node', () => {
+      expect(getComponent(span[0])).toEqual(null);
+      expect(getComponent<Child>(child[2])).toEqual(childComponent[2]);
+      fixture.componentInstance.spanVisible = false;
+      fixture.componentInstance.conditionalChildVisible = false;
+      fixture.detectChanges();
+      expect(getComponent(span[0])).toEqual(null);
+      expect(getComponent<Child>(child[2])).toEqual(childComponent[2]);
     });
   });
 
@@ -127,6 +139,12 @@ describe('discovery utils', () => {
       expect(getContext<{$implicit: boolean}>(child[2])!.$implicit).toEqual(true);
       expect(getContext<Child>(p[0])).toEqual(childComponent[0]);
     });
+    it('should return null for destroyed node', () => {
+      expect(getContext(span[0])).toBeTruthy();
+      fixture.componentInstance.spanVisible = false;
+      fixture.detectChanges();
+      expect(getContext(span[0])).toBeNull();
+    });
   });
 
   describe('getHostElement', () => {
@@ -141,6 +159,12 @@ describe('discovery utils', () => {
     });
     it('should throw on unknown target', () => {
       expect(() => getHostElement({})).toThrowError();  //
+    });
+    it('should return element for destroyed node', () => {
+      expect(getHostElement(span[0])).toEqual(span[0]);
+      fixture.componentInstance.spanVisible = false;
+      fixture.detectChanges();
+      expect(getHostElement(span[0])).toEqual(span[0]);
     });
   });
 
@@ -159,6 +183,12 @@ describe('discovery utils', () => {
       expect(getInjector(dirA[0]).get(String)).toEqual('Module');
       expect(getInjector(dirA[1]).get(String)).toEqual('Child');
     });
+    it('should retrieve injector from destroyed node', () => {
+      expect(getInjector(span[0])).toBeTruthy();
+      fixture.componentInstance.spanVisible = false;
+      fixture.detectChanges();
+      expect(getInjector(span[0])).toBeTruthy();
+    });
   });
 
   describe('getDirectives', () => {
@@ -170,6 +200,12 @@ describe('discovery utils', () => {
     it('should return just directives', () => {
       expect(getDirectives(div[0])).toEqual([dirA[0]]);
       expect(getDirectives(child[1])).toEqual([dirA[1]]);
+    });
+    it('should return empty array for destroyed node', () => {
+      expect(getDirectives(span[0])).toEqual([]);
+      fixture.componentInstance.spanVisible = false;
+      fixture.detectChanges();
+      expect(getDirectives(span[0])).toEqual([]);
     });
   });
 
@@ -198,6 +234,12 @@ describe('discovery utils', () => {
       expect(getOwningComponent<MyApp>(dirA[0])).toEqual(myApp);
       expect(getOwningComponent<MyApp>(dirA[1])).toEqual(myApp);
     });
+    it('should return null for destroyed node', () => {
+      expect(getOwningComponent<MyApp>(span[0])).toEqual(myApp);
+      fixture.componentInstance.spanVisible = false;
+      fixture.detectChanges();
+      expect(getOwningComponent<MyApp>(span[0])).toEqual(null);
+    });
   });
 
   describe('getLocalRefs', () => {
@@ -215,6 +257,13 @@ describe('discovery utils', () => {
       expect(getLocalRefs(child[1])).toEqual({child: childComponent[1]});
       expect(getLocalRefs(dirA[1])).toEqual({child: childComponent[1]});
     });
+
+    it('should retrieve from a destroyed node', () => {
+      expect(getLocalRefs(span[0])).toEqual({});
+      fixture.componentInstance.spanVisible = false;
+      fixture.detectChanges();
+      expect(getLocalRefs(span[0])).toEqual({});
+    });
   });
 
   describe('getRootComponents', () => {
@@ -229,6 +278,12 @@ describe('discovery utils', () => {
       expect(getRootComponents(child[1])).toEqual(rootComponents);
       expect(getRootComponents(div[0])).toEqual(rootComponents);
       expect(getRootComponents(p[0])).toEqual(rootComponents);
+    });
+    it('should return an empty array for a destroyed node', () => {
+      expect(getRootComponents(span[0])).toEqual([myApp]);
+      fixture.componentInstance.spanVisible = false;
+      fixture.detectChanges();
+      expect(getRootComponents(span[0])).toEqual([]);
     });
   });
 
@@ -247,6 +302,12 @@ describe('discovery utils', () => {
       listeners[0].callback('CLICKED');
       expect(log).toEqual(['CLICKED']);
     });
+    it('should return no listeners for destroyed node', () => {
+      expect(getListeners(span[0]).length).toEqual(1);
+      fixture.componentInstance.spanVisible = false;
+      fixture.detectChanges();
+      expect(getListeners(span[0]).length).toEqual(0);
+    });
   });
 
   describe('getInjectionTokens', () => {
@@ -254,6 +315,12 @@ describe('discovery utils', () => {
       expect(getInjectionTokens(fixture.nativeElement)).toEqual([MyApp]);
       expect(getInjectionTokens(child[0])).toEqual([String, Child]);
       expect(getInjectionTokens(child[1])).toEqual([String, Child, DirectiveA]);
+    });
+    it('should retrieve tokens from destroyed node', () => {
+      expect(getInjectionTokens(span[0])).toEqual([]);
+      fixture.componentInstance.spanVisible = false;
+      fixture.detectChanges();
+      expect(getInjectionTokens(span[0])).toEqual([]);
     });
   });
 

--- a/packages/core/test/acceptance/ngdevmode_debug_spec.ts
+++ b/packages/core/test/acceptance/ngdevmode_debug_spec.ts
@@ -44,7 +44,7 @@ describe('ngDevMode debug', () => {
 
       TestBed.configureTestingModule({declarations: [MyApp], imports: [CommonModule]});
       const fixture = TestBed.createComponent(MyApp);
-      const rootLView = getLContext(fixture.nativeElement)!.lView;
+      const rootLView = getLContext(fixture.nativeElement)!.lView!;
       expect(rootLView.constructor.name)
           .toEqual(targetSupportsArraySubclassing ? 'LRootView' : 'Array');
 
@@ -55,7 +55,7 @@ describe('ngDevMode debug', () => {
       const element: HTMLElement = fixture.nativeElement;
       fixture.detectChanges();
       const li = element.querySelector('li')!;
-      const embeddedLView = getLContext(li)!.lView;
+      const embeddedLView = getLContext(li)!.lView!;
       expect(embeddedLView.constructor.name)
           .toEqual(targetSupportsArraySubclassing ? 'LEmbeddedView' : 'Array');
     });
@@ -76,7 +76,7 @@ describe('ngDevMode debug', () => {
 
           TestBed.configureTestingModule({declarations: [MyApp], imports: [CommonModule]});
           const fixture = TestBed.createComponent(MyApp);
-          const rootLView = getLContext(fixture.nativeElement)!.lView;
+          const rootLView = getLContext(fixture.nativeElement)!.lView!;
           expect(rootLView.constructor.name)
               .toEqual(targetSupportsArraySubclassing ? 'LRootView' : 'Array');
 
@@ -86,7 +86,7 @@ describe('ngDevMode debug', () => {
           const element: HTMLElement = fixture.nativeElement;
           fixture.detectChanges();
           const li = element.querySelector('li')!;
-          const embeddedLView = getLContext(li)!.lView;
+          const embeddedLView = getLContext(li)!.lView!;
           expect(embeddedLView.constructor.name).toEqual('LEmbeddedView_MyApp_li_1');
         });
   });

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -480,6 +480,9 @@
     "name": "THROW_IF_NOT_FOUND"
   },
   {
+    "name": "TRACKED_LVIEWS"
+  },
+  {
     "name": "TRANSITION_ID"
   },
   {
@@ -1375,6 +1378,9 @@
   },
   {
     "name": "u"
+  },
+  {
+    "name": "uniqueIdCounter"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -39,6 +39,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "TRACKED_LVIEWS"
+  },
+  {
     "name": "TriggerComponent"
   },
   {
@@ -249,6 +252,9 @@
     "name": "isInlineTemplate"
   },
   {
+    "name": "isLView"
+  },
+  {
     "name": "isNodeMatchingSelector"
   },
   {
@@ -346,6 +352,9 @@
   },
   {
     "name": "setUpAttributes"
+  },
+  {
+    "name": "uniqueIdCounter"
   },
   {
     "name": "updateTransplantedViewCount"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -483,6 +483,9 @@
     "name": "THROW_IF_NOT_FOUND"
   },
   {
+    "name": "TRACKED_LVIEWS"
+  },
+  {
     "name": "TRANSITION_ID"
   },
   {
@@ -1534,6 +1537,9 @@
   },
   {
     "name": "u"
+  },
+  {
+    "name": "uniqueIdCounter"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/forms_reactive/forms_e2e_spec.ts
+++ b/packages/core/test/bundling/forms_reactive/forms_e2e_spec.ts
@@ -8,7 +8,6 @@
 
 import '@angular/compiler';
 
-import {ɵwhenRendered as whenRendered} from '@angular/core';
 import {withBody} from '@angular/private/testing';
 import * as path from 'path';
 
@@ -19,8 +18,8 @@ describe('functional test for reactive forms', () => {
   BUNDLES.forEach((bundle) => {
     describe(`using ${bundle} bundle`, () => {
       it('should render template form', withBody('<app-root></app-root>', async () => {
-           require(path.join(PACKAGE, bundle));
-           await (window as any).waitForApp;
+           const {whenRendered, bootstrapApp} = require(path.join(PACKAGE, bundle));
+           await bootstrapApp();
 
            // Reactive forms
            const reactiveFormsComponent = (window as any).reactiveFormsComponent;

--- a/packages/core/test/bundling/forms_reactive/index.ts
+++ b/packages/core/test/bundling/forms_reactive/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory} from '@angular/core';
+import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory, ɵwhenRendered as whenRendered} from '@angular/core';
 import {FormArray, FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/forms';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
@@ -93,5 +93,15 @@ class FormsExampleModule {
   }
 }
 
-(window as any).waitForApp = platformBrowser().bootstrapModuleFactory(
-    new NgModuleFactory(FormsExampleModule), {ngZone: 'noop'});
+function bootstrapApp() {
+  return platformBrowser().bootstrapModuleFactory(
+      new NgModuleFactory(FormsExampleModule), {ngZone: 'noop'});
+}
+
+// This bundle includes `@angular/core` within it which means that the test asserting
+// against it will load a different core bundle. These symbols are exposed so that they
+// can interact with the correct `@angular/core` instance.
+module.exports = {
+  whenRendered,
+  bootstrapApp
+};

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -477,6 +477,9 @@
     "name": "THROW_IF_NOT_FOUND"
   },
   {
+    "name": "TRACKED_LVIEWS"
+  },
+  {
     "name": "TRANSITION_ID"
   },
   {
@@ -1519,6 +1522,9 @@
   },
   {
     "name": "u"
+  },
+  {
+    "name": "uniqueIdCounter"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/forms_template_driven/forms_e2e_spec.ts
+++ b/packages/core/test/bundling/forms_template_driven/forms_e2e_spec.ts
@@ -8,7 +8,6 @@
 
 import '@angular/compiler';
 
-import {ɵwhenRendered as whenRendered} from '@angular/core';
 import {withBody} from '@angular/private/testing';
 import * as path from 'path';
 
@@ -19,8 +18,8 @@ describe('functional test for forms', () => {
   BUNDLES.forEach((bundle) => {
     describe(`using ${bundle} bundle`, () => {
       it('should render template form', withBody('<app-root></app-root>', async () => {
-           require(path.join(PACKAGE, bundle));
-           await (window as any).waitForApp;
+           const {bootstrapApp, whenRendered} = require(path.join(PACKAGE, bundle));
+           await bootstrapApp();
 
            // Template forms
            const templateFormsComponent = (window as any).templateFormsComponent;

--- a/packages/core/test/bundling/forms_template_driven/index.ts
+++ b/packages/core/test/bundling/forms_template_driven/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory} from '@angular/core';
+import {Component, NgModule, ɵNgModuleFactory as NgModuleFactory, ɵwhenRendered as whenRendered} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
@@ -70,5 +70,15 @@ class FormsExampleModule {
   }
 }
 
-(window as any).waitForApp = platformBrowser().bootstrapModuleFactory(
-    new NgModuleFactory(FormsExampleModule), {ngZone: 'noop'});
+function bootstrapApp() {
+  return platformBrowser().bootstrapModuleFactory(
+      new NgModuleFactory(FormsExampleModule), {ngZone: 'noop'});
+}
+
+// This bundle includes `@angular/core` within it which means that the test asserting
+// against it will load a different core bundle. These symbols are exposed so that they
+// can interact with the correct `@angular/core` instance.
+module.exports = {
+  whenRendered,
+  bootstrapApp
+};

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -39,6 +39,9 @@
     "name": "RuntimeError"
   },
   {
+    "name": "TRACKED_LVIEWS"
+  },
+  {
     "name": "ViewEncapsulation"
   },
   {
@@ -177,6 +180,9 @@
     "name": "isInCheckNoChangesMode"
   },
   {
+    "name": "isLView"
+  },
+  {
     "name": "isProceduralRenderer"
   },
   {
@@ -241,6 +247,9 @@
   },
   {
     "name": "setSelectedIndex"
+  },
+  {
+    "name": "uniqueIdCounter"
   },
   {
     "name": "updateTransplantedViewCount"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -660,6 +660,9 @@
     "name": "TQuery_"
   },
   {
+    "name": "TRACKED_LVIEWS"
+  },
+  {
     "name": "TRANSITION_ID"
   },
   {
@@ -1897,6 +1900,9 @@
   },
   {
     "name": "u"
+  },
+  {
+    "name": "uniqueIdCounter"
   },
   {
     "name": "unwrapElementRef"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -99,6 +99,9 @@
     "name": "SkipSelf"
   },
   {
+    "name": "TRACKED_LVIEWS"
+  },
+  {
     "name": "TemplateRef"
   },
   {
@@ -375,6 +378,9 @@
     "name": "getComponentLViewByIndex"
   },
   {
+    "name": "getComponentViewByInstance"
+  },
+  {
     "name": "getConstant"
   },
   {
@@ -397,6 +403,9 @@
   },
   {
     "name": "getLView"
+  },
+  {
+    "name": "getLViewById"
   },
   {
     "name": "getLViewParent"
@@ -790,6 +799,9 @@
   },
   {
     "name": "trackByIdentity"
+  },
+  {
+    "name": "uniqueIdCounter"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/todo/index.ts
+++ b/packages/core/test/bundling/todo/index.ts
@@ -9,7 +9,7 @@
 import '@angular/core/test/bundling/util/src/reflect_metadata';
 
 import {CommonModule} from '@angular/common';
-import {Component, Injectable, NgModule, ViewEncapsulation, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent} from '@angular/core';
+import {Component, Injectable, NgModule, ViewEncapsulation, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent, ɵwhenRendered as whenRendered} from '@angular/core';
 
 class Todo {
   editing: boolean;
@@ -133,7 +133,9 @@ class TodoStore {
 class ToDoAppComponent {
   newTodoText = '';
 
-  constructor(public todoStore: TodoStore) {}
+  constructor(public todoStore: TodoStore) {
+    (window as any).todoAppComponent = this;
+  }
 
   cancelEditingTodo(todo: Todo) {
     todo.editing = false;
@@ -200,3 +202,8 @@ class ToDoAppModule {
 }
 
 renderComponent(ToDoAppComponent);
+
+// This bundle includes `@angular/core` within it which means that the test asserting
+// against it will load a different core bundle. These symbols are exposed so that they
+// can interact with the correct `@angular/core` instance.
+module.exports = {whenRendered};

--- a/packages/core/test/bundling/todo/todo_e2e_spec.ts
+++ b/packages/core/test/bundling/todo/todo_e2e_spec.ts
@@ -8,8 +8,6 @@
 
 import '@angular/compiler';
 
-import {ɵwhenRendered as whenRendered} from '@angular/core';
-import {getComponent} from '@angular/core/src/render3';
 import {withBody} from '@angular/private/testing';
 import * as path from 'path';
 
@@ -20,13 +18,12 @@ describe('functional test for todo', () => {
   BUNDLES.forEach(bundle => {
     describe(bundle, () => {
       it('should render todo', withBody('<todo-app></todo-app>', async () => {
-           require(path.join(PACKAGE, bundle));
-           const toDoAppComponent = getComponent(document.querySelector('todo-app')!);
+           const {whenRendered} = require(path.join(PACKAGE, bundle));
            expect(document.body.textContent).toContain('todos');
            expect(document.body.textContent).toContain('Demonstrate Components');
            expect(document.body.textContent).toContain('4 items left');
            document.querySelector('button')!.click();
-           await whenRendered(toDoAppComponent);
+           await whenRendered((window as any).todoAppComponent);
            expect(document.body.textContent).toContain('3 items left');
          }));
     });

--- a/packages/core/test/bundling/todo_i18n/index.ts
+++ b/packages/core/test/bundling/todo_i18n/index.ts
@@ -8,7 +8,7 @@
 import '@angular/core/test/bundling/util/src/reflect_metadata';
 
 import {CommonModule} from '@angular/common';
-import {Component, Injectable, NgModule, ViewEncapsulation, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent} from '@angular/core';
+import {Component, Injectable, NgModule, ViewEncapsulation, ɵmarkDirty as markDirty, ɵrenderComponent as renderComponent, ɵwhenRendered as whenRendered} from '@angular/core';
 import {loadTranslations} from '@angular/localize';
 
 import {translations} from './translations';
@@ -130,7 +130,9 @@ class TodoStore {
 class ToDoAppComponent {
   newTodoText = '';
 
-  constructor(public todoStore: TodoStore) {}
+  constructor(public todoStore: TodoStore) {
+    (window as any).todoAppComponent = this;
+  }
 
   cancelEditingTodo(todo: Todo) {
     todo.editing = false;
@@ -198,3 +200,8 @@ class ToDoAppModule {
 
 loadTranslations(translations);
 renderComponent(ToDoAppComponent);
+
+// This bundle includes `@angular/core` within it which means that the test asserting
+// against it will load a different core bundle. These symbols are exposed so that they
+// can interact with the correct `@angular/core` instance.
+module.exports = {whenRendered};

--- a/packages/core/test/bundling/todo_i18n/todo_e2e_spec.ts
+++ b/packages/core/test/bundling/todo_i18n/todo_e2e_spec.ts
@@ -8,8 +8,6 @@
 import '@angular/localize/init';
 import '@angular/compiler';
 
-import {ɵwhenRendered as whenRendered} from '@angular/core';
-import {getComponent} from '@angular/core/src/render3';
 import {clearTranslations} from '@angular/localize';
 import {withBody} from '@angular/private/testing';
 import * as path from 'path';
@@ -22,8 +20,7 @@ describe('functional test for todo i18n', () => {
     describe(bundle, () => {
       it('should render todo i18n', withBody('<todo-app></todo-app>', async () => {
            clearTranslations();
-           require(path.join(PACKAGE, bundle));
-           const toDoAppComponent = getComponent(document.querySelector('todo-app')!);
+           const {whenRendered} = require(path.join(PACKAGE, bundle));
            expect(document.body.textContent).toContain('liste de tâches');
            expect(document.body.textContent).toContain('Démontrer les components');
            expect(document.body.textContent).toContain('Démontrer NgModules');
@@ -31,7 +28,7 @@ describe('functional test for todo i18n', () => {
            expect(document.querySelector('.new-todo')!.getAttribute('placeholder'))
                .toEqual(`Qu'y a-t-il à faire ?`);
            document.querySelector('button')!.click();
-           await whenRendered(toDoAppComponent);
+           await whenRendered((window as any).todoAppComponent);
            expect(document.body.textContent).toContain('3 tâches restantes');
          }));
     });

--- a/packages/core/test/bundling/todo_r2/index.ts
+++ b/packages/core/test/bundling/todo_r2/index.ts
@@ -9,7 +9,7 @@
 import '@angular/core/test/bundling/util/src/reflect_metadata';
 
 import {CommonModule} from '@angular/common';
-import {Component, Injectable, NgModule, ɵNgModuleFactory as NgModuleFactory} from '@angular/core';
+import {Component, Injectable, NgModule, ɵNgModuleFactory as NgModuleFactory, ɵwhenRendered as whenRendered} from '@angular/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
 class Todo {
@@ -195,5 +195,15 @@ class ToDoAppModule {
   }
 }
 
-(window as any).waitForApp =
-    platformBrowser().bootstrapModuleFactory(new NgModuleFactory(ToDoAppModule), {ngZone: 'noop'});
+function bootstrapApp() {
+  return platformBrowser().bootstrapModuleFactory(
+      new NgModuleFactory(ToDoAppModule), {ngZone: 'noop'});
+}
+
+// This bundle includes `@angular/core` within it which means that the test asserting
+// against it will load a different core bundle. These symbols are exposed so that they
+// can interact with the correct `@angular/core` instance.
+module.exports = {
+  whenRendered,
+  bootstrapApp
+};

--- a/packages/core/test/bundling/todo_r2/todo_e2e_spec.ts
+++ b/packages/core/test/bundling/todo_r2/todo_e2e_spec.ts
@@ -8,13 +8,9 @@
 
 import '@angular/compiler';
 
-import {ɵwhenRendered as whenRendered} from '@angular/core';
 import {withBody} from '@angular/private/testing';
 import * as path from 'path';
 
-const UTF8 = {
-  encoding: 'utf-8'
-};
 const PACKAGE = 'angular/packages/core/test/bundling/todo_r2';
 const BUNDLES = ['bundle.js', 'bundle.debug.min.js', 'bundle.min.js'];
 
@@ -23,8 +19,8 @@ describe('functional test for todo', () => {
     describe(bundle, () => {
       it('should place styles on the elements within the component',
          withBody('<todo-app></todo-app>', async () => {
-           require(path.join(PACKAGE, bundle));
-           await (window as any).waitForApp;
+           const {bootstrapApp, whenRendered} = require(path.join(PACKAGE, bundle));
+           await bootstrapApp();
            const toDoAppComponent = (window as any).toDoAppComponent;
            await whenRendered(toDoAppComponent);
 

--- a/packages/core/test/render3/i18n/i18n_parse_spec.ts
+++ b/packages/core/test/render3/i18n/i18n_parse_spec.ts
@@ -12,6 +12,7 @@ import {i18nStartFirstCreatePass} from '@angular/core/src/render3/i18n/i18n_pars
 import {getTIcu} from '@angular/core/src/render3/i18n/i18n_util';
 import {I18nUpdateOpCodes, IcuType, TI18n} from '@angular/core/src/render3/interfaces/i18n';
 import {HEADER_OFFSET, HOST} from '@angular/core/src/render3/interfaces/view';
+
 import {matchTI18n, matchTIcu} from '../matchers';
 import {matchDebug} from '../utils';
 import {ViewFixture} from '../view_fixture';
@@ -39,16 +40,16 @@ describe('i18n_parse', () => {
       //     TData                  | LView
       // ---------------------------+-------------------------------
       //                     ----- DECL -----
-      // 20: TI18n                  |
+      // 21: TI18n                  |
       //                     ----- VARS -----
-      // 21: Binding for ICU        |
+      // 22: Binding for ICU        |
       //                   ----- EXPANDO -----
-      // 22: null                   | #text(before|)
-      // 23: TIcu                   | <!-- ICU 20:0 -->
-      // 24: null                   | currently selected ICU case
-      // 25: null                   | #text(caseA)
-      // 26: null                   | #text(otherCase)
-      // 27: null                   | #text(|after)
+      // 23: null                   | #text(before|)
+      // 24: TIcu                   | <!-- ICU 20:0 -->
+      // 25: null                   | currently selected ICU case
+      // 26: null                   | #text(caseA)
+      // 27: null                   | #text(otherCase)
+      // 28: null                   | #text(|after)
       const tI18n = toT18n(`before|{
           �0�, select,
             A {caseA}
@@ -152,21 +153,21 @@ describe('i18n_parse', () => {
       //     TData                  | LView
       // ---------------------------+-------------------------------
       //                     ----- DECL -----
-      // 20: TI18n                  |
+      // 21: TI18n                  |
       //                     ----- VARS -----
-      // 21: Binding for parent ICU |
-      // 22: Binding for child ICU  |
+      // 22: Binding for parent ICU |
       // 23: Binding for child ICU  |
+      // 24: Binding for child ICU  |
       //                   ----- EXPANDO -----
-      // 24: TIcu (parent)          | <!-- ICU 20:0 -->
-      // 25: null                   | currently selected ICU case
-      // 26: null                   | #text( parentA )
-      // 27: TIcu (child)           | <!-- nested ICU 0 -->
-      // 28:     null               |     currently selected ICU case
-      // 29:     null               |     #text(nested0)
-      // 30:     null               |     #text({{�2�}})
-      // 31: null                   | #text( )
-      // 32: null                   | #text( parentOther )
+      // 25: TIcu (parent)          | <!-- ICU 20:0 -->
+      // 26: null                   | currently selected ICU case
+      // 27: null                   | #text( parentA )
+      // 28: TIcu (child)           | <!-- nested ICU 0 -->
+      // 29:     null               |     currently selected ICU case
+      // 30:     null               |     #text(nested0)
+      // 31:     null               |     #text({{�2�}})
+      // 32: null                   | #text( )
+      // 33: null                   | #text( parentOther )
       const tI18n = toT18n(`{
           �0�, select,
             A {parentA {�1�, select, 0 {nested0} other {�2�}}!}

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -15,7 +15,7 @@ import {AttributeMarker, ɵɵadvance, ɵɵattribute, ɵɵdefineComponent, ɵɵde
 import {ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵprojection, ɵɵprojectionDef, ɵɵtemplate, ɵɵtext} from '../../src/render3/instructions/all';
 import {RenderFlags} from '../../src/render3/interfaces/definition';
 import {domRendererFactory3, Renderer3, RendererFactory3} from '../../src/render3/interfaces/renderer';
-import {CONTEXT, HEADER_OFFSET} from '../../src/render3/interfaces/view';
+import {CONTEXT, HEADER_OFFSET, ID, LView} from '../../src/render3/interfaces/view';
 import {ɵɵsanitizeUrl} from '../../src/sanitization/sanitization';
 import {Sanitizer} from '../../src/sanitization/sanitizer';
 import {SecurityContext} from '../../src/sanitization/security';
@@ -400,19 +400,17 @@ describe('element discovery', () => {
 
     const section = fixture.hostElement.querySelector('section')!;
     const sectionContext = getLContext(section)!;
-    const sectionLView = sectionContext.lView!;
     expect(sectionContext.nodeIndex).toEqual(HEADER_OFFSET);
-    expect(sectionLView.length).toBeGreaterThan(HEADER_OFFSET);
+    expect(sectionContext.lView!.length).toBeGreaterThan(HEADER_OFFSET);
     expect(sectionContext.native).toBe(section);
 
     const div = fixture.hostElement.querySelector('div')!;
     const divContext = getLContext(div)!;
-    const divLView = divContext.lView!;
     expect(divContext.nodeIndex).toEqual(HEADER_OFFSET + 1);
-    expect(divLView.length).toBeGreaterThan(HEADER_OFFSET);
+    expect(divContext.lView!.length).toBeGreaterThan(HEADER_OFFSET);
     expect(divContext.native).toBe(div);
 
-    expect(divLView).toBe(sectionLView);
+    expect(divContext.lView).toBe(sectionContext.lView);
   });
 
   it('should cache the element context on a element was pre-emptively monkey-patched', () => {
@@ -739,7 +737,7 @@ describe('element discovery', () => {
        const div1 = hostElm.querySelector('div:first-child')! as any;
        const div2 = hostElm.querySelector('div:last-child')! as any;
        const context = getLContext(hostElm)!;
-       const componentView = context.lView[context.nodeIndex];
+       const componentView = context.lView![context.nodeIndex];
 
        expect(componentView).toContain(myDir1Instance);
        expect(componentView).toContain(myDir2Instance);
@@ -918,7 +916,7 @@ describe('element discovery', () => {
        const context = getLContext(child)!;
        expect(readPatchedData(child)).toBeTruthy();
 
-       const componentData = context.lView[context.nodeIndex];
+       const componentData = context.lView![context.nodeIndex];
        const component = componentData[CONTEXT];
        expect(component instanceof ChildComp).toBeTruthy();
        expect(readPatchedData(component)).toBe(context.lView);


### PR DESCRIPTION
These changes combine #41358 and #41894.

Currently we save a reference to an `LView` on most DOM nodes created by Angular either by saving the `LView` directly in the `__ngContext__` or by saving the `LContext` which has a reference to the `LView`. This can be a problem if the DOM node is retained in memory, because the `LView` has references to all of the child nodes of the view, as well as other internal data structures.

Previously we tried to resolve the issue by clearing the `__ngContext__` when a node is removed (see https://github.com/angular/angular/pull/36011), but we decided not to proceeed, because it can slow down destruction due to a megamorphic write.

These changes aim to address the issue while reducing the performance impact by assigning a unique ID when an `LView` is created and adding it to `__ngContext__`. All active views are tracked in a map where their unique ID is used as the key. We don't need to worry about leaks within that map,  because `LView`s are an internal data structure and we have complete control over when they are  created and destroyed.

Fixes #41047.