### PR TITLE
feat(forms): Add untyped versions of the model classes for use in migration.

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -144,9 +144,6 @@ export class AbstractFormGroupDirective extends ControlContainer implements OnIn
 }
 
 // @public
-export type AnyForUntypedForms = any;
-
-// @public
 export interface AsyncValidator extends Validator {
     validate(control: AbstractControl): Promise<ValidationErrors | null> | Observable<ValidationErrors | null>;
 }
@@ -724,6 +721,24 @@ export class SelectMultipleControlValueAccessor extends BuiltInControlValueAcces
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<SelectMultipleControlValueAccessor, never>;
 }
+
+// @public
+export type UntypedFormArray = FormArray;
+
+// @public (undocumented)
+export const UntypedFormArray: UntypedFormArrayCtor;
+
+// @public
+export type UntypedFormControl = FormControl;
+
+// @public (undocumented)
+export const UntypedFormControl: UntypedFormControlCtor;
+
+// @public
+export type UntypedFormGroup = FormGroup;
+
+// @public (undocumented)
+export const UntypedFormGroup: UntypedFormGroupCtor;
 
 // @public
 export type ValidationErrors = {

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -42,24 +42,8 @@ export {NgSelectOption, SelectControlValueAccessor} from './directives/select_co
 export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlOptions, FormControlStatus, FormGroup, ɵFormControlCtor} from './model';
+export {AbstractControl, AbstractControlOptions, FormArray, FormControl, FormControlOptions, FormControlStatus, FormGroup, UntypedFormArray, UntypedFormControl, UntypedFormGroup, ɵFormControlCtor} from './model';
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';
 export {VERSION} from './version';
-
-/**
- * `AnyForUntypedForms` is an alias for `any` used as part of the typed forms
- * migration.
- *
- * `AnyForUntypedForms` was inserted into your code automatically as part of a migration. To
- * continue opting out of strong types, simply replace it with `any`. To opt-in to typed forms,
- * remove
- * `<AnyForUntypedForms>` from your call site.
- *
- * This symbol is currently unused. Please do not use it. These docs will be updated when this
- * symbol is in use.
- *
- * @publicApi
- */
-export type AnyForUntypedForms = any;
 
 export * from './form_providers';

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -1594,6 +1594,28 @@ export const FormControl: ɵFormControlCtor =
       }
     });
 
+interface UntypedFormControlCtor {
+  new(): UntypedFormControl;
+
+  new(formState?: any, validatorOrOpts?: ValidatorFn|ValidatorFn[]|FormControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): UntypedFormControl;
+
+  /**
+   * The presence of an explicit `prototype` property provides backwards-compatibility for apps that
+   * manually inspect the prototype chain.
+   */
+  prototype: FormControl;
+}
+
+/**
+ * UntypedFormControl is a non-strongly-typed version of @see FormControl.
+ * Note: this is used for migration purposes only. Please avoid using it directly in your code and
+ * prefer `FormControl` instead, unless you have been migrated to it automatically.
+ */
+export type UntypedFormControl = FormControl;
+
+export const UntypedFormControl: UntypedFormControlCtor = FormControl;
+
 /**
  * Tracks the value and validity state of a group of `FormControl` instances.
  *
@@ -2041,6 +2063,27 @@ export class FormGroup extends AbstractControl {
     return this.controls.hasOwnProperty(name as string) ? this.controls[name as string] : null;
   }
 }
+
+interface UntypedFormGroupCtor {
+  new(controls: {[key: string]: AbstractControl},
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): UntypedFormGroup;
+
+  /**
+   * The presence of an explicit `prototype` property provides backwards-compatibility for apps that
+   * manually inspect the prototype chain.
+   */
+  prototype: FormGroup;
+}
+
+/**
+ * UntypedFormGroup is a non-strongly-typed version of @see FormGroup.
+ * Note: this is used for migration purposes only. Please avoid using it directly in your code and
+ * prefer `FormControl` instead, unless you have been migrated to it automatically.
+ */
+export type UntypedFormGroup = FormGroup;
+
+export const UntypedFormGroup: UntypedFormGroupCtor = FormGroup;
 
 /**
  * Tracks the value and validity state of an array of `FormControl`,
@@ -2506,3 +2549,24 @@ export class FormArray extends AbstractControl {
     return this.at(name as number) ?? null;
   }
 }
+
+interface UntypedFormArrayCtor {
+  new(controls: AbstractControl[],
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): UntypedFormArray;
+
+  /**
+   * The presence of an explicit `prototype` property provides backwards-compatibility for apps that
+   * manually inspect the prototype chain.
+   */
+  prototype: FormArray;
+}
+
+/**
+ * UntypedFormArray is a non-strongly-typed version of @see FormArray.
+ * Note: this is used for migration purposes only. Please avoid using it directly in your code and
+ * prefer `FormControl` instead, unless you have been migrated to it automatically.
+ */
+export type UntypedFormArray = FormArray;
+
+export const UntypedFormArray: UntypedFormArrayCtor = FormArray;


### PR DESCRIPTION
We had previously introduced an `AnyForUntypedForms` type alias. However, given our updated migration plan, we actually want to use aliases for the model classes themselves. This commit introduces these aliases, and adds them to the public API. It must be merged before the types, in order to migrate google3.