### PR TITLE
fix(router): validate lazy loaded configs

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1185,9 +1185,6 @@
     "name": "getFirstNativeNode"
   },
   {
-    "name": "getFullPath"
-  },
-  {
     "name": "getIdxOfMatchingSelector"
   },
   {
@@ -1903,12 +1900,6 @@
   },
   {
     "name": "urlParsingNode"
-  },
-  {
-    "name": "validateConfig"
-  },
-  {
-    "name": "validateNode"
   },
   {
     "name": "viewAttachedToChangeDetector"

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -34,6 +34,8 @@ import {Checks, getAllRouteGuards} from './utils/preactivation';
 import {isUrlTree} from './utils/type_guards';
 
 
+const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
+
 /**
  * @description
  *
@@ -1110,7 +1112,7 @@ export class Router {
    * ```
    */
   resetConfig(config: Routes): void {
-    validateConfig(config);
+    NG_DEV_MODE && validateConfig(config);
     this.config = config.map(standardizeConfig);
     this.navigated = false;
     this.lastSuccessfulId = -1;

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -10,9 +10,9 @@ import {Compiler, InjectFlags, InjectionToken, Injector, NgModuleFactory} from '
 import {ConnectableObservable, from, Observable, of, Subject} from 'rxjs';
 import {catchError, map, mergeMap, refCount, tap} from 'rxjs/operators';
 
-import {LoadChildren, LoadedRouterConfig, Route} from './models';
+import {LoadChildren, LoadedRouterConfig, Route, Routes} from './models';
 import {flatten, wrapIntoObservable} from './utils/collection';
-import {standardizeConfig} from './utils/config';
+import {standardizeConfig, validateConfig} from './utils/config';
 
 /**
  * The [DI token](guide/glossary/#di-token) for a router configuration.
@@ -47,15 +47,15 @@ export class RouterConfigLoader {
             this.onLoadEndListener(route);
           }
           const module = factory.create(parentInjector);
+          const routes =
+              flatten(module.injector.get(ROUTES, [], InjectFlags.Self | InjectFlags.Optional))
+                  .map(standardizeConfig);
+          validateConfig(routes);
           // When loading a module that doesn't provide `RouterModule.forChild()` preloader
           // will get stuck in an infinite loop. The child module's Injector will look to
           // its parent `Injector` when it doesn't find any ROUTES so it will return routes
           // for it's parent module instead.
-          return new LoadedRouterConfig(
-              flatten(
-                  module.injector.get(ROUTES, undefined, InjectFlags.Self | InjectFlags.Optional))
-                  .map(standardizeConfig),
-              module);
+          return new LoadedRouterConfig(routes, module);
         }),
         catchError((err) => {
           route._loader$ = undefined;

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -5300,6 +5300,24 @@ describe('Integration', () => {
          ]);
        })));
 
+    it('should emit an error when the lazily-loaded config is not valid', fakeAsync(() => {
+         const router = TestBed.inject(Router);
+         @NgModule({imports: [RouterModule.forChild([{path: 'loaded'}])]})
+         class LoadedModule {
+         }
+
+         const fixture = createRoot(router, RootCmp);
+         router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
+
+         let recordedError: any = null;
+         router.navigateByUrl('/lazy/loaded').catch(err => recordedError = err);
+         advance(fixture);
+
+         expect(recordedError.message)
+             .toEqual(
+                 `Invalid configuration of route 'loaded'. One of the following must be provided: component, redirectTo, children or loadChildren`);
+       }));
+
     it('should work with complex redirect rules',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
          @Component({selector: 'lazy', template: 'lazy-loaded'})


### PR DESCRIPTION
Lazy loaded configs are not validated at runtime like the initial set of
routes are. This change also validates lazy loaded configs right after
they're loaded.

BREAKING CHANGE: Lazy loaded configs are now also validated once loaded like the
initial set of routes are. Lazy loaded modules which have invalid Route
configs will now error. Note that this is only done in dev mode so
there is no production impact of this change.

Fixes #25431
