### PR TITLE
feat(core): DebugNode.triggerEventHandler should accept eventObj as an optional parameter

### DIFF
--- a/aio/content/examples/testing/src/app/app.component.spec.ts
+++ b/aio/content/examples/testing/src/app/app.component.spec.ts
@@ -137,7 +137,7 @@ function tests() {
       .withContext('should not have navigated yet')
       .toBeNull();
 
-    heroesLinkDe.triggerEventHandler('click', null);
+    heroesLinkDe.triggerEventHandler('click');
     fixture.detectChanges();
 
     expect(heroesLink.navigatedTo).toBe('/heroes');

--- a/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
+++ b/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
@@ -73,7 +73,7 @@ describe('DashboardHeroComponent when tested directly', () => {
     comp.selected.pipe(first()).subscribe((hero: Hero) => selectedHero = hero);
 
     // #docregion trigger-event-handler
-    heroDe.triggerEventHandler('click', null);
+    heroDe.triggerEventHandler('click');
     // #enddocregion trigger-event-handler
     expect(selectedHero).toBe(expectedHero);
   });

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -882,7 +882,7 @@ The "click" event binding responds by calling `DashboardHeroComponent.click()`.
 The Angular `DebugElement.triggerEventHandler` can raise _any data-bound event_ by its _event name_.
 The second parameter is the event object passed to the handler.
 
-The test triggered a "click" event with a `null` event object.
+The test triggered a "click" event.
 
 <code-example
   path="testing/src/app/dashboard/dashboard-hero.component.spec.ts" region="trigger-event-handler">

--- a/goldens/public-api/core/core.md
+++ b/goldens/public-api/core/core.md
@@ -320,7 +320,7 @@ export class DebugElement extends DebugNode {
     get styles(): {
         [key: string]: string | null;
     };
-    triggerEventHandler(eventName: string, eventObj: any): void;
+    triggerEventHandler(eventName: string, eventObj?: any): void;
 }
 
 // @public (undocumented)

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -343,7 +343,7 @@ export class DebugElement extends DebugNode {
    *
    * @see [Testing components scenarios](guide/testing-components-scenarios#trigger-event-handler)
    */
-  triggerEventHandler(eventName: string, eventObj: any): void {
+  triggerEventHandler(eventName: string, eventObj?: any): void {
     const node = this.nativeNode as any;
     const invokedListeners: Function[] = [];
 

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -978,11 +978,11 @@ class TestCmptWithPropInterpolation {
       const button = fixture.debugElement.query(By.css('button'));
 
       expect(() => {
-        button.triggerEventHandler('click', null);
+        button.triggerEventHandler('click');
         fixture.detectChanges();
       }).not.toThrow();
 
-      expect(value).toBeNull();
+      expect(value).toBeUndefined();
     });
 
     describe('componentInstance on DebugNode', () => {

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -3458,7 +3458,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 
-        inputEl.triggerEventHandler('compositionstart', null);
+        inputEl.triggerEventHandler('compositionstart');
 
         inputNativeEl.value = 'updatedValue';
         dispatchEvent(inputNativeEl, 'input');
@@ -3489,7 +3489,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 
-        inputEl.triggerEventHandler('compositionstart', null);
+        inputEl.triggerEventHandler('compositionstart');
 
         inputNativeEl.value = 'updatedValue';
         dispatchEvent(inputNativeEl, 'input');
@@ -3517,7 +3517,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 
-        inputEl.triggerEventHandler('compositionstart', null);
+        inputEl.triggerEventHandler('compositionstart');
 
         inputNativeEl.value = 'updatedValue';
         dispatchEvent(inputNativeEl, 'input');

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -2511,7 +2511,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
            expect(inputNativeEl.value).toEqual('oldValue');
 
-           inputEl.triggerEventHandler('compositionstart', null);
+           inputEl.triggerEventHandler('compositionstart');
 
            inputNativeEl.value = 'updatedValue';
            dispatchEvent(inputNativeEl, 'input');
@@ -2546,7 +2546,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
            expect(inputNativeEl.value).toEqual('oldValue');
 
-           inputEl.triggerEventHandler('compositionstart', null);
+           inputEl.triggerEventHandler('compositionstart');
 
            inputNativeEl.value = 'updatedValue';
            dispatchEvent(inputNativeEl, 'input');
@@ -2578,7 +2578,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
            expect(inputNativeEl.value).toEqual('oldValue');
 
-           inputEl.triggerEventHandler('compositionstart', null);
+           inputEl.triggerEventHandler('compositionstart');
 
            inputNativeEl.value = 'updatedValue';
            dispatchEvent(inputNativeEl, 'input');


### PR DESCRIPTION
Close https://github.com/angular/angular/issues/44724

`DebugNode.triggerEventHandler()` should accept the `eventObj` as an
optional parameter. So the user don't have to write code like

```
elem.triggerEventHandler('click', null);
```