### PR TITLE
fix(router): Remove `any` from `LoadChildrenCallback` type

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -261,7 +261,7 @@ export interface IsActiveMatchOptions {
 export type LoadChildren = LoadChildrenCallback;
 
 // @public
-export type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Observable<Type<any>> | Promise<NgModuleFactory<any> | Type<any> | any>;
+export type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Observable<Type<any>> | Promise<NgModuleFactory<any> | Type<any>>;
 
 // @public
 export interface Navigation {

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -106,8 +106,8 @@ export type ResolveData = {
  * @see [Route.loadChildren](api/router/Route#loadChildren)
  * @publicApi
  */
-export type LoadChildrenCallback = () => Type<any>|NgModuleFactory<any>|Observable<Type<any>>|
-    Promise<NgModuleFactory<any>|Type<any>|any>;
+export type LoadChildrenCallback = () =>
+    Type<any>|NgModuleFactory<any>|Observable<Type<any>>|Promise<NgModuleFactory<any>|Type<any>>;
 
 /**
  *


### PR DESCRIPTION
The `LoadChildrenCallback` type previously included `any` in the
possible return value union for `Promise`. This is too loose and should
be restricted to values that are actually supported.

BREAKING CHANGE: When returning a `Promise` from the
`LoadChildrenCallback`, the possible type is now restricted to
`Type<any>|NgModuleFactory<any>` rather than `any`.