### PR TITLE
Small router refactors

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1029,6 +1029,9 @@
     "name": "diPublicInInjector"
   },
   {
+    "name": "dispatch"
+  },
+  {
     "name": "domRendererFactory3"
   },
   {
@@ -1575,9 +1578,6 @@
     "name": "modules"
   },
   {
-    "name": "namedOutletsRedirect"
-  },
-  {
     "name": "nativeAppendChild"
   },
   {
@@ -1876,6 +1876,9 @@
   },
   {
     "name": "tap"
+  },
+  {
+    "name": "throwError5"
   },
   {
     "name": "throwIfEmpty"

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -7,7 +7,7 @@
  */
 
 import {Injector, NgModuleRef} from '@angular/core';
-import {EmptyError, from, Observable, Observer, of} from 'rxjs';
+import {EmptyError, from, Observable, Observer, of, throwError} from 'rxjs';
 import {catchError, concatMap, first, last, map, mergeMap, scan, tap} from 'rxjs/operators';
 
 import {CanLoadFn, LoadedRouterConfig, Route, Routes} from './models';
@@ -33,26 +33,22 @@ class AbsoluteRedirect {
 }
 
 function noMatch(segmentGroup: UrlSegmentGroup): Observable<UrlSegmentGroup> {
-  return new Observable<UrlSegmentGroup>(
-      (obs: Observer<UrlSegmentGroup>) => obs.error(new NoMatch(segmentGroup)));
+  return throwError(new NoMatch(segmentGroup));
 }
 
 function absoluteRedirect(newTree: UrlTree): Observable<any> {
-  return new Observable<UrlSegmentGroup>(
-      (obs: Observer<UrlSegmentGroup>) => obs.error(new AbsoluteRedirect(newTree)));
+  return throwError(new AbsoluteRedirect(newTree));
 }
 
 function namedOutletsRedirect(redirectTo: string): Observable<any> {
-  return new Observable<UrlSegmentGroup>(
-      (obs: Observer<UrlSegmentGroup>) => obs.error(new Error(
-          `Only absolute redirects can have named outlets. redirectTo: '${redirectTo}'`)));
+  return throwError(
+      new Error(`Only absolute redirects can have named outlets. redirectTo: '${redirectTo}'`));
 }
 
 function canLoadFails(route: Route): Observable<LoadedRouterConfig> {
-  return new Observable<LoadedRouterConfig>(
-      (obs: Observer<LoadedRouterConfig>) => obs.error(
-          navigationCancelingError(`Cannot load children because the guard of the route "path: '${
-              route.path}'" returned false`)));
+  return throwError(
+      navigationCancelingError(`Cannot load children because the guard of the route "path: '${
+          route.path}'" returned false`));
 }
 
 /**

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -258,7 +258,7 @@ class ApplyRedirects {
   private expandRegularSegmentAgainstRouteUsingRedirect(
       ngModule: NgModuleRef<any>, segmentGroup: UrlSegmentGroup, routes: Route[], route: Route,
       segments: UrlSegment[], outlet: string): Observable<UrlSegmentGroup> {
-    const {matched, consumedSegments, lastChild, positionalParamSegments} =
+    const {matched, consumedSegments, remainingSegments, positionalParamSegments} =
         match(segmentGroup, route, segments);
     if (!matched) return noMatch(segmentGroup);
 
@@ -270,8 +270,7 @@ class ApplyRedirects {
 
     return this.lineralizeSegments(route, newTree).pipe(mergeMap((newSegments: UrlSegment[]) => {
       return this.expandSegment(
-          ngModule, segmentGroup, routes, newSegments.concat(segments.slice(lastChild)), outlet,
-          false);
+          ngModule, segmentGroup, routes, newSegments.concat(remainingSegments), outlet, false);
     }));
   }
 
@@ -291,10 +290,9 @@ class ApplyRedirects {
       return of(new UrlSegmentGroup(segments, {}));
     }
 
-    const {matched, consumedSegments, lastChild} = match(rawSegmentGroup, route, segments);
+    const {matched, consumedSegments, remainingSegments} = match(rawSegmentGroup, route, segments);
     if (!matched) return noMatch(rawSegmentGroup);
 
-    const rawSlicedSegments = segments.slice(lastChild);
     const childConfig$ = this.getChildConfig(ngModule, route, segments);
 
     return childConfig$.pipe(mergeMap((routerConfig: LoadedRouterConfig) => {
@@ -302,7 +300,7 @@ class ApplyRedirects {
       const childConfig = routerConfig.routes;
 
       const {segmentGroup: splitSegmentGroup, slicedSegments} =
-          split(rawSegmentGroup, consumedSegments, rawSlicedSegments, childConfig);
+          split(rawSegmentGroup, consumedSegments, remainingSegments, childConfig);
       // See comment on the other call to `split` about why this is necessary.
       const segmentGroup =
           new UrlSegmentGroup(splitSegmentGroup.segments, splitSegmentGroup.children);

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -155,7 +155,7 @@ export class Recognizer {
 
     let snapshot: ActivatedRouteSnapshot;
     let consumedSegments: UrlSegment[] = [];
-    let rawSlicedSegments: UrlSegment[] = [];
+    let remainingSegments: UrlSegment[] = [];
 
     if (route.path === '**') {
       const params = segments.length > 0 ? last(segments)!.parameters : {};
@@ -170,7 +170,7 @@ export class Recognizer {
         return null;
       }
       consumedSegments = result.consumedSegments;
-      rawSlicedSegments = segments.slice(result.lastChild);
+      remainingSegments = result.remainingSegments;
 
       snapshot = new ActivatedRouteSnapshot(
           consumedSegments, result.parameters, Object.freeze({...this.urlTree.queryParams}),
@@ -182,7 +182,7 @@ export class Recognizer {
     const childConfig: Route[] = getChildConfig(route);
 
     const {segmentGroup, slicedSegments} = split(
-        rawSegment, consumedSegments, rawSlicedSegments,
+        rawSegment, consumedSegments, remainingSegments,
         // Filter out routes with redirectTo because we are trying to create activated route
         // snapshots and don't handle redirects here. That should have been done in
         // `applyRedirects`.

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -16,7 +16,7 @@ import {getOutlet} from './config';
 export interface MatchResult {
   matched: boolean;
   consumedSegments: UrlSegment[];
-  lastChild: number;
+  remainingSegments: UrlSegment[];
   parameters: {[k: string]: string};
   positionalParamSegments: {[k: string]: UrlSegment};
 }
@@ -24,7 +24,7 @@ export interface MatchResult {
 const noMatch: MatchResult = {
   matched: false,
   consumedSegments: [],
-  lastChild: 0,
+  remainingSegments: [],
   parameters: {},
   positionalParamSegments: {}
 };
@@ -39,7 +39,7 @@ export function match(
     return {
       matched: true,
       consumedSegments: [],
-      lastChild: 0,
+      remainingSegments: segments,
       parameters: {},
       positionalParamSegments: {}
     };
@@ -60,7 +60,7 @@ export function match(
   return {
     matched: true,
     consumedSegments: res.consumed,
-    lastChild: res.consumed.length,
+    remainingSegments: segments.slice(res.consumed.length),
     // TODO(atscott): investigate combining parameters and positionalParamSegments
     parameters,
     positionalParamSegments: res.posParams ?? {}


### PR DESCRIPTION
1. refactor(router): Update match result to be more explicit

The `lastChild` property in the match result is only used to compute the
remaining segments (i.e. the ones which were not consumed). The updated
type here makes it easier to use and more clear.

2. refactor(router): Refactor errors in applyRedirects to use common throwError function

The implementation of `throwError` in `rxjs` is identical to what is
done manually in the Router code.