### PR TITLE
Revert "refactor(forms): Move `getRawValue` into the `AbstractControl…

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -43,7 +43,6 @@ export abstract class AbstractControl {
     readonly errors: ValidationErrors | null;
     get(path: Array<string | number> | string): AbstractControl | null;
     getError(errorCode: string, path?: Array<string | number> | string): any;
-    getRawValue(): any;
     hasAsyncValidator(validator: AsyncValidatorFn): boolean;
     hasError(errorCode: string, path?: Array<string | number> | string): boolean;
     hasValidator(validator: ValidatorFn): boolean;

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -975,6 +975,9 @@
     "name": "getPromiseCtor"
   },
   {
+    "name": "getRawValue"
+  },
+  {
     "name": "getSelectedIndex"
   },
   {

--- a/packages/forms/src/model.ts
+++ b/packages/forms/src/model.ts
@@ -157,6 +157,10 @@ export const isFormGroup = (control: unknown): control is FormGroup => control i
 
 export const isFormArray = (control: unknown): control is FormArray => control instanceof FormArray;
 
+function getRawValue(control: AbstractControl): any {
+  return isFormControl(control) ? control.value : (control as FormGroup | FormArray).getRawValue();
+}
+
 function assertControlPresent(parent: FormGroup|FormArray, key: string|number): void {
   const isGroup = isFormGroup(parent);
   const controls = parent.controls as {[key: string|number]: unknown};
@@ -838,14 +842,6 @@ export abstract class AbstractControl {
    * Resets the control. Abstract method (implemented in sub-classes).
    */
   abstract reset(value?: any, options?: Object): void;
-
-  /**
-   * The raw value of this control. For most control implementations, the raw value will include
-   * disabled children.
-   */
-  getRawValue(): any {
-    return this.value;
-  }
 
   /**
    * Recalculates the value and validation status of the control.
@@ -1980,10 +1976,10 @@ export class FormGroup extends AbstractControl {
    * The `value` property is the best way to get the value of the group, because
    * it excludes disabled controls in the `FormGroup`.
    */
-  override getRawValue(): any {
+  getRawValue(): any {
     return this._reduceChildren(
         {}, (acc: {[k: string]: AbstractControl}, control: AbstractControl, name: string) => {
-          acc[name] = control.getRawValue();
+          acc[name] = getRawValue(control);
           return acc;
         });
   }
@@ -2446,8 +2442,8 @@ export class FormArray extends AbstractControl {
    * Reports all values regardless of disabled status.
    * For enabled controls only, the `value` property is the best way to get the value of the array.
    */
-  override getRawValue(): any[] {
-    return this.controls.map((control: AbstractControl) => control.getRawValue());
+  getRawValue(): any[] {
+    return this.controls.map((control: AbstractControl) => getRawValue(control));
   }
 
   /**


### PR DESCRIPTION
…` hierarchy. (#45200)"

This reverts commit dfc4301b33c3e08456af59f77e7f3bb611bceb6b.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
