### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/aio/aio-builds-setup/dockerbuild/scripts-js/lib/common/utils.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/lib/common/utils.ts
@@ -7,7 +7,7 @@ import {SHORT_SHA_LEN} from './constants';
  * @param sha The SHA to shorten.
  */
 export function computeShortSha(sha: string) {
-  return sha.substr(0, SHORT_SHA_LEN);
+  return sha.slice(0, SHORT_SHA_LEN);
 }
 
 /**

--- a/aio/aio-builds-setup/dockerbuild/scripts-js/test/preview-server/build-creator.spec.ts
+++ b/aio/aio-builds-setup/dockerbuild/scripts-js/test/preview-server/build-creator.spec.ts
@@ -16,7 +16,7 @@ import {customAsyncMatchers} from './jasmine-custom-async-matchers';
 describe('BuildCreator', () => {
   const pr = 9;
   const sha = '9'.repeat(40);
-  const shortSha = sha.substr(0, SHORT_SHA_LEN);
+  const shortSha = sha.slice(0, SHORT_SHA_LEN);
   const archive = 'snapshot.tar.gz';
   const buildsDir = 'builds/dir';
   const hiddenPrDir = path.join(buildsDir, `hidden--${pr}`);

--- a/aio/content/examples/architecture/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/architecture/e2e/src/app.e2e-spec.ts
@@ -90,7 +90,7 @@ async function heroFromDetail(detail: ElementFinder): Promise<Hero> {
   // Get name from the h2
   const name = await detail.element(by.css('app-hero-detail h2')).getText();
   return {
-    id: +id.substr(id.indexOf(' ') + 1),
-    name: name.substr(0, name.lastIndexOf(' ')),
+    id: +id.slice(id.indexOf(' ') + 1),
+    name: name.substring(0, name.lastIndexOf(' ')),
   };
 }

--- a/aio/content/examples/router/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/router/e2e/src/app.e2e-spec.ts
@@ -102,7 +102,7 @@ describe('Router', () => {
     const text = await heroEle.getText();
     expect(text.length).toBeGreaterThan(0, 'hero item text length');
     // remove leading id from text
-    const heroText = text.substr(text.indexOf(' ')).trim();
+    const heroText = text.slice(text.indexOf(' ')).trim();
 
     await heroEle.click();
     await browser.sleep(600);
@@ -168,7 +168,7 @@ describe('Router', () => {
     const text = await crisisEle.getText();
     expect(text.length).toBeGreaterThan(0, 'crisis item text length');
     // remove leading id from text
-    const crisisText = text.substr(text.indexOf(' ')).trim();
+    const crisisText = text.slice(text.indexOf(' ')).trim();
 
     await crisisEle.click();
     expect(await page.crisisDetail.isPresent()).toBe(true, 'crisis detail present');

--- a/aio/content/examples/routing-with-urlmatcher/src/app/app.module.ts
+++ b/aio/content/examples/routing-with-urlmatcher/src/app/app.module.ts
@@ -22,7 +22,7 @@ import { ProfileComponent } from './profile/profile.component';
             return {
               consumed: url,
               posParams: {
-                username: new UrlSegment(url[0].path.substr(1), {})
+                username: new UrlSegment(url[0].path.slice(1), {})
               }
             };
           }

--- a/aio/content/examples/testing/src/app/shared/title-case.pipe.ts
+++ b/aio/content/examples/testing/src/app/shared/title-case.pipe.ts
@@ -6,6 +6,6 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class TitleCasePipe implements PipeTransform {
   transform(input: string): string {
     return input.length === 0 ? '' :
-      input.replace(/\w\S*/g, (txt => txt[0].toUpperCase() + txt.substr(1).toLowerCase() ));
+      input.replace(/\w\S*/g, (txt => txt[0].toUpperCase() + txt.slice(1).toLowerCase() ));
   }
 }

--- a/aio/content/examples/testing/src/testing/jasmine-matchers.ts
+++ b/aio/content/examples/testing/src/testing/jasmine-matchers.ts
@@ -18,7 +18,7 @@ function toHaveText(): jasmine.CustomMatcher {
       return { pass, message };
 
       function composeMessage() {
-        const a = (actualText.length < 100 ? actualText : actualText.substr(0, 100) + '...');
+        const a = (actualText.length < 100 ? actualText : actualText.slice(0, 100) + '...');
         const efo = expectationFailOutput ? ` '${expectationFailOutput}'` : '';
         return `Expected element to have text content '${expectedText}' instead of '${a}'${efo}`;
       }

--- a/aio/content/examples/toh-pt1/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/toh-pt1/e2e/src/app.e2e-spec.ts
@@ -14,8 +14,8 @@ class Hero {
     // Get name from the h2
     const name = await detail.element(by.css('h2')).getText();
     return new Hero(
-      +id.substr(id.indexOf(' ') + 1),
-      name.substr(0, name.lastIndexOf(' '))
+      +id.slice(id.indexOf(' ') + 1),
+      name.substring(0, name.lastIndexOf(' '))
     );
   }
 }

--- a/aio/content/examples/toh-pt2/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/toh-pt2/e2e/src/app.e2e-spec.ts
@@ -14,8 +14,8 @@ class Hero {
   // Get hero from s formatted as '<id> <name>'.
   static fromString(s: string): Hero {
     return new Hero(
-      +s.substr(0, s.indexOf(' ')),
-      s.substr(s.indexOf(' ') + 1),
+      +s.substring(0, s.indexOf(' ')),
+      s.slice(s.indexOf(' ') + 1),
     );
   }
 
@@ -26,8 +26,8 @@ class Hero {
     // Get name from the h2
     const name = await detail.element(by.css('h2')).getText();
     return new Hero(
-      +id.substr(id.indexOf(' ') + 1),
-      name.substr(0, name.lastIndexOf(' '))
+      +id.slice(id.indexOf(' ') + 1),
+      name.substring(0, name.lastIndexOf(' '))
     );
   }
 }

--- a/aio/content/examples/toh-pt3/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/toh-pt3/e2e/src/app.e2e-spec.ts
@@ -14,8 +14,8 @@ class Hero {
   // Get hero from s formatted as '<id> <name>'.
   static fromString(s: string): Hero {
     return new Hero(
-      +s.substr(0, s.indexOf(' ')),
-      s.substr(s.indexOf(' ') + 1),
+      +s.substring(0, s.indexOf(' ')),
+      s.slice(s.indexOf(' ') + 1),
     );
   }
 
@@ -26,8 +26,8 @@ class Hero {
     // Get name from the h2
     const name = await detail.element(by.css('h2')).getText();
     return new Hero(
-      +id.substr(id.indexOf(' ') + 1),
-      name.substr(0, name.lastIndexOf(' '))
+      +id.slice(id.indexOf(' ') + 1),
+      name.substring(0, name.lastIndexOf(' '))
     );
   }
 }

