### PR TITLE
Set up 13.3.0 release for TypeScript 4.6 support

### DIFF
--- a/integration/typings_test_ts46/BUILD.bazel
+++ b/integration/typings_test_ts46/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//integration:index.bzl", "ng_integration_test")
+
+ng_integration_test(
+    name = "test",
+    # Special case for `typings_test_ts46` test as we want to pin
+    # `typescript` at version 4.6.x for that test and not link to the
+    # root @npm//typescript package.
+    pinned_npm_packages = ["typescript"],
+)

--- a/integration/typings_test_ts46/include-all.ts
+++ b/integration/typings_test_ts46/include-all.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+
+
+import * as animations from '@angular/animations';
+import * as animationsBrowser from '@angular/animations/browser';
+import * as animationsBrowserTesting from '@angular/animations/browser/testing';
+import * as common from '@angular/common';
+import * as commonHttp from '@angular/common/http';
+import * as commonTesting from '@angular/common/testing';
+import * as commonHttpTesting from '@angular/common/testing';
+import * as compiler from '@angular/compiler';
+import * as compilerTesting from '@angular/compiler/testing';
+import * as core from '@angular/core';
+import * as coreTesting from '@angular/core/testing';
+import * as elements from '@angular/elements';
+import * as forms from '@angular/forms';
+import * as localize from '@angular/localize';
+import * as platformBrowser from '@angular/platform-browser';
+import * as platformBrowserDynamic from '@angular/platform-browser-dynamic';
+import * as platformBrowserDynamicTesting from '@angular/platform-browser-dynamic/testing';
+import * as platformBrowserAnimations from '@angular/platform-browser/animations';
+import * as platformBrowserTesting from '@angular/platform-browser/testing';
+import * as platformServer from '@angular/platform-server';
+import * as platformServerInit from '@angular/platform-server/init';
+import * as platformServerTesting from '@angular/platform-server/testing';
+import * as router from '@angular/router';
+import * as routerTesting from '@angular/router/testing';
+import * as routerUpgrade from '@angular/router/upgrade';
+import * as serviceWorker from '@angular/service-worker';
+import * as upgrade from '@angular/upgrade';
+import * as upgradeStatic from '@angular/upgrade/static';
+import * as upgradeTesting from '@angular/upgrade/static/testing';
+
+export default {
+  animations,
+  animationsBrowser,
+  animationsBrowserTesting,
+  common,
+  commonTesting,
+  commonHttp,
+  commonHttpTesting,
+  compiler,
+  compilerTesting,
+  core,
+  coreTesting,
+  elements,
+  forms,
+  localize,
+  platformBrowser,
+  platformBrowserTesting,
+  platformBrowserDynamic,
+  platformBrowserDynamicTesting,
+  platformBrowserAnimations,
+  platformServer,
+  platformServerInit,
+  platformServerTesting,
+  router,
+  routerTesting,
+  routerUpgrade,
+  serviceWorker,
+  upgrade,
+  upgradeStatic,
+  upgradeTesting,
+};

--- a/integration/typings_test_ts46/package.json
+++ b/integration/typings_test_ts46/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "angular-integration",
+  "description": "Assert that users with TypeScript 4.6 can type-check an Angular application",
+  "version": "0.0.0",
+  "license": "MIT",
+  "dependencies": {
+    "@angular/animations": "file:../../dist/packages-dist/animations",
+    "@angular/common": "file:../../dist/packages-dist/common",
+    "@angular/compiler": "file:../../dist/packages-dist/compiler",
+    "@angular/compiler-cli": "file:../../dist/packages-dist/compiler-cli",
+    "@angular/core": "file:../../dist/packages-dist/core",
+    "@angular/elements": "file:../../dist/packages-dist/elements",
+    "@angular/forms": "file:../../dist/packages-dist/forms",
+    "@angular/localize": "file:../../dist/packages-dist/localize",
+    "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
+    "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
+    "@angular/platform-server": "file:../../dist/packages-dist/platform-server",
+    "@angular/router": "file:../../dist/packages-dist/router",
+    "@angular/service-worker": "file:../../dist/packages-dist/service-worker",
+    "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
+    "@types/jasmine": "file:../../node_modules/@types/jasmine",
+    "rxjs": "file:../../node_modules/rxjs",
+    "typescript": "~4.6.2",
+    "zone.js": "file:../../dist/zone.js-dist/archive/zone.js.tgz"
+  },
+  "scripts": {
+    "test": "tsc"
+  }
+}

--- a/integration/typings_test_ts46/tsconfig.json
+++ b/integration/typings_test_ts46/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "experimentalDecorators": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "outDir": "./dist/out-tsc",
+    "rootDir": ".",
+    "target": "es5",
+    "lib": [
+      "es5",
+      "dom",
+      "es2015.collection",
+      "es2015.iterable",
+      "es2015.promise"
+    ],
+    "types": [],
+  },
+  "files": [
+    "include-all.ts",
+    "node_modules/@types/jasmine/index.d.ts"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "13.2.6",
+  "version": "13.3.0-next.0",
   "private": true,
   "description": "Angular - a web framework for modern web apps",
   "homepage": "https://github.com/angular/angular",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "tsickle": "0.38.1",
     "tslib": "^2.3.0",
     "tslint": "6.1.3",
-    "typescript": "~4.5.2",
+    "typescript": "~4.6.2",
     "xhr2": "0.2.1",
     "yargs": "^17.2.1"
   },

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -35,7 +35,7 @@
     "rollup": "^2.56.3",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "terser": "^5.9.0",
