### PR TITLE
feat(forms): Introduce an `AbstractControlCollection` superclass.

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -65,7 +65,7 @@ export abstract class AbstractControl {
     markAsUntouched(opts?: {
         onlySelf?: boolean;
     }): void;
-    get parent(): FormGroup | FormArray | null;
+    get parent(): AbstractControlCollection | null;
     abstract patchValue(value: any, options?: Object): void;
     get pending(): boolean;
     readonly pristine: boolean;
@@ -78,7 +78,7 @@ export abstract class AbstractControl {
         emitEvent?: boolean;
     }): void;
     // (undocumented)
-    setParent(parent: FormGroup | FormArray): void;
+    setParent(parent: AbstractControlCollection): void;
     setValidators(validators: ValidatorFn | ValidatorFn[] | null): void;
     abstract setValue(value: any, options?: Object): void;
     readonly status: FormControlStatus;
@@ -223,7 +223,7 @@ export interface Form {
 }
 
 // @public
-export class FormArray extends AbstractControl {
+export class FormArray extends AbstractControlCollection {
     constructor(controls: AbstractControl[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
     at(index: number): AbstractControl;
     clear(options?: {
@@ -374,7 +374,7 @@ export interface FormControlOptions extends AbstractControlOptions {
 export type FormControlStatus = 'VALID' | 'INVALID' | 'PENDING' | 'DISABLED';
 
 // @public
-export class FormGroup extends AbstractControl {
+export class FormGroup extends AbstractControlCollection {
     constructor(controls: {
         [key: string]: AbstractControl;
     }, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -15,6 +15,9 @@
     "name": "AbstractControl"
   },
   {
+    "name": "AbstractControlCollection"
+  },
+  {
     "name": "AbstractControlDirective"
   },
   {
@@ -1114,9 +1117,6 @@
   },
   {
     "name": "isFormControl"
-  },
-  {
-    "name": "isFormGroup"
   },
   {
     "name": "isForwardRef"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -15,6 +15,9 @@
     "name": "AbstractControl"
   },
   {
+    "name": "AbstractControlCollection"
+  },
+  {
     "name": "AbstractControlDirective"
   },
   {
@@ -1075,9 +1078,6 @@
   },
   {
     "name": "isDirectiveHost"
-  },
-  {
-    "name": "isFormGroup"
   },
   {
     "name": "isForwardRef"


### PR DESCRIPTION
Currently, `AbstractControl` and the implementation classes depend on each other in several places, for example `AbstractControl.parent`. This is problematic for a few reasons:
* It makes refactoring hard, because there are circular dependencies. (For example, `FormGroup` extends `AbstractControl`, and `AbstractControl.parent` is `FormGroup|FormArray`, so the classes are permanently coupled together.)
* The code is less tree-shakable, because forms classes refer "down the tree". If you want `AbstractControl`, you get the symbols for its descendants as well.
* There are several places where `AbstractControl` accepts `FormGroup|FormArray`, which is non-extensible. Abstracting this away will allow better support for custom `AbstractControl` implementations.

In this change, I add a new abstract class to the hierarchy. `AbstractControlCollection` is an `AbstractControl` that contains other form controls inside, and `FormArray` and `FormGroup` extend this new class. This untangles the circular dependency, and solves the above issues.