### PR TITLE
feat(core): allow for injector to be specified when creating an embedded view

### DIFF
--- a/goldens/public-api/common/common.md
+++ b/goldens/public-api/common/common.md
@@ -589,8 +589,9 @@ export class NgTemplateOutlet implements OnChanges {
     ngOnChanges(changes: SimpleChanges): void;
     ngTemplateOutlet: TemplateRef<any> | null;
     ngTemplateOutletContext: Object | null;
+    ngTemplateOutletInjector: Injector | null;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgTemplateOutlet, "[ngTemplateOutlet]", never, { "ngTemplateOutletContext": "ngTemplateOutletContext"; "ngTemplateOutlet": "ngTemplateOutlet"; }, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgTemplateOutlet, "[ngTemplateOutlet]", never, { "ngTemplateOutletContext": "ngTemplateOutletContext"; "ngTemplateOutlet": "ngTemplateOutlet"; "ngTemplateOutletInjector": "ngTemplateOutletInjector"; }, {}, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgTemplateOutlet, never>;
 }

--- a/goldens/public-api/core/core.md
+++ b/goldens/public-api/core/core.md
@@ -1233,7 +1233,7 @@ export type StaticProvider = ValueProvider | ExistingProvider | StaticClassProvi
 
 // @public
 export abstract class TemplateRef<C> {
-    abstract createEmbeddedView(context: C): EmbeddedViewRef<C>;
+    abstract createEmbeddedView(context: C, injector?: Injector): EmbeddedViewRef<C>;
     abstract readonly elementRef: ElementRef;
 }
 
@@ -1379,6 +1379,10 @@ export abstract class ViewContainerRef {
     }): ComponentRef<C>;
     // @deprecated
     abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], ngModuleRef?: NgModuleRef<any>): ComponentRef<C>;
+    abstract createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, options?: {
+        index?: number;
+        injector?: Injector;
+    }): EmbeddedViewRef<C>;
     abstract createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, index?: number): EmbeddedViewRef<C>;
     abstract detach(index?: number): ViewRef | null;
     abstract get element(): ElementRef;

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 449672,
+        "main": 450268,
         "polyfills": 33869,
         "styles": 70416,
         "light-theme": 77582,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1083,
-        "main": 124515,
+        "main": 125129,
         "polyfills": 33824
       }
     }
@@ -15,7 +15,7 @@
         "main": "TODO(i): temporarily increase the payload size limit from 17597 - this needs to be investigate further what caused the increase.",
         "main": "Likely there is a missing PURE annotation https://github.com/angular/angular/pull/43344",
         "main": "Tracking issue: https://github.com/angular/angular/issues/43568",
-        "main": 20378,
+        "main": 20601,
         "polyfills": 33848
       }
     }
@@ -42,7 +42,7 @@
     "master": {
       "uncompressed": {
         "runtime": 2835,
-        "main": 232814,
+        "main": 233375,
         "polyfills": 33842,
         "src_app_lazy_lazy_module_ts": 795
       }
@@ -52,7 +52,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 156042,
+        "main": 156654,
         "polyfills": 33804
       }
     }
@@ -61,7 +61,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1070,
-        "main": 155753,
+        "main": 156290,
         "polyfills": 33814
       }
     }

--- a/packages/common/src/directives/ng_template_outlet.ts
+++ b/packages/common/src/directives/ng_template_outlet.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EmbeddedViewRef, Input, OnChanges, SimpleChange, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
+import {Directive, EmbeddedViewRef, Injector, Input, OnChanges, SimpleChanges, TemplateRef, ViewContainerRef} from '@angular/core';
 
 /**
  * @ngModule CommonModule
@@ -49,20 +49,31 @@ export class NgTemplateOutlet implements OnChanges {
    */
   @Input() public ngTemplateOutlet: TemplateRef<any>|null = null;
 
+  /** Injector to be used within the embedded view. */
+  @Input() public ngTemplateOutletInjector: Injector|null = null;
+
   constructor(private _viewContainerRef: ViewContainerRef) {}
 
   /** @nodoc */
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['ngTemplateOutlet']) {
+    if (changes['ngTemplateOutlet'] || changes['ngTemplateOutletInjector']) {
       const viewContainerRef = this._viewContainerRef;
 
       if (this._viewRef) {
         viewContainerRef.remove(viewContainerRef.indexOf(this._viewRef));
       }
 
-      this._viewRef = this.ngTemplateOutlet ?
-          viewContainerRef.createEmbeddedView(this.ngTemplateOutlet, this.ngTemplateOutletContext) :
-          null;
+      if (this.ngTemplateOutlet) {
+        const {
+          ngTemplateOutlet: template,
+          ngTemplateOutletContext: context,
+          ngTemplateOutletInjector: injector
+        } = this;
+        this._viewRef = viewContainerRef.createEmbeddedView(
+            template, context, injector ? {injector} : undefined);
+      } else {
+        this._viewRef = null;
+      }
     } else if (
         this._viewRef && changes['ngTemplateOutletContext'] && this.ngTemplateOutletContext) {
       this._viewRef.context = this.ngTemplateOutletContext;

--- a/packages/common/test/directives/ng_component_outlet_spec.ts
+++ b/packages/common/test/directives/ng_component_outlet_spec.ts
@@ -96,8 +96,10 @@ describe('insert/remove', () => {
 
        const uniqueValue = {};
        fixture.componentInstance.currentComponent = InjectedComponent;
-       fixture.componentInstance.injector = Injector.create(
-           [{provide: TEST_TOKEN, useValue: uniqueValue}], fixture.componentRef.injector);
+       fixture.componentInstance.injector = Injector.create({
+         providers: [{provide: TEST_TOKEN, useValue: uniqueValue}],
+         parent: fixture.componentRef.injector,
+       });
 
        fixture.detectChanges();
        let cmpRef: ComponentRef<InjectedComponent> = fixture.componentInstance.cmpRef!;
@@ -249,6 +251,21 @@ describe('insert/remove', () => {
        fixture.detectChanges();
 
        expect(fixture.nativeElement).toHaveText('bat');
+     }));
+
+  it('should override providers from parent component using custom injector', waitForAsync(() => {
+       TestBed.overrideComponent(InjectedComponent, {set: {template: 'Value: {{testToken}}'}});
+       TestBed.overrideComponent(
+           TestComponent, {set: {providers: [{provide: TEST_TOKEN, useValue: 'parent'}]}});
+       const fixture = TestBed.createComponent(TestComponent);
+       fixture.componentInstance.currentComponent = InjectedComponent;
+       fixture.componentInstance.injector = Injector.create({
+         providers: [{provide: TEST_TOKEN, useValue: 'child'}],
+         parent: fixture.componentInstance.vcRef.injector
+       });
+       fixture.detectChanges();
+
+       expect(fixture.nativeElement).toHaveText('Value: child');
      }));
 });
 

--- a/packages/common/test/directives/ng_template_outlet_spec.ts
+++ b/packages/common/test/directives/ng_template_outlet_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, ContentChildren, Directive, Injectable, NO_ERRORS_SCHEMA, OnDestroy, QueryList, TemplateRef} from '@angular/core';
+import {Component, ContentChildren, Directive, Inject, Injectable, InjectionToken, Injector, NO_ERRORS_SCHEMA, OnDestroy, Provider, QueryList, TemplateRef} from '@angular/core';
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
@@ -29,7 +29,13 @@ describe('NgTemplateOutlet', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [TestComponent, CaptureTplRefs, DestroyableCmpt, MultiContextComponent],
+      declarations: [
+        TestComponent,
+        CaptureTplRefs,
+        DestroyableCmpt,
+        MultiContextComponent,
+        InjectValueComponent,
+      ],
       imports: [CommonModule],
       providers: [DestroyedSpyService]
     });
@@ -262,7 +268,40 @@ describe('NgTemplateOutlet', () => {
     expect(componentInstance.context1).toEqual({name: 'two'});
     expect(componentInstance.context2).toEqual({name: 'one'});
   });
