### PR TITLE
fix(docs-infra): prevent framing of AIO with X-Frame-Options

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -215,6 +215,10 @@
             // csp.withgoogle.com is Google's CSP report collecting
             // infrastructure.
             "value": "require-trusted-types-for 'script'; trusted-types angular angular#bundler angular#unsafe-bypass aio#analytics google#safe; report-uri https://csp.withgoogle.com/csp/angular.io"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
           }
         ]
       },


### PR DESCRIPTION
Prevent the docs site from being place in an iframe.
