### PR TITLE
docs: fix footer uses <h3> out of order

### DIFF
--- a/aio/src/app/layout/footer/footer.component.html
+++ b/aio/src/app/layout/footer/footer.component.html
@@ -1,6 +1,6 @@
 <div class="grid-fluid">
   <div class="footer-block" *ngFor="let node of nodes">
-    <h3>{{node.title}}</h3>
+    <div class="footer-block-heading">{{ node.title }}</div>
     <ul>
       <li *ngFor="let item of node.children">
         <a class="link" [href]="item.url" [title]="item.tooltip || item.title">{{ item.title }}</a>

--- a/aio/src/styles/1-layouts/footer/_footer.scss
+++ b/aio/src/styles/1-layouts/footer/_footer.scss
@@ -43,7 +43,7 @@ footer {
       }
     }
 
-    h3 {
+    .footer-block-heading {
       @include mixins.font-size(16);
       text-transform: uppercase;
       font-weight: 400;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Angular documentation website's footer uses the `<h3>` tag out of order. According to a11y guidelines, all the heading tags should be in descending order like `<h1>` tag should be followed by `<h2>` tag and so on but in the docs footer `<h3>` tag is being used out of order.

Issue Number: #44338


## What is the new behavior?

Now, the footer instead of using the `<h3>` tag uses the `<div>` tag to display the title of each of the sections in the footer.  This resolves the out-of-order issue as we are no longer using any heading tag.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Fixes Issue: #44338