### PR TITLE
fix(bazel): ng module compilation workers are subject to linker race-conditions

### DIFF
--- a/packages/bazel/src/ngc-wrapped/BUILD.bazel
+++ b/packages/bazel/src/ngc-wrapped/BUILD.bazel
@@ -34,9 +34,11 @@ nodejs_binary(
         "@npm//tslib",
     ],
     entry_point = ":index.ts",
-    # TODO(josephperrott): update dependency usages to no longer need bazel patch module resolver
-    # See: https://github.com/bazelbuild/rules_nodejs/wiki#--bazel_patch_module_resolver-now-defaults-to-false-2324
-    templated_args = ["--bazel_patch_module_resolver"],
+    # Disables the Bazel node modules linker. The node module linker is unreliable for the
+    # persistent worker executable, as it would rely on the `node_modules/` folder in the
+    # execroot that can be shared in non-sandbox environments or for persistent workers.
+    # https://docs.bazel.build/versions/main/command-line-reference.html#flag--worker_sandboxing.
+    templated_args = ["--nobazel_run_linker"],
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
The Bazel NodeJS rules provide two ways of accessing node modules:

* A linker which creates a `node_modules` directory in the execroot/or in the runfiles.
* A patched module resolution where no node modules directory necessarily needs to exist.

The first is the default in `rules_nodejs` and the second is technically the most idiomatic
resolution mechanism in Bazel (as it matches with a runfile resolution library).

The linker is prone to race conditions in persistent workers, or non-sandbox environments (like
windows). This is because the linker for all workers will operate on a shared `execroot` directory
and the same `node_modules` directory is modified all the time / potentially conflicting with other
linker processes from other concurrently-running workers.

We rely on the patched module resolution anyway, but just need to disable the unused linker to avoid
issues like the following:

```
---8<---8<--- Start of log, file at /private/var/tmp/_bazel_splaktar/280f06d55552a0d01f89f0955b5acd78/bazel-workers/worker-8-TypeScriptCompile.log ---8<---8<---
[link_node_modules.js] An error has been reported: [Error: ENOENT: no such file or directory, unlink 'node_modules'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'unlink',
  path: 'node_modules'
} Error: ENOENT: no such file or directory, unlink 'node_modules'
---8<---8<--- End of log ---8<---8<---
INFO: Elapsed time: 12.796s, Critical Path: 5.39s
INFO: 645 processes: 477 internal, 12 darwin-sandbox, 156 worker.
```
