### PR TITLE
fix(core): keep original whitespace intact when sanitizing srcset att…

### DIFF
--- a/packages/core/src/sanitization/url_sanitizer.ts
+++ b/packages/core/src/sanitization/url_sanitizer.ts
@@ -35,12 +35,12 @@
  */
 const SAFE_URL_PATTERN = /^(?:(?:https?|mailto|ftp|tel|file|sms):|[^&:/?#]*(?:[/?#]|$))/gi;
 
-/* A pattern that matches safe srcset values */
-const SAFE_SRCSET_PATTERN = /^(?:(?:https?|file):|[^&:/?#]*(?:[/?#]|$))/gi;
-
 /** A pattern that matches safe data URLs. Only matches image, video and audio types. */
 const DATA_URL_PATTERN =
     /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+\/]+=*$/i;
+
+/** A pattern that extract a trimmed string while capturing leading and trailing whitespace. */
+const TRIM_PATTERN = /^(\s*)(.*?)(\s*)$/;
 
 export function _sanitizeUrl(url: string): string {
   url = String(url);
@@ -55,5 +55,12 @@ export function _sanitizeUrl(url: string): string {
 
 export function sanitizeSrcset(srcset: string): string {
   srcset = String(srcset);
-  return srcset.split(',').map((srcset) => _sanitizeUrl(srcset.trim())).join(', ');
+  return srcset.split(',')
+      .map((part) => {
+        // Trim the srcset part and capture the leading and trailing whitespace, such the whitespace
+        // is retained as is in the original srcset.
+        const [, leadingWs, trimmed, trailingWs] = part.match(TRIM_PATTERN)!;
+        return leadingWs + _sanitizeUrl(trimmed) + trailingWs;
+      })
+      .join(',');
 }

--- a/packages/core/test/sanitization/url_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/url_sanitizer_spec.ts
@@ -83,6 +83,9 @@ import {_sanitizeUrl, sanitizeSrcset} from '../../src/sanitization/url_sanitizer
         'http://angular.io/images/test.png',
         'http://angular.io/images/test.png, http://angular.io/images/test.png',
         'http://angular.io/images/test.png, http://angular.io/images/test.png, http://angular.io/images/test.png',
+        'http://angular.io/images/200,200/test.png',
+        'http://angular.io/images/200,200/test.png, http://angular.io/images/300,300/test.png',
+        'http://angular.io/images/200,200/test.png  ,  http://angular.io/images/300,300/test.png',
         'http://angular.io/images/test.png 2x',
         'http://angular.io/images/test.png 2x, http://angular.io/images/test.png 3x',
         'http://angular.io/images/test.png 1.5x',
@@ -108,6 +111,7 @@ import {_sanitizeUrl, sanitizeSrcset} from '../../src/sanitization/url_sanitizer
       const invalidSrcsets = [
         'ht:tp://angular.io/images/test.png',
         'http://angular.io/images/test.png, ht:tp://angular.io/images/test.png',
+        'http://angular.io/images/test.png,ht:tp://angular.io/images/test.png',
       ];
       for (const srcset of invalidSrcsets) {
         it(`valid ${srcset}`, () => expect(sanitizeSrcset(srcset)).toMatch(/unsafe:/));


### PR DESCRIPTION
…ribute

URLs in a `srcset` attribute can contain commas as part of an URL and the HTML
serializer would previously insert a space into such URLs next to the comma,
resulting in a broken URL. This commit adjusts the srcset sanitization logic to
keep the whitespace in the original srcset intact to avoid this issue.

Fixes #45164
