### PR TITLE
feat(forms): Narrow the type of `value` in several places from `any` to a more specific type.

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -248,7 +248,7 @@ export class FormArray extends AbstractControl {
     removeAt(index: number, options?: {
         emitEvent?: boolean;
     }): void;
-    reset(value?: any, options?: {
+    reset(value?: any[], options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
@@ -259,6 +259,10 @@ export class FormArray extends AbstractControl {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
+    // (undocumented)
+    value: any[];
+    // (undocumented)
+    valueChanges: Observable<any[]>;
 }
 
 // @public
@@ -399,7 +403,9 @@ export class FormGroup extends AbstractControl {
     removeControl(name: string, options?: {
         emitEvent?: boolean;
     }): void;
-    reset(value?: any, options?: {
+    reset(value?: {
+        [key: string]: any;
+    }, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
@@ -412,6 +418,14 @@ export class FormGroup extends AbstractControl {
         onlySelf?: boolean;
         emitEvent?: boolean;
     }): void;
+    // (undocumented)
+    value: {
+        [key: string]: any;
+    };
+    // (undocumented)
+    readonly valueChanges: Observable<{
+        [key: string]: any;
+    }>;
 }
 
 // @public

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1684,6 +1684,16 @@ export const FormControl: ɵFormControlCtor =
  */
 export class FormGroup extends AbstractControl {
   /**
+   * @see AbstractControl#value
+   */
+  public override value!: {[key: string]: any};
+
+  /**
+   * @see AbstractControl#valueChanges
+   */
+  public override readonly valueChanges!: Observable<{[key: string]: any}>;
+
+  /**
    * Creates a new `FormGroup` instance.
    *
    * @param controls A collection of child controls. The key for each child is the name
@@ -1954,7 +1964,10 @@ export class FormGroup extends AbstractControl {
    * console.log(form.get('first').status);  // 'DISABLED'
    * ```
    */
-  override reset(value: any = {}, options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  override reset(value: {[key: string]: any} = {}, options: {
+    onlySelf?: boolean,
+    emitEvent?: boolean
+  } = {}): void {
     this._forEachChild((control: AbstractControl, name: string) => {
       control.reset(value[name], {onlySelf: true, emitEvent: options.emitEvent});
     });
@@ -2118,6 +2131,16 @@ export class FormGroup extends AbstractControl {
  * @publicApi
  */
 export class FormArray extends AbstractControl {
+  /**
+   * @see AbstractControl#value
+   */
+  public override value!: any[];
+
+  /**
+   * @see AbstractControl#valueChanges
+   */
+  public override valueChanges!: Observable<any[]>;
+
   /**
    * Creates a new `FormArray` instance.
    *
@@ -2395,7 +2418,7 @@ export class FormArray extends AbstractControl {
    * The configuration options are passed to the {@link AbstractControl#updateValueAndValidity
    * updateValueAndValidity} method.
    */
-  override reset(value: any = [], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+  override reset(value: any[] = [], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
     this._forEachChild((control: AbstractControl, index: number) => {
       control.reset(value[index], {onlySelf: true, emitEvent: options.emitEvent});
     });


### PR DESCRIPTION
Currently, the type of `.value` is overly permissive for `FormGroup` and `FormArray`. This change narrows the type of `.value` to an index type (for groups) or an array type (for arrays).

BREAKING CHANGE: This enforces a more specific type, which may cause breakage in applications that were relying on the type of `FormGroup.value` or `FormArray.value` to be `any`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`FormGroup.value` and `FormArray.value` are overly permissive.

Issue Number: N/A


## What is the new behavior?

`FormGroup.value` is an index type. `FormArray.value` is an array type.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Extent of breakage and mitigation currently unknown, but likely large.

## Other information
