### PR TITLE
docs: remove activatedRouteData backward accesses in aio guides

### DIFF
--- a/aio/content/examples/animations/src/app/app.component.html
+++ b/aio/content/examples/animations/src/app/app.component.html
@@ -21,7 +21,7 @@
 </nav>
 
 <!-- #docregion route-animations-outlet -->
-<div [@routeAnimations]="prepareRoute(outlet)">
-  <router-outlet #outlet="outlet"></router-outlet>
+<div [@routeAnimations]="getRouteAnimationData()">
+  <router-outlet></router-outlet>
 </div>
 <!-- #enddocregion route-animations-outlet -->

--- a/aio/content/examples/animations/src/app/app.component.ts
+++ b/aio/content/examples/animations/src/app/app.component.ts
@@ -11,7 +11,7 @@ import {
 } from '@angular/animations';
 
 // #enddocregion imports
-import { RouterOutlet } from '@angular/router';
+import { ChildrenOutletContexts, RouterOutlet } from '@angular/router';
 import { slideInAnimation } from './animations';
 
 // #docregion decorator, toggle-app-animations, define
@@ -35,8 +35,10 @@ export class AppComponent {
 // #enddocregion toggle-app-animations
 
 // #docregion prepare-router-outlet
-  prepareRoute(outlet: RouterOutlet) {
-    return outlet?.activatedRouteData?.['animation'];
+  constructor(private contexts: ChildrenOutletContexts) {}
+
+  getRouteAnimationData() {
+    return this.contexts.getContext('primary')?.route?.snapshot?.data?.['animation'];
   }
 
 // #enddocregion prepare-router-outlet

--- a/aio/content/examples/animations/src/app/app.component.ts
+++ b/aio/content/examples/animations/src/app/app.component.ts
@@ -40,7 +40,6 @@ export class AppComponent {
   getRouteAnimationData() {
     return this.contexts.getContext('primary')?.route?.snapshot?.data?.['animation'];
   }
-
 // #enddocregion get-route-animations-data
 
   toggleAnimations() {

--- a/aio/content/examples/animations/src/app/app.component.ts
+++ b/aio/content/examples/animations/src/app/app.component.ts
@@ -34,14 +34,14 @@ export class AppComponent {
   public animationsDisabled = false;
 // #enddocregion toggle-app-animations
 
-// #docregion prepare-router-outlet
+// #docregion get-route-animations-data
   constructor(private contexts: ChildrenOutletContexts) {}
 
   getRouteAnimationData() {
     return this.contexts.getContext('primary')?.route?.snapshot?.data?.['animation'];
   }
 
-// #enddocregion prepare-router-outlet
+// #enddocregion get-route-animations-data
 
   toggleAnimations() {
     this.animationsDisabled = !this.animationsDisabled;

--- a/aio/content/examples/router/src/app/app.component.2.html
+++ b/aio/content/examples/router/src/app/app.component.2.html
@@ -4,6 +4,6 @@
   <a routerLink="/crisis-center" routerLinkActive="active">Crisis Center</a>
   <a routerLink="/heroes" routerLinkActive="active">Heroes</a>
 </nav>
-<div [@routeAnimation]="getAnimationData(routerOutlet)">
-  <router-outlet #routerOutlet="outlet"></router-outlet>
+<div [@routeAnimation]="getAnimationData()">
+  <router-outlet></router-outlet>
 </div>

--- a/aio/content/examples/router/src/app/app.component.2.ts
+++ b/aio/content/examples/router/src/app/app.component.2.ts
@@ -2,7 +2,7 @@
 // #docregion
 import { Component } from '@angular/core';
 // #docregion animation-imports
-import { RouterOutlet } from '@angular/router';
+import { ChildrenOutletContexts } from '@angular/router';
 import { slideInAnimation } from './animations';
 
 @Component({
@@ -14,8 +14,10 @@ import { slideInAnimation } from './animations';
 // #enddocregion animation-imports
 // #docregion function-binding
 export class AppComponent {
-  getAnimationData(outlet: RouterOutlet) {
-    return outlet?.activatedRouteData?.['animation'];
+  constructor(private contexts: ChildrenOutletContexts) {}
+
+  getAnimationData() {
+      return this.contexts.getContext('primary')?.route?.snapshot?.data?.['animation'];
   }
 }
 // #enddocregion function-binding

--- a/aio/content/examples/router/src/app/app.component.4.html
+++ b/aio/content/examples/router/src/app/app.component.4.html
@@ -8,8 +8,8 @@
   <!-- #enddocregion contact-link -->
 </nav>
 <!-- #docregion outlets -->
-<div [@routeAnimation]="getAnimationData(routerOutlet)">
-  <router-outlet #routerOutlet="outlet"></router-outlet>
+<div [@routeAnimation]="getAnimationData()">
+  <router-outlet></router-outlet>
 </div>
 <router-outlet name="popup"></router-outlet>
 <!-- #enddocregion outlets -->

--- a/aio/content/examples/router/src/app/app.component.5.html
+++ b/aio/content/examples/router/src/app/app.component.5.html
@@ -6,7 +6,7 @@
   <a routerLink="/admin" routerLinkActive="active">Admin</a>
   <a [routerLink]="[{ outlets: { popup: ['compose'] } }]">Contact</a>
 </nav>
-<div [@routeAnimation]="getAnimationData(routerOutlet)">
-  <router-outlet #routerOutlet="outlet"></router-outlet>
+<div [@routeAnimation]="getAnimationData()">
+  <router-outlet></router-outlet>
 </div>
 <router-outlet name="popup"></router-outlet>

--- a/aio/content/examples/router/src/app/app.component.6.html
+++ b/aio/content/examples/router/src/app/app.component.6.html
@@ -7,7 +7,7 @@
   <a routerLink="/login" routerLinkActive="active">Login</a>
   <a [routerLink]="[{ outlets: { popup: ['compose'] } }]">Contact</a>
 </nav>
-<div [@routeAnimation]="getAnimationData(routerOutlet)">
-  <router-outlet #routerOutlet="outlet"></router-outlet>
+<div [@routeAnimation]="getAnimationData()">
+  <router-outlet></router-outlet>
 </div>
 <router-outlet name="popup"></router-outlet>

--- a/aio/content/examples/router/src/app/app.component.html
+++ b/aio/content/examples/router/src/app/app.component.html
@@ -8,8 +8,8 @@
     <a routerLink="/login" routerLinkActive="active">Login</a>
     <a [routerLink]="[{ outlets: { popup: ['compose'] } }]">Contact</a>
   </nav>
-  <div [@routeAnimation]="getAnimationData(routerOutlet)">
-    <router-outlet #routerOutlet="outlet"></router-outlet>
+  <div [@routeAnimation]="getRouteAnimationData()">
+    <router-outlet></router-outlet>
   </div>
   <router-outlet name="popup"></router-outlet>
 </div>

--- a/aio/content/examples/router/src/app/app.component.ts
+++ b/aio/content/examples/router/src/app/app.component.ts
@@ -1,7 +1,7 @@
 // #docplaster
 // #docregion
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { ChildrenOutletContexts } from '@angular/router';
 import { slideInAnimation } from './animations';
 
 @Component({
@@ -11,7 +11,9 @@ import { slideInAnimation } from './animations';
   animations: [ slideInAnimation ]
 })
 export class AppComponent {
-  getAnimationData(outlet: RouterOutlet) {
-    return outlet?.activatedRouteData?.['animation'];
+  constructor(private contexts: ChildrenOutletContexts) {}
+
+  getRouteAnimationData() {
+    return this.contexts.getContext('primary')?.route?.snapshot?.data?.['animation'];
   }
 }

--- a/aio/content/guide/route-animations.md
+++ b/aio/content/guide/route-animations.md
@@ -59,7 +59,7 @@ In addition to `path` and `component`, the `data` property of each route defines
 
 After configuring the routes, add a `<router-outlet>` inside the root `AppComponent` template. The `<router-outlet>` directive tells the Angular router where to render the views when matched with a route.
 
-The `<router-outlet>` directive holds the custom data set for the currently active route which can be accessed via the route's `activatedRouteData` property, we can use such data to animate our routing transitions.
+The `ChildrenOutletContexts` holds information about outlets and activated routes. We can use the `data` property of each `Route` to animate our routing transitions.
 
 <code-example path="animations/src/app/app.component.html" header="src/app/app.component.html" region="route-animations-outlet"></code-example>
 
@@ -67,7 +67,7 @@ The `<router-outlet>` directive holds the custom data set for the currently acti
 
 <code-example path="animations/src/app/app.component.ts" header="src/app/app.component.ts" region="prepare-router-outlet" language="typescript"></code-example>
 
-Here, the `prepareRoute()` method takes the value of the outlet) and returns a string value representing the state of the animation based on the custom data of the current active route. Use this data to control which transition to execute for each route.
+Here, the `prepareRoute()` method takes the value of the outlet and returns a string which represents the state of the animation based on the custom data of the current active route. Use this data to control which transition to execute for each route.
 
 <div class="alert is-helpful">
 

--- a/aio/content/guide/route-animations.md
+++ b/aio/content/guide/route-animations.md
@@ -59,7 +59,7 @@ In addition to `path` and `component`, the `data` property of each route defines
 
 After configuring the routes, add a `<router-outlet>` inside the root `AppComponent` template. The `<router-outlet>` directive tells the Angular router where to render the views when matched with a route.
 
-The `<router-outlet>` directive holds the custom data set for the currently active route which can be accessed via the directive's `activatedRouteData` property, we can use such data to animate our routing transitions.
+The `<router-outlet>` directive holds the custom data set for the currently active route which can be accessed via the route's `activatedRouteData` property, we can use such data to animate our routing transitions.
 
 <code-example path="animations/src/app/app.component.html" header="src/app/app.component.html" region="route-animations-outlet"></code-example>
 
@@ -67,7 +67,26 @@ The `<router-outlet>` directive holds the custom data set for the currently acti
 
 <code-example path="animations/src/app/app.component.ts" header="src/app/app.component.ts" region="prepare-router-outlet" language="typescript"></code-example>
 
-Here, the `prepareRoute()` method takes the value of the outlet directive (established through `#outlet="outlet"`) and returns a string value representing the state of the animation based on the custom data of the current active route. Use this data to control which transition to execute for each route.
+Here, the `prepareRoute()` method takes the value of the outlet) and returns a string value representing the state of the animation based on the custom data of the current active route. Use this data to control which transition to execute for each route.
+
+<div class="alert is-helpful">
+
+  The `router-outlet` directive holds a `activatedRouteData` property which can be accessed by assigning a template variable to the directive and using that to access the directive's data.
+
+  Like so for example:
+  ```html
+    <div [@routeAnimations]="prepareRoute(outlet)">
+      <router-outlet #outlet="outlet"></router-outlet>
+    </div>
+  ```
+  ```typescript
+    prepareRoute(outlet: RouterOutlet) {
+      return outlet?.activatedRouteData?.['animation'];
+    }
+  ```
+
+  That is not however the correct way to access the outlet's data since, it is accessing the outlet before it is defined (as in, the `outlet` usage is before the `outlet` definition in the template), this is called __backward reference__ and can cause various issues since it is not supported by Angular.
+</div>
 
 ## Animation definition
 

--- a/aio/content/guide/route-animations.md
+++ b/aio/content/guide/route-animations.md
@@ -67,26 +67,7 @@ The `ChildrenOutletContexts` holds information about outlets and activated route
 
 <code-example path="animations/src/app/app.component.ts" header="src/app/app.component.ts" region="prepare-router-outlet" language="typescript"></code-example>
 
-Here, the `prepareRoute()` method takes the value of the outlet and returns a string which represents the state of the animation based on the custom data of the current active route. Use this data to control which transition to execute for each route.
-
-<div class="alert is-helpful">
-
-  The `router-outlet` directive holds a `activatedRouteData` property which can be accessed by assigning a template variable to the directive and using that to access the directive's data.
-
-  Like so for example:
-  ```html
-    <div [@routeAnimations]="prepareRoute(outlet)">
-      <router-outlet #outlet="outlet"></router-outlet>
-    </div>
-  ```
-  ```typescript
-    prepareRoute(outlet: RouterOutlet) {
-      return outlet?.activatedRouteData?.['animation'];
-    }
-  ```
-
-  That is not however the correct way to access the outlet's data since, it is accessing the outlet before it is defined (as in, the `outlet` usage is before the `outlet` definition in the template), this is called __backward reference__ and can cause various issues since it is not supported by Angular.
-</div>
+Here, the `getRouteAnimationData()` method takes the value of the outlet and returns a string which represents the state of the animation based on the custom data of the current active route. Use this data to control which transition to execute for each route.
 
 ## Animation definition
 

--- a/aio/content/guide/route-animations.md
+++ b/aio/content/guide/route-animations.md
@@ -65,7 +65,7 @@ The `ChildrenOutletContexts` holds information about outlets and activated route
 
 `AppComponent` defines a method that can detect when a view changes. The method assigns an animation state value to the animation trigger (`@routeAnimation`) based on the route configuration `data` property value. Here's an example of an `AppComponent` method that detects when a route change happens.
 
-<code-example path="animations/src/app/app.component.ts" header="src/app/app.component.ts" region="prepare-router-outlet" language="typescript"></code-example>
+<code-example path="animations/src/app/app.component.ts" header="src/app/app.component.ts" region="get-route-animations-data" language="typescript"></code-example>
 
 Here, the `getRouteAnimationData()` method takes the value of the outlet and returns a string which represents the state of the animation based on the custom data of the current active route. Use this data to control which transition to execute for each route.
 

--- a/aio/content/guide/router-tutorial-toh.md
+++ b/aio/content/guide/router-tutorial-toh.md
@@ -1225,8 +1225,8 @@ This example uses a variable of `routerOutlet`.
 
 <code-example path="router/src/app/app.component.2.html" header="src/app/app.component.html (router outlet)"></code-example>
 
-The `@routeAnimation` property is bound to the `getAnimationData()` with the provided `routerOutlet` reference, so the next step is to define that function in the `AppComponent`.
-The `getAnimationData()` function returns the animation property from the `data` provided through the `ActivatedRoute`. The `animation` property matches the `transition` names you used in the `slideInAnimation` defined in `animations.ts`.
+The `@routeAnimation` property is bound to the `getAnimationData()` which returns the animation property from the `data` provided by the primary route. The `animation` property matches the `transition` names you used in the `slideInAnimation` defined in `animations.ts`.
+
 
 <code-example path="router/src/app/app.component.2.ts" header="src/app/app.component.ts (router outlet)" region="function-binding"></code-example>
 


### PR DESCRIPTION
developers should not access the router-outlet directive in their
template before defining a template variable for it, such
implementation is present in a couple of aio guides, fix such guides
so that they show the more correct way of accessing the outlet's data

resolves #36173

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #36173


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 @atscott :slightly_smiling_face::+1: 