--- a/aio/content/examples/toh-pt4/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/toh-pt4/e2e/src/app.e2e-spec.ts
@@ -14,8 +14,8 @@ class Hero {
   // Get hero from s formatted as '<id> <name>'.
   static fromString(s: string): Hero {
     return new Hero(
-      +s.substr(0, s.indexOf(' ')),
-      s.substr(s.indexOf(' ') + 1),
+      +s.substring(0, s.indexOf(' ')),
+      s.slice(s.indexOf(' ') + 1),
     );
   }
 
@@ -26,8 +26,8 @@ class Hero {
     // Get name from the h2
     const name = await detail.element(by.css('h2')).getText();
     return new Hero(
-      +id.substr(id.indexOf(' ') + 1),
-      name.substr(0, name.lastIndexOf(' '))
+      +id.slice(id.indexOf(' ') + 1),
+      name.substring(0, name.lastIndexOf(' '))
     );
   }
 }

--- a/aio/content/examples/toh-pt5/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/toh-pt5/e2e/src/app.e2e-spec.ts
@@ -15,8 +15,8 @@ class Hero {
   // Get hero from s formatted as '<id> <name>'.
   static fromString(s: string): Hero {
     return new Hero(
-      +s.substr(0, s.indexOf(' ')),
-      s.substr(s.indexOf(' ') + 1),
+      +s.substring(0, s.indexOf(' ')),
+      s.slice(s.indexOf(' ') + 1),
     );
   }
 
@@ -27,8 +27,8 @@ class Hero {
     // Get name from the h2
     const name = await detail.element(by.css('h2')).getText();
     return {
-      id: +id.substr(id.indexOf(' ') + 1),
-      name: name.substr(0, name.lastIndexOf(' '))
+      id: +id.slice(id.indexOf(' ') + 1),
+      name: name.substring(0, name.lastIndexOf(' '))
     };
   }
 }

--- a/aio/content/examples/toh-pt6/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/toh-pt6/e2e/src/app.e2e-spec.ts
@@ -15,8 +15,8 @@ class Hero {
   // Hero from string formatted as '<id> <name>'.
   static fromString(s: string): Hero {
     return new Hero(
-      +s.substr(0, s.indexOf(' ')),
-      s.substr(s.indexOf(' ') + 1),
+      +s.substring(0, s.indexOf(' ')),
+      s.slice(s.indexOf(' ') + 1),
     );
   }
 
@@ -34,8 +34,8 @@ class Hero {
     // Get name from the h2
     const name = await detail.element(by.css('h2')).getText();
     return {
-      id: +id.substr(id.indexOf(' ') + 1),
-      name: name.substr(0, name.lastIndexOf(' '))
+      id: +id.slice(id.indexOf(' ') + 1),
+      name: name.substring(0, name.lastIndexOf(' '))
     };
   }
 }

--- a/aio/content/examples/universal/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/universal/e2e/src/app.e2e-spec.ts
@@ -8,8 +8,8 @@ class Hero {
   // Hero from string formatted as '<id> <name>'.
   static fromString(s: string): Hero {
     return new Hero(
-      +s.substr(0, s.indexOf(' ')),
-      s.substr(s.indexOf(' ') + 1),
+      +s.substring(0, s.indexOf(' ')),
+      s.slice(s.indexOf(' ') + 1),
     );
   }
 
@@ -27,8 +27,8 @@ class Hero {
     // Get name from the h2
     const name = await detail.element(by.css('h2')).getText();
     return {
-      id: +id.substr(id.indexOf(' ') + 1),
-      name: name.substr(0, name.lastIndexOf(' '))
+      id: +id.slice(id.indexOf(' ') + 1),
+      name: name.substring(0, name.lastIndexOf(' '))
     };
   }
 }

--- a/aio/content/examples/upgrade-phonecat-2-hybrid/karma-test-shim.1.js
+++ b/aio/content/examples/upgrade-phonecat-2-hybrid/karma-test-shim.1.js
@@ -20,7 +20,7 @@ function isSpecFile(path) {
 }
 
 function isBuiltFile(path) {
-  return isJsFile(path) && (path.substr(0, builtPath.length) == builtPath);
+  return isJsFile(path) && (path.slice(0, builtPath.length) == builtPath);
 }
 
 var allSpecFiles = Object.keys(window.__karma__.files)

--- a/aio/content/examples/upgrade-phonecat-2-hybrid/karma-test-shim.js
+++ b/aio/content/examples/upgrade-phonecat-2-hybrid/karma-test-shim.js
@@ -26,7 +26,7 @@ function isSpecFile(path) {
 function isBuiltFile(path) {
   return isJsFile(path) &&
          builtPaths.reduce(function(keep, bp) {
-           return keep || (path.substr(0, bp.length) === bp);
+           return keep || (path.slice(0, bp.length) === bp);
          }, false);
 }
 

--- a/aio/content/examples/upgrade-phonecat-3-final/karma-test-shim.js
+++ b/aio/content/examples/upgrade-phonecat-3-final/karma-test-shim.js
@@ -26,7 +26,7 @@ function isSpecFile(path) {
 function isBuiltFile(path) {
   return isJsFile(path) &&
          builtPaths.reduce(function(keep, bp) {
-           return keep || (path.substr(0, bp.length) === bp);
+           return keep || (path.slice(0, bp.length) === bp);
          }, false);
 }
 

--- a/aio/src/app/custom-elements/code/code.component.ts
+++ b/aio/src/app/custom-elements/code/code.component.ts
@@ -199,6 +199,6 @@ function leftAlign(text: TrustedHTML): TrustedHTML {
   });
 
   return htmlFromStringKnownToSatisfyTypeContract(
-      lines.map(line => line.substr(indent)).join('\n').trim(),
+      lines.map(line => line.slice(indent)).join('\n').trim(),
       'safe manipulation of existing trusted HTML');
 }

