### PR TITLE
perf(common): make `NgLocalization` token tree-shakable

### DIFF
--- a/goldens/public-api/common/common.md
+++ b/goldens/public-api/common/common.md
@@ -507,6 +507,10 @@ export class NgLocaleLocalization extends NgLocalization {
 export abstract class NgLocalization {
     // (undocumented)
     abstract getPluralCategory(value: any, locale?: string): string;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<NgLocalization, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<NgLocalization>;
 }
 
 // @public

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 450179,
+        "main": 449672,
         "polyfills": 33869,
         "styles": 70416,
         "light-theme": 77582,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1083,
-        "main": 126218,
+        "main": 124515,
         "polyfills": 33824
       }
     }
@@ -42,7 +42,7 @@
     "master": {
       "uncompressed": {
         "runtime": 2835,
-        "main": 233348,
+        "main": 232814,
         "polyfills": 33842,
         "src_app_lazy_lazy_module_ts": 795
       }
@@ -52,7 +52,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 158556,
+        "main": 156042,
         "polyfills": 33804
       }
     }
@@ -61,7 +61,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1070,
-        "main": 158300,
+        "main": 155753,
         "polyfills": 33814
       }
     }

--- a/packages/common/src/common_module.ts
+++ b/packages/common/src/common_module.ts
@@ -7,9 +7,10 @@
  */
 
 import {NgModule} from '@angular/core';
+
 import {COMMON_DIRECTIVES} from './directives/index';
-import {NgLocaleLocalization, NgLocalization} from './i18n/localization';
 import {COMMON_PIPES} from './pipes/index';
+
 
 
 // Note: This does not contain the location providers,
@@ -30,9 +31,6 @@ import {COMMON_PIPES} from './pipes/index';
 @NgModule({
   declarations: [COMMON_DIRECTIVES, COMMON_PIPES],
   exports: [COMMON_DIRECTIVES, COMMON_PIPES],
-  providers: [
-    {provide: NgLocalization, useClass: NgLocaleLocalization},
-  ],
 })
 export class CommonModule {
 }

--- a/packages/common/src/i18n/localization.ts
+++ b/packages/common/src/i18n/localization.ts
@@ -10,14 +10,17 @@ import {Inject, Injectable, LOCALE_ID} from '@angular/core';
 
 import {getLocalePluralCase, Plural} from './locale_data_api';
 
-
 /**
  * @publicApi
  */
+@Injectable({
+  providedIn: 'root',
+  useFactory: (locale: string) => new NgLocaleLocalization(locale),
+  deps: [LOCALE_ID],
+})
 export abstract class NgLocalization {
   abstract getPluralCategory(value: any, locale?: string): string;
 }
