### PR TITLE
refactor(core): remove deprecated `aotSummaries` fields in TestBed config

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -74,8 +74,6 @@ v14 - v17
 | `@angular/core`                     | [Factory-based signature of `ViewContainerRef.createComponent`](api/core/ViewContainerRef#createComponent) | <!-- v13 --> v15         |
 | `@angular/core/testing`             | [`TestBed.get`](#testing)                                                                                  | <!--  v9 --> v12         |
 | `@angular/core/testing`             | [`async`](#testing)                                                                                        | <!--  v9 --> v12         |
-| `@angular/core/testing`             | [`aotSummaries` argument in `TestBed.initTestEnvironment`](#testing)                                       | <!-- v13 --> v14         |
-| `@angular/core/testing`             | [`aotSummaries` field of the `TestModuleMetadata` type](#testing)                                          | <!-- v13 --> v14         |
 | `@angular/forms`                    | [`FormBuilder.group` legacy options parameter](api/forms/FormBuilder#group)                                | <!-- v11 --> v14         |
 | `@angular/platform-server`          | [`renderModuleFactory`](#platform-server)                                                                  | <!-- v13 --> v15         |
 | `@angular/router`                   | [`relativeLinkResolution`](#relativeLinkResolution)                                                        | <!-- v14 --> v16         |
@@ -148,8 +146,6 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 |:---                                                                                                      |:---                                                 |:---                   |:---     |
 | [`TestBed.get`](api/core/testing/TestBed#get)                                                            | [`TestBed.inject`](api/core/testing/TestBed#inject) | v9                    | Same behavior, but type safe.                 |
 | [`async`](api/core/testing/async)                                                                        | [`waitForAsync`](api/core/testing/waitForAsync)     | v10                   | Same behavior, but rename to avoid confusion. |
-| [`aotSummaries` argument in `TestBed.initTestEnvironment`](api/core/testing/TestBed#inittestenvironment) | No replacement needed                               | v13                   | Summary files are unused in Ivy.              |
-| [`aotSummaries` field of the `TestModuleMetadata` type](api/core/testing/TestModuleMetadata)             | No replacement needed                               | v13                   | Summary files are unused in Ivy.              |
 
 <a id="platform-browser-dynamic"></a>
 

--- a/aio/tests/e2e/src/api-pages.e2e-spec.ts
+++ b/aio/tests/e2e/src/api-pages.e2e-spec.ts
@@ -79,11 +79,11 @@ describe('Api pages', () => {
 
   it('should show all overloads of interface methods', async () => {
     await page.navigateTo('api/core/testing/TestBedStatic');
-    expect(await (await page.getInstanceMethodOverloads('initTestEnvironment')).length).toEqual(2);
+    expect(await (await page.getInstanceMethodOverloads('inject')).length).toEqual(2);
   });
 
   it('should show all overloads of pseudo-class methods', async () => {
     await page.navigateTo('api/core/testing/TestBed');
-    expect(await (await page.getInstanceMethodOverloads('initTestEnvironment')).length).toEqual(2);
+    expect(await (await page.getInstanceMethodOverloads('inject')).length).toEqual(2);
   });
 });

--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -114,8 +114,6 @@ export interface TestBed {
     // @deprecated (undocumented)
     get(token: any, notFoundValue?: any): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: TestEnvironmentOptions): void;
-    // @deprecated
-    initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
     // (undocumented)
     inject<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
     // (undocumented)
@@ -173,8 +171,6 @@ export interface TestBedStatic {
     // @deprecated (undocumented)
     get(token: any, notFoundValue?: any): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: TestEnvironmentOptions): TestBed;
-    // @deprecated
-    initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
     // (undocumented)
     inject<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
     // (undocumented)
@@ -219,8 +215,6 @@ export class TestComponentRenderer {
 
 // @public (undocumented)
 export interface TestEnvironmentOptions {
-    // @deprecated
-    aotSummaries?: () => any[];
     teardown?: ModuleTeardownOptions;
 }
 
@@ -230,7 +224,6 @@ export type TestModuleMetadata = {
     declarations?: any[];
     imports?: any[];
     schemas?: Array<SchemaMetadata | any[]>;
-    aotSummaries?: () => any[];
     teardown?: ModuleTeardownOptions;
 };
 

--- a/packages/core/testing/src/r3_test_bed.ts
+++ b/packages/core/testing/src/r3_test_bed.ts
@@ -80,9 +80,9 @@ export class TestBedRender3 implements TestBed {
    */
   static initTestEnvironment(
       ngModule: Type<any>|Type<any>[], platform: PlatformRef,
-      summariesOrOptions?: TestEnvironmentOptions|(() => any[])): TestBed {
+      options?: TestEnvironmentOptions): TestBed {
     const testBed = _getTestBedRender3();
-    testBed.initTestEnvironment(ngModule, platform, summariesOrOptions);
+    testBed.initTestEnvironment(ngModule, platform, options);
     return testBed;
   }
 
@@ -230,15 +230,12 @@ export class TestBedRender3 implements TestBed {
    */
   initTestEnvironment(
       ngModule: Type<any>|Type<any>[], platform: PlatformRef,
-      summariesOrOptions?: TestEnvironmentOptions|(() => any[])): void {
+      options?: TestEnvironmentOptions): void {
     if (this.platform || this.ngModule) {
       throw new Error('Cannot set base providers because it has already been called');
     }
 
-    // If `summariesOrOptions` is a function, it means that it's
-    // an AOT summaries factory which Ivy doesn't support.
-    TestBedRender3._environmentTeardownOptions =
-        typeof summariesOrOptions === 'function' ? undefined : summariesOrOptions?.teardown;
+    TestBedRender3._environmentTeardownOptions = options?.teardown;
 
     this.platform = platform;
     this.ngModule = ngModule;

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -35,22 +35,6 @@ export interface TestBed {
   initTestEnvironment(
       ngModule: Type<any>|Type<any>[], platform: PlatformRef,
       options?: TestEnvironmentOptions): void;
-  /**
-   * Initialize the environment for testing with a compiler factory, a PlatformRef, and an
-   * angular module. These are common to every test in the suite.
-   *
-   * This may only be called once, to set up the common providers for the current test
-   * suite on the current platform. If you absolutely need to change the providers,
-   * first use `resetTestEnvironment`.
-   *
-   * Test modules and platforms for individual platforms are available from
-   * '@angular/<platform_name>/testing'.
-   *
-   * @deprecated This API that allows providing AOT summaries is deprecated, since summary files are
-   *     unused in Ivy.
-   */
-  initTestEnvironment(
-      ngModule: Type<any>|Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): void;
 
   /**
    * Reset the providers for the test injector.

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -44,10 +44,6 @@ export type TestModuleMetadata = {
   declarations?: any[],
   imports?: any[],
   schemas?: Array<SchemaMetadata|any[]>,
-  /**
-   * @deprecated With Ivy, AOT summary files are unused.
-   */
-  aotSummaries?: () => any[],
   teardown?: ModuleTeardownOptions;
 };
 
@@ -55,13 +51,6 @@ export type TestModuleMetadata = {
  * @publicApi
  */
 export interface TestEnvironmentOptions {
-  /**
-   * Provides a way to specify AOT summaries to use in TestBed.
-   * This parameter is unused and deprecated in Ivy.
-   *
-   * @deprecated With Ivy, AOT summary files are unused.
-   */
-  aotSummaries?: () => any[];
   /**
    * Configures the test module teardown behavior in `TestBed`.
    */
@@ -102,22 +91,6 @@ export interface TestBedStatic {
   initTestEnvironment(
       ngModule: Type<any>|Type<any>[], platform: PlatformRef,
       options?: TestEnvironmentOptions): TestBed;
-  /**
-   * Initialize the environment for testing with a compiler factory, a PlatformRef, and an
-   * angular module. These are common to every test in the suite.
-   *
-   * This may only be called once, to set up the common providers for the current test
-   * suite on the current platform. If you absolutely need to change the providers,
-   * first use `resetTestEnvironment`.
-   *
-   * Test modules and platforms for individual platforms are available from
-   * '@angular/<platform_name>/testing'.
-   *
-   * @deprecated This API that allows providing AOT summaries is deprecated, since summary files are
-   *     unused in Ivy.
-   */
-  initTestEnvironment(
-      ngModule: Type<any>|Type<any>[], platform: PlatformRef, aotSummaries?: () => any[]): TestBed;
 
   /**
    * Reset the providers for the test injector.


### PR DESCRIPTION
BREAKING CHANGE:

Since Ivy, TestBed doesn't use AOT summaries. The `aotSummaries` fields in TestBed APIs were present, but unused. The fields were deprecated in previous major version and in v14 those fields are removed. The `aotSummaries` fields were completely unused, so you can just drop them from the TestBed APIs usage.

## PR Type
What kind of change does this PR introduce?

- [x] Other: removal of deprecated API

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No