### PR TITLE
fix(forms): Property renaming safe code

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -52,7 +52,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 156654,
+        "main": 157357,
         "polyfills": 33804
       }
     }

--- a/packages/forms/src/directives/ng_control_status.ts
+++ b/packages/forms/src/directives/ng_control_status.ts
@@ -12,9 +12,10 @@ import {AbstractControlDirective} from './abstract_control_directive';
 import {ControlContainer} from './control_container';
 import {NgControl} from './ng_control';
 
-type AnyControlStatus =
-    'untouched'|'touched'|'pristine'|'dirty'|'valid'|'invalid'|'pending'|'submitted';
-
+// DO NOT REFACTOR!
+// Each status is represented by a separate function to make sure that
+// advanced Closure Compiler optimizations related to property renaming
+// can work correctly.
 export class AbstractControlStatus {
   private _cd: AbstractControlDirective|null;
 
@@ -22,41 +23,54 @@ export class AbstractControlStatus {
     this._cd = cd;
   }
 
-  is(status: AnyControlStatus): boolean {
-    // Currently with ViewEngine (in AOT mode) it's not possible to use private methods in host
-    // bindings.
-    // TODO: once ViewEngine is removed, this function should be refactored:
-    //  - make the `is` method `protected`, so it's not accessible publicly
-    //  - move the `submitted` status logic to the `NgControlStatusGroup` class
-    //    and make it `private` or `protected` too.
-    if (status === 'submitted') {
-      // We check for the `submitted` field from `NgForm` and `FormGroupDirective` classes, but
-      // we avoid instanceof checks to prevent non-tree-shakable references to those types.
-      return !!(this._cd as unknown as {submitted: boolean} | null)?.submitted;
-    }
-    return !!this._cd?.control?.[status];
+  protected get isTouched() {
+    return !!this._cd?.control?.touched;
+  }
+
+  protected get isUntouched() {
+    return !!this._cd?.control?.untouched;
+  }
+
+  protected get isPristine() {
+    return !!this._cd?.control?.pristine;
+  }
+
+  protected get isDirty() {
+    return !!this._cd?.control?.dirty;
+  }
+
+  protected get isValid() {
+    return !!this._cd?.control?.valid;
+  }
+
+  protected get isInvalid() {
+    return !!this._cd?.control?.invalid;
+  }
+
+  protected get isPending() {
+    return !!this._cd?.control?.pending;
+  }
+
+  protected get isSubmitted() {
+    // We check for the `submitted` field from `NgForm` and `FormGroupDirective` classes, but
+    // we avoid instanceof checks to prevent non-tree-shakable references to those types.
+    return !!(this._cd as unknown as {submitted: boolean} | null)?.submitted;
   }
 }
 
 export const ngControlStatusHost = {
-  '[class.ng-untouched]': 'is("untouched")',
-  '[class.ng-touched]': 'is("touched")',
-  '[class.ng-pristine]': 'is("pristine")',
-  '[class.ng-dirty]': 'is("dirty")',
-  '[class.ng-valid]': 'is("valid")',
-  '[class.ng-invalid]': 'is("invalid")',
-  '[class.ng-pending]': 'is("pending")',
+  '[class.ng-untouched]': 'isUntouched',
+  '[class.ng-touched]': 'isTouched',
+  '[class.ng-pristine]': 'isPristine',
+  '[class.ng-dirty]': 'isDirty',
+  '[class.ng-valid]': 'isValid',
+  '[class.ng-invalid]': 'isInvalid',
+  '[class.ng-pending]': 'isPending',
 };
 
 export const ngGroupStatusHost = {
-  '[class.ng-untouched]': 'is("untouched")',
-  '[class.ng-touched]': 'is("touched")',
-  '[class.ng-pristine]': 'is("pristine")',
-  '[class.ng-dirty]': 'is("dirty")',
-  '[class.ng-valid]': 'is("valid")',
-  '[class.ng-invalid]': 'is("invalid")',
-  '[class.ng-pending]': 'is("pending")',
-  '[class.ng-submitted]': 'is("submitted")',
+  ...ngControlStatusHost,
+  '[class.ng-submitted]': 'isSubmitted',
 };
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
It was causing ng-touched not to be applied in optimized mode/prod where the compiler runs the full set of optimizations and compiler checks. This behavior is likely the case with all other ng control statuses.

Issue Number: N/A


## What is the new behavior?
ng-touched is now applied successfully in all javascript compilation modes.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
