### PR TITLE
docs: update template reference variables

### DIFF
--- a/aio/content/guide/template-reference-variables.md
+++ b/aio/content/guide/template-reference-variables.md
@@ -47,8 +47,7 @@ In most cases, Angular sets the template variable's value to the element on whic
 In the previous example, `phone` refers to the phone number `<input>`.
 The button's click handler passes the `<input>` value to the component's `callPhone()` method.
 
-The `NgForm` directive demonstrates getting a reference to a different value by referencing a directive's `exportAs` name.  
-(Worth noting that `NgForm` directive gets silently applied by Angular on every `<form>` element unless one among `NoNgForm` and `FormGroup` is already set).
+The `NgForm` directive is applied by Angular on `<form>` elements. This example demonstrates getting a reference to a different value by referencing a directive's `exportAs` name.
 
 <code-example header="src/app/hero-form.component.html" path="template-reference-variables/src/app/app.component.html" region="ngForm"></code-example>
 
@@ -68,7 +67,8 @@ When declaring a template reference variable on an element without defining a va
 - **Component**: instance of the specific Component class
 - **NgTemplate**: TemplateRef
 
-Keep in mind that just the presence of a directive applied to the element will **not** make the undefined variable default to an instance of that directive, it will still reference the native object.
+Referencing an element by its directive needs the directive `exportAs` property set as reference value.
+In case of unspecified variable value, the reference will return an `HTMLElement`, even if the element has one or more directive applied to itself.
 
 ## Template variable scope
 
@@ -150,9 +150,9 @@ Verbose syntax of the same loop shows why:
 {{ ref.value }}
 ```
 
-It's easy to notice how interpolation trying to access property `value` of `ref` occurs outside of referenced element's parent template, making it unreachable.
+The interpolation trying to access property `ref.value` occurs outside of the referenced element's parent template, making it unreachable.
 
-Moving the interpolation inside the template, will make the variable available referencing the right distinct value for every element the loop will render.
+Moving the interpolation inside the template makes the variable available. Now it references the correct distinct value for each element the loop renders.
 
 ```
 <ng-template ngFor let-i [ngForOf]="[1,2]">
@@ -161,7 +161,7 @@ Moving the interpolation inside the template, will make the variable available r
 </ng-template>
 ```
 
-This last snippet will show 2 `<input>` element with their respective value printed just after them
+This snippet shows 2 `<input>` elements, with their respective value printed.
 
 ### Accessing a template variable within `<ng-template>`
 

--- a/aio/content/guide/template-reference-variables.md
+++ b/aio/content/guide/template-reference-variables.md
@@ -143,23 +143,27 @@ Consider the following example that uses `*ngFor`.
 Here, `ref.value` doesn't work.
 Verbose syntax of the same loop shows why:
 
-```
-<ng-template ngFor let-i [ngForOf]="[1,2]">
-  <input #ref type="text" [value]="i" />
-</ng-template>
+<code-example format="html" language="html">
+  
+&lt;ng-template ngFor let-i [ngForOf]="[1,2]"&gt;
+  &lt;input #ref type="text" [value]="i" /&gt;
+&lt;/ng-template&gt;
 {{ ref.value }}
-```
+
+</code-example>
 
 The interpolation trying to access property `ref.value` occurs outside of the referenced element's parent template, making it unreachable.
 
 Moving the interpolation inside the template makes the variable available. Now it references the correct distinct value for each element the loop renders.
 
-```
-<ng-template ngFor let-i [ngForOf]="[1,2]">
-  <input #ref type="text" [value]="i" />
+<code-example format="html" language="html">
+  
+&lt;ng-template ngFor let-i [ngForOf]="[1,2]"&gt;
+  &lt;input #ref type="text" [value]="i" /&gt;
   {{ ref.value }}
-</ng-template>
-```
+&lt;/ng-template&gt;
+
+</code-example>
 
 This snippet shows 2 `<input>` elements, with their respective value printed.
 
@@ -195,6 +199,8 @@ If its value is omitted, it gets the `$implicit` template context's property val
 There are several such variables in this example: `hero`, `i`, and `odd`.  
 The first one takes the value of the iterated item, because `NgForOf` assigns that to `$implicit`
 
+<code-example format="html" language="html">
+  
 &lt;ng-template ngFor #hero let-hero [ngForOf]="heroes" let-i="index" let-odd="odd"&gt;
   &lt;div [class]="{'odd-row': odd}"&gt;{{i}}:{{hero.name}}&lt;/div&gt;
 &lt;/ng-template&gt;

--- a/aio/content/guide/template-reference-variables.md
+++ b/aio/content/guide/template-reference-variables.md
@@ -68,7 +68,7 @@ When declaring a template reference variable on an element without defining a va
 - **NgTemplate**: TemplateRef
 
 Referencing an element by its directive needs the directive `exportAs` property set as reference value.
-In case of unspecified variable value, the reference will return an `HTMLElement`, even if the element has one or more directive applied to itself.
+In case of an unspecified variable value, the reference will return an `HTMLElement`, even if the element has one or more directive applied to itself.
 
 ## Template variable scope
 


### PR DESCRIPTION
- Specify `NgForm` gets applied by default on `<form>` elements before the long example using it
- Move the strange (and questioned in a commented line) snippet about undefined ref vars in a standalone paragraph and clarify its meanings (adding the part about directive just because there was something similar already there)
- Extend and modify `*ngFor` example, since in the original that was misleading to think reference variables couldn't be used inside a loop
- Remove two lines stating that with `*ngIf` and `*ngFor` the framework cannot know if a template is ever instantiated (can't see how this relates with the page)
- Add an explanation of assignment of default `$implicit` value to undefined input variables
- Modify template example for template input variable to be a complete ngForOf loop instead of the original poorly intelligible truncated one
- Replace last generic statements about variable namespaces with a more pragmatic and explanatory one concerning the resolution in case of homonymy

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
