### PR TITLE
Revert animation completion

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AnimationTriggerNames, compileClassMetadata, compileComponentFromMetadata, compileDeclareClassMetadata, compileDeclareComponentFromMetadata, ConstantPool, CssSelector, DeclarationListEmitMode, DeclareComponentTemplateInfo, DEFAULT_INTERPOLATION_CONFIG, DomElementSchemaRegistry, Expression, FactoryTarget, makeBindingParser, R3ComponentMetadata, R3TargetBinder, R3UsedDirectiveMetadata, SelectorMatcher, ViewEncapsulation, WrappedNodeExpr} from '@angular/compiler';
+import {compileClassMetadata, compileComponentFromMetadata, compileDeclareClassMetadata, compileDeclareComponentFromMetadata, ConstantPool, CssSelector, DeclarationListEmitMode, DeclareComponentTemplateInfo, DEFAULT_INTERPOLATION_CONFIG, DomElementSchemaRegistry, Expression, FactoryTarget, makeBindingParser, R3ComponentMetadata, R3TargetBinder, R3UsedDirectiveMetadata, SelectorMatcher, ViewEncapsulation, WrappedNodeExpr} from '@angular/compiler';
 import ts from 'typescript';
 
 import {Cycle, CycleAnalyzer, CycleHandlingStrategy} from '../../../cycles';
@@ -35,7 +35,7 @@ import {ComponentAnalysisData, ComponentResolutionData} from './metadata';
 import {_extractTemplateStyleUrls, extractComponentStyleUrls, extractStyleResources, extractTemplate, makeResourceNotFoundError, ParsedTemplateWithSource, parseTemplateDeclaration, preloadAndParseTemplate, ResourceTypeForDiagnostics, StyleUrlMeta, transformDecoratorToInlineResources} from './resources';
 import {scopeTemplate} from './scope';
 import {ComponentSymbol} from './symbol';
-import {collectAnimationNames, validateAndFlattenComponentImports} from './util';
+import {validateAndFlattenComponentImports} from './util';
 
 const EMPTY_MAP = new Map<string, Expression>();
 const EMPTY_ARRAY: any[] = [];
@@ -208,12 +208,8 @@ export class ComponentDecoratorHandler implements
         resolveEnumValue(this.evaluator, component, 'changeDetection', 'ChangeDetectionStrategy');
 
     let animations: Expression|null = null;
-    let animationTriggerNames: AnimationTriggerNames|null = null;
     if (component.has('animations')) {
       animations = new WrappedNodeExpr(component.get('animations')!);
-      const animationsValue = this.evaluator.evaluate(component.get('animations')!);
-      animationTriggerNames = {includesDynamicAnimations: false, staticTriggerNames: []};
-      collectAnimationNames(animationsValue, animationTriggerNames);
     }
 
     // Go through the root directories for this project, and select the one with the smallest
@@ -420,7 +416,6 @@ export class ComponentDecoratorHandler implements
           template: templateResource,
         },
         isPoisoned,
-        animationTriggerNames,
         imports,
       },
       diagnostics,
@@ -458,7 +453,6 @@ export class ComponentDecoratorHandler implements
       isPoisoned: analysis.isPoisoned,
       isStructural: false,
       isStandalone: analysis.meta.isStandalone,
-      animationTriggerNames: analysis.animationTriggerNames,
     });
 
     this.resourceRegistry.registerResources(analysis.resources, node);

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AnimationTriggerNames, R3ClassMetadata, R3ComponentMetadata} from '@angular/compiler';
+import {R3ClassMetadata, R3ComponentMetadata} from '@angular/compiler';
 import ts from 'typescript';
 
 import {Reference} from '../../../imports';
