### PR TITLE
ci: instruct renovate to not update/override merge ready PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "semanticPrefix": "build",
   "separateMajorMinor": false,
   "prHourlyLimit": 2,
+  "stopUpdatingLabel": "action: merge",
   "labels": ["target: patch", "comp: build & ci", "action: review"],
   "timezone": "America/Tijuana",
   "lockFileMaintenance": {
@@ -46,7 +47,12 @@
   ],
   "packageRules": [
     {
-      "packagePatterns": ["^@angular/.*", "^@angular-devkit/.*", "^@schematics/.*", "angular/dev-infra"],
+      "packagePatterns": [
+        "^@angular/.*",
+        "^@angular-devkit/.*",
+        "^@schematics/.*",
+        "angular/dev-infra"
+      ],
       "groupName": "angular",
       "pinVersions": false
     },
@@ -74,7 +80,12 @@
       "enabled": false
     },
     {
-      "excludePackagePatterns": ["^@angular/.*", "^@angular-devkit/.*", "^@schematics/.*", "angular/dev-infra"],
+      "excludePackagePatterns": [
+        "^@angular/.*",
+        "^@angular-devkit/.*",
+        "^@schematics/.*",
+        "angular/dev-infra"
+      ],
       "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "matchCurrentVersion": ">=1",


### PR DESCRIPTION
Sometimes Renovate proposes an update and we need to add some
manual fixups, like updating a size golden. For this we push to
same upstream branch.

Renovate will update the PR though when another new revision/version
becomes available, overriding the fixup and discarding it.

This happened quite often now and causes significantly more
work required by the dev-infra time..