--- a/aio/src/app/custom-elements/code/pretty-printer.service.ts
+++ b/aio/src/app/custom-elements/code/pretty-printer.service.ts
@@ -54,7 +54,7 @@ export class PrettyPrinter {
           return htmlFromStringKnownToSatisfyTypeContract(
               ppo(code, language, linenums), 'prettify.js modifies already trusted HTML inline');
         } catch (err) {
-          const msg = `Could not format code that begins '${code.toString().substr(0, 50)}...'.`;
+          const msg = `Could not format code that begins '${code.toString().slice(0, 50)}...'.`;
           console.error(msg, err);
           throw new Error(msg);
         }

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -82,7 +82,7 @@ export class LocationService {
     const q = path.indexOf('?');
     if (q > -1) {
       try {
-          const params = path.substr(q + 1).split('&');
+          const params = path.slice(q + 1).split('&');
           params.forEach(p => {
             const pair = p.split('=');
             if (pair[0]) {

--- a/aio/src/index.html
+++ b/aio/src/index.html
@@ -94,7 +94,7 @@
           col = col || '?';
           stack = url + ':' + line + ':' + col;
         }
-        return (msg + '\n' + stack).substr(0, 150);
+        return (msg + '\n' + stack).slice(0, 150);
       }
     };
   </script>

--- a/aio/tools/example-zipper/exampleZipper.mjs
+++ b/aio/tools/example-zipper/exampleZipper.mjs
@@ -125,7 +125,7 @@ export class ExampleZipper {
               return file;
             }
 
-            return '!' + basePath + file.substr(1);
+            return '!' + basePath + file.slice(1);
           }
 
           return basePath + file;
@@ -144,7 +144,7 @@ export class ExampleZipper {
     let gpaths = json.files.map((fileName) => {
       fileName = fileName.trim();
       if (fileName[0] === '!') {
-        return '!' + path.join(exampleDirName, fileName.substr(1));
+        return '!' + path.join(exampleDirName, fileName.slice(1));
       } else {
         return path.join(exampleDirName, fileName);
       }
@@ -159,7 +159,7 @@ export class ExampleZipper {
       let relativePath = path.relative(exampleDirName, fileName);
       relativePath = this._renameFile(relativePath, exampleType);
       let content = fs.readFileSync(fileName, 'utf8');
-      let extn = path.extname(fileName).substr(1);
+      let extn = path.extname(fileName).slice(1);
       // if we don't need to clean up the file then we can do the following.
       // zip.append(fs.createReadStream(fileName), { name: relativePath });
       let output = regionExtractor()(content, extn).contents;

--- a/aio/tools/examples/shared/boilerplate/systemjs/protractor.config.js
+++ b/aio/tools/examples/shared/boilerplate/systemjs/protractor.config.js
@@ -133,10 +133,10 @@ function Reporter(outputFile) {
           spec.failedExpectations.forEach(function (fe) {
             results.push(pad + 'message: ' + fe.message);
           });
-          pad=pad.substr(2);
+          pad=pad.slice(2);
         }
       });
-      pad = pad.substr(2);
+      pad = pad.slice(2);
       results.push('');
     });
     results.push('');
@@ -148,7 +148,7 @@ function Reporter(outputFile) {
   function log(str, indent) {
     _pad = _pad || '';
     if (indent == -1) {
-      _pad = _pad.substr(2);
+      _pad = _pad.slice(2);
     }
     console.log(_pad + str);
     if (indent == 1) {

--- a/aio/tools/examples/shared/boilerplate/systemjs/src/systemjs-angular-loader.js
+++ b/aio/tools/examples/shared/boilerplate/systemjs/src/systemjs-angular-loader.js
@@ -26,7 +26,7 @@ module.exports.translate = function(load){
       var resolvedUrl = url;
 
       if (url.startsWith('.')) {
-        resolvedUrl = basePath + url.substr(1);
+        resolvedUrl = basePath + url.slice(1);
       }
 
       return 'templateUrl: "' + resolvedUrl + '"';
@@ -36,7 +36,7 @@ module.exports.translate = function(load){
 
       while ((match = stringRegex.exec(relativeUrls)) !== null) {
         if (match[2].startsWith('.')) {
-          urls.push('"' + basePath + match[2].substr(1) + '"');
+          urls.push('"' + basePath + match[2].slice(1) + '"');
         } else {
           urls.push('"' + match[2] + '"');
         }

--- a/aio/tools/stackblitz-builder/builder.mjs
+++ b/aio/tools/stackblitz-builder/builder.mjs
@@ -228,7 +228,7 @@ export class StackblitzBuilder {
         }
       }
 
-      content = regionExtractor()(content, extn.substr(1)).contents;
+      content = regionExtractor()(content, extn.slice(1)).contents;
 
       postData[`project[files][${relativeFileName}]`] = content;
     });
@@ -287,7 +287,7 @@ export class StackblitzBuilder {
     const gpaths = config.files.map((fileName) => {
       fileName = fileName.trim();
       if (fileName[0] === '!') {
-        return '!' + path.join(config.basePath, fileName.substr(1));
+        return '!' + path.join(config.basePath, fileName.slice(1));
       } else {
         includeSpec = includeSpec || /\.spec\.(ts|js)$/.test(fileName);
         return path.join(config.basePath, fileName);

--- a/aio/tools/transforms/angular-base-package/processors/splitDescription.js
+++ b/aio/tools/transforms/angular-base-package/processors/splitDescription.js
@@ -17,8 +17,8 @@ module.exports = function splitDescription() {
             doc.shortDescription = description;
             doc.description = '';
           } else {
-            doc.shortDescription = description.substr(0, endOfParagraph).trim();
-            doc.description = description.substr(endOfParagraph).trim();
+            doc.shortDescription = description.slice(0, endOfParagraph).trim();
+            doc.description = description.slice(endOfParagraph).trim();
           }
         }
       });

--- a/aio/tools/transforms/examples-package/processors/collect-examples.js
+++ b/aio/tools/transforms/examples-package/processors/collect-examples.js
@@ -36,7 +36,7 @@ module.exports = function collectExamples(exampleMap, regionParser, log, createD
             exampleFolders.some((folder) => {
               if (doc.fileInfo.relativePath.indexOf(folder) === 0) {
                 const relativePath =
-                    doc.fileInfo.relativePath.substr(folder.length).replace(/^\//, '');
+                    doc.fileInfo.relativePath.slice(folder.length).replace(/^\//, '');
                 exampleMap[folder][relativePath] = doc;
 
                 // We treat files that end in `.annotated` specially
@@ -45,7 +45,7 @@ module.exports = function collectExamples(exampleMap, regionParser, log, createD
                 // of the original but contains inline doc region comments
                 let fileType = doc.fileInfo.extension;
                 if (fileType === 'annotated') {
-                  fileType = extname(doc.fileInfo.baseName).substr(1) + '.' + fileType;
+                  fileType = extname(doc.fileInfo.baseName).slice(1) + '.' + fileType;
                 }
 
                 const parsedRegions = regionParser(doc.content, fileType);

--- a/aio/tools/transforms/examples-package/processors/collect-examples.spec.js
+++ b/aio/tools/transforms/examples-package/processors/collect-examples.spec.js
@@ -204,7 +204,7 @@ describe('collectExampleRegions processor', () => {
 
 function createDoc(content, relativePath, docType) {
   return {
-    fileInfo: {relativePath: relativePath, baseName: path.basename(relativePath), extension: path.extname(relativePath).substr(1)},
+    fileInfo: {relativePath: relativePath, baseName: path.basename(relativePath), extension: path.extname(relativePath).slice(1)},
     content: content,
     docType: docType || 'example-file',
     startingLine: 1

--- a/aio/tools/transforms/examples-package/services/parseArgString.js
+++ b/aio/tools/transforms/examples-package/services/parseArgString.js
@@ -37,14 +37,14 @@ module.exports = function parseArgString() {
           args[key] = arg;
           key = null;
         } else {
-          if (arg.substr(arg.length - 1) === '=') {
-            key = arg.substr(0, arg.length - 1);
+          if (arg.slice(-1) === '=') {
+            key = arg.slice(0, -1);
             // remove leading '-' (or '--') if it exists.
-            if (key.substr(0, 1) == '-') {
-              key = key.substr(1);
+            if (key.slice(0, 1) == '-') {
+              key = key.slice(1);
             }
-            if (key.substr(0, 1) == '-') {
-              key = key.substr(1);
+            if (key.slice(0, 1) == '-') {
+              key = key.slice(1);
             }
           } else {
             unnammedArgs.push(arg);

--- a/aio/tools/transforms/examples-package/services/region-parser.js
+++ b/aio/tools/transforms/examples-package/services/region-parser.js
@@ -138,7 +138,7 @@ function leftAlign(lines) {
       indent = Math.min(lineIndent, indent);
     }
   });
-  return lines.map(line => line.substr(indent));
+  return lines.map(line => line.slice(indent));
 }
 
 function RegionParserError(message, index) {

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -266,7 +266,7 @@ const getLevelDescriptorValue =
 
 const truncate = (str: string, max = 20): string => {
   if (str.length > max) {
-    return str.substr(0, max) + '...';
+    return str.substring(0, max) + '...';
   }
   return str;
 };

--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -488,7 +488,7 @@ function normalizeSelector(selector: string): [string, boolean] {
   // Note: the :enter and :leave aren't normalized here since those
   // selectors are filled in at runtime during timeline building
   selector = selector.replace(/@\*/g, NG_TRIGGER_SELECTOR)
-                 .replace(/@\w+/g, match => NG_TRIGGER_SELECTOR + '-' + match.substr(1))
+                 .replace(/@\w+/g, match => NG_TRIGGER_SELECTOR + '-' + match.slice(1))
                  .replace(/:animating/g, NG_ANIMATING_SELECTOR);
 
   return [selector, hasAmpersand];

--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -134,7 +134,7 @@ export function getOrSetDefaultValue<T, V>(map: Map<T, V>, key: T, defaultValue:
 export function parseTimelineCommand(command: string): [string, string] {
   const separatorPos = command.indexOf(':');
   const id = command.substring(1, separatorPos);
-  const action = command.substr(separatorPos + 1);
+  const action = command.slice(separatorPos + 1);
   return [id, action];
 }
 
@@ -201,7 +201,7 @@ export function validateStyleProperty(prop: string): boolean {
   if (_CACHED_BODY!.style && !containsVendorPrefix(prop)) {
     result = prop in _CACHED_BODY!.style;
     if (!result && _IS_WEBKIT) {
-      const camelProp = 'Webkit' + prop.charAt(0).toUpperCase() + prop.substr(1);
+      const camelProp = 'Webkit' + prop.charAt(0).toUpperCase() + prop.slice(1);
       result = camelProp in _CACHED_BODY!.style;
     }
   }

--- a/packages/bazel/src/ng_package/packager.ts
+++ b/packages/bazel/src/ng_package/packager.ts
@@ -226,7 +226,7 @@ function main(args: string[]): void {
    * is `@angular/cdk`, then for `@angular/cdk/a11y` just `a11y` would be returned.
    */
   function getEntryPointSubpath(moduleName: string): string {
-    return moduleName.substr(`${metadata.npmPackageName}/`.length);
+    return moduleName.slice(`${metadata.npmPackageName}/`.length);
   }
 
   /**

--- a/packages/bazel/src/ng_package/rollup.config.js
+++ b/packages/bazel/src/ng_package/rollup.config.js
@@ -119,7 +119,7 @@ function resolveBazel(importee, importer) {
   if (resolved) {
     if (path.extname(resolved) == '.js') {
       // check for .mjs file and prioritize that
-      const resolved_mjs = resolved.substr(0, resolved.length - 3) + '.mjs';
+      const resolved_mjs = resolved.slice(0, -3) + '.mjs';
       if (fileExists(resolved_mjs)) {
         resolved = resolved_mjs;
       }

--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -585,7 +585,7 @@ export function patchNgHostWithFileNameToModuleName(
     // break `esm2015` or `esm5` output for Angular package release output
     // Omit the `node_modules` prefix if the module name of an NPM package is requested.
     if (relativeTargetPath.startsWith(NODE_MODULES)) {
-      return relativeTargetPath.substr(NODE_MODULES.length);
+      return relativeTargetPath.slice(NODE_MODULES.length);
     } else if (
         containingFilePath == null || !bazelOpts.compilationTargetSrc.includes(importedFilePath)) {
       return manifestTargetPath;

--- a/packages/circular-deps-test.conf.js
+++ b/packages/circular-deps-test.conf.js
@@ -24,7 +24,7 @@ module.exports = {
  */
 function resolveModule(specifier) {
   if (specifier.startsWith('@angular/')) {
-    return path.join(__dirname, specifier.substr('@angular/'.length));
+    return path.join(__dirname, specifier.slice('@angular/'.length));
   }
   return null;
 }

--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -223,14 +223,14 @@ function padNumber(
     strNum = '0' + strNum;
   }
   if (trim) {
-    strNum = strNum.substr(strNum.length - digits);
+    strNum = strNum.slice(strNum.length - digits);
   }
   return neg + strNum;
 }
 
 function formatFractionalSeconds(milliseconds: number, digits: number): string {
   const strMs = padNumber(milliseconds, 3);
-  return strMs.substr(0, digits);
+  return strMs.substring(0, digits);
 }
 
 /**

--- a/packages/common/src/i18n/format_number.ts
+++ b/packages/common/src/i18n/format_number.ts
@@ -266,7 +266,7 @@ function parseNumberFormat(format: string, minusSign = '-'): ParsedNumberFormat 
       ],
         integer = positiveParts[0], fraction = positiveParts[1] || '';
 
-  p.posPre = integer.substr(0, integer.indexOf(DIGIT_CHAR));
+  p.posPre = integer.substring(0, integer.indexOf(DIGIT_CHAR));
 
   for (let i = 0; i < fraction.length; i++) {
     const ch = fraction.charAt(i);
@@ -287,8 +287,8 @@ function parseNumberFormat(format: string, minusSign = '-'): ParsedNumberFormat 
     const trunkLen = positive.length - p.posPre.length - p.posSuf.length,
           pos = negative.indexOf(DIGIT_CHAR);
 
-    p.negPre = negative.substr(0, pos).replace(/'/g, '');
-    p.negSuf = negative.substr(pos + trunkLen).replace(/'/g, '');
+    p.negPre = negative.substring(0, pos).replace(/'/g, '');
+    p.negSuf = negative.slice(pos + trunkLen).replace(/'/g, '');
   } else {
     p.negPre = minusSign + p.posPre;
     p.negSuf = p.posSuf;

--- a/packages/common/src/pipes/case_conversion_pipes.ts
+++ b/packages/common/src/pipes/case_conversion_pipes.ts
@@ -7,6 +7,7 @@
  */
 
 import {Pipe, PipeTransform} from '@angular/core';
+
 import {invalidPipeArgumentError} from './invalid_pipe_argument_error';
 
 /**
@@ -85,7 +86,7 @@ export class TitleCasePipe implements PipeTransform {
     }
 
     return value.replace(
-        unicodeWordMatch, (txt => txt[0].toUpperCase() + txt.substr(1).toLowerCase()));
+        unicodeWordMatch, (txt => txt[0].toUpperCase() + txt.slice(1).toLowerCase()));
   }
 }
 

--- a/packages/common/upgrade/src/location_shim.ts
+++ b/packages/common/upgrade/src/location_shim.ts
@@ -297,7 +297,7 @@ export class $locationShim {
 
   private stripBaseUrl(base: string, url: string) {
     if (url.startsWith(base)) {
-      return url.substr(base.length);
+      return url.slice(base.length);
     }
     return undefined;
   }
@@ -437,7 +437,7 @@ export class $locationShim {
 
   private composeUrls() {
     this.$$url = this.urlCodec.normalize(this.$$path, this.$$search, this.$$hash);
-    this.$$absUrl = this.getServerBase() + this.$$url.substr(1);  // remove '/' from front of URL
+    this.$$absUrl = this.getServerBase() + this.$$url.slice(1);  // remove '/' from front of URL
     this.updateBrowser = true;
   }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/common/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/test/diagnostics_spec.ts
@@ -97,7 +97,7 @@ runInEachFileSystem(() => {
 
 function getSourceCode(diag: ts.DiagnosticRelatedInformation): string {
   const text = diag.file!.text;
-  return text.substr(diag.start!, diag.length!);
+  return text.slice(diag.start!, diag.start! + diag.length!);
 }
 
 function createError(

--- a/packages/compiler-cli/src/ngtsc/cycles/test/util.ts
+++ b/packages/compiler-cli/src/ngtsc/cycles/test/util.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import ts from 'typescript';
+
 import {getFileSystem, PathManipulation} from '../../file_system';
 import {TestFile} from '../../file_system/testing';
 import {makeProgram} from '../../testing';
@@ -43,10 +44,10 @@ export function makeProgramFromGraph(fs: PathManipulation, graph: string): {
     const contents = (importList ? importList.split(',') : [])
                          .map(i => {
                            if (i.startsWith('*')) {
-                             const sym = i.substr(1);
+                             const sym = i.slice(1);
                              return `export {${sym}} from './${sym}';`;
                            } else if (i.endsWith('!')) {
-                             const sym = i.substr(0, i.length - 1);
+                             const sym = i.slice(0, -1);
                              return `import type {${sym}} from './${sym}';`;
                            } else {
                              return `import {${i}} from './${i}';`;

--- a/packages/compiler-cli/src/ngtsc/file_system/src/logical.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/logical.ts
@@ -109,7 +109,7 @@ export class LogicalFileSystem {
 
   private createLogicalProjectPath(file: AbsoluteFsPath, rootDir: AbsoluteFsPath):
       LogicalProjectPath {
-    const logicalPath = stripExtension(file.substr(rootDir.length));
+    const logicalPath = stripExtension(file.slice(rootDir.length));
     return (logicalPath.startsWith('/') ? logicalPath : '/' + logicalPath) as LogicalProjectPath;
   }
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -221,7 +221,7 @@ function afterUnderscore(str: string): string {
   if (pos === -1) {
     throw new Error(`Expected '${str}' to contain '_'`);
   }
-  return str.substr(pos + 1);
+  return str.slice(pos + 1);
 }
 
 /** Returns whether a class declaration has the necessary class fields to make it injectable. */

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/diagnostics_spec.ts
@@ -270,7 +270,7 @@ runInEachFileSystem(os => {
 
 function getSourceCode(diag: ts.DiagnosticRelatedInformation): string {
   const text = diag.file!.text;
-  return text.substr(diag.start!, diag.length!);
+  return text.slice(diag.start!, diag.start! + diag.length!);
 }
 
 function traceExpression(code: string, expr: string): ts.DiagnosticRelatedInformation[] {

--- a/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
+++ b/packages/compiler-cli/src/ngtsc/sourcemaps/src/source_file_loader.ts
@@ -252,7 +252,7 @@ export class SourceFileLoader {
     if (lastRealLineIndex === -1) {
       lastRealLineIndex = 0;
     }
-    return contents.substr(lastRealLineIndex + 1);
+    return contents.slice(lastRealLineIndex + 1);
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/src/utils.ts
@@ -145,5 +145,5 @@ export function getSourceCodeForDiagnostic(diag: ts.Diagnostic): string {
         `Unable to get source code for diagnostic. Provided diagnostic instance doesn't contain "file", "start" and/or "length" properties.`);
   }
   const text = diag.file.text;
-  return text.substr(diag.start, diag.length);
+  return text.slice(diag.start, diag.start + diag.length);
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
@@ -13,7 +13,6 @@ import {absoluteFrom, getSourceFileOrError} from '../../file_system';
 import {runInEachFileSystem} from '../../file_system/testing';
 import {getTokenAtPosition} from '../../util/src/typescript';
 import {CompletionKind, GlobalCompletion, TemplateTypeChecker, TypeCheckingConfig} from '../api';
-
 import {getClass, setup, TypeCheckingTarget} from '../testing';
 
 runInEachFileSystem(() => {
@@ -29,7 +28,7 @@ runInEachFileSystem(() => {
       }
       expect(node.expression.getText()).toEqual('ctx.');
       // The position should be between the '.' and a following space.
-      expect(tcbSf.text.substr(positionInShimFile - 1, 2)).toEqual('. ');
+      expect(tcbSf.text.slice(positionInShimFile - 1, positionInShimFile + 1)).toEqual('. ');
     });
 
     it('should return additional completions for references and variables when available', () => {

--- a/packages/compiler-cli/test/compliance/test_helpers/expect_emit.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/expect_emit.ts
@@ -69,7 +69,7 @@ function tokenize(text: string): Piece[] {
     const to = from + ERROR_CONTEXT_WIDTH;
     throw Error(
         `Invalid test, no token found for "${text[tokenizedTextEnd]}" ` +
-        `(context = '${text.substr(from, to)}...'`);
+        `(context = '${text.slice(from, to)}...'`);
   }
   // Reset the lastIndex in case we are in a recursive `tokenize()` call.
   TOKEN.lastIndex = lastIndex;
@@ -136,15 +136,15 @@ export function expectEmit(
         const contextLength = 50;
         const fullContext = source.substring(source.lastIndexOf('\n', last) + 1, last);
         const context = fullContext.length > contextLength ?
-            `...${fullContext.substr(-contextLength)}` :
+            `...${fullContext.slice(-contextLength)}` :
             fullContext;
         throw new Error(
             `${RED}${description}:\n${RESET}${BLUE}Failed to find${RESET} "${expectedPiece}"\n` +
             `${BLUE}After ${RESET}"${context}"\n` +
             `${BLUE}In generated file:${RESET}\n\n` +
-            `${source.substr(0, last)}` +
+            `${source.slice(0, last)}` +
             `${RED}[[[ <<<<---HERE expected "${GREEN}${expectedPiece}${RED}" ]]]${RESET}` +
-            `${source.substr(last)}`);
+            `${source.slice(last)}`);
       } else {
         last = (m.index || 0) + m[0].length;
       }

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -162,7 +162,7 @@ export class NgtscTestEnvironment {
     const writtenFiles = new Set<string>();
     this.multiCompileHostExt.getFilesWrittenSinceLastFlush().forEach(rawFile => {
       if (rawFile.startsWith(this.outDir)) {
-        writtenFiles.add(rawFile.substr(this.outDir.length));
+        writtenFiles.add(rawFile.slice(this.outDir.length));
       }
     });
     return writtenFiles;
@@ -315,7 +315,7 @@ class FileNameToModuleNameHost extends AugmentedCompilerHost {
     return moduleNames.map(moduleName => {
       if (moduleName.startsWith(ROOT_PREFIX)) {
         // Strip the artificially added root prefix.
-        moduleName = '/' + moduleName.substr(ROOT_PREFIX.length);
+        moduleName = '/' + moduleName.slice(ROOT_PREFIX.length);
       }
 
       return ts

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -37,7 +37,7 @@ const setClassMetadataRegExp = (expectedType: string): RegExp =>
 const testFiles = loadStandardTestFiles();
 
 function getDiagnosticSourceCode(diag: ts.Diagnostic): string {
-  return diag.file!.text.substr(diag.start!, diag.length!);
+  return diag.file!.text.slice(diag.start!, diag.start! + diag.length!);
 }
 
 runInEachFileSystem(allTests);
@@ -7518,7 +7518,7 @@ function allTests(os: string) {
                   'Cannot mark an element as translatable inside of a translatable section.' +
                   ' Please remove the nested i18n marker.');
           expect(diags[0].file?.fileName).toEqual(absoluteFrom('/test.ts'));
-          expect(diags[0].file?.text.substr(diags[0].start!, diags[0].length))
+          expect(diags[0].file?.text.slice(diags[0].start!, diags[0].start! + diags[0].length!))
               .toEqual('<div i18n>Content</div>');
         });
 
@@ -7540,7 +7540,7 @@ function allTests(os: string) {
                   'Cannot mark an element as translatable inside of a translatable section.' +
                   ' Please remove the nested i18n marker.');
           expect(diags[0].file?.fileName).toEqual(absoluteFrom('/test.ts'));
-          expect(diags[0].file?.text.substr(diags[0].start!, diags[0].length))
+          expect(diags[0].file?.text.slice(diags[0].start!, diags[0].start! + diags[0].length!))
               .toEqual('<div i18n>Content</div>');
         });
 
@@ -7562,7 +7562,7 @@ function allTests(os: string) {
                   'Cannot mark an element as translatable inside of a translatable section.' +
                   ' Please remove the nested i18n marker.');
           expect(diags[0].file?.fileName).toEqual(absoluteFrom('/test.ts'));
-          expect(diags[0].file?.text.substr(diags[0].start!, diags[0].length))
+          expect(diags[0].file?.text.slice(diags[0].start!, diags[0].start! + diags[0].length!))
               .toEqual('<ng-container i18n>Content</ng-container>');
         });
       });

--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -8,8 +8,8 @@
 
 import * as chars from '../chars';
 import {ParseError, ParseLocation, ParseSourceFile, ParseSourceSpan} from '../parse_util';
-import {NAMED_ENTITIES} from './entities';
 
+import {NAMED_ENTITIES} from './entities';
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig} from './interpolation_config';
 import {TagContentType, TagDefinition} from './tags';
 import {IncompleteTagOpenToken, TagOpenStartToken, Token, TokenType} from './tokens';
@@ -1202,7 +1202,7 @@ class EscapedCharacterCursor extends PlainCharacterCursor {
   }
 
   protected decodeHexDigits(start: EscapedCharacterCursor, length: number): number {
-    const hex = this.input.substr(start.internalState.offset, length);
+    const hex = this.input.slice(start.internalState.offset, start.internalState.offset + length);
     const charCode = parseInt(hex, 16);
     if (!isNaN(charCode)) {
       return charCode;

--- a/packages/compiler/src/parse_util.ts
+++ b/packages/compiler/src/parse_util.ts
@@ -29,7 +29,8 @@ export class ParseLocation {
       const ch = source.charCodeAt(offset);
       if (ch == chars.$LF) {
         line--;
-        const priorLine = source.substr(0, offset - 1).lastIndexOf(String.fromCharCode(chars.$LF));
+        const priorLine =
+            source.substring(0, offset - 1).lastIndexOf(String.fromCharCode(chars.$LF));
         col = priorLine > 0 ? offset - priorLine : offset;
       } else {
         col--;

--- a/packages/compiler/src/render3/view/style_parser.ts
+++ b/packages/compiler/src/render3/view/style_parser.ts
@@ -88,7 +88,7 @@ export function parse(value: string): string[] {
   }
 
   if (currentProp && valueStart) {
-    const styleVal = value.substr(valueStart).trim();
+    const styleVal = value.slice(valueStart).trim();
     styles.push(currentProp, valueHasQuotes ? stripUnnecessaryQuotes(styleVal) : styleVal);
   }
 

--- a/packages/compiler/src/render3/view/styling_builder.ts
+++ b/packages/compiler/src/render3/view/styling_builder.ts
@@ -201,8 +201,8 @@ export class StylingBuilder {
     const isStyle = name === 'style' || prefix === 'style.' || prefix === 'style!';
     const isClass = !isStyle && (name === 'class' || prefix === 'class.' || prefix === 'class!');
     if (isStyle || isClass) {
-      const isMapBased = name.charAt(5) !== '.';         // style.prop or class.prop makes this a no
-      const property = name.substr(isMapBased ? 5 : 6);  // the dot explains why there's a +1
+      const isMapBased = name.charAt(5) !== '.';        // style.prop or class.prop makes this a no
+      const property = name.slice(isMapBased ? 5 : 6);  // the dot explains why there's a +1
       if (isStyle) {
         binding = this.registerStyleInput(property, isMapBased, expression, sourceSpan);
       } else {
@@ -516,7 +516,7 @@ export function parseProperty(name: string):
   let property = name;
   const unitIndex = name.lastIndexOf('.');
   if (unitIndex > 0) {
-    suffix = name.substr(unitIndex + 1);
+    suffix = name.slice(unitIndex + 1);
     property = name.substring(0, unitIndex);
   }
 

--- a/packages/compiler/src/selector.ts
+++ b/packages/compiler/src/selector.ts
@@ -84,10 +84,10 @@ export class CssSelector {
         const prefix = match[SelectorRegexp.PREFIX];
         if (prefix === '#') {
           // #hash
-          current.addAttribute('id', tag.substr(1));
+          current.addAttribute('id', tag.slice(1));
         } else if (prefix === '.') {
           // Class
-          current.addClassName(tag.substr(1));
+          current.addClassName(tag.slice(1));
         } else {
           // Element
           current.setElement(tag);

--- a/packages/compiler/src/template_parser/binding_parser.ts
+++ b/packages/compiler/src/template_parser/binding_parser.ts
@@ -408,7 +408,7 @@ export class BindingParser {
     }
 
     if (isAnimationLabel(name)) {
-      name = name.substr(1);
+      name = name.slice(1);
       if (keySpan !== undefined) {
         keySpan = moveParseSourceSpan(
             keySpan, new AbsoluteSourceSpan(keySpan.start.offset + 1, keySpan.end.offset));

--- a/packages/compiler/test/schema/schema_extractor.ts
+++ b/packages/compiler/test/schema/schema_extractor.ts
@@ -191,7 +191,7 @@ function extractProperties(
   keys.sort();
   keys.forEach((name) => {
     if (name.startsWith('on')) {
-      props.push('*' + name.substr(2));
+      props.push('*' + name.slice(2));
     } else {
       const typeCh = _TYPE_MNEMONICS[typeof instance[name]];
       const descriptor = Object.getOwnPropertyDescriptor(prototype, name);

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -215,7 +215,7 @@ export function catchInjectorError(
 
 export function formatError(
     text: string, obj: any, injectorErrorName: string, source: string|null = null): string {
-  text = text && text.charAt(0) === '\n' && text.charAt(1) == NO_NEW_LINE ? text.substr(2) : text;
+  text = text && text.charAt(0) === '\n' && text.charAt(1) == NO_NEW_LINE ? text.slice(2) : text;
   let context = stringify(obj);
   if (Array.isArray(obj)) {
     context = obj.map(stringify).join(' -> ');

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -384,7 +384,7 @@ function removeInnerTemplateTranslation(message: string): string {
           `Tag mismatch: unable to find the end of the sub-template in the translation "${
               message}"`);
 
-  res += message.substr(index);
+  res += message.slice(index);
   return res;
 }
 
@@ -483,7 +483,7 @@ export function parseICUBlock(pattern: string): IcuExpression {
     } else {
       icuType = IcuType.plural;
     }
-    mainBinding = parseInt(binding.substr(1), 10);
+    mainBinding = parseInt(binding.slice(1), 10);
     return '';
   });
 

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -118,7 +118,7 @@ function getLViewToClone(type: TViewType, name: string|null): Array<any> {
 function nameSuffix(text: string|null|undefined): string {
   if (text == null) return '';
   const index = text.lastIndexOf('_Template');
-  return '_' + (index === -1 ? text : text.substr(0, index));
+  return '_' + (index === -1 ? text : text.slice(0, index));
 }
 
 /**

--- a/packages/core/src/render3/styling/styling_parser.ts
+++ b/packages/core/src/render3/styling/styling_parser.ts
@@ -309,6 +309,6 @@ function malformedStyleError(text: string, expecting: string, index: number): ne
   ngDevMode && assertEqual(typeof text === 'string', true, 'String expected here');
   throw throwError(
       `Malformed style at location ${index} in string '` + text.substring(0, index) + '[>>' +
-      text.substring(index, index + 1) + '<<]' + text.substr(index + 1) +
+      text.substring(index, index + 1) + '<<]' + text.slice(index + 1) +
       `'. Expecting '${expecting}'.`);
 }

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -1250,8 +1250,8 @@ function expectReplacementText(
 
   for (const entry of completions.entries) {
     expect(entry.replacementSpan).toBeDefined();
-    const completionReplaces =
-        text.substr(entry.replacementSpan!.start, entry.replacementSpan!.length);
+    const completionReplaces = text.slice(
+        entry.replacementSpan!.start, entry.replacementSpan!.start + entry.replacementSpan!.length);
     expect(completionReplaces).toBe(replacementText);
   }
 }

--- a/packages/language-service/test/definitions_spec.ts
+++ b/packages/language-service/test/definitions_spec.ts
@@ -56,7 +56,8 @@ describe('definitions', () => {
     template.moveCursorToText('da¦te');
 
     const {textSpan, definitions} = getDefinitionsAndAssertBoundSpan(env, template);
-    expect(template.contents.substr(textSpan.start, textSpan.length)).toEqual('date');
+    expect(template.contents.slice(textSpan.start, textSpan.start + textSpan.length))
+        .toEqual('date');
     expect(definitions.length).toEqual(3);
     assertTextSpans(definitions, ['transform']);
     assertFileNames(definitions, ['index.d.ts']);
@@ -95,7 +96,8 @@ describe('definitions', () => {
     template.moveCursorToText('inpu¦tA="abc"');
 
     const {textSpan, definitions} = getDefinitionsAndAssertBoundSpan(env, template);
-    expect(template.contents.substr(textSpan.start, textSpan.length)).toEqual('inputA');
+    expect(template.contents.slice(textSpan.start, textSpan.start + textSpan.length))
+        .toEqual('inputA');
 
     expect(definitions!.length).toEqual(2);
     const [def, def2] = definitions!;
@@ -140,7 +142,8 @@ describe('definitions', () => {
     template.moveCursorToText('(someEv¦ent)');
 
     const {textSpan, definitions} = getDefinitionsAndAssertBoundSpan(env, template);
-    expect(template.contents.substr(textSpan.start, textSpan.length)).toEqual('someEvent');
+    expect(template.contents.slice(textSpan.start, textSpan.start + textSpan.length))
+        .toEqual('someEvent');
 
     expect(definitions.length).toEqual(2);
     const [def, def2] = definitions;
@@ -170,7 +173,8 @@ describe('definitions', () => {
     const appFile = project.openFile('app.ts');
     appFile.moveCursorToText(`['./styl¦e.css']`);
     const {textSpan, definitions} = getDefinitionsAndAssertBoundSpan(env, appFile);
-    expect(appFile.contents.substr(textSpan.start, textSpan.length)).toEqual('./style.css');
+    expect(appFile.contents.slice(textSpan.start, textSpan.start + textSpan.length))
+        .toEqual('./style.css');
 
     expect(definitions.length).toEqual(1);
     assertFileNames(definitions, ['style.scss']);

--- a/packages/language-service/testing/src/buffer.ts
+++ b/packages/language-service/testing/src/buffer.ts
@@ -122,6 +122,6 @@ function extractCursorInfo(textWithCursor: string): {cursor: number, text: strin
 
   return {
     cursor,
-    text: textWithCursor.substr(0, cursor) + textWithCursor.substr(cursor + 1),
+    text: textWithCursor.slice(0, cursor) + textWithCursor.slice(cursor + 1),
   };
 }

--- a/packages/language-service/testing/src/util.ts
+++ b/packages/language-service/testing/src/util.ts
@@ -93,7 +93,7 @@ type Stringy<T> = {
 };
 
 export function getText(contents: string, textSpan: ts.TextSpan) {
-  return contents.substr(textSpan.start, textSpan.length);
+  return contents.slice(textSpan.start, textSpan.start + textSpan.length);
 }
 
 function last<T>(array: T[]): T {

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -248,7 +248,7 @@ export class AnimationRenderer extends BaseAnimationRenderer implements Renderer
         value = value === undefined ? true : !!value;
         this.disableAnimations(el, value as boolean);
       } else {
-        this.engine.process(this.namespaceId, el, name.substr(1), value);
+        this.engine.process(this.namespaceId, el, name.slice(1), value);
       }
     } else {
       this.delegate.setProperty(el, name, value);
@@ -260,7 +260,7 @@ export class AnimationRenderer extends BaseAnimationRenderer implements Renderer
       callback: (event: any) => any): () => void {
     if (eventName.charAt(0) == ANIMATION_PREFIX) {
       const element = resolveElementFromTarget(target);
-      let name = eventName.substr(1);
+      let name = eventName.slice(1);
       let phase = '';
       // @listener.phase is for trigger animation callbacks
       // @@listener is for animation builder callbacks
@@ -292,6 +292,6 @@ function resolveElementFromTarget(target: 'window'|'document'|'body'|any): any {
 function parseTriggerCallbackName(triggerName: string) {
   const dotIndex = triggerName.indexOf('.');
   const trigger = triggerName.substring(0, dotIndex);
-  const phase = triggerName.substr(dotIndex + 1);
+  const phase = triggerName.slice(dotIndex + 1);
   return [trigger, phase];
 }

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -288,8 +288,8 @@ function _readStyleAttribute(element: any): {[name: string]: string} {
         if (colonIndex === -1) {
           throw new Error(`Invalid CSS style: ${style}`);
         }
-        const name = style.substr(0, colonIndex).trim();
-        styleMap[name] = style.substr(colonIndex + 1).trim();
+        const name = style.slice(0, colonIndex).trim();
+        styleMap[name] = style.slice(colonIndex + 1).trim();
       }
     }
   }

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -686,7 +686,7 @@ class UrlParser {
 
       let outletName: string = undefined!;
       if (path.indexOf(':') > -1) {
-        outletName = path.substr(0, path.indexOf(':'));
+        outletName = path.slice(0, path.indexOf(':'));
         this.capture(outletName);
         this.capture(':');
       } else if (allowPrimary) {

--- a/packages/service-worker/config/src/generator.ts
+++ b/packages/service-worker/config/src/generator.ts
@@ -107,7 +107,7 @@ export function processNavigationUrls(
     baseHref: string, urls = DEFAULT_NAVIGATION_URLS): {positive: boolean, regex: string}[] {
   return urls.map(url => {
     const positive = !url.startsWith('!');
-    url = positive ? url : url.substr(1);
+    url = positive ? url : url.slice(1);
     return {positive, regex: `^${urlToRegex(url, baseHref)}$`};
   });
 }
@@ -131,7 +131,7 @@ function globListToMatcher(globs: string[]): (file: string) => boolean {
     if (pattern.startsWith('!')) {
       return {
         positive: false,
-        regex: new RegExp('^' + globToRegex(pattern.substr(1)) + '$'),
+        regex: new RegExp('^' + globToRegex(pattern.slice(1)) + '$'),
       };
     } else {
       return {
@@ -167,7 +167,7 @@ function urlToRegex(url: string, baseHref: string, literalQuestionMark?: boolean
 
 function joinUrls(a: string, b: string): string {
   if (a.endsWith('/') && b.startsWith('/')) {
-    return a + b.substr(1);
+    return a + b.slice(1);
   } else if (!a.endsWith('/') && !b.startsWith('/')) {
     return a + '/' + b;
   }

--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -215,7 +215,7 @@ export class AppVersion implements UpdateSource {
     }
 
     const urlPrefix = this.scope.registration.scope.replace(/\/$/, '');
-    const url = req.url.startsWith(urlPrefix) ? req.url.substr(urlPrefix.length) : req.url;
+    const url = req.url.startsWith(urlPrefix) ? req.url.slice(urlPrefix.length) : req.url;
     const urlWithoutQueryOrHash = url.replace(/[?#].*$/, '');
 
     return this.navigationUrls.include.some(regex => regex.test(urlWithoutQueryOrHash)) &&

--- a/packages/service-worker/worker/src/db-cache.ts
+++ b/packages/service-worker/worker/src/db-cache.ts
@@ -67,7 +67,7 @@ export class CacheTable implements Table {
   }
 
   keys(): Promise<string[]> {
-    return this.cache.keys().then(requests => requests.map(req => req.url.substr(1)));
+    return this.cache.keys().then(requests => requests.map(req => req.url.slice(1)));
   }
 
   read(key: string): Promise<any> {

--- a/packages/upgrade/src/common/src/component_info.ts
+++ b/packages/upgrade/src/common/src/component_info.ts
@@ -34,7 +34,7 @@ export class PropertyBinding {
     this.bracketAttr = `[${this.attr}]`;
     this.parenAttr = `(${this.attr})`;
     this.bracketParenAttr = `[(${this.attr})]`;
-    const capitalAttr = this.attr.charAt(0).toUpperCase() + this.attr.substr(1);
+    const capitalAttr = this.attr.charAt(0).toUpperCase() + this.attr.slice(1);
     this.onAttr = `on${capitalAttr}`;
     this.bindAttr = `bind${capitalAttr}`;
     this.bindonAttr = `bindon${capitalAttr}`;

--- a/packages/zone.js/lib/common/utils.ts
+++ b/packages/zone.js/lib/common/utils.ts
@@ -188,8 +188,8 @@ export function patchProperty(obj: any, prop: string, prototype?: any) {
   const originalDescGet = desc.get;
   const originalDescSet = desc.set;
 
-  // substr(2) cuz 'onclick' -> 'click', etc
-  const eventName = prop.substr(2);
+  // slice(2) cuz 'onclick' -> 'click', etc
+  const eventName = prop.slice(2);
 
   let eventNameSymbol = zoneSymbolEventNames[eventName];
   if (!eventNameSymbol) {
@@ -268,7 +268,7 @@ export function patchOnProperties(obj: any, properties: string[]|null, prototype
   } else {
     const onProperties = [];
     for (const prop in obj) {
-      if (prop.substr(0, 2) == 'on') {
+      if (prop.slice(0, 2) == 'on') {
         onProperties.push(prop);
       }
     }

--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -380,7 +380,7 @@ describe('Zone', function() {
                   ignoredProperties.filter(ignoreProp => ignoreProp === prop).length > 0) {
                 continue;
               }
-              if (prop.substr(0, 2) === 'on' && prop.length > 2) {
+              if (prop.slice(0, 2) === 'on' && prop.length > 2) {
                 let propExistsOnTarget = false;
                 let checkTarget = target;
                 while (checkTarget && checkTarget !== Object) {
@@ -396,12 +396,12 @@ describe('Zone', function() {
                   continue;
                 }
                 target[prop] = noop;
-                if (!target[Zone.__symbol__('ON_PROPERTY' + prop.substr(2))]) {
+                if (!target[Zone.__symbol__('ON_PROPERTY' + prop.slice(2))]) {
                   fail(`${prop} of ${target} is not patched`);
                 } else {
                   expect(target[prop]).toBe(noop);
                   target[prop] = null;
-                  expect(target[Zone.__symbol__('ON_PROPERTY' + prop.substr(2))]).toBeNull();
+                  expect(target[Zone.__symbol__('ON_PROPERTY' + prop.slice(2))]).toBeNull();
                 }
               }
             }

--- a/scripts/github/utils/json_extract.js
+++ b/scripts/github/utils/json_extract.js
@@ -45,7 +45,7 @@ function extractPaths(obj, paths) {
             if (index == 0) {
               objs[i] = o = o[name];
             } else if (name.charAt(0) == '^') {
-              if (o.indexOf(name.substr(1)) !== 0) {
+              if (o.indexOf(name.slice(1)) !== 0) {
                 objs.splice(i, 1);
                 i--;
               }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## What is the new behavior?

Everything should behave the same way

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
