### PR TITLE
WIP(core): Add callback to waitForAsync() test helper

### DIFF
--- a/packages/core/testing/src/async.ts
+++ b/packages/core/testing/src/async.ts
@@ -50,3 +50,76 @@ export function waitForAsync(fn: Function): (done: any) => any {
 export function async(fn: Function): (done: any) => any {
   return waitForAsync(fn);
 }
+
+/**
+ * Register a callback function when all the async tasks finished inside
+ * the waitForAsync() test function.
+ *
+ * Example:
+ *
+ * ```
+ * it('...', waitForAsync(() => {
+ *   let timeoutCalled = false;
+ *   setTimeout(() => {
+ *     timeoutCalled = true;
+ *   });
+ *   onWaitForAsyncFinished(() => {
+ *     expect(timeoutCalled).toBe(true);
+ *   });
+ * });
+ * ```
+ *
+ * @publicApi
+ */
+export function onWaitForAsyncFinished(fn: Function): void {
+  const _Zone: any = typeof Zone !== 'undefined' ? Zone : null;
+  if (!_Zone) {
+    throw new Error(
+        'Zone is needed for the waitForAsync() test helper but could not be found. ' +
+        'Please make sure that your environment includes zone.js');
+  };
+  const onWaitForAsyncFinished = _Zone && _Zone[_Zone.__symbol__('onWaitForAsyncFinished')];
+  if (typeof onWaitForAsyncFinished === 'function') {
+    onWaitForAsyncFinished(fn);
+  } else {
+    throw new Error(
+        'zone-testing is needed for the onWaitForAsyncFinished() test helper but could not be found. ' +
+        'Please make sure that your environment includes zone-testing.js');
+  }
+}
+
+/**
+ * Register a callback function when error thrown in the async tasks inside
+ * the waitForAsync() test function.
+ *
+ * Example:
+ *
+ * ```
+ * it('...', waitForAsync(() => {
+ *   setTimeout(() => {
+ *     throw new Error('test');
+ *   });
+ *   onWaitForAsyncThrowError((err) => {
+ *     expect(err.message).toEqual('test');
+ *   });
+ * });
+ * ```
+ *
+ * @publicApi
+ */
+export function onWaitForAsyncThrowError(fn: (error: any) => void): void {
+  const _Zone: any = typeof Zone !== 'undefined' ? Zone : null;
+  if (!_Zone) {
+    throw new Error(
+        'Zone is needed for the waitForAsync() test helper but could not be found. ' +
+        'Please make sure that your environment includes zone.js');
+  };
+  const onWaitForAsyncThrowError = _Zone && _Zone[_Zone.__symbol__('onWaitForAsyncThrowError')];
+  if (typeof onWaitForAsyncThrowError === 'function') {
+    onWaitForAsyncThrowError(fn);
+  } else {
+    throw new Error(
+        'zone-testing is needed for the onWaitForAsyncThrowError() test helper but could not be found. ' +
+        'Please make sure that your environment includes zone-testing.js');
+  }
+}


### PR DESCRIPTION
It is not easy to use `waitForAsync()` to test async operations since the user don't know when all async tasks finished. For example,

```
export class ComponentA {
  value = 0;
  doSomething() {
     setTimeout(() => value = 1, 50);
  }
}

it('test setTimeout`, waitForAsync(() => {
  compa.doSomething();
  setTimeout(() => {
   expect(compa.value).toBe(1);
  }, 100);
}));
```

To test the `async` operation such as `setTimeout` inside `waitForAsync()`, we need to know the exact `delay` of the `async` operations. But it is hard to know the exact delay duration in the real user case. So in this PR, there is a new API `onWaitForAsyncFinished()` is added to provide a callback to the user, the `callback` will be invoked when all `async` operations are finished.

 ```
export class ComponentA {
  value = 0;
  doSomething() {
     setTimeout(() => value = 1, 50);
  }
}

it('test setTimeout`, waitForAsync(() => {
  compa.doSomething();
  onWaitForAsyncFinished(() => { 
   expect(compa.value).toBe(1);
  });
}));
```

Also this PR provide another API `onWaitForAsyncThrowError()` to catch all errors thrown inside the async operations.
```
export class ComponentA {
  value = 0;
  doSomething() {
     setTimeout(() => throw new Error('test'), 50);
  }
}

it('test setTimeout`, waitForAsync(() => {
  compa.doSomething();
  onWaitForAsyncThrowError((err) => { 
   expect(err.message).toBe('test');
  });
}));
```
