### PR TITLE
docs: add manual changelog edits from `13.3.x` to main branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 <a name="13.3.0-rc.0"></a>
 # 13.3.0-rc.0 (2022-03-10)
+### core
+| Commit | Type | Description |
+| -- | -- | -- |
+| [b5bb614c74](https://github.com/angular/angular/commit/61a316c68fd27bc2375b1b3043afd8b5bb614c74) | feat | support TypeScript 4.6 ([#45190](https://github.com/angular/angular/pull/45190)) |
 ## Special Thanks
 Alistair Kane, Andrew Scott and Kristiyan Kostadinov
 


### PR DESCRIPTION
Adds the manual changelog edits from the `13.3.x` branch to the
main branch (where users primarily will look at).