-
 
 /**
  * Returns the plural category for a given value.

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -240,16 +240,10 @@
     "name": "LEAVE_TOKEN_REGEX"
   },
   {
-    "name": "LOCALE_DATA"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
     "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "LocaleDataIndex"
   },
   {
     "name": "MODIFIER_KEYS"
@@ -324,12 +318,6 @@
     "name": "NULL_REMOVED_QUERIED_STATE"
   },
   {
-    "name": "NgLocaleLocalization"
-  },
-  {
-    "name": "NgLocalization"
-  },
-  {
     "name": "NgModuleRef"
   },
   {
@@ -370,9 +358,6 @@
   },
   {
     "name": "PlatformRef"
-  },
-  {
-    "name": "Plural"
   },
   {
     "name": "R3Injector"
@@ -852,9 +837,6 @@
     "name": "getLViewParent"
   },
   {
-    "name": "getLocaleData"
-  },
-  {
     "name": "getNativeByTNode"
   },
   {
@@ -1081,9 +1063,6 @@
   },
   {
     "name": "listenOnPlayer"
-  },
-  {
-    "name": "locale_en_default"
   },
   {
     "name": "lookupTokenUsingModuleInjector"
@@ -1348,9 +1327,6 @@
   },
   {
     "name": "transition"
-  },
-  {
-    "name": "u"
   },
   {
     "name": "uniqueIdCounter"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -222,16 +222,10 @@
     "name": "KeyEventsPlugin"
   },
   {
-    "name": "LOCALE_DATA"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
     "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "LocaleDataIndex"
   },
   {
     "name": "MODIFIER_KEYS"
@@ -327,12 +321,6 @@
     "name": "NgForOf"
   },
   {
-    "name": "NgLocaleLocalization"
-  },
-  {
-    "name": "NgLocalization"
-  },
-  {
     "name": "NgModuleFactory2"
   },
   {
@@ -373,9 +361,6 @@
   },
   {
     "name": "PlatformRef"
-  },
-  {
-    "name": "Plural"
   },
   {
     "name": "R3Injector"
@@ -906,9 +891,6 @@
     "name": "getLViewParent"
   },
   {
-    "name": "getLocaleData"
-  },
-  {
     "name": "getNativeByTNode"
   },
   {
@@ -1201,9 +1183,6 @@
   },
   {
     "name": "leaveViewLight"
-  },
-  {
-    "name": "locale_en_default"
   },
   {
     "name": "lookupTokenUsingModuleInjector"
@@ -1513,9 +1492,6 @@
   },
   {
     "name": "trackByIdentity"
-  },
-  {
-    "name": "u"
   },
   {
     "name": "uniqueIdCounter"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -210,16 +210,10 @@
     "name": "KeyEventsPlugin"
   },
   {
-    "name": "LOCALE_DATA"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
     "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "LocaleDataIndex"
   },
   {
     "name": "MODIFIER_KEYS"
@@ -315,12 +309,6 @@
     "name": "NgForm"
   },
   {
-    "name": "NgLocaleLocalization"
-  },
-  {
-    "name": "NgLocalization"
-  },
-  {
     "name": "NgModel"
   },
   {
@@ -367,9 +355,6 @@
   },
   {
     "name": "PlatformRef"
-  },
-  {
-    "name": "Plural"
   },
   {
     "name": "R3Injector"
@@ -870,9 +855,6 @@
     "name": "getLViewParent"
   },
   {
-    "name": "getLocaleData"
-  },
-  {
     "name": "getNativeByTNode"
   },
   {
@@ -1162,9 +1144,6 @@
   },
   {
     "name": "leaveViewLight"
-  },
-  {
-    "name": "locale_en_default"
   },
   {
     "name": "lookupTokenUsingModuleInjector"
@@ -1492,9 +1471,6 @@
   },
   {
     "name": "trackByIdentity"
-  },
-  {
-    "name": "u"
   },
   {
     "name": "uniqueIdCounter"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -252,9 +252,6 @@
     "name": "KeyEventsPlugin"
   },
   {
-    "name": "LOCALE_DATA"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
@@ -274,9 +271,6 @@
   },
   {
     "name": "LoadedRouterConfig"
-  },
-  {
-    "name": "LocaleDataIndex"
   },
   {
     "name": "Location"
@@ -372,12 +366,6 @@
     "name": "NavigationStart"
   },
   {
-    "name": "NgLocaleLocalization"
-  },
-  {
-    "name": "NgLocalization"
-  },
-  {
     "name": "NgModuleFactory"
   },
   {
@@ -442,9 +430,6 @@
   },
   {
     "name": "PlatformRef"
-  },
-  {
-    "name": "Plural"
   },
   {
     "name": "Position"
@@ -1221,9 +1206,6 @@
     "name": "getLViewParent"
   },
   {
-    "name": "getLocaleData"
-  },
-  {
     "name": "getNativeByTNode"
   },
   {
@@ -1516,9 +1498,6 @@
   },
   {
     "name": "leaveViewLight"
-  },
-  {
-    "name": "locale_en_default"
   },
   {
     "name": "locateDirectiveOrProvider"
@@ -1891,9 +1870,6 @@
   },
   {
     "name": "tree"
-  },
-  {
-    "name": "u"
   },
   {
     "name": "uniqueIdCounter"


### PR DESCRIPTION
This commit updates the `NgLocalization` token to become tree-shakable (vs using a direct reference to that token in the `providers` section of the `CommonModule`). The `NgLocalization` token is used for apps that use i18n and for other apps it would be excluded from the bundle.

## PR Type
What kind of change does this PR introduce?

- [x] Performance improvement


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No