### PR TITLE
Remove defaultProject workspace option

### DIFF
--- a/aio/angular.json
+++ b/aio/angular.json
@@ -221,6 +221,5 @@
         }
       }
     }
-  },
-  "defaultProject": "site"
+  }
 }

--- a/aio/content/examples/i18n/angular.json
+++ b/aio/content/examples/i18n/angular.json
@@ -149,9 +149,8 @@
       }
       // #enddocregion build-single-locale, build-production-french
     }
-  },
+  }
   // #enddocregion i18n-baseHref
-  "defaultProject": "angular.io-example"
   // #docregion i18n-baseHref
 }
 // #enddocregion locale-config, i18n-baseHref

--- a/aio/content/examples/schematics-for-libraries/projects/my-lib/schematics/my-service/index.ts
+++ b/aio/content/examples/schematics-for-libraries/projects/my-lib/schematics/my-service/index.ts
@@ -41,12 +41,6 @@ export function myService(options: MyServiceSchema): Rule {
 // #enddocregion workspace
 
 // #docregion project-info
-// #docregion project-fallback
-    if (!options.project && typeof workspace.extensions.defaultProject === 'string') {
-      options.project = workspace.extensions.defaultProject;
-    }
-// #enddocregion project-fallback
-
     const project = (options.project != null) ? workspace.projects.get(options.project) : null;
     if (!project) {
       throw new SchematicsException(`Invalid project name: ${options.project}`);

--- a/aio/content/guide/schematics-for-libraries.md
+++ b/aio/content/guide/schematics-for-libraries.md
@@ -228,12 +228,6 @@ The `Tree` methods give you access to the complete file tree in your workspace, 
 
     Be sure to check that the context exists and throw the appropriate error.
 
-1. The `workspace.extensions` property includes a `defaultProject` value for determining which project to use if not provided.
-   You will use that value as a fallback, if no project is explicitly specified in the `ng generate` command.
-
-    <code-example header="projects/my-lib/schematics/my-service/index.ts (Default Project)" path="schematics-for-libraries/projects/my-lib/schematics/my-service/index.ts" region="project-fallback">
-    </code-example>
-
 1. Now that you have the project name, use it to retrieve the project-specific configuration information.
 
     <code-example header="projects/my-lib/schematics/my-service/index.ts (Project)" path="schematics-for-libraries/projects/my-lib/schematics/my-service/index.ts" region="project-info">

--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -11,7 +11,6 @@ The following properties, at the top-level of the file, configure the workspace.
 
 *   `version`: The configuration-file version.
 *   `newProjectRoot`: Path where new projects are created. Absolute or relative to the workspace folder.
-*   `defaultProject`: Default project name to use in commands, where not provided as an argument. When you use `ng new` to create a new application in a new workspace, that application is the default project for the workspace until you change it here.
 *   `cli` : A set of options that customize the [Angular CLI](cli). See the [CLI configuration options](#cli-configuration-options) section.
 *   `schematics` : A set of [schematics](guide/glossary#schematic) that customize the `ng generate` sub-command option defaults for this workspace. See the [Generation schematics](#schematics) section.
 *   `projects` : Contains a subsection for each project (library or application) in the workspace, with the per-project configuration options.

--- a/aio/tools/examples/shared/boilerplate/cli/angular.json
+++ b/aio/tools/examples/shared/boilerplate/cli/angular.json
@@ -113,6 +113,5 @@
         }
       }
     }
-  },
-  "defaultProject": "angular.io-example"
+  }
 }

--- a/aio/tools/examples/shared/boilerplate/i18n/angular.json
+++ b/aio/tools/examples/shared/boilerplate/i18n/angular.json
@@ -128,6 +128,4 @@
         }
       }
     }
-  },
-  "defaultProject": "angular.io-example"
-}
+  }

--- a/aio/tools/examples/shared/boilerplate/schematics/angular.json
+++ b/aio/tools/examples/shared/boilerplate/schematics/angular.json
@@ -133,9 +133,8 @@
             "tsConfig": "projects/my-lib/tsconfig.spec.json",
             "karmaConfig": "projects/my-lib/karma.conf.js"
           }
-        },
+        }
       }
     }
-  },
-  "defaultProject": "angular.io-example"
+  }
 }

--- a/aio/tools/examples/shared/boilerplate/service-worker/angular.json
+++ b/aio/tools/examples/shared/boilerplate/service-worker/angular.json
@@ -115,6 +115,5 @@
         }
       }
     }
-  },
-  "defaultProject": "angular.io-example"
+  }
 }

--- a/aio/tools/examples/shared/boilerplate/testing/angular.json
+++ b/aio/tools/examples/shared/boilerplate/testing/angular.json
@@ -114,6 +114,5 @@
         }
       }
     }
-  },
-  "defaultProject": "angular.io-example"
+  }
 }

--- a/aio/tools/examples/shared/boilerplate/universal/angular.json
+++ b/aio/tools/examples/shared/boilerplate/universal/angular.json
@@ -171,6 +171,5 @@
         }
       }
     }
-  },
-  "defaultProject": "angular.io-example"
+  }
 }

