### PR TITLE
docs: change link for devtools to angular repo

### DIFF
--- a/aio/content/guide/devtools.md
+++ b/aio/content/guide/devtools.md
@@ -32,7 +32,7 @@ In the top-right corner of Angular DevTools you'll find which version of Angular
 
 ## Bug reports
 
-Report issues and feature requests on [GitHub](https://github.com/rangle/angular-devtools/issues).
+Report issues and feature requests on [GitHub](https://github.com/angular/angular/issues).
 
 To report an issue with the Profiler, export the Profiler recording by clicking the **Save Profile** button, and then attaching that export as a file in the issue.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Link goes to issues on the archived `rangle/angular-devtools` repository


## What is the new behavior?
Link goes to issues on this (`angular/angular`) repository

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
