### PR TITLE
fix(http): encode + signs in query params as %2B (#11058)

### DIFF
--- a/packages/common/http/src/params.ts
+++ b/packages/common/http/src/params.ts
@@ -100,7 +100,6 @@ const STANDARD_ENCODING_REPLACEMENTS: {[x: string]: string} = {
   '24': '$',
   '2C': ',',
   '3B': ';',
-  '2B': '+',
   '3D': '=',
   '3F': '?',
   '2F': '/',

--- a/packages/common/http/test/params_spec.ts
+++ b/packages/common/http/test/params_spec.ts
@@ -178,8 +178,8 @@ import {HttpParams} from '@angular/common/http/src/params';
       it('should encode parameters', () => {
         const body = new HttpParams({fromString: 'a=standard_chars'});
         expect(body.toString()).toEqual('a=standard_chars');
-        const body2 = new HttpParams({fromString: 'a=1 2 3&b=mail@test&c=3_^[]$&d=eq=1'});
-        expect(body2.toString()).toEqual('a=1%202%203&b=mail@test&c=3_%5E%5B%5D$&d=eq=1');
+        const body2 = new HttpParams({fromString: 'a=1 2 3&b=mail@test&c=3_^[]$&d=eq=1&e=1+1'});
+        expect(body2.toString()).toEqual('a=1%202%203&b=mail@test&c=3_%5E%5B%5D$&d=eq=1&e=1%2B1');
       });
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) - affected code was undocumented.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`+` in query params is not encoded. Servers usually decode `+` as a space, which is undesirable when one actually wants to query for a plus. Workarounds involve custom codecs.

Issue Number: #11058
Fixes: #11058

## What is the new behavior?

`+` is encoded as `%2B`, which is decoded by servers as `+`. If someone wants to send a space, they can just use one in the query string.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`HttpParams` previously had a bug where a `+` in a parameter value would not be escaped during serialization. Escaping `+` is necessary as the literal `+` character is interpreted by servers as an escaped space.

While applications which have worked around this problem using a custom `HttpParameterCodec` will be unaffected, any server-side workarounds will need to be disabled following this fix.

Applications that relied on query parameters with `+` to be interpreted as space on the server-side will need to be adapted. Using a space in a query parameter is perfectly legal and will be properly URL-encoded as `%20`, which most servers decode back to the space.
Example: Replace `this.http.get('/api/foo', {params: {search: 'foo+bar'}})` with `this.http.get('/api/foo', {params: {search: 'foo bar'}})`, which behaves identically.

## Other information

#37385 addresses the same problem, but adds another opt-in workaround instead of fixing the problem directly at the cost of a breaking change.