### PR TITLE
feat(zone.js): several enhancement of `flush()` and `tickRAF()` for `fakeAsync`

### DIFF
--- a/goldens/public-api/core/testing/testing.md
+++ b/goldens/public-api/core/testing/testing.md
@@ -240,6 +240,9 @@ export function tick(millis?: number, tickOptions?: {
 }): void;
 
 // @public
+export function tickRAF(): void;
+
+// @public
 export function waitForAsync(fn: Function): (done: any) => any;
 
 // @public (undocumented)

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -130,8 +130,20 @@ export function tick(
 }
 
 /**
- * Flushes any pending microtasks and simulates the asynchronous passage of time for the timers in
- * the `fakeAsync` zone by
+ * Simulates the render tick in the `fakeAsync` zone
+ * to trigger requestAnimationFrame callbacks.
+ *
+ * @publicApi
+ */
+export function tickRAF(): void {
+  if (fakeAsyncTestModule) {
+    return fakeAsyncTestModule.tickRAF();
+  }
+  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+}
+
+/**
+ * Simulates the asynchronous passage of time for the timers in the `fakeAsync` zone by
  * draining the macrotask queue until it is empty.
  *
  * @param maxTurns The maximum number of times the scheduler attempts to clear its queue before

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -142,7 +142,7 @@ export function tick(
  */
 export function flush(maxTurns?: number): number {
   if (fakeAsyncTestModule) {
-    return fakeAsyncTestModule.flush(maxTurns);
+    return fakeAsyncTestModule.flush(maxTurns, true);
   }
   throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
 }

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -833,6 +833,14 @@ Zone.__load_patch('fakeasync', (global: any, Zone: ZoneType, api: _ZonePrivate) 
   }
 
   /**
+   * Simulates render tick to trigger requestAnimationFrame callbacks.
+   */
+
+  function tickRAF(): void {
+    _getFakeAsyncZoneSpec().tickRAF();
+  }
+
+  /**
    * Simulates the asynchronous passage of time for the timers in the fakeAsync zone by
    * draining the macrotask queue until it is empty. The returned value is the milliseconds
    * of time that would have been elapsed.
@@ -866,5 +874,5 @@ Zone.__load_patch('fakeasync', (global: any, Zone: ZoneType, api: _ZonePrivate) 
     _getFakeAsyncZoneSpec().flushMicrotasks();
   }
   (Zone as any)[api.symbol('fakeAsyncTest')] =
-      {resetFakeAsyncZone, flushMicrotasks, discardPeriodicTasks, tick, flush, fakeAsync};
+      {resetFakeAsyncZone, flushMicrotasks, discardPeriodicTasks, tick, tickRAF, flush, fakeAsync};
 }, true);

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -515,6 +515,10 @@ class FakeAsyncTestZoneSpec implements ZoneSpec {
     }
   }
 
+  tickRAF(doTick?: (elapsed: number) => void) {
+    this.tick(16, doTick);
+  }
+
   flushMicrotasks(): void {
     FakeAsyncTestZoneSpec.assertInZone();
     const flushErrors = () => {

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -764,6 +764,17 @@ describe('FakeAsyncTestZoneSpec', () => {
                      expect(ran).toEqual(true);
                    });
                  });
+                 it('should schedule a requestAnimationFrame with tickRAF', () => {
+                   fakeAsyncTestZone.run(() => {
+                     let ran = false;
+                     requestAnimationFrame(() => {
+                       ran = true;
+                     });
+
+                     testZoneSpec.tickRAF();
+                     expect(ran).toEqual(true);
+                   });
+                 });
                  it('does not count as a pending timer', () => {
                    fakeAsyncTestZone.run(() => {
                      requestAnimationFrame(() => {});
@@ -798,6 +809,16 @@ describe('FakeAsyncTestZoneSpec', () => {
                      expect(ran).toEqual(true);
                    });
                  });
+                 it('is ticked by tickRAF()', () => {
+                   let ran = false;
+                   fakeAsyncTestZone.run(() => {
+                     requestAnimationFrame(() => {
+                       ran = true;
+                     });
+                     testZoneSpec.tickRAF();
+                     expect(ran).toEqual(true);
+                   });
+                 });
                  it('should pass timestamp as parameter', () => {
                    let timestamp = 0;
                    let timestamp1 = 0;
@@ -811,6 +832,23 @@ describe('FakeAsyncTestZoneSpec', () => {
                      const elapsed = testZoneSpec.flush(20);
                      expect(elapsed).toEqual(32);
                      expect(timestamp).toEqual(16);
+                     expect(timestamp1).toEqual(32);
+                   });
+                 });
+                 it('should pass timestamp as parameter with tickRAF()', () => {
+                   let timestamp = 0;
+                   let timestamp1 = 0;
+                   fakeAsyncTestZone.run(() => {
+                     requestAnimationFrame((ts) => {
+                       timestamp = ts;
+                       requestAnimationFrame(ts1 => {
+                         timestamp1 = ts1;
+                       });
+                     });
+                     testZoneSpec.tickRAF();
+                     expect(timestamp).toEqual(16);
+                     expect(timestamp1).toEqual(0);
+                     testZoneSpec.tickRAF();
                      expect(timestamp1).toEqual(32);
                    });
                  });


### PR DESCRIPTION
- fakeAsyncZone.flush() should flush `requestAnimationFrame`  and scheduled interval.
Current `FakeAsyncZoneSpec.flush()` behavior is not consistent in some use cases.

Close #43875

1. `flush()` is not flusing `requestAnimationFrame`. But `tick(16)`
trigger both `requestAnimationFrame()` and `macrotasks`
2. `flush()` will not trigger `setInterval()` in some cases.

```
it('test timeout and interval', fakeAsync(() => {
  let timeoutCalled = false;
  let intervalCount = 0;
  setTimeout(() => timeoutCalled = true, 50);
  setInterval(() => {
    intervalCount ++;
  }, 50);
  flush();
  expect(timeoutCalled).toBeTrue();
  expect(intervalCounter).toBe(1);
});
```

In this case, both `setTimeout` and `setInterval` callbacks will be triggered.

But consider the following cases.

```
it('test interval', fakeAsync(() => {
  let intervalCount = 0;
  setInterval(() => {
    intervalCount ++;
  }, 50);
  flush();
  expect(intervalCounter).toBe(1);
});
```

this case will fail, since all remaining tasks are `interval`, which
is confusing to the user.

So this PR make the following changes.
1. `flush()` will also trigger `requestAnimationFrame` callbacks.
2. `flush()` will also trigger all `scheduled` tasks.

So consider the following test case

```
it('test interval', fakeAsync(() => {
  let intervalCount = 0;
  setInterval(() => {
    intervalCount ++;
  }, 50);
  flush();
  expect(intervalCounter).toBe(1);
});
```
The case will success, the `flush()` will trigger the scheduled
macrotask(`setInterval` in this case), and will not continue to
`flush` since the remaing tasks are all `interval tasks`.

- feat(zone.js): add tickRAF() to fakeAsyncZone

Now in the `FakeAsyncZoneSpec`, to trigger the `requestAnimationFrame`
callback, we need to call `tick(16)` which is not a good degin since
we need to reply on this `16` magic number, and we may handle the
requestAnimationFrame differently in the future, so in this PR
add a new API `tickRAF()`, internally it is still calling `tick(16)`
to keep the backward compatibility.


NOTE: `aio` document updates need to wait for the new `tickRAF()` API released with the new version of `zone.js`.