--- a/integration/animations/angular.json
+++ b/integration/animations/angular.json
@@ -136,6 +136,5 @@
         }
       }
     }
-  },
-  "defaultProject": "animations"
+  }
 }

--- a/integration/cli-elements-universal/angular.json
+++ b/integration/cli-elements-universal/angular.json
@@ -163,6 +163,5 @@
         }
       }
     }
-  },
-  "defaultProject": "cli-elements-universal"
+  }
 }

--- a/integration/cli-hello-world-ivy-compat/angular.json
+++ b/integration/cli-hello-world-ivy-compat/angular.json
@@ -19,13 +19,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false
           },
@@ -68,10 +63,9 @@
             "production": {
               "browserTarget": "cli-hello-world-ivy-compat:build:production"
             },
-            "ci": {
-            },
+            "ci": {},
             "ci-production": {
-              "browserTarget": "cli-hello-world-ivy-compat:build:production",
+              "browserTarget": "cli-hello-world-ivy-compat:build:production"
             }
           }
         },
@@ -88,13 +82,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false,
             "watch": false
@@ -103,14 +92,8 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "tsconfig.app.json",
-              "tsconfig.spec.json",
-              "e2e/tsconfig.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "tsConfig": ["tsconfig.app.json", "tsconfig.spec.json", "e2e/tsconfig.json"],
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -133,6 +116,6 @@
           }
         }
       }
-    }},
-  "defaultProject": "cli-hello-world-ivy-compat"
+    }
+  }
 }

--- a/integration/cli-hello-world-ivy-i18n/angular.json
+++ b/integration/cli-hello-world-ivy-i18n/angular.json
@@ -25,13 +25,8 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false,
             "i18nMissingTranslation": "error"
@@ -106,13 +101,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false,
             "watch": false
@@ -121,14 +111,8 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "tsconfig.app.json",
-              "tsconfig.spec.json",
-              "e2e/tsconfig.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "tsConfig": ["tsconfig.app.json", "tsconfig.spec.json", "e2e/tsconfig.json"],
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -149,12 +133,12 @@
               "specs": ["./fr/app.e2e-spec.ts"]
             },
             "de": {
-             "devServerTarget": "cli-hello-world-ivy-i18n:serve:de",
+              "devServerTarget": "cli-hello-world-ivy-i18n:serve:de",
               "specs": ["./de/app.e2e-spec.ts"]
             }
           }
         }
       }
-    }},
-  "defaultProject": "cli-hello-world-ivy-i18n"
+    }
+  }
 }

--- a/integration/cli-hello-world-ivy-minimal/angular.json
+++ b/integration/cli-hello-world-ivy-minimal/angular.json
@@ -19,13 +19,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false
           },
@@ -68,10 +63,9 @@
             "production": {
               "browserTarget": "cli-hello-world-ivy-minimal:build:production"
             },
-            "ci": {
-            },
+            "ci": {},
             "ci-production": {
-              "browserTarget": "cli-hello-world-ivy-minimal:build:production",
+              "browserTarget": "cli-hello-world-ivy-minimal:build:production"
             }
           }
         },
@@ -88,13 +82,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false,
             "watch": false
@@ -103,14 +92,8 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "tsconfig.app.json",
-              "tsconfig.spec.json",
-              "e2e/tsconfig.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "tsConfig": ["tsconfig.app.json", "tsconfig.spec.json", "e2e/tsconfig.json"],
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -133,6 +116,6 @@
           }
         }
       }
-    }},
-  "defaultProject": "cli-hello-world-ivy-minimal"
+    }
+  }
 }

--- a/integration/cli-hello-world-lazy/angular.json
+++ b/integration/cli-hello-world-lazy/angular.json
@@ -20,13 +20,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false
           },
@@ -83,27 +78,16 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": []
           }
         },
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "tsconfig.app.json",
-              "tsconfig.spec.json",
-              "e2e/tsconfig.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "tsConfig": ["tsconfig.app.json", "tsconfig.spec.json", "e2e/tsconfig.json"],
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -120,6 +104,6 @@
           }
         }
       }
-    }},
-  "defaultProject": "cli-hello-world-lazy"
+    }
+  }
 }

--- a/integration/cli-hello-world-mocha/angular.json
+++ b/integration/cli-hello-world-mocha/angular.json
@@ -19,13 +19,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false
           },
@@ -71,10 +66,9 @@
             "production": {
               "browserTarget": "cli-hello-world:build:production"
             },
-            "ci": {
-            },
+            "ci": {},
             "ci-production": {
-              "browserTarget": "cli-hello-world:build:production",
+              "browserTarget": "cli-hello-world:build:production"
             }
           }
         },
@@ -91,13 +85,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false,
             "watch": false
@@ -106,14 +95,8 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "tsconfig.app.json",
-              "tsconfig.spec.json",
-              "e2e/tsconfig.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "tsConfig": ["tsconfig.app.json", "tsconfig.spec.json", "e2e/tsconfig.json"],
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -136,6 +119,6 @@
           }
         }
       }
-    }},
-  "defaultProject": "cli-hello-world"
+    }
+  }
 }

