### PR TITLE
fix(docs-infra): make hamburger menu non focusable when not visible

### DIFF
--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -34,6 +34,7 @@ mat-toolbar.app-toolbar {
       .hamburger {
         // Hamburger shown on non-marketing pages even on large screens.
         margin: $hamburgerShownMargin;
+        visibility: visible;
       }
     }
   }

--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -52,6 +52,7 @@ mat-toolbar.app-toolbar {
       // Hamburger hidden by default on large screens.
       // (Will be shown per doc.)
       margin: $hamburgerHiddenMargin;
+      visibility: hidden;
     }
 
     @media (max-width: 480px) {


### PR DESCRIPTION
the header hamburger menu gets removed from the page by moving it
outside the screen, it can however still be accessed via keyboard
navigation, add a visibility hidden to the element to prevent such
behavior

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The aio hamburger menu is still interactable when off screen 

![Peek 2022-02-13 17-01](https://user-images.githubusercontent.com/61631103/153766022-13efbcaa-9145-40d6-9cb2-a0743e0b8817.gif)

## What is the new behavior?

The menu is not interactable when off screen

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