@@ -64,7 +64,6 @@ export interface ComponentAnalysisData {
   inlineStyles: string[]|null;
 
   isPoisoned: boolean;
-  animationTriggerNames: AnimationTriggerNames|null;
 
   imports: {
     resolved: Reference<ClassDeclaration>[],

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
@@ -6,37 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AnimationTriggerNames} from '@angular/compiler';
 import ts from 'typescript';
 
 import {Reference} from '../../../imports';
 import {ResolvedValue} from '../../../partial_evaluator';
 import {ClassDeclaration, isNamedClassDeclaration} from '../../../reflection';
 import {createValueHasWrongTypeError} from '../../common';
-
-/**
- * Collect the animation names from the static evaluation result.
- * @param value the static evaluation result of the animations
- * @param animationTriggerNames the animation names collected and whether some names could not be
- *     statically evaluated.
- */
-export function collectAnimationNames(
-    value: ResolvedValue, animationTriggerNames: AnimationTriggerNames) {
-  if (value instanceof Map) {
-    const name = value.get('name');
-    if (typeof name === 'string') {
-      animationTriggerNames.staticTriggerNames.push(name);
-    } else {
-      animationTriggerNames.includesDynamicAnimations = true;
-    }
-  } else if (Array.isArray(value)) {
-    for (const resolvedValue of value) {
-      collectAnimationNames(resolvedValue, animationTriggerNames);
-    }
-  } else {
-    animationTriggerNames.includesDynamicAnimations = true;
-  }
-}
 
 export function validateAndFlattenComponentImports(imports: ResolvedValue, expr: ts.Expression): {
   imports: Reference<ClassDeclaration>[],

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -13,7 +13,7 @@ import {CycleAnalyzer, CycleHandlingStrategy, ImportGraph} from '../../../cycles
 import {ErrorCode, FatalDiagnosticError} from '../../../diagnostics';
 import {absoluteFrom} from '../../../file_system';
 import {runInEachFileSystem} from '../../../file_system/testing';
-import {ModuleResolver, Reference, ReferenceEmitter} from '../../../imports';
+import {ModuleResolver, ReferenceEmitter} from '../../../imports';
 import {CompoundMetadataReader, DtsMetadataReader, InjectableClassRegistry, LocalMetadataRegistry, ResourceRegistry} from '../../../metadata';
 import {PartialEvaluator} from '../../../partial_evaluator';
 import {NOOP_PERF_RECORDER} from '../../../perf';
@@ -88,7 +88,7 @@ function setup(program: ts.Program, options: ts.CompilerOptions, host: ts.Compil
       /* annotateForClosureCompiler */ false,
       NOOP_PERF_RECORDER,
   );
-  return {reflectionHost, handler, resourceLoader, metaRegistry};
+  return {reflectionHost, handler, resourceLoader};
 }
 
 runInEachFileSystem(() => {
@@ -400,124 +400,6 @@ runInEachFileSystem(() => {
       await handler.preanalyze(TestCmp, detected.metadata);
 
       expect(() => handler.analyze(TestCmp, detected.metadata)).not.toThrow();
-    });
-
-    it('should evaluate the name of animations', () => {
-      const {program, options, host} = makeProgram([
-        {
-          name: _('/node_modules/@angular/core/index.d.ts'),
-          contents: 'export const Component: any;',
-        },
-        {
-          name: _('/entry.ts'),
-          contents: `
-          import {Component} from '@angular/core';
-          function trigger(name) {
-            return {name};
-          }
-          @Component({
-            template: '',
-            animations: [
-              trigger('animationName'),
-              [trigger('nestedAnimationName')],
-            ],
-          })
-          class TestCmp {}
-      `
-        },
-      ]);
-      const {reflectionHost, handler, metaRegistry} = setup(program, options, host);
-      const TestCmp = getDeclaration(program, _('/entry.ts'), 'TestCmp', isNamedClassDeclaration);
-      const detected = handler.detect(TestCmp, reflectionHost.getDecoratorsOfDeclaration(TestCmp));
-      if (detected === undefined) {
-        return fail('Failed to recognize @Component');
-      }
-      const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      handler.register(TestCmp, analysis!);
-      const meta = metaRegistry.getDirectiveMetadata(new Reference(TestCmp));
-      expect(meta?.animationTriggerNames?.staticTriggerNames).toEqual([
-        'animationName', 'nestedAnimationName'
-      ]);
-      expect(meta?.animationTriggerNames?.includesDynamicAnimations).toBeFalse();
-    });
-
-    it('should tell if the animations include a dynamic value', () => {
-      const {program, options, host} = makeProgram([
-        {
-          name: _('/node_modules/@angular/core/index.d.ts'),
-          contents: 'export const Component: any;',
-        },
-        {
-          name: _('/entry.ts'),
-          contents: `
-          import {Component} from '@angular/core';
-          function trigger(name) {
-            return {name};
-          }
-          function buildComplexAnimations() {
-            const name = 'complex';
-            return [trigger(name)];
-          }
-          @Component({
-            template: '',
-            animations: [
-              trigger('animationName'),
-              buildComplexAnimations(),
-            ],
-          })
-          class TestCmp {}
-      `
-        },
-      ]);
-      const {reflectionHost, handler, metaRegistry} = setup(program, options, host);
-      const TestCmp = getDeclaration(program, _('/entry.ts'), 'TestCmp', isNamedClassDeclaration);
-      const detected = handler.detect(TestCmp, reflectionHost.getDecoratorsOfDeclaration(TestCmp));
-      if (detected === undefined) {
-        return fail('Failed to recognize @Component');
-      }
-      const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      handler.register(TestCmp, analysis!);
-      const meta = metaRegistry.getDirectiveMetadata(new Reference(TestCmp));
-      expect(meta?.animationTriggerNames?.staticTriggerNames).toEqual(['animationName']);
-      expect(meta?.animationTriggerNames?.includesDynamicAnimations).toBeTrue();
-    });
-
-    it('should treat complex animations expressions as dynamic', () => {
-      const {program, options, host} = makeProgram([
-        {
-          name: _('/node_modules/@angular/core/index.d.ts'),
-          contents: 'export const Component: any;',
-        },
-        {
-          name: _('/entry.ts'),
-          contents: `
-          import {Component} from '@angular/core';
-          function trigger(name) {
-            return {name};
-          }
-          function buildComplexAnimations() {
-            const name = 'complex';
-            return [trigger(name)];
-          }
-          @Component({
-            template: '',
-            animations: buildComplexAnimations(),
-          })
-          class TestCmp {}
-      `
-        },
-      ]);
-      const {reflectionHost, handler, metaRegistry} = setup(program, options, host);
-      const TestCmp = getDeclaration(program, _('/entry.ts'), 'TestCmp', isNamedClassDeclaration);
-      const detected = handler.detect(TestCmp, reflectionHost.getDecoratorsOfDeclaration(TestCmp));
-      if (detected === undefined) {
-        return fail('Failed to recognize @Component');
-      }
-      const {analysis} = handler.analyze(TestCmp, detected.metadata);
-      handler.register(TestCmp, analysis!);
-      const meta = metaRegistry.getDirectiveMetadata(new Reference(TestCmp));
-      expect(meta?.animationTriggerNames?.includesDynamicAnimations).toBeTrue();
-      expect(meta?.animationTriggerNames?.staticTriggerNames.length).toBe(0);
     });
   });
 

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -140,7 +140,6 @@ export class DirectiveDecoratorHandler implements
       ...analysis.typeCheckMeta,
       isPoisoned: analysis.isPoisoned,
       isStructural: analysis.isStructural,
-      animationTriggerNames: null,
       isStandalone: analysis.meta.isStandalone,
     });
 

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/test/directive_spec.ts
@@ -107,7 +107,6 @@ runInEachFileSystem(() => {
         name: 'Dir',
         selector: '[dir]',
         isStructural: false,
-        animationTriggerNames: null,
       };
       matcher.addSelectables(CssSelector.parse('[dir]'), dirMeta);
 

--- a/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/test/util.ts
@@ -55,7 +55,6 @@ export function getBoundTemplate(
       outputs: ClassPropertyMapping.fromMappedObject({}),
       exportAs: null,
       isStructural: false,
-      animationTriggerNames: null,
     });
   });
   const binder = new R3TargetBinder(matcher);

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -106,7 +106,6 @@ export class DtsMetadataReader implements MetadataReader {
       baseClass: readBaseClass(clazz, this.checker, this.reflector),
       isPoisoned: false,
       isStructural,
-      animationTriggerNames: null,
       isStandalone: false,  // TODO: read this from the compiled metadata.
     };
   }

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -251,7 +251,6 @@ function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
     baseClass: null,
     isPoisoned: false,
     isStructural: false,
