### PR TITLE
fix(core): make inline event handlers compatible with Trusted Types

### DIFF
--- a/integration/trusted-types/src/app/app.component.html
+++ b/integration/trusted-types/src/app/app.component.html
@@ -520,6 +520,9 @@
   <embed id="trusted-types-embed" src="data:text/html,&lt;body&gt;&lt;h1&gt;Hello from embed&lt;/h1&gt;&lt;/body&gt;" />
   <iframe id="trusted-types-iframe" [srcdoc]="iframeHtml"></iframe>
   <object id="trusted-types-object" [data]="safeResourceUrl" codebase="/"></object>
+
+  <input type="text" oninput="this.value = this.value.toUpperCase()" />
+  <div one="two"></div>
 </div>
 
 <router-outlet></router-outlet>

--- a/packages/core/src/util/char_code.ts
+++ b/packages/core/src/util/char_code.ts
@@ -41,7 +41,9 @@ export const enum CharCode {
   U = 85,             // "U"
   R = 82,             // "R"
   L = 76,             // "L"
-  Z = 90,             // "A"
+  N = 78,             // "N"
+  O = 79,             // "O"
+  Z = 90,             // "Z"
   a = 97,             // "a"
   z = 122,            // "z"
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
Inline event handlers are allowed in Angular templates as long as their
values are constant. However, specifying such attributes currently leads
to Trusted Types violations being generated, as Angular passes their
constant values as plain strings to setAttribute, which in this case is
a Trusted Types sink. This is made worse by a Chromium bug
(https://crbug.com/993268) which treats any attribute starting with `on`
as a Trusted Types sink, causing a Trusted Types violation when any
custom attribute starting with `on` is specified in an Angular template.

## What is the new behavior?
Fix this by promoting constant (and thus safe) values of inline event
handlers to TrustedScript before they are passed to the setAttribute
call. Note that all attributes that start with 'on' (e.g. 'onload' or
'onerror') are promoted to a TrustedScript, even though they are not
necessarily an inline event handler (e.g. 'online' or 'one'). This is
not security sensitive and will essentially be a no-op as the values get
stringified. This is done to work around the Chromium bug and minimize
code size impact, which would otherwise require listing all valid inline
event handler names in Angular's DOM schema.

Developers interested in restricting usage of inline event handlers in
their templates will still be able to do so by setting a Content
Security Policy that does not include the 'unsafe-inline' directive.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
