### PR TITLE
perf(core): make more `ApplicationModule` providers tree-shakable

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 450729,
+        "main": 450085,
         "polyfills": 37297,
         "styles": 70379,
         "light-theme": 77582,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1083,
-        "main": 127944,
+        "main": 126218,
         "polyfills": 37226
       }
     }
@@ -24,7 +24,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1105,
-        "main": 133608,
+        "main": 131882,
         "polyfills": 37248
       }
     }
@@ -33,7 +33,7 @@
     "master": {
       "uncompressed": {
         "runtime": 929,
-        "main": 126275,
+        "main": 124544,
         "polyfills": 37933
       }
     }
@@ -52,7 +52,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 159637,
+        "main": 158556,
         "polyfills": 36975
       }
     }
@@ -61,7 +61,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1070,
-        "main": 159755,
+        "main": 158300,
         "polyfills": 37242
       }
     }

--- a/packages/core/src/application_init.ts
+++ b/packages/core/src/application_init.ts
@@ -92,7 +92,7 @@ export const APP_INITIALIZER =
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class ApplicationInitStatus {
   private resolve = noop;
   private reject = noop;

--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -6,18 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 import {ApplicationRef} from './application_ref';
 import {APP_ID_RANDOM_PROVIDER} from './application_tokens';
-import {Injector, StaticProvider} from './di';
+import {StaticProvider} from './di';
 import {Inject, Optional, SkipSelf} from './di/metadata';
-import {ErrorHandler} from './error_handler';
 import {DEFAULT_LOCALE_ID, USD_CURRENCY_CODE} from './i18n/localization';
 import {DEFAULT_CURRENCY_CODE, LOCALE_ID} from './i18n/tokens';
-import {ComponentFactoryResolver} from './linker';
-import {Compiler} from './linker/compiler';
 import {NgModule} from './metadata';
-import {NgZone} from './zone';
 
 declare const $localize: {locale?: string};
 
@@ -56,17 +51,6 @@ export function getGlobalLocale(): string {
  * that is used to configure the root injector for bootstrapping.
  */
 export const APPLICATION_MODULE_PROVIDERS: StaticProvider[] = [
-  {
-    provide: ApplicationRef,
-    useClass: ApplicationRef,
-    deps: [NgZone, Injector, ErrorHandler, ComponentFactoryResolver, ApplicationInitStatus]
-  },
-  {
-    provide: ApplicationInitStatus,
-    useClass: ApplicationInitStatus,
-    deps: [[new Optional(), APP_INITIALIZER]]
-  },
-  {provide: Compiler, useClass: Compiler, deps: []},
   APP_ID_RANDOM_PROVIDER,
   {
     provide: LOCALE_ID,

--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -7,70 +7,16 @@
  */
 
 import {ApplicationRef} from './application_ref';
-import {APP_ID_RANDOM_PROVIDER} from './application_tokens';
-import {StaticProvider} from './di';
-import {Inject, Optional, SkipSelf} from './di/metadata';
-import {DEFAULT_LOCALE_ID, USD_CURRENCY_CODE} from './i18n/localization';
-import {DEFAULT_CURRENCY_CODE, LOCALE_ID} from './i18n/tokens';
 import {NgModule} from './metadata';
 
-declare const $localize: {locale?: string};
-
-export function _localeFactory(locale?: string): string {
-  return locale || getGlobalLocale();
-}
 /**
- * Work out the locale from the potential global properties.
- *
- * * Closure Compiler: use `goog.getLocale()`.
- * * Ivy enabled: use `$localize.locale`
- */
-export function getGlobalLocale(): string {
-  if (typeof ngI18nClosureMode !== 'undefined' && ngI18nClosureMode &&
-      typeof goog !== 'undefined' && goog.getLocale() !== 'en') {
-    // * The default `goog.getLocale()` value is `en`, while Angular used `en-US`.
-    // * In order to preserve backwards compatibility, we use Angular default value over
-    //   Closure Compiler's one.
-    return goog.getLocale();
-  } else {
-    // KEEP `typeof $localize !== 'undefined' && $localize.locale` IN SYNC WITH THE LOCALIZE
-    // COMPILE-TIME INLINER.
-    //
-    // * During compile time inlining of translations the expression will be replaced
-    //   with a string literal that is the current locale. Other forms of this expression are not
-    //   guaranteed to be replaced.
-    //
-    // * During runtime translation evaluation, the developer is required to set `$localize.locale`
-    //   if required, or just to provide their own `LOCALE_ID` provider.
-    return (typeof $localize !== 'undefined' && $localize.locale) || DEFAULT_LOCALE_ID;
-  }
-}
-
-/**
- * A built-in [dependency injection token](guide/glossary#di-token)
- * that is used to configure the root injector for bootstrapping.
- */
-export const APPLICATION_MODULE_PROVIDERS: StaticProvider[] = [
-  APP_ID_RANDOM_PROVIDER,
-  {
-    provide: LOCALE_ID,
-    useFactory: _localeFactory,
-    deps: [[new Inject(LOCALE_ID), new Optional(), new SkipSelf()]]
-  },
-  {provide: DEFAULT_CURRENCY_CODE, useValue: USD_CURRENCY_CODE},
-];
-
-/**
- * Configures the root injector for an app with
- * providers of `@angular/core` dependencies that `ApplicationRef` needs
- * to bootstrap components.
- *
  * Re-exported by `BrowserModule`, which is included automatically in the root
- * `AppModule` when you create a new app with the CLI `new` command.
+ * `AppModule` when you create a new app with the CLI `new` command. Eagerly injects
+ * `ApplicationRef` to instantiate it.
  *
  * @publicApi
  */
-@NgModule({providers: APPLICATION_MODULE_PROVIDERS})
+@NgModule()
 export class ApplicationModule {
   // Inject ApplicationRef to make it eager...
   constructor(appRef: ApplicationRef) {}

--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -17,7 +17,6 @@ import {DEFAULT_CURRENCY_CODE, LOCALE_ID} from './i18n/tokens';
 import {ComponentFactoryResolver} from './linker';
 import {Compiler} from './linker/compiler';
 import {NgModule} from './metadata';
-import {SCHEDULER} from './render3/component_ref';
 import {NgZone} from './zone';
 
 declare const $localize: {locale?: string};
@@ -62,7 +61,6 @@ export const APPLICATION_MODULE_PROVIDERS: StaticProvider[] = [
     useClass: ApplicationRef,
     deps: [NgZone, Injector, ErrorHandler, ComponentFactoryResolver, ApplicationInitStatus]
   },
-  {provide: SCHEDULER, deps: [NgZone], useFactory: zoneSchedulerFactory},
   {
     provide: ApplicationInitStatus,
     useClass: ApplicationInitStatus,
@@ -77,27 +75,6 @@ export const APPLICATION_MODULE_PROVIDERS: StaticProvider[] = [
   },
   {provide: DEFAULT_CURRENCY_CODE, useValue: USD_CURRENCY_CODE},
 ];
-
-/**
- * Schedule work at next available slot.
- *
- * In Ivy this is just `requestAnimationFrame`. For compatibility reasons when bootstrapped
- * using `platformRef.bootstrap` we need to use `NgZone.onStable` as the scheduling mechanism.
- * This overrides the scheduling mechanism in Ivy to `NgZone.onStable`.
- *
- * @param ngZone NgZone to use for scheduling.
- */
-export function zoneSchedulerFactory(ngZone: NgZone): (fn: () => void) => void {
-  let queue: (() => void)[] = [];
-  ngZone.onStable.subscribe(() => {
-    while (queue.length) {
-      queue.pop()!();
-    }
-  });
-  return function(fn: () => void) {
-    queue.push(fn);
-  };
-}
 
 /**
  * Configures the root injector for an app with

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -564,7 +564,7 @@ function optionsReducer<T extends Object>(dst: any, objs: T|T[]): T {
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class ApplicationRef {
   /** @internal */
   private _bootstrapListeners: ((compRef: ComponentRef<any>) => void)[] = [];

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -21,7 +21,10 @@ import {ComponentRef} from './linker/component_factory';
  *
  * @publicApi
  */
-export const APP_ID = new InjectionToken<string>('AppId');
+export const APP_ID = new InjectionToken<string>('AppId', {
+  providedIn: 'root',
+  factory: _appIdRandomProviderFactory,
+});
 
 export function _appIdRandomProviderFactory() {
   return `${_randomChar()}${_randomChar()}${_randomChar()}`;

--- a/packages/core/src/linker/compiler.ts
+++ b/packages/core/src/linker/compiler.ts
@@ -52,7 +52,7 @@ export class ModuleWithComponentFactories<T> {
  * See [JIT API changes due to ViewEngine deprecation](guide/deprecations#jit-api-changes) for
  * additional context.
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class Compiler {
   /**
    * Compiles the given NgModule and all of its components. All templates of the components listed

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -7,7 +7,6 @@
  */
 
 import {ChangeDetectorRef as ViewEngine_ChangeDetectorRef} from '../change_detection/change_detector_ref';
-import {InjectionToken} from '../di/injection_token';
 import {Injector} from '../di/injector';
 import {InjectFlags} from '../di/interface/injector';
 import {ProviderToken} from '../di/provider_token';
@@ -36,7 +35,6 @@ import {createElementNode, writeDirectClass} from './node_manipulation';
 import {extractAttrsAndClassesFromSelector, stringifyCSSSelectorList} from './node_selector_matcher';
 import {enterView, leaveView} from './state';
 import {setUpAttributes} from './util/attrs_utils';
-import {defaultScheduler} from './util/misc_utils';
 import {getTNode} from './util/view_utils';
 import {RootViewRef, ViewRef} from './view_ref';
 
@@ -70,15 +68,6 @@ function getNamespace(elementName: string): string|null {
   const name = elementName.toLowerCase();
   return name === 'svg' ? SVG_NAMESPACE : (name === 'math' ? MATH_ML_NAMESPACE : null);
 }
-
-/**
- * A change detection scheduler token for {@link RootContext}. This token is the default value used
- * for the default `RootContext` found in the {@link ROOT_CONTEXT} token.
- */
-export const SCHEDULER = new InjectionToken<((fn: () => void) => void)>('SCHEDULER_TOKEN', {
-  providedIn: 'root',
-  factory: () => defaultScheduler,
-});
 
 function createChainedInjector(rootViewInjector: Injector, moduleInjector: Injector): Injector {
   return {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -123,9 +123,6 @@
     "name": "CommonModule"
   },
   {
-    "name": "Compiler"
-  },
-  {
     "name": "ComponentFactory"
   },
   {
@@ -345,9 +342,6 @@
     "name": "NgLocalization"
   },
   {
-    "name": "NgModuleFactory2"
-  },
-  {
     "name": "NgModuleRef"
   },
   {
@@ -418,9 +412,6 @@
   },
   {
     "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULER"
   },
   {
     "name": "SELF_TOKEN_REGEX"
@@ -673,6 +664,9 @@
   },
   {
     "name": "collectNativeNodes"
+  },
+  {
+    "name": "compileNgModuleFactory"
   },
   {
     "name": "computeStaticStyling"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -6,16 +6,10 @@
     "name": "ANIMATION_MODULE_TYPE"
   },
   {
-    "name": "APPLICATION_MODULE_PROVIDERS"
-  },
-  {
     "name": "APP_BOOTSTRAP_LISTENER"
   },
   {
     "name": "APP_ID"
-  },
-  {
-    "name": "APP_ID_RANDOM_PROVIDER"
   },
   {
     "name": "APP_INITIALIZER"
@@ -150,9 +144,6 @@
     "name": "DASH_CASE_REGEXP"
   },
   {
-    "name": "DEFAULT_CURRENCY_CODE"
-  },
-  {
     "name": "DEFAULT_NOOP_PREVIOUS_NODE"
   },
   {
@@ -232,9 +223,6 @@
   },
   {
     "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "Inject"
   },
   {
     "name": "InjectFlags"
@@ -372,9 +360,6 @@
     "name": "Observable"
   },
   {
-    "name": "Optional"
-  },
-  {
     "name": "PARAM_REGEX"
   },
   {
@@ -439,9 +424,6 @@
   },
   {
     "name": "SimpleOuterSubscriber"
-  },
-  {
-    "name": "SkipSelf"
   },
   {
     "name": "SpecialCasedStyles"
@@ -613,9 +595,6 @@
   },
   {
     "name": "applyView"
-  },
-  {
-    "name": "attachInjectFlag"
   },
   {
     "name": "attachPatchData"
@@ -966,6 +945,9 @@
     "name": "initTNodeFlags"
   },
   {
+    "name": "inject"
+  },
+  {
     "name": "injectArgs"
   },
   {
@@ -1108,9 +1090,6 @@
   },
   {
     "name": "makeLambdaFromStates"
-  },
-  {
-    "name": "makeParamDecorator"
   },
   {
     "name": "makeRecord"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -87,9 +87,6 @@
     "name": "CommonModule"
   },
   {
-    "name": "Compiler"
-  },
-  {
     "name": "ComponentFactory"
   },
   {
@@ -436,9 +433,6 @@
   },
   {
     "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULER"
   },
   {
     "name": "SERVER_TRANSITION_PROVIDERS"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -3,16 +3,10 @@
     "name": "ALLOW_MULTIPLE_PLATFORMS"
   },
   {
-    "name": "APPLICATION_MODULE_PROVIDERS"
-  },
-  {
     "name": "APP_BOOTSTRAP_LISTENER"
   },
   {
     "name": "APP_ID"
-  },
-  {
-    "name": "APP_ID_RANDOM_PROVIDER"
   },
   {
     "name": "APP_INITIALIZER"
@@ -114,9 +108,6 @@
     "name": "ControlContainer"
   },
   {
-    "name": "DEFAULT_CURRENCY_CODE"
-  },
-  {
     "name": "DEFAULT_VALUE_ACCESSOR"
   },
   {
@@ -211,9 +202,6 @@
   },
   {
     "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "Inject"
   },
   {
     "name": "InjectFlags"
@@ -1057,6 +1045,9 @@
   },
   {
     "name": "initTNodeFlags"
+  },
+  {
+    "name": "inject"
   },
   {
     "name": "injectArgs"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -93,9 +93,6 @@
     "name": "CommonModule"
   },
   {
-    "name": "Compiler"
-  },
-  {
     "name": "ComponentFactory"
   },
   {
@@ -430,9 +427,6 @@
   },
   {
     "name": "RuntimeError"
-  },
-  {
-    "name": "SCHEDULER"
   },
   {
     "name": "SERVER_TRANSITION_PROVIDERS"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -3,16 +3,10 @@
     "name": "ALLOW_MULTIPLE_PLATFORMS"
   },
   {
-    "name": "APPLICATION_MODULE_PROVIDERS"
-  },
-  {
     "name": "APP_BOOTSTRAP_LISTENER"
   },
   {
     "name": "APP_ID"
-  },
-  {
-    "name": "APP_ID_RANDOM_PROVIDER"
   },
   {
     "name": "APP_INITIALIZER"
@@ -120,9 +114,6 @@
     "name": "ControlContainer"
   },
   {
-    "name": "DEFAULT_CURRENCY_CODE"
-  },
-  {
     "name": "DEFAULT_VALUE_ACCESSOR"
   },
   {
@@ -202,9 +193,6 @@
   },
   {
     "name": "INJECTOR_SCOPE"
-  },
-  {
-    "name": "Inject"
   },
   {
     "name": "InjectFlags"
@@ -1030,6 +1018,9 @@
   },
   {
     "name": "initTNodeFlags"
+  },
+  {
+    "name": "inject"
   },
   {
     "name": "injectArgs"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -585,9 +585,6 @@
     "name": "SAFE_URL_PATTERN"
   },
   {
-    "name": "SCHEDULER"
-  },
-  {
     "name": "SEGMENT_RE"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -6,9 +6,6 @@
     "name": "ANALYZE_FOR_ENTRY_COMPONENTS"
   },
   {
-    "name": "APPLICATION_MODULE_PROVIDERS"
-  },
-  {
     "name": "APP_BASE_HREF"
   },
   {
@@ -16,9 +13,6 @@
   },
   {
     "name": "APP_ID"
-  },
-  {
-    "name": "APP_ID_RANDOM_PROVIDER"
   },
   {
     "name": "APP_INITIALIZER"
@@ -136,9 +130,6 @@
   },
   {
     "name": "DATA_URL_PATTERN"
-  },
-  {
-    "name": "DEFAULT_CURRENCY_CODE"
   },
   {
     "name": "DEFAULT_SERIALIZER"
@@ -1363,6 +1354,9 @@
   },
   {
     "name": "initTNodeFlags"
+  },
+  {
+    "name": "inject"
   },
   {
     "name": "injectArgs"


### PR DESCRIPTION
This PR refactors `ApplicationModule` providers to make them tree-shakable. See individual commits for additional details.

## PR Type
What kind of change does this PR introduce?

- [x] Performance improvement

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No