### PR TITLE
docs(service-worker): improve description of `NoNewVersionDetectedEvent`

### DIFF
--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -21,7 +21,7 @@ The `SwUpdate` service supports three separate operations:
 
 The `versionUpdates` is an `Observable` property of `SwUpdate` and emits four event types:
 * `VersionDetectedEvent` is emitted when the service worker has detected a new version of the app on the server and is about to start downloading it.
-* `NoNewVersionDetectedEvent` is emitted when the service worker has checked the version of the app on the server and it is the same as the installed version.
+* `NoNewVersionDetectedEvent` is emitted when the service worker has checked the version of the app on the server and did not find a new version.
 * `VersionReadyEvent` is emitted when a new version of the app is available to be activated by clients.
   It may be used to notify the user of an available update or prompt them to refresh the page.
 * `VersionInstallationFailedEvent` is emitted when the installation of a new version failed.

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -47,8 +47,8 @@ export interface UpdateActivatedEvent {
 }
 
 /**
- * An event emitted when the service worker has checked the version of the app on the server
- * and it is the same as the installed version.
+ * An event emitted when the service worker has checked the version of the app on the server and it
+ * didn't find a new version that it doesn't have already downloaded.
  *
  * @see {@link guide/service-worker-communications Service worker communication guide}
  *


### PR DESCRIPTION
The `NoNewVersionDetectedEvent` does not imply that the latest version on the server is the same as the version the client is on (because a client could be on an older version).

Update the description of the event to better describe what it actually means (i.e. that the SW didn't find a version it didn't already know about, but without implying anything about the version the current client is using).
