### PR TITLE
[13.2.x] perf(core): make `IterableDiffers` and `KeyValueDiffers` tree-shakable

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1083,
-        "main": 139416,
+        "main": 127944,
         "polyfills": 37226
       }
     }
@@ -24,7 +24,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1105,
-        "main": 145132,
+        "main": 133608,
         "polyfills": 37248
       }
     }
@@ -33,7 +33,7 @@
     "master": {
       "uncompressed": {
         "runtime": 929,
-        "main": 137712,
+        "main": 126275,
         "polyfills": 37933
       }
     }
@@ -52,7 +52,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 163160,
+        "main": 159637,
         "polyfills": 36975
       }
     }
@@ -61,7 +61,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1070,
-        "main": 171374,
+        "main": 159755,
         "polyfills": 37242
       }
     }

--- a/packages/core/src/application_module.ts
+++ b/packages/core/src/application_module.ts
@@ -9,7 +9,6 @@
 import {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 import {ApplicationRef} from './application_ref';
 import {APP_ID_RANDOM_PROVIDER} from './application_tokens';
-import {defaultIterableDiffers, defaultKeyValueDiffers, IterableDiffers, KeyValueDiffers} from './change_detection/change_detection';
 import {Injector, StaticProvider} from './di';
 import {Inject, Optional, SkipSelf} from './di/metadata';
 import {ErrorHandler} from './error_handler';
@@ -22,14 +21,6 @@ import {SCHEDULER} from './render3/component_ref';
 import {NgZone} from './zone';
 
 declare const $localize: {locale?: string};
-
-export function _iterableDiffersFactory() {
-  return defaultIterableDiffers;
-}
-
-export function _keyValueDiffersFactory() {
-  return defaultKeyValueDiffers;
-}
 
 export function _localeFactory(locale?: string): string {
   return locale || getGlobalLocale();
@@ -79,8 +70,6 @@ export const APPLICATION_MODULE_PROVIDERS: StaticProvider[] = [
   },
   {provide: Compiler, useClass: Compiler, deps: []},
   APP_ID_RANDOM_PROVIDER,
-  {provide: IterableDiffers, useFactory: _iterableDiffersFactory, deps: []},
-  {provide: KeyValueDiffers, useFactory: _keyValueDiffersFactory, deps: []},
   {
     provide: LOCALE_ID,
     useFactory: _localeFactory,

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -174,18 +174,6 @@
     "name": "DefaultDomRenderer2"
   },
   {
-    "name": "DefaultIterableDiffer"
-  },
-  {
-    "name": "DefaultIterableDifferFactory"
-  },
-  {
-    "name": "DefaultKeyValueDiffer"
-  },
-  {
-    "name": "DefaultKeyValueDifferFactory"
-  },
-  {
     "name": "DomEventsPlugin"
   },
   {
@@ -264,19 +252,7 @@
     "name": "Injector"
   },
   {
-    "name": "IterableChangeRecord_"
-  },
-  {
-    "name": "IterableDiffers"
-  },
-  {
     "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "KeyValueChangeRecord_"
-  },
-  {
-    "name": "KeyValueDiffers"
   },
   {
     "name": "LEAVE_TOKEN_REGEX"
@@ -549,9 +525,6 @@
     "name": "_DOM"
   },
   {
-    "name": "_DuplicateMap"
-  },
-  {
     "name": "_IS_WEBKIT"
   },
   {
@@ -610,9 +583,6 @@
   },
   {
     "name": "_renderCompCount"
-  },
-  {
-    "name": "_symbolIterator"
   },
   {
     "name": "_testabilityGetter"
@@ -778,18 +748,6 @@
   },
   {
     "name": "defaultErrorLogger"
-  },
-  {
-    "name": "defaultIterableDiffers"
-  },
-  {
-    "name": "defaultIterableDiffersFactory"
-  },
-  {
-    "name": "defaultKeyValueDiffers"
-  },
-  {
-    "name": "defaultKeyValueDiffersFactory"
   },
   {
     "name": "defaultScheduler"
@@ -966,9 +924,6 @@
     "name": "getPlatform"
   },
   {
-    "name": "getPreviousIndex"
-  },
-  {
     "name": "getProjectionNodes"
   },
   {
@@ -979,9 +934,6 @@
   },
   {
     "name": "getStyleAttributeString"
-  },
-  {
-    "name": "getSymbolIterator"
   },
   {
     "name": "getSymbolIterator2"
@@ -1089,16 +1041,10 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isJsObject"
-  },
-  {
     "name": "isLContainer"
   },
   {
     "name": "isLView"
-  },
-  {
-    "name": "isListLikeIterable"
   },
   {
     "name": "isNode"
@@ -1144,9 +1090,6 @@
   },
   {
     "name": "iteratorToArray"
-  },
-  {
-    "name": "keyValDiff"
   },
   {
     "name": "leaveDI"
@@ -1426,9 +1369,6 @@
   },
   {
     "name": "toRefArray"
-  },
-  {
-    "name": "trackByIdentity"
   },
   {
     "name": "transition"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -138,12 +138,6 @@
     "name": "DefaultIterableDifferFactory"
   },
   {
-    "name": "DefaultKeyValueDiffer"
-  },
-  {
-    "name": "DefaultKeyValueDifferFactory"
-  },
-  {
     "name": "DefaultValueAccessor"
   },
   {
@@ -241,12 +235,6 @@
   },
   {
     "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "KeyValueChangeRecord_"
-  },
-  {
-    "name": "KeyValueDiffers"
   },
   {
     "name": "LOCALE_DATA"
@@ -768,16 +756,7 @@
     "name": "defaultErrorLogger"
   },
   {
-    "name": "defaultIterableDiffers"
-  },
-  {
     "name": "defaultIterableDiffersFactory"
-  },
-  {
-    "name": "defaultKeyValueDiffers"
-  },
-  {
-    "name": "defaultKeyValueDiffersFactory"
   },
   {
     "name": "defaultScheduler"
@@ -1170,9 +1149,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isJsObject"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -1225,9 +1201,6 @@
   },
   {
     "name": "iterator"
-  },
-  {
-    "name": "keyValDiff"
   },
   {
     "name": "keyValueArrayGet"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -144,12 +144,6 @@
     "name": "DefaultIterableDifferFactory"
   },
   {
-    "name": "DefaultKeyValueDiffer"
-  },
-  {
-    "name": "DefaultKeyValueDifferFactory"
-  },
-  {
     "name": "DefaultValueAccessor"
   },
   {
@@ -232,12 +226,6 @@
   },
   {
     "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "KeyValueChangeRecord_"
-  },
-  {
-    "name": "KeyValueDiffers"
   },
   {
     "name": "LOCALE_DATA"
@@ -747,16 +735,7 @@
     "name": "defaultErrorLogger"
   },
   {
-    "name": "defaultIterableDiffers"
-  },
-  {
     "name": "defaultIterableDiffersFactory"
-  },
-  {
-    "name": "defaultKeyValueDiffers"
-  },
-  {
-    "name": "defaultKeyValueDiffersFactory"
   },
   {
     "name": "defaultScheduler"
@@ -1134,9 +1113,6 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isJsObject"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -1189,9 +1165,6 @@
   },
   {
     "name": "iterator"
-  },
-  {
-    "name": "keyValDiff"
   },
   {
     "name": "keyValueArrayGet"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -159,18 +159,6 @@
     "name": "DefaultIfEmptySubscriber"
   },
   {
-    "name": "DefaultIterableDiffer"
-  },
-  {
-    "name": "DefaultIterableDifferFactory"
-  },
-  {
-    "name": "DefaultKeyValueDiffer"
-  },
-  {
-    "name": "DefaultKeyValueDifferFactory"
-  },
-  {
     "name": "DefaultUrlSerializer"
   },
   {
@@ -267,19 +255,7 @@
     "name": "ItemComponent"
   },
   {
-    "name": "IterableChangeRecord_"
-  },
-  {
-    "name": "IterableDiffers"
-  },
-  {
     "name": "KeyEventsPlugin"
-  },
-  {
-    "name": "KeyValueChangeRecord_"
-  },
-  {
-    "name": "KeyValueDiffers"
   },
   {
     "name": "LOCALE_DATA"
@@ -762,9 +738,6 @@
     "name": "_DOM"
   },
   {
-    "name": "_DuplicateMap"
-  },
-  {
     "name": "_NullComponentFactoryResolver"
   },
   {
@@ -1018,18 +991,6 @@
   },
   {
     "name": "defaultIfEmpty"
-  },
-  {
-    "name": "defaultIterableDiffers"
-  },
-  {
-    "name": "defaultIterableDiffersFactory"
-  },
-  {
-    "name": "defaultKeyValueDiffers"
-  },
-  {
-    "name": "defaultKeyValueDiffersFactory"
   },
   {
     "name": "defaultMalformedUriErrorHandler"
@@ -1320,9 +1281,6 @@
     "name": "getPlatform"
   },
   {
-    "name": "getPreviousIndex"
-  },
-  {
     "name": "getProjectionNodes"
   },
   {
@@ -1485,16 +1443,10 @@
     "name": "isInlineTemplate"
   },
   {
-    "name": "isJsObject"
-  },
-  {
     "name": "isLContainer"
   },
   {
     "name": "isLView"
-  },
-  {
-    "name": "isListLikeIterable"
   },
   {
     "name": "isMatrixParams"
@@ -1543,9 +1495,6 @@
   },
   {
     "name": "joinWithSlash"
-  },
-  {
-    "name": "keyValDiff"
   },
   {
     "name": "last2"
@@ -1930,9 +1879,6 @@
   },
   {
     "name": "toRefArray"
-  },
-  {
-    "name": "trackByIdentity"
   },
   {
     "name": "tree"


### PR DESCRIPTION
This is a patch-only version of PR #45094 (conflicted with 13.2.x branch).