### PR TITLE
refactor(router): Use helper function to throw NoMatch

### DIFF
--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -200,7 +200,7 @@ class ApplyRedirects {
             if (noLeftoversInUrl(segmentGroup, segments, outlet)) {
               return of(new UrlSegmentGroup([], {}));
             }
-            throw new NoMatch(segmentGroup);
+            return noMatch(segmentGroup);
           }
           throw e;
         }));


### PR DESCRIPTION
…should be thrown

Throwing something that does not extend `Error` will not have a stack trace
attached to it, making debugging significantly more difficult.
