### PR TITLE
refactor(compiler): remove usages of deprecated AST creation functions

### DIFF
--- a/packages/compiler-cli/ngcc/src/migrations/utils.ts
+++ b/packages/compiler-cli/ngcc/src/migrations/utils.ts
@@ -6,8 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import ts from 'typescript';
+
 import {Reference} from '../../../src/ngtsc/imports';
 import {ClassDeclaration, Decorator, isNamedClassDeclaration, isNamedFunctionDeclaration, isNamedVariableDeclaration} from '../../../src/ngtsc/reflection';
+
 import {MigrationHost} from './migration';
 
 export function isClassDeclaration(clazz: ts.Node): clazz is ClassDeclaration<ts.Declaration> {
@@ -53,7 +55,7 @@ export function createDirectiveDecorator(
     if (metadata.exportAs !== null) {
       metaArgs.push(property('exportAs', metadata.exportAs.join(', ')));
     }
-    args.push(reifySourceFile(ts.createObjectLiteral(metaArgs)));
+    args.push(reifySourceFile(ts.factory.createObjectLiteralExpression(metaArgs)));
   }
   return {
     name: 'Directive',
@@ -87,7 +89,7 @@ export function createComponentDecorator(
     node: null,
     synthesizedFor: clazz.name,
     args: [
-      reifySourceFile(ts.createObjectLiteral(metaArgs)),
+      reifySourceFile(ts.factory.createObjectLiteralExpression(metaArgs)),
     ],
   };
 }
@@ -107,7 +109,7 @@ export function createInjectableDecorator(clazz: ClassDeclaration): Decorator {
 }
 
 function property(name: string, value: string): ts.PropertyAssignment {
-  return ts.createPropertyAssignment(name, ts.createStringLiteral(value));
+  return ts.factory.createPropertyAssignment(name, ts.factory.createStringLiteral(value));
 }
 
 const EMPTY_SF = ts.createSourceFile('(empty)', '', ts.ScriptTarget.Latest);

--- a/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/commonjs_rendering_formatter_spec.ts
@@ -161,8 +161,8 @@ exports.D = D;
         renderer.addImports(
             output,
             [
-              {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-              {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+              {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+              {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
             ],
             sourceFile);
         expect(output.toString()).toContain(`/* A copyright notice */
@@ -242,7 +242,8 @@ var A = (function() {`);
         const output = new MagicString(PROGRAM.contents);
         renderer.addConstants(output, 'var x = 3;', file);
         renderer.addImports(
-            output, [{specifier: '@angular/core', qualifier: ts.createIdentifier('i0')}], file);
+            output, [{specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')}],
+            file);
         expect(output.toString()).toContain(`
 var core = require('@angular/core');
 var i0 = require('@angular/core');

--- a/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm5_rendering_formatter_spec.ts
@@ -172,8 +172,8 @@ export { F };
         renderer.addImports(
             output,
             [
-              {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-              {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+              {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+              {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
             ],
             sourceFile);
         expect(output.toString()).toContain(`/* A copyright notice */
@@ -248,7 +248,8 @@ var A = (function() {`);
         const output = new MagicString(PROGRAM.contents);
         renderer.addConstants(output, 'var x = 3;', file);
         renderer.addImports(
-            output, [{specifier: '@angular/core', qualifier: ts.createIdentifier('i0')}], file);
+            output, [{specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')}],
+            file);
         expect(output.toString()).toContain(`
 import {Directive} from '@angular/core';
 import * as i0 from '@angular/core';

--- a/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/esm_rendering_formatter_spec.ts
@@ -129,8 +129,8 @@ runInEachFileSystem(() => {
           renderer.addImports(
               output,
               [
-                {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-                {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+                {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+                {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
               ],
               sourceFile);
           expect(output.toString()).toContain(`/* A copyright notice */
@@ -205,7 +205,8 @@ const x = 3;
           const output = new MagicString(PROGRAM.contents);
           renderer.addConstants(output, 'const x = 3;', file);
           renderer.addImports(
-              output, [{specifier: '@angular/core', qualifier: ts.createIdentifier('i0')}], file);
+              output, [{specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')}],
+              file);
           expect(output.toString()).toContain(`
 import {Directive} from '@angular/core';
 import * as i0 from '@angular/core';

--- a/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
+++ b/packages/compiler-cli/ngcc/test/rendering/umd_rendering_formatter_spec.ts
@@ -199,8 +199,8 @@ exports.BadIife = BadIife;
             renderer.addImports(
                 output,
                 [
-                  {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-                  {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+                  {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+                  {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
                 ],
                 file);
             expect(output.toString())
@@ -222,8 +222,8 @@ exports.BadIife = BadIife;
               renderer.addImports(
                   output,
                   [
-                    {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-                    {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+                    {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+                    {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
                   ],
                   file);
               expect(output.toString())
@@ -241,8 +241,8 @@ exports.BadIife = BadIife;
             renderer.addImports(
                 output,
                 [
-                  {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-                  {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+                  {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+                  {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
                 ],
                 file);
             expect(output.toString())
@@ -262,8 +262,8 @@ exports.BadIife = BadIife;
             renderer.addImports(
                 output,
                 [
-                  {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-                  {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+                  {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+                  {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
                 ],
                 file);
             expect(output.toString())
@@ -281,12 +281,15 @@ exports.BadIife = BadIife;
             renderer.addImports(
                 output,
                 [
-                  {specifier: '@ngrx/store', qualifier: ts.createIdentifier('i0')}, {
+                  {specifier: '@ngrx/store', qualifier: ts.factory.createIdentifier('i0')}, {
                     specifier: '@angular/platform-browser-dynamic',
-                    qualifier: ts.createIdentifier('i1')
+                    qualifier: ts.factory.createIdentifier('i1')
                   },
-                  {specifier: '@angular/common/testing', qualifier: ts.createIdentifier('i2')},
-                  {specifier: '@angular-foo/package', qualifier: ts.createIdentifier('i3')}
+                  {
+                    specifier: '@angular/common/testing',
+                    qualifier: ts.factory.createIdentifier('i2')
+                  },
+                  {specifier: '@angular-foo/package', qualifier: ts.factory.createIdentifier('i3')}
                 ],
                 file);
             expect(output.toString())
@@ -311,8 +314,8 @@ exports.BadIife = BadIife;
                  renderer.addImports(
                      output,
                      [
-                       {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-                       {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+                       {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+                       {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
                      ],
                      file);
                  expect(output.toString())
@@ -330,8 +333,8 @@ exports.BadIife = BadIife;
                renderer.addImports(
                    output,
                    [
-                     {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-                     {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+                     {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+                     {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
                    ],
                    file);
                expect(output.toString())
@@ -361,8 +364,8 @@ exports.BadIife = BadIife;
             renderer.addImports(
                 output,
                 [
-                  {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-                  {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+                  {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+                  {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
                 ],
                 file);
             const outputSrc = output.toString();
@@ -425,8 +428,8 @@ exports.BadIife = BadIife;
             renderer.addImports(
                 output,
                 [
-                  {specifier: '@angular/core', qualifier: ts.createIdentifier('i0')},
-                  {specifier: '@angular/common', qualifier: ts.createIdentifier('i1')}
+                  {specifier: '@angular/core', qualifier: ts.factory.createIdentifier('i0')},
+                  {specifier: '@angular/common', qualifier: ts.factory.createIdentifier('i1')}
                 ],
                 file);
             const outputSrc = output.toString();

--- a/packages/compiler-cli/ngcc/test/utils_spec.ts
+++ b/packages/compiler-cli/ngcc/test/utils_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import ts from 'typescript';
+
 import {absoluteFrom as _abs} from '../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
 import {KnownDeclaration} from '../../src/ngtsc/reflection';
@@ -55,10 +56,10 @@ describe('FactoryMap', () => {
 });
 
 describe('getTsHelperFnFromDeclaration()', () => {
-  const createFunctionDeclaration = (fnName?: string) => ts.createFunctionDeclaration(
+  const createFunctionDeclaration = (fnName?: string) => ts.factory.createFunctionDeclaration(
       undefined, undefined, undefined, fnName, undefined, [], undefined, undefined);
   const createVariableDeclaration = (varName: string) =>
-      ts.createVariableDeclaration(varName, undefined, undefined);
+      ts.factory.createVariableDeclaration(varName, undefined, undefined, undefined);
 
   it('should recognize the `__assign` helper as function declaration', () => {
     const decl1 = createFunctionDeclaration('__assign');
@@ -141,8 +142,8 @@ describe('getTsHelperFnFromDeclaration()', () => {
   });
 
   it('should return null for non-function/variable declarations', () => {
-    const classDecl =
-        ts.createClassDeclaration(undefined, undefined, '__assign', undefined, undefined, []);
+    const classDecl = ts.factory.createClassDeclaration(
+        undefined, undefined, '__assign', undefined, undefined, []);
 
     expect(classDecl.name!.text).toBe('__assign');
     expect(getTsHelperFnFromDeclaration(classDecl)).toBe(null);
@@ -151,41 +152,41 @@ describe('getTsHelperFnFromDeclaration()', () => {
 
 describe('getTsHelperFnFromIdentifier()', () => {
   it('should recognize the `__assign` helper', () => {
-    const id1 = ts.createIdentifier('__assign');
-    const id2 = ts.createIdentifier('__assign$42');
+    const id1 = ts.factory.createIdentifier('__assign');
+    const id2 = ts.factory.createIdentifier('__assign$42');
 
     expect(getTsHelperFnFromIdentifier(id1)).toBe(KnownDeclaration.TsHelperAssign);
     expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperAssign);
   });
 
   it('should recognize the `__spread` helper', () => {
-    const id1 = ts.createIdentifier('__spread');
-    const id2 = ts.createIdentifier('__spread$42');
+    const id1 = ts.factory.createIdentifier('__spread');
+    const id2 = ts.factory.createIdentifier('__spread$42');
 
     expect(getTsHelperFnFromIdentifier(id1)).toBe(KnownDeclaration.TsHelperSpread);
     expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperSpread);
   });
 
   it('should recognize the `__spreadArrays` helper', () => {
-    const id1 = ts.createIdentifier('__spreadArrays');
-    const id2 = ts.createIdentifier('__spreadArrays$42');
+    const id1 = ts.factory.createIdentifier('__spreadArrays');
+    const id2 = ts.factory.createIdentifier('__spreadArrays$42');
 
     expect(getTsHelperFnFromIdentifier(id1)).toBe(KnownDeclaration.TsHelperSpreadArrays);
     expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperSpreadArrays);
   });
 
   it('should recognize the `__spreadArray` helper', () => {
-    const id1 = ts.createIdentifier('__spreadArray');
-    const id2 = ts.createIdentifier('__spreadArray$42');
+    const id1 = ts.factory.createIdentifier('__spreadArray');
+    const id2 = ts.factory.createIdentifier('__spreadArray$42');
 
     expect(getTsHelperFnFromIdentifier(id1)).toBe(KnownDeclaration.TsHelperSpreadArray);
     expect(getTsHelperFnFromIdentifier(id2)).toBe(KnownDeclaration.TsHelperSpreadArray);
   });
 
   it('should return null for unrecognized helpers', () => {
-    const id1 = ts.createIdentifier('__foo');
-    const id2 = ts.createIdentifier('spread');
-    const id3 = ts.createIdentifier('spread$42');
+    const id1 = ts.factory.createIdentifier('__foo');
+    const id2 = ts.factory.createIdentifier('spread');
+    const id3 = ts.factory.createIdentifier('spread$42');
 
     expect(getTsHelperFnFromIdentifier(id1)).toBe(null);
     expect(getTsHelperFnFromIdentifier(id2)).toBe(null);

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/di.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/di.ts
@@ -73,7 +73,7 @@ export function getConstructorDependencies(
           attributeNameType = new LiteralExpr(attributeName.text);
         } else {
           attributeNameType =
-              new WrappedNodeExpr(ts.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword));
+              new WrappedNodeExpr(ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword));
         }
       } else {
         throw new FatalDiagnosticError(

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/metadata.ts
@@ -50,7 +50,8 @@ export function extractClassMetadata(
   if (ngClassDecorators.length === 0) {
     return null;
   }
-  const metaDecorators = new WrappedNodeExpr(ts.createArrayLiteral(ngClassDecorators));
+  const metaDecorators =
+      new WrappedNodeExpr(ts.factory.createArrayLiteralExpression(ngClassDecorators));
 
   // Convert the constructor parameters to metadata, passing null if none are present.
   let metaCtorParameters: Expression|null = null;
@@ -79,7 +80,8 @@ export function extractClassMetadata(
   const decoratedMembers = classMembers.map(
       member => classMemberToMetadata(member.nameNode ?? member.name, member.decorators!, isCore));
   if (decoratedMembers.length > 0) {
-    metaPropDecorators = new WrappedNodeExpr(ts.createObjectLiteral(decoratedMembers));
+    metaPropDecorators =
+        new WrappedNodeExpr(ts.factory.createObjectLiteralExpression(decoratedMembers));
   }
 
   return {
@@ -108,7 +110,7 @@ function ctorParameterToMetadata(param: CtorParameter, isCore: boolean): Express
   if (param.decorators !== null) {
     const ngDecorators = param.decorators.filter(dec => isAngularDecorator(dec, isCore))
                              .map((decorator: Decorator) => decoratorToMetadata(decorator));
-    const value = new WrappedNodeExpr(ts.createArrayLiteral(ngDecorators));
+    const value = new WrappedNodeExpr(ts.factory.createArrayLiteralExpression(ngDecorators));
     mapEntries.push({key: 'decorators', value, quoted: false});
   }
   return literalMap(mapEntries);
@@ -121,8 +123,8 @@ function classMemberToMetadata(
     name: ts.PropertyName|string, decorators: Decorator[], isCore: boolean): ts.PropertyAssignment {
   const ngDecorators = decorators.filter(dec => isAngularDecorator(dec, isCore))
                            .map((decorator: Decorator) => decoratorToMetadata(decorator));
-  const decoratorMeta = ts.createArrayLiteral(ngDecorators);
-  return ts.createPropertyAssignment(name, decoratorMeta);
+  const decoratorMeta = ts.factory.createArrayLiteralExpression(ngDecorators);
+  return ts.factory.createPropertyAssignment(name, decoratorMeta);
 }
 
 /**
@@ -135,7 +137,7 @@ function decoratorToMetadata(
   }
   // Decorators have a type.
   const properties: ts.ObjectLiteralElementLike[] = [
-    ts.createPropertyAssignment('type', ts.getMutableClone(decorator.identifier)),
+    ts.factory.createPropertyAssignment('type', ts.getMutableClone(decorator.identifier)),
   ];
   // Sometimes they have arguments.
   if (decorator.args !== null && decorator.args.length > 0) {
@@ -143,9 +145,10 @@ function decoratorToMetadata(
       const expr = ts.getMutableClone(arg);
       return wrapFunctionsInParens ? wrapFunctionExpressionsInParens(expr) : expr;
     });
-    properties.push(ts.createPropertyAssignment('args', ts.createArrayLiteral(args)));
+    properties.push(
+        ts.factory.createPropertyAssignment('args', ts.factory.createArrayLiteralExpression(args)));
   }
-  return ts.createObjectLiteral(properties, true);
+  return ts.factory.createObjectLiteralExpression(properties, true);
 }
 
 /**
@@ -166,7 +169,7 @@ function removeIdentifierReferences<T extends ts.Node>(node: T, name: string): T
   const result = ts.transform(
       node, [context => root => ts.visitNode(root, function walk(current: ts.Node): ts.Node {
         return ts.isIdentifier(current) && current.text === name ?
-            ts.createIdentifier(current.text) :
+            ts.factory.createIdentifier(current.text) :
             ts.visitEachChild(current, walk, context);
       })]);
 

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/util.ts
@@ -226,7 +226,7 @@ const parensWrapperTransformerFactory: ts.TransformerFactory<ts.Expression> =
       const visitor: ts.Visitor = (node: ts.Node): ts.Node => {
         const visited = ts.visitEachChild(node, visitor, context);
         if (ts.isArrowFunction(visited) || ts.isFunctionExpression(visited)) {
-          return ts.createParen(visited);
+          return ts.factory.createParenthesizedExpression(visited);
         }
         return visited;
       };

--- a/packages/compiler-cli/src/ngtsc/annotations/common/test/util_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/test/util_spec.ts
@@ -12,24 +12,26 @@ import {unwrapExpression} from '../src/util';
 
 describe('ngtsc annotation utilities', () => {
   describe('unwrapExpression', () => {
-    const obj = ts.createObjectLiteral();
+    const obj = ts.factory.createObjectLiteralExpression();
     it('should pass through an ObjectLiteralExpression', () => {
       expect(unwrapExpression(obj)).toBe(obj);
     });
 
     it('should unwrap an ObjectLiteralExpression in parentheses', () => {
-      const wrapped = ts.createParen(obj);
+      const wrapped = ts.factory.createParenthesizedExpression(obj);
       expect(unwrapExpression(wrapped)).toBe(obj);
     });
 
     it('should unwrap an ObjectLiteralExpression with a type cast', () => {
-      const cast = ts.createAsExpression(obj, ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
+      const cast = ts.factory.createAsExpression(
+          obj, ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
       expect(unwrapExpression(cast)).toBe(obj);
     });
 
     it('should unwrap an ObjectLiteralExpression with a type cast in parentheses', () => {
-      const cast = ts.createAsExpression(obj, ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
-      const wrapped = ts.createParen(cast);
+      const cast = ts.factory.createAsExpression(
+          obj, ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
+      const wrapped = ts.factory.createParenthesizedExpression(cast);
       expect(unwrapExpression(wrapped)).toBe(obj);
     });
   });

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
@@ -435,23 +435,26 @@ export function transformDecoratorToInlineResources(
   // Set the `template` property if the `templateUrl` property is set.
   if (metadata.has('templateUrl')) {
     metadata.delete('templateUrl');
-    metadata.set('template', ts.createStringLiteral(template.content));
+    metadata.set('template', ts.factory.createStringLiteral(template.content));
   }
 
   // Set the `styles` property if the `styleUrls` property is set.
   if (metadata.has('styleUrls')) {
     metadata.delete('styleUrls');
-    metadata.set('styles', ts.createArrayLiteral(styles.map(s => ts.createStringLiteral(s))));
+    metadata.set(
+        'styles',
+        ts.factory.createArrayLiteralExpression(
+            styles.map(s => ts.factory.createStringLiteral(s))));
   }
 
   // Convert the metadata to TypeScript AST object literal element nodes.
   const newMetadataFields: ts.ObjectLiteralElementLike[] = [];
   for (const [name, value] of metadata.entries()) {
-    newMetadataFields.push(ts.createPropertyAssignment(name, value));
+    newMetadataFields.push(ts.factory.createPropertyAssignment(name, value));
   }
 
   // Return the original decorator with the overridden metadata argument.
-  return {...dec, args: [ts.createObjectLiteral(newMetadataFields)]};
+  return {...dec, args: [ts.factory.createObjectLiteralExpression(newMetadataFields)]};
 }
 
 export function extractComponentStyleUrls(

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -160,7 +160,7 @@ export class NgModuleDecoratorHandler implements
     // @NgModule can be invoked without arguments. In case it is, pretend as if a blank object
     // literal was specified. This simplifies the code below.
     const meta = decorator.args.length === 1 ? unwrapExpression(decorator.args[0]) :
-                                               ts.createObjectLiteral([]);
+                                               ts.factory.createObjectLiteralExpression([]);
 
     if (!ts.isObjectLiteralExpression(meta)) {
       throw new FatalDiagnosticError(

--- a/packages/compiler-cli/src/ngtsc/imports/src/default.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/default.ts
@@ -118,9 +118,9 @@ export class DefaultImportTracker {
         //
         // 1. Using `ts.updateImportDeclaration` does not cause the import to be retained.
         //
-        // 2. Using `ts.createImportDeclaration` with the same `ts.ImportClause` causes the import
-        //    to correctly be retained, but when emitting CommonJS module format code, references
-        //    to the imported value will not match the import variable.
+        // 2. Using `ts.factory.createImportDeclaration` with the same `ts.ImportClause` causes the
+        //    import to correctly be retained, but when emitting CommonJS module format code,
+        //    references to the imported value will not match the import variable.
         //
         // 3. Emitting "import * as" imports instead generates the correct import variable, but
         //    references are missing the ".default" access. This happens to work for tsickle code
@@ -147,6 +147,6 @@ export class DefaultImportTracker {
     // file.
     this.sourceFileToUsedImports.delete(originalSf);
 
-    return ts.updateSourceFileNode(sf, statements);
+    return ts.factory.updateSourceFile(sf, statements);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import ts from 'typescript';
+
 import {absoluteFrom} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {getDeclaration, makeProgram} from '../../testing';
@@ -88,10 +89,10 @@ runInEachFileSystem(() => {
     return (context: ts.TransformationContext) => {
       return (sf: ts.SourceFile) => {
         if (id.getSourceFile().fileName === sf.fileName) {
-          return ts.updateSourceFileNode(sf, [
+          return ts.factory.updateSourceFile(sf, [
             ...sf.statements,
-            ts.createVariableStatement(undefined, ts.createVariableDeclarationList([
-              ts.createVariableDeclaration('ref', undefined, id),
+            ts.factory.createVariableStatement(undefined, ts.factory.createVariableDeclarationList([
+              ts.factory.createVariableDeclaration('ref', undefined, undefined, id),
             ]))
           ]);
         }

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/diagnostics_spec.ts
@@ -48,7 +48,7 @@ runInEachFileSystem(os => {
       });
 
       it('should describe references', () => {
-        const namedFn = ts.createFunctionDeclaration(
+        const namedFn = ts.factory.createFunctionDeclaration(
             /* decorators */ undefined,
             /* modifiers */ undefined,
             /* asteriskToken */ undefined,
@@ -60,7 +60,7 @@ runInEachFileSystem(os => {
         );
         expect(describeResolvedType(new Reference(namedFn))).toBe('test');
 
-        const anonymousFn = ts.createFunctionDeclaration(
+        const anonymousFn = ts.factory.createFunctionDeclaration(
             /* decorators */ undefined,
             /* modifiers */ undefined,
             /* asteriskToken */ undefined,
@@ -74,18 +74,19 @@ runInEachFileSystem(os => {
       });
 
       it('should describe enum values', () => {
-        const decl = ts.createEnumDeclaration(
+        const decl = ts.factory.createEnumDeclaration(
             /* decorators */ undefined,
             /* modifiers */ undefined,
             /* name */ 'MyEnum',
-            /* members */[ts.createEnumMember('member', ts.createNumericLiteral('1'))],
+            /* members */[ts.factory.createEnumMember(
+                'member', ts.factory.createNumericLiteral(1))],
         );
         const ref = new Reference(decl);
         expect(describeResolvedType(new EnumValue(ref, 'member', 1))).toBe('MyEnum');
       });
 
       it('should describe dynamic values', () => {
-        const node = ts.createObjectLiteral();
+        const node = ts.factory.createObjectLiteralExpression();
         expect(describeResolvedType(DynamicValue.fromUnsupportedSyntax(node)))
             .toBe('(not statically analyzable)');
       });

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/evaluator_spec.ts
@@ -1153,8 +1153,14 @@ runInEachFileSystem(() => {
       const declaration = super.getDeclarationOfIdentifier(id);
       if (declaration !== null && isConcreteDeclaration(declaration)) {
         const enumMembers = [
-          {name: ts.createStringLiteral('ValueA'), initializer: ts.createStringLiteral('a')},
-          {name: ts.createStringLiteral('ValueB'), initializer: ts.createStringLiteral('b')},
+          {
+            name: ts.factory.createStringLiteral('ValueA'),
+            initializer: ts.factory.createStringLiteral('a')
+          },
+          {
+            name: ts.factory.createStringLiteral('ValueB'),
+            initializer: ts.factory.createStringLiteral('b')
+          },
         ];
         declaration.identity = {kind: SpecialDeclarationKind.DownleveledEnum, enumMembers};
       }

--- a/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
@@ -265,7 +265,7 @@ function resolveTypeSymbols(typeRef: ts.TypeReferenceNode, checker: ts.TypeCheck
 function entityNameToValue(node: ts.EntityName): ts.Expression|null {
   if (ts.isQualifiedName(node)) {
     const left = entityNameToValue(node.left);
-    return left !== null ? ts.createPropertyAccess(left, node.right) : null;
+    return left !== null ? ts.factory.createPropertyAccessExpression(left, node.right) : null;
   } else if (ts.isIdentifier(node)) {
     return ts.getMutableClone(node);
   } else {

--- a/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
+++ b/packages/compiler-cli/src/ngtsc/shims/src/factory_generator.ts
@@ -159,9 +159,9 @@ function transformFactorySourceFile(
       const rewrittenModuleSpecifier =
           importRewriter.rewriteSpecifier('@angular/core', sourceFilePath);
       if (rewrittenModuleSpecifier !== stmt.moduleSpecifier.text) {
-        transformedStatements.push(ts.updateImportDeclaration(
+        transformedStatements.push(ts.factory.updateImportDeclaration(
             stmt, stmt.decorators, stmt.modifiers, stmt.importClause,
-            ts.createStringLiteral(rewrittenModuleSpecifier), undefined));
+            ts.factory.createStringLiteral(rewrittenModuleSpecifier), undefined));
 
         // Record the identifier by which this imported module goes, so references to its symbols
         // can be discovered later.
@@ -220,7 +220,7 @@ function transformFactorySourceFile(
     transformedStatements.push(nonEmptyExport);
   }
 
-  file = ts.updateSourceFileNode(file, transformedStatements);
+  file = ts.factory.updateSourceFile(file, transformedStatements);
 
   // If any imports to @angular/core were detected and rewritten (which happens when compiling
   // @angular/core), go through the SourceFile and rewrite references to symbols imported from core.
@@ -235,8 +235,8 @@ function transformFactorySourceFile(
         // This is an import of a symbol from @angular/core. Transform it with the importRewriter.
         const rewrittenSymbol = importRewriter.rewriteSymbol(node.name.text, '@angular/core');
         if (rewrittenSymbol !== node.name.text) {
-          const updated =
-              ts.updatePropertyAccess(node, node.expression, ts.createIdentifier(rewrittenSymbol));
+          const updated = ts.factory.updatePropertyAccessExpression(
+              node, node.expression, ts.factory.createIdentifier(rewrittenSymbol));
           node = updated as T & ts.PropertyAccessExpression;
         }
       }
@@ -291,25 +291,25 @@ function getFileoverviewComment(sourceFile: ts.SourceFile): string|null {
  * Example: Takes `1 + 2` and returns `i0.ɵnoSideEffects(() => 1 + 2)`.
  */
 function wrapInNoSideEffects(expr: ts.Expression): ts.Expression {
-  const noSideEffects = ts.createPropertyAccess(
-      ts.createIdentifier('i0'),
+  const noSideEffects = ts.factory.createPropertyAccessExpression(
+      ts.factory.createIdentifier('i0'),
       'ɵnoSideEffects',
   );
 
-  return ts.createCall(
+  return ts.factory.createCallExpression(
       noSideEffects,
       /* typeArguments */[],
       /* arguments */
       [
-        ts.createFunctionExpression(
+        ts.factory.createFunctionExpression(
             /* modifiers */[],
             /* asteriskToken */ undefined,
             /* name */ undefined,
             /* typeParameters */[],
             /* parameters */[],
             /* type */ undefined,
-            /* body */ ts.createBlock([
-              ts.createReturn(expr),
+            /* body */ ts.factory.createBlock([
+              ts.factory.createReturnStatement(expr),
             ]),
             ),
       ],
@@ -324,10 +324,10 @@ function updateInitializers(
     stmt: ts.VariableStatement,
     update: (initializer?: ts.Expression) => ts.Expression | undefined,
     ): ts.VariableStatement {
-  return ts.updateVariableStatement(
+  return ts.factory.updateVariableStatement(
       stmt,
       stmt.modifiers,
-      ts.updateVariableDeclarationList(
+      ts.factory.updateVariableDeclarationList(
           stmt.declarationList,
           stmt.declarationList.declarations.map(
               (decl) => ts.updateVariableDeclaration(

--- a/packages/compiler-cli/src/ngtsc/transform/src/alias.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/alias.ts
@@ -20,16 +20,17 @@ export function aliasTransformFactory(exportStatements: Map<string, Map<string, 
 
       const statements = [...file.statements];
       exportStatements.get(file.fileName)!.forEach(([moduleName, symbolName], aliasName) => {
-        const stmt = ts.createExportDeclaration(
+        const stmt = ts.factory.createExportDeclaration(
             /* decorators */ undefined,
             /* modifiers */ undefined,
+            /* isTypeOnly */ false,
             /* exportClause */ ts.createNamedExports([createExportSpecifier(
                 symbolName, aliasName)]),
-            /* moduleSpecifier */ ts.createStringLiteral(moduleName));
+            /* moduleSpecifier */ ts.factory.createStringLiteral(moduleName));
         statements.push(stmt);
       });
 
-      return ts.updateSourceFileNode(file, statements);
+      return ts.factory.updateSourceFile(file, statements);
     };
   };
 }

--- a/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/declaration.ts
@@ -140,7 +140,7 @@ class DtsTransformer {
     // If some elements have been transformed but the class itself has not been transformed, create
     // an updated class declaration with the updated elements.
     if (elementsChanged && clazz === newClazz) {
-      newClazz = ts.updateClassDeclaration(
+      newClazz = ts.factory.updateClassDeclaration(
           /* node */ clazz,
           /* decorators */ clazz.decorators,
           /* modifiers */ clazz.modifiers,
@@ -191,10 +191,10 @@ export class IvyDeclarationDtsTransform implements DtsTransform {
     const fields = this.declarationFields.get(original)!;
 
     const newMembers = fields.map(decl => {
-      const modifiers = [ts.createModifier(ts.SyntaxKind.StaticKeyword)];
+      const modifiers = [ts.factory.createModifier(ts.SyntaxKind.StaticKeyword)];
       const typeRef = translateType(decl.type, imports);
       markForEmitAsSingleLine(typeRef);
-      return ts.createProperty(
+      return ts.factory.createPropertyDeclaration(
           /* decorators */ undefined,
           /* modifiers */ modifiers,
           /* name */ decl.name,
@@ -203,7 +203,7 @@ export class IvyDeclarationDtsTransform implements DtsTransform {
           /* initializer */ undefined);
     });
 
-    return ts.updateClassDeclaration(
+    return ts.factory.updateClassDeclaration(
         /* node */ clazz,
         /* decorators */ clazz.decorators,
         /* modifiers */ clazz.modifiers,

--- a/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
@@ -109,8 +109,8 @@ class IvyTransformationVisitor extends Visitor {
       const exprNode = translateExpression(field.initializer, this.importManager, translateOptions);
 
       // Create a static property declaration for the new field.
-      const property = ts.createProperty(
-          undefined, [ts.createToken(ts.SyntaxKind.StaticKeyword)], field.name, undefined,
+      const property = ts.factory.createPropertyDeclaration(
+          undefined, [ts.factory.createToken(ts.SyntaxKind.StaticKeyword)], field.name, undefined,
           undefined, exprNode);
 
       if (this.isClosureCompilerEnabled) {
@@ -130,7 +130,7 @@ class IvyTransformationVisitor extends Visitor {
     }
 
     // Replace the class declaration with an updated version.
-    node = ts.updateClassDeclaration(
+    node = ts.factory.updateClassDeclaration(
         node,
         // Remove the decorator which triggered this compilation, leaving the others alone.
         maybeFilterDecorator(node.decorators, this.compilation.decoratorsFor(node)), node.modifiers,
@@ -191,7 +191,7 @@ class IvyTransformationVisitor extends Visitor {
     }
 
     // Create a new `NodeArray` with the filtered decorators that sourcemaps back to the original.
-    const array = ts.createNodeArray(filtered);
+    const array = ts.factory.createNodeArray(filtered);
     (array.pos as number) = node.decorators.pos;
     (array.end as number) = node.decorators.end;
     return array;
@@ -206,40 +206,40 @@ class IvyTransformationVisitor extends Visitor {
   private _stripAngularDecorators<T extends ts.Node>(node: T): T {
     if (ts.isParameter(node)) {
       // Strip decorators from parameters (probably of the constructor).
-      node = ts.updateParameter(
+      node = ts.factory.updateParameterDeclaration(
                  node, this._nonCoreDecoratorsOnly(node), node.modifiers, node.dotDotDotToken,
                  node.name, node.questionToken, node.type, node.initializer) as T &
           ts.ParameterDeclaration;
     } else if (ts.isMethodDeclaration(node) && node.decorators !== undefined) {
       // Strip decorators of methods.
-      node = ts.updateMethod(
+      node = ts.factory.updateMethodDeclaration(
                  node, this._nonCoreDecoratorsOnly(node), node.modifiers, node.asteriskToken,
                  node.name, node.questionToken, node.typeParameters, node.parameters, node.type,
                  node.body) as T &
           ts.MethodDeclaration;
     } else if (ts.isPropertyDeclaration(node) && node.decorators !== undefined) {
       // Strip decorators of properties.
-      node = ts.updateProperty(
+      node = ts.factory.updatePropertyDeclaration(
                  node, this._nonCoreDecoratorsOnly(node), node.modifiers, node.name,
                  node.questionToken, node.type, node.initializer) as T &
           ts.PropertyDeclaration;
     } else if (ts.isGetAccessor(node)) {
       // Strip decorators of getters.
-      node = ts.updateGetAccessor(
+      node = ts.factory.updateGetAccessorDeclaration(
                  node, this._nonCoreDecoratorsOnly(node), node.modifiers, node.name,
                  node.parameters, node.type, node.body) as T &
           ts.GetAccessorDeclaration;
     } else if (ts.isSetAccessor(node)) {
       // Strip decorators of setters.
-      node = ts.updateSetAccessor(
+      node = ts.factory.updateSetAccessorDeclaration(
                  node, this._nonCoreDecoratorsOnly(node), node.modifiers, node.name,
                  node.parameters, node.body) as T &
           ts.SetAccessorDeclaration;
     } else if (ts.isConstructorDeclaration(node)) {
       // For constructors, strip decorators of the parameters.
       const parameters = node.parameters.map(param => this._stripAngularDecorators(param));
-      node =
-          ts.updateConstructor(node, node.decorators, node.modifiers, parameters, node.body) as T &
+      node = ts.factory.updateConstructorDeclaration(
+                 node, node.decorators, node.modifiers, parameters, node.body) as T &
           ts.ConstructorDeclaration;
     }
     return node;
@@ -364,7 +364,7 @@ function maybeFilterDecorator(
   if (filtered.length === 0) {
     return undefined;
   }
-  return ts.createNodeArray(filtered);
+  return ts.factory.createNodeArray(filtered);
 }
 
 function isFromAngularCore(decorator: Decorator): boolean {

--- a/packages/compiler-cli/src/ngtsc/transform/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/utils.ts
@@ -19,15 +19,16 @@ export function addImports(
     extraStatements: ts.Statement[] = []): ts.SourceFile {
   // Generate the import statements to prepend.
   const addedImports = importManager.getAllImports(sf.fileName).map(i => {
-    const qualifier = ts.createIdentifier(i.qualifier.text);
-    const importClause = ts.createImportClause(
+    const qualifier = ts.factory.createIdentifier(i.qualifier.text);
+    const importClause = ts.factory.createImportClause(
+        /* isTypeOnly */ false,
         /* name */ undefined,
-        /* namedBindings */ ts.createNamespaceImport(qualifier));
-    const decl = ts.createImportDeclaration(
+        /* namedBindings */ ts.factory.createNamespaceImport(qualifier));
+    const decl = ts.factory.createImportDeclaration(
         /* decorators */ undefined,
         /* modifiers */ undefined,
         /* importClause */ importClause,
-        /* moduleSpecifier */ ts.createLiteral(i.specifier));
+        /* moduleSpecifier */ ts.factory.createStringLiteral(i.specifier));
 
     // Set the qualifier's original TS node to the `ts.ImportDeclaration`. This allows downstream
     // transforms such as tsickle to properly process references to this import.
@@ -51,8 +52,8 @@ export function addImports(
     // If we prepend imports, we also prepend NotEmittedStatement to use it as an anchor
     // for @fileoverview Closure annotation. If there is no @fileoverview annotations, this
     // statement would be a noop.
-    const fileoverviewAnchorStmt = ts.createNotEmittedStatement(sf);
-    return ts.updateSourceFileNode(sf, ts.createNodeArray([
+    const fileoverviewAnchorStmt = ts.factory.createNotEmittedStatement(sf);
+    return ts.factory.updateSourceFile(sf, ts.factory.createNodeArray([
       fileoverviewAnchorStmt, ...existingImports, ...addedImports, ...extraStatements, ...body
     ]));
   }

--- a/packages/compiler-cli/src/ngtsc/translator/src/import_manager.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/import_manager.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import ts from 'typescript';
+
 import {ImportRewriter, NoopImportRewriter} from '../../imports';
+
 import {ImportGenerator, NamedImport} from './api/import_generator';
 
 /**
@@ -29,7 +31,7 @@ export class ImportManager implements ImportGenerator<ts.Identifier> {
   generateNamespaceImport(moduleName: string): ts.Identifier {
     if (!this.specifierToIdentifier.has(moduleName)) {
       this.specifierToIdentifier.set(
-          moduleName, ts.createIdentifier(`${this.prefix}${this.nextIndex++}`));
+          moduleName, ts.factory.createIdentifier(`${this.prefix}${this.nextIndex++}`));
     }
     return this.specifierToIdentifier.get(moduleName)!;
   }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -524,7 +524,7 @@ class InlineTcbOp implements Op {
   execute(im: ImportManager, sf: ts.SourceFile, refEmitter: ReferenceEmitter, printer: ts.Printer):
       string {
     const env = new Environment(this.config, im, refEmitter, this.reflector, sf);
-    const fnName = ts.createIdentifier(`_tcb_${this.ref.node.pos}`);
+    const fnName = ts.factory.createIdentifier(`_tcb_${this.ref.node.pos}`);
 
     // Inline TCBs should copy any generic type parameter nodes directly, as the TCB code is inlined
     // into the class in a context where that will always be legal.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/diagnostics.ts
@@ -7,15 +7,18 @@
  */
 import {AbsoluteSourceSpan, ParseSourceSpan} from '@angular/compiler';
 import ts from 'typescript';
+
 import {TemplateDiagnostic, TemplateId} from '../api';
 import {makeTemplateDiagnostic} from '../diagnostics';
+
 import {getTemplateMapping, TemplateSourceResolver} from './tcb_util';
 
 
 /**
  * Wraps the node in parenthesis such that inserted span comments become attached to the proper
- * node. This is an alias for `ts.createParen` with the benefit that it signifies that the
- * inserted parenthesis are for diagnostic purposes, not for correctness of the rendered TCB code.
+ * node. This is an alias for `ts.factory.createParenthesizedExpression` with the benefit that it
+ * signifies that the inserted parenthesis are for diagnostic purposes, not for correctness of the
+ * rendered TCB code.
  *
  * Note that it is important that nodes and its attached comment are not wrapped into parenthesis
  * by default, as it prevents correct translation of e.g. diagnostics produced for incorrect method
@@ -23,17 +26,17 @@ import {getTemplateMapping, TemplateSourceResolver} from './tcb_util';
  * positional comment would be located within that node, resulting in a mismatch.
  */
 export function wrapForDiagnostics(expr: ts.Expression): ts.Expression {
-  return ts.createParen(expr);
+  return ts.factory.createParenthesizedExpression(expr);
 }
 
 /**
  * Wraps the node in parenthesis such that inserted span comments become attached to the proper
- * node. This is an alias for `ts.createParen` with the benefit that it signifies that the
- * inserted parenthesis are for use by the type checker, not for correctness of the rendered TCB
- * code.
+ * node. This is an alias for `ts.factory.createParenthesizedExpression` with the benefit that it
+ * signifies that the inserted parenthesis are for use by the type checker, not for correctness of
+ * the rendered TCB code.
  */
 export function wrapForTypeChecker(expr: ts.Expression): ts.Expression {
-  return ts.createParen(expr);
+  return ts.factory.createParenthesizedExpression(expr);
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -64,7 +64,7 @@ export class Environment implements ReferenceEmitEnvironment {
       // The constructor has already been created inline, we just need to construct a reference to
       // it.
       const ref = this.reference(dirRef);
-      const typeCtorExpr = ts.createPropertyAccess(ref, 'ngTypeCtor');
+      const typeCtorExpr = ts.factory.createPropertyAccessExpression(ref, 'ngTypeCtor');
       this.typeCtors.set(node, typeCtorExpr);
       return typeCtorExpr;
     } else {
@@ -87,7 +87,7 @@ export class Environment implements ReferenceEmitEnvironment {
       const typeParams = this.emitTypeParameters(node);
       const typeCtor = generateTypeCtorDeclarationFn(node, meta, nodeTypeRef.typeName, typeParams);
       this.typeCtorStatements.push(typeCtor);
-      const fnId = ts.createIdentifier(fnName);
+      const fnId = ts.factory.createIdentifier(fnName);
       this.typeCtors.set(node, fnId);
       return fnId;
     }
@@ -102,7 +102,7 @@ export class Environment implements ReferenceEmitEnvironment {
     }
 
     const pipeType = this.referenceType(ref);
-    const pipeInstId = ts.createIdentifier(`_pipe${this.nextIds.pipeInst++}`);
+    const pipeInstId = ts.factory.createIdentifier(`_pipe${this.nextIds.pipeInst++}`);
 
     this.pipeInstStatements.push(tsDeclareVariable(pipeInstId, pipeType));
     this.pipeInsts.set(ref.node, pipeInstId);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
@@ -7,7 +7,9 @@
  */
 
 import ts from 'typescript';
+
 import {ClassDeclaration} from '../../reflection';
+
 
 /**
  * A `Set` of `ts.SyntaxKind`s of `ts.Expression` which are safe to wrap in a `ts.AsExpression`
@@ -45,12 +47,12 @@ const SAFE_TO_CAST_WITHOUT_PARENS: Set<ts.SyntaxKind> = new Set([
 export function tsCastToAny(expr: ts.Expression): ts.Expression {
   // Wrap `expr` in parentheses if needed (see `SAFE_TO_CAST_WITHOUT_PARENS` above).
   if (!SAFE_TO_CAST_WITHOUT_PARENS.has(expr.kind)) {
-    expr = ts.createParen(expr);
+    expr = ts.factory.createParenthesizedExpression(expr);
   }
 
   // The outer expression is always wrapped in parentheses.
-  return ts.createParen(
-      ts.createAsExpression(expr, ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)));
+  return ts.factory.createParenthesizedExpression(ts.factory.createAsExpression(
+      expr, ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)));
 }
 
 
@@ -61,12 +63,12 @@ export function tsCastToAny(expr: ts.Expression): ts.Expression {
  * based on the tag name, including for custom elements that have appropriate .d.ts definitions.
  */
 export function tsCreateElement(tagName: string): ts.Expression {
-  const createElement = ts.createPropertyAccess(
-      /* expression */ ts.createIdentifier('document'), 'createElement');
-  return ts.createCall(
+  const createElement = ts.factory.createPropertyAccessExpression(
+      /* expression */ ts.factory.createIdentifier('document'), 'createElement');
+  return ts.factory.createCallExpression(
       /* expression */ createElement,
       /* typeArguments */ undefined,
-      /* argumentsArray */[ts.createLiteral(tagName)]);
+      /* argumentsArray */[ts.factory.createStringLiteral(tagName)]);
 }
 
 /**
@@ -77,11 +79,12 @@ export function tsCreateElement(tagName: string): ts.Expression {
  * Unlike with `tsCreateVariable`, the type of the variable is explicitly specified.
  */
 export function tsDeclareVariable(id: ts.Identifier, type: ts.TypeNode): ts.VariableStatement {
-  const decl = ts.createVariableDeclaration(
+  const decl = ts.factory.createVariableDeclaration(
       /* name */ id,
+      /* exclamationToken */ undefined,
       /* type */ type,
-      /* initializer */ ts.createNonNullExpression(ts.createNull()));
-  return ts.createVariableStatement(
+      /* initializer */ ts.factory.createNonNullExpression(ts.factory.createNull()));
+  return ts.factory.createVariableStatement(
       /* modifiers */ undefined,
       /* declarationList */[decl]);
 }
@@ -97,8 +100,8 @@ export function tsDeclareVariable(id: ts.Identifier, type: ts.TypeNode): ts.Vari
  */
 export function tsCreateTypeQueryForCoercedInput(
     typeName: ts.EntityName, coercedInputName: string): ts.TypeQueryNode {
-  return ts.createTypeQueryNode(
-      ts.createQualifiedName(typeName, `ngAcceptInputType_${coercedInputName}`));
+  return ts.factory.createTypeQueryNode(
+      ts.factory.createQualifiedName(typeName, `ngAcceptInputType_${coercedInputName}`));
 }
 
 /**
@@ -109,11 +112,12 @@ export function tsCreateTypeQueryForCoercedInput(
  */
 export function tsCreateVariable(
     id: ts.Identifier, initializer: ts.Expression): ts.VariableStatement {
-  const decl = ts.createVariableDeclaration(
+  const decl = ts.factory.createVariableDeclaration(
       /* name */ id,
+      /* exclamationToken */ undefined,
       /* type */ undefined,
       /* initializer */ initializer);
-  return ts.createVariableStatement(
+  return ts.factory.createVariableStatement(
       /* modifiers */ undefined,
       /* declarationList */[decl]);
 }
@@ -123,8 +127,8 @@ export function tsCreateVariable(
  */
 export function tsCallMethod(
     receiver: ts.Expression, methodName: string, args: ts.Expression[] = []): ts.CallExpression {
-  const methodAccess = ts.createPropertyAccess(receiver, methodName);
-  return ts.createCall(
+  const methodAccess = ts.factory.createPropertyAccessExpression(receiver, methodName);
+  return ts.factory.createCallExpression(
       /* expression */ methodAccess,
       /* typeArguments */ undefined,
       /* argumentsArray */ args);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -120,15 +120,16 @@ export function generateTypeCheckBlock(
   const paramList = [tcbCtxParam(ref.node, ctxRawType.typeName, typeArguments)];
 
   const scopeStatements = scope.render();
-  const innerBody = ts.createBlock([
+  const innerBody = ts.factory.createBlock([
     ...env.getPreludeStatements(),
     ...scopeStatements,
   ]);
 
   // Wrap the body in an "if (true)" expression. This is unnecessary but has the effect of causing
   // the `ts.Printer` to format the type-check block nicely.
-  const body = ts.createBlock([ts.createIf(ts.createTrue(), innerBody, undefined)]);
-  const fnDecl = ts.createFunctionDeclaration(
+  const body = ts.factory.createBlock(
+      [ts.factory.createIfStatement(ts.factory.createTrue(), innerBody, undefined)]);
+  const fnDecl = ts.factory.createFunctionDeclaration(
       /* decorators */ undefined,
       /* modifiers */ undefined,
       /* asteriskToken */ undefined,
@@ -233,7 +234,7 @@ class TcbVariableOp extends TcbOp {
     // Allocate an identifier for the TmplAstVariable, and initialize it to a read of the variable
     // on the template context.
     const id = this.tcb.allocateId();
-    const initializer = ts.createPropertyAccess(
+    const initializer = ts.factory.createPropertyAccessExpression(
         /* expression */ ctx,
         /* name */ this.variable.value || '$implicit');
     addParseSpanInfo(id, this.variable.keySpan);
@@ -269,7 +270,7 @@ class TcbTemplateContextOp extends TcbOp {
     // Allocate a template ctx variable and declare it with an 'any' type. The type of this variable
     // may be narrowed as a result of template guard conditions.
     const ctx = this.tcb.allocateId();
-    const type = ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+    const type = ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
     this.scope.addStatement(tsDeclareVariable(ctx, type));
     return ctx;
   }
@@ -371,8 +372,8 @@ class TcbTemplateBodyOp extends TcbOp {
       // Pop the first value and use it as the initializer to reduce(). This way, a single guard
       // will be used on its own, but two or more will be combined into binary AND expressions.
       guard = directiveGuards.reduce(
-          (expr, dirGuard) =>
-              ts.createBinary(expr, ts.SyntaxKind.AmpersandAmpersandToken, dirGuard),
+          (expr, dirGuard) => ts.factory.createBinaryExpression(
+              expr, ts.SyntaxKind.AmpersandAmpersandToken, dirGuard),
           directiveGuards.pop()!);
     }
 
@@ -392,11 +393,12 @@ class TcbTemplateBodyOp extends TcbOp {
       return null;
     }
 
-    let tmplBlock: ts.Statement = ts.createBlock(statements);
+    let tmplBlock: ts.Statement = ts.factory.createBlock(statements);
     if (guard !== null) {
       // The scope has a guard that needs to be applied, so wrap the template block into an `if`
       // statement containing the guard expression.
-      tmplBlock = ts.createIf(/* expression */ guard, /* thenStatement */ tmplBlock);
+      tmplBlock =
+          ts.factory.createIfStatement(/* expression */ guard, /* thenStatement */ tmplBlock);
     }
     this.scope.addStatement(tmplBlock);
 
@@ -420,7 +422,7 @@ class TcbTextInterpolationOp extends TcbOp {
 
   override execute(): null {
     const expr = tcbExpression(this.binding.value, this.tcb, this.scope);
-    this.scope.addStatement(ts.createExpressionStatement(expr));
+    this.scope.addStatement(ts.factory.createExpressionStatement(expr));
     return null;
   }
 }
@@ -559,18 +561,18 @@ class TcbReferenceOp extends TcbOp {
       // References to DOM nodes are pinned to 'any' when `checkTypeOfDomReferences` is `false`.
       // References to `TemplateRef`s and directives are pinned to 'any' when
       // `checkTypeOfNonDomReferences` is `false`.
-      initializer =
-          ts.createAsExpression(initializer, ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
+      initializer = ts.factory.createAsExpression(
+          initializer, ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
     } else if (this.target instanceof TmplAstTemplate) {
       // Direct references to an <ng-template> node simply require a value of type
       // `TemplateRef<any>`. To get this, an expression of the form
       // `(_t1 as any as TemplateRef<any>)` is constructed.
-      initializer =
-          ts.createAsExpression(initializer, ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
-      initializer = ts.createAsExpression(
+      initializer = ts.factory.createAsExpression(
+          initializer, ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
+      initializer = ts.factory.createAsExpression(
           initializer,
           this.tcb.env.referenceExternalType('@angular/core', 'TemplateRef', [DYNAMIC_TYPE]));
-      initializer = ts.createParen(initializer);
+      initializer = ts.factory.createParenthesizedExpression(initializer);
     }
     addParseSpanInfo(initializer, this.node.sourceSpan);
     addParseSpanInfo(id, this.node.keySpan);
@@ -745,9 +747,9 @@ class TcbDirectiveInputsOp extends TcbOp {
             throw new Error(
                 `Expected TypeReferenceNode from reference to ${this.dir.ref.debugName}`);
           }
-          const type = ts.createIndexedAccessTypeNode(
-              ts.createTypeQueryNode(dirId as ts.Identifier),
-              ts.createLiteralTypeNode(ts.createStringLiteral(fieldName)));
+          const type = ts.factory.createIndexedAccessTypeNode(
+              ts.factory.createTypeQueryNode(dirId as ts.Identifier),
+              ts.factory.createLiteralTypeNode(ts.factory.createStringLiteral(fieldName)));
           const temp = tsDeclareVariable(id, type);
           this.scope.addStatement(temp);
           target = id;
@@ -760,15 +762,18 @@ class TcbDirectiveInputsOp extends TcbOp {
           // when possible. String literal fields may not be valid JS identifiers so we use
           // literal element access instead for those cases.
           target = this.dir.stringLiteralInputFields.has(fieldName) ?
-              ts.createElementAccess(dirId, ts.createStringLiteral(fieldName)) :
-              ts.createPropertyAccess(dirId, ts.createIdentifier(fieldName));
+              ts.factory.createElementAccessExpression(
+                  dirId, ts.factory.createStringLiteral(fieldName)) :
+              ts.factory.createPropertyAccessExpression(
+                  dirId, ts.factory.createIdentifier(fieldName));
         }
 
         if (input.attribute.keySpan !== undefined) {
           addParseSpanInfo(target, input.attribute.keySpan);
         }
         // Finally the assignment is extended by assigning it into the target expression.
-        assignment = ts.createBinary(target, ts.SyntaxKind.EqualsToken, assignment);
+        assignment =
+            ts.factory.createBinaryExpression(target, ts.SyntaxKind.EqualsToken, assignment);
       }
 
       addParseSpanInfo(assignment, input.attribute.sourceSpan);
@@ -778,7 +783,7 @@ class TcbDirectiveInputsOp extends TcbOp {
         markIgnoreDiagnostics(assignment);
       }
 
-      this.scope.addStatement(ts.createExpressionStatement(assignment));
+      this.scope.addStatement(ts.factory.createExpressionStatement(assignment));
     }
 
     return null;
@@ -813,8 +818,9 @@ class TcbDirectiveCtorCircularFallbackOp extends TcbOp {
   override execute(): ts.Identifier {
     const id = this.tcb.allocateId();
     const typeCtor = this.tcb.env.typeCtorFor(this.dir);
-    const circularPlaceholder = ts.createCall(
-        typeCtor, /* typeArguments */ undefined, [ts.createNonNullExpression(ts.createNull())]);
+    const circularPlaceholder = ts.factory.createCallExpression(
+        typeCtor, /* typeArguments */ undefined,
+        [ts.factory.createNonNullExpression(ts.factory.createNull())]);
     this.scope.addStatement(tsCreateVariable(id, circularPlaceholder));
     return id;
   }
@@ -922,18 +928,20 @@ class TcbUnclaimedInputsOp extends TcbOp {
           }
           // A direct binding to a property.
           const propertyName = ATTR_TO_PROP[binding.name] || binding.name;
-          const prop = ts.createElementAccess(elId, ts.createStringLiteral(propertyName));
-          const stmt = ts.createBinary(prop, ts.SyntaxKind.EqualsToken, wrapForDiagnostics(expr));
+          const prop = ts.factory.createElementAccessExpression(
+              elId, ts.factory.createStringLiteral(propertyName));
+          const stmt = ts.factory.createBinaryExpression(
+              prop, ts.SyntaxKind.EqualsToken, wrapForDiagnostics(expr));
           addParseSpanInfo(stmt, binding.sourceSpan);
-          this.scope.addStatement(ts.createExpressionStatement(stmt));
+          this.scope.addStatement(ts.factory.createExpressionStatement(stmt));
         } else {
-          this.scope.addStatement(ts.createExpressionStatement(expr));
+          this.scope.addStatement(ts.factory.createExpressionStatement(expr));
         }
       } else {
         // A binding to an animation, attribute, class or style. For now, only validate the right-
         // hand side of the expression.
         // TODO: properly check class and style bindings.
-        this.scope.addStatement(ts.createExpressionStatement(expr));
+        this.scope.addStatement(ts.factory.createExpressionStatement(expr));
       }
     }
 
@@ -977,17 +985,19 @@ export class TcbDirectiveOutputsOp extends TcbOp {
       if (dirId === null) {
         dirId = this.scope.resolve(this.node, this.dir);
       }
-      const outputField = ts.createElementAccess(dirId, ts.createStringLiteral(field));
+      const outputField =
+          ts.factory.createElementAccessExpression(dirId, ts.factory.createStringLiteral(field));
       addParseSpanInfo(outputField, output.keySpan);
       if (this.tcb.env.config.checkTypeOfOutputEvents) {
         // For strict checking of directive events, generate a call to the `subscribe` method
         // on the directive's output field to let type information flow into the handler function's
         // `$event` parameter.
         const handler = tcbCreateEventHandler(output, this.tcb, this.scope, EventParamType.Infer);
-        const subscribeFn = ts.createPropertyAccess(outputField, 'subscribe');
-        const call = ts.createCall(subscribeFn, /* typeArguments */ undefined, [handler]);
+        const subscribeFn = ts.factory.createPropertyAccessExpression(outputField, 'subscribe');
+        const call =
+            ts.factory.createCallExpression(subscribeFn, /* typeArguments */ undefined, [handler]);
         addParseSpanInfo(call, output.sourceSpan);
-        this.scope.addStatement(ts.createExpressionStatement(call));
+        this.scope.addStatement(ts.factory.createExpressionStatement(call));
       } else {
         // If strict checking of directive events is disabled:
         //
@@ -995,9 +1005,9 @@ export class TcbDirectiveOutputsOp extends TcbOp {
         //   of the `TemplateTypeChecker` can still find the node for the class member for the
         //   output.
         // * Emit a handler function where the `$event` parameter has an explicit `any` type.
-        this.scope.addStatement(ts.createExpressionStatement(outputField));
+        this.scope.addStatement(ts.factory.createExpressionStatement(outputField));
         const handler = tcbCreateEventHandler(output, this.tcb, this.scope, EventParamType.Any);
-        this.scope.addStatement(ts.createExpressionStatement(handler));
+        this.scope.addStatement(ts.factory.createExpressionStatement(handler));
       }
 
       ExpressionSemanticVisitor.visit(
@@ -1051,7 +1061,7 @@ class TcbUnclaimedOutputsOp extends TcbOp {
             EventParamType.Any;
 
         const handler = tcbCreateEventHandler(output, this.tcb, this.scope, eventType);
-        this.scope.addStatement(ts.createExpressionStatement(handler));
+        this.scope.addStatement(ts.factory.createExpressionStatement(handler));
       } else if (this.tcb.env.config.checkTypeOfDomEvents) {
         // If strict checking of DOM events is enabled, generate a call to `addEventListener` on
         // the element instance so that TypeScript's type inference for
@@ -1063,19 +1073,19 @@ class TcbUnclaimedOutputsOp extends TcbOp {
         if (elId === null) {
           elId = this.scope.resolve(this.element);
         }
-        const propertyAccess = ts.createPropertyAccess(elId, 'addEventListener');
+        const propertyAccess = ts.factory.createPropertyAccessExpression(elId, 'addEventListener');
         addParseSpanInfo(propertyAccess, output.keySpan);
-        const call = ts.createCall(
+        const call = ts.factory.createCallExpression(
             /* expression */ propertyAccess,
             /* typeArguments */ undefined,
-            /* arguments */[ts.createStringLiteral(output.name), handler]);
+            /* arguments */[ts.factory.createStringLiteral(output.name), handler]);
         addParseSpanInfo(call, output.sourceSpan);
-        this.scope.addStatement(ts.createExpressionStatement(call));
+        this.scope.addStatement(ts.factory.createExpressionStatement(call));
       } else {
         // If strict checking of DOM inputs is disabled, emit a handler function where the `$event`
         // parameter has an explicit `any` type.
         const handler = tcbCreateEventHandler(output, this.tcb, this.scope, EventParamType.Any);
-        this.scope.addStatement(ts.createExpressionStatement(handler));
+        this.scope.addStatement(ts.factory.createExpressionStatement(handler));
       }
 
       ExpressionSemanticVisitor.visit(
@@ -1101,11 +1111,11 @@ class TcbComponentContextCompletionOp extends TcbOp {
   override readonly optional = false;
 
   override execute(): null {
-    const ctx = ts.createIdentifier('ctx');
-    const ctxDot = ts.createPropertyAccess(ctx, '');
+    const ctx = ts.factory.createIdentifier('ctx');
+    const ctxDot = ts.factory.createPropertyAccessExpression(ctx, '');
     markIgnoreDiagnostics(ctxDot);
     addExpressionIdentifier(ctxDot, ExpressionIdentifier.COMPONENT_COMPLETION);
-    this.scope.addStatement(ts.createExpressionStatement(ctxDot));
+    this.scope.addStatement(ts.factory.createExpressionStatement(ctxDot));
     return null;
   }
 }
@@ -1117,7 +1127,7 @@ class TcbComponentContextCompletionOp extends TcbOp {
  * assertion of the null value (in TypeScript, the expression `null!`). This construction will infer
  * the least narrow type for whatever it's assigned to.
  */
-const INFER_TYPE_FOR_CIRCULAR_OP_EXPR = ts.createNonNullExpression(ts.createNull());
+const INFER_TYPE_FOR_CIRCULAR_OP_EXPR = ts.factory.createNonNullExpression(ts.factory.createNull());
 
 /**
  * Overall generation context for the type check block.
@@ -1143,7 +1153,7 @@ export class Context {
    * might change depending on the type of data being stored.
    */
   allocateId(): ts.Identifier {
-    return ts.createIdentifier(`_t${this.nextId++}`);
+    return ts.factory.createIdentifier(`_t${this.nextId++}`);
   }
 
   getPipeByName(name: string): Reference<ClassDeclaration<ts.ClassDeclaration>>|null {
@@ -1358,7 +1368,8 @@ class Scope {
       // Both the parent scope and this scope provide a guard, so create a combination of the two.
       // It is important that the parent guard is used as left operand, given that it may provide
       // narrowing that is required for this scope's guard to be valid.
-      return ts.createBinary(parentGuards, ts.SyntaxKind.AmpersandAmpersandToken, this.guard);
+      return ts.factory.createBinaryExpression(
+          parentGuards, ts.SyntaxKind.AmpersandAmpersandToken, this.guard);
     }
   }
 
@@ -1680,7 +1691,8 @@ class TcbExpressionTranslator {
       }
 
       const expr = this.translate(ast.value);
-      const result = ts.createParen(ts.createBinary(target, ts.SyntaxKind.EqualsToken, expr));
+      const result = ts.factory.createParenthesizedExpression(
+          ts.factory.createBinaryExpression(target, ts.SyntaxKind.EqualsToken, expr));
       addParseSpanInfo(result, ast.sourceSpan);
       return result;
     } else if (ast instanceof ImplicitReceiver) {
@@ -1696,7 +1708,7 @@ class TcbExpressionTranslator {
       // Therefore if `resolve` is called on an `ImplicitReceiver`, it's because no outer
       // PropertyRead/Call resolved to a variable or reference, and therefore this is a
       // property read or method call on the component context itself.
-      return ts.createIdentifier('ctx');
+      return ts.factory.createIdentifier('ctx');
     } else if (ast instanceof BindingPipe) {
       const expr = this.translate(ast.exp);
       const pipeRef = this.tcb.getPipeByName(ast.name);
@@ -1720,7 +1732,7 @@ class TcbExpressionTranslator {
             methodAccess, ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
       }
 
-      const result = ts.createCall(
+      const result = ts.factory.createCallExpression(
           /* expression */ methodAccess,
           /* typeArguments */ undefined,
           /* argumentsArray */[expr, ...args]);
@@ -1735,9 +1747,9 @@ class TcbExpressionTranslator {
           !(ast.receiver.receiver instanceof ThisReceiver) && ast.receiver.name === '$any' &&
           ast.args.length === 1) {
         const expr = this.translate(ast.args[0]);
-        const exprAsAny =
-            ts.createAsExpression(expr, ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
-        const result = ts.createParen(exprAsAny);
+        const exprAsAny = ts.factory.createAsExpression(
+            expr, ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
+        const result = ts.factory.createParenthesizedExpression(exprAsAny);
         addParseSpanInfo(result, ast.sourceSpan);
         return result;
       }
@@ -1754,7 +1766,7 @@ class TcbExpressionTranslator {
       const method = wrapForDiagnostics(receiver);
       addParseSpanInfo(method, ast.receiver.nameSpan);
       const args = ast.args.map(arg => this.translate(arg));
-      const node = ts.createCall(method, undefined, args);
+      const node = ts.factory.createCallExpression(method, undefined, args);
       addParseSpanInfo(node, ast.sourceSpan);
       return node;
     } else {
@@ -1790,28 +1802,29 @@ function tcbCallTypeCtor(
 
   // Construct an array of `ts.PropertyAssignment`s for each of the directive's inputs.
   const members = inputs.map(input => {
-    const propertyName = ts.createStringLiteral(input.field);
+    const propertyName = ts.factory.createStringLiteral(input.field);
 
     if (input.type === 'binding') {
       // For bound inputs, the property is assigned the binding expression.
       const expr = widenBinding(input.expression, tcb);
 
-      const assignment = ts.createPropertyAssignment(propertyName, wrapForDiagnostics(expr));
+      const assignment =
+          ts.factory.createPropertyAssignment(propertyName, wrapForDiagnostics(expr));
       addParseSpanInfo(assignment, input.sourceSpan);
       return assignment;
     } else {
       // A type constructor is required to be called with all input properties, so any unset
       // inputs are simply assigned a value of type `any` to ignore them.
-      return ts.createPropertyAssignment(propertyName, NULL_AS_ANY);
+      return ts.factory.createPropertyAssignment(propertyName, NULL_AS_ANY);
     }
   });
 
   // Call the `ngTypeCtor` method on the directive class, with an object literal argument created
   // from the matched inputs.
-  return ts.createCall(
+  return ts.factory.createCallExpression(
       /* expression */ typeCtor,
       /* typeArguments */ undefined,
-      /* argumentsArray */[ts.createObjectLiteral(members)]);
+      /* argumentsArray */[ts.factory.createObjectLiteralExpression(members)]);
 }
 
 function getBoundInputs(
@@ -1853,7 +1866,7 @@ function translateInput(
     return tcbExpression(attr.value, tcb, scope);
   } else {
     // For regular attributes with a static string value, use the represented string literal.
-    return ts.createStringLiteral(attr.value);
+    return ts.factory.createStringLiteral(attr.value);
   }
 }
 
@@ -1874,7 +1887,7 @@ function widenBinding(expr: ts.Expression, tcb: Context): ts.Expression {
     } else {
       // If strict null checks are disabled, erase `null` and `undefined` from the type by
       // wrapping the expression in a non-null assertion.
-      return ts.createNonNullExpression(expr);
+      return ts.factory.createNonNullExpression(expr);
     }
   } else {
     // No widening is requested, use the expression as is.
@@ -1948,7 +1961,7 @@ function tcbCreateEventHandler(
   if (eventType === EventParamType.Infer) {
     eventParamType = undefined;
   } else if (eventType === EventParamType.Any) {
-    eventParamType = ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+    eventParamType = ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
   } else {
     eventParamType = eventType;
   }
@@ -1957,13 +1970,13 @@ function tcbCreateEventHandler(
   // repeated within the handler function for their narrowing to be in effect within the handler.
   const guards = scope.guards();
 
-  let body: ts.Statement = ts.createExpressionStatement(handler);
+  let body: ts.Statement = ts.factory.createExpressionStatement(handler);
   if (guards !== null) {
     // Wrap the body in an `if` statement containing all guards that have to be applied.
-    body = ts.createIf(guards, body);
+    body = ts.factory.createIfStatement(guards, body);
   }
 
-  const eventParam = ts.createParameter(
+  const eventParam = ts.factory.createParameterDeclaration(
       /* decorators */ undefined,
       /* modifiers */ undefined,
       /* dotDotDotToken */ undefined,
@@ -1972,14 +1985,14 @@ function tcbCreateEventHandler(
       /* type */ eventParamType);
   addExpressionIdentifier(eventParam, ExpressionIdentifier.EVENT_PARAMETER);
 
-  return ts.createFunctionExpression(
+  return ts.factory.createFunctionExpression(
       /* modifier */ undefined,
       /* asteriskToken */ undefined,
       /* name */ undefined,
       /* typeParameters */ undefined,
       /* parameters */[eventParam],
-      /* type */ ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
-      /* body */ ts.createBlock([body]));
+      /* type */ ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+      /* body */ ts.factory.createBlock([body]));
 }
 
 /**
@@ -2025,7 +2038,7 @@ class TcbEventHandlerTranslator extends TcbExpressionTranslator {
     // parameter by its name.
     if (ast instanceof PropertyRead && ast.receiver instanceof ImplicitReceiver &&
         !(ast.receiver instanceof ThisReceiver) && ast.name === EVENT_PARAMETER) {
-      const event = ts.createIdentifier(EVENT_PARAMETER);
+      const event = ts.factory.createIdentifier(EVENT_PARAMETER);
       addParseSpanInfo(event, ast.nameSpan);
       return event;
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_file.ts
@@ -45,7 +45,7 @@ export class TypeCheckFile extends Environment {
       ref: Reference<ClassDeclaration<ts.ClassDeclaration>>, meta: TypeCheckBlockMetadata,
       domSchemaChecker: DomSchemaChecker, oobRecorder: OutOfBandDiagnosticRecorder,
       genericContextBehavior: TcbGenericContextBehavior): void {
-    const fnId = ts.createIdentifier(`_tcb${this.nextTcbId++}`);
+    const fnId = ts.factory.createIdentifier(`_tcb${this.nextTcbId++}`);
     const fn = generateTypeCheckBlock(
         this, ref, fnId, meta, domSchemaChecker, oobRecorder, genericContextBehavior);
     this.tcbStatements.push(fn);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_emitter.ts
@@ -143,9 +143,10 @@ export class TypeEmitter {
     // Emit the type arguments, if any.
     let typeArguments: ts.NodeArray<ts.TypeNode>|undefined = undefined;
     if (type.typeArguments !== undefined) {
-      typeArguments = ts.createNodeArray(type.typeArguments.map(typeArg => this.emitType(typeArg)));
+      typeArguments =
+          ts.factory.createNodeArray(type.typeArguments.map(typeArg => this.emitType(typeArg)));
     }
 
-    return ts.updateTypeReferenceNode(type, translatedType.typeName, typeArguments);
+    return ts.factory.updateTypeReferenceNode(type, translatedType.typeName, typeArguments);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
@@ -73,7 +73,7 @@ export class TypeParameterEmitter {
       const defaultType =
           typeParam.default !== undefined ? emitter.emitType(typeParam.default) : undefined;
 
-      return ts.updateTypeParameterDeclaration(
+      return ts.factory.updateTypeParameterDeclaration(
           /* node */ typeParam,
           /* name */ typeParam.name,
           /* constraint */ constraint,

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -668,11 +668,13 @@ class FakeEnvironment /* implements Environment */ {
   constructor(readonly config: TypeCheckingConfig) {}
 
   typeCtorFor(dir: TypeCheckableDirectiveMeta): ts.Expression {
-    return ts.createPropertyAccess(ts.createIdentifier(dir.name), 'ngTypeCtor');
+    return ts.factory.createPropertyAccessExpression(
+        ts.factory.createIdentifier(dir.name), 'ngTypeCtor');
   }
 
   pipeInst(ref: Reference<ClassDeclaration<ts.ClassDeclaration>>): ts.Expression {
-    return ts.createParen(ts.createAsExpression(ts.createNull(), this.referenceType(ref)));
+    return ts.factory.createParenthesizedExpression(
+        ts.factory.createAsExpression(ts.factory.createNull(), this.referenceType(ref)));
   }
 
   reference(ref: Reference<ClassDeclaration<ts.ClassDeclaration>>): ts.Expression {
@@ -680,20 +682,20 @@ class FakeEnvironment /* implements Environment */ {
   }
 
   referenceType(ref: Reference<ClassDeclaration<ts.ClassDeclaration>>): ts.TypeNode {
-    return ts.createTypeReferenceNode(ref.node.name, /* typeArguments */ undefined);
+    return ts.factory.createTypeReferenceNode(ref.node.name, /* typeArguments */ undefined);
   }
 
   referenceExternalType(moduleName: string, name: string, typeParams?: Type[]): ts.TypeNode {
     const typeArgs: ts.TypeNode[] = [];
     if (typeParams !== undefined) {
       for (let i = 0; i < typeParams.length; i++) {
-        typeArgs.push(ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
+        typeArgs.push(ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
       }
     }
 
-    const ns = ts.createIdentifier(moduleName.replace('@angular/', ''));
-    const qName = ts.createQualifiedName(ns, name);
-    return ts.createTypeReferenceNode(qName, typeArgs.length > 0 ? typeArgs : undefined);
+    const ns = ts.factory.createIdentifier(moduleName.replace('@angular/', ''));
+    const qName = ts.factory.createQualifiedName(ns, name);
+    return ts.factory.createTypeReferenceNode(qName, typeArgs.length > 0 ? typeArgs : undefined);
   }
 
   getPreludeStatements(): ts.Statement[] {

--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -213,8 +213,9 @@ export function toUnredirectedSourceFile(sf: ts.SourceFile): ts.SourceFile {
 export function createExportSpecifier(
     propertyName: string|ts.Identifier|undefined, name: string|ts.Identifier,
     isTypeOnly = false): ts.ExportSpecifier {
-  return PARSED_TS_VERSION > 4.4 ? ts.createExportSpecifier(isTypeOnly, propertyName, name) :
-                                   // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
-                                   // Should be cleaned up when we drop support for it.
-                                   (ts.createExportSpecifier as any)(propertyName, name);
+  return PARSED_TS_VERSION > 4.4 ?
+      ts.factory.createExportSpecifier(isTypeOnly, propertyName, name) :
+      // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
+      // Should be cleaned up when we drop support for it.
+      (ts.createExportSpecifier as any)(propertyName, name);
 }

--- a/packages/compiler-cli/src/ngtsc/util/src/visitor.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/visitor.ts
@@ -121,7 +121,7 @@ export abstract class Visitor {
         this._after.delete(stmt);
       }
     });
-    clone.statements = ts.createNodeArray(newStatements, node.statements.hasTrailingComma);
+    clone.statements = ts.factory.createNodeArray(newStatements, node.statements.hasTrailingComma);
     return clone;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/util/test/visitor_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/util/test/visitor_spec.ts
@@ -27,10 +27,11 @@ class TestAstVisitor extends Visitor {
       return {
         node,
         before: [
-          ts.createVariableStatement(
+          ts.factory.createVariableStatement(
               undefined,
               [
-                ts.createVariableDeclaration(`${name}_id`, undefined, idStatic.initializer),
+                ts.factory.createVariableDeclaration(
+                    `${name}_id`, undefined, undefined, idStatic.initializer),
               ]),
         ],
       };

--- a/packages/core/schematics/migrations/entry-components/util.ts
+++ b/packages/core/schematics/migrations/entry-components/util.ts
@@ -29,7 +29,7 @@ export function migrateEntryComponentsUsages(
                 property.name.text === 'entryComponents');
 
         if (entryComponentsProp) {
-          const replacementNode = ts.updateObjectLiteral(
+          const replacementNode = ts.factory.updateObjectLiteralExpression(
               literal, literal.properties.filter(prop => prop !== entryComponentsProp));
 
           results.push({

--- a/packages/core/schematics/utils/typescript/imports.ts
+++ b/packages/core/schematics/utils/typescript/imports.ts
@@ -101,17 +101,18 @@ export function replaceImport(
   }
 
   const importPropertyName =
-      existingImportNode.propertyName ? ts.createIdentifier(newImportName) : undefined;
+      existingImportNode.propertyName ? ts.factory.createIdentifier(newImportName) : undefined;
   const importName = existingImportNode.propertyName ? existingImportNode.name :
-                                                       ts.createIdentifier(newImportName);
+                                                       ts.factory.createIdentifier(newImportName);
 
-  return ts.updateNamedImports(node, [
+  return ts.factory.updateNamedImports(node, [
     ...node.elements.filter(current => current !== existingImportNode),
     // Create a new import while trying to preserve the alias of the old one.
-    PARSED_TS_VERSION > 4.4 ? ts.createImportSpecifier(false, importPropertyName, importName) :
-                              // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
-                              // Should be cleaned up when we drop support for it.
-                              (ts.createImportSpecifier as any)(importPropertyName, importName)
+    PARSED_TS_VERSION > 4.4 ?
+        ts.factory.createImportSpecifier(false, importPropertyName, importName) :
+        // TODO(crisbeto): backwards-compatibility layer for TS 4.4.
+        // Should be cleaned up when we drop support for it.
+        (ts.createImportSpecifier as any)(importPropertyName, importName)
   ]);
 }
 


### PR DESCRIPTION
Proactively replaces our usages of the deprecated `ts.create*` methods in favor of using `ts.factory.create*` so that we're not surprised when the TS removes them in the future. Also accounts for some cases where the signature had changed.