### PR TITLE
feat(common): AVOID_PUSH_STATE injection token

### DIFF
--- a/goldens/public-api/common/common.md
+++ b/goldens/public-api/common/common.md
@@ -49,6 +49,9 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
 }
 
 // @public
+export const AVOID_PUSH_STATE: InjectionToken<boolean>;
+
+// @public
 export class CommonModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<CommonModule, never>;

--- a/packages/common/src/location/index.ts
+++ b/packages/common/src/location/index.ts
@@ -9,4 +9,4 @@
 export {HashLocationStrategy} from './hash_location_strategy';
 export {Location, PopStateEvent} from './location';
 export {APP_BASE_HREF, LocationStrategy, PathLocationStrategy} from './location_strategy';
-export {LOCATION_INITIALIZED, LocationChangeEvent, LocationChangeListener, PlatformLocation} from './platform_location';
+export {AVOID_PUSH_STATE, LOCATION_INITIALIZED, LocationChangeEvent, LocationChangeListener, PlatformLocation} from './platform_location';

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -18,6 +18,9 @@
     "name": "APP_INITIALIZER"
   },
   {
+    "name": "AVOID_PUSH_STATE"
+  },
+  {
     "name": "AbsoluteRedirect"
   },
   {


### PR DESCRIPTION
The `AVOID_PUSH_STATE` injection token allows to configure as a boolean whether `history.pushState` and `history.replaceState` are avoided (even if supported by the browser).

The following example shows how to use this token to configure the root app injector so that the DI framework can supply the value anywhere in the app.

```typescript
import {Component, NgModule} from '@angular/core';
import {AVOID_PUSH_STATE} from '@angular/common';

@NgModule({
  providers: [{provide: AVOID_PUSH_STATE, useValue: true}]
})
class AppModule {}

```
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

When using a base href that is different from the current document URL through the `<base href="...">` tag, and using the `HashLocationStrategy`, Angular does not only change the hash when calling `HashLocationStrategy.go`, it appends the new hash to the base href which ends up with a fully different URL.
This feels wrong, as already discussed in several issues: #36688, #33000
This PR provides a simpler way to fix these issues, making sure Angular will never change the full URL but only the hash.

In addition to changing the URL, `pushState` or `replaceState` (unlike changing the `hash`) makes the request a GET request, which has an impact if the user then refreshes the page, as stated in the specifications:

> Update entry so that it represents a GET request, if it currently represents a non-GET request (e.g. it was the result of a POST submission).

cf https://html.spec.whatwg.org/multipage/history.html#dom-history-pushstate

Note that, or course, instead of implementing this PR, we could also do:
```
window.history.pushState = null;
```
But it is a bit ugly and does not look like an option supported by Angular.

## What is the new behavior?

If AVOID_PUSH_STATE is set to true, Angular will never call `pushState` or `replaceState` even if the browser supports it and will only change the hash part of the URL through `location.hash = ...`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
