### PR TITLE
[13.2.x] perf(common): make `NgLocalization` token tree-shakable (#45118)

### DIFF
--- a/goldens/public-api/common/common.md
+++ b/goldens/public-api/common/common.md
@@ -503,6 +503,10 @@ export class NgLocaleLocalization extends NgLocalization {
 export abstract class NgLocalization {
     // (undocumented)
     abstract getPluralCategory(value: any, locale?: string): string;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<NgLocalization, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<NgLocalization>;
 }
 
 // @public

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 450840,
+        "main": 450239,
         "polyfills": 37297,
         "styles": 70379,
         "light-theme": 77582,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1083,
-        "main": 126218,
+        "main": 124282,
         "polyfills": 37226
       }
     }
@@ -24,7 +24,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1105,
-        "main": 131882,
+        "main": 131270,
         "polyfills": 37248
       }
     }
@@ -33,7 +33,7 @@
     "master": {
       "uncompressed": {
         "runtime": 929,
-        "main": 124544,
+        "main": 123958,
         "polyfills": 37933
       }
     }
@@ -42,7 +42,7 @@
     "master": {
       "uncompressed": {
         "runtime": 2835,
-        "main": 231381,
+        "main": 230780,
         "polyfills": 37244,
         "src_app_lazy_lazy_module_ts": 795
       }
@@ -52,7 +52,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 158556,
+        "main": 155607,
         "polyfills": 36975
       }
     }
@@ -61,7 +61,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1070,
-        "main": 158300,
+        "main": 155563,
         "polyfills": 37242
       }
     }

--- a/packages/common/src/common_module.ts
+++ b/packages/common/src/common_module.ts
@@ -7,9 +7,10 @@
  */
 
 import {NgModule} from '@angular/core';
+
 import {COMMON_DIRECTIVES} from './directives/index';
-import {NgLocaleLocalization, NgLocalization} from './i18n/localization';
 import {COMMON_PIPES} from './pipes/index';
+
 
 
 // Note: This does not contain the location providers,
@@ -30,9 +31,6 @@ import {COMMON_PIPES} from './pipes/index';
 @NgModule({
   declarations: [COMMON_DIRECTIVES, COMMON_PIPES],
   exports: [COMMON_DIRECTIVES, COMMON_PIPES],
-  providers: [
-    {provide: NgLocalization, useClass: NgLocaleLocalization},
-  ],
 })
 export class CommonModule {
 }

--- a/packages/common/src/i18n/localization.ts
+++ b/packages/common/src/i18n/localization.ts
@@ -10,14 +10,17 @@ import {Inject, Injectable, LOCALE_ID} from '@angular/core';
 
 import {getLocalePluralCase, Plural} from './locale_data_api';
 
-
 /**
  * @publicApi
  */
+@Injectable({
+  providedIn: 'root',
+  useFactory: (locale: string) => new NgLocaleLocalization(locale),
+  deps: [LOCALE_ID],
+})
 export abstract class NgLocalization {
   abstract getPluralCategory(value: any, locale?: string): string;
 }