+
+  it('should be able to specify an injector', waitForAsync(() => {
+       const template = `<ng-template #tpl><inject-value></inject-value></ng-template>` +
+           `<ng-container *ngTemplateOutlet="tpl; injector: injector"></ng-container>`;
+       fixture = createTestComponent(template);
+       fixture.componentInstance.injector =
+           Injector.create({providers: [{provide: templateToken, useValue: 'world'}]});
+       detectChangesAndExpectText('Hello world');
+     }));
+
+  it('should re-render if the injector changes', waitForAsync(() => {
+       const template = `<ng-template #tpl><inject-value></inject-value></ng-template>` +
+           `<ng-container *ngTemplateOutlet="tpl; injector: injector"></ng-container>`;
+       fixture = createTestComponent(template);
+       fixture.componentInstance.injector =
+           Injector.create({providers: [{provide: templateToken, useValue: 'world'}]});
+       detectChangesAndExpectText('Hello world');
+
+       fixture.componentInstance.injector =
+           Injector.create({providers: [{provide: templateToken, useValue: 'there'}]});
+       detectChangesAndExpectText('Hello there');
+     }));
+
+  it('should override providers from parent component using custom injector', waitForAsync(() => {
+       const template = `<ng-template #tpl><inject-value></inject-value></ng-template>` +
+           `<ng-container *ngTemplateOutlet="tpl; injector: injector"></ng-container>`;
+       fixture = createTestComponent(template, [{provide: templateToken, useValue: 'parent'}]);
+       fixture.componentInstance.injector =
+           Injector.create({providers: [{provide: templateToken, useValue: 'world'}]});
+       detectChangesAndExpectText('Hello world');
+     }));
 });
