### PR TITLE
fix(animations): apply default params when resolved value is null or undefined

### DIFF
--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -9,7 +9,7 @@ import {AnimationOptions, ɵStyleDataMap} from '@angular/animations';
 
 import {AnimationDriver} from '../render/animation_driver';
 import {getOrSetDefaultValue} from '../render/shared';
-import {copyObj, interpolateParams, iteratorToArray, resolveTimingValue} from '../util';
+import {copyObj, interpolateParams, iteratorToArray} from '../util';
 
 import {StyleAst, TransitionAst} from './animation_ast';
 import {buildAnimationTimelines} from './animation_timeline_builder';
@@ -57,7 +57,7 @@ export class AnimationTransitionFactory {
     const isRemoval = nextState === 'void';
 
     const animationOptions: AnimationOptions = {
-      params: {...transitionAnimationParams, ...nextAnimationParams},
+      params: applyParamDefaults(nextAnimationParams, transitionAnimationParams),
       delay: this.ast.options?.delay,
     };
 
@@ -102,6 +102,18 @@ function oneOrMoreTransitionsMatch(
     matchFns: TransitionMatcherFn[], currentState: any, nextState: any, element: any,
     params: {[key: string]: any}): boolean {
   return matchFns.some(fn => fn(currentState, nextState, element, params));
+}
+
+function applyParamDefaults(userParams: Record<string, any>, defaults: Record<string, any>) {
+  const result: Record<string, any> = copyObj(defaults);
+
+  for (const key in userParams) {
+    if (userParams.hasOwnProperty(key) && userParams[key] != null) {
+      result[key] = userParams[key];
+    }
+  }
+
+  return result;
 }
 
 export class AnimationStateStyles {

--- a/packages/animations/browser/src/util.ts
+++ b/packages/animations/browser/src/util.ts
@@ -249,7 +249,7 @@ export function interpolateParams(
   const str = original.replace(PARAM_REGEX, (_, varName) => {
     let localVal = params[varName];
     // this means that the value was never overridden by the data passed in by the user
-    if (!params.hasOwnProperty(varName)) {
+    if (localVal == null) {
       errors.push(invalidParamValue(varName));
       localVal = '';
     }

--- a/packages/animations/browser/test/dsl/animation_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_spec.ts
@@ -570,6 +570,16 @@ function createDiv() {
                      ],
                      buildParams({start: 'blue', end: 'red'})))
                  .toThrowError(/Please provide a value for the animation param time/);
+
+             expect(
+                 () => invokeAnimationSequence(
+                     rootElement, [style({color: '{{ color }}'})], buildParams({color: undefined})))
+                 .toThrowError(/Please provide a value for the animation param color/);
+
+             expect(
+                 () => invokeAnimationSequence(
+                     rootElement, [style({color: '{{ color }}'})], buildParams({color: null})))
+                 .toThrowError(/Please provide a value for the animation param color/);
            });
       });
 

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -2394,6 +2394,42 @@ describe('animation tests', function() {
          expect(hasStyle(element, 'height', '100px')).toBeTruthy();
        }));
 
+    it('should apply default params when resolved animation value is null or undefined', () => {
+      @Component({
+        selector: 'ani-cmp',
+        template: `<div [@myAnimation]="exp"></div>`,
+        animations: [trigger(
+            'myAnimation',
+            [transition(
+                'a => b',
+                [style({opacity: '{{ start }}'}), animate(1000, style({opacity: '{{ end }}'}))],
+                buildParams({start: '0.4', end: '0.7'}))])]
+      })
+      class Cmp {
+        public exp: any;
+      }
+
+      TestBed.configureTestingModule({declarations: [Cmp]});
+
+      const engine = TestBed.inject(ɵAnimationEngine);
+      const fixture = TestBed.createComponent(Cmp);
+      const cmp = fixture.componentInstance;
+
+      cmp.exp = {value: 'a'};
+      fixture.detectChanges();
+      engine.flush();
+      resetLog();
+
+      cmp.exp = {value: 'b', params: {start: undefined, end: null}};
+      fixture.detectChanges();
+      engine.flush();
+      const player = getLog().pop()!;
+      expect(player.keyframes).toEqual([
+        new Map<string, string|number>([['opacity', '0.4'], ['offset', 0]]),
+        new Map<string, string|number>([['opacity', '0.7'], ['offset', 1]])
+      ]);
+    });
+
     it('should not flush animations twice when an inner component runs change detection', () => {
       @Component({
         selector: 'outer-cmp',

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -576,6 +576,9 @@
     "name": "applyNodes"
   },
   {
+    "name": "applyParamDefaults"
+  },
+  {
     "name": "applyProjectionRecursive"
   },
   {


### PR DESCRIPTION
The animations package supports adding default parameter values to an animation that will be used as a fallback if some parameters aren't defined. The problem is that they're applied using a spread expression which means that any own property of the animation parameters will override the defaults, even if it resolves to null or undefined. This can lead to obscure errors like "Cannot read property toString of undefined" for an animation that looks like `{params: {foo: undefined}}` with defaults `{foo: 123}`.

I ran into this issue while debugging some test failures on Material.

These changes address the issue by:
1. Applying the defaults if the resolved value is null or undefined.
2. Updating the validation function to use a null check instead of `hasOwnProperty`.