### PR TITLE
fix(localize): avoid imports into `compiler-cli` package

### DIFF
--- a/integration/typings_test_ts44/include-all.ts
+++ b/integration/typings_test_ts44/include-all.ts
@@ -21,6 +21,7 @@ import * as core from '@angular/core';
 import * as coreTesting from '@angular/core/testing';
 import * as elements from '@angular/elements';
 import * as forms from '@angular/forms';
+import * as localize from '@angular/localize';
 import * as platformBrowser from '@angular/platform-browser';
 import * as platformBrowserDynamic from '@angular/platform-browser-dynamic';
 import * as platformBrowserDynamicTesting from '@angular/platform-browser-dynamic/testing';
@@ -51,6 +52,7 @@ export default {
   coreTesting,
   elements,
   forms,
+  localize,
   platformBrowser,
   platformBrowserTesting,
   platformBrowserDynamic,

--- a/integration/typings_test_ts44/package.json
+++ b/integration/typings_test_ts44/package.json
@@ -11,6 +11,7 @@
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/elements": "file:../../dist/packages-dist/elements",
     "@angular/forms": "file:../../dist/packages-dist/forms",
+    "@angular/localize": "file:../../dist/packages-dist/localize",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/platform-server": "file:../../dist/packages-dist/platform-server",

--- a/integration/typings_test_ts45/include-all.ts
+++ b/integration/typings_test_ts45/include-all.ts
@@ -21,6 +21,7 @@ import * as core from '@angular/core';
 import * as coreTesting from '@angular/core/testing';
 import * as elements from '@angular/elements';
 import * as forms from '@angular/forms';
+import * as localize from '@angular/localize';
 import * as platformBrowser from '@angular/platform-browser';
 import * as platformBrowserDynamic from '@angular/platform-browser-dynamic';
 import * as platformBrowserDynamicTesting from '@angular/platform-browser-dynamic/testing';
@@ -51,6 +52,7 @@ export default {
   coreTesting,
   elements,
   forms,
+  localize,
   platformBrowser,
   platformBrowserTesting,
   platformBrowserDynamic,

--- a/integration/typings_test_ts45/package.json
+++ b/integration/typings_test_ts45/package.json
@@ -11,6 +11,7 @@
     "@angular/core": "file:../../dist/packages-dist/core",
     "@angular/elements": "file:../../dist/packages-dist/elements",
     "@angular/forms": "file:../../dist/packages-dist/forms",
+    "@angular/localize": "file:../../dist/packages-dist/localize",
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/platform-server": "file:../../dist/packages-dist/platform-server",

--- a/packages/localize/src/utils/BUILD.bazel
+++ b/packages/localize/src/utils/BUILD.bazel
@@ -13,6 +13,5 @@ ts_library(
     module_name = "@angular/localize/src/utils",
     deps = [
         "//packages/compiler",
-        "//packages/compiler-cli/private",
     ],
 )

--- a/packages/localize/src/utils/src/messages.ts
+++ b/packages/localize/src/utils/src/messages.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {computeMsgId} from '@angular/compiler';
-import {AbsoluteFsPath} from '@angular/compiler-cli/private/localize';
 
 import {BLOCK_MARKER, ID_SEPARATOR, LEGACY_ID_INDICATOR, MEANING_SEPARATOR} from './constants';
 
@@ -40,6 +39,18 @@ export type TargetMessage = string;
 export type MessageId = string;
 
 /**
+ * Declares a copy of the `AbsoluteFsPath` branded type in `@angular/compiler-cli` to avoid an
+ * import into `@angular/compiler-cli`. The compiler-cli's declaration files are not necessarily
+ * compatible with web environments that use `@angular/localize`, and would inadvertently include
+ * `typescript` declaration files in any compilation unit that uses `@angular/localize` (which
+ * increases parsing time and memory usage during builds) using a default import that only
+ * type-checks when `allowSyntheticDefaultImports` is enabled.
+ *
+ * @see https://github.com/angular/angular/issues/45179
+ */
+type AbsoluteFsPathLocalizeCopy = string&{_brand: 'AbsoluteFsPath'};
+
+/**
  * The location of the message in the source file.
  *
  * The `line` and `column` values for the `start` and `end` properties are zero-based.
@@ -47,7 +58,7 @@ export type MessageId = string;
 export interface SourceLocation {
   start: {line: number, column: number};
   end: {line: number, column: number};
-  file: AbsoluteFsPath;
+  file: AbsoluteFsPathLocalizeCopy;
   text?: string;
 }
 


### PR DESCRIPTION
The compiler-cli's declaration files are not necessarily compatible with web
environments that use `@angular/localize`, and would inadvertently include
`typescript` declaration files in any compilation unit that uses
`@angular/localize` (which increases parsing time and memory usage during
builds) using a default import that only type-checks when
`allowSyntheticDefaultImports` is enabled.

Fixes #45179