### PR TITLE
refactor(forms): Introduce untyped aliases for forms classes.

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -144,9 +144,6 @@ export class AbstractFormGroupDirective extends ControlContainer implements OnIn
 }
 
 // @public
-export type AnyForUntypedForms = any;
-
-// @public
 export interface AsyncValidator extends Validator {
     validate(control: AbstractControl): Promise<ValidationErrors | null> | Observable<ValidationErrors | null>;
 }
@@ -724,6 +721,47 @@ export class SelectMultipleControlValueAccessor extends BuiltInControlValueAcces
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SelectMultipleControlValueAccessor, never>;
 }
+
+// @public (undocumented)
+export type UntypedFormArray = FormArray;
+
+// @public
+export const UntypedFormArray: UntypedFormArrayCtor;
+
+// @public
+export class UntypedFormBuilder {
+    constructor();
+    // (undocumented)
+    array(controlsConfig: any[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormArray;
+    // (undocumented)
+    control(formState: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl;
+    // (undocumented)
+    group(controlsConfig: {
+        [key: string]: any;
+    }, options?: AbstractControlOptions | null): FormGroup;
+    // (undocumented)
+    group(controlsConfig: {
+        [key: string]: any;
+    }, options: {
+        [key: string]: any;
+    }): FormGroup;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<UntypedFormBuilder, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<UntypedFormBuilder>;
+}
+
+// @public (undocumented)
+export type UntypedFormControl = FormControl;
+
+// @public
+export const UntypedFormControl: UntypedFormControlCtor;
+
+// @public (undocumented)
+export type UntypedFormGroup = FormGroup;
+
+// @public
+export const UntypedFormGroup: UntypedFormGroupCtor;
 
 // @public
 export type ValidationErrors = {

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -179,3 +179,41 @@ export class FormBuilder {
     }
   }
 }
+
+/**
+ * This will be used in a future version of Angular to support typed forms. Do not use it.
+ */
+@Injectable({providedIn: ReactiveFormsModule})
+export class UntypedFormBuilder {
+  private _typedBuilder: FormBuilder;
+
+  constructor() {
+    this._typedBuilder = new FormBuilder();
+  }
+
+  group(
+      controlsConfig: {[key: string]: any},
+      options?: AbstractControlOptions|null,
+      ): FormGroup;
+  group(
+      controlsConfig: {[key: string]: any},
+      options: {[key: string]: any},
+      ): FormGroup;
+  group(
+      controlsConfig: {[key: string]: any},
+      options: AbstractControlOptions|{[key: string]: any}|null = null):
+      FormGroup{return this._typedBuilder.group(controlsConfig, options)}
+
+  control(
+      formState: any, validatorOrOpts?: ValidatorFn|ValidatorFn[]|FormControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): FormControl {
+    return this._typedBuilder.control(formState, validatorOrOpts, asyncValidator);
+  }
+
+  array(
+      controlsConfig: any[],
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): FormArray {
+    return this._typedBuilder.array(controlsConfig, validatorOrOpts, asyncValidator);
+  }
+}

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -41,25 +41,9 @@ export {FormArrayName, FormGroupName} from './directives/reactive_directives/for
 export {NgSelectOption, SelectControlValueAccessor} from './directives/select_control_value_accessor';
 export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
-export {FormBuilder} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlOptions, FormControlStatus, FormGroup, ɵFormControlCtor} from './model';
+export {FormBuilder, UntypedFormBuilder} from './form_builder';
+export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlOptions, FormControlStatus, FormGroup, UntypedFormArray, UntypedFormControl, UntypedFormGroup, ɵFormControlCtor} from './model';
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';
 export {VERSION} from './version';
-
-/**
- * `AnyForUntypedForms` is an alias for `any` used as part of the typed forms
- * migration.
- *
- * `AnyForUntypedForms` was inserted into your code automatically as part of a migration. To
- * continue opting out of strong types, simply replace it with `any`. To opt-in to typed forms,
- * remove
- * `<AnyForUntypedForms>` from your call site.
- *
- * This symbol is currently unused. Please do not use it. These docs will be updated when this
- * symbol is in use.
- *
- * @publicApi
- */
-export type AnyForUntypedForms = any;
 
 export * from './form_providers';

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1610,6 +1610,18 @@ export const FormControl: ɵFormControlCtor =
       }
     });
 
+interface UntypedFormControlCtor {
+  new(formState?: any, validatorOrOpts?: ValidatorFn|ValidatorFn[]|FormControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): UntypedFormControl;
+}
+
+export type UntypedFormControl = FormControl;
+
+/**
+ * This will be used in a future version of Angular to support typed forms. Do not use it.
+ */
+export const UntypedFormControl: UntypedFormControlCtor = FormControl;
+
 /**
  * Tracks the value and validity state of a group of `FormControl` instances.
  *
@@ -2052,6 +2064,19 @@ export class FormGroup extends AbstractControl {
     return Object.keys(this.controls).length > 0 || this.disabled;
   }
 }
+
+interface UntypedFormGroupCtor {
+  new(controls: {[key: string]: AbstractControl},
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): UntypedFormGroup;
+}
+
+export type UntypedFormGroup = FormGroup;
+
+/**
+ * This will be used in a future version of Angular to support typed forms. Do not use it.
+ */
+export const UntypedFormGroup: UntypedFormGroupCtor = FormGroup;
 
 /**
  * Tracks the value and validity state of an array of `FormControl`,
@@ -2512,3 +2537,16 @@ export class FormArray extends AbstractControl {
     control._registerOnCollectionChange(this._onCollectionChange);
   }
 }
+
+interface UntypedFormArrayCtor {
+  new(controls: AbstractControl[],
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): UntypedFormArray;
+}
+
+export type UntypedFormArray = FormArray;
+
+/**
+ * This will be used in a future version of Angular to support typed forms. Do not use it.
+ */
+export const UntypedFormArray: UntypedFormArrayCtor = FormArray;


### PR DESCRIPTION
As part of typed forms, there must be a way to opt-out of the new types. The original proposal involved passing an explicit `<any>` as a generic argument. However, it turns out that this causes serious backwards-compatibility problems, because `any` is not the correct value type in all cases.

For example, consider `FormArray`:
```
let c = new FormArray<any>([new FormControl(0)]);
c.at(0).valueChanges.subscribe(v => {});
```
This will trigger a compiler warning, because `c.at(0)` has type `any`. In fact, the correct type for `c.at(0)` is `AbstractControl<any>`.

Therefore, opting out with `<any>` is not the correct solution.

I discussed several possible alternatives with @alxhub, and we concluded that the best approach is to provide alises for untyped versions of the forms classes. This PR introduces these alises for future use -- they need to be checked in separately, in order to use them in the google3 migration.