### PR TITLE
test(animations): add route animation delay to pages tests

### DIFF
--- a/aio/content/examples/animations/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/animations/e2e/src/app.e2e-spec.ts
@@ -11,6 +11,8 @@ import { getLinkById, sleepFor } from './util';
 import { getComponentSection, getToggleButton } from './querying.po';
 
 describe('Animation Tests', () => {
+  const routingAnimationDuration = 350;
+
   const openCloseHref = getLinkById('open-close');
   const statusSliderHref = getLinkById('status');
   const toggleHref = getLinkById('toggle');
@@ -20,6 +22,8 @@ describe('Animation Tests', () => {
   const heroGroupsHref = getLinkById('hero-groups');
   const queryingHref = getLinkById('querying');
 
+  const newPageSleepFor = (ms = 0) => sleepFor(ms + routingAnimationDuration);
+
   beforeAll(() => browser.get(''));
 
   describe('Open/Close Component', () => {
@@ -28,7 +32,7 @@ describe('Animation Tests', () => {
 
     beforeAll(async () => {
       await openCloseHref.click();
-      await sleepFor();
+      await newPageSleepFor();
     });
 
     it('should be open', async () => {
@@ -84,7 +88,7 @@ describe('Animation Tests', () => {
 
     beforeAll(async () => {
       await statusSliderHref.click();
-      await sleepFor(2000);
+      await newPageSleepFor(2000);
     });
 
     it('should be inactive with a blue background', async () => {
@@ -125,7 +129,7 @@ describe('Animation Tests', () => {
   describe('Toggle Animations Component', () => {
     beforeAll(async () => {
       await toggleHref.click();
-      await sleepFor();
+      await newPageSleepFor();
     });
 
     it('should disabled animations on the child element', async () => {
@@ -143,7 +147,7 @@ describe('Animation Tests', () => {
   describe('Enter/Leave Component', () => {
     beforeAll(async () => {
       await enterLeaveHref.click();
-      await sleepFor(100);
+      await newPageSleepFor(100);
     });
 
     it('should attach a flyInOut trigger to the list of items', async () => {
@@ -169,7 +173,7 @@ describe('Animation Tests', () => {
   describe('Auto Calculation Component', () => {
     beforeAll(async () => {
       await autoHref.click();
-      await sleepFor(300);
+      await newPageSleepFor();
     });
 
     it('should attach a shrinkOut trigger to the list of items', async () => {
@@ -193,7 +197,7 @@ describe('Animation Tests', () => {
   describe('Filter/Stagger Component', () => {
     beforeAll(async () => {
       await filterHref.click();
-      await sleepFor();
+      await newPageSleepFor();
     });
 
     it('should attach a filterAnimations trigger to the list container', async () => {
@@ -220,7 +224,7 @@ describe('Animation Tests', () => {
   describe('Hero Groups Component', () => {
     beforeAll(async () => {
       await heroGroupsHref.click();
-      await sleepFor(400);
+      await newPageSleepFor(400);
     });
 
     it('should attach a flyInOut trigger to the list of items', async () => {
@@ -250,7 +254,7 @@ describe('Animation Tests', () => {
 
     beforeAll(async () => {
       await queryingHref.click();
-      await sleepFor(queryingAnimationDuration);
+      await newPageSleepFor(queryingAnimationDuration);
     });
 
     it('should toggle the section', async () => {
@@ -261,14 +265,14 @@ describe('Animation Tests', () => {
 
       // toggling off
       await toggleButton.click();
-      await sleepFor(queryingAnimationDuration);
+      await newPageSleepFor(queryingAnimationDuration);
       expect(await section.isPresent()).toBe(false);
 
       // toggling on
       await toggleButton.click();
-      await sleepFor(queryingAnimationDuration);
+      await newPageSleepFor(queryingAnimationDuration);
       expect(await section.isPresent()).toBe(true);
-      await sleepFor(queryingAnimationDuration);
+      await newPageSleepFor(queryingAnimationDuration);
     });
 
     it(`should disable the button for the animation's duration`, async () => {
@@ -278,13 +282,13 @@ describe('Animation Tests', () => {
       // toggling off
       await toggleButton.click();
       expect(await toggleButton.isEnabled()).toBe(false);
-      await sleepFor(queryingAnimationDuration);
+      await newPageSleepFor(queryingAnimationDuration);
       expect(await toggleButton.isEnabled()).toBe(true);
 
       // toggling on
       await toggleButton.click();
       expect(await toggleButton.isEnabled()).toBe(false);
-      await sleepFor(queryingAnimationDuration);
+      await newPageSleepFor(queryingAnimationDuration);
       expect(await toggleButton.isEnabled()).toBe(true);
     });
 


### PR DESCRIPTION
PR #44550 introduced an animation for pages/tabs transitions in the
animations example application, after such change intermittent e2e
failures started to occur (see for example: #45083), add a delay to
account for such animation to all the animations pages/tabs e2e tests so
to fix the flakyness caused by the animation

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: fixes intermittent CI failures


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

@jessicajaniuk I am opening this PR as I saw other animations example e2e fails (specifically here: #45142), so I've been thinking and one thing that I changed is the animation between the pages/tabs in the example, and I did not add anything in the e2es to account for that, so I think that may be actually the thing causing the issues (and its duration matches with the milliseconds we needed to add to the initial sleep calls).

I am sort of going out on a limb here, but it soft of does make sense and checks out what we've been seeing, please let me know what you think :slightly_smiling_face: 