### PR TITLE
fix(zone.js): in TaskTrackingZoneSpec track a periodic task until it is cancelled

### DIFF
--- a/packages/zone.js/lib/zone-spec/task-tracking.ts
+++ b/packages/zone.js/lib/zone-spec/task-tracking.ts
@@ -58,7 +58,7 @@ class TaskTrackingZoneSpec implements ZoneSpec {
   onInvokeTask(
       parentZoneDelegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, task: Task,
       applyThis: any, applyArgs: any): any {
-    if (task.type === 'eventTask')
+    if (task.type === 'eventTask' || task.data?.isPeriodic)
       return parentZoneDelegate.invokeTask(targetZone, task, applyThis, applyArgs);
     const tasks = this.getTasksFor(task.type);
     for (let i = 0; i < tasks.length; i++) {

--- a/packages/zone.js/test/zone-spec/task-tracking.spec.ts
+++ b/packages/zone.js/test/zone-spec/task-tracking.spec.ts
@@ -75,4 +75,25 @@ describe('TaskTrackingZone', function() {
       expect((taskTrackingZoneSpec!.macroTasks[0] as any)['creationLocation']).toBeTruthy();
     });
   });
+
+  it('should track periodic task until it is canceled', (done) => {
+    taskTrackingZone.run(() => {
+      const intervalCallback = jasmine.createSpy('intervalCallback');
+      const interval = setInterval(intervalCallback, 1);
+
+      expect(intervalCallback).not.toHaveBeenCalled();
+      expect(taskTrackingZoneSpec!.macroTasks.length).toBe(1);
+      expect(taskTrackingZoneSpec!.macroTasks[0].source).toBe('setInterval');
+
+      setTimeout(() => {
+        expect(intervalCallback).toHaveBeenCalled();
+        expect(taskTrackingZoneSpec!.macroTasks.length).toBe(1);
+        expect(taskTrackingZoneSpec!.macroTasks[0].source).toBe('setInterval');
+
+        clearInterval(interval);
+        expect(taskTrackingZoneSpec!.macroTasks.length).toBe(0);
+        done();
+      }, 2);
+    });
+  });
 });


### PR DESCRIPTION
Before this change, the macrotask for `setInterval(callback, ms)` was no
longer tracked by `TaskTrackingZoneSpec` after the `callback` was
invoked for the first time. Now the periodic macrotask is tracked until
it is cancelled, e.g. `clearInterval(id)`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/45350

Before this change, the macrotask for `setInterval(callback, ms)` was no
longer tracked by `TaskTrackingZoneSpec` after the `callback` was
invoked for the first time.

## What is the new behavior?
Now the periodic macrotask is tracked by `TaskTrackingZoneSpec` until
the task is cancelled, e.g. `clearInterval(id)`.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
The breaking change is scoped only to the plugin `zone.js/plugins/task-tracking`. If you used `TaskTrackingZoneSpec` and checked the pending macroTasks e.g. using `(this.ngZone as any)._inner._parent._properties.TaskTrackingZone.getTasksFor('macroTask')`, then its behavior slightly changed for periodic macrotasks. For example, previously the `setInterval` macrotask was no longer tracked after its callback was executed for the first time. Now it's tracked until the task is explicitly cancelled, e.g  with `clearInterval(id)`.