### PR TITLE
ci: make payload size tracking script work with CircleCI and Bazel limitations

### DIFF
--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -85,7 +85,6 @@ echo "export PROJECT_ROOT=\"${PROJECT_ROOT}\";" >> $bazelVarEnv
 echo "export CI_BRANCH=\"${CI_BRANCH}\";" >> $bazelVarEnv
 echo "export CI_BUILD_URL=\"${CI_BUILD_URL}\";" >> $bazelVarEnv
 echo "export CI_COMMIT=\"${CI_COMMIT}\";" >> $bazelVarEnv
-echo "export CI_COMMIT_RANGE=\"${CI_COMMIT_RANGE}\";" >> $bazelVarEnv
 echo "export CI_PULL_REQUEST=\"${CI_PULL_REQUEST}\";" >> $bazelVarEnv
 echo "export CI_REPO_NAME=\"${CI_REPO_NAME}\";" >> $bazelVarEnv
 echo "export CI_REPO_OWNER=\"${CI_REPO_OWNER}\";" >> $bazelVarEnv

--- a/scripts/ci/payload-size.js
+++ b/scripts/ci/payload-size.js
@@ -13,12 +13,15 @@ const fs = require('fs');
 const path = require('path');
 
 // Get branch and project name from command line arguments.
-const [, , limitFile, project, branch, commit] = process.argv;
+const [, , limitFile, project, commit] = process.argv;
 
 // Load sizes.
 const currentSizes = JSON.parse(fs.readFileSync('/tmp/current.log', 'utf8'));
 const allLimitSizes = JSON.parse(fs.readFileSync(limitFile, 'utf8'));
-const limitSizes = allLimitSizes[project][branch] || allLimitSizes[project]['master'];
+
+// TODO: Change the `master` golden key to something more obvious, or remove it. The branch
+// name is unreasonable since the limits are always taken from the currently checked-out revision.
+const limitSizes = allLimitSizes[project]['master'];
 
 // Check current sizes against limits.
 let failed = false;


### PR DESCRIPTION
For quite some time now, since we started to use Bazel for integration tests, we
relied on some size tracking logic that did not actually fully work under Bazel.

It was thought that all the necessary CI push/PR information is available to the
Bazel test, but that was not the case. This was now fixed with the recent Rules NodeJS
v5 update where I made sure the `env.sh` variables are actually available before we
write them to the temporary file for the Bazel-access.

This now will unveil an issue because payload size goldens would start being based
on their branch name. e.g. the golden key in `13.3.x` should not be `master` but
`13.3.x`. This makes more sense than `master` as key, but makes things more
cumbersome and ideally we would not store the branch name at all (this is a larger
change though -- not worth now since we might refactor this anyway -- the payload limits
are always based on the currently checked-out branch/revision). For now we will
update the size tracking logic to always use `master` as golden key (like it worked
in the past year(s))

With the environment fix we now (again) start uploading payload size results to Firebase.
This did not work by accident either. The uploading logic is reliant on the CircleCI
commit range which is not working/reliable in upstream branches. This commit
removes this reliance on `COMMIT_RANGE` since it's not strictly necessary and
currently breaking renovate PRs. We can re-enable this when we have a solution with
CircleCI, or a workaround/resolution logic provided in e.g. `ng-dev ci determine-commit-range`.

(Internal discussion for later reference: https://angular-team.slack.com/archives/C029MM6RS4B/p1648240555186009)