### PR TITLE
fix(router): merge inherited resolved data and static data in layers

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1323,6 +1323,9 @@
     "name": "hasParentInjector"
   },
   {
+    "name": "hasStaticTitle"
+  },
+  {
     "name": "hasTagAndTypeMatch"
   },
   {

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -248,9 +248,10 @@ function flattenInherited(pathFromRoot: ActivatedRouteSnapshot[]): Inherited {
   return pathFromRoot.reduce((res, curr) => {
     const params = {...res.params, ...curr.params};
     const data = {...res.data, ...curr.data};
-    const resolve = {...res.resolve, ...curr._resolvedData};
+    const resolve =
+        {...curr.data, ...res.resolve, ...curr.routeConfig?.data, ...curr._resolvedData};
     return {params, data, resolve};
-  }, <any>{params: {}, data: {}, resolve: {}});
+  }, {params: {}, data: {}, resolve: {}});
 }
 
 /**


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Right now, route static `data` are collected from its parents based on the logic described in [`router_state.ts`](https://github.com/angular/angular/blob/14.0.0-next.5/packages/router/src/router_state.ts#L217-L244), **merged into a single object and then merged again with merged data from resolvers**. This means that a **child's data will be overriden by a resolver defined in its parent (#34361) if they're using the same keys**. However, I don't think this behavior is documented anywhere, resolvers are used in https://angular.io/guide/router-tutorial-toh#resolve-pre-fetching-component-data but it doesn't mention the way static `data` is merged with resolved data.

The logic when and why route's data is merged with its parents isn't documented anywhere either (at least I couldn't find anything). Based on the logic here [`inheritedParamsDataResolve()`](https://github.com/angular/angular/blob/14.0.0-next.5/packages/router/src/router_state.ts#L217`) a route inherits its parent's data (recursively) only when:
- The route has an empty path.
- Its parent is componentless.

For example the following route structure:

```
[{
  path: 'a',
  component: WrapperCmp,
  resolve: {prop2: 'resolveTwo'},
  data: {prop: 'wrapper-a'},
  children: [
    // will inherit data from this child route because it has `path` and its parent has component
    {
      path: 'b',
      data: {prop: 'nested-b'},
      resolve: {prop3: 'resolveFour'},
      children: [
        {
        path: 'c',
        children:
          [{path: '', component: NestedComponentWithData, data: {prop3: 'nested'}}]
        },
      ]
    },
  ],
}]
```

... will for URL `/a/b/c` produce `{prop: 'nested-b', prop3: 4}` data for component `NestedComponentWithData`. This is because `'c'` inherits data from `'b'` (but not `'a'`) and the resolver `{prop3: 'resolveFour'}` will override static data set in `'c'` (`{prop3: 'nested'}`). This is the same situation as in #34361.

Stackblitz demo: https://stackblitz.com/edit/angular-ivy-ynjet6?file=src%2Fapp%2Fapp.module.ts

Issue Number: #34361

## What is the new behavior?

This PR changes this behavior and merges static data and resolved data in "layers" (route by route) so child's static data and resolved data cannot be overriden by their parents.

For the same example the data generated for route `'c'` will be `{prop: 'nested-b', prop3: 'nested'}` because `prop3` has priority over `prop3` defined in the parent route.

I also added more tests to cover the expected behavior when inheriting data from parents as defined by `inheritedParamsDataResolve()`.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This is probably a breaking change, although the current behavior doesn't seem to be defined anywhere so it's hard to tell if anyone might be rallying on it.

## Other information
