### PR TITLE
build(docs-infra): upgrade cli command docs sources to 207de70b7

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js a517160a2",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 207de70b7",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint && yarn security-lint",
     "test": "yarn check-env && ng test",
     "test:bazel": "bazelisk test //aio:test",


### PR DESCRIPTION
Updating [angular#master](https://github.com/angular/angular/tree/master) from [cli-builds#master](https://github.com/angular/cli-builds/tree/master).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/a517160a2...207de70b7):

**Modified**
- help/add.json
- help/analytics.json
- help/build.json
- help/config.json
- help/deploy.json
- help/doc.json
- help/e2e.json
- help/extract-i18n.json
- help/generate.json
- help/lint.json
- help/new.json
- help/run.json
- help/serve.json
- help/test.json
- help/update.json
- help/version.json

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/d84f03bf0...207de70b7) since PR #45361:

**Modified**
- help/generate.json
- help/update.json

##
Closes #45330
Closes #45346
Closes #45361