### PR TITLE
fix(zone.js): patch node for nested fs functions

### DIFF
--- a/packages/zone.js/lib/node/fs.ts
+++ b/packages/zone.js/lib/node/fs.ts
@@ -17,6 +17,10 @@ Zone.__load_patch('fs', () => {
 
   // watch, watchFile, unwatchFile has been patched
   // because EventEmitter has been patched
+  const TO_PATCH_MACROTASK_NESTED = [
+    {'parent': 'realpath', 'nested': 'native'},
+    {'parent': 'realpathSync', 'nested': 'native'},
+  ];
   const TO_PATCH_MACROTASK_METHODS = [
     'access',  'appendFile', 'chmod',    'chown',    'close',     'exists',    'fchmod',
     'fchown',  'fdatasync',  'fstat',    'fsync',    'ftruncate', 'futimes',   'lchmod',
@@ -26,6 +30,26 @@ Zone.__load_patch('fs', () => {
   ];
 
   if (fs) {
+    // store the patched nested function temporarily first
+    const tempNestedResults: {[key: string]: any} = {};
+    TO_PATCH_MACROTASK_NESTED
+        .filter(
+            method => !!fs?.[method.parent][method.nested] &&
+                typeof fs[method.parent][method.nested] === 'function')
+        .forEach(function(method) {
+          patchMacroTask(fs[method.parent], method.nested, function(self, args) {
+            return {
+              name: 'fs.' + method.parent + '.' + method.nested,
+              args: args,
+              cbIdx: args.length > 0 ? args.length - 1 : -1,
+              target: self
+            };
+          });
+          tempNestedResults[method.parent] = tempNestedResults[method.parent] || {};
+          tempNestedResults[method.parent][method.nested] = fs[method.parent][method.nested];
+        });
+
+    // patching of direct fs functions will override nested functions
     TO_PATCH_MACROTASK_METHODS.filter(name => !!fs[name] && typeof fs[name] === 'function')
         .forEach(name => {
           patchMacroTask(fs, name, (self: any, args: any[]) => {
@@ -37,5 +61,10 @@ Zone.__load_patch('fs', () => {
             };
           });
         });
+
+    // re-populate the nested function as it became undefined
+    for (let method of TO_PATCH_MACROTASK_NESTED) {
+      fs[method.parent][method.nested] = tempNestedResults[method.parent][method.nested];
+    }
   }
 });

--- a/packages/zone.js/test/node/fs.spec.ts
+++ b/packages/zone.js/test/node/fs.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {closeSync, exists, fstatSync, openSync, read, unlink, unlinkSync, unwatchFile, watch, watchFile, write, writeFile} from 'fs';
+import {closeSync, exists, fstatSync, openSync, read, realpath, unlink, unlinkSync, unwatchFile, watch, watchFile, write, writeFile} from 'fs';
 import * as util from 'util';
 
 describe('nodejs file system', () => {
@@ -33,6 +33,42 @@ describe('nodejs file system', () => {
       spyOn(zoneASpec, 'onScheduleTask').and.callThrough();
       zoneA.run(() => {
         exists('testfile', (_) => {
+          expect(zoneASpec.onScheduleTask).toHaveBeenCalled();
+          done();
+        });
+      });
+    });
+
+    it('realpath should patched as macroTask', (done) => {
+      const zoneASpec = {
+        name: 'A',
+        onScheduleTask: (delegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, task: Task):
+            Task => {
+              return delegate.scheduleTask(targetZone, task);
+            }
+      };
+      const zoneA = Zone.current.fork(zoneASpec);
+      spyOn(zoneASpec, 'onScheduleTask').and.callThrough();
+      zoneA.run(() => {
+        realpath('testfile', (_) => {
+          expect(zoneASpec.onScheduleTask).toHaveBeenCalled();
+          done();
+        });
+      });
+    });
+
+    it('realpath.native should patched as macroTask', (done) => {
+      const zoneASpec = {
+        name: 'A',
+        onScheduleTask: (delegate: ZoneDelegate, currentZone: Zone, targetZone: Zone, task: Task):
+            Task => {
+              return delegate.scheduleTask(targetZone, task);
+            }
+      };
+      const zoneA = Zone.current.fork(zoneASpec);
+      spyOn(zoneASpec, 'onScheduleTask').and.callThrough();
+      zoneA.run(() => {
+        realpath.native('testfile', (_) => {
           expect(zoneASpec.onScheduleTask).toHaveBeenCalled();
           done();
         });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Only direct `fs` functions are patched by `zone.js/node`.
After `zone.js/node` patches `fs` functions, nested `fs` functions become `undefined`. 
* `fs.realpath.native` is `undefined`
* `fs.realpathSync.native` is `undefined`

Issue Number: angular#45546


## What is the new behavior?
It patches the nested functions `fs.realpath.native` and `fs.realpathSync.native` first, storing them in a temporary space, before patching the usual `fs` functions (which will cause the nested functions to be `undefined`). Lastly, it populates back the patched nested functions from the temporary space back to `fs`.

* `fs.realpath.native` is patched by `zone.js/node` and is no longer `undefined`
* `fs.realpathSync.native` is patched by `zone.js/node` and is no longer `undefined`


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Fixes: angular#45546