### PR TITLE
feat(animations): make validateStyleProperty check dev-mode only

### DIFF
--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -314,19 +314,20 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
       if (typeof tuple === 'string') return;
 
       tuple.forEach((value, prop) => {
-        if (!this._driver.validateStyleProperty(prop)) {
-          tuple.delete(prop);
-          context.unsupportedCSSPropertiesFound.add(prop);
-          return;
-        }
-
-        if ((typeof ngDevMode === 'undefined' || ngDevMode) &&
-            this._driver.validateAnimatableStyleProperty) {
-          if (!this._driver.validateAnimatableStyleProperty(prop)) {
-            context.nonAnimatableCSSPropertiesFound.add(prop);
-            // note: non animatable properties are not removed for the tuple just in case they are
-            //       categorized as non animatable but can actually be animated
+        if (typeof ngDevMode === 'undefined' || ngDevMode) {
+          if (!this._driver.validateStyleProperty(prop)) {
+            tuple.delete(prop);
+            context.unsupportedCSSPropertiesFound.add(prop);
             return;
+          }
+
+          if (this._driver.validateAnimatableStyleProperty) {
+            if (!this._driver.validateAnimatableStyleProperty(prop)) {
+              context.nonAnimatableCSSPropertiesFound.add(prop);
+              // note: non animatable properties are not removed for the tuple just in case they are
+              //       categorized as non animatable but can actually be animated
+              return;
+            }
           }
         }
 

--- a/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
@@ -25,7 +25,7 @@ export class WebAnimationsDriver implements AnimationDriver {
 
   validateAnimatableStyleProperty(prop: string): boolean {
     // Perform actual validation in dev mode only, in prod mode this check is a noop.
-    if (ngDevMode) {
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
       const cssProp = camelCaseToDashCase(prop);
       return validateWebAnimatableStyleProperty(cssProp);
     }

--- a/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_driver.ts
@@ -16,7 +16,11 @@ import {WebAnimationsPlayer} from './web_animations_player';
 
 export class WebAnimationsDriver implements AnimationDriver {
   validateStyleProperty(prop: string): boolean {
-    return validateStyleProperty(prop);
+    // Perform actual validation in dev mode only, in prod mode this check is a noop.
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      return validateStyleProperty(prop);
+    }
+    return true;
   }
 
   validateAnimatableStyleProperty(prop: string): boolean {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1347,9 +1347,6 @@
     "name": "urlParsingNode"
   },
   {
-    "name": "validateStyleProperty"
-  },
-  {
     "name": "viewAttachedToChangeDetector"
   },
   {


### PR DESCRIPTION
make the validateStyleProperty check dev-mode only so that it is
consistent with the validateAnimatableStyleProperty check introduced in
PR #45212

besides consistency this change also reduces the payload size and
increases performance (since less logic is executed)

original conversation: https://github.com/angular/angular/pull/45212#discussion_r818106737

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - @AndrewKushnir :slightly_smiling_face: