### PR TITLE
refactor(platform-browser): remove obsolete shim for Map comparison in Jasmine

### DIFF
--- a/packages/platform-browser/testing/src/matchers.ts
+++ b/packages/platform-browser/testing/src/matchers.ts
@@ -131,26 +131,6 @@ export const expect: <T = any>(actual: T) => NgMatchers<T> = _global.expect;
 };
 
 _global.beforeEach(function() {
-  // Custom handler for Map as we use Jasmine 2.4, and support for maps is not
-  // added until Jasmine 2.6.
-  // TODO(crisbeto): This entire equality tester should be removed.
-  // Keeping it in for now until the cleanup in cl/440328102 has landed.
-  if ((jasmine as any).matchersUtil) {
-    jasmine.addCustomEqualityTester(function compareMap(actual: any, expected: any): boolean {
-      if (actual instanceof Map) {
-        let pass = actual.size === expected.size;
-        if (pass) {
-          actual.forEach((v: any, k: any) => {
-            pass = pass && (jasmine as any).matchersUtil.equals(v, expected.get(k));
-          });
-        }
-        return pass;
-      } else {
-        // TODO(misko): we should change the return, but jasmine.d.ts is not null safe
-        return undefined!;
-      }
-    });
-  }
   jasmine.addMatchers({
     toBePromise: function() {
       return {


### PR DESCRIPTION
Angular now uses Jasmine 2.8 as a minimum version (required by
protractor; most of it is using ^3.5.0 which currently resolves to
3.99.0), which makes this shim obsolete - all versions of Jasmine used
have Map comparison built in.

This shim causes problems for custom equality checkers - when using a
Map containing types needing a custom equality check, this  fails
because the call to `jasmine.matchersUtil.equals` from the shim does not
use any of the custom equality matchers.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

Jasmine tests comparing equality of Maps containing types requiring custom equality matchers fail

## What is the new behavior?

Tests will pass

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No