-    "typescript": ">=4.4.2 <4.6"
+    "typescript": ">=4.4.2 <4.7"
   },
   "peerDependenciesMeta": {
     "terser": {

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -66,7 +66,7 @@
   },
   "peerDependencies": {
     "@angular/compiler": "0.0.0-PLACEHOLDER",
-    "typescript": ">=4.4.2 <4.6"
+    "typescript": ">=4.4.2 <4.7"
   },
   "repository": {
     "type": "git",

--- a/packages/compiler-cli/src/typescript_support.ts
+++ b/packages/compiler-cli/src/typescript_support.ts
@@ -26,7 +26,7 @@ const MIN_TS_VERSION = '4.4.2';
  * Note: this check is disabled in g3, search for
  * `angularCompilerOptions.disableTypeScriptVersionCheck` config param value in g3.
  */
-const MAX_TS_VERSION = '4.6.0';
+const MAX_TS_VERSION = '4.7.0';
 
 /**
  * The currently used version of TypeScript, which can be adjusted for testing purposes using

--- a/packages/compiler-cli/test/downlevel_decorators_transform_spec.ts
+++ b/packages/compiler-cli/test/downlevel_decorators_transform_spec.ts
@@ -183,7 +183,7 @@ describe('downlevel decorator transform', () => {
 
     expect(diagnostics.length).toBe(0);
     expect(output).toContain(dedent`
-       MyClass = (0, tslib_1.__decorate)([
+       MyClass = tslib_1.__decorate([
          SomeUnknownDecorator()
        ], MyClass);
      `);
@@ -198,7 +198,7 @@ describe('downlevel decorator transform', () => {
 
     expect(diagnostics.length).toBe(0);
     expect(output).toContain(dedent`
-       MyClass = (0, tslib_1.__decorate)([
+       MyClass = tslib_1.__decorate([
          DecoratorBuilder().customClassDecorator
        ], MyClass);
      `);
@@ -232,7 +232,7 @@ describe('downlevel decorator transform', () => {
 
     expect(diagnostics.length).toBe(0);
     expect(output).toContain(dedent`
-       (0, tslib_1.__decorate)([
+       tslib_1.__decorate([
          SomeDecorator()
        ], MyDir.prototype, "disabled", void 0);
      `);
@@ -274,7 +274,7 @@ describe('downlevel decorator transform', () => {
           ShouldBeProcessed.ctorParameters = () => [
             { type: ZoneToken }
           ];
-          ShouldBeProcessed = (0, tslib_1.__decorate)([
+          ShouldBeProcessed = tslib_1.__decorate([
             (0, core_1.Injectable)()
           ], ShouldBeProcessed);
         }
@@ -716,7 +716,7 @@ describe('downlevel decorator transform', () => {
       expect(diagnostics.length).toBe(0);
       expect(output).not.toContain('MyService.decorators');
       expect(output).toContain(dedent`
-         MyService = (0, tslib_1.__decorate)([
+         MyService = tslib_1.__decorate([
            (0, core_1.Injectable)()
          ], MyService);
        `);
@@ -742,7 +742,7 @@ describe('downlevel decorator transform', () => {
          MyService.ctorParameters = () => [
            { type: InjectClass }
          ];
-         MyService = (0, tslib_1.__decorate)([
+         MyService = tslib_1.__decorate([
            (0, core_1.Injectable)()
          ], MyService);
        `);
@@ -768,7 +768,7 @@ describe('downlevel decorator transform', () => {
          MyService.ctorParameters = () => [
            { type: InjectClass, decorators: [{ type: core_1.Inject, args: ['test',] }] }
          ];
-         MyService = (0, tslib_1.__decorate)([
+         MyService = tslib_1.__decorate([
            (0, core_1.Injectable)()
          ], MyService);
        `);

--- a/packages/service-worker/worker/testing/clients.ts
+++ b/packages/service-worker/worker/testing/clients.ts
@@ -26,7 +26,8 @@ export class MockClient implements Client {
 
 export class MockWindowClient extends MockClient implements WindowClient {
   readonly focused: boolean = false;
-  readonly visibilityState: VisibilityState = 'visible';
+  // TODO(crisbeto): change the type here to DocumentVisibilityState when we drop support for TS 4.5
+  readonly visibilityState: 'visible'|'hidden' = 'visible';
 
   constructor(id: string, url: string, frameType: FrameType = 'top-level') {
     super(id, url, 'window', frameType);

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -19,7 +19,7 @@
     "mocha": "^9.0.0",
     "mock-require": "3.0.3",
     "promises-aplus-tests": "^2.1.2",
-    "typescript": "~4.5.2"
+    "typescript": "~4.6.2"
   },
   "scripts": {
     "closuretest": "./scripts/closure/closure_compiler.sh",

--- a/packages/zone.js/test/typings/package.json
+++ b/packages/zone.js/test/typings/package.json
@@ -14,6 +14,6 @@
     "zone.js": "file:../../../../dist/bin/packages/zone.js/npm_package"
   },
   "devDependencies": {
-    "typescript": "~4.5.2"
+    "typescript": "~4.6.2"
   }
 }

--- a/packages/zone.js/yarn.lock
+++ b/packages/zone.js/yarn.lock
@@ -3986,10 +3986,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@~4.5.2:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@~4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14720,6 +14720,11 @@ typescript@^3.9.5, typescript@^3.9.7:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
+typescript@~4.6.2:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+
 ua-parser-js@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.2.tgz#e2976c34dbfb30b15d2c300b2a53eac87c57a775"


### PR DESCRIPTION
Includes the following changes:

* Cherry-picked support for TypeScript 4.6 to the current minor version.
* Bumping up the version in the package.json so that the tooling can pick it up.