-    animationTriggerNames: null,
     isStandalone: false,
   };
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -582,7 +582,6 @@ function prepareDeclarations(
       outputs: ClassPropertyMapping.fromMappedObject(decl.outputs || {}),
       queries: decl.queries || [],
       isStructural: false,
-      animationTriggerNames: null,
     };
     matcher.addSelectables(selector, meta);
   }
@@ -647,7 +646,6 @@ function makeScope(program: ts.Program, sf: ts.SourceFile, decls: TestDeclaratio
         isGeneric: decl.isGeneric ?? false,
         isPoisoned: false,
         isStructural: false,
-        animationTriggerNames: null,
         isStandalone: false,
       });
     } else if (decl.type === 'pipe') {

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -37,15 +37,6 @@ export interface InputOutputPropertySet {
 }
 
 /**
- * A data structure which captures the animation trigger names that are statically resolvable
- * and whether some names could not be statically evaluated.
- */
-export interface AnimationTriggerNames {
-  includesDynamicAnimations: boolean;
-  staticTriggerNames: string[];
-}
-
-/**
  * Metadata regarding a directive that's needed to match it against template elements. This is
  * provided by a consumer of the t2 APIs.
  */
@@ -85,12 +76,6 @@ export interface DirectiveMeta {
   exportAs: string[]|null;
 
   isStructural: boolean;
-
-  /**
-   * The name of animations that the user defines in the component.
-   * Only includes the animation names.
-   */
-  animationTriggerNames: AnimationTriggerNames|null;
 }
 
 /**

--- a/packages/compiler/test/render3/view/binding_spec.ts
+++ b/packages/compiler/test/render3/view/binding_spec.ts
@@ -40,7 +40,6 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta> {
     isComponent: false,
     isStructural: true,
     selector: '[ngFor][ngForOf]',
-    animationTriggerNames: null,
   });
   matcher.addSelectables(CssSelector.parse('[dir]'), {
     name: 'Dir',
@@ -50,7 +49,6 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta> {
     isComponent: false,
     isStructural: false,
     selector: '[dir]',
-    animationTriggerNames: null,
   });
   matcher.addSelectables(CssSelector.parse('[hasOutput]'), {
     name: 'HasOutput',
@@ -60,7 +58,6 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta> {
     isComponent: false,
     isStructural: false,
     selector: '[hasOutput]',
-    animationTriggerNames: null,
   });
   matcher.addSelectables(CssSelector.parse('[hasInput]'), {
     name: 'HasInput',
@@ -70,7 +67,6 @@ function makeSelectorMatcher(): SelectorMatcher<DirectiveMeta> {
     isComponent: false,
     isStructural: false,
     selector: '[hasInput]',
-    animationTriggerNames: null,
   });
   return matcher;
 }
@@ -117,7 +113,6 @@ describe('t2 binding', () => {
       isComponent: false,
       isStructural: false,
       selector: 'text[dir]',
-      animationTriggerNames: null,
     });
     const binder = new R3TargetBinder(matcher);
     const res = binder.bind({template: template.nodes});

--- a/packages/language-service/src/attribute_completions.ts
+++ b/packages/language-service/src/attribute_completions.ts
@@ -621,16 +621,3 @@ function getStructuralAttributes(meta: TypeCheckableDirectiveMeta): string[] {
 
   return structuralAttributes;
 }
-
-export function buildAnimationCompletionEntries(
-    animations: string[], replacementSpan: ts.TextSpan,
-    kind: DisplayInfoKind): ts.CompletionEntry[] {
-  return animations.map(animation => {
-    return {
-      kind: unsafeCastDisplayInfoKindToScriptElementKind(kind),
-      name: animation,
-      sortText: animation,
-      replacementSpan,
-    };
-  });
-}

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -6,16 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AST, ASTWithSource, BindingPipe, BindingType, Call, EmptyExpr, ImplicitReceiver, LiteralPrimitive, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, SafePropertyRead, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstElement, TmplAstNode, TmplAstReference, TmplAstTemplate, TmplAstText, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
+import {AST, ASTWithSource, BindingPipe, EmptyExpr, ImplicitReceiver, LiteralPrimitive, ParseSourceSpan, PropertyRead, PropertyWrite, SafePropertyRead, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstElement, TmplAstNode, TmplAstReference, TmplAstTemplate, TmplAstText, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
 import {CompletionKind, DirectiveInScope, SymbolKind, TemplateDeclarationSymbol} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import {BoundEvent, TextAttribute} from '@angular/compiler/src/render3/r3_ast';
 import ts from 'typescript';
 
-import {addAttributeCompletionEntries, AttributeCompletionKind, buildAnimationCompletionEntries, buildAttributeCompletionTable, getAttributeCompletionSymbol} from './attribute_completions';
+import {addAttributeCompletionEntries, AttributeCompletionKind, buildAttributeCompletionTable, getAttributeCompletionSymbol} from './attribute_completions';
 import {DisplayInfo, DisplayInfoKind, getDirectiveDisplayInfo, getSymbolDisplayInfo, getTsSymbolDisplayInfo, unsafeCastDisplayInfoKindToScriptElementKind} from './display_parts';
 import {TargetContext, TargetNodeKind, TemplateTarget} from './template_target';
-import {filterAliasImports, isBoundEventWithSyntheticHandler, isWithin} from './utils';
+import {filterAliasImports, isBoundEventWithSyntheticHandler} from './utils';
 
 type PropertyExpressionCompletionBuilder =
     CompletionBuilder<PropertyRead|PropertyWrite|EmptyExpr|SafePropertyRead|TmplAstBoundEvent>;
@@ -27,8 +27,6 @@ type PipeCompletionBuilder = CompletionBuilder<BindingPipe>;
 
 type LiteralCompletionBuilder = CompletionBuilder<LiteralPrimitive|TextAttribute>;
 
-type ElementAnimationCompletionBuilder = CompletionBuilder<TmplAstBoundAttribute|TmplAstBoundEvent>;
-
 export enum CompletionNodeContext {
   None,
   ElementTag,
@@ -37,8 +35,6 @@ export enum CompletionNodeContext {
   EventValue,
   TwoWayBinding,
 }
-
-const ANIMATION_PHASES = ['start', 'done'];
 
 /**
  * Performs autocompletion operations on a given node in the template.
@@ -74,11 +70,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     } else if (this.isElementTagCompletion()) {
       return this.getElementTagCompletion();
     } else if (this.isElementAttributeCompletion()) {
-      if (this.isAnimationCompletion()) {
-        return this.getAnimationCompletions();
-      } else {
-        return this.getElementAttributeCompletions(options);
-      }
+      return this.getElementAttributeCompletions(options);
     } else if (this.isPipeCompletion()) {
       return this.getPipeCompletions();
     } else if (this.isLiteralCompletion()) {
@@ -539,68 +531,6 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     return directive?.tsSymbol;
   }
 
-  private isAnimationCompletion(): this is ElementAnimationCompletionBuilder {
-    return (this.node instanceof TmplAstBoundAttribute &&
-            this.node.type === BindingType.Animation) ||
-        (this.node instanceof TmplAstBoundEvent && this.node.type === ParsedEventType.Animation);
-  }
-
-  private getAnimationCompletions(this: ElementAnimationCompletionBuilder):
-      ts.WithMetadata<ts.CompletionInfo>|undefined {
-    if (this.node instanceof TmplAstBoundAttribute) {
-      const animations = this.compiler.getTemplateTypeChecker()
-                             .getDirectiveMetadata(this.component)
-                             ?.animationTriggerNames?.staticTriggerNames;
-      const replacementSpan = makeReplacementSpanFromParseSourceSpan(this.node.keySpan);
-
-      if (animations === undefined) {
-        return undefined;
-      }
-
-      const entries = buildAnimationCompletionEntries(
-          [...animations, '.disabled'], replacementSpan, DisplayInfoKind.ATTRIBUTE);
-      return {
-        entries,
-        isGlobalCompletion: false,
-        isMemberCompletion: false,
-        isNewIdentifierLocation: true,
-      };
-    } else {
-      const animationNameSpan = buildAnimationNameSpan(this.node);
-      const phaseSpan = buildAnimationPhaseSpan(this.node);
-      if (isWithin(this.position, animationNameSpan)) {
-        const animations = this.compiler.getTemplateTypeChecker()
-                               .getDirectiveMetadata(this.component)
-                               ?.animationTriggerNames?.staticTriggerNames;
-        const replacementSpan = makeReplacementSpanFromParseSourceSpan(animationNameSpan);
-
-        if (animations === undefined) {
-          return undefined;
-        }
-
-        const entries =
-            buildAnimationCompletionEntries(animations, replacementSpan, DisplayInfoKind.EVENT);
-        return {
-          entries,
-          isGlobalCompletion: false,
-          isMemberCompletion: false,
-          isNewIdentifierLocation: true,
-        };
-      }
-      if (phaseSpan !== null && isWithin(this.position, phaseSpan)) {
-        const replacementSpan = makeReplacementSpanFromParseSourceSpan(phaseSpan);
-        const entries = buildAnimationCompletionEntries(
-            ANIMATION_PHASES, replacementSpan, DisplayInfoKind.EVENT);
-        return {
-          entries,
-          isGlobalCompletion: false,
-          isMemberCompletion: false,
-          isNewIdentifierLocation: true,
-        };
-      }
-    }
-  }
-
   private isElementAttributeCompletion(): this is ElementAttributeCompletionBuilder {
     return (this.nodeContext === CompletionNodeContext.ElementAttributeKey ||
             this.nodeContext === CompletionNodeContext.TwoWayBinding) &&
@@ -953,15 +883,4 @@ function nodeContextFromTarget(target: TargetContext): CompletionNodeContext {
       // No special context is available.
       return CompletionNodeContext.None;
   }
-}
-
-function buildAnimationNameSpan(node: TmplAstBoundEvent): ParseSourceSpan {
-  return new ParseSourceSpan(node.keySpan.start, node.keySpan.start.moveBy(node.name.length));
-}
-
-function buildAnimationPhaseSpan(node: TmplAstBoundEvent): ParseSourceSpan|null {
-  if (node.phase !== null) {
-    return new ParseSourceSpan(node.keySpan.end.moveBy(-node.phase.length), node.keySpan.end);
-  }
-  return null;
 }

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -140,14 +140,6 @@ const UNION_TYPE_PIPE = {
     `
 };
 
-const ANIMATION_TRIGGER_FUNCTION = `
-function trigger(name: string) {
-  return {name};
-}
-`;
-
-const ANIMATION_METADATA = `animations: [trigger('animationName')],`;
-
 describe('completions', () => {
   beforeEach(() => {
     initMockFileSystem('Native');
@@ -679,92 +671,6 @@ describe('completions', () => {
         });
       });
 
-      describe('animations', () => {
-        it('should return animation names for the property binding', () => {
-          const {templateFile} =
-              setup(`<input [@my]>`, '', {}, ANIMATION_TRIGGER_FUNCTION, ANIMATION_METADATA);
-          templateFile.moveCursorToText('[@my¦]');
-
-          const completions = templateFile.getCompletionsAtPosition();
-          expectContain(
-              completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.ATTRIBUTE),
-              ['animationName']);
-          expectReplacementText(completions, templateFile.contents, 'my');
-        });
-
-        it('should return animation names when the property binding animation name is empty',
-           () => {
-             const {templateFile} =
-                 setup(`<input [@]>`, '', {}, ANIMATION_TRIGGER_FUNCTION, ANIMATION_METADATA);
-             templateFile.moveCursorToText('[@¦]');
-
-             const completions = templateFile.getCompletionsAtPosition();
-             expectContain(
-                 completions,
-                 unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.ATTRIBUTE),
-                 ['animationName']);
-           });
-
-        it('should return the special animation control binding called @.disabled ', () => {
-          const {templateFile} =
-              setup(`<input [@.dis]>`, '', {}, ANIMATION_TRIGGER_FUNCTION, ANIMATION_METADATA);
-          templateFile.moveCursorToText('[@.dis¦]');
-
-          const completions = templateFile.getCompletionsAtPosition();
-          expectContain(
-              completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.ATTRIBUTE),
-              ['.disabled']);
-          expectReplacementText(completions, templateFile.contents, '.dis');
-        });
-
-        it('should return animation names for the event binding', () => {
-          const {templateFile} =
-              setup(`<input (@my)>`, '', {}, ANIMATION_TRIGGER_FUNCTION, ANIMATION_METADATA);
-          templateFile.moveCursorToText('(@my¦)');
-
-          const completions = templateFile.getCompletionsAtPosition();
-          expectContain(
-              completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.EVENT),
-              ['animationName']);
-          expectReplacementText(completions, templateFile.contents, 'my');
-        });
-
-        it('should return animation names when the event binding animation name is empty', () => {
-          const {templateFile} =
-              setup(`<input (@)>`, '', {}, ANIMATION_TRIGGER_FUNCTION, ANIMATION_METADATA);
-          templateFile.moveCursorToText('(@¦)');
-
-          const completions = templateFile.getCompletionsAtPosition();
-          expectContain(
-              completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.EVENT),
-              ['animationName']);
-        });
-
-        it('should return the animation phase for the event binding', () => {
-          const {templateFile} =
-              setup(`<input (@my.do)>`, '', {}, ANIMATION_TRIGGER_FUNCTION, ANIMATION_METADATA);
-          templateFile.moveCursorToText('(@my.do¦)');
-
-          const completions = templateFile.getCompletionsAtPosition();
-          expectContain(
-              completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.EVENT),
-              ['done']);
-          expectReplacementText(completions, templateFile.contents, 'do');
-        });
-
-        it('should return the animation phase when the event binding animation phase is empty',
-           () => {
-             const {templateFile} =
-                 setup(`<input (@my.)>`, '', {}, ANIMATION_TRIGGER_FUNCTION, ANIMATION_METADATA);
-             templateFile.moveCursorToText('(@my.¦)');
-
-             const completions = templateFile.getCompletionsAtPosition();
-             expectContain(
-                 completions, unsafeCastDisplayInfoKindToScriptElementKind(DisplayInfoKind.EVENT),
-                 ['done']);
-           });
-      });
-
       it('should return input completions for a partial attribute', () => {
         const {templateFile} = setup(`<input my>`, '', DIR_WITH_SELECTED_INPUT);
         templateFile.moveCursorToText('my¦>');
@@ -1261,8 +1167,7 @@ function toText(displayParts?: ts.SymbolDisplayPart[]): string {
 }
 
 function setup(
-    template: string, classContents: string, otherDeclarations: {[name: string]: string} = {},
-    functionDeclarations: string = '', componentMetadata: string = ''): {
+    template: string, classContents: string, otherDeclarations: {[name: string]: string} = {}): {
   templateFile: OpenBuffer,
 } {
   const decls = ['AppCmp', ...Object.keys(otherDeclarations)];
@@ -1274,12 +1179,9 @@ function setup(
     'test.ts': `
          import {Component, Directive, NgModule, Pipe, TemplateRef} from '@angular/core';
 
-         ${functionDeclarations}
-
          @Component({
            templateUrl: './test.html',
            selector: 'app-cmp',
-           ${componentMetadata}
          })
          export class AppCmp {
            ${classContents}


### PR DESCRIPTION
In the real world, the `trigger` method is imported from `@angular/animations`,
and the compiler resolves the value in the DTS as dynamic. This doesn't work as
expected.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
