### PR TITLE
ci: add permissions to current github action workflows

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 jobs:
   labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/feature-requests.yml
+++ b/.github/workflows/feature-requests.yml
@@ -5,6 +5,10 @@ on:
     # Run at 14:00 every day
     - cron: '0 14 * * *'
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 jobs:
   feature_triage:
     if: github.repository == 'angular/angular'

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -5,6 +5,10 @@ on:
     # Run at 16:00 every day
     - cron: '0 16 * * *'
 
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
 jobs:
   lock_closed:
     if: github.repository == 'angular/angular'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   analysis:


### PR DESCRIPTION
The currently recommended best practice for Github action workflows is to set top-level permissions to read only. And if the job uses the automatic `GITHUB_TOKEN`, fine-grained permissions for each job based on the job's requirements should also be added.
All existing workflows in the repository now have top-level read only permission blocks.
Only the `scorecard` workflow currently requires additional job level permissions and the minimum set of permissions were already present for the job.