### PR TITLE
fix(router): Fix type of Route.pathMatch to be more accurate

### DIFF
--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -449,7 +449,7 @@ export interface Route {
     matcher?: UrlMatcher;
     outlet?: string;
     path?: string;
-    pathMatch?: string;
+    pathMatch?: 'prefix' | 'full';
     redirectTo?: string;
     resolve?: ResolveData;
     runGuardsAndResolvers?: RunGuardsAndResolvers;

--- a/modules/playground/src/routing/app/inbox-app.ts
+++ b/modules/playground/src/routing/app/inbox-app.ts
@@ -8,7 +8,7 @@
 
 
 import {Component, Injectable} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
+import {ActivatedRoute, Router, Routes} from '@angular/router';
 
 import * as db from './data';
 
@@ -122,7 +122,7 @@ export class DraftsCmp {
   }
 }
 
-export const ROUTER_CONFIG = [
+export const ROUTER_CONFIG: Routes = [
   {path: '', pathMatch: 'full', redirectTo: 'inbox'}, {path: 'inbox', component: InboxCmp},
   {path: 'drafts', component: DraftsCmp},
   {path: 'detail', loadChildren: () => import('./inbox-detail.js').then(mod => mod.default)}

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -403,7 +403,7 @@ export interface Route {
    * to the redirect destination, creating an endless loop.
    *
    */
-  pathMatch?: string;
+  pathMatch?: 'prefix'|'full';
   /**
    * A custom URL-matching function. Cannot be used together with `path`.
    */

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -86,10 +86,6 @@ function validateNode(route: Route, fullPath: string): void {
       throw new Error(`Invalid configuration of route '{path: "${fullPath}", redirectTo: "${
           route.redirectTo}"}': please provide 'pathMatch'. ${exp}`);
     }
-    if (route.pathMatch !== void 0 && route.pathMatch !== 'full' && route.pathMatch !== 'prefix') {
-      throw new Error(`Invalid configuration of route '${
-          fullPath}': pathMatch can only be set to 'prefix' or 'full'`);
-    }
   }
   if (route.children) {
     validateConfig(route.children, fullPath);

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -144,14 +144,6 @@ describe('config', () => {
          }).toThrowError(/Invalid configuration of route '{path: "", redirectTo: "b"}'/);
        });
 
-    it('should throw when pathMatch is invalid', () => {
-      expect(() => {
-        validateConfig([{path: 'a', pathMatch: 'invalid', component: ComponentB}]);
-      })
-          .toThrowError(
-              /Invalid configuration of route 'a': pathMatch can only be set to 'prefix' or 'full'/);
-    });
-
     it('should throw when path/outlet combination is invalid', () => {
       expect(() => {
         validateConfig([{path: 'a', outlet: 'aux'}]);

--- a/packages/router/test/create_router_state.spec.ts
+++ b/packages/router/test/create_router_state.spec.ts
@@ -93,7 +93,7 @@ describe('create router state', () => {
   });
 
   it('should not retrieve routes when `shouldAttach` is always false', () => {
-    const config = [
+    const config: Routes = [
       {path: 'a', component: ComponentA}, {path: 'b', component: ComponentB, outlet: 'left'},
       {path: 'c', component: ComponentC, outlet: 'left'}
     ];
@@ -107,7 +107,7 @@ describe('create router state', () => {
   });
 
   it('should consistently represent future and current state', () => {
-    const config = [
+    const config: Routes = [
       {path: '', pathMatch: 'full', component: ComponentA},
       {path: 'product/:id', component: ComponentB}
     ];


### PR DESCRIPTION
Route.pathMatch only allows `'full'|'prefix'` in reality. This commit
adjusts the type to be more strict and also adds a migration to adjust
existing code.

resolves #37469

BREAKING CHANGE:
The type of `Route.pathMatch` is now more strict. Places that use
`pathMatch` will likely need to be updated to have an explicit
`Route`/`Routes` type so that TypeScript does not infer the type as
`string`.

reviewer notes: migration is in a separate PR (#45084) and has already been run in g3