### PR TITLE
fix(core): keep running change detection if the document is hidden

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 450913,
+        "main": 450856,
         "polyfills": 33869,
         "styles": 70416,
         "light-theme": 77582,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -24,7 +24,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1105,
-        "main": 132392,
+        "main": 132337,
         "polyfills": 33846
       }
     }
@@ -33,7 +33,7 @@
     "master": {
       "uncompressed": {
         "runtime": 929,
-        "main": 124544,
+        "main": 125199,
         "polyfills": 34530
       }
     }
@@ -61,7 +61,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1070,
-        "main": 156290,
+        "main": 156823,
         "polyfills": 33814
       }
     }

--- a/packages/core/src/util/timeout.ts
+++ b/packages/core/src/util/timeout.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {global} from './global';
+
+export function getNativeSetTimeout() {
+  let nativeSetTimeout: (callback: TimerHandler, timeout?: number) => number = global['setTimeout'];
+  let nativeClearTimeout: (handle: number) => void = global['clearTimeout'];
+  if (typeof Zone !== 'undefined' && nativeSetTimeout && nativeClearTimeout) {
+    // Use unpatched version of `setTimeout` (native delegate) if possible
+    // to avoid another change detection.
+    const unpatchedSetTimeout =
+        (nativeSetTimeout as any)[(Zone as any).__symbol__('OriginalDelegate')];
+    if (unpatchedSetTimeout) {
+      nativeSetTimeout = unpatchedSetTimeout;
+    }
+    const unpatchedClearTimeout =
+        (nativeClearTimeout as any)[(Zone as any).__symbol__('OriginalDelegate')];
+    if (unpatchedClearTimeout) {
+      nativeClearTimeout = unpatchedClearTimeout;
+    }
+  }
+  return {nativeSetTimeout, nativeClearTimeout};
+}

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -816,6 +816,9 @@
     "name": "getDeclarationTNode"
   },
   {
+    "name": "getDocument"
+  },
+  {
     "name": "getFactoryDef"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -864,6 +864,9 @@
     "name": "getDeclarationTNode"
   },
   {
+    "name": "getDocument"
+  },
+  {
     "name": "getFactoryDef"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -828,6 +828,9 @@
     "name": "getDeclarationTNode"
   },
   {
+    "name": "getDocument"
+  },
+  {
     "name": "getFactoryDef"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1176,6 +1176,9 @@
     "name": "getDeclarationTNode"
   },
   {
+    "name": "getDocument"
+  },
+  {
     "name": "getFactoryDef"
   },
   {

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {EventEmitter, NgZone} from '@angular/core';
+import {getDocument, setDocument} from '@angular/core/src/render3/interfaces/document';
 import {fakeAsync, flushMicrotasks, inject, waitForAsync} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
@@ -1135,6 +1136,18 @@ function commonTests() {
           expect(logs).toEqual(['microTask empty']);
           done();
         });
+      });
+
+      it('should run in setTimeout async when the document is hidden', done => {
+        const document = getDocument();
+        setDocument(<any>{hidden: true});
+        coalesceZone.run(() => {});
+        expect(logs).toEqual([]);
+        nativeSetTimeout(() => {
+          expect(logs).toEqual(['microTask empty']);
+          setDocument(document);
+          done();
+        }, 16);
       });
 
       it('should only emit onMicroTaskEmpty once within the same event loop for multiple ngZone.run',


### PR DESCRIPTION
Currently, the change detection stops running when the `ngZoneRunCoalescing`
is enabled and the document is hidden. This is because change detection is scheduled
through the `requestAnimationFrame`, which only queues tasks if the document `hidden`
property equals false (https://www.w3.org/TR/animation-timing/#processingmodel).

This commit adds a check if the document is hidden or not before calling `requestAnimationFrame`
and calls `setTimeout` instead.

## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)


## PR Type
- [x] Bugfix


## What is the current behavior?
Issue Number: #44314


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No