### PR TITLE
docs(forms): add value to formControl for better demonstration of requiredTrue validator

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -192,7 +192,7 @@ export class Validators {
    * ### Validate that the field is non-empty
    *
    * ```typescript
-   * const control = new FormControl('some value', Validators.required);
+   * const control = new FormControl('', Validators.required);
    *
    * console.log(control.errors); // {required: true}
    * ```

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -192,7 +192,7 @@ export class Validators {
    * ### Validate that the field is non-empty
    *
    * ```typescript
-   * const control = new FormControl('', Validators.required);
+   * const control = new FormControl('some value', Validators.required);
    *
    * console.log(control.errors); // {required: true}
    * ```
@@ -217,7 +217,7 @@ export class Validators {
    * ### Validate that the field value is true
    *
    * ```typescript
-   * const control = new FormControl('', Validators.requiredTrue);
+   * const control = new FormControl('some value', Validators.requiredTrue);
    *
    * console.log(control.errors); // {required: true}
    * ```


### PR DESCRIPTION
in the validators documentation, the value for the formControl for both required and requiredTrue validators is an empty string. This is OK for required since it gives us an error. But I think if we set the value of formControl responsible for requiredTrue to something other than an empty string (e.g.: 'some value'), it would demonstrate the difference between required and requiredTrue better.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
