### PR TITLE
test(animations): update test to use an object instead of a Map

### DIFF
--- a/packages/animations/browser/test/dsl/animation_ast_builder_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_ast_builder_spec.ts
@@ -46,7 +46,7 @@ import {MockAnimationDriver} from '../../testing';
           timings: {delay: 0, duration: 1000, easing: 'ease-in-out'},
           style: {
             type: 6,
-            styles: [new Map([['backgroundColor', '#000']])],
+            styles: [{backgroundColor: '#000'}],
             easing: null,
             offset: null,
             containsDynamicStyles: false,


### PR DESCRIPTION
The code in the patch branch is slightly different from the master branch: the master branch contains some changes where Map are used instead of objects in animations. As a result, one of the tests is failing in patch, since it expects Maps, but receives objects.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: an update to a failing test


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No