### PR TITLE
refactor: replace deprecated `HTMLDocument` with `Document`

### DIFF
--- a/devtools/projects/shell-chrome/src/app/ng-validate.ts
+++ b/devtools/projects/shell-chrome/src/app/ng-validate.ts
@@ -71,6 +71,6 @@ function installScript(fn: string): void {
   }
 }
 
-if (document instanceof HTMLDocument) {
+if (document instanceof Document) {
   installScript(detectAngular.toString());
 }

--- a/packages/common/src/dom_adapter.ts
+++ b/packages/common/src/dom_adapter.ts
@@ -37,7 +37,7 @@ export abstract class DomAdapter {
   // Used by Meta
   abstract remove(el: any): void;
   abstract createElement(tagName: any, doc?: any): HTMLElement;
-  abstract createHtmlDocument(): HTMLDocument;
+  abstract createHtmlDocument(): Document;
   abstract getDefaultDocument(): Document;
 
   // Used by By.css

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -42,7 +42,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     doc = doc || this.getDefaultDocument();
     return doc.createElement(tagName);
   }
-  createHtmlDocument(): HTMLDocument {
+  createHtmlDocument(): Document {
     return document.implementation.createHTMLDocument('fakeTitle');
   }
   getDefaultDocument(): Document {

--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -44,7 +44,7 @@ export class DominoAdapter extends BrowserDomAdapter {
   override readonly supportsDOMEvents = false;
   private static defaultDoc: Document;
 
-  override createHtmlDocument(): HTMLDocument {
+  override createHtmlDocument(): Document {
     return parseDocument('<html><head><title>fakeTitle</title></head><body></body></html>');
   }
 


### PR DESCRIPTION

`HTMLDocument` is deprecated in favor of `Document`. This change replaces the usages of `HTMLDocument`.

See: https://github.com/microsoft/TypeScript/blob/20c93d3b1da44d8ee740b466a5cde7894e8b3260/lib/lib.dom.d.ts#L6370-L6376