### PR TITLE
build(docs-infra): upgrade cli command docs sources to 1d39cdcfb

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -18,7 +18,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 9aa2eb03f",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 1d39cdcfb",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint && yarn security-lint",
     "test": "yarn check-env && ng test",
     "pree2e": "yarn check-env && yarn update-webdriver",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/9aa2eb03f...1d39cdcfb):

**Modified**
- help/add.json
- help/analytics.json
- help/build.json
- help/config.json
- help/deploy.json
- help/doc.json
- help/e2e.json
- help/extract-i18n.json
- help/generate.json
- help/lint.json
- help/new.json
- help/run.json
- help/serve.json
- help/test.json
- help/update.json
- help/version.json

**Removed**
- help/help.json
- help/make-this-awesome.json