### PR TITLE
fix(docs-infra): apply various a11y aio improvements

### DIFF
--- a/aio/scripts/test-aio-a11y.mjs
+++ b/aio/scripts/test-aio-a11y.mjs
@@ -29,8 +29,8 @@ const MIN_SCORES_PER_PAGE = {
   'cli/add': 100,
   'docs': 100,
   'guide/docs-style-guide': 96,
-  'start/start-routing': 98,
-  'tutorial': 98,
+  'start/start-routing': 97,
+  'tutorial': 97,
 };
 
 // Run

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -47,7 +47,7 @@
 
 <aio-search-results #searchResultsView *ngIf="showSearchResults" [searchResults]="searchResults | async" (resultSelected)="hideSearchResults()"></aio-search-results>
 
-<mat-sidenav-container class="sidenav-container" [class.no-animations]="disableAnimations" [class.has-floating-toc]="hasFloatingToc" role="main">
+<mat-sidenav-container class="sidenav-container" [class.no-animations]="disableAnimations" [class.has-floating-toc]="hasFloatingToc">
 
   <mat-sidenav [ngClass]="{'collapsed': !dockSideNav}" #sidenav class="sidenav" [mode]="mode" [opened]="isOpened" (openedChange)="updateHostClasses()">
     <aio-nav-menu *ngIf="!showTopMenu" [nodes]="topMenuNarrowNodes" [currentNode]="currentNodes?.TopBarNarrow" [isWide]="dockSideNav"></aio-nav-menu>
@@ -60,7 +60,7 @@
 
   <section class="sidenav-content-container">
 
-    <main class="sidenav-content" [id]="pageId" role="main">
+    <main class="sidenav-content" [id]="pageId">
       <div id="main-content" tabindex="-1"></div>
       <aio-mode-banner [mode]="deployment.mode" [version]="versionInfo"></aio-mode-banner>
       <aio-doc-viewer [class.no-animations]="disableAnimations" [doc]="currentDocument" (docReady)="onDocReady()" (docRemoved)="onDocRemoved()" (docInserted)="onDocInserted()" (docRendered)="onDocRendered()">

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -8,40 +8,42 @@
   <mat-progress-bar mode="indeterminate" color="warn"></mat-progress-bar>
 </div>
 
-<mat-toolbar color="primary" class="app-toolbar no-print" [class.transitioning]="isTransitioning">
-  <mat-toolbar-row class="notification-container">
-    <aio-notification notificationId="survey-january-2022" expirationDate="2022-02-01" [dismissOnContentClick]="true" (dismissed)="notificationDismissed()">
-      <a href="https://stateofjs.com">
-        <mat-icon class="icon" svgIcon="insert_comment" aria-label="Announcement"></mat-icon>
-        <span class="message">Share your experience with Angular in <b>The State of JavaScript</b></span>
-        <span class="action-button">Go to survey</span>
+<header>
+  <mat-toolbar color="primary" class="app-toolbar no-print" [class.transitioning]="isTransitioning">
+    <mat-toolbar-row class="notification-container">
+      <aio-notification notificationId="survey-january-2022" expirationDate="2022-02-01" [dismissOnContentClick]="true" (dismissed)="notificationDismissed()">
+        <a href="https://stateofjs.com">
+          <mat-icon class="icon" svgIcon="insert_comment" aria-label="Announcement"></mat-icon>
+          <span class="message">Share your experience with Angular in <b>The State of JavaScript</b></span>
+          <span class="action-button">Go to survey</span>
+        </a>
+      </aio-notification>
+    </mat-toolbar-row>
+    <mat-toolbar-row>
+      <button mat-button class="hamburger" [class.no-animations]="disableAnimations" (click)="sidenav.toggle()" title="Docs menu">
+        <mat-icon svgIcon="menu"></mat-icon>
+      </button>
+      <a class="nav-link home" href="/" [ngSwitch]="showTopMenu">
+        <img *ngSwitchCase="true" src="assets/images/logos/angular/logo-nav@2x.png" width="150" height="40" title="Home" alt="Home">
+        <img *ngSwitchDefault src="assets/images/logos/angular/shield-large.svg" width="37" height="40" title="Home" alt="Home">
       </a>
