### PR TITLE
fix(forms): Add UntypedFormBuilder

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -730,6 +730,29 @@ export type UntypedFormArray = FormArray;
 export const UntypedFormArray: UntypedFormArrayCtor;
 
 // @public
+export class UntypedFormBuilder {
+    constructor();
+    // (undocumented)
+    array(controlsConfig: any[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): UntypedFormArray;
+    // (undocumented)
+    control(formState: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): UntypedFormControl;
+    // (undocumented)
+    group(controlsConfig: {
+        [key: string]: any;
+    }, options?: AbstractControlOptions | null): UntypedFormGroup;
+    // @deprecated (undocumented)
+    group(controlsConfig: {
+        [key: string]: any;
+    }, options: {
+        [key: string]: any;
+    }): UntypedFormGroup;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<UntypedFormBuilder, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<UntypedFormBuilder>;
+}
+
+// @public
 export type UntypedFormControl = FormControl;
 
 // @public (undocumented)

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -11,9 +11,9 @@ import {Injectable} from '@angular/core';
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
 import {ReactiveFormsModule} from './form_providers';
 import {AbstractControl, AbstractControlOptions, FormHooks} from './model/abstract_model';
-import {FormArray, isFormArray} from './model/form_array';
-import {FormControl, FormControlOptions, isFormControl} from './model/form_control';
-import {FormGroup, isFormGroup} from './model/form_group';
+import {FormArray, isFormArray, UntypedFormArray} from './model/form_array';
+import {FormControl, FormControlOptions, isFormControl, UntypedFormControl} from './model/form_control';
+import {FormGroup, isFormGroup, UntypedFormGroup} from './model/form_group';
 
 function isAbstractControlOptions(options: AbstractControlOptions|
                                   {[key: string]: any}): options is AbstractControlOptions {
@@ -180,5 +180,56 @@ export class FormBuilder {
     } else {
       return this.control(controlConfig);
     }
+  }
+}
+
+/**
+ * UntypedFormBuilder is the same as @see FormBuilder, but it provides untyped controls.
+ */
+@Injectable({providedIn: ReactiveFormsModule})
+export class UntypedFormBuilder {
+  private _typedBuilder: FormBuilder;
+
+  constructor() {
+    this._typedBuilder = new FormBuilder();
+  }
+
+  /**
+   * @see FormBuilder#group
+   */
+  group(
+      controlsConfig: {[key: string]: any},
+      options?: AbstractControlOptions|null,
+      ): UntypedFormGroup;
+  /**
+   * @deprecated
+   */
+  group(
+      controlsConfig: {[key: string]: any},
+      options: {[key: string]: any},
+      ): UntypedFormGroup;
+  group(
+      controlsConfig: {[key: string]: any},
+      options: AbstractControlOptions|{[key: string]: any}|null = null): UntypedFormGroup {
+    return this._typedBuilder.group(controlsConfig, options);
+  }
+
+  /**
+   * @see FormBuilder#control
+   */
+  control(
+      formState: any, validatorOrOpts?: ValidatorFn|ValidatorFn[]|FormControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): UntypedFormControl {
+    return this._typedBuilder.control(formState, validatorOrOpts, asyncValidator);
+  }
+
+  /**
+   * @see FormBuilder#array
+   */
+  array(
+      controlsConfig: any[],
+      validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
+      asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): UntypedFormArray {
+    return this._typedBuilder.array(controlsConfig, validatorOrOpts, asyncValidator);
   }
 }

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -41,7 +41,7 @@ export {FormArrayName, FormGroupName} from './directives/reactive_directives/for
 export {NgSelectOption, SelectControlValueAccessor} from './directives/select_control_value_accessor';
 export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
-export {FormBuilder} from './form_builder';
+export {FormBuilder, UntypedFormBuilder} from './form_builder';
 export {AbstractControl, AbstractControlOptions, FormControlStatus} from './model/abstract_model';
 export {FormArray, UntypedFormArray} from './model/form_array';
 export {FormControl, FormControlOptions, UntypedFormControl, ɵFormControlCtor} from './model/form_control';


### PR DESCRIPTION
This was intended to be part of #45205, but was left out. Adds a new class for use in migration.
