### PR TITLE
ci: fix stamping for builds performed in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,8 @@ commands:
     steps:
       - run:
           name: Save month to file
+          # Note: Make sure this file is excluded in the `.gitignore` as otherwise the
+          # snapshot stamping would have the `-with-local-changes` suffix.
           command: date +%Y-%m > month.txt
 
   # Normally this would be an individual job instead of a command.

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -3,7 +3,6 @@
 # Variables
 readonly projectDir=$(realpath "$(dirname ${BASH_SOURCE[0]})/..")
 readonly envHelpersPath="$projectDir/.circleci/env-helpers.inc.sh";
-readonly bashEnvCachePath="$projectDir/.circleci/bash_env_cache";
 
 # Load helpers and make them available everywhere (through `$BASH_ENV`).
 source $envHelpersPath;

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 *.log
 node_modules
 
+# CircleCI temporary file for cache key computation.
+# See `save_month_to_file` in `.circleci/config.yml`.
+month.txt
+
 # Include when developing application packages.
 pubspec.lock
 .c9


### PR DESCRIPTION
Fixes the stamping for snapshot builds and the artifact deployment job.
Currently the stamped versions will have the `.with-local-changes` version
suffix given that we add a file to the Git repo that is just
needed for the CircleCI cache key computation.