### PR TITLE
build: disable payload size uploading within bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,7 +6,7 @@ exports_files([
     "LICENSE",
     "karma-js.conf.js",
     "browser-providers.conf.js",
-    "scripts/ci/track-payload-size.sh",
+    "scripts/ci/bazel-payload-size.sh",
     "scripts/ci/payload-size.sh",
     "scripts/ci/payload-size.js",
     "package.json",

--- a/integration/index.bzl
+++ b/integration/index.bzl
@@ -59,11 +59,11 @@ def _ng_integration_test(name, setup_chromium = False, **kwargs):
         commands += [
             "yarn build",
             # TODO: Replace the track payload-size script with a RBE and Windows-compatible script.
-            "$(rootpath //:scripts/ci/track-payload-size.sh) %s 'dist/*.js' true $${RUNFILES}/angular/$(rootpath //goldens:size-tracking/integration-payloads.json)" % track_payload_size,
+            "$(rootpath //:scripts/ci/bazel-payload-size.sh) %s 'dist/*.js' true $${RUNFILES}/angular/$(rootpath //goldens:size-tracking/integration-payloads.json)" % track_payload_size,
         ]
         data += [
             "//goldens:size-tracking/integration-payloads.json",
-            "//:scripts/ci/track-payload-size.sh",
+            "//:scripts/ci/bazel-payload-size.sh",
             "//:scripts/ci/payload-size.sh",
             "//:scripts/ci/payload-size.js",
         ]

--- a/scripts/ci/bazel-payload-size.sh
+++ b/scripts/ci/bazel-payload-size.sh
@@ -14,5 +14,11 @@ if [[ -z "${PROJECT_ROOT:-}" ]]; then
   PROJECT_ROOT=$(cd $(dirname $0)/../..; pwd)
 fi
 
+# Bazel payload size tracking should always be treated as if this runs as part of
+# a pull request. i.e. the results are not uploaded. This is necessary as Bazel test
+# targets do not necessarily run for every commit, and cached results might originate
+# from RBE-built pull requests. We will overhaut size-tracking anyway..
+export CI_PULL_REQUEST="true"
+
 source ${PROJECT_ROOT}/scripts/ci/payload-size.sh
 trackPayloadSize "$@"


### PR DESCRIPTION
Uploading payload size is unreliable from within Bazel. This is
because tests might not run for every commit, tests might have
been cached from a pull request RBE-build (causing payload uploading
to be skipped most of the time as every change comes from a PR)

We should disable the uploading as this is a fundamental problem
(good thing to note now) that we can solve with better payload
size tracking that we want to establish as part of dev-infra

More details on why this is relevant now. Renovate PRs have problems with uploading from Bazel -- and it's not worth putting effort into this anyway now: https://github.com/angular/angular/commit/1177b4e2f85d052aafc6e2ff173f07033878ddcd