### PR TITLE
perf(animations): improve algorithm to balance animation namespaces

### DIFF
--- a/goldens/public-api/animations/browser/browser.md
+++ b/goldens/public-api/animations/browser/browser.md
@@ -12,6 +12,7 @@ export abstract class AnimationDriver {
     abstract computeStyle(element: any, prop: string, defaultValue?: string): string;
     // (undocumented)
     abstract containsElement(elm1: any, elm2: any): boolean;
+    abstract getParentElement?(element: unknown): unknown;
     // @deprecated (undocumented)
     abstract matchesElement(element: any, selector: string): boolean;
     // (undocumented)

--- a/goldens/public-api/animations/browser/testing/testing.md
+++ b/goldens/public-api/animations/browser/testing/testing.md
@@ -18,6 +18,8 @@ export class MockAnimationDriver implements AnimationDriver {
     // (undocumented)
     containsElement(elm1: any, elm2: any): boolean;
     // (undocumented)
+    getParentElement(element: unknown): unknown;
+    // (undocumented)
     static log: AnimationPlayer[];
     // (undocumented)
     matchesElement(_element: any, _selector: string): boolean;

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 449957,
+        "main": 450729,
         "polyfills": 37297,
         "styles": 70379,
         "light-theme": 77582,

--- a/packages/animations/browser/src/private_export.ts
+++ b/packages/animations/browser/src/private_export.ts
@@ -10,7 +10,7 @@ export {AnimationStyleNormalizer as ɵAnimationStyleNormalizer, NoopAnimationSty
 export {WebAnimationsStyleNormalizer as ɵWebAnimationsStyleNormalizer} from './dsl/style_normalization/web_animations_style_normalizer';
 export {NoopAnimationDriver as ɵNoopAnimationDriver} from './render/animation_driver';
 export {AnimationEngine as ɵAnimationEngine} from './render/animation_engine_next';
-export {containsElement as ɵcontainsElement, invokeQuery as ɵinvokeQuery, validateStyleProperty as ɵvalidateStyleProperty} from './render/shared';
+export {containsElement as ɵcontainsElement, getParentElement as ɵgetParentElement, invokeQuery as ɵinvokeQuery, validateStyleProperty as ɵvalidateStyleProperty} from './render/shared';
 export {WebAnimationsDriver as ɵWebAnimationsDriver} from './render/web_animations/web_animations_driver';
 export {WebAnimationsPlayer as ɵWebAnimationsPlayer} from './render/web_animations/web_animations_player';
 export {allowPreviousPlayerStylesMerge as ɵallowPreviousPlayerStylesMerge, normalizeKeyframes as ɵnormalizeKeyframes} from './util';

--- a/packages/animations/browser/src/render/animation_driver.ts
+++ b/packages/animations/browser/src/render/animation_driver.ts
@@ -8,7 +8,7 @@
 import {AnimationPlayer, NoopAnimationPlayer} from '@angular/animations';
 import {Injectable} from '@angular/core';
 
-import {containsElement, invokeQuery, validateStyleProperty} from './shared';
+import {containsElement, getParentElement, invokeQuery, validateStyleProperty} from './shared';
 
 /**
  * @publicApi
@@ -26,6 +26,10 @@ export class NoopAnimationDriver implements AnimationDriver {
 
   containsElement(elm1: any, elm2: any): boolean {
     return containsElement(elm1, elm2);
+  }
+
+  getParentElement(element: unknown): unknown {
+    return getParentElement(element);
   }
 
   query(element: any, selector: string, multi: boolean): any[] {
@@ -58,6 +62,15 @@ export abstract class AnimationDriver {
   abstract matchesElement(element: any, selector: string): boolean;
 
   abstract containsElement(elm1: any, elm2: any): boolean;
+
+  /**
+   * Obtains the parent element, if any. `null` is returned if the element does not have a parent.
+   *
+   * This method is optional to avoid a breaking change where implementors of this interface would
+   * be required to implement this method. This method is to become required in a major version of
+   * Angular.
+   */
+  abstract getParentElement?(element: unknown): unknown;
 
   abstract query(element: any, selector: string, multi: boolean): any[];
 

--- a/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
@@ -9,7 +9,7 @@ import {AnimationPlayer, ɵStyleDataMap} from '@angular/animations';
 
 import {allowPreviousPlayerStylesMerge, balancePreviousStylesIntoKeyframes, copyStyles, normalizeKeyframes} from '../../util';
 import {AnimationDriver} from '../animation_driver';
-import {containsElement, invokeQuery, isBrowser, validateStyleProperty} from '../shared';
+import {containsElement, getParentElement, invokeQuery, validateStyleProperty} from '../shared';
 import {packageNonAnimatableStyles} from '../special_cased_styles';
 
 import {WebAnimationsPlayer} from './web_animations_player';
@@ -26,6 +26,10 @@ export class WebAnimationsDriver implements AnimationDriver {
 
   containsElement(elm1: any, elm2: any): boolean {
     return containsElement(elm1, elm2);
+  }
+
+  getParentElement(element: unknown): unknown {
+    return getParentElement(element);
   }
 
   query(element: any, selector: string, multi: boolean): any[] {

--- a/packages/animations/browser/testing/src/mock_animation_driver.ts
+++ b/packages/animations/browser/testing/src/mock_animation_driver.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AnimationPlayer, AUTO_STYLE, NoopAnimationPlayer, ɵStyleDataMap} from '@angular/animations';
-import {AnimationDriver, ɵallowPreviousPlayerStylesMerge as allowPreviousPlayerStylesMerge, ɵcontainsElement as containsElement, ɵinvokeQuery as invokeQuery, ɵnormalizeKeyframes as normalizeKeyframes, ɵvalidateStyleProperty as validateStyleProperty} from '@angular/animations/browser';
+import {AnimationDriver, ɵallowPreviousPlayerStylesMerge as allowPreviousPlayerStylesMerge, ɵcontainsElement as containsElement, ɵgetParentElement as getParentElement, ɵinvokeQuery as invokeQuery, ɵnormalizeKeyframes as normalizeKeyframes, ɵvalidateStyleProperty as validateStyleProperty,} from '@angular/animations/browser';
 
 /**
  * @publicApi
@@ -24,6 +24,10 @@ export class MockAnimationDriver implements AnimationDriver {
 
   containsElement(elm1: any, elm2: any): boolean {
     return containsElement(elm1, elm2);
+  }
+
+  getParentElement(element: unknown): unknown {
+    return getParentElement(element);
   }
 
   query(element: any, selector: string, multi: boolean): any[] {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -582,6 +582,9 @@
     "name": "_currentInjector"
   },
   {
+    "name": "_documentElement"
+  },
+  {
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
@@ -952,6 +955,9 @@
   },
   {
     "name": "getOwnDefinition"
+  },
+  {
+    "name": "getParentElement"
   },
   {
     "name": "getParentInjectorIndex"


### PR DESCRIPTION
The prior approach would consider all existing namespaces from back to front
to find the one that's the closest ancestor for a given host element. An
expensive `contains` operation was used which needed to traverse all the
way up the document root _for each existing namespace_. This commit implements
an optimization where the closest namespace is found by traversing up from
the host element, avoiding repeated DOM traversal.

Closes #45055