+
+const templateToken = new InjectionToken<string>('templateToken');
 
 @Injectable()
 class DestroyedSpyService {
@@ -290,6 +329,15 @@ class TestComponent {
   currentTplRef!: TemplateRef<any>;
   context: any = {foo: 'bar'};
   value = 'bar';
+  injector: Injector|null = null;
+}
+
+@Component({
+  selector: 'inject-value',
+  template: 'Hello {{tokenValue}}',
+})
+class InjectValueComponent {
+  constructor(@Inject(templateToken) public tokenValue: string) {}
 }
 
 @Component({
@@ -305,8 +353,9 @@ class MultiContextComponent {
   context2: {name: string}|undefined;
 }
 
-function createTestComponent(template: string): ComponentFixture<TestComponent> {
-  return TestBed.overrideComponent(TestComponent, {set: {template: template}})
+function createTestComponent(
+    template: string, providers: Provider[] = []): ComponentFixture<TestComponent> {
+  return TestBed.overrideComponent(TestComponent, {set: {template: template, providers}})
       .configureTestingModule({schemas: [NO_ERRORS_SCHEMA]})
       .createComponent(TestComponent);
 }

--- a/packages/core/src/linker/template_ref.ts
+++ b/packages/core/src/linker/template_ref.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Injector} from '../di/injector';
 import {assertLContainer} from '../render3/assert';
 import {createLView, renderView} from '../render3/instructions/shared';
 import {TContainerNode, TNode, TNodeType} from '../render3/interfaces/node';
@@ -55,9 +56,10 @@ export abstract class TemplateRef<C> {
    * and attaches it to the view container.
    * @param context The data-binding context of the embedded view, as declared
    * in the `<ng-template>` usage.
+   * @param injector Injector to be used within the embedded view.
    * @returns The new embedded view object.
    */
-  abstract createEmbeddedView(context: C): EmbeddedViewRef<C>;
+  abstract createEmbeddedView(context: C, injector?: Injector): EmbeddedViewRef<C>;
 
   /**
    * @internal
@@ -77,11 +79,11 @@ const R3TemplateRef = class TemplateRef<T> extends ViewEngineTemplateRef<T> {
     super();
   }
 
-  override createEmbeddedView(context: T): EmbeddedViewRef<T> {
+  override createEmbeddedView(context: T, injector?: Injector): EmbeddedViewRef<T> {
     const embeddedTView = this._declarationTContainer.tViews as TView;
     const embeddedLView = createLView(
         this._declarationLView, embeddedTView, context, LViewFlags.CheckAlways, null,
-        embeddedTView.declTNode, null, null, null, null);
+        embeddedTView.declTNode, null, null, null, null, injector || null);
 
     const declarationLContainer = this._declarationLView[this._declarationTContainer.index];
     ngDevMode && assertLContainer(declarationLContainer);

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -96,6 +96,24 @@ export abstract class ViewContainerRef {
    * @param templateRef The HTML template that defines the view.
    * @param context The data-binding context of the embedded view, as declared
    * in the `<ng-template>` usage.
+   * @param options Extra configuration for the created view. Includes:
+   *  * index: The 0-based index at which to insert the new view into this container.
+   *           If not specified, appends the new view as the last entry.
+   *  * injector: Injector to be used within the embedded view.
+   *
+   * @returns The `ViewRef` instance for the newly created view.
+   */
+  abstract createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, options?: {
+    index?: number,
+    injector?: Injector
+  }): EmbeddedViewRef<C>;
+
+  /**
+   * Instantiates an embedded view and inserts it
+   * into this container.
+   * @param templateRef The HTML template that defines the view.
+   * @param context The data-binding context of the embedded view, as declared
+   * in the `<ng-template>` usage.
    * @param index The 0-based index at which to insert the new view into this container.
    * If not specified, appends the new view as the last entry.
    *
@@ -258,9 +276,27 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
     return this._lContainer.length - CONTAINER_HEADER_OFFSET;
   }
 
+  override createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, options?: {
+    index?: number,
+    injector?: Injector
+  }): EmbeddedViewRef<C>;
   override createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, index?: number):
-      EmbeddedViewRef<C> {
-    const viewRef = templateRef.createEmbeddedView(context || <any>{});
+      EmbeddedViewRef<C>;
+  override createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, indexOrOptions?: number|{
+    index?: number,
+    injector?: Injector
+  }): EmbeddedViewRef<C> {
+    let index: number|undefined;
+    let injector: Injector|undefined;
+
+    if (typeof indexOrOptions === 'number') {
+      index = indexOrOptions;
+    } else if (indexOrOptions != null) {
+      index = indexOrOptions.index;
+      injector = indexOrOptions.injector;
+    }
+
+    const viewRef = templateRef.createEmbeddedView(context || <any>{}, injector);
     this.insert(viewRef, index);
     return viewRef;
   }

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -134,7 +134,7 @@ export function renderComponent<T>(
   const rootTView = createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, null);
   const rootView: LView = createLView(
       null, rootTView, rootContext, rootFlags, null, null, rendererFactory, renderer, null,
-      opts.injector || null);
+      opts.injector || null, null);
 
   enterView(rootView);
   let component: T;
@@ -200,7 +200,7 @@ export function createRootComponentView(
   const componentView = createLView(
       rootView, getOrCreateTComponentView(def), null,
       def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, rootView[index], tNode,
-      rendererFactory, viewRenderer, sanitizer || null, null);
+      rendererFactory, viewRenderer, sanitizer || null, null, null);
 
   if (tView.firstCreatePass) {
     diPublicInInjector(getOrCreateNodeInjectorForNode(tNode, rootView), tView, def.type);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -32,7 +32,7 @@ import {isProceduralRenderer, Renderer3, RendererFactory3} from '../interfaces/r
 import {RComment, RElement, RNode, RText} from '../interfaces/renderer_dom';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {isComponentDef, isComponentHost, isContentQueryHost, isRootView} from '../interfaces/type_checks';
-import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, FLAGS, HEADER_OFFSET, HOST, HostBindingOpCodes, ID, InitPhaseState, INJECTOR, LView, LViewFlags, NEXT, PARENT, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, T_HOST, TData, TRANSPLANTED_VIEWS_TO_REFRESH, TVIEW, TView, TViewType} from '../interfaces/view';
+import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, EMBEDDED_VIEW_INJECTOR, FLAGS, HEADER_OFFSET, HOST, HostBindingOpCodes, ID, InitPhaseState, INJECTOR, LView, LViewFlags, NEXT, PARENT, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, T_HOST, TData, TRANSPLANTED_VIEWS_TO_REFRESH, TVIEW, TView, TViewType} from '../interfaces/view';
 import {assertPureTNodeType, assertTNodeType} from '../node_assert';
 import {updateTextNode} from '../node_manipulation';
 import {isInlineTemplate, isNodeMatchingSelectorList} from '../node_selector_matcher';
@@ -126,11 +126,16 @@ function renderChildComponents(hostLView: LView, components: number[]): void {
 export function createLView<T>(
     parentLView: LView|null, tView: TView, context: T|null, flags: LViewFlags, host: RElement|null,
     tHostNode: TNode|null, rendererFactory: RendererFactory3|null, renderer: Renderer3|null,
-    sanitizer: Sanitizer|null, injector: Injector|null): LView {
+    sanitizer: Sanitizer|null, injector: Injector|null,
+    embeddedViewInjector: Injector|null): LView {
   const lView =
       ngDevMode ? cloneToLViewFromTViewBlueprint(tView) : tView.blueprint.slice() as LView;
   lView[HOST] = host;
   lView[FLAGS] = flags | LViewFlags.CreationMode | LViewFlags.Attached | LViewFlags.FirstLViewPass;
+  if (embeddedViewInjector !== null ||
+      (parentLView && (parentLView[FLAGS] & LViewFlags.HasEmbeddedViewInjector))) {
+    lView[FLAGS] |= LViewFlags.HasEmbeddedViewInjector;
+  }
   resetPreOrderHookFlags(lView);
   ngDevMode && tView.declTNode && parentLView && assertTNodeForLView(tView.declTNode, parentLView);
   lView[PARENT] = lView[DECLARATION_VIEW] = parentLView;
@@ -143,6 +148,7 @@ export function createLView<T>(
   lView[INJECTOR as any] = injector || parentLView && parentLView[INJECTOR] || null;
   lView[T_HOST] = tHostNode;
   lView[ID] = getUniqueLViewId();
+  lView[EMBEDDED_VIEW_INJECTOR as any] = embeddedViewInjector;
   ngDevMode &&
       assertEqual(
           tView.type == TViewType.Embedded ? parentLView !== null : true, true,
@@ -1499,7 +1505,7 @@ function addComponentLogic<T>(lView: LView, hostTNode: TElementNode, def: Compon
       createLView(
           lView, tView, null, def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, native,
           hostTNode as TElementNode, rendererFactory, rendererFactory.createRenderer(native, def),
-          null, null));
+          null, null, null));
 
   // Component view will always be created before any injected LContainers,
   // so this is a regular element, wrap it with the component view

--- a/packages/core/src/render3/interfaces/injector.ts
+++ b/packages/core/src/render3/interfaces/injector.ts
@@ -48,7 +48,7 @@ import {LView, TData} from './view';
  * index + 7: cumulative bloom filter
  * index + 8: cumulative bloom filter
  * index + TNODE: TNode associated with this `NodeInjector`
- *                `canst tNode = tView.data[index + NodeInjectorOffset.TNODE]`
+ *                `const tNode = tView.data[index + NodeInjectorOffset.TNODE]`
  * ```
  */
 export const enum NodeInjectorOffset {

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -49,6 +49,7 @@ export const DECLARATION_LCONTAINER = 17;
 export const PREORDER_HOOK_FLAGS = 18;
 export const QUERIES = 19;
 export const ID = 20;
+export const EMBEDDED_VIEW_INJECTOR = 21;
 /**
  * Size of LView's header. Necessary to adjust for it when setting slots.
  *
@@ -56,7 +57,7 @@ export const ID = 20;
  * instruction index into `LView` index. All other indexes should be in the `LView` index space and
  * there should be no need to refer to `HEADER_OFFSET` anywhere else.
  */
-export const HEADER_OFFSET = 21;
+export const HEADER_OFFSET = 22;
 
 
 // This interface replaces the real LView interface if it is an arg or a
@@ -331,6 +332,12 @@ export interface LView extends Array<any> {
 
   /** Unique ID of the view. Used for `__ngContext__` lookups in the `LView` registry. */
   [ID]: number;
+
+  /**
+   * Optional injector assigned to embedded views that takes
+   * precedence over the element and module injectors.
+   */
+  readonly[EMBEDDED_VIEW_INJECTOR]: Injector|null;
 }
 
 /** Flags associated with an LView (saved in LView[FLAGS]) */
@@ -396,12 +403,15 @@ export const enum LViewFlags {
    */
   RefreshTransplantedView = 0b0010000000000,
 
+  /** Indicates that the view **or any of its ancestors** have an embedded view injector. */
+  HasEmbeddedViewInjector = 0b0100000000000,
+
   /**
    * Index of the current init phase on last 21 bits
    */
-  IndexWithinInitPhaseIncrementer = 0b0100000000000,
-  IndexWithinInitPhaseShift = 11,
-  IndexWithinInitPhaseReset = 0b0011111111111,
+  IndexWithinInitPhaseIncrementer = 0b01000000000000,
+  IndexWithinInitPhaseShift = 12,
+  IndexWithinInitPhaseReset = 0b00111111111111,
 }
 
 /**

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -3546,4 +3546,823 @@ describe('di', () => {
     TestBed.configureTestingModule({declarations: [App]});
     expect(() => TestBed.createComponent(App)).toThrowError(/NullInjectorError/);
   });
+
+  describe('injector when creating embedded view', () => {
+    const token = new InjectionToken<string>('greeting');
+
+    @Directive({selector: 'menu-trigger'})
+    class MenuTrigger {
+      @Input('triggerFor') menu!: TemplateRef<unknown>;
+
+      constructor(private viewContainerRef: ViewContainerRef) {}
+
+      open(injector: Injector|undefined) {
+        this.viewContainerRef.createEmbeddedView(this.menu, undefined, {injector});
+      }
+    }
+
+    it('should be able to provide an injection token through a custom injector', () => {
+      @Directive({selector: 'menu'})
+      class Menu {
+        constructor(@Inject(token) public tokenValue: string) {}
+      }
+
+      @Component({
+        template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <menu></menu>
+          </ng-template>
+      `
+      })
+      class App {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(Menu) menu!: Menu;
+      }
+
+      TestBed.configureTestingModule({declarations: [App, MenuTrigger, Menu]});
+      const injector = Injector.create({providers: [{provide: token, useValue: 'hello'}]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.open(injector);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.menu.tokenValue).toBe('hello');
+    });
+
+    it('should be able to provide an injection token to a nested template through a custom injector',
+       () => {
+         @Directive({selector: 'menu'})
+         class Menu {
+           constructor(@Inject(token) public tokenValue: string) {}
+         }
+
+         @Component({
+           template: `
+            <menu-trigger #outerTrigger [triggerFor]="outerTemplate"></menu-trigger>
+            <ng-template #outerTemplate>
+              <menu></menu>
+
+              <menu-trigger #innerTrigger [triggerFor]="innerTemplate"></menu-trigger>
+              <ng-template #innerTemplate>
+                <menu #innerMenu></menu>
+              </ng-template>
+            </ng-template>
+          `
+         })
+         class App {
+           @ViewChild('outerTrigger', {read: MenuTrigger}) outerTrigger!: MenuTrigger;
+           @ViewChild('innerTrigger', {read: MenuTrigger}) innerTrigger!: MenuTrigger;
+           @ViewChild('innerMenu', {read: Menu}) innerMenu!: Menu;
+         }
+
+         TestBed.configureTestingModule({declarations: [App, MenuTrigger, Menu]});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         fixture.componentInstance.outerTrigger.open(
+             Injector.create({providers: [{provide: token, useValue: 'hello'}]}));
+         fixture.detectChanges();
+
+         fixture.componentInstance.innerTrigger.open(undefined);
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.innerMenu.tokenValue).toBe('hello');
+       });
+
+    it('should be able to resolve a token from a custom grandparent injector if the token is not provided in the parent',
+       () => {
+         @Directive({selector: 'menu'})
+         class Menu {
+           constructor(@Inject(token) public tokenValue: string) {}
+         }
+
+         @Component({
+           template: `
+            <menu-trigger #grandparentTrigger [triggerFor]="grandparentTemplate"></menu-trigger>
+            <ng-template #grandparentTemplate>
+              <menu></menu>
+
+              <menu-trigger #parentTrigger [triggerFor]="parentTemplate"></menu-trigger>
+              <ng-template #parentTemplate>
+                <menu></menu>
+
+                <menu-trigger #childTrigger [triggerFor]="childTemplate"></menu-trigger>
+                <ng-template #childTemplate>
+                  <menu #childMenu></menu>
+                </ng-template>
+              </ng-template>
+            </ng-template>
+          `
+         })
+         class App {
+           @ViewChild('grandparentTrigger', {read: MenuTrigger}) grandparentTrigger!: MenuTrigger;
+           @ViewChild('parentTrigger', {read: MenuTrigger}) parentTrigger!: MenuTrigger;
+           @ViewChild('childTrigger', {read: MenuTrigger}) childTrigger!: MenuTrigger;
+           @ViewChild('childMenu', {read: Menu}) childMenu!: Menu;
+         }
+
+         TestBed.configureTestingModule({declarations: [App, MenuTrigger, Menu]});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         fixture.componentInstance.grandparentTrigger.open(
+             Injector.create({providers: [{provide: token, useValue: 'hello'}]}));
+         fixture.detectChanges();
+
+         fixture.componentInstance.parentTrigger.open(Injector.create({providers: []}));
+         fixture.detectChanges();
+
+         fixture.componentInstance.childTrigger.open(undefined);
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.childMenu.tokenValue).toBe('hello');
+       });
+
+    it('should resolve value from node injector if it is lower than embedded view injector', () => {
+      @Directive({selector: 'menu'})
+      class Menu {
+        constructor(@Inject(token) public tokenValue: string) {}
+      }
+
+      @Component({
+        selector: 'wrapper',
+        providers: [{provide: token, useValue: 'hello from wrapper'}],
+        template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <menu></menu>
+          </ng-template>
+        `
+      })
+      class Wrapper {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(Menu) menu!: Menu;
+      }
+
+      @Component({
+        template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <wrapper></wrapper>
+          </ng-template>
+        `
+      })
+      class App {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(Wrapper) wrapper!: Wrapper;
+      }
+
+      TestBed.configureTestingModule({declarations: [App, MenuTrigger, Menu, Wrapper]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.open(
+          Injector.create({providers: [{provide: token, useValue: 'hello from injector'}]}));
+      fixture.detectChanges();
+
+      fixture.componentInstance.wrapper.trigger.open(undefined);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.wrapper.menu.tokenValue).toBe('hello from wrapper');
+    });
+
+    it('should be able to inject a value provided at the module level', () => {
+      @Directive({selector: 'menu'})
+      class Menu {
+        constructor(@Inject(token) public tokenValue: string) {}
+      }
+
+      @Component({
+        template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <menu></menu>
+          </ng-template>
+      `
+      })
+      class App {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(Menu) menu!: Menu;
+      }
+
+      @NgModule({
+        declarations: [App, MenuTrigger, Menu],
+        exports: [App, MenuTrigger, Menu],
+        providers: [{provide: token, useValue: 'hello'}]
+      })
+      class Module {
+      }
+
+      TestBed.configureTestingModule({imports: [Module]});
+      const injector = Injector.create({providers: []});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.open(injector);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.menu.tokenValue).toBe('hello');
+    });
+
+    it('should have value from custom injector take precedence over module injector', () => {
+      @Directive({selector: 'menu'})
+      class Menu {
+        constructor(@Inject(token) public tokenValue: string) {}
+      }
+
+      @Component({
+        template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <menu></menu>
+          </ng-template>
+      `
+      })
+      class App {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(Menu) menu!: Menu;
+      }
+
+      @NgModule({
+        declarations: [App, MenuTrigger, Menu],
+        exports: [App, MenuTrigger, Menu],
+        providers: [{provide: token, useValue: 'hello from module'}]
+      })
+      class Module {
+      }
+
+      TestBed.configureTestingModule({imports: [Module]});
+      const injector =
+          Injector.create({providers: [{provide: token, useValue: 'hello from injector'}]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.open(injector);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.menu.tokenValue).toBe('hello from injector');
+    });
+
+    it('should have value from custom injector take precedence over parent injector', () => {
+      @Directive({selector: 'menu'})
+      class Menu {
+        constructor(@Inject(token) public tokenValue: string) {}
+      }
+
+      @Component({
+        template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <menu></menu>
+          </ng-template>
+      `,
+        providers: [{provide: token, useValue: 'hello from parent'}]
+      })
+      class App {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(Menu) menu!: Menu;
+      }
+
+      @NgModule({
+        declarations: [App, MenuTrigger, Menu],
+        exports: [App, MenuTrigger, Menu],
+      })
+      class Module {
+      }
+
+      TestBed.configureTestingModule({imports: [Module]});
+      const injector =
+          Injector.create({providers: [{provide: token, useValue: 'hello from injector'}]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.open(injector);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.menu.tokenValue).toBe('hello from injector');
+    });
+
+    it('should be able to inject built-in tokens when a custom injector is provided', () => {
+      @Directive({selector: 'menu'})
+      class Menu {
+        constructor(public elementRef: ElementRef, public changeDetectorRef: ChangeDetectorRef) {}
+      }
+
+      @Component({
+        template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <menu></menu>
+          </ng-template>
+      `
+      })
+      class App {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(Menu) menu!: Menu;
+      }
+
+      TestBed.configureTestingModule({declarations: [App, MenuTrigger, Menu]});
+      const injector = Injector.create({providers: []});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.open(injector);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.menu.elementRef.nativeElement)
+          .toBe(fixture.nativeElement.querySelector('menu'));
+      expect(fixture.componentInstance.menu.changeDetectorRef).toBeTruthy();
+    });
+
+    it('should have value from parent component injector take precedence over module injector',
+       () => {
+         @Directive({selector: 'menu'})
+         class Menu {
+           constructor(@Inject(token) public tokenValue: string) {}
+         }
+
+         @Component({
+           template: `
+            <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+            <ng-template #menuTemplate>
+              <menu></menu>
+            </ng-template>
+          `,
+           providers: [{provide: token, useValue: 'hello from parent'}]
+         })
+         class App {
+           @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+           @ViewChild(Menu) menu!: Menu;
+         }
+
+         @NgModule({
+           declarations: [App, MenuTrigger, Menu],
+           exports: [App, MenuTrigger, Menu],
+           providers: [{provide: token, useValue: 'hello from module'}]
+         })
+         class Module {
+         }
+
+         TestBed.configureTestingModule({imports: [Module]});
+         const injector = Injector.create({providers: []});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         fixture.componentInstance.trigger.open(injector);
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.menu.tokenValue).toBe('hello from parent');
+       });
+
+    it('should be able to inject an injectable with dependencies', () => {
+      @Injectable()
+      class Greeter {
+        constructor(@Inject(token) private tokenValue: string) {}
+
+        greet() {
+          return `hello from ${this.tokenValue}`;
+        }
+      }
+
+      @Directive({selector: 'menu'})
+      class Menu {
+        constructor(public greeter: Greeter) {}
+      }
+
+      @Component({
+        template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <menu></menu>
+          </ng-template>
+      `
+      })
+      class App {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(Menu) menu!: Menu;
+      }
+
+      @NgModule({
+        declarations: [App, MenuTrigger, Menu],
+        exports: [App, MenuTrigger, Menu],
+        providers: [{provide: token, useValue: 'module'}]
+      })
+      class Module {
+      }
+
+      TestBed.configureTestingModule({imports: [Module]});
+      const injector = Injector.create({
+        providers: [
+          {provide: Greeter, useClass: Greeter},
+          {provide: token, useValue: 'injector'},
+        ]
+      });
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.open(injector);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.menu.greeter.greet()).toBe('hello from injector');
+    });
+
+    it('should be able to inject a value from a grandparent component when a custom injector is provided',
+       () => {
+         @Directive({selector: 'menu'})
+         class Menu {
+           constructor(@Inject(token) public tokenValue: string) {}
+         }
+
+         @Component({
+           selector: 'parent',
+           template: `
+            <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+            <ng-template #menuTemplate>
+              <menu></menu>
+            </ng-template>
+           `
+         })
+         class Parent {
+           @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+           @ViewChild(Menu) menu!: Menu;
+         }
+
+         @Component({
+           template: '<parent></parent>',
+           providers: [{provide: token, useValue: 'hello from grandparent'}]
+         })
+         class GrandParent {
+           @ViewChild(Parent) parent!: Parent;
+         }
+
+         TestBed.configureTestingModule({declarations: [GrandParent, Parent, MenuTrigger, Menu]});
+         const injector = Injector.create({providers: []});
+         const fixture = TestBed.createComponent(GrandParent);
+         fixture.detectChanges();
+
+         fixture.componentInstance.parent.trigger.open(injector);
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.parent.menu.tokenValue).toBe('hello from grandparent');
+       });
+
+    it('should be able to use a custom injector when created through TemplateRef', () => {
+      let injectedValue: string|undefined;
+
+      @Directive({selector: 'menu'})
+      class Menu {
+        constructor(@Inject(token) tokenValue: string) {
+          injectedValue = tokenValue;
+        }
+      }
+
+      @Component({
+        template: `
+          <ng-template>
+            <menu></menu>
+          </ng-template>
+        `
+      })
+      class App {
+        @ViewChild(TemplateRef) template!: TemplateRef<unknown>;
+      }
+
+      @NgModule({
+        declarations: [App, Menu],
+        exports: [App, Menu],
+        providers: [{provide: token, useValue: 'hello from module'}]
+      })
+      class Module {
+      }
+
+      TestBed.configureTestingModule({imports: [Module]});
+      const injector =
+          Injector.create({providers: [{provide: token, useValue: 'hello from injector'}]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.template.createEmbeddedView({}, injector);
+      fixture.detectChanges();
+
+      expect(injectedValue).toBe('hello from injector');
+    });
+
+    it('should use a custom injector when the view is created outside of the declaration view',
+       () => {
+         const declarerToken = new InjectionToken<string>('declarerToken');
+         const creatorToken = new InjectionToken<string>('creatorToken');
+
+         @Directive({selector: 'menu'})
+         class Menu {
+           constructor(
+               @Inject(token) public tokenValue: string,
+               @Optional() @Inject(declarerToken) public declarerTokenValue: string,
+               @Optional() @Inject(creatorToken) public creatorTokenValue: string) {}
+         }
+
+         @Component({
+           selector: 'declarer',
+           template: '<ng-template><menu></menu></ng-template>',
+           providers: [{provide: declarerToken, useValue: 'hello from declarer'}]
+         })
+         class Declarer {
+           @ViewChild(Menu) menu!: Menu;
+           @ViewChild(TemplateRef) template!: TemplateRef<unknown>;
+         }
+
+         @Component({
+           selector: 'creator',
+           template: '<menu-trigger></menu-trigger>',
+           providers: [{provide: creatorToken, useValue: 'hello from creator'}]
+         })
+         class Creator {
+           @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+         }
+
+         @Component({
+           template: `
+              <declarer></declarer>
+              <creator></creator>
+            `
+         })
+         class App {
+           @ViewChild(Declarer) declarer!: Declarer;
+           @ViewChild(Creator) creator!: Creator;
+         }
+
+         TestBed.configureTestingModule(
+             {declarations: [App, MenuTrigger, Menu, Declarer, Creator]});
+         const injector = Injector.create({providers: [{provide: token, useValue: 'hello'}]});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+         const {declarer, creator} = fixture.componentInstance;
+
+         creator.trigger.menu = declarer.template;
+         creator.trigger.open(injector);
+         fixture.detectChanges();
+
+         expect(declarer.menu.tokenValue).toBe('hello');
+         expect(declarer.menu.declarerTokenValue).toBe('hello from declarer');
+         expect(declarer.menu.creatorTokenValue).toBeNull();
+       });
+
+    it('should give precedence to value provided lower in the tree over custom injector', () => {
+      @Directive({selector: 'menu'})
+      class Menu {
+        constructor(@Inject(token) public tokenValue: string) {}
+      }
+
+      @Directive({
+        selector: '[provide-token]',
+        providers: [{provide: token, useValue: 'hello from directive'}]
+      })
+      class ProvideToken {
+      }
+
+      @Component({
+        template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <section>
+              <div provide-token>
+                <menu></menu>
+              </div>
+            </section>
+          </ng-template>
+        `,
+        providers: [{provide: token, useValue: 'hello from parent'}]
+      })
+      class App {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(Menu) menu!: Menu;
+      }
+
+      @NgModule({
+        declarations: [App, MenuTrigger, Menu, ProvideToken],
+        exports: [App, MenuTrigger, Menu, ProvideToken],
+      })
+      class Module {
+      }
+
+      TestBed.configureTestingModule({imports: [Module]});
+      const injector =
+          Injector.create({providers: [{provide: token, useValue: 'hello from injector'}]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.open(injector);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.menu.tokenValue).toBe('hello from directive');
+    });
+
+    it('should give precedence to value provided in custom injector over one provided higher',
+       () => {
+         @Directive({selector: 'menu'})
+         class Menu {
+           constructor(@Inject(token) public tokenValue: string) {}
+         }
+
+         @Directive({
+           selector: '[provide-token]',
+           providers: [{provide: token, useValue: 'hello from directive'}]
+         })
+         class ProvideToken {
+         }
+
+         @Component({
+           template: `
+              <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+              <div provide-token>
+                <ng-template #menuTemplate>
+                  <menu></menu>
+                </ng-template>
+              </div>
+            `,
+           providers: [{provide: token, useValue: 'hello from parent'}]
+         })
+         class App {
+           @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+           @ViewChild(Menu) menu!: Menu;
+         }
+
+         @NgModule({
+           declarations: [App, MenuTrigger, Menu, ProvideToken],
+           exports: [App, MenuTrigger, Menu, ProvideToken],
+         })
+         class Module {
+         }
+
+         TestBed.configureTestingModule({imports: [Module]});
+         const injector =
+             Injector.create({providers: [{provide: token, useValue: 'hello from injector'}]});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         fixture.componentInstance.trigger.open(injector);
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.menu.tokenValue).toBe('hello from injector');
+       });
+
+    it('should give precedence to value provided lower in the tree over custom injector when crossing view boundaries',
+       () => {
+         @Directive({selector: 'menu'})
+         class Menu {
+           constructor(@Inject(token) public tokenValue: string) {}
+         }
+
+         @Directive({
+           selector: '[provide-token]',
+           providers: [{provide: token, useValue: 'hello from directive'}]
+         })
+         class ProvideToken {
+         }
+
+         @Component({selector: 'wrapper', template: `<div><menu></menu></div>`})
+         class Wrapper {
+           @ViewChild(Menu) menu!: Menu;
+         }
+
+         @Component({
+           template: `
+              <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+              <ng-template #menuTemplate>
+                <section provide-token>
+                  <wrapper></wrapper>
+                </section>
+              </ng-template>
+            `,
+           providers: [{provide: token, useValue: 'hello from parent'}]
+         })
+         class App {
+           @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+           @ViewChild(Wrapper) wrapper!: Wrapper;
+         }
+
+         @NgModule({
+           declarations: [App, MenuTrigger, Menu, ProvideToken, Wrapper],
+           exports: [App, MenuTrigger, Menu, ProvideToken, Wrapper],
+         })
+         class Module {
+         }
+
+         TestBed.configureTestingModule({imports: [Module]});
+         const injector =
+             Injector.create({providers: [{provide: token, useValue: 'hello from injector'}]});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         fixture.componentInstance.trigger.open(injector);
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.wrapper.menu.tokenValue).toBe('hello from directive');
+       });
+
+    it('should give precedence to value provided in custom injector over one provided higher when crossing view boundaries',
+       () => {
+         @Directive({selector: 'menu'})
+         class Menu {
+           constructor(@Inject(token) public tokenValue: string) {}
+         }
+
+         @Directive({
+           selector: '[provide-token]',
+           providers: [{provide: token, useValue: 'hello from directive'}]
+         })
+         class ProvideToken {
+         }
+
+         @Component({selector: 'wrapper', template: `<div><menu></menu></div>`})
+         class Wrapper {
+           @ViewChild(Menu) menu!: Menu;
+         }
+
+
+         @Component({
+           template: `
+              <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+              <div provide-token>
+                <ng-template #menuTemplate>
+                  <wrapper></wrapper>
+                </ng-template>
+              </div>
+            `,
+           providers: [{provide: token, useValue: 'hello from parent'}]
+         })
+         class App {
+           @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+           @ViewChild(Wrapper) wrapper!: Wrapper;
+         }
+
+         @NgModule({
+           declarations: [App, MenuTrigger, Menu, ProvideToken, Wrapper],
+           exports: [App, MenuTrigger, Menu, ProvideToken, Wrapper],
+         })
+         class Module {
+         }
+
+         TestBed.configureTestingModule({imports: [Module]});
+         const injector =
+             Injector.create({providers: [{provide: token, useValue: 'hello from injector'}]});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         fixture.componentInstance.trigger.open(injector);
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.wrapper.menu.tokenValue).toBe('hello from injector');
+       });
+
+    it('should not resolve value at insertion location', () => {
+      @Directive({selector: 'menu'})
+      class Menu {
+        constructor(@Inject(token) public tokenValue: string) {}
+      }
+
+      @Directive({
+        selector: '[provide-token]',
+        providers: [{provide: token, useValue: 'hello from directive'}]
+      })
+      class ProvideToken {
+      }
+
+      @Component({
+        template: `
+          <div provide-token>
+            <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          </div>
+
+          <ng-template #menuTemplate>
+            <menu></menu>
+          </ng-template>
+        `,
+        providers: [{provide: token, useValue: 'hello from parent'}]
+      })
+      class App {
+        @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+        @ViewChild(Menu) menu!: Menu;
+      }
+
+      @NgModule({
+        declarations: [App, MenuTrigger, Menu, ProvideToken],
+        exports: [App, MenuTrigger, Menu, ProvideToken],
+      })
+      class Module {
+      }
+
+      TestBed.configureTestingModule({imports: [Module]});
+      // Provide an empty injector so we hit the new code path.
+      const injector = Injector.create({providers: []});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      fixture.componentInstance.trigger.open(injector);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.menu.tokenValue).toBe('hello from parent');
+    });
+  });
 });

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -906,6 +906,9 @@
     "name": "getTNode"
   },
   {
+    "name": "getTNodeFromLView"
+  },
+  {
     "name": "getTView"
   },
   {
@@ -1066,6 +1069,9 @@
   },
   {
     "name": "lookupTokenUsingModuleInjector"
+  },
+  {
+    "name": "lookupTokenUsingNodeInjector"
   },
   {
     "name": "makeAnimationEvent"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -207,6 +207,9 @@
     "name": "getSimpleChangesStore"
   },
   {
+    "name": "getTNodeFromLView"
+  },
+  {
     "name": "getTView"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -972,6 +972,9 @@
     "name": "getTNode"
   },
   {
+    "name": "getTNodeFromLView"
+  },
+  {
     "name": "getTStylingRangeNext"
   },
   {
@@ -1183,6 +1186,9 @@
   },
   {
     "name": "lookupTokenUsingModuleInjector"
+  },
+  {
+    "name": "lookupTokenUsingNodeInjector"
   },
   {
     "name": "makeParamDecorator"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -939,6 +939,9 @@
     "name": "getTNode"
   },
   {
+    "name": "getTNodeFromLView"
+  },
+  {
     "name": "getTStylingRangeNext"
   },
   {
@@ -1144,6 +1147,9 @@
   },
   {
     "name": "lookupTokenUsingModuleInjector"
+  },
+  {
+    "name": "lookupTokenUsingNodeInjector"
   },
   {
     "name": "makeParamDecorator"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -162,6 +162,9 @@
     "name": "getSimpleChangesStore"
   },
   {
+    "name": "getTNodeFromLView"
+  },
+  {
     "name": "includeViewProviders"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1299,6 +1299,9 @@
     "name": "getTNode"
   },
   {
+    "name": "getTNodeFromLView"
+  },
+  {
     "name": "getTQuery"
   },
   {
@@ -1504,6 +1507,9 @@
   },
   {
     "name": "lookupTokenUsingModuleInjector"
+  },
+  {
+    "name": "lookupTokenUsingNodeInjector"
   },
   {
     "name": "makeParamDecorator"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -480,6 +480,9 @@
     "name": "getTNode"
   },
   {
+    "name": "getTNodeFromLView"
+  },
+  {
     "name": "getTStylingRangeNext"
   },
   {
@@ -613,6 +616,9 @@
   },
   {
     "name": "lookupTokenUsingModuleInjector"
+  },
+  {
+    "name": "lookupTokenUsingNodeInjector"
   },
   {
     "name": "makeParamDecorator"

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -236,7 +236,7 @@ describe('di', () => {
     it('should handle initial undefined state', () => {
       const contentView = createLView(
           null, createTView(TViewType.Component, null, null, 1, 0, null, null, null, null, null),
-          {}, LViewFlags.CheckAlways, null, null, {} as any, {} as any, null, null);
+          {}, LViewFlags.CheckAlways, null, null, {} as any, {} as any, null, null, null);
       enterView(contentView);
       try {
         const parentTNode = getOrCreateTNode(contentView[TVIEW], 0, TNodeType.Element, null, null);

--- a/packages/core/test/render3/instructions/shared_spec.ts
+++ b/packages/core/test/render3/instructions/shared_spec.ts
@@ -42,7 +42,7 @@ export function enterViewWithOneDiv() {
   const tNode = tView.firstChild = createTNode(tView, null!, TNodeType.Element, 0, 'div', null);
   const lView = createLView(
       null, tView, null, LViewFlags.CheckAlways, null, null, domRendererFactory3, renderer, null,
-      null);
+      null, null);
   lView[HEADER_OFFSET] = div;
   tView.data[HEADER_OFFSET] = tNode;
   enterView(lView);

--- a/packages/core/test/render3/perf/BUILD.bazel
+++ b/packages/core/test/render3/perf/BUILD.bazel
@@ -287,3 +287,17 @@ ng_benchmark(
     name = "render_stringify",
     bundle = ":render_stringify_lib",
 )
+
+app_bundle(
+    name = "embedded_view_injector_lib",
+    entry_point = ":embedded_view_injector/index.ts",
+    external = ["perf_hooks"],
+    deps = [
+        ":perf_lib",
+    ],
+)
+
+ng_benchmark(
+    name = "embedded_view_injector",
+    bundle = ":embedded_view_injector_lib",
+)

--- a/packages/core/test/render3/perf/directive_instantiate/index.ts
+++ b/packages/core/test/render3/perf/directive_instantiate/index.ts
@@ -76,7 +76,7 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const rootLView = createLView(
     null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
-    LViewFlags.IsRoot, null, null, null, null, null, null);
+    LViewFlags.IsRoot, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(

--- a/packages/core/test/render3/perf/element_text_create/index.ts
+++ b/packages/core/test/render3/perf/element_text_create/index.ts
@@ -65,7 +65,7 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const rootLView = createLView(
     null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
-    LViewFlags.IsRoot, null, null, null, null, null, null);
+    LViewFlags.IsRoot, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(

--- a/packages/core/test/render3/perf/embedded_view_injector/app_component.ts
+++ b/packages/core/test/render3/perf/embedded_view_injector/app_component.ts
@@ -1,0 +1,89 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injector} from '@angular/core';
+import {RenderFlags, ɵɵadvance, ɵɵdefineComponent, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵproperty, ɵɵreference, ɵɵtemplate, ɵɵtemplateRefExtractor} from '@angular/core/src/render3';
+
+import {createInnerComponent} from './inner_component';
+import {createRenderTemplateDirective} from './render_template_directive';
+
+/**
+ * Creates the root component of the benchmark. The goal is to add a few more layers of elements
+ * between the root and the `ng-template` that renders out the `inner-comp`.
+ * The template corresponds to:
+ *
+ * <div>
+ *   <div>
+ *     <div>
+ *       <div>
+ *         <div [renderTemplate]="template"></div>
+ *         <div>
+ *           <ng-template #template>
+ *             <div>
+ *               <div>
+ *                 <div>
+ *                   <div>
+ *                     <div>
+ *                       <inner-comp></inner-comp>
+ *                     </div>
+ *                   </div>
+ *                 </div>
+ *               </div>
+ *             </div>
+ *           </ng-template>
+ *         </div>
+ *       </div>
+ *     </div>
+ *   </div>
+ * </div>
+ */
+export function createAppComponent(injector: Injector|undefined) {
+  const RenderTemplate = createRenderTemplateDirective(injector);
+  const InnerComp = createInnerComponent(RenderTemplate);
+
+  function App_ng_template_6_Template(rf: RenderFlags, ctx: any) {
+    if (rf & 1) {
+      ɵɵelementStart(0, 'div')(1, 'div')(2, 'div')(3, 'div')(4, 'div');
+      ɵɵelement(5, 'inner-comp');
+      ɵɵelementEnd()()()()();
+    }
+  }
+
+  return class App {
+    static ɵfac() {
+      return new App();
+    }
+
+    static ɵcmp = ɵɵdefineComponent({
+                    type: App,
+                    selectors: [['app']],
+                    decls: 8,
+                    vars: 1,
+                    consts: [[3, 'renderTemplate'], ['template', '']],
+                    template:
+                        function App_Template(rf, ctx) {
+                          if (rf & 1) {
+                            ɵɵelementStart(0, 'div')(1, 'div')(2, 'div')(3, 'div');
+                            ɵɵelement(4, 'div', 0);
+                            ɵɵelementStart(5, 'div');
+                            ɵɵtemplate(
+                                6, App_ng_template_6_Template, 6, 0, 'ng-template', null, 1,
+                                ɵɵtemplateRefExtractor);
+                            ɵɵelementEnd()()()()();
+                          }
+                          if (rf & 2) {
+                            const _r0 = ɵɵreference(7);
+                            ɵɵadvance(4);
+                            ɵɵproperty('renderTemplate', _r0);
+                          }
+                        },
+                    directives: [RenderTemplate, InnerComp],
+                    encapsulation: 2
+                  }) as never;
+  };
+}

--- a/packages/core/test/render3/perf/embedded_view_injector/index.ts
+++ b/packages/core/test/render3/perf/embedded_view_injector/index.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {Injector, ɵɵelement} from '@angular/core';
+
+import {RenderFlags} from '../../../../src/render3/interfaces/definition';
+import {createBenchmark} from '../micro_bench';
+import {setupTestHarness} from '../setup';
+
+import {createAppComponent} from './app_component';
+
+
+function template(rf: RenderFlags, ctx: any) {
+  if (rf & 1) {
+    ɵɵelement(0, 'app');
+  }
+}
+
+// App where no injector is provided when creating the embedded views.
+const noInjectorApp = createAppComponent(undefined);
+
+// App where an empty injector is provided when creating the embedded views. We provide an
+// empty injector so that the entire view hierarchy has to be traversed during DI.
+const withInjectorApp = createAppComponent(Injector.create({providers: []}));
+
+const noInjectorHarness = setupTestHarness(template, 1, 0, 1, {}, null, [noInjectorApp.ɵcmp]);
+const withInjectorHarness = setupTestHarness(template, 1, 0, 1, {}, null, [withInjectorApp.ɵcmp]);
+
+const benchmark = createBenchmark('embedded_view_injector');
+const noEmbeddedInjectorTime = benchmark('no injector');
+const withEmbeddedInjectorTime = benchmark('with embedded view injector');
+
+while (noEmbeddedInjectorTime()) {
+  noInjectorHarness.createEmbeddedLView();
+  noInjectorHarness.detectChanges();
+}
+
+while (withEmbeddedInjectorTime()) {
+  withInjectorHarness.createEmbeddedLView();
+  withInjectorHarness.detectChanges();
+}
+
+benchmark.report();

--- a/packages/core/test/render3/perf/embedded_view_injector/injector_component.ts
+++ b/packages/core/test/render3/perf/embedded_view_injector/injector_component.ts
@@ -1,0 +1,41 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectFlags, InjectionToken, ɵɵdefineComponent, ɵɵtext} from '@angular/core';
+import {RenderFlags, ɵɵdirectiveInject, ɵɵtextInterpolate1} from '@angular/core/src/render3';
+
+const token = new InjectionToken<string>('token');
+
+/**
+ * Leaf component that tries to inject a token.
+ * Template corresponds to `Hello {{tokenValue}}`
+ */
+export class InjectorComp {
+  static ɵcmp = ɵɵdefineComponent({
+    type: InjectorComp,
+    selectors: [['injector-comp']],
+    decls: 1,
+    vars: 1,
+    encapsulation: 2,
+    template:
+        function InjectorComp_Template(rf: RenderFlags, ctx: any) {
+          if (rf & 1) {
+            ɵɵtext(0);
+          }
+          if (rf & 2) {
+            ɵɵtextInterpolate1('Hello ', ctx.tokenValue, '');
+          }
+        }
+  });
+
+  static ɵfac() {
+    return new InjectorComp(ɵɵdirectiveInject(token, InjectFlags.Optional));
+  }
+
+  constructor(public tokenValue: string) {}
+}

--- a/packages/core/test/render3/perf/embedded_view_injector/inner_component.ts
+++ b/packages/core/test/render3/perf/embedded_view_injector/inner_component.ts
@@ -1,0 +1,86 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Type, ɵɵadvance, ɵɵdefineComponent, ɵɵelement, ɵɵelementEnd, ɵɵelementStart, ɵɵproperty, ɵɵreference, ɵɵtemplate, ɵɵtemplateRefExtractor} from '@angular/core';
+import {RenderFlags} from '@angular/core/src/render3';
+
+import {InjectorComp} from './injector_component';
+
+/**
+ * Creates a component that will be rendered inside the main app that adds a few layers of elements
+ * between the root and where the template with the injector component will be rendered.
+ * Template corresponds to:
+ *
+ *
+ * <div>
+ *   <div>
+ *     <div>
+ *       <div>
+ *         <div [renderTemplate]="template"></div>
+ *         <div>
+ *           <ng-template #template>
+ *             <div>
+ *               <div>
+ *                 <div>
+ *                   <div>
+ *                     <div>
+ *                       <injector-comp></injector-comp>
+ *                     </div>
+ *                   </div>
+ *                 </div>
+ *               </div>
+ *             </div>
+ *           </ng-template>
+ *         </div>
+ *       </div>
+ *     </div>
+ *   </div>
+ * </div>
+ */
+export function createInnerComponent(renderTemplateDirective: Type<{}>) {
+  function InnerComp_ng_template_6_Template(rf: RenderFlags, ctx: any) {
+    if (rf & 1) {
+      ɵɵelementStart(0, 'div')(1, 'div')(2, 'div')(3, 'div')(4, 'div');
+      ɵɵelement(5, 'injector-comp');
+      ɵɵelementEnd()()()()();
+    }
+  }
+
+  return class InnerComp {
+    static ɵfac() {
+      return new InnerComp();
+    }
+
+    static ɵcmp = ɵɵdefineComponent({
+      type: InnerComp,
+      selectors: [['inner-comp']],
+      decls: 8,
+      vars: 1,
+      consts: [[3, 'renderTemplate'], ['template', '']],
+      template:
+          function InnerComp_Template(rf, ctx: any) {
+            if (rf & 1) {
+              ɵɵelementStart(0, 'div')(1, 'div')(2, 'div')(3, 'div');
+              ɵɵelement(4, 'div', 0);
+              ɵɵelementStart(5, 'div');
+              ɵɵtemplate(
+                  6, InnerComp_ng_template_6_Template, 6, 0, 'ng-template', null, 1,
+                  ɵɵtemplateRefExtractor);
+              ɵɵelementEnd()()()()();
+            }
+            if (rf & 2) {
+              const _r0 = ɵɵreference(7);
+              ɵɵadvance(4);
+              ɵɵproperty('renderTemplate', _r0);
+            }
+          },
+      directives: [renderTemplateDirective, InjectorComp],
+      encapsulation: 2
+    });
+  };
+}

--- a/packages/core/test/render3/perf/embedded_view_injector/render_template_directive.ts
+++ b/packages/core/test/render3/perf/embedded_view_injector/render_template_directive.ts
@@ -1,0 +1,45 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injector, TemplateRef, ViewContainerRef, ɵɵdefineDirective, ɵɵdirectiveInject} from '@angular/core';
+import {injectViewContainerRef} from '@angular/core/src/linker/view_container_ref';
+
+
+class ViewContainerRefToken {
+  /**
+   * @internal
+   * @nocollapse
+   */
+  static __NG_ELEMENT_ID__(): ViewContainerRef {
+    return injectViewContainerRef();
+  }
+}
+
+/**
+ * Creates a helper directive that renders out a template
+ * reference that is passed in as an input.
+ */
+export function createRenderTemplateDirective(injector: Injector|undefined) {
+  return class RenderTemplate {
+    static ɵfac() {
+      return new RenderTemplate(ɵɵdirectiveInject(ViewContainerRefToken as any));
+    }
+
+    static ɵdir = ɵɵdefineDirective({
+      type: RenderTemplate,
+      selectors: [['', 'renderTemplate', '']],
+      inputs: {template: ['renderTemplate', 'template']}
+    });
+
+    constructor(public viewContainerRef: ViewContainerRef) {}
+
+    set template(template: TemplateRef<any>) {
+      this.viewContainerRef.createEmbeddedView(template, undefined, {injector});
+    }
+  };
+}

--- a/packages/core/test/render3/perf/listeners/index.ts
+++ b/packages/core/test/render3/perf/listeners/index.ts
@@ -67,7 +67,7 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const rootLView = createLView(
     null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
-    LViewFlags.IsRoot, null, null, null, null, null, null);
+    LViewFlags.IsRoot, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(

--- a/packages/core/test/render3/perf/ng_template/index.ts
+++ b/packages/core/test/render3/perf/ng_template/index.ts
@@ -64,7 +64,7 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const rootLView = createLView(
     null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
-    LViewFlags.IsRoot, null, null, null, null, null, null);
+    LViewFlags.IsRoot, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(

--- a/packages/core/test/render3/perf/noop_renderer.ts
+++ b/packages/core/test/render3/perf/noop_renderer.ts
@@ -50,7 +50,7 @@ export class MicroBenchmarkRenderer implements ProceduralRenderer3 {
     return null;
   }
   nextSibling(node: RNode): RNode|null {
-    throw new Error('Method not implemented.');
+    return null;
   }
   setAttribute(el: RElement, name: string, value: string, namespace?: string|null|undefined): void {
     if (name === 'class' && isOurNode(el)) {

--- a/packages/core/test/render3/perf/setup.ts
+++ b/packages/core/test/render3/perf/setup.ts
@@ -23,7 +23,7 @@ export function createAndRenderLView(
     parentLView: LView, tView: TView, hostTNode: TElementNode): LView {
   const embeddedLView = createLView(
       parentLView, tView, {}, LViewFlags.CheckAlways, null, hostTNode, rendererFactory, renderer,
-      null, null);
+      null, null, null);
   renderView(tView, embeddedLView, null);
   return embeddedLView;
 }
@@ -55,7 +55,7 @@ export function setupTestHarness(
   const hostNode = renderer.createElement('div');
   const hostLView = createLView(
       null, hostTView, {}, LViewFlags.CheckAlways | LViewFlags.IsRoot, hostNode, null,
-      rendererFactory, renderer, null, null);
+      rendererFactory, renderer, null, null, null);
   const mockRCommentNode = renderer.createComment('');
   const lContainer =
       createLContainer(mockRCommentNode, hostLView, mockRCommentNode, tContainerNode);
@@ -71,7 +71,7 @@ export function setupTestHarness(
   function createEmbeddedLView(): LView {
     const embeddedLView = createLView(
         hostLView, embeddedTView, embeddedViewContext, LViewFlags.CheckAlways, null, viewTNode,
-        rendererFactory, renderer, null, null);
+        rendererFactory, renderer, null, null, null);
     renderView(embeddedTView, embeddedLView, embeddedViewContext);
     return embeddedLView;
   }

--- a/packages/core/test/render3/perf/view_destroy_hook/index.ts
+++ b/packages/core/test/render3/perf/view_destroy_hook/index.ts
@@ -53,7 +53,7 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const rootLView = createLView(
     null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
-    LViewFlags.IsRoot, null, null, null, null, null, null);
+    LViewFlags.IsRoot, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -292,7 +292,7 @@ export function renderTemplate<T>(
     const tView = createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, null);
     const hostLView = createLView(
         null, tView, {}, LViewFlags.CheckAlways | LViewFlags.IsRoot, null, null,
-        providedRendererFactory, renderer, null, null);
+        providedRendererFactory, renderer, null, null, null);
     enterView(hostLView);
 
     const def = ɵɵdefineComponent({
@@ -310,7 +310,7 @@ export function renderTemplate<T>(
     hostLView[hostTNode.index] = hostNode;
     componentView = createLView(
         hostLView, componentTView, context, LViewFlags.CheckAlways, hostNode, hostTNode,
-        providedRendererFactory, renderer, sanitizer || null, null);
+        providedRendererFactory, renderer, sanitizer || null, null, null);
   }
   renderComponentOrTemplate(componentView[TVIEW], componentView, templateFn, context);
   return componentView;

--- a/packages/core/test/render3/view_fixture.ts
+++ b/packages/core/test/render3/view_fixture.ts
@@ -48,7 +48,7 @@ export class ViewFixture {
     const hostTView = createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, null);
     const hostLView = createLView(
         null, hostTView, {}, LViewFlags.CheckAlways | LViewFlags.IsRoot, null, null,
-        domRendererFactory3, hostRenderer, null, null);
+        domRendererFactory3, hostRenderer, null, null, null);
 
 
     this.tView = createTView(
@@ -58,7 +58,7 @@ export class ViewFixture {
         createTNode(hostTView, null, TNodeType.Element, 0, 'host-element', null) as TElementNode;
     this.lView = createLView(
         hostLView, this.tView, context || {}, LViewFlags.CheckAlways, this.host, hostTNode,
-        domRendererFactory3, hostRenderer, null, null);
+        domRendererFactory3, hostRenderer, null, null, null);
   }
 
   /**


### PR DESCRIPTION
Adds support for passing in an optional injector when creating an embedded view through `ViewContainerRef.createEmbeddedView` and `TemplateRef.createEmbeddedView`. The injector allows for the DI behavior to be customized within the specific template.

This is a second stab at the changes in #44666. The difference this time is that the new injector acts as a node injector, rather than a module injector.

Fixes #14935.