### PR TITLE
refactor(migrations): update `isReferenceToImport` to not use `valueD…

### DIFF
--- a/packages/core/schematics/utils/typescript/symbol.ts
+++ b/packages/core/schematics/utils/typescript/symbol.ts
@@ -24,8 +24,8 @@ export function isReferenceToImport(
     typeChecker: ts.TypeChecker, node: ts.Node, importSpecifier: ts.ImportSpecifier): boolean {
   const nodeSymbol = typeChecker.getTypeAtLocation(node).getSymbol();
   const importSymbol = typeChecker.getTypeAtLocation(importSpecifier).getSymbol();
-  return !!(nodeSymbol && importSymbol) &&
-      nodeSymbol.valueDeclaration === importSymbol.valueDeclaration;
+  return !!(nodeSymbol?.declarations?.[0] && importSymbol?.declarations?.[0]) &&
+      nodeSymbol.declarations[0] === importSymbol.declarations[0];
 }
 
 /** Checks whether a node's type is nullable (`null`, `undefined` or `void`). */


### PR DESCRIPTION
…eclaration`

valueDeclaration is only set when the Symbol type is a `Value`:

* [setValueDeclaration](https://sourcegraph.com/github.com/microsoft/TypeScript@d8b21a8d6cef772fea5cf2a507b651c5d38194bd/-/blob/src/compiler/binder.ts?L321-322)
* [Value union](https://sourcegraph.com/github.com/microsoft/TypeScript@d8b21a8d6cef772fea5cf2a507b651c5d38194bd/-/blob/src/compiler/types.ts?L4849:9#tab=references)

This won't be the case if the symbol is an interface (notice that `Interface` is not in the union for `Value` above).

For this reason, we can't rely on the `valueDeclaration` property of the symbol.
Instead, it's more reliable to just compare the first items in the `declarations` list.
