### PR TITLE
fix(core): remove individual commands for updating gold files

### DIFF
--- a/packages/core/test/bundling/README.md
+++ b/packages/core/test/bundling/README.md
@@ -3,20 +3,7 @@
 ## `js_expected_symbol_test`
 This folder contains tests which assert that most of the code is tree shaken away.
 This is asserted by keeping gold files of all symbols which are expected to be retained.
-When doing renaming it is often necessary to update the gold files, to do so use these commands:
-
-```
-yarn bazel run //packages/core/test/bundling/injection:symbol_test.accept
-yarn bazel run //packages/core/test/bundling/cyclic_import:symbol_test.accept
-yarn bazel run //packages/core/test/bundling/forms:symbol_test.accept
-yarn bazel run //packages/core/test/bundling/hello_world:symbol_test.accept
-yarn bazel run //packages/core/test/bundling/router:symbol_test.accept
-yarn bazel run //packages/core/test/bundling/todo:symbol_test.accept
-yarn bazel run //packages/core/test/bundling/animations:symbol_test.accept
-```
-
-## Running all symbol tests
-To run all symbol tests with one command, you can use the following scripts:
+When doing renaming it is often necessary to update the gold files; to do so use these scripts:
 
 ```
 yarn run symbol-extractor:check


### PR DESCRIPTION
## PR Type

- [x] Build documentation fix

The documented command for updating the forms gold files was outdated and didn't work.  Since this command list can easily become outdated, the individual commands are now removed in favor of the simpler global scripts.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No