### PR TITLE
feat(zone.js): update electron patch to support electron/remote 14

### DIFF
--- a/packages/zone.js/lib/extra/electron.ts
+++ b/packages/zone.js/lib/extra/electron.ts
@@ -11,7 +11,17 @@ Zone.__load_patch('electron', (global: any, Zone: ZoneType, api: _ZonePrivate) =
       return delegate && delegate.apply(self, api.bindArguments(args, source));
     });
   }
-  const {desktopCapturer, shell, CallbacksRegistry, ipcRenderer} = require('electron');
+  let {desktopCapturer, shell, CallbacksRegistry, ipcRenderer} = require('electron');
+  if (!CallbacksRegistry) {
+    try {
+      // Try to load CallbacksRegistry class from @electron/remote src
+      // since from electron 14+, the CallbacksRegistry is moved to @electron/remote
+      // pacakge and not exported to outside, so this is a hack to patch CallbacksRegistry.
+      CallbacksRegistry =
+          require('@electron/remote/dist/src/renderer/callbacks-registry').CallbacksRegistry;
+    } catch (err) {
+    }
+  }
   // patch api in renderer process directly
   // desktopCapturer
   if (desktopCapturer) {


### PR DESCRIPTION
Close #43346

From electron 14, the `CallbacksRegistry` is moved to `@electron/remote` package,
so all `remote` call between `main` process and `renderer` process is
not being patched since the new version of electron released.
Also `CallbacksRegistry` is not exported outside, so this commit make a
`hack` patch to load `CallbacksRegistry` from
`@electron/remote/dist/src/renderer/callbacks-registry` for patching.

