### PR TITLE
docs(docs-infra): fix the stackblitz on page i18n-example

### DIFF
--- a/aio/content/examples/i18n/angular.json
+++ b/aio/content/examples/i18n/angular.json
@@ -44,13 +44,8 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             // #docregion missing-translation-error
             "i18nMissingTranslation": "error"
@@ -82,6 +77,16 @@
               "outputHashing": "all"
             },
             "development": {
+              "localize": ["en-US"],
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true
+            },
+            "development:fr": {
+              "localize": ["fr"],
               "buildOptimizer": false,
               "optimization": false,
               "vendorChunk": true,
@@ -91,9 +96,7 @@
             },
             // #docregion build-single-locale, build-production-french
             "fr": {
-              "localize": [
-                "fr"
-              ]
+              "localize": ["fr"]
             }
           },
           // #enddocregion build-single-locale, build-production-french
@@ -113,7 +116,7 @@
             },
             // #docregion build-single-locale, build-production-french
             "fr": {
-              "browserTarget": "angular.io-example:build:fr"
+              "browserTarget": "angular.io-example:build:development:fr"
             }
           },
           // #enddocregion build-single-locale, build-production-french
@@ -134,13 +137,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": []
           }
         },

--- a/aio/content/examples/i18n/angular.json
+++ b/aio/content/examples/i18n/angular.json
@@ -77,16 +77,7 @@
               "outputHashing": "all"
             },
             "development": {
-              "localize": ["en-US"],
-              "buildOptimizer": false,
-              "optimization": false,
-              "vendorChunk": true,
-              "extractLicenses": false,
-              "sourceMap": true,
-              "namedChunks": true
-            },
-            "development:fr": {
-              "localize": ["fr"],
+              "localize": false,
               "buildOptimizer": false,
               "optimization": false,
               "vendorChunk": true,
@@ -116,7 +107,7 @@
             },
             // #docregion build-single-locale, build-production-french
             "fr": {
-              "browserTarget": "angular.io-example:build:development:fr"
+              "browserTarget": "angular.io-example:build:development,fr"
             }
           },
           // #enddocregion build-single-locale, build-production-french

--- a/aio/tools/examples/shared/boilerplate/i18n/package.json
+++ b/aio/tools/examples/shared/boilerplate/i18n/package.json
@@ -8,7 +8,6 @@
     "start": "ng serve",
     "start:fr": "ng serve --configuration=fr",
     "build": "ng build",
-    "build:fr": "ng build --configuration=production-fr",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "e2e": "ng e2e",


### PR DESCRIPTION
Pasted from the issue #45066
> Description
> The provided I18n live example does not run succesfully and raises an error.
>
>What is the affected URL?
>https://angular.io/guide/i18n-example

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The provided I18n live example does not run succesfully and raises an error.

Issue Number: #45066


## What is the new behavior?
The provided I18n live example runs succesfully.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
