### PR TITLE
docs: replace `defaultCollection` with `schematicCollections`

### DIFF
--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -48,14 +48,14 @@ For more information, see [Workspace and project file structure](guide/file-stru
 
 The following configuration properties are a set of options that customize the Angular CLI.
 
-| Property            | Description                                                                                      | Value Type                                               |
-| :------------------ | :----------------------------------------------------------------------------------------------- | :------------------------------------------------------- |
-| `analytics`         | Share anonymous [usage data](cli/usage-analytics-gathering) with the Angular Team.               | `boolean` \| `ci`                                        |
-| `analyticsSharing`  | A set of analytics sharing options.                                                              | [Analytics sharing options](#analytics-sharing-options)  |
-| `cache`             | Control [persistent disk cache](cli/cache) used by [Angular CLI Builders](guide/cli-builder).    | [Cache options](#cache-options)                          |
-| `defaultCollection` | The default schematics collection to use.                                                        | `string`                                                 |
-| `packageManager`    | The preferred package manager tool to use.                                                        | `npm` \| `cnpm` \| `pnpm` \| `yarn`                      |
-| `warnings`          | Control CLI specific console warnings.                                                           | [Warnings options](#warnings-options)                    |
+| Property               | Description                                                                                      | Value Type                                               |
+| :--------------------- | :----------------------------------------------------------------------------------------------- | :------------------------------------------------------- |
+| `analytics`            | Share anonymous [usage data](cli/usage-analytics-gathering) with the Angular Team.               | `boolean` \| `ci`                                        |
+| `analyticsSharing`     | A set of analytics sharing options.                                                              | [Analytics sharing options](#analytics-sharing-options)  |
+| `cache`                | Control [persistent disk cache](cli/cache) used by [Angular CLI Builders](guide/cli-builder).    | [Cache options](#cache-options)                          |
+| `schematicCollections` | A list of schematics collections to use.                                                         | `string[]`                                               |
+| `packageManager`       | The preferred package manager tool to use.                                                       | `npm` \| `cnpm` \| `pnpm` \| `yarn`                      |
+| `warnings`             | Control CLI specific console warnings.                                                           | [Warnings options](#warnings-options)                    |
 
 ### Analytics sharing options
 


### PR DESCRIPTION
`defaultCollection` has deprecated in favor of `schematicCollections`.

Related to https://github.com/angular/angular-cli/pull/22860
