### PR TITLE
fix(zone.js): do not silence uncaught promise rejections when the `finally` is called

### DIFF
--- a/packages/zone.js/test/common/Promise.spec.ts
+++ b/packages/zone.js/test/common/Promise.spec.ts
@@ -376,6 +376,28 @@ describe(
                });
              });
 
+          it('should not silence rejected promise errors after .finally has been called', done => {
+            Zone.current.fork({name: 'promise-error'}).run(() => {
+              (Zone as any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] = false;
+              const originalConsoleError = console.error;
+              const spy = console.error = jasmine.createSpy('console.error');
+              new Promise((resolve, reject) => {
+                throw new Error('promise error');
+              }).finally(() => {
+                // Ensure that uncaught promise `console.error` is called after the `finally` is
+                // called.
+                expect(spy).not.toHaveBeenCalled();
+                setTimeout(() => {
+                  const {args} = spy.calls.mostRecent();
+                  expect(args).toContain('Unhandled Promise rejection:');
+                  expect(args).toContain('promise error');
+                  console.error = originalConsoleError;
+                  done();
+                }, 10);
+              });
+            });
+          });
+
           it('should not output error to console if ignoreConsoleErrorUncaughtError is true',
              (done) => {
                Zone.current.fork({name: 'promise-error'}).run(() => {


### PR DESCRIPTION
The native promise implementation logs unhandled promise rejections after `onFinally`
has been called. We may rely on the `scheduledByFinally` argument, which is `false` by
default, to avoid creating a breaking change; this will also allow us to reduce the number of
changes. The `finally` function should not silence unhandled promise rejections, because
they're not silenced in any implementation. If the `scheduleResolveOrReject` is called within
the `finally` we won't clear unhandled rejections. We'll keep the same behaviour if the
`scheduleResolveOrReject` is called within the `then`.

## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)


## PR Type
- [x] Bugfix


## What is the current behavior?
Issue Number: #43206


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No