### PR TITLE
docs: adding a missing close tag in AIO template

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -23,6 +23,7 @@
           <span class="message">Help Provide Humanitarian Aid to Ukraine.</span>
         </a>
       </aio-notification>
+    </mat-toolbar-row>
     <mat-toolbar-row>
       <button mat-button class="hamburger" [class.no-animations]="disableAnimations" (click)="sidenav.toggle()" title="Docs menu">
         <mat-icon svgIcon="menu"></mat-icon>


### PR DESCRIPTION
Commit 6e45777f01373304b9bcfe076ffd5585704444fe introduced a change where 1 closing tag was accidentally removed. This commit adds that tag back.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No