-
 
 /**
  * Returns the plural category for a given value.

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -243,16 +243,10 @@
     "name": "LEAVE_TOKEN_REGEX"
   },
   {
-    "name": "LOCALE_DATA"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
     "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "LocaleDataIndex"
   },
   {
     "name": "MODIFIER_KEYS"
@@ -327,12 +321,6 @@
     "name": "NULL_REMOVED_QUERIED_STATE"
   },
   {
-    "name": "NgLocaleLocalization"
-  },
-  {
-    "name": "NgLocalization"
-  },
-  {
     "name": "NgModuleRef"
   },
   {
@@ -373,9 +361,6 @@
   },
   {
     "name": "PlatformRef"
-  },
-  {
-    "name": "Plural"
   },
   {
     "name": "R3Injector"
@@ -849,9 +834,6 @@
     "name": "getLViewParent"
   },
   {
-    "name": "getLocaleData"
-  },
-  {
     "name": "getNativeByTNode"
   },
   {
@@ -1084,9 +1066,6 @@
   },
   {
     "name": "listenOnPlayer"
-  },
-  {
-    "name": "locale_en_default"
   },
   {
     "name": "lookupTokenUsingModuleInjector"
@@ -1351,9 +1330,6 @@
   },
   {
     "name": "transition"
-  },
-  {
-    "name": "u"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -222,16 +222,10 @@
     "name": "KeyEventsPlugin"
   },
   {
-    "name": "LOCALE_DATA"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
     "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "LocaleDataIndex"
   },
   {
     "name": "MODIFIER_KEYS"
@@ -327,12 +321,6 @@
     "name": "NgForOf"
   },
   {
-    "name": "NgLocaleLocalization"
-  },
-  {
-    "name": "NgLocalization"
-  },
-  {
     "name": "NgModuleFactory2"
   },
   {
@@ -373,9 +361,6 @@
   },
   {
     "name": "PlatformRef"
-  },
-  {
-    "name": "Plural"
   },
   {
     "name": "R3Injector"
@@ -903,9 +888,6 @@
     "name": "getLViewParent"
   },
   {
-    "name": "getLocaleData"
-  },
-  {
     "name": "getNativeByTNode"
   },
   {
@@ -1204,9 +1186,6 @@
   },
   {
     "name": "leaveViewLight"
-  },
-  {
-    "name": "locale_en_default"
   },
   {
     "name": "lookupTokenUsingModuleInjector"
@@ -1516,9 +1495,6 @@
   },
   {
     "name": "trackByIdentity"
-  },
-  {
-    "name": "u"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -213,16 +213,10 @@
     "name": "KeyEventsPlugin"
   },
   {
-    "name": "LOCALE_DATA"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
     "name": "LifecycleHooksFeature"
-  },
-  {
-    "name": "LocaleDataIndex"
   },
   {
     "name": "MODIFIER_KEYS"
@@ -318,12 +312,6 @@
     "name": "NgForm"
   },
   {
-    "name": "NgLocaleLocalization"
-  },
-  {
-    "name": "NgLocalization"
-  },
-  {
     "name": "NgModel"
   },
   {
@@ -370,9 +358,6 @@
   },
   {
     "name": "PlatformRef"
-  },
-  {
-    "name": "Plural"
   },
   {
     "name": "R3Injector"
@@ -873,9 +858,6 @@
     "name": "getLViewParent"
   },
   {
-    "name": "getLocaleData"
-  },
-  {
     "name": "getNativeByTNode"
   },
   {
@@ -1168,9 +1150,6 @@
   },
   {
     "name": "leaveViewLight"
-  },
-  {
-    "name": "locale_en_default"
   },
   {
     "name": "lookupTokenUsingModuleInjector"
@@ -1498,9 +1477,6 @@
   },
   {
     "name": "trackByIdentity"
-  },
-  {
-    "name": "u"
   },
   {
     "name": "unwrapRNode"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -249,9 +249,6 @@
     "name": "KeyEventsPlugin"
   },
   {
-    "name": "LOCALE_DATA"
-  },
-  {
     "name": "LOCALE_ID2"
   },
   {
@@ -271,9 +268,6 @@
   },
   {
     "name": "LoadedRouterConfig"
-  },
-  {
-    "name": "LocaleDataIndex"
   },
   {
     "name": "Location"
@@ -369,12 +363,6 @@
     "name": "NavigationStart"
   },
   {
-    "name": "NgLocaleLocalization"
-  },
-  {
-    "name": "NgLocalization"
-  },
-  {
     "name": "NgModuleFactory"
   },
   {
@@ -439,9 +427,6 @@
   },
   {
     "name": "PlatformRef"
-  },
-  {
-    "name": "Plural"
   },
   {
     "name": "Position"
@@ -1206,9 +1191,6 @@
     "name": "getLViewParent"
   },
   {
-    "name": "getLocaleData"
-  },
-  {
     "name": "getNativeByTNode"
   },
   {
@@ -1501,9 +1483,6 @@
   },
   {
     "name": "leaveViewLight"
-  },
-  {
-    "name": "locale_en_default"
   },
   {
     "name": "locateDirectiveOrProvider"
@@ -1876,9 +1855,6 @@
   },
   {
     "name": "tree"
-  },
-  {
-    "name": "u"
   },
   {
     "name": "unwrapElementRef"


### PR DESCRIPTION
This PR is a patch-only version of PR #45118.