### PR TITLE
refactor(core): switch over to new closure LOCALE vs getLocale()

### DIFF
--- a/packages/core/src/i18n/tokens.ts
+++ b/packages/core/src/i18n/tokens.ts
@@ -17,16 +17,16 @@ declare const $localize: {locale?: string};
 /**
  * Work out the locale from the potential global properties.
  *
- * * Closure Compiler: use `goog.getLocale()`.
+ * * Closure Compiler: use `goog.LOCALE`.
  * * Ivy enabled: use `$localize.locale`
  */
 export function getGlobalLocale(): string {
   if (typeof ngI18nClosureMode !== 'undefined' && ngI18nClosureMode &&
-      typeof goog !== 'undefined' && goog.getLocale() !== 'en') {
-    // * The default `goog.getLocale()` value is `en`, while Angular used `en-US`.
+      typeof goog !== 'undefined' && goog.LOCALE !== 'en') {
+    // * The default `goog.LOCALE` value is `en`, while Angular used `en-US`.
     // * In order to preserve backwards compatibility, we use Angular default value over
     //   Closure Compiler's one.
-    return goog.getLocale();
+    return goog.LOCALE;
   } else {
     // KEEP `typeof $localize !== 'undefined' && $localize.locale` IN SYNC WITH THE LOCALIZE
     // COMPILE-TIME INLINER.


### PR DESCRIPTION
This is a change requested via an LSC due to a deprecation.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We're currently relying on an outdated method of retrieving locale information in closure libraries.
Issue Number: N/A


## What is the new behavior?
We get locale from the updated property

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