--- a/integration/cli-hello-world/angular.json
+++ b/integration/cli-hello-world/angular.json
@@ -19,13 +19,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false
           },
@@ -71,10 +66,9 @@
             "production": {
               "browserTarget": "cli-hello-world:build:production"
             },
-            "ci": {
-            },
+            "ci": {},
             "ci-production": {
-              "browserTarget": "cli-hello-world:build:production",
+              "browserTarget": "cli-hello-world:build:production"
             }
           }
         },
@@ -91,13 +85,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false,
             "watch": false
@@ -106,14 +95,8 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "tsconfig.app.json",
-              "tsconfig.spec.json",
-              "e2e/tsconfig.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "tsConfig": ["tsconfig.app.json", "tsconfig.spec.json", "e2e/tsconfig.json"],
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -136,6 +119,6 @@
           }
         }
       }
-    }},
-  "defaultProject": "cli-hello-world"
+    }
+  }
 }

--- a/integration/forms/angular.json
+++ b/integration/forms/angular.json
@@ -19,13 +19,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false
           },
@@ -71,10 +66,9 @@
             "production": {
               "browserTarget": "forms:build:production"
             },
-            "ci": {
-            },
+            "ci": {},
             "ci-production": {
-              "browserTarget": "forms:build:production",
+              "browserTarget": "forms:build:production"
             }
           }
         },
@@ -91,13 +85,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false,
             "watch": false
@@ -106,14 +95,8 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "tsconfig.app.json",
-              "tsconfig.spec.json",
-              "e2e/tsconfig.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "tsConfig": ["tsconfig.app.json", "tsconfig.spec.json", "e2e/tsconfig.json"],
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -136,6 +119,6 @@
           }
         }
       }
-    }},
-  "defaultProject": "forms"
+    }
+  }
 }

--- a/integration/ivy-i18n/angular.json
+++ b/integration/ivy-i18n/angular.json
@@ -20,13 +20,8 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false
           },
@@ -102,13 +97,12 @@
             "production": {
               "browserTarget": "cli-hello-world-ivy-i18n:build:production"
             },
-            "ci": {
-            },
+            "ci": {},
             "ci-production": {
-              "browserTarget": "cli-hello-world-ivy-i18n:build:production",
+              "browserTarget": "cli-hello-world-ivy-i18n:build:production"
             },
             "runtime-translations": {
-              "browserTarget": "cli-hello-world-ivy-i18n:build:runtime-translations",
+              "browserTarget": "cli-hello-world-ivy-i18n:build:runtime-translations"
             }
           }
         },
@@ -127,13 +121,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false,
             "watch": false
@@ -142,14 +131,8 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "tsconfig.app.json",
-              "tsconfig.spec.json",
-              "e2e/tsconfig.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "tsConfig": ["tsconfig.app.json", "tsconfig.spec.json", "e2e/tsconfig.json"],
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -193,6 +176,5 @@
         }
       }
     }
-  },
-  "defaultProject": "cli-hello-world-ivy-i18n"
+  }
 }

--- a/integration/ng-add-localize/angular.json
+++ b/integration/ng-add-localize/angular.json
@@ -45,13 +45,8 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": []
           },
           "configurations": {
@@ -107,6 +102,5 @@
         }
       }
     }
-  },
-  "defaultProject": "ng-add-localize"
+  }
 }

--- a/integration/ng_update_migrations/angular.json
+++ b/integration/ng_update_migrations/angular.json
@@ -22,13 +22,8 @@
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.less"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.less"],
             "scripts": [],
             "es5BrowserSupport": true
           },
@@ -77,6 +72,5 @@
         }
       }
     }
-  },
-  "defaultProject": "ng-update-migrations"
+  }
 }

--- a/integration/trusted-types/angular.json
+++ b/integration/trusted-types/angular.json
@@ -23,13 +23,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "aot": true,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false
           },
@@ -75,9 +70,9 @@
             "production": {
               "browserTarget": "trusted-types:build:production"
             },
-            "ci": { },
+            "ci": {},
             "ci-production": {
-              "browserTarget": "trusted-types:build:production",
+              "browserTarget": "trusted-types:build:production"
             }
           }
         },
@@ -94,13 +89,8 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.css"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.css"],
             "scripts": [],
             "progress": false,
             "watch": false
@@ -109,14 +99,8 @@
         "lint": {
           "builder": "@angular-devkit/build-angular:tslint",
           "options": {
-            "tsConfig": [
-              "tsconfig.app.json",
-              "tsconfig.spec.json",
-              "e2e/tsconfig.json"
-            ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "tsConfig": ["tsconfig.app.json", "tsconfig.spec.json", "e2e/tsconfig.json"],
+            "exclude": ["**/node_modules/**"]
           }
         },
         "e2e": {
@@ -140,6 +124,5 @@
         }
       }
     }
-  },
-  "defaultProject": "trusted-types"
+  }
 }


### PR DESCRIPTION

The `defaultProject` workspace option has been deprecated. The project to use will be determined from the current working directory.

See: https://github.com/angular/angular-cli/pull/22852