### PR TITLE
fix(docs-infra): prevent framing of AIO with X-Frame-Options

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -142,6 +142,15 @@
     ],
     "headers": [
       {
+        "source": "**",
+        "headers": [
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
+          }
+        ]
+      },
+      {
         // All paths (URLs without a file extension).
         "source": "**/!(*.*)",
         "headers": [


### PR DESCRIPTION
[11.2.x] Prevent the docs site from being place in an iframe.
