### PR TITLE
fix(compiler-cli): Support resolve animation name from the DTS

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -35,7 +35,7 @@ import {ComponentAnalysisData, ComponentResolutionData} from './metadata';
 import {_extractTemplateStyleUrls, extractComponentStyleUrls, extractStyleResources, extractTemplate, makeResourceNotFoundError, ParsedTemplateWithSource, parseTemplateDeclaration, preloadAndParseTemplate, ResourceTypeForDiagnostics, StyleUrlMeta, transformDecoratorToInlineResources} from './resources';
 import {scopeTemplate} from './scope';
 import {ComponentSymbol} from './symbol';
-import {collectAnimationNames, validateAndFlattenComponentImports} from './util';
+import {animationTriggerResolver, collectAnimationNames, validateAndFlattenComponentImports} from './util';
 
 const EMPTY_MAP = new Map<string, Expression>();
 const EMPTY_ARRAY: any[] = [];
@@ -210,8 +210,10 @@ export class ComponentDecoratorHandler implements
     let animations: Expression|null = null;
     let animationTriggerNames: AnimationTriggerNames|null = null;
     if (component.has('animations')) {
-      animations = new WrappedNodeExpr(component.get('animations')!);
-      const animationsValue = this.evaluator.evaluate(component.get('animations')!);
+      const animationExpression = component.get('animations')!;
+      animations = new WrappedNodeExpr(animationExpression);
+      const animationsValue =
+          this.evaluator.evaluate(animationExpression, animationTriggerResolver);
       animationTriggerNames = {includesDynamicAnimations: false, staticTriggerNames: []};
       collectAnimationNames(animationsValue, animationTriggerNames);
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -409,12 +409,15 @@ runInEachFileSystem(() => {
           contents: 'export const Component: any;',
         },
         {
+          name: _('/node_modules/@angular/animations/index.d.ts'),
+          contents: 'export declare function trigger(name: any): any',
+        },
+        {
           name: _('/entry.ts'),
           contents: `
           import {Component} from '@angular/core';
-          function trigger(name) {
-            return {name};
-          }
+          import {trigger} from '@angular/animations';
+
           @Component({
             template: '',
             animations: [
@@ -448,12 +451,15 @@ runInEachFileSystem(() => {
           contents: 'export const Component: any;',
         },
         {
+          name: _('/node_modules/@angular/animations/index.d.ts'),
+          contents: 'export declare function trigger(name: any): any',
+        },
+        {
           name: _('/entry.ts'),
           contents: `
           import {Component} from '@angular/core';
-          function trigger(name) {
-            return {name};
-          }
+          import {trigger} from '@angular/animations';
+
           function buildComplexAnimations() {
             const name = 'complex';
             return [trigger(name)];
@@ -489,12 +495,15 @@ runInEachFileSystem(() => {
           contents: 'export const Component: any;',
         },
         {
+          name: _('/node_modules/@angular/animations/index.d.ts'),
+          contents: 'export declare function trigger(name: any): any',
+        },
+        {
           name: _('/entry.ts'),
           contents: `
           import {Component} from '@angular/core';
-          function trigger(name) {
-            return {name};
-          }
+          import {trigger} from '@angular/animations';
+
           function buildComplexAnimations() {
             const name = 'complex';
             return [trigger(name)];


### PR DESCRIPTION
Before this, the compiler resolves the value in the DTS as dynamic.
If the `trigger` is imported from `@angular/animations`, this PR will
use FFR to simulate the actual implementation in JS and extracts the
animation name.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
