### PR TITLE
refactor(core): make ComponentFactoryResolver lazily instantiated in ApplicationRef

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -595,7 +595,6 @@ export class ApplicationRef {
   /** @internal */
   constructor(
       private _zone: NgZone, private _injector: Injector, private _exceptionHandler: ErrorHandler,
-      private _componentFactoryResolver: ComponentFactoryResolver,
       private _initStatus: ApplicationInitStatus) {
     this._onMicrotaskEmptySubscription = this._zone.onMicrotaskEmpty.subscribe({
       next: () => {
@@ -786,8 +785,8 @@ export class ApplicationRef {
     if (componentOrFactory instanceof ComponentFactory) {
       componentFactory = componentOrFactory;
     } else {
-      componentFactory =
-          this._componentFactoryResolver.resolveComponentFactory(componentOrFactory)!;
+      const resolver = this._injector.get(ComponentFactoryResolver);
+      componentFactory = resolver.resolveComponentFactory(componentOrFactory)!;
     }
     this.componentTypes.push(componentFactory.componentType);
 


### PR DESCRIPTION
This commit removes the `ComponentFactoryResolver` as a constructor argument of the `ApplicationRef` class. This makes it lazily instantiated + simplifies further refactoring in a context of Standalone Components.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No