### PR TITLE
fix(zone.js): always run microtasks in `Promise.then` to avoid drain microtasks too early.

### DIFF
--- a/packages/zone.js/lib/jasmine/jasmine.ts
+++ b/packages/zone.js/lib/jasmine/jasmine.ts
@@ -10,19 +10,18 @@
 
 import {ZoneType} from '../zone-impl';
 
-'use strict';
+('use strict');
 declare let jest: any;
 
 export function patchJasmine(Zone: ZoneType): void {
   Zone.__load_patch('jasmine', (global: any, Zone: ZoneType, api: _ZonePrivate) => {
-    const __extends = function(d: any, b: any) {
-      for (const p in b)
-        if (b.hasOwnProperty(p)) d[p] = b[p];
+    const __extends = function (d: any, b: any) {
+      for (const p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
       function __(this: Object) {
         this.constructor = d;
       }
       d.prototype =
-          b === null ? Object.create(b) : ((__.prototype = b.prototype), new (__ as any)());
+        b === null ? Object.create(b) : ((__.prototype = b.prototype), new (__ as any)());
     };
     // Patch jasmine's describe/it/beforeEach/afterEach functions so test code always runs
     // in a testZone (ProxyZone). (See: angular/zone.js#91 & angular/angular#10503)
@@ -51,9 +50,10 @@ export function patchJasmine(Zone: ZoneType): void {
     // the original variable name fakeAsyncPatchLock is not accurate, so the name will be
     // fakeAsyncAutoFakeAsyncWhenClockPatched and if this enablePatchingJasmineClock is false, we
     // also automatically disable the auto jump into fakeAsync feature
-    const enableAutoFakeAsyncWhenClockPatched = !disablePatchingJasmineClock &&
-        ((global[symbol('fakeAsyncPatchLock')] === true) ||
-         (global[symbol('fakeAsyncAutoFakeAsyncWhenClockPatched')] === true));
+    const enableAutoFakeAsyncWhenClockPatched =
+      !disablePatchingJasmineClock &&
+      (global[symbol('fakeAsyncPatchLock')] === true ||
+        global[symbol('fakeAsyncAutoFakeAsyncWhenClockPatched')] === true);
 
     const ignoreUnhandledRejection = global[symbol('ignoreUnhandledRejection')] === true;
 
@@ -61,12 +61,12 @@ export function patchJasmine(Zone: ZoneType): void {
       const globalErrors = (jasmine as any).GlobalErrors;
       if (globalErrors && !(jasmine as any)[symbol('GlobalErrors')]) {
         (jasmine as any)[symbol('GlobalErrors')] = globalErrors;
-        (jasmine as any).GlobalErrors = function() {
+        (jasmine as any).GlobalErrors = function () {
           const instance = new globalErrors();
           const originalInstall = instance.install;
           if (originalInstall && !instance[symbol('install')]) {
             instance[symbol('install')] = originalInstall;
-            instance.install = function() {
+            instance.install = function () {
               const isNode = typeof process !== 'undefined' && !!process.on;
               // Note: Jasmine checks internally if `process` and `process.on` is defined.
               // Otherwise, it installs the browser rejection handler through the
@@ -74,13 +74,15 @@ export function patchJasmine(Zone: ZoneType): void {
               // `process` is not defined, and this will lead to a runtime exception since Webpack 5
               // removed automatic Node.js polyfills. Note, that events are named differently, it's
               // `unhandledRejection` in Node.js and `unhandledrejection` in the browser.
-              const originalHandlers: any[] = isNode ? process.listeners('unhandledRejection') :
-                                                       global.eventListeners('unhandledrejection');
+              const originalHandlers: any[] = isNode
+                ? process.listeners('unhandledRejection')
+                : global.eventListeners('unhandledrejection');
               const result = originalInstall.apply(this, arguments);
-              isNode ? process.removeAllListeners('unhandledRejection') :
-                       global.removeAllListeners('unhandledrejection');
+              isNode
+                ? process.removeAllListeners('unhandledRejection')
+                : global.removeAllListeners('unhandledrejection');
               if (originalHandlers) {
-                originalHandlers.forEach(handler => {
+                originalHandlers.forEach((handler) => {
                   if (isNode) {
                     process.on('unhandledRejection', handler);
                   } else {
@@ -98,26 +100,32 @@ export function patchJasmine(Zone: ZoneType): void {
 
     // Monkey patch all of the jasmine DSL so that each function runs in appropriate zone.
     const jasmineEnv: any = jasmine.getEnv();
-    ['describe', 'xdescribe', 'fdescribe'].forEach(methodName => {
+    ['describe', 'xdescribe', 'fdescribe'].forEach((methodName) => {
       let originalJasmineFn: Function = jasmineEnv[methodName];
-      jasmineEnv[methodName] = function(description: string, specDefinitions: Function) {
+      jasmineEnv[methodName] = function (description: string, specDefinitions: Function) {
         return originalJasmineFn.call(
-            this, description, wrapDescribeInZone(description, specDefinitions));
+          this,
+          description,
+          wrapDescribeInZone(description, specDefinitions),
+        );
       };
     });
-    ['it', 'xit', 'fit'].forEach(methodName => {
+    ['it', 'xit', 'fit'].forEach((methodName) => {
       let originalJasmineFn: Function = jasmineEnv[methodName];
       jasmineEnv[symbol(methodName)] = originalJasmineFn;
-      jasmineEnv[methodName] = function(
-          description: string, specDefinitions: Function, timeout: number) {
+      jasmineEnv[methodName] = function (
+        description: string,
+        specDefinitions: Function,
+        timeout: number,
+      ) {
         arguments[1] = wrapTestInZone(specDefinitions);
         return originalJasmineFn.apply(this, arguments);
       };
     });
-    ['beforeEach', 'afterEach', 'beforeAll', 'afterAll'].forEach(methodName => {
+    ['beforeEach', 'afterEach', 'beforeAll', 'afterAll'].forEach((methodName) => {
       let originalJasmineFn: Function = jasmineEnv[methodName];
       jasmineEnv[symbol(methodName)] = originalJasmineFn;
-      jasmineEnv[methodName] = function(specDefinitions: Function, timeout: number) {
+      jasmineEnv[methodName] = function (specDefinitions: Function, timeout: number) {
         arguments[0] = wrapTestInZone(specDefinitions);
         return originalJasmineFn.apply(this, arguments);
       };
@@ -127,12 +135,12 @@ export function patchJasmine(Zone: ZoneType): void {
       // need to patch jasmine.clock().mockDate and jasmine.clock().tick() so
       // they can work properly in FakeAsyncTest
       const originalClockFn: Function = ((jasmine as any)[symbol('clock')] = jasmine['clock']);
-      (jasmine as any)['clock'] = function() {
+      (jasmine as any)['clock'] = function () {
         const clock = originalClockFn.apply(this, arguments);
         if (!clock[symbol('patched')]) {
           clock[symbol('patched')] = symbol('patched');
           const originalTick = (clock[symbol('tick')] = clock.tick);
-          clock.tick = function() {
+          clock.tick = function () {
             const fakeAsyncZoneSpec = Zone.current.get('FakeAsyncTestZoneSpec');
             if (fakeAsyncZoneSpec) {
               return fakeAsyncZoneSpec.tick.apply(fakeAsyncZoneSpec, arguments);
@@ -140,22 +148,24 @@ export function patchJasmine(Zone: ZoneType): void {
             return originalTick.apply(this, arguments);
           };
           const originalMockDate = (clock[symbol('mockDate')] = clock.mockDate);
-          clock.mockDate = function() {
+          clock.mockDate = function () {
             const fakeAsyncZoneSpec = Zone.current.get('FakeAsyncTestZoneSpec');
             if (fakeAsyncZoneSpec) {
               const dateTime = arguments.length > 0 ? arguments[0] : new Date();
               return fakeAsyncZoneSpec.setFakeBaseSystemTime.apply(
-                  fakeAsyncZoneSpec,
-                  dateTime && typeof dateTime.getTime === 'function' ? [dateTime.getTime()] :
-                                                                       arguments);
+                fakeAsyncZoneSpec,
+                dateTime && typeof dateTime.getTime === 'function'
+                  ? [dateTime.getTime()]
+                  : arguments,
+              );
             }
             return originalMockDate.apply(this, arguments);
           };
           // for auto go into fakeAsync feature, we need the flag to enable it
           if (enableAutoFakeAsyncWhenClockPatched) {
-            ['install', 'uninstall'].forEach(methodName => {
+            ['install', 'uninstall'].forEach((methodName) => {
               const originalClockFn: Function = (clock[symbol(methodName)] = clock[methodName]);
-              clock[methodName] = function() {
+              clock[methodName] = function () {
                 const FakeAsyncTestZoneSpec = (Zone as any)['FakeAsyncTestZoneSpec'];
                 if (FakeAsyncTestZoneSpec) {
                   (jasmine as any)[symbol('clockInstalled')] = 'install' === methodName;
@@ -174,15 +184,18 @@ export function patchJasmine(Zone: ZoneType): void {
     if (!(jasmine as any)[Zone.__symbol__('createSpyObj')]) {
       const originalCreateSpyObj = jasmine.createSpyObj;
       (jasmine as any)[Zone.__symbol__('createSpyObj')] = originalCreateSpyObj;
-      jasmine.createSpyObj = function() {
+      jasmine.createSpyObj = function () {
         const args: any = Array.prototype.slice.call(arguments);
         const propertyNames = args.length >= 3 ? args[2] : null;
         let spyObj: any;
         if (propertyNames) {
           const defineProperty = Object.defineProperty;
-          Object.defineProperty = function<T>(obj: T, p: PropertyKey, attributes: any) {
-            return defineProperty.call(
-                       this, obj, p, {...attributes, configurable: true, enumerable: true}) as T;
+          Object.defineProperty = function <T>(obj: T, p: PropertyKey, attributes: any) {
+            return defineProperty.call(this, obj, p, {
+              ...attributes,
+              configurable: true,
+              enumerable: true,
+            }) as T;
           };
           try {
             spyObj = originalCreateSpyObj.apply(this, args);
@@ -201,16 +214,20 @@ export function patchJasmine(Zone: ZoneType): void {
      * synchronous-only zone.
      */
     function wrapDescribeInZone(description: string, describeBody: Function): Function {
-      return function(this: unknown) {
+      return function (this: unknown) {
         // Create a synchronous-only zone in which to run `describe` blocks in order to raise an
         // error if any asynchronous operations are attempted inside of a `describe`.
         const syncZone = ambientZone.fork(new SyncTestZoneSpec(`jasmine.describe#${description}`));
-        return syncZone.run(describeBody, this, (arguments as any) as any[]);
+        return syncZone.run(describeBody, this, arguments as any as any[]);
       };
     }
 
     function runInTestZone(
-        testBody: Function, applyThis: any, queueRunner: QueueRunner, done?: Function) {
+      testBody: Function,
+      applyThis: any,
+      queueRunner: QueueRunner,
+      done?: Function,
+    ) {
       const isClockInstalled = !!(jasmine as any)[symbol('clockInstalled')];
       const testProxyZoneSpec = queueRunner.testProxyZoneSpec!;
       const testProxyZone = queueRunner.testProxyZone!;
@@ -239,16 +256,20 @@ export function patchJasmine(Zone: ZoneType): void {
       // Note we have to make a function with correct number of arguments, otherwise jasmine will
       // think that all functions are sync or async.
       return (
-          testBody && (testBody.length ? function(this: QueueRunnerUserContext, done: Function) {
-            return runInTestZone(testBody, this, this.queueRunner!, done);
-          } : function(this: QueueRunnerUserContext) {
-            return runInTestZone(testBody, this, this.queueRunner!);
-          }));
+        testBody &&
+        (testBody.length
+          ? function (this: QueueRunnerUserContext, done: Function) {
+              return runInTestZone(testBody, this, this.queueRunner!, done);
+            }
+          : function (this: QueueRunnerUserContext) {
+              return runInTestZone(testBody, this, this.queueRunner!);
+            })
+      );
     }
     interface QueueRunner {
       execute(): void;
-      testProxyZoneSpec: ZoneSpec|null;
-      testProxyZone: Zone|null;
+      testProxyZoneSpec: ZoneSpec | null;
+      testProxyZone: Zone | null;
     }
     interface QueueRunnerAttrs {
       queueableFns: {fn: Function}[];
@@ -264,15 +285,15 @@ export function patchJasmine(Zone: ZoneType): void {
     const QueueRunner = (jasmine as any).QueueRunner as {
       new (attrs: QueueRunnerAttrs): QueueRunner;
     };
-    (jasmine as any).QueueRunner = (function(_super) {
+    (jasmine as any).QueueRunner = (function (_super) {
       __extends(ZoneQueueRunner, _super);
       function ZoneQueueRunner(this: QueueRunner, attrs: QueueRunnerAttrs) {
         if (attrs.onComplete) {
-          attrs.onComplete = (fn => () => {
+          attrs.onComplete = ((fn) => () => {
             // All functions are done, clear the test zone.
             this.testProxyZone = null;
             this.testProxyZoneSpec = null;
-            ambientZone.scheduleMicroTask('jasmine.onComplete', fn);
+            ambientZone.run(fn);
           })(attrs.onComplete);
         }
 
@@ -282,7 +303,7 @@ export function patchJasmine(Zone: ZoneType): void {
           // should run setTimeout inside jasmine outside of zone
           attrs.timeout = {
             setTimeout: nativeSetTimeout ? nativeSetTimeout : global.setTimeout,
-            clearTimeout: nativeClearTimeout ? nativeClearTimeout : global.clearTimeout
+            clearTimeout: nativeClearTimeout ? nativeClearTimeout : global.clearTimeout,
           };
         }
 
@@ -302,10 +323,12 @@ export function patchJasmine(Zone: ZoneType): void {
 
         // patch attrs.onException
         const onException = attrs.onException;
-        attrs.onException = function(this: undefined|QueueRunner, error: any) {
-          if (error &&
-              error.message ===
-                  'Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.') {
+        attrs.onException = function (this: undefined | QueueRunner, error: any) {
+          if (
+            error &&
+            error.message ===
+              'Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL.'
+          ) {
             // jasmine timeout, we can make the error message more
             // reasonable to tell what tasks are pending
             const proxyZoneSpec: any = this && this.testProxyZoneSpec;
@@ -314,8 +337,7 @@ export function patchJasmine(Zone: ZoneType): void {
               try {
                 // try catch here in case error.message is not writable
                 error.message += pendingTasksInfo;
-              } catch (err) {
-              }
+              } catch (err) {}
             }
           }
           if (onException) {
@@ -325,8 +347,8 @@ export function patchJasmine(Zone: ZoneType): void {
 
         _super.call(this, attrs);
       }
-      ZoneQueueRunner.prototype.execute = function() {
-        let zone: Zone|null = Zone.current;
+      ZoneQueueRunner.prototype.execute = function () {
+        let zone: Zone | null = Zone.current;
         let isChildOfAmbientZone = false;
         while (zone) {
           if (zone === ambientZone) {
@@ -350,17 +372,7 @@ export function patchJasmine(Zone: ZoneType): void {
 
         this.testProxyZoneSpec = new ProxyZoneSpec();
         this.testProxyZone = ambientZone.fork(this.testProxyZoneSpec);
-        if (!Zone.currentTask) {
-          // if we are not running in a task then if someone would register a
-          // element.addEventListener and then calling element.click() the
-          // addEventListener callback would think that it is the top most task and would
-          // drain the microtask queue on element.click() which would be incorrect.
-          // For this reason we always force a task when running jasmine tests.
-          Zone.current.scheduleMicroTask(
-              'jasmine.execute().forceTask', () => QueueRunner.prototype.execute.call(this));
-        } else {
-          _super.prototype.execute.call(this);
-        }
+        _super.prototype.execute.call(this);
       };
       return ZoneQueueRunner;
     })(QueueRunner);

--- a/packages/zone.js/lib/mocha/mocha.ts
+++ b/packages/zone.js/lib/mocha/mocha.ts
@@ -8,7 +8,7 @@
 
 import {ZoneType} from '../zone-impl';
 
-'use strict';
+('use strict');
 
 export function patchMocha(Zone: ZoneType): void {
   Zone.__load_patch('mocha', (global: any, Zone: ZoneType) => {
@@ -39,7 +39,7 @@ export function patchMocha(Zone: ZoneType): void {
 
     const rootZone = Zone.current;
     const syncZone = rootZone.fork(new SyncTestZoneSpec('Mocha.describe'));
-    let testZone: Zone|null = null;
+    let testZone: Zone | null = null;
     const suiteZone = rootZone.fork(new ProxyZoneSpec());
 
     const mochaOriginal = {
@@ -48,7 +48,7 @@ export function patchMocha(Zone: ZoneType): void {
       before: global.before,
       beforeEach: global.beforeEach,
       describe: global.describe,
-      it: global.it
+      it: global.it,
     };
 
     function modifyArguments(args: IArguments, syncTest: Function, asyncTest?: Function): any[] {
@@ -60,10 +60,10 @@ export function patchMocha(Zone: ZoneType): void {
           // Note we have to make a function with correct number of arguments,
           // otherwise mocha will
           // think that all functions are sync or async.
-          args[i] = (arg.length === 0) ? syncTest(arg) : asyncTest!(arg);
+          args[i] = arg.length === 0 ? syncTest(arg) : asyncTest!(arg);
           // Mocha uses toString to view the test body in the result list, make sure we return the
           // correct function body
-          args[i].toString = function() {
+          args[i].toString = function () {
             return arg.toString();
           };
         }
@@ -73,8 +73,8 @@ export function patchMocha(Zone: ZoneType): void {
     }
 
     function wrapDescribeInZone(args: IArguments): any[] {
-      const syncTest: any = function(fn: Function) {
-        return function(this: unknown) {
+      const syncTest: any = function (fn: Function) {
+        return function (this: unknown) {
           return syncZone.run(fn, this, arguments as any as any[]);
         };
       };
@@ -83,14 +83,14 @@ export function patchMocha(Zone: ZoneType): void {
     }
 
     function wrapTestInZone(args: IArguments): any[] {
-      const asyncTest = function(fn: Function) {
-        return function(this: unknown, done: Function) {
+      const asyncTest = function (fn: Function) {
+        return function (this: unknown, done: Function) {
           return testZone!.run(fn, this, [done]);
         };
       };
 
-      const syncTest: any = function(fn: Function) {
-        return function(this: unknown) {
+      const syncTest: any = function (fn: Function) {
+        return function (this: unknown) {
           return testZone!.run(fn, this);
         };
       };
@@ -99,14 +99,14 @@ export function patchMocha(Zone: ZoneType): void {
     }
 
     function wrapSuiteInZone(args: IArguments): any[] {
-      const asyncTest = function(fn: Function) {
-        return function(this: unknown, done: Function) {
+      const asyncTest = function (fn: Function) {
+        return function (this: unknown, done: Function) {
           return suiteZone.run(fn, this, [done]);
         };
       };
 
-      const syncTest: any = function(fn: Function) {
-        return function(this: unknown) {
+      const syncTest: any = function (fn: Function) {
+        return function (this: unknown) {
           return suiteZone.run(fn, this);
         };
       };
@@ -114,54 +114,57 @@ export function patchMocha(Zone: ZoneType): void {
       return modifyArguments(args, syncTest, asyncTest);
     }
 
-    global.describe = global.suite = function() {
+    global.describe = global.suite = function () {
       return mochaOriginal.describe.apply(this, wrapDescribeInZone(arguments));
     };
 
-    global.xdescribe = global.suite.skip = global.describe.skip = function() {
-      return mochaOriginal.describe.skip.apply(this, wrapDescribeInZone(arguments));
-    };
+    global.xdescribe =
+      global.suite.skip =
+      global.describe.skip =
+        function () {
+          return mochaOriginal.describe.skip.apply(this, wrapDescribeInZone(arguments));
+        };
 
-    global.describe.only = global.suite.only = function() {
+    global.describe.only = global.suite.only = function () {
       return mochaOriginal.describe.only.apply(this, wrapDescribeInZone(arguments));
     };
 
-    global.it = global.specify = global.test = function() {
-      return mochaOriginal.it.apply(this, wrapTestInZone(arguments));
-    };
+    global.it =
+      global.specify =
+      global.test =
+        function () {
+          return mochaOriginal.it.apply(this, wrapTestInZone(arguments));
+        };
 
-    global.xit = global.xspecify = global.it.skip = function() {
-      return mochaOriginal.it.skip.apply(this, wrapTestInZone(arguments));
-    };
+    global.xit =
+      global.xspecify =
+      global.it.skip =
+        function () {
+          return mochaOriginal.it.skip.apply(this, wrapTestInZone(arguments));
+        };
 
-    global.it.only = global.test.only = function() {
+    global.it.only = global.test.only = function () {
       return mochaOriginal.it.only.apply(this, wrapTestInZone(arguments));
     };
 
-    global.after = global.suiteTeardown = function() {
+    global.after = global.suiteTeardown = function () {
       return mochaOriginal.after.apply(this, wrapSuiteInZone(arguments));
     };
 
-    global.afterEach = global.teardown = function() {
+    global.afterEach = global.teardown = function () {
       return mochaOriginal.afterEach.apply(this, wrapTestInZone(arguments));
     };
 
-    global.before = global.suiteSetup = function() {
+    global.before = global.suiteSetup = function () {
       return mochaOriginal.before.apply(this, wrapSuiteInZone(arguments));
     };
 
-    global.beforeEach = global.setup = function() {
+    global.beforeEach = global.setup = function () {
       return mochaOriginal.beforeEach.apply(this, wrapTestInZone(arguments));
     };
 
-    ((originalRunTest, originalRun) => {
-      Mocha.Runner.prototype.runTest = function(fn: Function) {
-        Zone.current.scheduleMicroTask('mocha.forceTask', () => {
-          originalRunTest.call(this, fn);
-        });
-      };
-
-      Mocha.Runner.prototype.run = function(fn: Function) {
+    ((originalRun) => {
+      Mocha.Runner.prototype.run = function (fn: Function) {
         this.on('test', (e: any) => {
           testZone = rootZone.fork(new ProxyZoneSpec());
         });
@@ -172,13 +175,12 @@ export function patchMocha(Zone: ZoneType): void {
             try {
               // try catch here in case err.message is not writable
               err.message += proxyZoneSpec.getAndClearPendingTasksInfo();
-            } catch (error) {
-            }
+            } catch (error) {}
           }
         });
 
         return originalRun.call(this, fn);
       };
-    })(Mocha.Runner.prototype.runTest, Mocha.Runner.prototype.run);
+    })(Mocha.Runner.prototype.run);
   });
 }

--- a/packages/zone.js/lib/zone-impl.ts
+++ b/packages/zone.js/lib/zone-impl.ts
@@ -138,7 +138,7 @@ export declare interface Zone {
    *
    * @returns {Zone} The parent Zone.
    */
-  parent: Zone|null;
+  parent: Zone | null;
   /**
    * @returns {string} The Zone name (useful for debugging)
    */
@@ -163,7 +163,7 @@ export declare interface Zone {
    * @param key The key to use for identification of the returned zone.
    * @returns {Zone} The Zone which defines the `key`, `null` if not found.
    */
-  getZoneWith(key: string): Zone|null;
+  getZoneWith(key: string): Zone | null;
 
   /**
    * Used to create a child zone.
@@ -237,8 +237,11 @@ export declare interface Zone {
    * @param customSchedule
    */
   scheduleMicroTask(
-      source: string, callback: Function, data?: TaskData,
-      customSchedule?: (task: Task) => void): MicroTask;
+    source: string,
+    callback: Function,
+    data?: TaskData,
+    customSchedule?: (task: Task) => void,
+  ): MicroTask;
 
   /**
    * Schedule a MacroTask.
@@ -250,8 +253,12 @@ export declare interface Zone {
    * @param customCancel
    */
   scheduleMacroTask(
-      source: string, callback: Function, data?: TaskData, customSchedule?: (task: Task) => void,
-      customCancel?: (task: Task) => void): MacroTask;
+    source: string,
+    callback: Function,
+    data?: TaskData,
+    customSchedule?: (task: Task) => void,
+    customCancel?: (task: Task) => void,
+  ): MacroTask;
 
   /**
    * Schedule an EventTask.
@@ -263,8 +270,12 @@ export declare interface Zone {
    * @param customCancel
    */
   scheduleEventTask(
-      source: string, callback: Function, data?: TaskData, customSchedule?: (task: Task) => void,
-      customCancel?: (task: Task) => void): EventTask;
+    source: string,
+    callback: Function,
+    data?: TaskData,
+    customSchedule?: (task: Task) => void,
+    customCancel?: (task: Task) => void,
+  ): EventTask;
 
   /**
    * Schedule an existing Task.
@@ -298,7 +309,7 @@ export declare interface ZoneType {
   /**
    * @returns {Task} The task associated with the current execution.
    */
-  currentTask: Task|null;
+  currentTask: Task | null;
 
   /**
    * Verify that Zone has been correctly patched. Specifically that Promise is zone aware.
@@ -339,21 +350,32 @@ export declare interface ZonePrivate {
   microtaskDrainDone: () => void;
   showUncaughtError: () => boolean;
   patchEventTarget: (global: any, api: ZonePrivate, apis: any[], options?: any) => boolean[];
-  patchOnProperties: (obj: any, properties: string[]|null, prototype?: any) => void;
+  patchOnProperties: (obj: any, properties: string[] | null, prototype?: any) => void;
   patchThen: (ctro: Function) => void;
-  patchMethod:
-      (target: any, name: string,
-       patchFn: (delegate: Function, delegateName: string, name: string) =>
-           (self: any, args: any[]) => any) => Function | null;
+  patchMethod: (
+    target: any,
+    name: string,
+    patchFn: (
+      delegate: Function,
+      delegateName: string,
+      name: string,
+    ) => (self: any, args: any[]) => any,
+  ) => Function | null;
   bindArguments: (args: any[], source: string) => any[];
-  patchMacroTask:
-      (obj: any, funcName: string, metaCreator: (self: any, args: any[]) => any) => void;
+  patchMacroTask: (
+    obj: any,
+    funcName: string,
+    metaCreator: (self: any, args: any[]) => any,
+  ) => void;
   patchEventPrototype: (_global: any, api: ZonePrivate) => void;
   isIEOrEdge: () => boolean;
-  ObjectDefineProperty:
-      (o: any, p: PropertyKey, attributes: PropertyDescriptor&ThisType<any>) => any;
+  ObjectDefineProperty: (
+    o: any,
+    p: PropertyKey,
+    attributes: PropertyDescriptor & ThisType<any>,
+  ) => any;
   ObjectGetOwnPropertyDescriptor: (o: any, p: PropertyKey) => PropertyDescriptor | undefined;
-  ObjectCreate(o: object|null, properties?: PropertyDescriptorMap&ThisType<any>): any;
+  ObjectCreate(o: object | null, properties?: PropertyDescriptorMap & ThisType<any>): any;
   ArraySlice(start?: number, end?: number): any[];
   patchClass: (className: string) => void;
   wrapWithCurrentZone: (callback: any, source: string) => any;
@@ -361,22 +383,35 @@ export declare interface ZonePrivate {
   attachOriginToPatched: (target: any, origin: any) => void;
   _redefineProperty: (target: any, callback: string, desc: any) => void;
   nativeScheduleMicroTask: (func: Function) => void;
-  patchCallbacks:
-      (api: ZonePrivate, target: any, targetName: string, method: string,
-       callbacks: string[]) => void;
-  getGlobalObjects: () => {
-    globalSources: any, zoneSymbolEventNames: any, eventNames: string[], isBrowser: boolean,
-        isMix: boolean, isNode: boolean, TRUE_STR: string, FALSE_STR: string,
-        ZONE_SYMBOL_PREFIX: string, ADD_EVENT_LISTENER_STR: string,
-        REMOVE_EVENT_LISTENER_STR: string
-  } | undefined;
+  patchCallbacks: (
+    api: ZonePrivate,
+    target: any,
+    targetName: string,
+    method: string,
+    callbacks: string[],
+  ) => void;
+  getGlobalObjects: () =>
+    | {
+        globalSources: any;
+        zoneSymbolEventNames: any;
+        eventNames: string[];
+        isBrowser: boolean;
+        isMix: boolean;
+        isNode: boolean;
+        TRUE_STR: string;
+        FALSE_STR: string;
+        ZONE_SYMBOL_PREFIX: string;
+        ADD_EVENT_LISTENER_STR: string;
+        REMOVE_EVENT_LISTENER_STR: string;
+      }
+    | undefined;
 }
 
 /**
  * ZoneFrame represents zone stack frame information
  */
 export declare interface ZoneFrame {
-  parent: ZoneFrame|null;
+  parent: ZoneFrame | null;
   zone: Zone;
 }
 
@@ -414,9 +449,12 @@ export declare interface ZoneSpec {
    * @param targetZone The [Zone] which originally received the request.
    * @param zoneSpec The argument passed into the `fork` method.
    */
-  onFork?:
-      (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone,
-       zoneSpec: ZoneSpec) => Zone;
+  onFork?: (
+    parentZoneDelegate: ZoneDelegate,
+    currentZone: Zone,
+    targetZone: Zone,
+    zoneSpec: ZoneSpec,
+  ) => Zone;
 
   /**
    * Allows interception of the wrapping of the callback.
@@ -427,9 +465,13 @@ export declare interface ZoneSpec {
    * @param delegate The argument passed into the `wrap` method.
    * @param source The argument passed into the `wrap` method.
    */
-  onIntercept?:
-      (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, delegate: Function,
-       source: string) => Function;
+  onIntercept?: (
+    parentZoneDelegate: ZoneDelegate,
+    currentZone: Zone,
+    targetZone: Zone,
+    delegate: Function,
+    source: string,
+  ) => Function;
 
   /**
    * Allows interception of the callback invocation.
@@ -442,9 +484,15 @@ export declare interface ZoneSpec {
    * @param applyArgs The argument passed into the `run` method.
    * @param source The argument passed into the `run` method.
    */
-  onInvoke?:
-      (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, delegate: Function,
-       applyThis: any, applyArgs?: any[], source?: string) => any;
+  onInvoke?: (
+    parentZoneDelegate: ZoneDelegate,
+    currentZone: Zone,
+    targetZone: Zone,
+    delegate: Function,
+    applyThis: any,
+    applyArgs?: any[],
+    source?: string,
+  ) => any;
 
   /**
    * Allows interception of the error handling.
@@ -454,9 +502,12 @@ export declare interface ZoneSpec {
    * @param targetZone The [Zone] which originally received the request.
    * @param error The argument passed into the `handleError` method.
    */
-  onHandleError?:
-      (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone,
-       error: any) => boolean;
+  onHandleError?: (
+    parentZoneDelegate: ZoneDelegate,
+    currentZone: Zone,
+    targetZone: Zone,
+    error: any,
+  ) => boolean;
 
   /**
    * Allows interception of task scheduling.
@@ -466,12 +517,21 @@ export declare interface ZoneSpec {
    * @param targetZone The [Zone] which originally received the request.
    * @param task The argument passed into the `scheduleTask` method.
    */
-  onScheduleTask?:
-      (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, task: Task) => Task;
+  onScheduleTask?: (
+    parentZoneDelegate: ZoneDelegate,
+    currentZone: Zone,
+    targetZone: Zone,
+    task: Task,
+  ) => Task;
 
-  onInvokeTask?:
-      (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, task: Task,
-       applyThis: any, applyArgs?: any[]) => any;
+  onInvokeTask?: (
+    parentZoneDelegate: ZoneDelegate,
+    currentZone: Zone,
+    targetZone: Zone,
+    task: Task,
+    applyThis: any,
+    applyArgs?: any[],
+  ) => any;
 
   /**
    * Allows interception of task cancellation.
@@ -481,8 +541,12 @@ export declare interface ZoneSpec {
    * @param targetZone The [Zone] which originally received the request.
    * @param task The argument passed into the `cancelTask` method.
    */
-  onCancelTask?:
-      (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, task: Task) => any;
+  onCancelTask?: (
+    parentZoneDelegate: ZoneDelegate,
+    currentZone: Zone,
+    targetZone: Zone,
+    task: Task,
+  ) => any;
 
   /**
    * Notifies of changes to the task queue empty status.
@@ -492,11 +556,13 @@ export declare interface ZoneSpec {
    * @param targetZone The [Zone] which originally received the request.
    * @param hasTaskState
    */
-  onHasTask?:
-      (parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone,
-       hasTaskState: HasTaskState) => void;
+  onHasTask?: (
+    parentZoneDelegate: ZoneDelegate,
+    currentZone: Zone,
+    targetZone: Zone,
+    hasTaskState: HasTaskState,
+  ) => void;
 }
-
 
 /**
  *  A delegate when intercepting zone operations.
@@ -533,8 +599,13 @@ export declare interface ZoneDelegate {
   zone: Zone;
   fork(targetZone: Zone, zoneSpec: ZoneSpec): Zone;
   intercept(targetZone: Zone, callback: Function, source: string): Function;
-  invoke(targetZone: Zone, callback: Function, applyThis?: any, applyArgs?: any[], source?: string):
-      any;
+  invoke(
+    targetZone: Zone,
+    callback: Function,
+    applyThis?: any,
+    applyArgs?: any[],
+    source?: string,
+  ): any;
   handleError(targetZone: Zone, error: any): boolean;
   scheduleTask(targetZone: Zone, task: Task): Task;
   invokeTask(targetZone: Zone, task: Task, applyThis?: any, applyArgs?: any[]): any;
@@ -543,19 +614,27 @@ export declare interface ZoneDelegate {
 }
 
 export type HasTaskState = {
-  microTask: boolean; macroTask: boolean; eventTask: boolean; change: TaskType;
+  microTask: boolean;
+  macroTask: boolean;
+  eventTask: boolean;
+  change: TaskType;
 };
 
 /**
  * Task type: `microTask`, `macroTask`, `eventTask`.
  */
-export type TaskType = 'microTask'|'macroTask'|'eventTask';
+export type TaskType = 'microTask' | 'macroTask' | 'eventTask';
 
 /**
  * Task type: `notScheduled`, `scheduling`, `scheduled`, `running`, `canceling`, 'unknown'.
  */
-export type TaskState = 'notScheduled'|'scheduling'|'scheduled'|'running'|'canceling'|'unknown';
-
+export type TaskState =
+  | 'notScheduled'
+  | 'scheduling'
+  | 'scheduled'
+  | 'running'
+  | 'canceling'
+  | 'unknown';
 
 /**
  */
@@ -684,8 +763,8 @@ export function __symbol__(name: string) {
 }
 
 export function initZone(): ZoneType {
-  const performance: {mark(name: string): void; measure(name: string, label: string): void;} =
-      global['performance'];
+  const performance: {mark(name: string): void; measure(name: string, label: string): void} =
+    global['performance'];
   function mark(name: string) {
     performance && performance['mark'] && performance['mark'](name);
   }
@@ -701,11 +780,12 @@ export function initZone(): ZoneType {
     static assertZonePatched() {
       if (global['Promise'] !== patches['ZoneAwarePromise']) {
         throw new Error(
-            'Zone.js has detected that ZoneAwarePromise `(window|global).Promise` ' +
+          'Zone.js has detected that ZoneAwarePromise `(window|global).Promise` ' +
             'has been overwritten.\n' +
             'Most likely cause is that a Promise polyfill has been loaded ' +
             'after Zone.js (Polyfilling Promise api is not necessary when zone.js is loaded. ' +
-            'If you must load one, do so before loading zone.js.)');
+            'If you must load one, do so before loading zone.js.)',
+        );
       }
     }
 
@@ -721,7 +801,7 @@ export function initZone(): ZoneType {
       return _currentZoneFrame.zone;
     }
 
-    static get currentTask(): Task|null {
+    static get currentTask(): Task | null {
       return _currentTask;
     }
 
@@ -743,7 +823,7 @@ export function initZone(): ZoneType {
       }
     }
 
-    public get parent(): AmbientZone|null {
+    public get parent(): AmbientZone | null {
       return this._parent;
     }
 
@@ -751,18 +831,20 @@ export function initZone(): ZoneType {
       return this._name;
     }
 
-
-    private _parent: ZoneImpl|null;
+    private _parent: ZoneImpl | null;
     private _name: string;
     private _properties: {[key: string]: any};
     private _zoneDelegate: _ZoneDelegate;
 
-    constructor(parent: ZoneImpl|null, zoneSpec: ZoneSpec|null) {
+    constructor(parent: ZoneImpl | null, zoneSpec: ZoneSpec | null) {
       this._parent = parent as ZoneImpl;
       this._name = zoneSpec ? zoneSpec.name || 'unnamed' : '<root>';
-      this._properties = zoneSpec && zoneSpec.properties || {};
-      this._zoneDelegate =
-          new _ZoneDelegate(this, this._parent && this._parent._zoneDelegate, zoneSpec);
+      this._properties = (zoneSpec && zoneSpec.properties) || {};
+      this._zoneDelegate = new _ZoneDelegate(
+        this,
+        this._parent && this._parent._zoneDelegate,
+        zoneSpec,
+      );
     }
 
     public get(key: string): any {
@@ -770,8 +852,8 @@ export function initZone(): ZoneType {
       if (zone) return zone._properties[key];
     }
 
-    public getZoneWith(key: string): AmbientZone|null {
-      let current: ZoneImpl|null = this;
+    public getZoneWith(key: string): AmbientZone | null {
+      let current: ZoneImpl | null = this;
       while (current) {
         if (current._properties.hasOwnProperty(key)) {
           return current;
@@ -792,14 +874,18 @@ export function initZone(): ZoneType {
       }
       const _callback = this._zoneDelegate.intercept(this, callback, source);
       const zone: ZoneImpl = this;
-      return function(this: unknown) {
+      return function (this: unknown) {
         return zone.runGuarded(_callback, this, <any>arguments, source);
       } as any as T;
     }
 
     public run(callback: Function, applyThis?: any, applyArgs?: any[], source?: string): any;
     public run<T>(
-        callback: (...args: any[]) => T, applyThis?: any, applyArgs?: any[], source?: string): T {
+      callback: (...args: any[]) => T,
+      applyThis?: any,
+      applyArgs?: any[],
+      source?: string,
+    ): T {
       _currentZoneFrame = {parent: _currentZoneFrame, zone: this};
       try {
         return this._zoneDelegate.invoke(this, callback, applyThis, applyArgs, source);
@@ -810,8 +896,11 @@ export function initZone(): ZoneType {
 
     public runGuarded(callback: Function, applyThis?: any, applyArgs?: any[], source?: string): any;
     public runGuarded<T>(
-        callback: (...args: any[]) => T, applyThis: any = null, applyArgs?: any[],
-        source?: string) {
+      callback: (...args: any[]) => T,
+      applyThis: any = null,
+      applyArgs?: any[],
+      source?: string,
+    ) {
       _currentZoneFrame = {parent: _currentZoneFrame, zone: this};
       try {
         try {
@@ -826,12 +915,15 @@ export function initZone(): ZoneType {
       }
     }
 
-
     runTask(task: Task, applyThis?: any, applyArgs?: any): any {
       if (task.zone != this) {
         throw new Error(
-            'A task can only be run in the zone of creation! (Creation: ' +
-            (task.zone || NO_ZONE).name + '; Execution: ' + this.name + ')');
+          'A task can only be run in the zone of creation! (Creation: ' +
+            (task.zone || NO_ZONE).name +
+            '; Execution: ' +
+            this.name +
+            ')',
+        );
       }
       // https://github.com/angular/zone.js/issues/778, sometimes eventTask
       // will run in notScheduled(canceled) state, we should not try to
@@ -868,7 +960,7 @@ export function initZone(): ZoneType {
             task.runCount = 0;
             this._updateTaskCount(task as ZoneTask<any>, -1);
             reEntryGuard &&
-                (task as ZoneTask<any>)._transitionTo(notScheduled, running, notScheduled);
+              (task as ZoneTask<any>)._transitionTo(notScheduled, running, notScheduled);
           }
         }
         _currentZoneFrame = _currentZoneFrame.parent!;
@@ -883,8 +975,9 @@ export function initZone(): ZoneType {
         let newZone: any = this;
         while (newZone) {
           if (newZone === task.zone) {
-            throw Error(`can not reschedule task to ${
-                this.name} which is descendants of the original zone ${task.zone.name}`);
+            throw Error(
+              `can not reschedule task to ${this.name} which is descendants of the original zone ${task.zone.name}`,
+            );
           }
           newZone = newZone.parent;
         }
@@ -914,31 +1007,49 @@ export function initZone(): ZoneType {
     }
 
     scheduleMicroTask(
-        source: string, callback: Function, data?: TaskData,
-        customSchedule?: (task: Task) => void): MicroTask {
+      source: string,
+      callback: Function,
+      data?: TaskData,
+      customSchedule?: (task: Task) => void,
+    ): MicroTask {
       return this.scheduleTask(
-          new ZoneTask(microTask, source, callback, data, customSchedule, undefined));
+        new ZoneTask(microTask, source, callback, data, customSchedule, undefined),
+      );
     }
 
     scheduleMacroTask(
-        source: string, callback: Function, data?: TaskData, customSchedule?: (task: Task) => void,
-        customCancel?: (task: Task) => void): MacroTask {
+      source: string,
+      callback: Function,
+      data?: TaskData,
+      customSchedule?: (task: Task) => void,
+      customCancel?: (task: Task) => void,
+    ): MacroTask {
       return this.scheduleTask(
-          new ZoneTask(macroTask, source, callback, data, customSchedule, customCancel));
+        new ZoneTask(macroTask, source, callback, data, customSchedule, customCancel),
+      );
     }
 
     scheduleEventTask(
-        source: string, callback: Function, data?: TaskData, customSchedule?: (task: Task) => void,
-        customCancel?: (task: Task) => void): EventTask {
+      source: string,
+      callback: Function,
+      data?: TaskData,
+      customSchedule?: (task: Task) => void,
+      customCancel?: (task: Task) => void,
+    ): EventTask {
       return this.scheduleTask(
-          new ZoneTask(eventTask, source, callback, data, customSchedule, customCancel));
+        new ZoneTask(eventTask, source, callback, data, customSchedule, customCancel),
+      );
     }
 
     cancelTask(task: Task): any {
       if (task.zone != this)
         throw new Error(
-            'A task can only be cancelled in the zone of creation! (Creation: ' +
-            (task.zone || NO_ZONE).name + '; Execution: ' + this.name + ')');
+          'A task can only be cancelled in the zone of creation! (Creation: ' +
+            (task.zone || NO_ZONE).name +
+            '; Execution: ' +
+            this.name +
+            ')',
+        );
 
       if (task.state !== scheduled && task.state !== running) {
         return;
@@ -972,16 +1083,28 @@ export function initZone(): ZoneType {
 
   const DELEGATE_ZS: ZoneSpec = {
     name: '',
-    onHasTask:
-        (delegate: ZoneDelegate, _: AmbientZone, target: AmbientZone, hasTaskState: HasTaskState):
-            void => delegate.hasTask(target, hasTaskState),
-    onScheduleTask: (delegate: ZoneDelegate, _: AmbientZone, target: AmbientZone, task: Task):
-        Task => delegate.scheduleTask(target, task),
-    onInvokeTask:
-        (delegate: ZoneDelegate, _: AmbientZone, target: AmbientZone, task: Task, applyThis: any,
-         applyArgs: any): any => delegate.invokeTask(target, task, applyThis, applyArgs),
+    onHasTask: (
+      delegate: ZoneDelegate,
+      _: AmbientZone,
+      target: AmbientZone,
+      hasTaskState: HasTaskState,
+    ): void => delegate.hasTask(target, hasTaskState),
+    onScheduleTask: (
+      delegate: ZoneDelegate,
+      _: AmbientZone,
+      target: AmbientZone,
+      task: Task,
+    ): Task => delegate.scheduleTask(target, task),
+    onInvokeTask: (
+      delegate: ZoneDelegate,
+      _: AmbientZone,
+      target: AmbientZone,
+      task: Task,
+      applyThis: any,
+      applyArgs: any,
+    ): any => delegate.invokeTask(target, task, applyThis, applyArgs),
     onCancelTask: (delegate: ZoneDelegate, _: AmbientZone, target: AmbientZone, task: Task): any =>
-        delegate.cancelTask(target, task)
+      delegate.cancelTask(target, task),
   };
 
   class _ZoneDelegate implements ZoneDelegate {
@@ -990,95 +1113,96 @@ export function initZone(): ZoneType {
     }
     private _zone: ZoneImpl;
 
-    private _taskCounts:
-        {microTask: number,
-         macroTask: number,
-         eventTask: number} = {'microTask': 0, 'macroTask': 0, 'eventTask': 0};
+    private _taskCounts: {microTask: number; macroTask: number; eventTask: number} = {
+      'microTask': 0,
+      'macroTask': 0,
+      'eventTask': 0,
+    };
 
-    private _parentDelegate: _ZoneDelegate|null;
+    private _parentDelegate: _ZoneDelegate | null;
 
-    private _forkDlgt: _ZoneDelegate|null;
-    private _forkZS: ZoneSpec|null;
-    private _forkCurrZone: Zone|null;
+    private _forkDlgt: _ZoneDelegate | null;
+    private _forkZS: ZoneSpec | null;
+    private _forkCurrZone: Zone | null;
 
-    private _interceptDlgt: _ZoneDelegate|null;
-    private _interceptZS: ZoneSpec|null;
-    private _interceptCurrZone: Zone|null;
+    private _interceptDlgt: _ZoneDelegate | null;
+    private _interceptZS: ZoneSpec | null;
+    private _interceptCurrZone: Zone | null;
 
-    private _invokeDlgt: _ZoneDelegate|null;
-    private _invokeZS: ZoneSpec|null;
-    private _invokeCurrZone: ZoneImpl|null;
+    private _invokeDlgt: _ZoneDelegate | null;
+    private _invokeZS: ZoneSpec | null;
+    private _invokeCurrZone: ZoneImpl | null;
 
-    private _handleErrorDlgt: _ZoneDelegate|null;
-    private _handleErrorZS: ZoneSpec|null;
-    private _handleErrorCurrZone: ZoneImpl|null;
+    private _handleErrorDlgt: _ZoneDelegate | null;
+    private _handleErrorZS: ZoneSpec | null;
+    private _handleErrorCurrZone: ZoneImpl | null;
 
-    private _scheduleTaskDlgt: _ZoneDelegate|null;
-    private _scheduleTaskZS: ZoneSpec|null;
-    private _scheduleTaskCurrZone: ZoneImpl|null;
+    private _scheduleTaskDlgt: _ZoneDelegate | null;
+    private _scheduleTaskZS: ZoneSpec | null;
+    private _scheduleTaskCurrZone: ZoneImpl | null;
 
-    private _invokeTaskDlgt: _ZoneDelegate|null;
-    private _invokeTaskZS: ZoneSpec|null;
-    private _invokeTaskCurrZone: ZoneImpl|null;
+    private _invokeTaskDlgt: _ZoneDelegate | null;
+    private _invokeTaskZS: ZoneSpec | null;
+    private _invokeTaskCurrZone: ZoneImpl | null;
 
-    private _cancelTaskDlgt: _ZoneDelegate|null;
-    private _cancelTaskZS: ZoneSpec|null;
-    private _cancelTaskCurrZone: ZoneImpl|null;
+    private _cancelTaskDlgt: _ZoneDelegate | null;
+    private _cancelTaskZS: ZoneSpec | null;
+    private _cancelTaskCurrZone: ZoneImpl | null;
 
-    private _hasTaskDlgt: _ZoneDelegate|null;
-    private _hasTaskDlgtOwner: _ZoneDelegate|null;
-    private _hasTaskZS: ZoneSpec|null;
-    private _hasTaskCurrZone: ZoneImpl|null;
+    private _hasTaskDlgt: _ZoneDelegate | null;
+    private _hasTaskDlgtOwner: _ZoneDelegate | null;
+    private _hasTaskZS: ZoneSpec | null;
+    private _hasTaskCurrZone: ZoneImpl | null;
 
-    constructor(zone: Zone, parentDelegate: _ZoneDelegate|null, zoneSpec: ZoneSpec|null) {
+    constructor(zone: Zone, parentDelegate: _ZoneDelegate | null, zoneSpec: ZoneSpec | null) {
       this._zone = zone as ZoneImpl;
       this._parentDelegate = parentDelegate;
 
       this._forkZS = zoneSpec && (zoneSpec && zoneSpec.onFork ? zoneSpec : parentDelegate!._forkZS);
       this._forkDlgt = zoneSpec && (zoneSpec.onFork ? parentDelegate : parentDelegate!._forkDlgt);
       this._forkCurrZone =
-          zoneSpec && (zoneSpec.onFork ? this._zone : parentDelegate!._forkCurrZone);
+        zoneSpec && (zoneSpec.onFork ? this._zone : parentDelegate!._forkCurrZone);
 
       this._interceptZS =
-          zoneSpec && (zoneSpec.onIntercept ? zoneSpec : parentDelegate!._interceptZS);
+        zoneSpec && (zoneSpec.onIntercept ? zoneSpec : parentDelegate!._interceptZS);
       this._interceptDlgt =
-          zoneSpec && (zoneSpec.onIntercept ? parentDelegate : parentDelegate!._interceptDlgt);
+        zoneSpec && (zoneSpec.onIntercept ? parentDelegate : parentDelegate!._interceptDlgt);
       this._interceptCurrZone =
-          zoneSpec && (zoneSpec.onIntercept ? this._zone : parentDelegate!._interceptCurrZone);
+        zoneSpec && (zoneSpec.onIntercept ? this._zone : parentDelegate!._interceptCurrZone);
 
       this._invokeZS = zoneSpec && (zoneSpec.onInvoke ? zoneSpec : parentDelegate!._invokeZS);
       this._invokeDlgt =
-          zoneSpec && (zoneSpec.onInvoke ? parentDelegate! : parentDelegate!._invokeDlgt);
+        zoneSpec && (zoneSpec.onInvoke ? parentDelegate! : parentDelegate!._invokeDlgt);
       this._invokeCurrZone =
-          zoneSpec && (zoneSpec.onInvoke ? this._zone : parentDelegate!._invokeCurrZone);
+        zoneSpec && (zoneSpec.onInvoke ? this._zone : parentDelegate!._invokeCurrZone);
 
       this._handleErrorZS =
-          zoneSpec && (zoneSpec.onHandleError ? zoneSpec : parentDelegate!._handleErrorZS);
+        zoneSpec && (zoneSpec.onHandleError ? zoneSpec : parentDelegate!._handleErrorZS);
       this._handleErrorDlgt =
-          zoneSpec && (zoneSpec.onHandleError ? parentDelegate! : parentDelegate!._handleErrorDlgt);
+        zoneSpec && (zoneSpec.onHandleError ? parentDelegate! : parentDelegate!._handleErrorDlgt);
       this._handleErrorCurrZone =
-          zoneSpec && (zoneSpec.onHandleError ? this._zone : parentDelegate!._handleErrorCurrZone);
+        zoneSpec && (zoneSpec.onHandleError ? this._zone : parentDelegate!._handleErrorCurrZone);
 
       this._scheduleTaskZS =
-          zoneSpec && (zoneSpec.onScheduleTask ? zoneSpec : parentDelegate!._scheduleTaskZS);
-      this._scheduleTaskDlgt = zoneSpec &&
-          (zoneSpec.onScheduleTask ? parentDelegate! : parentDelegate!._scheduleTaskDlgt);
-      this._scheduleTaskCurrZone = zoneSpec &&
-          (zoneSpec.onScheduleTask ? this._zone : parentDelegate!._scheduleTaskCurrZone);
+        zoneSpec && (zoneSpec.onScheduleTask ? zoneSpec : parentDelegate!._scheduleTaskZS);
+      this._scheduleTaskDlgt =
+        zoneSpec && (zoneSpec.onScheduleTask ? parentDelegate! : parentDelegate!._scheduleTaskDlgt);
+      this._scheduleTaskCurrZone =
+        zoneSpec && (zoneSpec.onScheduleTask ? this._zone : parentDelegate!._scheduleTaskCurrZone);
 
       this._invokeTaskZS =
-          zoneSpec && (zoneSpec.onInvokeTask ? zoneSpec : parentDelegate!._invokeTaskZS);
+        zoneSpec && (zoneSpec.onInvokeTask ? zoneSpec : parentDelegate!._invokeTaskZS);
       this._invokeTaskDlgt =
-          zoneSpec && (zoneSpec.onInvokeTask ? parentDelegate! : parentDelegate!._invokeTaskDlgt);
+        zoneSpec && (zoneSpec.onInvokeTask ? parentDelegate! : parentDelegate!._invokeTaskDlgt);
       this._invokeTaskCurrZone =
-          zoneSpec && (zoneSpec.onInvokeTask ? this._zone : parentDelegate!._invokeTaskCurrZone);
+        zoneSpec && (zoneSpec.onInvokeTask ? this._zone : parentDelegate!._invokeTaskCurrZone);
 
       this._cancelTaskZS =
-          zoneSpec && (zoneSpec.onCancelTask ? zoneSpec : parentDelegate!._cancelTaskZS);
+        zoneSpec && (zoneSpec.onCancelTask ? zoneSpec : parentDelegate!._cancelTaskZS);
       this._cancelTaskDlgt =
-          zoneSpec && (zoneSpec.onCancelTask ? parentDelegate! : parentDelegate!._cancelTaskDlgt);
+        zoneSpec && (zoneSpec.onCancelTask ? parentDelegate! : parentDelegate!._cancelTaskDlgt);
       this._cancelTaskCurrZone =
-          zoneSpec && (zoneSpec.onCancelTask ? this._zone : parentDelegate!._cancelTaskCurrZone);
+        zoneSpec && (zoneSpec.onCancelTask ? this._zone : parentDelegate!._cancelTaskCurrZone);
 
       this._hasTaskZS = null;
       this._hasTaskDlgt = null;
@@ -1113,31 +1237,52 @@ export function initZone(): ZoneType {
     }
 
     fork(targetZone: ZoneImpl, zoneSpec: ZoneSpec): AmbientZone {
-      return this._forkZS ? this._forkZS.onFork!(this._forkDlgt!, this.zone, targetZone, zoneSpec) :
-                            new ZoneImpl(targetZone, zoneSpec);
+      return this._forkZS
+        ? this._forkZS.onFork!(this._forkDlgt!, this.zone, targetZone, zoneSpec)
+        : new ZoneImpl(targetZone, zoneSpec);
     }
 
     intercept(targetZone: ZoneImpl, callback: Function, source: string): Function {
-      return this._interceptZS ?
-          this._interceptZS.onIntercept!
-          (this._interceptDlgt!, this._interceptCurrZone!, targetZone, callback, source) :
-          callback;
+      return this._interceptZS
+        ? this._interceptZS.onIntercept!(
+            this._interceptDlgt!,
+            this._interceptCurrZone!,
+            targetZone,
+            callback,
+            source,
+          )
+        : callback;
     }
 
     invoke(
-        targetZone: ZoneImpl, callback: Function, applyThis: any, applyArgs?: any[],
-        source?: string): any {
-      return this._invokeZS ? this._invokeZS.onInvoke!
-                              (this._invokeDlgt!, this._invokeCurrZone!, targetZone, callback,
-                               applyThis, applyArgs, source) :
-                              callback.apply(applyThis, applyArgs);
+      targetZone: ZoneImpl,
+      callback: Function,
+      applyThis: any,
+      applyArgs?: any[],
+      source?: string,
+    ): any {
+      return this._invokeZS
+        ? this._invokeZS.onInvoke!(
+            this._invokeDlgt!,
+            this._invokeCurrZone!,
+            targetZone,
+            callback,
+            applyThis,
+            applyArgs,
+            source,
+          )
+        : callback.apply(applyThis, applyArgs);
     }
 
     handleError(targetZone: ZoneImpl, error: any): boolean {
-      return this._handleErrorZS ?
-          this._handleErrorZS.onHandleError!
-          (this._handleErrorDlgt!, this._handleErrorCurrZone!, targetZone, error) :
-          true;
+      return this._handleErrorZS
+        ? this._handleErrorZS.onHandleError!(
+            this._handleErrorDlgt!,
+            this._handleErrorCurrZone!,
+            targetZone,
+            error,
+          )
+        : true;
     }
 
     scheduleTask(targetZone: ZoneImpl, task: Task): Task {
@@ -1147,8 +1292,12 @@ export function initZone(): ZoneType {
           returnTask._zoneDelegates!.push(this._hasTaskDlgtOwner!);
         }
         // clang-format off
-      returnTask = this._scheduleTaskZS.onScheduleTask !(
-          this._scheduleTaskDlgt !, this._scheduleTaskCurrZone !, targetZone, task) as ZoneTask<any>;
+        returnTask = this._scheduleTaskZS.onScheduleTask!(
+          this._scheduleTaskDlgt!,
+          this._scheduleTaskCurrZone!,
+          targetZone,
+          task,
+        ) as ZoneTask<any>;
         // clang-format on
         if (!returnTask) returnTask = task as ZoneTask<any>;
       } else {
@@ -1164,17 +1313,27 @@ export function initZone(): ZoneType {
     }
 
     invokeTask(targetZone: ZoneImpl, task: Task, applyThis: any, applyArgs?: any[]): any {
-      return this._invokeTaskZS ? this._invokeTaskZS.onInvokeTask!
-                                  (this._invokeTaskDlgt!, this._invokeTaskCurrZone!, targetZone,
-                                   task, applyThis, applyArgs) :
-                                  task.callback.apply(applyThis, applyArgs);
+      return this._invokeTaskZS
+        ? this._invokeTaskZS.onInvokeTask!(
+            this._invokeTaskDlgt!,
+            this._invokeTaskCurrZone!,
+            targetZone,
+            task,
+            applyThis,
+            applyArgs,
+          )
+        : task.callback.apply(applyThis, applyArgs);
     }
 
     cancelTask(targetZone: ZoneImpl, task: Task): any {
       let value: any;
       if (this._cancelTaskZS) {
-        value = this._cancelTaskZS.onCancelTask!
-                (this._cancelTaskDlgt!, this._cancelTaskCurrZone!, targetZone, task);
+        value = this._cancelTaskZS.onCancelTask!(
+          this._cancelTaskDlgt!,
+          this._cancelTaskCurrZone!,
+          targetZone,
+          task,
+        );
       } else {
         if (!task.cancelFn) {
           throw Error('Task is not cancelable');
@@ -1189,8 +1348,12 @@ export function initZone(): ZoneType {
       // can still trigger hasTask callback
       try {
         this._hasTaskZS &&
-            this._hasTaskZS.onHasTask!
-            (this._hasTaskDlgt!, this._hasTaskCurrZone!, targetZone, isEmpty);
+          this._hasTaskZS.onHasTask!(
+            this._hasTaskDlgt!,
+            this._hasTaskCurrZone!,
+            targetZone,
+            isEmpty,
+          );
       } catch (err) {
         this.handleError(targetZone, err);
       }
@@ -1200,7 +1363,7 @@ export function initZone(): ZoneType {
     _updateTaskCount(type: TaskType, count: number) {
       const counts = this._taskCounts;
       const prev = counts[type];
-      const next = counts[type] = prev + count;
+      const next = (counts[type] = prev + count);
       if (next < 0) {
         throw new Error('More tasks executed then were scheduled.');
       }
@@ -1209,7 +1372,7 @@ export function initZone(): ZoneType {
           microTask: counts['microTask'] > 0,
           macroTask: counts['macroTask'] > 0,
           eventTask: counts['eventTask'] > 0,
-          change: type
+          change: type,
         };
         this.hasTask(this._zone, isEmpty);
       }
@@ -1221,20 +1384,25 @@ export function initZone(): ZoneType {
     public source: string;
     public invoke: Function;
     public callback: Function;
-    public data: TaskData|undefined;
-    public scheduleFn: ((task: Task) => void)|undefined;
-    public cancelFn: ((task: Task) => void)|undefined;
+    public data: TaskData | undefined;
+    public scheduleFn: ((task: Task) => void) | undefined;
+    public cancelFn: ((task: Task) => void) | undefined;
     // tslint:disable-next-line:require-internal-with-underscore
-    _zone: ZoneImpl|null = null;
+    _zone: ZoneImpl | null = null;
     public runCount: number = 0;
     // tslint:disable-next-line:require-internal-with-underscore
-    _zoneDelegates: _ZoneDelegate[]|null = null;
+    _zoneDelegates: _ZoneDelegate[] | null = null;
     // tslint:disable-next-line:require-internal-with-underscore
     _state: TaskState = 'notScheduled';
 
     constructor(
-        type: T, source: string, callback: Function, options: TaskData|undefined,
-        scheduleFn: ((task: Task) => void)|undefined, cancelFn: ((task: Task) => void)|undefined) {
+      type: T,
+      source: string,
+      callback: Function,
+      options: TaskData | undefined,
+      scheduleFn: ((task: Task) => void) | undefined,
+      cancelFn: ((task: Task) => void) | undefined,
+    ) {
       this.type = type;
       this.source = source;
       this.data = options;
@@ -1249,7 +1417,7 @@ export function initZone(): ZoneType {
       if (type === eventTask && options && (options as any).useG) {
         this.invoke = ZoneTask.invokeTask;
       } else {
-        this.invoke = function() {
+        this.invoke = function () {
           return ZoneTask.invokeTask.call(global, self, this, <any>arguments);
         };
       }
@@ -1265,7 +1433,7 @@ export function initZone(): ZoneType {
         return task.zone.runTask(task, target, args);
       } finally {
         if (_numberOfNestedTaskFrames == 1) {
-          drainMicroTaskQueue();
+          scheduleDrainMicroTaskQueue();
         }
         _numberOfNestedTaskFrames--;
       }
@@ -1291,9 +1459,11 @@ export function initZone(): ZoneType {
           this._zoneDelegates = null;
         }
       } else {
-        throw new Error(`${this.type} '${this.source}': can not transition to '${
-            toState}', expecting state '${fromState1}'${
-            fromState2 ? ' or \'' + fromState2 + '\'' : ''}, was '${this._state}'.`);
+        throw new Error(
+          `${this.type} '${this.source}': can not transition to '${toState}', expecting state '${fromState1}'${fromState2 ? " or '" + fromState2 + "'" : ''}, was '${
+            this._state
+          }'.`,
+        );
       }
     }
 
@@ -1313,11 +1483,10 @@ export function initZone(): ZoneType {
         state: this.state,
         source: this.source,
         zone: this.zone.name,
-        runCount: this.runCount
+        runCount: this.runCount,
       };
     }
   }
-
 
   //////////////////////////////////////////////////////
   //////////////////////////////////////////////////////
@@ -1351,13 +1520,21 @@ export function initZone(): ZoneType {
   }
 
   function scheduleMicroTask(task?: MicroTask) {
-    // if we are not running in any task, and there has not been anything scheduled
+    // if we are not draining microtask queue with the native Promise.then,
     // we must bootstrap the initial task creation by manually scheduling the drain
-    if (_numberOfNestedTaskFrames === 0 && _microTaskQueue.length === 0) {
+    if (!_isDrainingMicrotaskQueue) {
       // We are not running in Task, so we need to kickstart the microtask queue.
       nativeScheduleMicroTask(drainMicroTaskQueue);
     }
     task && _microTaskQueue.push(task);
+  }
+
+  function scheduleDrainMicroTaskQueue() {
+    // if we are not draining microtask queue with the native Promise.then,
+    // and also there is pending microtask, we need to manually schedule the drain process.
+    if (!_isDrainingMicrotaskQueue && _microTaskQueue.length) {
+      nativeScheduleMicroTask(drainMicroTaskQueue);
+    }
   }
 
   function drainMicroTaskQueue() {
@@ -1375,8 +1552,8 @@ export function initZone(): ZoneType {
           }
         }
       }
-      _api.microtaskDrainDone();
       _isDrainingMicrotaskQueue = false;
+      _api.microtaskDrainDone();
     }
   }
 
@@ -1386,13 +1563,16 @@ export function initZone(): ZoneType {
   //////////////////////////////////////////////////////
   //////////////////////////////////////////////////////
 
-
   const NO_ZONE = {name: 'NO ZONE'};
-  const notScheduled: 'notScheduled' = 'notScheduled', scheduling: 'scheduling' = 'scheduling',
-                      scheduled: 'scheduled' = 'scheduled', running: 'running' = 'running',
-                      canceling: 'canceling' = 'canceling', unknown: 'unknown' = 'unknown';
-  const microTask: 'microTask' = 'microTask', macroTask: 'macroTask' = 'macroTask',
-                   eventTask: 'eventTask' = 'eventTask';
+  const notScheduled: 'notScheduled' = 'notScheduled',
+    scheduling: 'scheduling' = 'scheduling',
+    scheduled: 'scheduled' = 'scheduled',
+    running: 'running' = 'running',
+    canceling: 'canceling' = 'canceling',
+    unknown: 'unknown' = 'unknown';
+  const microTask: 'microTask' = 'microTask',
+    macroTask: 'macroTask' = 'macroTask',
+    eventTask: 'eventTask' = 'eventTask';
 
   const patches: {[key: string]: any} = {};
   const _api: ZonePrivate = {
@@ -1421,10 +1601,10 @@ export function initZone(): ZoneType {
     attachOriginToPatched: () => noop,
     _redefineProperty: () => noop,
     patchCallbacks: () => noop,
-    nativeScheduleMicroTask: nativeScheduleMicroTask
+    nativeScheduleMicroTask: nativeScheduleMicroTask,
   };
   let _currentZoneFrame: ZoneFrame = {parent: null, zone: new ZoneImpl(null, null)};
-  let _currentTask: Task|null = null;
+  let _currentTask: Task | null = null;
   let _numberOfNestedTaskFrames = 0;
 
   function noop() {}

--- a/packages/zone.js/lib/zone.ts
+++ b/packages/zone.js/lib/zone.ts
@@ -6,7 +6,26 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {__symbol__, EventTask as _EventTask, HasTaskState as _HasTaskState, initZone, MacroTask as _MacroTask, MicroTask as _MicroTask, PatchFn, Task as _Task, TaskData as _TaskData, TaskState as _TaskState, TaskType as _TaskType, UncaughtPromiseError as _UncaughtPromiseError, Zone as _Zone, ZoneDelegate as _ZoneDelegate, ZoneFrame, ZonePrivate, ZoneSpec as _ZoneSpec, ZoneType as _ZoneType} from './zone-impl';
+import {
+  __symbol__,
+  EventTask as _EventTask,
+  HasTaskState as _HasTaskState,
+  initZone,
+  MacroTask as _MacroTask,
+  MicroTask as _MicroTask,
+  PatchFn,
+  Task as _Task,
+  TaskData as _TaskData,
+  TaskState as _TaskState,
+  TaskType as _TaskType,
+  UncaughtPromiseError as _UncaughtPromiseError,
+  Zone as _Zone,
+  ZoneDelegate as _ZoneDelegate,
+  ZoneFrame,
+  ZonePrivate,
+  ZoneSpec as _ZoneSpec,
+  ZoneType as _ZoneType,
+} from './zone-impl';
 
 declare global {
   const Zone: ZoneType;

--- a/packages/zone.js/test/browser/element.spec.ts
+++ b/packages/zone.js/test/browser/element.spec.ts
@@ -70,26 +70,12 @@ describe('element', function() {
     done();
   });
 
-  it('should call microtasks early when an event is invoked', function(done) {
+  it('should not call microtasks early when an event is invoked', function(done) {
     /*
      * In this test we escape the Zone using unpatched setTimeout.
      * This way the eventTask invoked from click will think it is the top most
-     * task and eagerly drain the microtask queue.
+     * task.
      *
-     * THIS IS THE WRONG BEHAVIOR!
-     *
-     * But there is no easy way for the task to know if it is the top most task.
-     *
-     * Given that this can only arise when someone is emulating clicks on DOM in a synchronous
-     * fashion we have few choices:
-     * 1. Ignore as this is unlikely to be a problem outside of tests.
-     * 2. Monkey patch the event methods to increment the _numberOfNestedTaskFrames and prevent
-     *    eager drainage.
-     * 3. Pay the cost of throwing an exception in event tasks and verifying that we are the
-     *    top most frame.
-     *
-     * For now we are choosing to ignore it and assume that this arises in tests only.
-     * As an added measure we make sure that all jasmine tests always run in a task. See: jasmine.ts
      */
     (window as any)[(Zone as any).__symbol__('setTimeout')](() => {
       let log = '';
@@ -99,7 +85,7 @@ describe('element', function() {
       });
       button.click();
 
-      expect(log).toEqual('click;microtask;');
+      expect(log).toEqual('click;');
       done();
     });
   });

--- a/packages/zone.js/test/jasmine-patch.spec.ts
+++ b/packages/zone.js/test/jasmine-patch.spec.ts
@@ -15,11 +15,6 @@ function supportJasmineSpec() {
 (supportJasmineSpec as any).message = 'jasmine spec';
 
 ifEnvSupports(supportJasmineSpec, () => {
-  beforeEach(() => {
-    // assert that each jasmine run has a task, so that drainMicrotask works properly.
-    expect(Zone.currentTask).toBeTruthy();
-  });
-
   describe('jasmine', () => {
     let throwOnAsync = false;
     let beforeEachZone: Zone|null = null;


### PR DESCRIPTION
always `drainMicrotaskQueue` in `Promise.then`.

Consider the following case.

```
const listener = () => {
  Promise.resolve().then(() => console.log(`promise then`));
};

document.body.addEventListener('click', listener);
document.body.click();
console.log('main stack');
```

Without `zone.js` patch, the output should be 
```
main stack
promise then
```
since `Promise.resolve().then()` should run as microtask after `main stack` finish.
But with `zone.js` patch, it becomes 
```
promise then
main stack
```

The reason is currently `zone.js` maintain a `microtask queue` themselves, and after a `task` is invoked (in this case, the `click` eventTask), it will try to `drainMicrotaskQueue` synchronizely if the `task` is the `top task`. 

This PR make sure that the `dranMicroTaskQueue` happen inside a Browser native microTask.

This new behavior is the correct behavior but it is very risky since it changes the microTask consuming timing and may impact a lot of existing apps.

Close #44446, #41506 
