### PR TITLE
refactor(forms): Clean up the find function.

### DIFF
--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1116,9 +1116,6 @@
     "name": "isEmptyInputValue"
   },
   {
-    "name": "isFormArray"
-  },
-  {
     "name": "isFormControl"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -174,9 +174,6 @@
     "name": "EventManagerPlugin"
   },
   {
-    "name": "FormArray"
-  },
-  {
     "name": "FormControl"
   },
   {
@@ -600,12 +597,6 @@
     "name": "applyViewChange"
   },
   {
-    "name": "assertAllValuesPresent"
-  },
-  {
-    "name": "assertControlPresent"
-  },
-  {
     "name": "attachInjectFlag"
   },
   {
@@ -946,9 +937,6 @@
   },
   {
     "name": "getPromiseCtor"
-  },
-  {
-    "name": "getRawValue"
   },
   {
     "name": "getSelectedIndex"


### PR DESCRIPTION
Move `find` into the `AbstractControl` hierarchy, and clean up a longstanding implementation todo.