### PR TITLE
fix(docs-infra): remove anchor tags from heritage docs

### DIFF
--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -3,10 +3,10 @@
 
 {%- macro renderHeritage(exportDoc) -%}
   {%- if exportDoc.extendsClauses.length %} extends {% for clause in exportDoc.extendsClauses -%}
-  {% if clause.doc.path %}<a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% else %}{$ clause.text | escape $}{% endif %}{% if not loop.last %}, {% endif -%}
+  {$ clause.text | escape $}{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
   {%- if exportDoc.implementsClauses.length %} implements {% for clause in exportDoc.implementsClauses -%}
-  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% if not loop.last %}, {% endif -%}
+  {$ clause.text | escape $}{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
 {%- endmacro -%}
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Current HTML (described by `memberHelpers.html`) inserts links to the extended classes (if the link exists) and implemented interfaces (no matter if it exists). This way, if the interface doesn't really exist (like in [this example](https://angular.io/api/core/QueryList)), the link won't be shown properly. Please take a look at this image:

<img width="981" alt="image" src="https://user-images.githubusercontent.com/28087049/157098246-83325f31-0dee-4a81-9eee-a43327aeb98d.png">

With this PR, the `<a>` tags are removed. But, how will this help and what will happen to links? While generating the docs, [`autoLinkCode`](https://github.com/angular/angular/blob/4332897baa/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js#L7) processor will make sure they get inserted anyway. And they won't be inserted to non-existing docs - like the one from image above.

But, why is this not working in the first place? Because having anchor tags [blocks `autoLinkCode`](https://github.com/angular/angular/blob/4332897baa/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js#L49-L52) from creating new ones.

Issue Number: N/A

## What is the new behavior?
The links will be inserted anyway, but they won't be there for non-existing docs. Example (from the local run):

<img width="963" alt="image" src="https://user-images.githubusercontent.com/28087049/157112832-58bc5608-a573-4e22-a359-8ea25bf5d323.png">

Another example:

<img width="832" alt="image" src="https://user-images.githubusercontent.com/28087049/157113014-bd60b547-bc0a-4baf-99ee-16bccc119e19.png">

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
Related ReactiveX/rxjs#6864

I couldn't ever find an example in this repo such as the one from related issue (ReactiveX/rxjs#6864). In RxJS project, there is an interface `OperatorFunction` which has this signature `interface OperatorFunction<T, R> extends UnaryFunction<Observable<T>, Observable<R>> {}` making it effectively generic-inside-generic where the inner generic type `Observable` is a valid document that could be a link to that type. Please read the related issue for more info.