### PR TITLE
docs: fix style guide example app included as routing

### DIFF
--- a/aio/content/guide/example-apps-list.md
+++ b/aio/content/guide/example-apps-list.md
@@ -430,6 +430,7 @@ Demonstrates Angular's fundamental routing techniques.
 For more information, see [Using Angular routes in a single-page application](guide/router-tutorial).
 
 
+## Documentation
 
 ### Style guide for Documentation contributions
 


### PR DESCRIPTION
in the aio example apps page the style guide for documentation
contributions is included in the Routing section instead of being
in its own section, add a documentation section and include the example
in that one

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

In the aio example apps page the style guide for documentation contributions is wrongly places in the routing section:
![Screenshot at 2022-02-20 11-58-54](https://user-images.githubusercontent.com/61631103/154841389-c59f2cba-4b23-41f7-bde3-368904414888.png)


## What is the new behavior?

A new Documentation section has been added with the style guide example in it:
![Screenshot at 2022-02-20 11-56-38](https://user-images.githubusercontent.com/61631103/154841322-5fc2a5ca-3261-47c2-ae13-e4f5e3211320.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
