### PR TITLE
feat(service-worker): emit a notification when the service worker is already up to date after check

### DIFF
--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -19,8 +19,9 @@ The `SwUpdate` service supports three separate operations:
 
 ### Version updates
 
-The `versionUpdates` is an `Observable` property of `SwUpdate` and emits three event types:
+The `versionUpdates` is an `Observable` property of `SwUpdate` and emits four event types:
 * `VersionDetectedEvent` is emitted when the service worker has detected a new version of the app on the server and is about to start downloading it.
+* `NoNewVersionDetectedEvent` is emitted when the service worker has checked the version of the app on the server and it is the same as the installed version.
 * `VersionReadyEvent` is emitted when a new version of the app is available to be activated by clients.
   It may be used to notify the user of an available update or prompt them to refresh the page.
 * `VersionInstallationFailedEvent` is emitted when the installation of a new version failed.

--- a/goldens/public-api/service-worker/service-worker.md
+++ b/goldens/public-api/service-worker/service-worker.md
@@ -118,7 +118,7 @@ export interface VersionDetectedEvent {
 }
 
 // @public
-export type VersionEvent = VersionDetectedEvent | VersionInstallationFailedEvent | VersionReadyEvent;
+export type VersionEvent = VersionDetectedEvent | VersionInstallationFailedEvent | VersionReadyEvent | NoNewVersionDetectedEvent;
 
 // @public
 export interface VersionInstallationFailedEvent {

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -56,7 +56,7 @@ export interface UpdateActivatedEvent {
  */
 export interface NoNewVersionDetectedEvent {
   type: 'NO_NEW_VERSION_DETECTED';
-  version: {hash: string; appData?: object;};
+  version: {hash: string; appData?: Object;};
 }
 
 /**

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -47,6 +47,19 @@ export interface UpdateActivatedEvent {
 }
 
 /**
+ * An event emitted when the service worker has checked the version of the app on the server
+ * and it is the same as the installed version.
+ *
+ * @see {@link guide/service-worker-communications Service worker communication guide}
+ *
+ * @publicApi
+ */
+export interface NoNewVersionDetectedEvent {
+  type: 'NO_NEW_VERSION_DETECTED';
+  version: {hash: string; appData?: object;};
+}
+
+/**
  * An event emitted when the service worker has detected a new version of the app on the server and
  * is about to start downloading it.
  *
@@ -93,7 +106,8 @@ export interface VersionReadyEvent {
  *
  * @publicApi
  */
-export type VersionEvent = VersionDetectedEvent|VersionInstallationFailedEvent|VersionReadyEvent;
+export type VersionEvent =
+    VersionDetectedEvent|VersionInstallationFailedEvent|VersionReadyEvent|NoNewVersionDetectedEvent;
 
 /**
  * An event emitted when the version of the app used by the service worker to serve this client is

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -86,8 +86,12 @@ export class SwUpdate {
       this.unrecoverable = NEVER;
       return;
     }
-    this.versionUpdates = this.sw.eventsOfType<VersionEvent>(
-        ['VERSION_DETECTED', 'VERSION_INSTALLATION_FAILED', 'VERSION_READY']);
+    this.versionUpdates = this.sw.eventsOfType<VersionEvent>([
+      'VERSION_DETECTED',
+      'VERSION_INSTALLATION_FAILED',
+      'VERSION_READY',
+      'NO_NEW_VERSION_DETECTED',
+    ]);
     this.available = this.versionUpdates.pipe(
         filter((evt: VersionEvent): evt is VersionReadyEvent => evt.type === 'VERSION_READY'),
         map(evt => ({

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -460,6 +460,19 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
           },
         });
       });
+      it('processes a no new version event when sent', done => {
+        update.versionUpdates.subscribe(event => {
+          expect(event.type).toEqual('NO_NEW_VERSION_DETECTED');
+          expect((event as VersionDetectedEvent).version).toEqual({hash: 'A'});
+          done();
+        });
+        mock.sendMessage({
+          type: 'NO_NEW_VERSION_DETECTED',
+          version: {
+            hash: 'A',
+          },
+        });
+      });
       it('process any version update event when sent', done => {
         update.versionUpdates.subscribe(event => {
           expect(event.type).toEqual('VERSION_DETECTED');

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -8,7 +8,7 @@
 
 import {PLATFORM_ID} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {NgswCommChannel, VersionDetectedEvent} from '@angular/service-worker/src/low_level';
+import {NgswCommChannel, NoNewVersionDetectedEvent, VersionDetectedEvent} from '@angular/service-worker/src/low_level';
 import {ngswCommChannelFactory, SwRegistrationOptions} from '@angular/service-worker/src/module';
 import {SwPush} from '@angular/service-worker/src/push';
 import {SwUpdate} from '@angular/service-worker/src/update';
@@ -463,7 +463,7 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
       it('processes a no new version event when sent', done => {
         update.versionUpdates.subscribe(event => {
           expect(event.type).toEqual('NO_NEW_VERSION_DETECTED');
-          expect((event as VersionDetectedEvent).version).toEqual({hash: 'A'});
+          expect((event as NoNewVersionDetectedEvent).version).toEqual({hash: 'A'});
           done();
         });
         mock.sendMessage({

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -878,6 +878,7 @@ export class Driver implements Debuggable, UpdateSource {
 
       // Check whether this is really an update.
       if (this.versions.has(hash)) {
+        await this.notifyClientsAboutNoNewVersionDetected(manifest, hash);
         return false;
       }
 
@@ -1070,6 +1071,18 @@ export class Driver implements Debuggable, UpdateSource {
         version: this.mergeHashWithAppData(manifest, hash),
         error: errorToString(error),
       });
+    }));
+  }
+
+  async notifyClientsAboutNoNewVersionDetected(manifest: Manifest, hash: string): Promise<void> {
+    await this.initialized;
+
+    const clients = await this.scope.clients.matchAll();
+
+    await Promise.all(clients.map(async client => {
+      // Send a notice.
+      client.postMessage(
+          {type: 'NO_NEW_VERSION_DETECTED', version: this.mergeHashWithAppData(manifest, hash)});
     }));
   }
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -666,6 +666,25 @@ describe('Driver', () => {
     serverUpdate.assertNoOtherRequests();
   });
 
+  it('sends a notification message after finding the same version on the server and installed',
+     async () => {
+       expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
+       await driver.initialized;
+
+       const client = scope.clients.getMock('default')!;
+
+       expect(await driver.checkForUpdate()).toEqual(false);
+       serverUpdate.clearRequests();
+
+       expect(client.messages).toEqual([
+         {
+           type: 'NO_NEW_VERSION_DETECTED',
+           version: {hash: manifestHash, appData: {version: 'original'}},
+         },
+       ]);
+       serverUpdate.assertNoOtherRequests();
+     });
+
   it('cleans up properly when manually requested', async () => {
     expect(await makeRequest(scope, '/foo.txt')).toEqual('this is foo');
     await driver.initialized;


### PR DESCRIPTION
When the service worker checks for an update and finds that the version on the server is the same as
the version locally installed, it currently noops.  This change introduces an event which it emits
in this situation which notifies clients a check has occurred without error and no update was found.
