### PR TITLE
docs: release notes for the v13.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+<a name="13.3.1"></a>
+# 13.3.1 (2022-03-30)
+### bazel
+| Commit | Type | Description |
+| -- | -- | -- |
+| [960e42b2ac](https://github.com/angular/angular/commit/960e42b2ac1ad01b4930f107afbdc731d8daa9ec) | fix | ng module compilation workers are subject to linker race-conditions ([#45393](https://github.com/angular/angular/pull/45393)) |
+### compiler
+| Commit | Type | Description |
+| -- | -- | -- |
+| [3714305f84](https://github.com/angular/angular/commit/3714305f84da8ec74ef7d8f5090344b47d0f5dbe) | fix | scope css rules within `@layer` blocks ([#45396](https://github.com/angular/angular/pull/45396)) |
+### compiler-cli
+| Commit | Type | Description |
+| -- | -- | -- |
+| [7f53c0f4ac](https://github.com/angular/angular/commit/7f53c0f4acfac4c50e3a8ba210e7879dd87d4720) | fix | handle inline type-check blocks in nullish coalescing extended check ([#45478](https://github.com/angular/angular/pull/45478)) |
+## Special Thanks
+AlirezaEbrahimkhani, Andrew Kushnir, Andrew Scott, Ben Brook, Dylan Hunn, George Kalpakas, JiaLiPassion, Joey Perrott, JoostK, Mike, Paul Gschwendtner, Willian Corrêa, arturovt, dario-piotrowicz, khai and mgechev
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="14.0.0-next.10"></a>
 # 14.0.0-next.10 (2022-03-30)
 ## Breaking Changes


### PR DESCRIPTION
Cherry-picks the changelog from the "13.3.x" branch to the next branch (master).