### PR TITLE
html_sanitizer: add id and style html attrs as allowed to avoid dropping of them by sanitizer

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 450342,
+        "main": 450891,
         "polyfills": 33869,
         "styles": 70416,
         "light-theme": 77582,

--- a/packages/core/test/sanitization/html_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/html_sanitizer_spec.ts
@@ -8,7 +8,7 @@
 
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 
-import {_sanitizeHtml} from '../../src/sanitization/html_sanitizer';
+import {_sanitizeHtml, UNSAFE_SPEC_ATTRS_VALUES} from '../../src/sanitization/html_sanitizer';
 import {isDOMParserAvailable} from '../../src/sanitization/inert_body';
 
 function sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): string {
@@ -153,11 +153,24 @@ function sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): string {
     });
 
     describe('should strip dangerous attributes', () => {
-      const dangerousAttrs = ['id', 'name', 'style'];
+      const dangerousAttrs = ['id', 'name'];
 
       for (const attr of dangerousAttrs) {
         it(`${attr}`, () => {
           expect(sanitizeHtml(defaultDoc, `<a ${attr}="x">evil!</a>`)).toEqual('<a>evil!</a>');
+        });
+      }
+    });
+
+    describe('should sanitize content in dangerous attributes', () => {
+      const dangerousAttrs = ['style'];
+
+      for (const attr of dangerousAttrs) {
+        it(`${attr}`, () => {
+          for (const unsafeAttrVal of UNSAFE_SPEC_ATTRS_VALUES) {
+            expect(sanitizeHtml(defaultDoc, `<a ${attr}="${unsafeAttrVal}">evil!</a>`))
+                .toEqual(`<a ${attr}="unsafe:${unsafeAttrVal}">evil!</a>`);
+          }
         });
       }
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 45270

https://github.com/angular/angular/issues/45270
## What is the new behavior?
style and id attrs should be kept in html security context but sanitized inside.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
