### PR TITLE
feat(forms): Create a new ControlCollection interface.

### DIFF
--- a/goldens/public-api/forms/forms.md
+++ b/goldens/public-api/forms/forms.md
@@ -65,7 +65,7 @@ export abstract class AbstractControl {
     markAsUntouched(opts?: {
         onlySelf?: boolean;
     }): void;
-    get parent(): FormGroup | FormArray | null;
+    get parent(): ControlCollection | null;
     abstract patchValue(value: any, options?: Object): void;
     get pending(): boolean;
     readonly pristine: boolean;
@@ -78,7 +78,7 @@ export abstract class AbstractControl {
         emitEvent?: boolean;
     }): void;
     // (undocumented)
-    setParent(parent: FormGroup | FormArray): void;
+    setParent(parent: ControlCollection): void;
     setValidators(validators: ValidatorFn | ValidatorFn[] | null): void;
     abstract setValue(value: any, options?: Object): void;
     readonly status: FormControlStatus;
@@ -174,6 +174,9 @@ export class CheckboxRequiredValidator extends RequiredValidator {
 
 // @public
 export const COMPOSITION_BUFFER_MODE: InjectionToken<boolean>;
+
+// @public
+export type ControlCollection = FormGroup | FormArray;
 
 // @public
 export abstract class ControlContainer extends AbstractControlDirective {

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -42,7 +42,7 @@ export {NgSelectOption, SelectControlValueAccessor} from './directives/select_co
 export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder, UntypedFormBuilder} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormControlStatus} from './model/abstract_model';
+export {AbstractControl, AbstractControlOptions, ControlCollection, FormControlStatus} from './model/abstract_model';
 export {FormArray, UntypedFormArray} from './model/form_array';
 export {FormControl, FormControlOptions, UntypedFormControl, ɵFormControlCtor} from './model/form_control';
 export {FormGroup, UntypedFormGroup} from './model/form_group';

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -188,7 +188,7 @@ export abstract class AbstractControl {
   /** @internal */
   _updateOn?: FormHooks;
 
-  private _parent: FormGroup|FormArray|null = null;
+  private _parent: ControlCollection|null = null;
   private _asyncValidationSubscription: any;
 
   /**
@@ -285,7 +285,7 @@ export abstract class AbstractControl {
   /**
    * The parent control.
    */
-  get parent(): FormGroup|FormArray|null {
+  get parent(): ControlCollection|null {
     return this._parent;
   }
 
@@ -792,7 +792,7 @@ export abstract class AbstractControl {
   /**
    * @param parent Sets the parent of the control
    */
-  setParent(parent: FormGroup|FormArray): void {
+  setParent(parent: ControlCollection): void {
     this._parent = parent;
   }
 
@@ -1147,3 +1147,8 @@ export abstract class AbstractControl {
     return null;
   }
 }
+
+/**
+ * A `ControlCollection` is a control that has other controls as children.
+ */
+export type ControlCollection = FormGroup|FormArray;


### PR DESCRIPTION
`FormGroup` and `FormArray` can both contain other controls as children. There are some places in our API, such as `AbstractControl.parent`, where we use the union type `FormGroup|FormArray`. Refactoring this into a named type will make it easier to add additional collection types, such as the upcoming `FormRecord`.