### PR TITLE
docs: deprecated relativeLinkResolution in the Router

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -79,6 +79,7 @@ v14 -> v17
 | `@angular/service-worker`           | [`SwUpdate#available`](api/service-worker/SwUpdate#available)                                              | <!--v13--> v16        |
 | template syntax                     | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector)                                         | <!--v7--> unspecified |
 | template syntax                     | [`bind-`, `on-`, `bindon-`, and `ref-`](#bind-syntax)                                                      | <!--v13--> v15        |
+| `@angular/router`                     | [`relativeLinkResolution`](#relativeLinkResolution)                                                      | <!--v14--> v16        |
 
 For information about Angular CDK and Angular Material deprecations, see the [changelog](https://github.com/angular/components/blob/master/CHANGELOG.md).
 
@@ -296,6 +297,10 @@ In v5, Angular replaced the `ReflectiveInjector` with the `StaticInjector`. The 
 **After**:
 
 <code-example path="deprecation-guide/src/app/app.component.ts" language="typescript" region="static-injector-example"></code-example>
+
+{@a relativeLinkResolution}
+
+The `relativeLinkResolution` option is being removed. The default was changed to the corrected behavior in version 11. Once this option is removed, the corrected behavior will always be used without the option to opt-in to the old, broken behavior.
 
 {@a loadChildren}
 

--- a/goldens/public-api/router/router.md
+++ b/goldens/public-api/router/router.md
@@ -205,6 +205,7 @@ export interface ExtraOptions {
     onSameUrlNavigation?: 'reload' | 'ignore';
     paramsInheritanceStrategy?: 'emptyOnly' | 'always';
     preloadingStrategy?: any;
+    // @deprecated
     relativeLinkResolution?: 'legacy' | 'corrected';
     scrollOffset?: [number, number] | (() => [number, number]);
     scrollPositionRestoration?: 'disabled' | 'enabled' | 'top';
@@ -500,6 +501,7 @@ export class Router {
     onSameUrlNavigation: 'reload' | 'ignore';
     paramsInheritanceStrategy: 'emptyOnly' | 'always';
     parseUrl(url: string): UrlTree;
+    // @deprecated
     relativeLinkResolution: 'legacy' | 'corrected';
     resetConfig(config: Routes): void;
     routeReuseStrategy: RouteReuseStrategy;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -553,6 +553,8 @@ export class Router {
   /**
    * Enables a bug fix that corrects relative link resolution in components with empty paths.
    * @see `RouterModule`
+   *
+   * @deprecated
    */
   relativeLinkResolution: 'legacy'|'corrected' = 'corrected';
 

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -425,6 +425,8 @@ export interface ExtraOptions {
    * resolution is set to `'legacy'`.
    *
    * The default in v11 is `corrected`.
+   *
+   * @deprecated
    */
   relativeLinkResolution?: 'legacy'|'corrected';
 


### PR DESCRIPTION
The `relativeLinkResolution` option was added as an option to opt-in to
corrected behavior when generating links relative to a route that has an
empty path parent. This was needed to avoid a breaking change. Since
then, we have switched the default to be the corrected behavior.
It's time to close the turn the lights off on this option so we no
longer have to maintain and document buggy behavior.
