### PR TITLE
docs: clarify install of build schematics deps

### DIFF
--- a/aio/content/guide/schematics-for-libraries.md
+++ b/aio/content/guide/schematics-for-libraries.md
@@ -99,8 +99,8 @@ To tell the library how to build the schematics, add a `tsconfig.schematics.json
 
     * The `build` script compiles your schematic using the custom `tsconfig.schematics.json` file.
     * The `postbuild` script copies the schematic files after the `build` script completes.
-    * Both the `build` and the `postbuild` scripts require dependencies that are found in their parent directory.
-      They can be installed by running `npm install` prior to running the scripts.
+    * Both the `build` and the `postbuild` scripts require the `copyfiles` and `typescript` dependencies.
+      To install them, navigate to their path defined in `devDependencies` and run `npm install` before running the scripts.
 
 ## Providing generation support
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The step of installing the `copyfiles` and `typescript` dependencies is not clear if it is needed for going through building the schematics. This PR modifies that step so that it is clear to the user that they should run `npm install` beforehand in order to install the dependencies.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
