### PR TITLE
refactor(forms): split apart `model.ts`

### DIFF
--- a/aio/content/guide/form-validation.md
+++ b/aio/content/guide/form-validation.md
@@ -248,7 +248,7 @@ The validator code is as follows.
 
 The `identity` validator implements the `ValidatorFn` interface. It takes an Angular control object as an argument and returns either null if the form is valid, or `ValidationErrors` otherwise.
 
-The validator retrieves the child controls by calling the `FormGroup`'s [get](api/forms/AbstractControl#get) method, then compares the values of the `name` and `alterEgo` controls.
+The validator retrieves the child controls by calling the `FormGroup`'s [get](api/forms/AbstractControl) `get` method, then compares the values of the `name` and `alterEgo` controls.
 
 If the values do not match, the hero's identity remains secret, both are valid, and the validator returns null.
 If they do match, the hero's identity is revealed and the validator must mark the form as invalid by returning an error object.

--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -20,86 +20,16 @@ import { Renderer2 } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
 import { Version } from '@angular/core';
 
-// @public
-export abstract class AbstractControl {
-    constructor(validators: ValidatorFn | ValidatorFn[] | null, asyncValidators: AsyncValidatorFn | AsyncValidatorFn[] | null);
-    addAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void;
-    addValidators(validators: ValidatorFn | ValidatorFn[]): void;
-    get asyncValidator(): AsyncValidatorFn | null;
-    set asyncValidator(asyncValidatorFn: AsyncValidatorFn | null);
-    clearAsyncValidators(): void;
-    clearValidators(): void;
-    get dirty(): boolean;
-    disable(opts?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-    get disabled(): boolean;
-    enable(opts?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-    get enabled(): boolean;
-    readonly errors: ValidationErrors | null;
-    get(path: Array<string | number> | string): AbstractControl | null;
-    getError(errorCode: string, path?: Array<string | number> | string): any;
-    hasAsyncValidator(validator: AsyncValidatorFn): boolean;
-    hasError(errorCode: string, path?: Array<string | number> | string): boolean;
-    hasValidator(validator: ValidatorFn): boolean;
-    get invalid(): boolean;
-    markAllAsTouched(): void;
-    markAsDirty(opts?: {
-        onlySelf?: boolean;
-    }): void;
-    markAsPending(opts?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-    markAsPristine(opts?: {
-        onlySelf?: boolean;
-    }): void;
-    markAsTouched(opts?: {
-        onlySelf?: boolean;
-    }): void;
-    markAsUntouched(opts?: {
-        onlySelf?: boolean;
-    }): void;
-    get parent(): FormGroup | FormArray | null;
-    abstract patchValue(value: any, options?: Object): void;
-    get pending(): boolean;
-    readonly pristine: boolean;
-    removeAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[]): void;
-    removeValidators(validators: ValidatorFn | ValidatorFn[]): void;
-    abstract reset(value?: any, options?: Object): void;
-    get root(): AbstractControl;
-    setAsyncValidators(validators: AsyncValidatorFn | AsyncValidatorFn[] | null): void;
-    setErrors(errors: ValidationErrors | null, opts?: {
-        emitEvent?: boolean;
-    }): void;
-    // (undocumented)
-    setParent(parent: FormGroup | FormArray): void;
-    setValidators(validators: ValidatorFn | ValidatorFn[] | null): void;
-    abstract setValue(value: any, options?: Object): void;
-    readonly status: FormControlStatus;
-    readonly statusChanges: Observable<FormControlStatus>;
-    readonly touched: boolean;
-    get untouched(): boolean;
-    get updateOn(): FormHooks;
-    updateValueAndValidity(opts?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-    get valid(): boolean;
-    get validator(): ValidatorFn | null;
-    set validator(validatorFn: ValidatorFn | null);
-    readonly value: any;
-    readonly valueChanges: Observable<any>;
-}
+// @public (undocumented)
+export const AbstractControl: AbstractControlCtor;
+
+// @public (undocumented)
+export type AbstractControl = AbstractControl_2;
 
 // @public
 export abstract class AbstractControlDirective {
     get asyncValidator(): AsyncValidatorFn | null;
-    abstract get control(): AbstractControl | null;
+    abstract get control(): AbstractControl_2 | null;
     get dirty(): boolean | null;
     get disabled(): boolean | null;
     get enabled(): boolean | null;
@@ -130,7 +60,7 @@ export interface AbstractControlOptions {
 
 // @public
 export class AbstractFormGroupDirective extends ControlContainer implements OnInit, OnDestroy {
-    get control(): FormGroup;
+    get control(): FormGroup_2;
     get formDirective(): Form | null;
     // (undocumented)
     ngOnDestroy(): void;
@@ -148,13 +78,13 @@ export type AnyForUntypedForms = any;
 
 // @public
 export interface AsyncValidator extends Validator {
-    validate(control: AbstractControl): Promise<ValidationErrors | null> | Observable<ValidationErrors | null>;
+    validate(control: AbstractControl_2): Promise<ValidationErrors | null> | Observable<ValidationErrors | null>;
 }
 
 // @public
 export interface AsyncValidatorFn {
     // (undocumented)
-    (control: AbstractControl): Promise<ValidationErrors | null> | Observable<ValidationErrors | null>;
+    (control: AbstractControl_2): Promise<ValidationErrors | null> | Observable<ValidationErrors | null>;
 }
 
 // @public
@@ -217,54 +147,23 @@ export class EmailValidator extends AbstractValidatorDirective {
 export interface Form {
     addControl(dir: NgControl): void;
     addFormGroup(dir: AbstractFormGroupDirective): void;
-    getControl(dir: NgControl): FormControl;
-    getFormGroup(dir: AbstractFormGroupDirective): FormGroup;
+    getControl(dir: NgControl): FormControl_2;
+    getFormGroup(dir: AbstractFormGroupDirective): FormGroup_2;
     removeControl(dir: NgControl): void;
     removeFormGroup(dir: AbstractFormGroupDirective): void;
     updateModel(dir: NgControl, value: any): void;
 }
 
-// @public
-export class FormArray extends AbstractControl {
-    constructor(controls: AbstractControl[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
-    at(index: number): AbstractControl;
-    clear(options?: {
-        emitEvent?: boolean;
-    }): void;
-    // (undocumented)
-    controls: AbstractControl[];
-    getRawValue(): any[];
-    insert(index: number, control: AbstractControl, options?: {
-        emitEvent?: boolean;
-    }): void;
-    get length(): number;
-    patchValue(value: any[], options?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-    push(control: AbstractControl, options?: {
-        emitEvent?: boolean;
-    }): void;
-    removeAt(index: number, options?: {
-        emitEvent?: boolean;
-    }): void;
-    reset(value?: any, options?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-    setControl(index: number, control: AbstractControl, options?: {
-        emitEvent?: boolean;
-    }): void;
-    setValue(value: any[], options?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-}
+// @public (undocumented)
+export const FormArray: ɵFormArrayCtor;
+
+// @public (undocumented)
+export type FormArray = FormArray_2;
 
 // @public
 export class FormArrayName extends ControlContainer implements OnInit, OnDestroy {
     constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[]);
-    get control(): FormArray;
+    get control(): FormArray_2;
     get formDirective(): FormGroupDirective | null;
     name: string | number | null;
     ngOnDestroy(): void;
@@ -295,37 +194,17 @@ export class FormBuilder {
     static ɵprov: i0.ɵɵInjectableDeclaration<FormBuilder>;
 }
 
-// @public
-export interface FormControl extends AbstractControl {
-    readonly defaultValue: any;
-    patchValue(value: any, options?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-        emitModelToViewChange?: boolean;
-        emitViewToModelChange?: boolean;
-    }): void;
-    registerOnChange(fn: Function): void;
-    registerOnDisabledChange(fn: (isDisabled: boolean) => void): void;
-    reset(formState?: any, options?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-    setValue(value: any, options?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-        emitModelToViewChange?: boolean;
-        emitViewToModelChange?: boolean;
-    }): void;
-}
-
 // @public (undocumented)
 export const FormControl: ɵFormControlCtor;
+
+// @public (undocumented)
+export type FormControl = FormControl_2;
 
 // @public
 export class FormControlDirective extends NgControl implements OnChanges, OnDestroy {
     constructor(validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
-    get control(): FormControl;
-    form: FormControl;
+    get control(): FormControl_2;
+    form: FormControl_2;
     set isDisabled(isDisabled: boolean);
     // @deprecated (undocumented)
     model: any;
@@ -347,7 +226,7 @@ export class FormControlDirective extends NgControl implements OnChanges, OnDest
 // @public
 export class FormControlName extends NgControl implements OnChanges, OnDestroy {
     constructor(parent: ControlContainer, validators: (Validator | ValidatorFn)[], asyncValidators: (AsyncValidator | AsyncValidatorFn)[], valueAccessors: ControlValueAccessor[], _ngModelWarningConfig: string | null);
-    readonly control: FormControl;
+    readonly control: FormControl_2;
     get formDirective(): any;
     set isDisabled(isDisabled: boolean);
     // @deprecated (undocumented)
@@ -375,44 +254,11 @@ export interface FormControlOptions extends AbstractControlOptions {
 // @public
 export type FormControlStatus = 'VALID' | 'INVALID' | 'PENDING' | 'DISABLED';
 
-// @public
-export class FormGroup extends AbstractControl {
-    constructor(controls: {
-        [key: string]: AbstractControl;
-    }, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
-    addControl(name: string, control: AbstractControl, options?: {
-        emitEvent?: boolean;
-    }): void;
-    contains(controlName: string): boolean;
-    // (undocumented)
-    controls: {
-        [key: string]: AbstractControl;
-    };
-    getRawValue(): any;
-    patchValue(value: {
-        [key: string]: any;
-    }, options?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-    registerControl(name: string, control: AbstractControl): AbstractControl;
-    removeControl(name: string, options?: {
-        emitEvent?: boolean;
-    }): void;
-    reset(value?: any, options?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-    setControl(name: string, control: AbstractControl, options?: {
-        emitEvent?: boolean;
-    }): void;
-    setValue(value: {
-        [key: string]: any;
-    }, options?: {
-        onlySelf?: boolean;
-        emitEvent?: boolean;
-    }): void;
-}
+// @public (undocumented)
+export const FormGroup: ɵFormGroupCtor;
+
+// @public (undocumented)
+export type FormGroup = FormGroup_2;
 
 // @public
 export class FormGroupDirective extends ControlContainer implements Form, OnChanges, OnDestroy {
@@ -420,13 +266,13 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
     addControl(dir: FormControlName): FormControl;
     addFormArray(dir: FormArrayName): void;
     addFormGroup(dir: FormGroupName): void;
-    get control(): FormGroup;
+    get control(): FormGroup_2;
     directives: FormControlName[];
-    form: FormGroup;
+    form: FormGroup_2;
     get formDirective(): Form;
     getControl(dir: FormControlName): FormControl;
-    getFormArray(dir: FormArrayName): FormArray;
-    getFormGroup(dir: FormGroupName): FormGroup;
+    getFormArray(dir: FormArrayName): FormArray_2;
+    getFormGroup(dir: FormGroupName): FormGroup_2;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
@@ -544,11 +390,11 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
     addFormGroup(dir: NgModelGroup): void;
     get control(): FormGroup;
     get controls(): {
-        [key: string]: AbstractControl;
+        [key: string]: AbstractControl_2;
     };
     form: FormGroup;
     get formDirective(): Form;
-    getControl(dir: NgModel): FormControl;
+    getControl(dir: NgModel): FormControl_2;
     getFormGroup(dir: NgModelGroup): FormGroup;
     // (undocumented)
     ngAfterViewInit(): void;
@@ -733,13 +579,13 @@ export type ValidationErrors = {
 // @public
 export interface Validator {
     registerOnValidatorChange?(fn: () => void): void;
-    validate(control: AbstractControl): ValidationErrors | null;
+    validate(control: AbstractControl_2): ValidationErrors | null;
 }
 
 // @public
 export interface ValidatorFn {
     // (undocumented)
-    (control: AbstractControl): ValidationErrors | null;
+    (control: AbstractControl_2): ValidationErrors | null;
 }
 
 // @public
@@ -748,15 +594,15 @@ export class Validators {
     // (undocumented)
     static compose(validators: (ValidatorFn | null | undefined)[]): ValidatorFn | null;
     static composeAsync(validators: (AsyncValidatorFn | null)[]): AsyncValidatorFn | null;
-    static email(control: AbstractControl): ValidationErrors | null;
+    static email(control: AbstractControl_2): ValidationErrors | null;
     static max(max: number): ValidatorFn;
     static maxLength(maxLength: number): ValidatorFn;
     static min(min: number): ValidatorFn;
     static minLength(minLength: number): ValidatorFn;
-    static nullValidator(control: AbstractControl): ValidationErrors | null;
+    static nullValidator(control: AbstractControl_2): ValidationErrors | null;
     static pattern(pattern: string | RegExp): ValidatorFn;
-    static required(control: AbstractControl): ValidationErrors | null;
-    static requiredTrue(control: AbstractControl): ValidationErrors | null;
+    static required(control: AbstractControl_2): ValidationErrors | null;
+    static requiredTrue(control: AbstractControl_2): ValidationErrors | null;
 }
 
 // @public (undocumented)

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -171,7 +171,7 @@
     "name": "EventManagerPlugin"
   },
   {
-    "name": "FormArray"
+    "name": "FormArray2"
   },
   {
     "name": "FormArrayName"
@@ -180,16 +180,22 @@
     "name": "FormBuilder"
   },
   {
-    "name": "FormControl"
+    "name": "FormControl2"
+  },
+  {
+    "name": "FormControlImpl"
   },
   {
     "name": "FormControlName"
   },
   {
-    "name": "FormGroup"
+    "name": "FormGroup2"
   },
   {
     "name": "FormGroupDirective"
+  },
+  {
+    "name": "FormGroupImpl"
   },
   {
     "name": "FormGroupName"
@@ -1114,15 +1120,6 @@
   },
   {
     "name": "isEmptyInputValue"
-  },
-  {
-    "name": "isFormArray"
-  },
-  {
-    "name": "isFormControl"
-  },
-  {
-    "name": "isFormGroup"
   },
   {
     "name": "isForwardRef"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -174,13 +174,16 @@
     "name": "EventManagerPlugin"
   },
   {
-    "name": "FormArray"
+    "name": "FormControl2"
   },
   {
-    "name": "FormControl"
+    "name": "FormControlImpl"
   },
   {
-    "name": "FormGroup"
+    "name": "FormGroup2"
+  },
+  {
+    "name": "FormGroupImpl"
   },
   {
     "name": "FormsExampleModule"
@@ -600,12 +603,6 @@
     "name": "applyViewChange"
   },
   {
-    "name": "assertAllValuesPresent"
-  },
-  {
-    "name": "assertControlPresent"
-  },
-  {
     "name": "attachInjectFlag"
   },
   {
@@ -948,9 +945,6 @@
     "name": "getPromiseCtor"
   },
   {
-    "name": "getRawValue"
-  },
-  {
     "name": "getSelectedIndex"
   },
   {
@@ -1087,9 +1081,6 @@
   },
   {
     "name": "isDirectiveHost"
-  },
-  {
-    "name": "isFormGroup"
   },
   {
     "name": "isForwardRef"

--- a/packages/forms/src/directives/abstract_control_directive.ts
+++ b/packages/forms/src/directives/abstract_control_directive.ts
@@ -8,7 +8,7 @@
 
 import {Observable} from 'rxjs';
 
-import {AbstractControl} from '../model';
+import {AbstractControl} from '../model/api';
 import {composeAsyncValidators, composeValidators} from '../validators';
 
 import {AsyncValidator, AsyncValidatorFn, ValidationErrors, Validator, ValidatorFn} from './validators';

--- a/packages/forms/src/directives/abstract_form_group_directive.ts
+++ b/packages/forms/src/directives/abstract_form_group_directive.ts
@@ -8,7 +8,7 @@
 
 import {Directive, OnDestroy, OnInit} from '@angular/core';
 
-import {FormGroup} from '../model';
+import {FormGroup} from '../model/api';
 
 import {ControlContainer} from './control_container';
 import {Form} from './form_interface';

--- a/packages/forms/src/directives/form_interface.ts
+++ b/packages/forms/src/directives/form_interface.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {FormControl, FormGroup} from '../model';
+import {FormControl, FormGroup} from '../model/api';
 
 import {AbstractFormGroupDirective} from './abstract_form_group_directive';
 import {NgControl} from './ng_control';

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -8,7 +8,8 @@
 
 import {AfterViewInit, Directive, EventEmitter, forwardRef, Inject, Input, Optional, Self} from '@angular/core';
 
-import {AbstractControl, FormControl, FormGroup, FormHooks} from '../model';
+import {AbstractControl, FormControl, FormHooks} from '../model/api';
+import {FormGroup} from '../model/form_group';
 import {composeAsyncValidators, composeValidators, NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
 
 import {ControlContainer} from './control_container';

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -8,7 +8,8 @@
 
 import {ChangeDetectorRef, Directive, EventEmitter, forwardRef, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, ɵcoerceToBoolean as coerceToBoolean} from '@angular/core';
 
-import {FormControl, FormHooks} from '../model';
+import {FormHooks} from '../model/api';
+import {FormControl} from '../model/form_control';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../validators';
 
 import {AbstractFormGroupDirective} from './abstract_form_group_directive';

--- a/packages/forms/src/directives/reactive_directives/form_control_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_directive.ts
@@ -8,7 +8,7 @@
 
 import {Directive, EventEmitter, forwardRef, Inject, InjectionToken, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges} from '@angular/core';
 
-import {FormControl} from '../../model';
+import {FormControl} from '../../model/api';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '../control_value_accessor';
 import {NgControl} from '../ng_control';

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -8,7 +8,7 @@
 
 import {Directive, EventEmitter, forwardRef, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges, SkipSelf} from '@angular/core';
 
-import {FormControl} from '../../model';
+import {FormControl} from '../../model/api';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {AbstractFormGroupDirective} from '../abstract_form_group_directive';
 import {ControlContainer} from '../control_container';

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -8,7 +8,8 @@
 
 import {Directive, EventEmitter, forwardRef, Inject, Input, OnChanges, OnDestroy, Optional, Output, Self, SimpleChanges} from '@angular/core';
 
-import {FormArray, FormControl, FormGroup, isFormControl} from '../../model';
+import {FormArray, FormGroup} from '../../model/api';
+import {FormControl} from '../../model/form_control';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {ControlContainer} from '../control_container';
 import {Form} from '../form_interface';
@@ -307,7 +308,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
         // Note: we don't need to clear the list of directives (`this.directives`) here, it would be
         // taken care of in the `removeControl` method invoked when corresponding `formControlName`
         // directive instance is being removed (invoked from `FormControlName.ngOnDestroy`).
-        if (isFormControl(newCtrl)) {
+        if (newCtrl instanceof FormControl) {
           setUpControl(newCtrl, dir);
           (dir as {control: FormControl}).control = newCtrl;
         }

--- a/packages/forms/src/directives/reactive_directives/form_group_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_name.ts
@@ -8,7 +8,7 @@
 
 import {Directive, forwardRef, Host, Inject, Input, OnDestroy, OnInit, Optional, Self, SkipSelf} from '@angular/core';
 
-import {FormArray} from '../../model';
+import {FormArray} from '../../model/api';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
 import {AbstractFormGroupDirective} from '../abstract_form_group_directive';
 import {ControlContainer} from '../control_container';

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbstractControl, FormArray, FormControl, FormGroup} from '../model';
+import {AbstractControl, FormArray, FormControl, FormGroup} from '../model/api';
 import {getControlAsyncValidators, getControlValidators, mergeValidators} from '../validators';
 
 import {AbstractControlDirective} from './abstract_control_directive';

--- a/packages/forms/src/directives/validators.ts
+++ b/packages/forms/src/directives/validators.ts
@@ -9,7 +9,7 @@
 import {Directive, forwardRef, Input, OnChanges, SimpleChanges, StaticProvider, ɵcoerceToBoolean as coerceToBoolean} from '@angular/core';
 import {Observable} from 'rxjs';
 
-import {AbstractControl} from '../model';
+import {AbstractControl} from '../model/api';
 import {emailValidator, maxLengthValidator, maxValidator, minLengthValidator, minValidator, NG_VALIDATORS, nullValidator, patternValidator, requiredTrueValidator, requiredValidator} from '../validators';
 
 /**

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -10,7 +10,11 @@ import {Injectable} from '@angular/core';
 
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
 import {ReactiveFormsModule} from './form_providers';
-import {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlOptions, FormGroup, FormHooks, isFormArray, isFormControl, isFormGroup} from './model';
+import {AbstractControl} from './model/abstract_control';
+import {AbstractControlOptions, FormControlOptions, FormHooks} from './model/api';
+import {FormArray} from './model/form_array';
+import {FormControl,} from './model/form_control';
+import {FormGroup} from './model/form_group';
 
 function isAbstractControlOptions(options: AbstractControlOptions|
                                   {[key: string]: any}): options is AbstractControlOptions {
@@ -165,7 +169,8 @@ export class FormBuilder {
 
   /** @internal */
   _createControl(controlConfig: any): AbstractControl {
-    if (isFormControl(controlConfig) || isFormGroup(controlConfig) || isFormArray(controlConfig)) {
+    if (controlConfig instanceof FormControl || controlConfig instanceof FormGroup ||
+        controlConfig instanceof FormArray) {
       return controlConfig;
 
     } else if (Array.isArray(controlConfig)) {

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -42,7 +42,11 @@ export {NgSelectOption, SelectControlValueAccessor} from './directives/select_co
 export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlOptions, FormControlStatus, FormGroup, ɵFormControlCtor} from './model';
+export {AbstractControl} from './model/abstract_control';
+export {AbstractControlOptions, FormControlOptions, FormControlStatus} from './model/api';
+export {FormArray, ɵFormArrayCtor} from './model/form_array';
+export {FormControl, ɵFormControlCtor} from './model/form_control';
+export {FormGroup, ɵFormGroupCtor} from './model/form_group';
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';
 export {VERSION} from './version';
 

--- a/packages/forms/src/model/abstract_control.ts
+++ b/packages/forms/src/model/abstract_control.ts
@@ -1,0 +1,486 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {EventEmitter} from '@angular/core';
+import {Observable} from 'rxjs';
+
+import {AsyncValidatorFn, ValidationErrors, ValidatorFn} from '../directives/validators';
+import {addValidators, hasValidator, removeValidators, toObservable} from '../validators';
+
+import {AbstractControl as IAbstractControl, AbstractControlOptions, DISABLED, FormArray, FormControlStatus, FormGroup, FormHooks, INVALID, PENDING, VALID} from './api';
+import {_find, coerceToAsyncValidator, coerceToValidator, isOptionsObj} from './util';
+
+const AbstractControlImpl = function() {
+  // We use an IIFE for the initialization here because class expressions cannot be abstract.
+
+  abstract class AbstractControl implements IAbstractControl {
+    /** @internal */
+    _pendingDirty = false;
+
+    /** @internal */
+    _hasOwnPendingAsyncValidator = false;
+
+    /** @internal */
+    _pendingTouched = false;
+
+    /** @internal */
+    _onCollectionChange = () => {};
+
+    /** @internal */
+    _updateOn?: FormHooks;
+
+    private _parent: FormGroup|FormArray|null = null;
+    private _asyncValidationSubscription: any;
+
+    private _composedValidatorFn: ValidatorFn|null;
+
+    private _composedAsyncValidatorFn: AsyncValidatorFn|null;
+
+    private _rawValidators: ValidatorFn|ValidatorFn[]|null;
+
+    private _rawAsyncValidators: AsyncValidatorFn|AsyncValidatorFn[]|null;
+
+    public readonly value: any;
+
+    constructor(
+        validators: ValidatorFn|ValidatorFn[]|null,
+        asyncValidators: AsyncValidatorFn|AsyncValidatorFn[]|null) {
+      this._rawValidators = validators;
+      this._rawAsyncValidators = asyncValidators;
+      this._composedValidatorFn = coerceToValidator(this._rawValidators);
+      this._composedAsyncValidatorFn = coerceToAsyncValidator(this._rawAsyncValidators);
+    }
+
+
+    get validator(): ValidatorFn|null {
+      return this._composedValidatorFn;
+    }
+
+    set validator(validatorFn: ValidatorFn|null) {
+      this._rawValidators = this._composedValidatorFn = validatorFn;
+    }
+
+    get asyncValidator(): AsyncValidatorFn|null {
+      return this._composedAsyncValidatorFn;
+    }
+
+    set asyncValidator(asyncValidatorFn: AsyncValidatorFn|null) {
+      this._rawAsyncValidators = this._composedAsyncValidatorFn = asyncValidatorFn;
+    }
+
+    get parent(): FormGroup|FormArray|null {
+      return this._parent;
+    }
+
+    public readonly status!: FormControlStatus;
+
+    get valid(): boolean {
+      return this.status === VALID;
+    }
+
+    get invalid(): boolean {
+      return this.status === INVALID;
+    }
+
+    get pending(): boolean {
+      return this.status == PENDING;
+    }
+
+    get disabled(): boolean {
+      return this.status === DISABLED;
+    }
+
+    get enabled(): boolean {
+      return this.status !== DISABLED;
+    }
+
+    public readonly errors!: ValidationErrors|null;
+
+    public readonly pristine: boolean = true;
+
+    get dirty(): boolean {
+      return !this.pristine;
+    }
+
+    public readonly touched: boolean = false;
+
+    get untouched(): boolean {
+      return !this.touched;
+    }
+
+    public readonly valueChanges!: Observable<any>;
+
+    public readonly statusChanges!: Observable<FormControlStatus>;
+
+    get updateOn(): FormHooks {
+      return this._updateOn ? this._updateOn : (this.parent ? this.parent.updateOn : 'change');
+    }
+
+    setValidators(validators: ValidatorFn|ValidatorFn[]|null): void {
+      this._rawValidators = validators;
+      this._composedValidatorFn = coerceToValidator(validators);
+    }
+
+    setAsyncValidators(validators: AsyncValidatorFn|AsyncValidatorFn[]|null): void {
+      this._rawAsyncValidators = validators;
+      this._composedAsyncValidatorFn = coerceToAsyncValidator(validators);
+    }
+
+    addValidators(validators: ValidatorFn|ValidatorFn[]): void {
+      this.setValidators(addValidators(validators, this._rawValidators));
+    }
+
+    addAsyncValidators(validators: AsyncValidatorFn|AsyncValidatorFn[]): void {
+      this.setAsyncValidators(addValidators(validators, this._rawAsyncValidators));
+    }
+
+    removeValidators(validators: ValidatorFn|ValidatorFn[]): void {
+      this.setValidators(removeValidators(validators, this._rawValidators));
+    }
+
+    removeAsyncValidators(validators: AsyncValidatorFn|AsyncValidatorFn[]): void {
+      this.setAsyncValidators(removeValidators(validators, this._rawAsyncValidators));
+    }
+
+    hasValidator(validator: ValidatorFn): boolean {
+      return hasValidator(this._rawValidators, validator);
+    }
+
+    hasAsyncValidator(validator: AsyncValidatorFn): boolean {
+      return hasValidator(this._rawAsyncValidators, validator);
+    }
+
+    clearValidators(): void {
+      this.validator = null;
+    }
+
+    clearAsyncValidators(): void {
+      this.asyncValidator = null;
+    }
+
+    markAsTouched(opts: {onlySelf?: boolean} = {}): void {
+      (this as {touched: boolean}).touched = true;
+
+      if (this._parent && !opts.onlySelf) {
+        this._parent.markAsTouched(opts);
+      }
+    }
+
+    markAllAsTouched(): void {
+      this.markAsTouched({onlySelf: true});
+
+      this._forEachChild((control: AbstractControl) => control.markAllAsTouched());
+    }
+
+    markAsUntouched(opts: {onlySelf?: boolean} = {}): void {
+      (this as {touched: boolean}).touched = false;
+      this._pendingTouched = false;
+
+      this._forEachChild((control: AbstractControl) => {
+        control.markAsUntouched({onlySelf: true});
+      });
+
+      if (this._parent && !opts.onlySelf) {
+        this._parent._updateTouched(opts);
+      }
+    }
+
+    markAsDirty(opts: {onlySelf?: boolean} = {}): void {
+      (this as {pristine: boolean}).pristine = false;
+
+      if (this._parent && !opts.onlySelf) {
+        this._parent.markAsDirty(opts);
+      }
+    }
+
+    markAsPristine(opts: {onlySelf?: boolean} = {}): void {
+      (this as {pristine: boolean}).pristine = true;
+      this._pendingDirty = false;
+
+      this._forEachChild((control: AbstractControl) => {
+        control.markAsPristine({onlySelf: true});
+      });
+
+      if (this._parent && !opts.onlySelf) {
+        this._parent._updatePristine(opts);
+      }
+    }
+
+    markAsPending(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+      (this as {status: FormControlStatus}).status = PENDING;
+
+      if (opts.emitEvent !== false) {
+        (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
+      }
+
+      if (this._parent && !opts.onlySelf) {
+        this._parent.markAsPending(opts);
+      }
+    }
+
+    disable(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+      // If parent has been marked artificially dirty we don't want to re-calculate the
+      // parent's dirtiness based on the children.
+      const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
+
+      (this as {status: FormControlStatus}).status = DISABLED;
+      (this as {errors: ValidationErrors | null}).errors = null;
+      this._forEachChild((control: AbstractControl) => {
+        control.disable({...opts, onlySelf: true});
+      });
+      this._updateValue();
+
+      if (opts.emitEvent !== false) {
+        (this.valueChanges as EventEmitter<any>).emit(this.value);
+        (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
+      }
+
+      this._updateAncestors({...opts, skipPristineCheck});
+      this._onDisabledChange.forEach((changeFn) => changeFn(true));
+    }
+
+    enable(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+      // If parent has been marked artificially dirty we don't want to re-calculate the
+      // parent's dirtiness based on the children.
+      const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
+
+      (this as {status: FormControlStatus}).status = VALID;
+      this._forEachChild((control: AbstractControl) => {
+        control.enable({...opts, onlySelf: true});
+      });
+      this.updateValueAndValidity({onlySelf: true, emitEvent: opts.emitEvent});
+
+      this._updateAncestors({...opts, skipPristineCheck});
+      this._onDisabledChange.forEach((changeFn) => changeFn(false));
+    }
+
+    private _updateAncestors(
+        opts: {onlySelf?: boolean, emitEvent?: boolean, skipPristineCheck?: boolean}) {
+      if (this._parent && !opts.onlySelf) {
+        this._parent.updateValueAndValidity(opts);
+        if (!opts.skipPristineCheck) {
+          this._parent._updatePristine();
+        }
+        this._parent._updateTouched();
+      }
+    }
+
+    setParent(parent: FormGroup|FormArray): void {
+      this._parent = parent;
+    }
+
+    abstract setValue(value: any, options?: Object): void;
+
+    abstract patchValue(value: any, options?: Object): void;
+
+    abstract reset(value?: any, options?: Object): void;
+
+    updateValueAndValidity(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+      this._setInitialStatus();
+      this._updateValue();
+
+      if (this.enabled) {
+        this._cancelExistingSubscription();
+        (this as {errors: ValidationErrors | null}).errors = this._runValidator();
+        (this as {status: FormControlStatus}).status = this._calculateStatus();
+
+        if (this.status === VALID || this.status === PENDING) {
+          this._runAsyncValidator(opts.emitEvent);
+        }
+      }
+
+      if (opts.emitEvent !== false) {
+        (this.valueChanges as EventEmitter<any>).emit(this.value);
+        (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
+      }
+
+      if (this._parent && !opts.onlySelf) {
+        this._parent.updateValueAndValidity(opts);
+      }
+    }
+
+    /** @internal */
+    _updateTreeValidity(opts: {emitEvent?: boolean} = {emitEvent: true}) {
+      this._forEachChild((ctrl: AbstractControl) => ctrl._updateTreeValidity(opts));
+      this.updateValueAndValidity({onlySelf: true, emitEvent: opts.emitEvent});
+    }
+
+    private _setInitialStatus() {
+      (this as {status: FormControlStatus}).status = this._allControlsDisabled() ? DISABLED : VALID;
+    }
+
+    private _runValidator(): ValidationErrors|null {
+      return this.validator ? this.validator(this) : null;
+    }
+
+    private _runAsyncValidator(emitEvent?: boolean): void {
+      if (this.asyncValidator) {
+        (this as {status: FormControlStatus}).status = PENDING;
+        this._hasOwnPendingAsyncValidator = true;
+        const obs = toObservable(this.asyncValidator(this));
+        this._asyncValidationSubscription = obs.subscribe((errors: ValidationErrors|null) => {
+          this._hasOwnPendingAsyncValidator = false;
+          // This will trigger the recalculation of the validation status, which depends on
+          // the state of the asynchronous validation (whether it is in progress or not). So, it is
+          // necessary that we have updated the `_hasOwnPendingAsyncValidator` boolean flag first.
+          this.setErrors(errors, {emitEvent});
+        });
+      }
+    }
+
+    private _cancelExistingSubscription(): void {
+      if (this._asyncValidationSubscription) {
+        this._asyncValidationSubscription.unsubscribe();
+        this._hasOwnPendingAsyncValidator = false;
+      }
+    }
+
+    setErrors(errors: ValidationErrors|null, opts: {emitEvent?: boolean} = {}): void {
+      (this as {errors: ValidationErrors | null}).errors = errors;
+      this._updateControlsErrors(opts.emitEvent !== false);
+    }
+
+    get(path: Array<string|number>|string): IAbstractControl|null {
+      return _find(this, path, '.');
+    }
+
+    getError(errorCode: string, path?: Array<string|number>|string): any {
+      const control = path ? this.get(path) : this;
+      return control && control.errors ? control.errors[errorCode] : null;
+    }
+
+    hasError(errorCode: string, path?: Array<string|number>|string): boolean {
+      return !!this.getError(errorCode, path);
+    }
+
+    get root(): IAbstractControl {
+      let x: IAbstractControl = this;
+
+      while (x.parent) {
+        x = x.parent;
+      }
+
+      return x;
+    }
+
+    /** @internal */
+    _updateControlsErrors(emitEvent: boolean): void {
+      (this as {status: FormControlStatus}).status = this._calculateStatus();
+
+      if (emitEvent) {
+        (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
+      }
+
+      if (this._parent) {
+        this._parent._updateControlsErrors(emitEvent);
+      }
+    }
+
+    /** @internal */
+    _initObservables() {
+      (this as {valueChanges: Observable<any>}).valueChanges = new EventEmitter();
+      (this as {statusChanges: Observable<FormControlStatus>}).statusChanges = new EventEmitter();
+    }
+
+    private _calculateStatus(): FormControlStatus {
+      if (this._allControlsDisabled()) return DISABLED;
+      if (this.errors) return INVALID;
+      if (this._hasOwnPendingAsyncValidator || this._anyControlsHaveStatus(PENDING)) return PENDING;
+      if (this._anyControlsHaveStatus(INVALID)) return INVALID;
+      return VALID;
+    }
+
+    /** @internal */
+    abstract _updateValue(): void;
+
+    /** @internal */
+    abstract _forEachChild(cb: (c: AbstractControl) => void): void;
+
+    /** @internal */
+    abstract _anyControls(condition: (c: AbstractControl) => boolean): boolean;
+
+    /** @internal */
+    abstract _allControlsDisabled(): boolean;
+
+    /** @internal */
+    abstract _syncPendingControls(): boolean;
+
+    /** @internal */
+    _anyControlsHaveStatus(status: FormControlStatus): boolean {
+      return this._anyControls((control: AbstractControl) => control.status === status);
+    }
+
+    /** @internal */
+    _anyControlsDirty(): boolean {
+      return this._anyControls((control: AbstractControl) => control.dirty);
+    }
+
+    /** @internal */
+    _anyControlsTouched(): boolean {
+      return this._anyControls((control: AbstractControl) => control.touched);
+    }
+
+    /** @internal */
+    _updatePristine(opts: {onlySelf?: boolean} = {}): void {
+      (this as {pristine: boolean}).pristine = !this._anyControlsDirty();
+
+      if (this._parent && !opts.onlySelf) {
+        this._parent._updatePristine(opts);
+      }
+    }
+
+    /** @internal */
+    _updateTouched(opts: {onlySelf?: boolean} = {}): void {
+      (this as {touched: boolean}).touched = this._anyControlsTouched();
+
+      if (this._parent && !opts.onlySelf) {
+        this._parent._updateTouched(opts);
+      }
+    }
+
+    /** @internal */
+    _onDisabledChange: Array<(isDisabled: boolean) => void> = [];
+
+    /** @internal */
+    _isBoxedValue(formState: any): boolean {
+      return typeof formState === 'object' && formState !== null &&
+          Object.keys(formState).length === 2 && 'value' in formState && 'disabled' in formState;
+    }
+
+    /** @internal */
+    _registerOnCollectionChange(fn: () => void): void {
+      this._onCollectionChange = fn;
+    }
+
+    /** @internal */
+    _setUpdateStrategy(opts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null): void {
+      if (isOptionsObj(opts) && opts.updateOn != null) {
+        this._updateOn = opts.updateOn!;
+      }
+    }
+
+    /** @internal */
+    _find(name: string|number): AbstractControl|null {
+      return null;
+    }
+
+    private _parentMarkedDirty(onlySelf?: boolean): boolean {
+      const parentDirty = this._parent && this._parent.dirty;
+      return !onlySelf && !!parentDirty && !this._parent!._anyControlsDirty();
+    }
+  }
+
+  return AbstractControl;
+}();
+
+type AbstractControlCtor = abstract new (
+    validators: ValidatorFn|ValidatorFn[]|null,
+    asyncValidators: AsyncValidatorFn|AsyncValidatorFn[]|null) => IAbstractControl;
+
+export const AbstractControl: AbstractControlCtor = AbstractControlImpl as AbstractControlCtor;
+export type AbstractControl = IAbstractControl;

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
+
+import {AbstractControl} from './abstract_control';
+import {AbstractControlOptions, FormArray as IFormArray} from './api';
+import {getRawValue} from './form_control';
+import {assertAllValuesPresent, assertControlPresent} from './form_group';
+import {pickAsyncValidators, pickValidators} from './util';
+
+const FormArrayImpl = class FormArray extends AbstractControl implements IFormArray {
+  constructor(
+      public controls: AbstractControl[],
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null) {
+    super(pickValidators(validatorOrOpts), pickAsyncValidators(asyncValidator, validatorOrOpts));
+    this._initObservables();
+    this._setUpdateStrategy(validatorOrOpts);
+    this._setUpControls();
+    this.updateValueAndValidity({
+      onlySelf: true,
+      // If `asyncValidator` is present, it will trigger control status change from `PENDING` to
+      // `VALID` or `INVALID`.
+      // The status should be broadcasted via the `statusChanges` observable, so we set `emitEvent`
+      // to `true` to allow that during the control creation process.
+      emitEvent: !!this.asyncValidator
+    });
+  }
+
+  at(index: number): AbstractControl {
+    return this.controls[this._adjustIndex(index)];
+  }
+
+  push(control: AbstractControl, options: {emitEvent?: boolean} = {}): void {
+    this.controls.push(control);
+    this._registerControl(control);
+    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this._onCollectionChange();
+  }
+
+  insert(index: number, control: AbstractControl, options: {emitEvent?: boolean} = {}): void {
+    this.controls.splice(index, 0, control);
+
+    this._registerControl(control);
+    this.updateValueAndValidity({emitEvent: options.emitEvent});
+  }
+
+  removeAt(index: number, options: {emitEvent?: boolean} = {}): void {
+    // Adjust the index, then clamp it at no less than 0 to prevent undesired underflows.
+    let adjustedIndex = this._adjustIndex(index);
+    if (adjustedIndex < 0) adjustedIndex = 0;
+
+    if (this.controls[adjustedIndex])
+      this.controls[adjustedIndex]._registerOnCollectionChange(() => {});
+    this.controls.splice(adjustedIndex, 1);
+    this.updateValueAndValidity({emitEvent: options.emitEvent});
+  }
+
+  setControl(index: number, control: AbstractControl, options: {emitEvent?: boolean} = {}): void {
+    // Adjust the index, then clamp it at no less than 0 to prevent undesired underflows.
+    let adjustedIndex = this._adjustIndex(index);
+    if (adjustedIndex < 0) adjustedIndex = 0;
+
+    if (this.controls[adjustedIndex])
+      this.controls[adjustedIndex]._registerOnCollectionChange(() => {});
+    this.controls.splice(adjustedIndex, 1);
+
+    if (control) {
+      this.controls.splice(adjustedIndex, 0, control);
+      this._registerControl(control);
+    }
+
+    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this._onCollectionChange();
+  }
+
+  get length(): number {
+    return this.controls.length;
+  }
+
+  override setValue(value: any[], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    assertAllValuesPresent(this, value);
+    value.forEach((newValue: any, index: number) => {
+      assertControlPresent(this, index);
+      this.at(index).setValue(newValue, {onlySelf: true, emitEvent: options.emitEvent});
+    });
+    this.updateValueAndValidity(options);
+  }
+
+  override patchValue(value: any[], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    // Even though the `value` argument type doesn't allow `null` and `undefined` values, the
+    // `patchValue` can be called recursively and inner data structures might have these values, so
+    // we just ignore such cases when a field containing FormArray instance receives `null` or
+    // `undefined` as a value.
+    if (value == null /* both `null` and `undefined` */) return;
+
+    value.forEach((newValue: any, index: number) => {
+      if (this.at(index)) {
+        this.at(index).patchValue(newValue, {onlySelf: true, emitEvent: options.emitEvent});
+      }
+    });
+    this.updateValueAndValidity(options);
+  }
+
+  override reset(value: any = [], options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    this._forEachChild((control: AbstractControl, index: number) => {
+      control.reset(value[index], {onlySelf: true, emitEvent: options.emitEvent});
+    });
+    this._updatePristine(options);
+    this._updateTouched(options);
+    this.updateValueAndValidity(options);
+  }
+
+  getRawValue(): any[] {
+    return this.controls.map(control => getRawValue(control));
+  }
+
+  clear(options: {emitEvent?: boolean} = {}): void {
+    if (this.controls.length < 1) return;
+    this._forEachChild((control: AbstractControl) => control._registerOnCollectionChange(() => {}));
+    this.controls.splice(0);
+    this.updateValueAndValidity({emitEvent: options.emitEvent});
+  }
+
+  /**
+   * Adjusts a negative index by summing it with the length of the array. For very negative indices,
+   * the result may remain negative.
+   */
+  private _adjustIndex(index: number): number {
+    return index < 0 ? index + this.length : index;
+  }
+
+  /** @internal */
+  override _syncPendingControls(): boolean {
+    let subtreeUpdated = this.controls.reduce((updated: boolean, child: AbstractControl) => {
+      return child._syncPendingControls() ? true : updated;
+    }, false);
+    if (subtreeUpdated) this.updateValueAndValidity({onlySelf: true});
+    return subtreeUpdated;
+  }
+
+  /** @internal */
+  override _forEachChild(cb: (c: AbstractControl, index: number) => void): void {
+    this.controls.forEach((control: AbstractControl, index: number) => {
+      cb(control, index);
+    });
+  }
+
+  /** @internal */
+  override _updateValue(): void {
+    (this as {value: any}).value =
+        this.controls.filter((control) => control.enabled || this.disabled)
+            .map((control) => control.value);
+  }
+
+  /** @internal */
+  override _anyControls(condition: (c: AbstractControl) => boolean): boolean {
+    return this.controls.some((control: AbstractControl) => control.enabled && condition(control));
+  }
+
+  /** @internal */
+  _setUpControls(): void {
+    this._forEachChild((control: AbstractControl) => this._registerControl(control));
+  }
+
+  /** @internal */
+  override _allControlsDisabled(): boolean {
+    for (const control of this.controls) {
+      if (control.enabled) return false;
+    }
+    return this.controls.length > 0 || this.disabled;
+  }
+
+  /** @internal */
+  override _find(name: string|number): AbstractControl|null {
+    return this.at(name as number) || null;
+  }
+
+  private _registerControl(control: AbstractControl) {
+    control.setParent(this);
+    control._registerOnCollectionChange(this._onCollectionChange);
+  }
+};
+
+export interface ɵFormArrayCtor {
+  new(controls: AbstractControl[],
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): IFormArray;
+}
+
+export const FormArray: ɵFormArrayCtor = FormArrayImpl;
+export type FormArray = IFormArray;

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -1,0 +1,139 @@
+
+import {removeListItem} from '../directives/shared';
+import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
+
+import {AbstractControl} from './abstract_control';
+import {FormArray as IFormArray, FormControl as IFormControl, FormControlOptions, FormGroup as IFormGroup} from './api';
+import {isOptionsObj, pickAsyncValidators, pickValidators} from './util';
+
+const FormControlImpl = class FormControl extends AbstractControl implements IFormControl {
+  public readonly defaultValue: any = null;
+
+  _onChange: Function[] = [];
+
+  _pendingValue: any;
+
+  _pendingChange: boolean = false;
+
+  constructor(
+      formState: any = null, validatorOrOpts?: ValidatorFn|ValidatorFn[]|FormControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null) {
+    super(pickValidators(validatorOrOpts), pickAsyncValidators(asyncValidator, validatorOrOpts));
+    this._applyFormState(formState);
+    this._setUpdateStrategy(validatorOrOpts);
+    this._initObservables();
+    this.updateValueAndValidity({
+      onlySelf: true,
+      // If `asyncValidator` is present, it will trigger control status change from `PENDING` to
+      // `VALID` or `INVALID`.
+      // The status should be broadcasted via the `statusChanges` observable, so we set
+      // `emitEvent` to `true` to allow that during the control creation process.
+      emitEvent: !!this.asyncValidator
+    });
+    if (isOptionsObj(validatorOrOpts) && validatorOrOpts.initialValueIsDefault) {
+      if (this._isBoxedValue(formState)) {
+        (this.defaultValue as any) = formState.value;
+      } else {
+        (this.defaultValue as any) = formState;
+      }
+    }
+  }
+
+  override setValue(value: any, options: {
+    onlySelf?: boolean,
+    emitEvent?: boolean,
+    emitModelToViewChange?: boolean,
+    emitViewToModelChange?: boolean
+  } = {}): void {
+    (this as {value: any}).value = this._pendingValue = value;
+    if (this._onChange.length && options.emitModelToViewChange !== false) {
+      this._onChange.forEach(
+          (changeFn) => changeFn(this.value, options.emitViewToModelChange !== false));
+    }
+    this.updateValueAndValidity(options);
+  }
+
+  override patchValue(value: any, options: {
+    onlySelf?: boolean,
+    emitEvent?: boolean,
+    emitModelToViewChange?: boolean,
+    emitViewToModelChange?: boolean
+  } = {}): void {
+    this.setValue(value, options);
+  }
+
+  override reset(formState: any = this.defaultValue, options: {
+    onlySelf?: boolean,
+    emitEvent?: boolean
+  } = {}): void {
+    this._applyFormState(formState);
+    this.markAsPristine(options);
+    this.markAsUntouched(options);
+    this.setValue(this.value, options);
+    this._pendingChange = false;
+  }
+
+  override _updateValue(): void {}
+
+  override _anyControls(condition: (c: AbstractControl) => boolean): boolean {
+    return false;
+  }
+
+  override _allControlsDisabled(): boolean {
+    return this.disabled;
+  }
+
+  registerOnChange(fn: Function): void {
+    this._onChange.push(fn);
+  }
+
+  _unregisterOnChange(fn: (value?: any, emitModelEvent?: boolean) => void): void {
+    removeListItem(this._onChange, fn);
+  }
+
+  registerOnDisabledChange(fn: (isDisabled: boolean) => void): void {
+    this._onDisabledChange.push(fn);
+  }
+
+  _unregisterOnDisabledChange(fn: (isDisabled: boolean) => void): void {
+    removeListItem(this._onDisabledChange, fn);
+  }
+
+  override _forEachChild(cb: (c: AbstractControl) => void): void {}
+
+  override _syncPendingControls(): boolean {
+    if (this.updateOn === 'submit') {
+      if (this._pendingDirty) this.markAsDirty();
+      if (this._pendingTouched) this.markAsTouched();
+      if (this._pendingChange) {
+        this.setValue(this._pendingValue, {onlySelf: true, emitModelToViewChange: false});
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private _applyFormState(formState: any) {
+    if (this._isBoxedValue(formState)) {
+      (this as {value: any}).value = this._pendingValue = formState.value;
+      formState.disabled ? this.disable({onlySelf: true, emitEvent: false}) :
+                           this.enable({onlySelf: true, emitEvent: false});
+    } else {
+      (this as {value: any}).value = this._pendingValue = formState;
+    }
+  }
+}
+
+export interface ɵFormControlCtor {
+  new(formState?: any, validatorOrOpts?: ValidatorFn|ValidatorFn[]|FormControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): IFormControl;
+}
+
+export const FormControl: ɵFormControlCtor = FormControlImpl as ɵFormControlCtor;
+export type FormControl = IFormControl;
+
+
+export function getRawValue(control: AbstractControl): any {
+  return control instanceof FormControlImpl ? control.value :
+                                              (control as IFormGroup | IFormArray).getRawValue();
+}

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -1,0 +1,227 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ɵRuntimeError as RuntimeError} from '@angular/core';
+
+import {missingControlError, missingControlValueError, noControlsError} from '../directives/reactive_errors';
+import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
+import {RuntimeErrorCode} from '../errors';
+
+import {AbstractControl} from './abstract_control';
+import {AbstractControlOptions, FormArray as IFormArray, FormGroup as IFormGroup} from './api';
+import {getRawValue} from './form_control';
+import {pickAsyncValidators, pickValidators} from './util';
+
+const FormGroupImpl = class FormGroup extends AbstractControl implements IFormGroup {
+  constructor(
+      public controls: {[key: string]: AbstractControl},
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null) {
+    super(pickValidators(validatorOrOpts), pickAsyncValidators(asyncValidator, validatorOrOpts));
+    this._initObservables();
+    this._setUpdateStrategy(validatorOrOpts);
+    this._setUpControls();
+    this.updateValueAndValidity({
+      onlySelf: true,
+      // If `asyncValidator` is present, it will trigger control status change from `PENDING` to
+      // `VALID` or `INVALID`. The status should be broadcasted via the `statusChanges` observable,
+      // so we set `emitEvent` to `true` to allow that during the control creation process.
+      emitEvent: !!this.asyncValidator
+    });
+  }
+
+  registerControl(name: string, control: AbstractControl): AbstractControl {
+    if (this.controls[name]) return this.controls[name];
+    this.controls[name] = control;
+    control.setParent(this);
+    control._registerOnCollectionChange(this._onCollectionChange);
+    return control;
+  }
+
+  addControl(name: string, control: AbstractControl, options: {emitEvent?: boolean} = {}): void {
+    this.registerControl(name, control);
+    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this._onCollectionChange();
+  }
+
+  removeControl(name: string, options: {emitEvent?: boolean} = {}): void {
+    if (this.controls[name]) this.controls[name]._registerOnCollectionChange(() => {});
+    delete (this.controls[name]);
+    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this._onCollectionChange();
+  }
+
+  setControl(name: string, control: AbstractControl, options: {emitEvent?: boolean} = {}): void {
+    if (this.controls[name]) this.controls[name]._registerOnCollectionChange(() => {});
+    delete (this.controls[name]);
+    if (control) this.registerControl(name, control);
+    this.updateValueAndValidity({emitEvent: options.emitEvent});
+    this._onCollectionChange();
+  }
+
+  contains(controlName: string): boolean {
+    return this.controls.hasOwnProperty(controlName) && this.controls[controlName].enabled;
+  }
+
+  override setValue(
+      value: {[key: string]: any}, options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    assertAllValuesPresent(this, value);
+    Object.keys(value).forEach(name => {
+      assertControlPresent(this, name);
+      this.controls[name].setValue(value[name], {onlySelf: true, emitEvent: options.emitEvent});
+    });
+    this.updateValueAndValidity(options);
+  }
+
+  override patchValue(
+      value: {[key: string]: any}, options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    // Even though the `value` argument type doesn't allow `null` and `undefined` values, the
+    // `patchValue` can be called recursively and inner data structures might have these values, so
+    // we just ignore such cases when a field containing FormGroup instance receives `null` or
+    // `undefined` as a value.
+    if (value == null /* both `null` and `undefined` */) return;
+
+    Object.keys(value).forEach(name => {
+      if (this.controls[name]) {
+        this.controls[name].patchValue(value[name], {onlySelf: true, emitEvent: options.emitEvent});
+      }
+    });
+    this.updateValueAndValidity(options);
+  }
+
+  override reset(value: any = {}, options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    this._forEachChild((control: AbstractControl, name: string) => {
+      control.reset(value[name], {onlySelf: true, emitEvent: options.emitEvent});
+    });
+    this._updatePristine(options);
+    this._updateTouched(options);
+    this.updateValueAndValidity(options);
+  }
+
+  getRawValue(): any {
+    return this._reduceChildren(
+        {}, (acc: {[k: string]: AbstractControl}, control: AbstractControl, name: string) => {
+          acc[name] = getRawValue(control);
+          return acc;
+        });
+  }
+
+  /** @internal */
+  override _syncPendingControls(): boolean {
+    let subtreeUpdated = this._reduceChildren(false, (updated: boolean, child: AbstractControl) => {
+      return child._syncPendingControls() ? true : updated;
+    });
+    if (subtreeUpdated) this.updateValueAndValidity({onlySelf: true});
+    return subtreeUpdated;
+  }
+
+  /** @internal */
+  override _forEachChild(cb: (v: any, k: string) => void): void {
+    Object.keys(this.controls).forEach(key => {
+      // The list of controls can change (for ex. controls might be removed) while the loop
+      // is running (as a result of invoking Forms API in `valueChanges` subscription), so we
+      // have to null check before invoking the callback.
+      const control = this.controls[key];
+      control && cb(control, key);
+    });
+  }
+
+  /** @internal */
+  _setUpControls(): void {
+    this._forEachChild((control: AbstractControl) => {
+      control.setParent(this);
+      control._registerOnCollectionChange(this._onCollectionChange);
+    });
+  }
+
+  /** @internal */
+  override _updateValue(): void {
+    (this as {value: any}).value = this._reduceValue();
+  }
+
+  /** @internal */
+  override _anyControls(condition: (c: AbstractControl) => boolean): boolean {
+    for (const controlName of Object.keys(this.controls)) {
+      const control = this.controls[controlName];
+      if (this.contains(controlName) && condition(control)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  _reduceValue() {
+    return this._reduceChildren(
+        {}, (acc: {[k: string]: any}, control: AbstractControl, name: string): any => {
+          if (control.enabled || this.disabled) {
+            acc[name] = control.value;
+          }
+          return acc;
+        });
+  }
+
+  /** @internal */
+  _reduceChildren<T>(initValue: T, fn: (acc: T, control: AbstractControl, name: string) => T): T {
+    let res = initValue;
+    this._forEachChild((control: AbstractControl, name: string) => {
+      res = fn(res, control, name);
+    });
+    return res;
+  }
+
+  /** @internal */
+  override _allControlsDisabled(): boolean {
+    for (const controlName of Object.keys(this.controls)) {
+      if (this.controls[controlName].enabled) {
+        return false;
+      }
+    }
+    return Object.keys(this.controls).length > 0 || this.disabled;
+  }
+
+  /** @internal */
+  override _find(name: string|number): AbstractControl|null {
+    return this.controls.hasOwnProperty(name as string) ? this.controls[name as string] : null;
+  }
+}
+
+export interface ɵFormGroupCtor {
+  new(controls: {[key: string]: AbstractControl},
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): IFormGroup;
+}
+
+export const FormGroup: ɵFormGroupCtor = FormGroupImpl;
+export type FormGroup = IFormGroup;
+
+const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
+
+export function assertAllValuesPresent(control: IFormGroup|IFormArray, value: any): void {
+  const isGroup = control instanceof FormGroupImpl;
+  control._forEachChild((_: unknown, key: string|number) => {
+    if (value[key] === undefined) {
+      throw new RuntimeError(
+          RuntimeErrorCode.MISSING_CONTROL_VALUE,
+          NG_DEV_MODE ? missingControlValueError(isGroup, key) : '');
+    }
+  });
+}
+
+export function assertControlPresent(parent: IFormGroup|IFormArray, key: string|number): void {
+  const isGroup = parent instanceof FormGroupImpl;
+  const controls = parent.controls as {[key: string|number]: unknown};
+  const collection = isGroup ? Object.keys(controls) : controls;
+  if (!collection.length) {
+    throw new RuntimeError(
+        RuntimeErrorCode.NO_CONTROLS, NG_DEV_MODE ? noControlsError(isGroup) : '');
+  }
+  if (!controls[key]) {
+    throw new RuntimeError(
+        RuntimeErrorCode.MISSING_CONTROL, NG_DEV_MODE ? missingControlError(isGroup, key) : '');
+  }
+}

--- a/packages/forms/src/model/util.ts
+++ b/packages/forms/src/model/util.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
+import {addValidators, composeAsyncValidators, composeValidators, hasValidator, removeValidators, toObservable} from '../validators';
+
+import {AbstractControl, AbstractControlOptions} from './api';
+
+/**
+ * Creates validator function by combining provided validators.
+ */
+export function coerceToValidator(validator: ValidatorFn|ValidatorFn[]|null): ValidatorFn|null {
+  return Array.isArray(validator) ? composeValidators(validator) : validator || null;
+}
+
+/**
+ * Creates async validator function by combining provided async validators.
+ */
+export function coerceToAsyncValidator(asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|
+                                       null): AsyncValidatorFn|null {
+  return Array.isArray(asyncValidator) ? composeAsyncValidators(asyncValidator) :
+                                         asyncValidator || null;
+}
+
+export function _find(
+    control: AbstractControl, path: Array<string|number>|string, delimiter: string) {
+  if (path == null) return null;
+
+  if (!Array.isArray(path)) {
+    path = path.split(delimiter);
+  }
+  if (Array.isArray(path) && path.length === 0) return null;
+
+  // Not using Array.reduce here due to a Chrome 80 bug
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1049982
+  let controlToFind: AbstractControl|null = control;
+  for (const name of path) {
+    controlToFind = controlToFind && controlToFind._find(name);
+    //   if (isFormGroup(controlToFind)) {
+    //     controlToFind = controlToFind.controls.hasOwnProperty(name as string) ?
+    //         controlToFind.controls[name] :
+    //         null;
+    //   } else if (isFormArray(controlToFind)) {
+    //     controlToFind = controlToFind.at(<number>name) || null;
+    //   } else {
+    //     controlToFind = null;
+    //   }
+  }
+  return controlToFind;
+}
+
+export function isOptionsObj(validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|
+                             null): validatorOrOpts is AbstractControlOptions {
+  return validatorOrOpts != null && !Array.isArray(validatorOrOpts) &&
+      typeof validatorOrOpts === 'object';
+}
+
+
+/**
+ * Gets validators from either an options object or given validators.
+ */
+export function pickValidators(validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|
+                               null): ValidatorFn|ValidatorFn[]|null {
+  return (isOptionsObj(validatorOrOpts) ? validatorOrOpts.validators : validatorOrOpts) || null;
+}
+
+/**
+ * Gets async validators from either an options object or given validators.
+ */
+export function pickAsyncValidators(
+    asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null,
+    validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null): AsyncValidatorFn|
+    AsyncValidatorFn[]|null {
+  return (isOptionsObj(validatorOrOpts) ? validatorOrOpts.asyncValidators : asyncValidator) || null;
+}

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -11,7 +11,7 @@ import {forkJoin, from, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
 import {AsyncValidator, AsyncValidatorFn, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
-import {AbstractControl} from './model';
+import {AbstractControl} from './model/api';
 
 function isEmptyInputValue(value: any): boolean {
   /**


### PR DESCRIPTION
In the forms package, the main abstractions for controls were previously defined in a file `model.ts`, which contained several thousand lines of code. This made changing the forms abstractions in any way a challenging operation. Additionally, there were several import cycles involving this file and other parts of the forms system.

In this commit, `model.ts` is broken out into a number of files. Several strategies were used to effect this refactoring:

 * The interfaces of the main abstractions are interdependent, and are split out into a separate `model/api.ts` file.
 * Each interface is implemented by a private implementation class.
 * Constructors for each abstraction are defined with a separate constructor signature, and a `const` constructor declaration which is merged with
   the interface type.
 * The `_find` operation, which previously depended on `instanceof` checks with the actual constructor types to achieve different behavior for different types of controls, has been refactored to rely on an internal method on the `AbstractControl` hierarchy instead.

Together, these changes will make the forms package much more maintainable, and pave the way for type-specific changes needed to strongly type the forms abstractions.

Note: this PR was originally drafted by @alxhub, but I am shepherding it through review, since it will prepare typed forms for an easier API review.

Co-authored-by: alxhub