### PR TITLE
refactor(forms): Move `getRawValue` into the `AbstractControl` hierarchy

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -43,6 +43,7 @@ export abstract class AbstractControl {
     readonly errors: ValidationErrors | null;
     get(path: Array<string | number> | string): AbstractControl | null;
     getError(errorCode: string, path?: Array<string | number> | string): any;
+    getRawValue(): any;
     hasAsyncValidator(validator: AsyncValidatorFn): boolean;
     hasError(errorCode: string, path?: Array<string | number> | string): boolean;
     hasValidator(validator: ValidatorFn): boolean;

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -975,9 +975,6 @@
     "name": "getPromiseCtor"
   },
   {
-    "name": "getRawValue"
-  },
-  {
     "name": "getSelectedIndex"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -948,9 +948,6 @@
     "name": "getPromiseCtor"
   },
   {
-    "name": "getRawValue"
-  },
-  {
     "name": "getSelectedIndex"
   },
   {

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -182,10 +182,6 @@ export const isFormGroup = (control: unknown): control is FormGroup => control i
 
 export const isFormArray = (control: unknown): control is FormArray => control instanceof FormArray;
 
-function getRawValue(control: AbstractControl): any {
-  return isFormControl(control) ? control.value : (control as FormGroup | FormArray).getRawValue();
-}
-
 function assertControlPresent(parent: FormGroup|FormArray, key: string|number): void {
   const isGroup = isFormGroup(parent);
   const controls = parent.controls as {[key: string|number]: unknown};
@@ -867,6 +863,14 @@ export abstract class AbstractControl {
    * Resets the control. Abstract method (implemented in sub-classes).
    */
   abstract reset(value?: any, options?: Object): void;
+
+  /**
+   * The raw value of this control. For most control implementations, the raw value will include
+   * disabled children.
+   */
+  getRawValue(): any {
+    return this.value;
+  }
 
   /**
    * Recalculates the value and validation status of the control.
@@ -1970,10 +1974,10 @@ export class FormGroup extends AbstractControl {
    * The `value` property is the best way to get the value of the group, because
    * it excludes disabled controls in the `FormGroup`.
    */
-  getRawValue(): any {
+  override getRawValue(): any {
     return this._reduceChildren(
         {}, (acc: {[k: string]: AbstractControl}, control: AbstractControl, name: string) => {
-          acc[name] = getRawValue(control);
+          acc[name] = control.getRawValue();
           return acc;
         });
   }
@@ -2410,8 +2414,8 @@ export class FormArray extends AbstractControl {
    * Reports all values regardless of disabled status.
    * For enabled controls only, the `value` property is the best way to get the value of the array.
    */
-  getRawValue(): any[] {
-    return this.controls.map((control: AbstractControl) => getRawValue(control));
+  override getRawValue(): any[] {
+    return this.controls.map((control: AbstractControl) => control.getRawValue());
   }
 
   /**


### PR DESCRIPTION
Currently, there is a freestanding `getRawValue` function which examines the type of the control. This is an issue for refactoring `model.ts` because it creates unnecessary dependencies between the `AbstractControl` classes. It is cleaner to simply add this method to the model hierarchy and call it directly, and will ease upcoming refactoring.