### PR TITLE
fix(docs-infra): don't wrap subcommands in code element

### DIFF
--- a/aio/tools/transforms/templates/cli/cli-command.template.html
+++ b/aio/tools/transforms/templates/cli/cli-command.template.html
@@ -23,7 +23,7 @@
     <p>This command has the following <a href="#{$ doc.name $}-commands">commands</a>:<p>
     <ul>
       {% for subcommand in doc.subcommands %}
-      <li><code class="no-auto-link"><a class="code-anchor" href="#{$ subcommand.name $}-command">{$ subcommand.name $}</a></code></li>
+      <li><a class="code-anchor" href="#{$ subcommand.name $}-command">{$ subcommand.name $}</a></li>
       {% endfor %}
     </ul>
     {% endif %}

--- a/aio/tools/transforms/templates/cli/lib/cli.html
+++ b/aio/tools/transforms/templates/cli/lib/cli.html
@@ -90,7 +90,7 @@
 {% if container.subcommands.length %}
 <h2><a id="{$ container.name $}-commands"></a>{$ container.name | title $} commands</h2>
 {% for subcommand in container.subcommands %}
-<h3><code class="no-auto-link"><a id="{$ subcommand.name $}-command"></a>{$ subcommand.name $}</code></h3>
+<h3><a id="{$ subcommand.name $}-command"></a>{$ subcommand.name $}</h3>
 {$ renderSyntax(subcommand, name) $}
 {$ subcommand.shortDescription | marked $}
 {# for now we assume that commands do not have further sub-commands #}


### PR DESCRIPTION
With this change we no longer wrap subcommands titles and sub navigation items in code element for nicer UI

**Before**
![Screenshot 2022-03-14 at 13 35 24](https://user-images.githubusercontent.com/17563226/158174320-390ee98e-6fcd-4bbf-a3e2-97823da1c86f.png)

![Screenshot 2022-03-14 at 13 33 57](https://user-images.githubusercontent.com/17563226/158174329-5c06260c-efb4-45fd-8692-f0beab36433d.png)

**After**
![Screenshot 2022-03-14 at 13 43 14](https://user-images.githubusercontent.com/17563226/158174789-ea56dce2-fe11-4a98-aaae-17f819497b5f.png)

![Screenshot 2022-03-14 at 13 40 43](https://user-images.githubusercontent.com/17563226/158174926-2049842d-d6ec-4c56-bcf6-ec54c82e3ed9.png)

