### PR TITLE
perf(animations): improve algorithm to balance animation namespaces [v13 backport]

### DIFF
--- a/goldens/public-api/animations/browser/browser.md
+++ b/goldens/public-api/animations/browser/browser.md
@@ -14,6 +14,7 @@ export abstract class AnimationDriver {
     abstract computeStyle(element: any, prop: string, defaultValue?: string): string;
     // (undocumented)
     abstract containsElement(elm1: any, elm2: any): boolean;
+    abstract getParentElement?(element: unknown): unknown;
     // @deprecated (undocumented)
     abstract matchesElement(element: any, selector: string): boolean;
     // (undocumented)

--- a/goldens/public-api/animations/browser/testing/testing.md
+++ b/goldens/public-api/animations/browser/testing/testing.md
@@ -20,6 +20,8 @@ export class MockAnimationDriver implements AnimationDriver {
     // (undocumented)
     containsElement(elm1: any, elm2: any): boolean;
     // (undocumented)
+    getParentElement(element: unknown): unknown;
+    // (undocumented)
     static log: AnimationPlayer[];
     // (undocumented)
     matchesElement(_element: any, _selector: string): boolean;

--- a/packages/animations/browser/src/private_export.ts
+++ b/packages/animations/browser/src/private_export.ts
@@ -10,7 +10,7 @@ export {AnimationStyleNormalizer as ɵAnimationStyleNormalizer, NoopAnimationSty
 export {WebAnimationsStyleNormalizer as ɵWebAnimationsStyleNormalizer} from './dsl/style_normalization/web_animations_style_normalizer';
 export {NoopAnimationDriver as ɵNoopAnimationDriver} from './render/animation_driver';
 export {AnimationEngine as ɵAnimationEngine} from './render/animation_engine_next';
-export {containsElement as ɵcontainsElement, invokeQuery as ɵinvokeQuery, validateStyleProperty as ɵvalidateStyleProperty} from './render/shared';
+export {containsElement as ɵcontainsElement, getParentElement as ɵgetParentElement, invokeQuery as ɵinvokeQuery, validateStyleProperty as ɵvalidateStyleProperty} from './render/shared';
 export {WebAnimationsDriver as ɵWebAnimationsDriver} from './render/web_animations/web_animations_driver';
 export {WebAnimationsPlayer as ɵWebAnimationsPlayer} from './render/web_animations/web_animations_player';
 export {allowPreviousPlayerStylesMerge as ɵallowPreviousPlayerStylesMerge} from './util';

--- a/packages/animations/browser/src/render/animation_driver.ts
+++ b/packages/animations/browser/src/render/animation_driver.ts
@@ -8,7 +8,7 @@
 import {AnimationPlayer, NoopAnimationPlayer} from '@angular/animations';
 import {Injectable} from '@angular/core';
 
-import {containsElement, invokeQuery, validateStyleProperty} from './shared';
+import {containsElement, getParentElement, invokeQuery, validateStyleProperty} from './shared';
 
 /**
  * @publicApi
@@ -26,6 +26,10 @@ export class NoopAnimationDriver implements AnimationDriver {
 
   containsElement(elm1: any, elm2: any): boolean {
     return containsElement(elm1, elm2);
+  }
+
+  getParentElement(element: unknown): unknown {
+    return getParentElement(element);
   }
 
   query(element: any, selector: string, multi: boolean): any[] {
@@ -58,6 +62,15 @@ export abstract class AnimationDriver {
   abstract matchesElement(element: any, selector: string): boolean;
 
   abstract containsElement(elm1: any, elm2: any): boolean;
+
+  /**
+   * Obtains the parent element, if any. `null` is returned if the element does not have a parent.
+   *
+   * This method is optional to avoid a breaking change where implementors of this interface would
+   * be required to implement this method. This method is to become required in a major version of
+   * Angular.
+   */
+  abstract getParentElement?(element: unknown): unknown;
 
   abstract query(element: any, selector: string, multi: boolean): any[];
 

--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -152,6 +152,15 @@ let _query: (element: any, selector: string, multi: boolean) => any[] =
     (element: any, selector: string, multi: boolean) => {
       return [];
     };
+let _documentElement: unknown|null = null;
+
+export function getParentElement(element: any): unknown|null {
+  const parent = element.parentNode || element.host;  // consider host to support shadow DOM
+  if (parent === _documentElement) {
+    return null;
+  }
+  return parent;
+}
 
 // Define utility methods for browsers and platform-server(domino) where Element
 // and utility methods exist.
@@ -160,12 +169,15 @@ if (_isNode || typeof Element !== 'undefined') {
   if (!isBrowser()) {
     _contains = (elm1, elm2) => elm1.contains(elm2);
   } else {
+    // Read the document element in an IIFE that's been marked pure to avoid a top-level property
+    // read that may prevent tree-shaking.
+    _documentElement = /* @__PURE__ */ (() => document.documentElement)();
     _contains = (elm1, elm2) => {
-      while (elm2 && elm2 !== document.documentElement) {
+      while (elm2) {
         if (elm2 === elm1) {
           return true;
         }
-        elm2 = elm2.parentNode || elm2.host;  // consider host to support shadow DOM
+        elm2 = getParentElement(elm2);
       }
       return false;
     };

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -591,25 +591,51 @@ export class TransitionAnimationEngine {
   }
 
   private _balanceNamespaceList(ns: AnimationTransitionNamespace, hostElement: any) {
-    const limit = this._namespaceList.length - 1;
+    const namespaceList = this._namespaceList;
+    const namespacesByHostElement = this.namespacesByHostElement;
+    const limit = namespaceList.length - 1;
     if (limit >= 0) {
       let found = false;
-      for (let i = limit; i >= 0; i--) {
-        const nextNamespace = this._namespaceList[i];
-        if (this.driver.containsElement(nextNamespace.hostElement, hostElement)) {
-          this._namespaceList.splice(i + 1, 0, ns);
-          found = true;
-          break;
+      if (this.driver.getParentElement !== undefined) {
+        // Fast path for when the driver implements `getParentElement`, which allows us to find the
+        // closest ancestor with an existing namespace that we can then insert `ns` after, without
+        // having to inspect all existing namespaces.
+        let ancestor = this.driver.getParentElement(hostElement);
+        while (ancestor) {
+          const ancestorNs = namespacesByHostElement.get(ancestor);
+          if (ancestorNs) {
+            // An animation namespace has been registered for this ancestor, so we insert `ns`
+            // right after it to establish top-down ordering of animation namespaces.
+            const index = namespaceList.indexOf(ancestorNs);
+            namespaceList.splice(index + 1, 0, ns);
+            found = true;
+            break;
+          }
+          ancestor = this.driver.getParentElement(ancestor);
+        }
+      } else {
+        // Slow path for backwards compatibility if the driver does not implement
+        // `getParentElement`, to be removed once `getParentElement` is a required method.
+        for (let i = limit; i >= 0; i--) {
+          const nextNamespace = namespaceList[i];
+          if (this.driver.containsElement(nextNamespace.hostElement, hostElement)) {
+            namespaceList.splice(i + 1, 0, ns);
+            found = true;
+            break;
+          }
         }
       }
       if (!found) {
-        this._namespaceList.splice(0, 0, ns);
+        // No namespace exists that is an ancestor of `ns`, so `ns` is inserted at the front to
+        // ensure that any existing descendants are ordered after `ns`, retaining the desired
+        // top-down ordering.
+        namespaceList.unshift(ns);
       }
     } else {
-      this._namespaceList.push(ns);
+      namespaceList.push(ns);
     }
 
-    this.namespacesByHostElement.set(hostElement, ns);
+    namespacesByHostElement.set(hostElement, ns);
     return ns;
   }
 

--- a/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
@@ -9,7 +9,7 @@ import {AnimationPlayer, ɵStyleData} from '@angular/animations';
 
 import {allowPreviousPlayerStylesMerge, balancePreviousStylesIntoKeyframes, copyStyles} from '../../util';
 import {AnimationDriver} from '../animation_driver';
-import {containsElement, invokeQuery, isBrowser, validateStyleProperty} from '../shared';
+import {containsElement, getParentElement, invokeQuery, validateStyleProperty} from '../shared';
 import {packageNonAnimatableStyles} from '../special_cased_styles';
 
 import {WebAnimationsPlayer} from './web_animations_player';
@@ -26,6 +26,10 @@ export class WebAnimationsDriver implements AnimationDriver {
 
   containsElement(elm1: any, elm2: any): boolean {
     return containsElement(elm1, elm2);
+  }
+
+  getParentElement(element: unknown): unknown {
+    return getParentElement(element);
   }
 
   query(element: any, selector: string, multi: boolean): any[] {

--- a/packages/animations/browser/testing/src/mock_animation_driver.ts
+++ b/packages/animations/browser/testing/src/mock_animation_driver.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AnimationPlayer, AUTO_STYLE, NoopAnimationPlayer, ɵStyleData} from '@angular/animations';
-import {AnimationDriver, ɵallowPreviousPlayerStylesMerge as allowPreviousPlayerStylesMerge, ɵcontainsElement as containsElement, ɵinvokeQuery as invokeQuery, ɵvalidateStyleProperty as validateStyleProperty} from '@angular/animations/browser';
+import {AnimationDriver, ɵallowPreviousPlayerStylesMerge as allowPreviousPlayerStylesMerge, ɵcontainsElement as containsElement, ɵgetParentElement as getParentElement, ɵinvokeQuery as invokeQuery, ɵvalidateStyleProperty as validateStyleProperty} from '@angular/animations/browser';
 
 
 /**
@@ -25,6 +25,10 @@ export class MockAnimationDriver implements AnimationDriver {
 
   containsElement(elm1: any, elm2: any): boolean {
     return containsElement(elm1, elm2);
+  }
+
+  getParentElement(element: unknown): unknown {
+    return getParentElement(element);
   }
 
   query(element: any, selector: string, multi: boolean): any[] {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -585,6 +585,9 @@
     "name": "_currentInjector"
   },
   {
+    "name": "_documentElement"
+  },
+  {
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
@@ -952,6 +955,9 @@
   },
   {
     "name": "getOwnDefinition"
+  },
+  {
+    "name": "getParentElement"
   },
   {
     "name": "getParentInjectorIndex"


### PR DESCRIPTION
The prior approach would consider all existing namespaces from back to front
to find the one that's the closest ancestor for a given host element. An
expensive `contains` operation was used which needed to traverse all the
way up the document root _for each existing namespace_. This commit implements
an optimization where the closest namespace is found by traversing up from
the host element, avoiding repeated DOM traversal.

Closes #45055

---

Cherry-pick of #45057.