### PR TITLE
perf(core): only track LViews that are referenced in __ngContext__

### DIFF
--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -12,7 +12,7 @@ import {EMPTY_ARRAY} from '../util/empty';
 
 import {assertLView} from './assert';
 import {LContext} from './interfaces/context';
-import {getLViewById} from './interfaces/lview_tracking';
+import {getLViewById, registerLView} from './interfaces/lview_tracking';
 import {TNode, TNodeFlags} from './interfaces/node';
 import {RElement, RNode} from './interfaces/renderer_dom';
 import {isLView} from './interfaces/type_checks';
@@ -178,7 +178,12 @@ export function attachPatchData(target: any, data: LView|LContext) {
   // Only attach the ID of the view in order to avoid memory leaks (see #41047). We only do this
   // for `LView`, because we have control over when an `LView` is created and destroyed, whereas
   // we can't know when to remove an `LContext`.
-  target[MONKEY_PATCH_KEY_NAME] = isLView(data) ? data[ID] : data;
+  if (isLView(data)) {
+    target[MONKEY_PATCH_KEY_NAME] = data[ID];
+    registerLView(data);
+  } else {
+    target[MONKEY_PATCH_KEY_NAME] = data;
+  }
 }
 
 /**

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -26,7 +26,7 @@ import {executeCheckHooks, executeInitAndCheckHooks, incrementInitPhaseFlags} fr
 import {CONTAINER_HEADER_OFFSET, HAS_TRANSPLANTED_VIEWS, LContainer, MOVED_VIEWS} from '../interfaces/container';
 import {ComponentDef, ComponentTemplate, DirectiveDef, DirectiveDefListOrFactory, HostBindingsFunction, PipeDefListOrFactory, RenderFlags, ViewQueriesFunction} from '../interfaces/definition';
 import {NodeInjectorFactory} from '../interfaces/injector';
-import {registerLView} from '../interfaces/lview_tracking';
+import {getUniqueLViewId} from '../interfaces/lview_tracking';
 import {AttributeMarker, InitialInputData, InitialInputs, LocalRefExtractor, PropertyAliases, PropertyAliasValue, TAttributes, TConstantsOrFactory, TContainerNode, TDirectiveHostNode, TElementContainerNode, TElementNode, TIcuContainerNode, TNode, TNodeFlags, TNodeType, TProjectionNode} from '../interfaces/node';
 import {isProceduralRenderer, Renderer3, RendererFactory3} from '../interfaces/renderer';
 import {RComment, RElement, RNode, RText} from '../interfaces/renderer_dom';
@@ -142,7 +142,7 @@ export function createLView<T>(
   lView[SANITIZER] = sanitizer || parentLView && parentLView[SANITIZER] || null!;
   lView[INJECTOR as any] = injector || parentLView && parentLView[INJECTOR] || null;
   lView[T_HOST] = tHostNode;
-  lView[ID] = registerLView(lView);
+  lView[ID] = getUniqueLViewId();
   ngDevMode &&
       assertEqual(
           tView.type == TViewType.Embedded ? parentLView !== null : true, true,
@@ -1322,7 +1322,6 @@ function instantiateAllDirectives(
 function invokeDirectivesHostBindings(tView: TView, lView: LView, tNode: TNode) {
   const start = tNode.directiveStart;
   const end = tNode.directiveEnd;
-  const firstCreatePass = tView.firstCreatePass;
   const elementIndex = tNode.index;
   const currentDirectiveIndex = getCurrentDirectiveIndex();
   try {

--- a/packages/core/src/render3/interfaces/lview_tracking.ts
+++ b/packages/core/src/render3/interfaces/lview_tracking.ts
@@ -16,11 +16,15 @@ const TRACKED_LVIEWS = new Map<number, LView>();
 // Used for generating unique IDs for LViews.
 let uniqueIdCounter = 0;
 
-/** Starts tracking an LView and returns a unique ID that can be used for future lookups. */
-export function registerLView(lView: LView): number {
-  const id = uniqueIdCounter++;
-  TRACKED_LVIEWS.set(id, lView);
-  return id;
+/** Gets a unique ID that can be assigned to an LView. */
+export function getUniqueLViewId(): number {
+  return uniqueIdCounter++;
+}
+
+/** Starts tracking an LView. */
+export function registerLView(lView: LView): void {
+  ngDevMode && assertNumber(lView[ID], 'LView must have an ID in order to be registered');
+  TRACKED_LVIEWS.set(lView[ID], lView);
 }
 
 /** Gets an LView by its unique ID. */


### PR DESCRIPTION
Follow-up to #45051 where every `LView` that was being created was tracked in the `TRACKED_LVIEWS` map. This isn't necessary, because we only need to track the view that have been referenced by an `__ngContext__`.