### PR TITLE
fix(zone.js): correct defineProperties for symbol props.

### DIFF
--- a/packages/zone.js/lib/browser/define-property.ts
+++ b/packages/zone.js/lib/browser/define-property.ts
@@ -40,10 +40,10 @@ export function propertyPatch() {
       Object.defineProperty(obj, prop, props[prop]);
     });
     Object.getOwnPropertySymbols &&
-      Object.getOwnPropertySymbols(props).forEach((sym: symbol) => {
-        // tslint:disable-next-line:no-any
-        Object.defineProperty(obj, sym, (props as any)[sym]);
-      });
+        Object.getOwnPropertySymbols(props).forEach((sym: symbol) => {
+          // tslint:disable-next-line:no-any
+          Object.defineProperty(obj, sym, (props as any)[sym]);
+        });
     return obj;
   };
 

--- a/packages/zone.js/lib/browser/define-property.ts
+++ b/packages/zone.js/lib/browser/define-property.ts
@@ -35,14 +35,15 @@ export function propertyPatch() {
     return _tryDefineProperty(obj, prop, desc, originalConfigurableFlag);
   };
 
-  Object.defineProperties = function(obj, props) {
+  Object.defineProperties = function<T>(obj: T, props: PropertyDescriptorMap&ThisType<any>&{
+    [s: symbol]: PropertyDescriptor;
+  }): T {
     Object.keys(props).forEach(function(prop) {
       Object.defineProperty(obj, prop, props[prop]);
     });
     if (Object.getOwnPropertySymbols) {
       for (const sym of Object.getOwnPropertySymbols(props)) {
-        // tslint:disable-next-line:no-any
-        Object.defineProperty(obj, sym, (props as any)[sym]);
+        Object.defineProperty(obj, sym, props[sym]);
       }
     }
     return obj;

--- a/packages/zone.js/lib/browser/define-property.ts
+++ b/packages/zone.js/lib/browser/define-property.ts
@@ -39,6 +39,11 @@ export function propertyPatch() {
     Object.keys(props).forEach(function(prop) {
       Object.defineProperty(obj, prop, props[prop]);
     });
+    Object.getOwnPropertySymbols &&
+      Object.getOwnPropertySymbols(props).forEach((sym: symbol) => {
+        // tslint:disable-next-line:no-any
+        Object.defineProperty(obj, sym, (props as any)[sym]);
+      });
     return obj;
   };
 

--- a/packages/zone.js/lib/browser/define-property.ts
+++ b/packages/zone.js/lib/browser/define-property.ts
@@ -39,11 +39,12 @@ export function propertyPatch() {
     Object.keys(props).forEach(function(prop) {
       Object.defineProperty(obj, prop, props[prop]);
     });
-    Object.getOwnPropertySymbols &&
-        Object.getOwnPropertySymbols(props).forEach((sym: symbol) => {
-          // tslint:disable-next-line:no-any
-          Object.defineProperty(obj, sym, (props as any)[sym]);
-        });
+    if (Object.getOwnPropertySymbols) {
+      for (const sym of Object.getOwnPropertySymbols(props)) {
+        // tslint:disable-next-line:no-any
+        Object.defineProperty(obj, sym, (props as any)[sym]);
+      }
+    }
     return obj;
   };
 

--- a/packages/zone.js/lib/browser/define-property.ts
+++ b/packages/zone.js/lib/browser/define-property.ts
@@ -39,6 +39,12 @@ export function propertyPatch() {
     Object.keys(props).forEach(function(prop) {
       Object.defineProperty(obj, prop, props[prop]);
     });
+    if (Object.getOwnPropertySymbols) {
+      for (const sym of Object.getOwnPropertySymbols(props)) {
+        // tslint:disable-next-line:no-any
+        Object.defineProperty(obj, sym, (props as any)[sym]);
+      }
+    }
     return obj;
   };
 

--- a/packages/zone.js/test/browser/define-property.spec.ts
+++ b/packages/zone.js/test/browser/define-property.spec.ts
@@ -37,3 +37,64 @@ describe('defineProperty', function() {
     expect((obj as any).prop).toBeFalsy();
   });
 });
+
+describe('defineProperties', () => {
+  it('should set string props', () => {
+    const obj: any = {};
+    Object.defineProperties(obj, {
+      'property1': {value: true, writable: true, enumerable: true},
+      'property2': {value: 'Hello', writable: false, enumerable: true},
+      'property3': {
+        enumerable: true,
+        get: () => {
+          return obj.p3
+        },
+        set: (val: string) => obj.p3 = val
+      },
+      'property4': {enumerable: false, writable: true, value: 'hidden'}
+    });
+    expect(Object.keys(obj).sort()).toEqual(['property1', 'property2', 'property3']);
+    expect(obj.property1).toBeTrue();
+    expect(obj.property2).toEqual('Hello');
+    expect(obj.property3).toBeUndefined();
+    expect(obj.property4).toEqual('hidden');
+    obj.property1 = false;
+    expect(obj.property1).toBeFalse();
+    expect(() => obj.property2 = 'new Hello').toThrow();
+    obj.property3 = 'property3';
+    expect(obj.property3).toEqual('property3');
+    obj.property4 = 'property4';
+    expect(obj.property4).toEqual('property4');
+  });
+  it('should set symbol props', () => {
+    let a = Symbol();
+    let b = Symbol();
+    const obj: any = {};
+    Object.defineProperties(obj, {
+      [a]: {value: true, writable: true},
+      [b]: {get: () => obj.b1, set: (val: string) => obj.b1 = val}
+    });
+    expect(Object.keys(obj)).toEqual([]);
+    expect(obj[a]).toBeTrue();
+    expect(obj[b]).toBeUndefined();
+    obj[a] = false;
+    expect(obj[a]).toBeFalse();
+    obj[b] = 'b1';
+    expect(obj[b]).toEqual('b1');
+  });
+  it('should set string and symbol props', () => {
+    let a = Symbol();
+    const obj: any = {};
+    Object.defineProperties(obj, {
+      [a]: {value: true, writable: true},
+      'property1': {value: true, writable: true, enumerable: true},
+    });
+    expect(Object.keys(obj)).toEqual(['property1']);
+    expect(obj.property1).toBeTrue();
+    expect(obj[a]).toBeTrue();
+    obj.property1 = false;
+    expect(obj.property1).toBeFalse();
+    obj[a] = false;
+    expect(obj[a]).toBeFalse();
+  });
+});


### PR DESCRIPTION
Currently, this `defineProperties` patch does not work for symbol properties which will not be enumerated by Object.keys. This CL adds a second case for symbols, with a small feature guard for IE.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I'm unsure if this change requires a change to tests or docs. Please let me know if it does.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Allows usage of Object.defineProperties with symbol properties.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Not unless there is an application currently depending on a symbol property _not_ being applied by defineProperties.

## Other information
