### PR TITLE
fix(core): throw an "unknown element" error instead of logging a message in a console

### DIFF
--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {formatRuntimeError, RuntimeErrorCode} from '../../errors';
+import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../../errors';
 import {assertDefined, assertEqual, assertIndexInRange} from '../../util/assert';
 import {assertFirstCreatePass, assertHasParent} from '../assert';
 import {attachPatchData} from '../context_discovery';
@@ -226,7 +226,7 @@ function logUnknownElementError(
         message +=
             `2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`;
       }
-      console.error(formatRuntimeError(RuntimeErrorCode.UNKNOWN_ELEMENT, message));
+      throw new RuntimeError(RuntimeErrorCode.UNKNOWN_ELEMENT, message);
     }
   }
 }

--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -199,30 +199,30 @@ describe('NgModule', () => {
       }).not.toThrow();
     });
 
-    it('should log an error about unknown element without CUSTOM_ELEMENTS_SCHEMA for element with dash in tag name',
+    it('should throw an error about unknown element without CUSTOM_ELEMENTS_SCHEMA for element with dash in tag name',
        () => {
          @Component({template: `<custom-el></custom-el>`})
          class MyComp {
          }
 
-         const spy = spyOn(console, 'error');
          TestBed.configureTestingModule({declarations: [MyComp]});
-         const fixture = TestBed.createComponent(MyComp);
-         fixture.detectChanges();
-         expect(spy.calls.mostRecent().args[0]).toMatch(/'custom-el' is not a known element/);
+         expect(() => {
+          const fixture = TestBed.createComponent(MyComp);
+          fixture.detectChanges();
+         }).toThrowError(/NG0304: 'custom-el' is not a known element/g);
        });
 
-    it('should log an error about unknown element without CUSTOM_ELEMENTS_SCHEMA for element without dash in tag name',
+    it('should throw an error about unknown element without CUSTOM_ELEMENTS_SCHEMA for element without dash in tag name',
        () => {
          @Component({template: `<custom></custom>`})
          class MyComp {
          }
 
-         const spy = spyOn(console, 'error');
          TestBed.configureTestingModule({declarations: [MyComp]});
-         const fixture = TestBed.createComponent(MyComp);
-         fixture.detectChanges();
-         expect(spy.calls.mostRecent().args[0]).toMatch(/'custom' is not a known element/);
+         expect(() => {
+          const fixture = TestBed.createComponent(MyComp);
+          fixture.detectChanges();
+         }).toThrowError(/NG0304: 'custom' is not a known element/g);
        });
 
     it('should report unknown property bindings on ng-content', () => {


### PR DESCRIPTION
**NOTE: this is a TEST-ONLY PR at this moment, we are doing some testing and collecting information on how break'y this change is.**

Currently, Angular runtime code outputs a message into a console, when it comes across an unknown element. This commit transforms the `console.log` to a `throw` instead, so those errors are more visible for developers.

Related: #36430.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No