-    </aio-notification>
-  </mat-toolbar-row>
-  <mat-toolbar-row>
-    <button mat-button class="hamburger" [class.no-animations]="disableAnimations" (click)="sidenav.toggle()" title="Docs menu">
-      <mat-icon svgIcon="menu"></mat-icon>
-    </button>
-    <a class="nav-link home" href="/" [ngSwitch]="showTopMenu">
-      <img *ngSwitchCase="true" src="assets/images/logos/angular/logo-nav@2x.png" width="150" height="40" title="Home" alt="Home">
-      <img *ngSwitchDefault src="assets/images/logos/angular/shield-large.svg" width="37" height="40" title="Home" alt="Home">
-    </a>
-    <aio-top-menu *ngIf="showTopMenu" [nodes]="topMenuNodes" [currentNode]="currentNodes?.TopBar"></aio-top-menu>
-    <aio-search-box class="search-container" #searchBox (onSearch)="doSearch($event)" (onFocus)="doSearch($event)"></aio-search-box>
-    <aio-theme-toggle></aio-theme-toggle>
-    <div class="toolbar-external-icons-container">
-      <a mat-icon-button href="https://twitter.com/angular" title="Twitter" aria-label="Angular on twitter">
-        <mat-icon svgIcon="logos:twitter"></mat-icon>
-      </a>
-      <a mat-icon-button href="https://github.com/angular/angular" title="GitHub" aria-label="Angular on github">
-        <mat-icon svgIcon="logos:github"></mat-icon>
-      </a>
-      <a mat-icon-button href="https://youtube.com/angular" title="YouTube" aria-label="Angular on YouTube">
-        <mat-icon svgIcon="logos:youtube"></mat-icon>
-      </a>
-    </div>
-  </mat-toolbar-row>
-</mat-toolbar>
+      <aio-top-menu *ngIf="showTopMenu" [nodes]="topMenuNodes" [currentNode]="currentNodes?.TopBar"></aio-top-menu>
+      <aio-search-box class="search-container" #searchBox (onSearch)="doSearch($event)" (onFocus)="doSearch($event)"></aio-search-box>
+      <aio-theme-toggle></aio-theme-toggle>
+      <div class="toolbar-external-icons-container">
+        <a mat-icon-button href="https://twitter.com/angular" title="Twitter" aria-label="Angular on twitter">
+          <mat-icon svgIcon="logos:twitter"></mat-icon>
+        </a>
+        <a mat-icon-button href="https://github.com/angular/angular" title="GitHub" aria-label="Angular on github">
+          <mat-icon svgIcon="logos:github"></mat-icon>
+        </a>
+        <a mat-icon-button href="https://youtube.com/angular" title="YouTube" aria-label="Angular on YouTube">
+          <mat-icon svgIcon="logos:youtube"></mat-icon>
+        </a>
+      </div>
+    </mat-toolbar-row>
+  </mat-toolbar>
+</header>
 
 <aio-search-results #searchResultsView *ngIf="showSearchResults" [searchResults]="searchResults | async" (resultSelected)="hideSearchResults()"></aio-search-results>
 

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -50,8 +50,8 @@
 <mat-sidenav-container class="sidenav-container" [class.no-animations]="disableAnimations" [class.has-floating-toc]="hasFloatingToc">
 
   <mat-sidenav [ngClass]="{'collapsed': !dockSideNav}" #sidenav class="sidenav" [mode]="mode" [opened]="isOpened" (openedChange)="updateHostClasses()">
-    <aio-nav-menu *ngIf="!showTopMenu" [nodes]="topMenuNarrowNodes" [currentNode]="currentNodes?.TopBarNarrow" [isWide]="dockSideNav"></aio-nav-menu>
-    <aio-nav-menu [nodes]="sideNavNodes" [currentNode]="currentNodes?.SideNav" [isWide]="dockSideNav"></aio-nav-menu>
+    <aio-nav-menu *ngIf="!showTopMenu" [nodes]="topMenuNarrowNodes" [currentNode]="currentNodes?.TopBarNarrow" [isWide]="dockSideNav" navLabel="primary"></aio-nav-menu>
+    <aio-nav-menu [nodes]="sideNavNodes" [currentNode]="currentNodes?.SideNav" [isWide]="dockSideNav" navLabel="guides and docs"></aio-nav-menu>
 
     <div class="doc-version">
       <aio-select (change)="onDocVersionChange($event.index)" [options]="docVersions" [selected]="currentDocVersion"></aio-select>

--- a/aio/src/app/layout/nav-menu/nav-menu.component.ts
+++ b/aio/src/app/layout/nav-menu/nav-menu.component.ts
@@ -4,12 +4,18 @@ import { CurrentNode, NavigationNode } from 'app/navigation/navigation.service';
 @Component({
   selector: 'aio-nav-menu',
   template: `
-  <aio-nav-item *ngFor="let node of filteredNodes" [node]="node" [selectedNodes]="currentNode?.nodes" [isWide]="isWide">
-  </aio-nav-item>`
+  <nav [attr.aria-label]="navLabel || null">
+    <aio-nav-item *ngFor="let node of filteredNodes"
+      [node]="node"
+      [selectedNodes]="currentNode?.nodes"
+      [isWide]="isWide">
+    </aio-nav-item>
+  </nav>`
 })
 export class NavMenuComponent {
   @Input() currentNode: CurrentNode | undefined;
   @Input() isWide = false;
   @Input() nodes: NavigationNode[];
+  @Input() navLabel: string;
   get filteredNodes() { return this.nodes ? this.nodes.filter(n => !n.hidden) : []; }
 }

--- a/aio/src/app/layout/top-menu/top-menu.component.ts
+++ b/aio/src/app/layout/top-menu/top-menu.component.ts
@@ -4,13 +4,15 @@ import { CurrentNode, NavigationNode } from 'app/navigation/navigation.service';
 @Component({
   selector: 'aio-top-menu',
   template: `
-    <ul role="navigation">
-      <li *ngFor="let node of nodes" [ngClass]="{selected: node.url === currentUrl}">
-        <a class="nav-link" [href]="node.url" [title]="node.tooltip">
-          <span class="nav-link-inner">{{ node.title }}</span>
-        </a>
-      </li>
-    </ul>`
+    <nav aria-label="primary">
+      <ul>
+        <li *ngFor="let node of nodes" [ngClass]="{selected: node.url === currentUrl}">
+          <a class="nav-link" [href]="node.url" [title]="node.tooltip">
+            <span class="nav-link-inner">{{ node.title }}</span>
+          </a>
+        </li>
+      </ul>
+    </nav>`
 })
 export class TopMenuComponent {
   @Input() nodes: NavigationNode[];


### PR DESCRIPTION
changes:
 - currently the navigation `ul` used in `aio-top-menu` has a role of
   navigation, but listitems should be owned by list parents
   (see more: https://www.w3.org/TR/wai-aria-1.1/#listitem)
   so wrap the `ul` in a `nav` and remove the `role="navigation"` from the
   `ul` element to fix such issue
 - wrap the main aio mat-toolbar in a header element to provide better
   accessibility
 - remove reduntant role="main"
 - (try to) make sure that there in only a single main in the aio page
 - (try to) make sure all elements are included in landmarks
 - (try to) make sure the main navs have different labels

resolves #16938
resolves #44562

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
