### PR TITLE
refactor(core): make platform core providers tree-shakable

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -281,7 +281,7 @@ export interface BootstrapOptions {
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: 'platform'})
 export class PlatformRef {
   private _modules: NgModuleRef<any>[] = [];
   private _destroyListeners: Function[] = [];

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -54,7 +54,10 @@ export const PLATFORM_INITIALIZER = new InjectionToken<Array<() => void>>('Platf
  * A token that indicates an opaque platform ID.
  * @publicApi
  */
-export const PLATFORM_ID = new InjectionToken<Object>('Platform ID');
+export const PLATFORM_ID = new InjectionToken<Object>('Platform ID', {
+  providedIn: 'platform',
+  factory: () => 'unknown',  // set a default platform name, when none set explicitly
+});
 
 /**
  * A [DI token](guide/glossary#di-token "DI token definition") that provides a set of callbacks to

--- a/packages/core/src/console.ts
+++ b/packages/core/src/console.ts
@@ -8,7 +8,7 @@
 
 import {Injectable} from './di';
 
-@Injectable()
+@Injectable({providedIn: 'platform'})
 export class Console {
   log(message: string): void {
     // tslint:disable-next-line:no-console

--- a/packages/core/src/platform_core_providers.ts
+++ b/packages/core/src/platform_core_providers.ts
@@ -7,22 +7,12 @@
  */
 
 import {createPlatformFactory, PlatformRef} from './application_ref';
-import {PLATFORM_ID} from './application_tokens';
-import {Console} from './console';
-import {Injector, StaticProvider} from './di';
-import {TestabilityRegistry} from './testability/testability';
-
-const _CORE_PLATFORM_PROVIDERS: StaticProvider[] = [
-  // Set a default platform name for platforms that don't set it explicitly.
-  {provide: PLATFORM_ID, useValue: 'unknown'},
-  {provide: PlatformRef, deps: [Injector]},
-  {provide: TestabilityRegistry, deps: []},
-  {provide: Console, deps: []},
-];
+import {StaticProvider} from './di';
 
 /**
  * This platform has to be included in any other platform
  *
  * @publicApi
  */
-export const platformCore = createPlatformFactory(null, 'core', _CORE_PLATFORM_PROVIDERS);
+export const platformCore: (extraProviders?: StaticProvider[]|undefined) => PlatformRef =
+    createPlatformFactory(null, 'core', []);

--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -230,7 +230,7 @@ export class Testability implements PublicTestability {
  * A global registry of {@link Testability} instances for specific elements.
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: 'platform'})
 export class TestabilityRegistry {
   /** @internal */
   _applications = new Map<any, Testability>();

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -138,9 +138,6 @@
     "name": "ConnectableSubscriber"
   },
   {
-    "name": "Console"
-  },
-  {
     "name": "DASH_CASE_REGEXP"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -102,9 +102,6 @@
     "name": "ConnectableSubscriber"
   },
   {
-    "name": "Console"
-  },
-  {
     "name": "ControlContainer"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -108,9 +108,6 @@
     "name": "ConnectableSubscriber"
   },
   {
-    "name": "Console"
-  },
-  {
     "name": "ControlContainer"
   },
   {


### PR DESCRIPTION
This commit refactors the set of hardcoded platform core providers into tree-shakable providers.
In addition to making them tree-shakable, this would also avoid the need to rely on the platform creation logic in an upcoming bootstrap logic for Standalone Components.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No