### PR TITLE
fix(http): Throw error when headers are supplied in JSONP request

### DIFF
--- a/packages/common/http/src/jsonp.ts
+++ b/packages/common/http/src/jsonp.ts
@@ -36,6 +36,10 @@ export const JSONP_ERR_NO_CALLBACK = 'JSONP injected script did not invoke callb
 export const JSONP_ERR_WRONG_METHOD = 'JSONP requests must use JSONP request method.';
 export const JSONP_ERR_WRONG_RESPONSE_TYPE = 'JSONP requests must use Json response type.';
 
+// Error text given when a request is passed to the JsonpClientBackend that has
+// headers set
+export const JSONP_ERR_HEADERS_NOT_SUPPORTED = 'JSONP requests do not support headers.';
+
 /**
  * DI token/abstract type representing a map of JSONP callbacks.
  *
@@ -84,6 +88,12 @@ export class JsonpClientBackend implements HttpBackend {
       throw new Error(JSONP_ERR_WRONG_METHOD);
     } else if (req.responseType !== 'json') {
       throw new Error(JSONP_ERR_WRONG_RESPONSE_TYPE);
+    }
+
+    // Check the request headers. JSONP doesn't support headers and
+    // cannot set any that were supplied.
+    if (req.headers.keys().length > 0) {
+      throw new Error(JSONP_ERR_HEADERS_NOT_SUPPORTED);
     }
 
     // Everything else happens inside the Observable boundary.

--- a/packages/common/http/test/jsonp_spec.ts
+++ b/packages/common/http/test/jsonp_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {JSONP_ERR_NO_CALLBACK, JSONP_ERR_WRONG_METHOD, JSONP_ERR_WRONG_RESPONSE_TYPE, JsonpClientBackend} from '@angular/common/http/src/jsonp';
+import {HttpHeaders} from '@angular/common/http/src/headers';
+import {JSONP_ERR_HEADERS_NOT_SUPPORTED, JSONP_ERR_NO_CALLBACK, JSONP_ERR_WRONG_METHOD, JSONP_ERR_WRONG_RESPONSE_TYPE, JsonpClientBackend} from '@angular/common/http/src/jsonp';
 import {HttpRequest} from '@angular/common/http/src/request';
 import {HttpErrorResponse, HttpEventType} from '@angular/common/http/src/response';
 import {toArray} from 'rxjs/operators';
@@ -83,6 +84,10 @@ const SAMPLE_REQ = new HttpRequest<never>('JSONP', '/test');
       it('when response type is not json',
          () => expect(() => backend.handle(SAMPLE_REQ.clone<never>({responseType: 'text'})))
                    .toThrowError(JSONP_ERR_WRONG_RESPONSE_TYPE));
+      it('when headers are set in request',
+         () => expect(() => backend.handle(SAMPLE_REQ.clone<never>({
+                 headers: new HttpHeaders({'Content-Type': 'application/json'})
+               }))).toThrowError(JSONP_ERR_HEADERS_NOT_SUPPORTED));
       it('when callback is never called', done => {
         backend.handle(SAMPLE_REQ).subscribe(undefined, (err: HttpErrorResponse) => {
           expect(err.status).toBe(0);


### PR DESCRIPTION
JSONP does not support headers being set on requests. This
enables JSONP to throw an error when headers are supplied
in the request to prevent attempts to set them.

Closes #9141

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 9141


## What is the new behavior?
JSONP throws an error if a request is processed that has headers set.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
JSONP does not support headers being set on requests. Before when a request was sent to a JSONP backend that had headers set the headers were ignored. The JSONP backend will now throw an error if it receives a request that has any headers set. Any uses of JSONP on requests with headers set will need to remove the headers to avoid the error.

## Other information
