### PR TITLE
feat(core): drop support for Node.js 12

### DIFF
--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -12,7 +12,7 @@
   },
   "//engines-comment": "Keep this in sync with /package.json and /aio/package.json",
   "engines": {
-    "node": "^12.20.0 || >=14.0.0",
+    "node": ">=14.0.0",
     "yarn": ">=1.21.1 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },

--- a/modules/playground/e2e_test/sourcemap/sourcemap_spec.ts
+++ b/modules/playground/e2e_test/sourcemap/sourcemap_spec.ts
@@ -44,7 +44,7 @@ describe('sourcemaps', function() {
       const decoder = new SourceMapConsumer(JSON.parse(sourceMapData) as RawSourceMap);
       const originalPosition = decoder.originalPositionFor({line: errorLine, column: errorColumn});
       const sourceCodeLines = readFileSync(require.resolve('../../src/sourcemap/index.ts'), {
-                                encoding: 'UTF-8'
+                                encoding: 'utf-8'
                               }).split('\n');
       expect(sourceCodeLines[originalPosition.line - 1])
           .toMatch(/throw new Error\(\'Sourcemap test\'\)/);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "//engines-comment": "Keep this in sync with /aio/package.json and /aio/tools/examples/shared/package.json",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0",
+    "node": "^14.15.0 || >=16.10.0",
     "yarn": ">=1.22.4 <2",
     "npm": "Please use yarn instead of NPM to install dependencies"
   },
@@ -96,7 +96,7 @@
     "@types/jasmine-ajax": "^3.3.1",
     "@types/jasminewd2": "^2.0.8",
     "@types/multimatch": "^4.0.0",
-    "@types/node": "^12.11.1",
+    "@types/node": "^14.15.0",
     "@types/resize-observer-browser": "^0.1.5",
     "@types/selenium-webdriver": "3.0.7",
     "@types/semver": "^7.3.4",

--- a/packages/animations/package.json
+++ b/packages/animations/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "bin": {
     "api-extractor": "./src/api-extractor/index.js",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "locales": "locales",
   "dependencies": {

--- a/packages/compiler-cli/ngcc/src/execution/cluster/utils.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/utils.ts
@@ -82,6 +82,6 @@ export const sendMessageToWorker = (workerId: number, msg: MessageToWorker): Pro
   }
 
   return new Promise((resolve, reject) => {
-    worker.send(msg, (err: Error|null) => (err === null) ? resolve() : reject(err));
+    worker.send(msg, undefined, (err: Error|null) => (err === null) ? resolve() : reject(err));
   });
 };

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -79,7 +79,7 @@
   ],
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "bugs": {
     "url": "https://github.com/angular/angular/issues"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "exports": {
     "./schematics/*": {

--- a/packages/core/test/bundling/animations/treeshaking_spec.ts
+++ b/packages/core/test/bundling/animations/treeshaking_spec.ts
@@ -11,9 +11,6 @@ import '@angular/compiler';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const UTF8 = {
-  encoding: 'utf-8'
-};
 const PACKAGE = 'angular/packages/core/test/bundling/animations';
 
 describe('treeshaking with uglify', () => {
@@ -22,7 +19,7 @@ describe('treeshaking with uglify', () => {
   // always pass)
   const contentPath = require.resolve(path.join(PACKAGE, 'bundle.debug.min.js'));
   beforeAll(() => {
-    content = fs.readFileSync(contentPath, UTF8);
+    content = fs.readFileSync(contentPath, {encoding: 'utf-8'});
   });
 
   it('should drop unused TypeScript helpers', () => {

--- a/packages/core/test/bundling/cyclic_import/integration_spec.ts
+++ b/packages/core/test/bundling/cyclic_import/integration_spec.ts
@@ -12,16 +12,13 @@ import {withBody} from '@angular/private/testing';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const UTF8 = {
-  encoding: 'utf-8'
-};
 const PACKAGE = 'angular/packages/core/test/bundling/cyclic_import';
 
 describe('treeshaking with uglify', () => {
   let content: string;
   const contentPath = require.resolve(path.join(PACKAGE, 'bundle.debug.min.js'));
   beforeAll(() => {
-    content = fs.readFileSync(contentPath, UTF8);
+    content = fs.readFileSync(contentPath, {encoding: 'utf-8'});
   });
 
   describe('functional test in domino', () => {

--- a/packages/core/test/bundling/forms_reactive/treeshaking_spec.ts
+++ b/packages/core/test/bundling/forms_reactive/treeshaking_spec.ts
@@ -11,9 +11,6 @@ import '@angular/compiler';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const UTF8 = {
-  encoding: 'utf-8'
-};
 const PACKAGE = 'angular/packages/core/test/bundling/forms_reactive';
 
 describe('treeshaking with uglify', () => {
@@ -22,7 +19,7 @@ describe('treeshaking with uglify', () => {
   // always pass)
   const contentPath = require.resolve(path.join(PACKAGE, 'bundle.debug.min.js'));
   beforeAll(() => {
-    content = fs.readFileSync(contentPath, UTF8);
+    content = fs.readFileSync(contentPath, {encoding: 'utf-8'});
   });
 
   it('should drop unused TypeScript helpers', () => {

--- a/packages/core/test/bundling/forms_template_driven/treeshaking_spec.ts
+++ b/packages/core/test/bundling/forms_template_driven/treeshaking_spec.ts
@@ -11,9 +11,6 @@ import '@angular/compiler';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const UTF8 = {
-  encoding: 'utf-8'
-};
 const PACKAGE = 'angular/packages/core/test/bundling/forms_template_driven';
 
 describe('treeshaking with uglify', () => {
@@ -22,7 +19,7 @@ describe('treeshaking with uglify', () => {
   // always pass)
   const contentPath = require.resolve(path.join(PACKAGE, 'bundle.debug.min.js'));
   beforeAll(() => {
-    content = fs.readFileSync(contentPath, UTF8);
+    content = fs.readFileSync(contentPath, {encoding: 'utf-8'});
   });
 
   it('should drop unused TypeScript helpers', () => {

--- a/packages/core/test/bundling/hello_world/treeshaking_spec.ts
+++ b/packages/core/test/bundling/hello_world/treeshaking_spec.ts
@@ -12,16 +12,13 @@ import {withBody} from '@angular/private/testing';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const UTF8 = {
-  encoding: 'utf-8'
-};
 const PACKAGE = 'angular/packages/core/test/bundling/hello_world';
 
 describe('treeshaking with uglify', () => {
   let content: string;
   const contentPath = require.resolve(path.join(PACKAGE, 'bundle.debug.min.js'));
   beforeAll(() => {
-    content = fs.readFileSync(contentPath, UTF8);
+    content = fs.readFileSync(contentPath, {encoding: 'utf-8'});
   });
 
   it('should drop unused TypeScript helpers', () => {

--- a/packages/core/test/bundling/hello_world_r2/treeshaking_spec.ts
+++ b/packages/core/test/bundling/hello_world_r2/treeshaking_spec.ts
@@ -11,16 +11,13 @@ import '@angular/compiler';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const UTF8 = {
-  encoding: 'utf-8'
-};
 const PACKAGE = 'angular/packages/core/test/bundling/hello_world_r2';
 
 describe('treeshaking with uglify', () => {
   let content: string;
   const contentPath = require.resolve(path.join(PACKAGE, 'bundle.debug.min.js'));
   beforeAll(() => {
-    content = fs.readFileSync(contentPath, UTF8);
+    content = fs.readFileSync(contentPath, {encoding: 'utf-8'});
   });
 
   it('should drop unused TypeScript helpers', () => {

--- a/packages/core/test/bundling/router/treeshaking_spec.ts
+++ b/packages/core/test/bundling/router/treeshaking_spec.ts
@@ -11,9 +11,6 @@ import '@angular/compiler';
 import * as fs from 'fs';
 import * as path from 'path';
 
-const UTF8 = {
-  encoding: 'utf-8'
-};
 const PACKAGE = 'angular/packages/core/test/bundling/router';
 
 describe('treeshaking with uglify', () => {
@@ -22,7 +19,7 @@ describe('treeshaking with uglify', () => {
   // always pass)
   const contentPath = require.resolve(path.join(PACKAGE, 'bundle.debug.min.js'));
   beforeAll(() => {
-    content = fs.readFileSync(contentPath, UTF8);
+    content = fs.readFileSync(contentPath, {encoding: 'utf-8'});
   });
 
   it('should drop unused TypeScript helpers', () => {

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -7,7 +7,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "repository": {
     "type": "git",

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -16,7 +16,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "repository": {
     "type": "git",

--- a/packages/platform-browser-dynamic/package.json
+++ b/packages/platform-browser-dynamic/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/platform-browser/package.json
+++ b/packages/platform-browser/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "peerDependencies": {
     "@angular/animations": "0.0.0-PLACEHOLDER",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -14,7 +14,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "bugs": {
     "url": "https://github.com/angular/angular/issues"

--- a/packages/service-worker/package.json
+++ b/packages/service-worker/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "exports": {
     "./ngsw-worker.js": {

--- a/packages/upgrade/package.json
+++ b/packages/upgrade/package.json
@@ -5,7 +5,7 @@
   "author": "angular",
   "license": "MIT",
   "engines": {
-    "node": "^12.20.0 || ^14.15.0 || >=16.10.0"
+    "node": "^14.15.0 || >=16.10.0"
   },
   "dependencies": {
     "tslib": "^2.3.0"

--- a/tools/source-map-test/parseMap.js
+++ b/tools/source-map-test/parseMap.js
@@ -57,7 +57,7 @@ module.exports = function getMappings(bundlePath) {
 };
 
 function getFile(filePath) {
-  return fs.readFileSync(path.resolve(process.cwd(), filePath), 'UTF-8');
+  return fs.readFileSync(path.resolve(process.cwd(), filePath), 'utf-8');
 }
 
 function decodeLines(sourceMap) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,7 +318,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#cf1639a1714f9767471721d0d58d84b6cc173600":
   version "0.0.0-ff24a8ca7be9066fc9a7ece62c1b62d064c3dfff"
-  uid cf1639a1714f9767471721d0d58d84b6cc173600
   resolved "https://github.com/angular/dev-infra-private-builds.git#cf1639a1714f9767471721d0d58d84b6cc173600"
   dependencies:
     "@angular-devkit/build-angular" "14.0.0-next.3"
@@ -2470,10 +2469,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.54.tgz#59ed60e7b0d56905a654292e8d73275034eb6283"
   integrity sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g==
 
-"@types/node@^12.11.1":
-  version "12.20.46"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.46.tgz#7e49dee4c54fd19584e6a9e0da5f3dc2e9136bc7"
-  integrity sha512-cPjLXj8d6anFPzFvOPxS3fvly3Shm5nTfl6g8X5smexixbuGUf7hfr21J5tX9JW+UPStp/5P5R8qrKL5IyVJ+A==
+"@types/node@^14.15.0":
+  version "14.18.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.12.tgz#0d4557fd3b94497d793efd4e7d92df2f83b4ef24"
+  integrity sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
Node.js v12 will become EOL on 2022-04-30. As a result, Angular CLI v14 will no longer support Node.js v12.

BREAKING CHANGE:

Support for Node.js v12 has been removed as it will become EOL on 2022-04-30. Please use Node.js v14.15 or later.
