### PR TITLE
refactor(compiler): specify `@angular/core` as peer dependency

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -10,6 +10,14 @@
   "dependencies": {
     "tslib": "^2.3.0"
   },
+  "peerDependencies": {
+    "@angular/core": "0.0.0-PLACEHOLDER"
+  },
+  "peerDependenciesMeta": {
+    "@angular/core": {
+      "optional": true
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git",


### PR DESCRIPTION
The compiler generates code for the Angular runtime in `@angular/core` which
has to be the exact same version, as otherwise there may be version skew
between what the compiler generates and what the runtime supports. This would
result in hard to diagnose problems at runtime. By adding a peer dependency
for `@angular/compiler` on `@angular/core` we can let the package manager
report an error (NPM 7+) or warning (NPM 6, Yarn) during installation to
signal that the set of packages is incompatible.
