### PR TITLE
refactor(animations): make `AnimationDriver.getParentElement` required

### DIFF
--- a/goldens/public-api/animations/browser/browser.md
+++ b/goldens/public-api/animations/browser/browser.md
@@ -12,7 +12,7 @@ export abstract class AnimationDriver {
     abstract computeStyle(element: any, prop: string, defaultValue?: string): string;
     // (undocumented)
     abstract containsElement(elm1: any, elm2: any): boolean;
-    abstract getParentElement?(element: unknown): unknown;
+    abstract getParentElement(element: unknown): unknown;
     // @deprecated (undocumented)
     abstract matchesElement(element: any, selector: string): boolean;
     // (undocumented)

--- a/packages/animations/browser/src/render/animation_driver.ts
+++ b/packages/animations/browser/src/render/animation_driver.ts
@@ -65,12 +65,8 @@ export abstract class AnimationDriver {
 
   /**
    * Obtains the parent element, if any. `null` is returned if the element does not have a parent.
-   *
-   * This method is optional to avoid a breaking change where implementors of this interface would
-   * be required to implement this method. This method is to become required in a major version of
-   * Angular.
    */
-  abstract getParentElement?(element: unknown): unknown;
+  abstract getParentElement(element: unknown): unknown;
 
   abstract query(element: any, selector: string, multi: boolean): any[];
 

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -594,34 +594,20 @@ export class TransitionAnimationEngine {
     const limit = namespaceList.length - 1;
     if (limit >= 0) {
       let found = false;
-      if (this.driver.getParentElement !== undefined) {
-        // Fast path for when the driver implements `getParentElement`, which allows us to find the
-        // closest ancestor with an existing namespace that we can then insert `ns` after, without
-        // having to inspect all existing namespaces.
-        let ancestor = this.driver.getParentElement(hostElement);
-        while (ancestor) {
-          const ancestorNs = namespacesByHostElement.get(ancestor);
-          if (ancestorNs) {
-            // An animation namespace has been registered for this ancestor, so we insert `ns`
-            // right after it to establish top-down ordering of animation namespaces.
-            const index = namespaceList.indexOf(ancestorNs);
-            namespaceList.splice(index + 1, 0, ns);
-            found = true;
-            break;
-          }
-          ancestor = this.driver.getParentElement(ancestor);
+      // Find the closest ancestor with an existing namespace so we can then insert `ns` after it,
+      // establishing a top-down ordering of namespaces in `this._namespaceList`.
+      let ancestor = this.driver.getParentElement(hostElement);
+      while (ancestor) {
+        const ancestorNs = namespacesByHostElement.get(ancestor);
+        if (ancestorNs) {
+          // An animation namespace has been registered for this ancestor, so we insert `ns`
+          // right after it to establish top-down ordering of animation namespaces.
+          const index = namespaceList.indexOf(ancestorNs);
+          namespaceList.splice(index + 1, 0, ns);
+          found = true;
+          break;
         }
-      } else {
-        // Slow path for backwards compatibility if the driver does not implement
-        // `getParentElement`, to be removed once `getParentElement` is a required method.
-        for (let i = limit; i >= 0; i--) {
-          const nextNamespace = namespaceList[i];
-          if (this.driver.containsElement(nextNamespace.hostElement, hostElement)) {
-            namespaceList.splice(i + 1, 0, ns);
-            found = true;
-            break;
-          }
-        }
+        ancestor = this.driver.getParentElement(ancestor);
       }
       if (!found) {
         // No namespace exists that is an ancestor of `ns`, so `ns` is inserted at the front to


### PR DESCRIPTION
This change is a follow up to #45057 to make `AnimationDriver.getParentElement`
a required method, which allows removing the slow path for the animation
namespace insertion logic.

BREAKING CHANGE:

The `AnimationDriver.getParentElement` method has become required, so any
implementors of this interface are now required to provide an implementation
for this method. This breakage is unlikely to affect application developers,
as `AnimationDriver` is not expected to be implemented in user code.