### PR TITLE
feat(docs-infra): add close button to search-results aio panel

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -50,7 +50,12 @@
   </mat-toolbar>
 </header>
 
-<aio-search-results #searchResultsView *ngIf="showSearchResults" [searchResults]="searchResults | async" (resultSelected)="hideSearchResults()"></aio-search-results>
+<aio-search-results *ngIf="showSearchResults"
+  #searchResultsView
+  [searchResults]="searchResults | async"
+  (resultSelected)="hideSearchResults()"
+  (closeButtonClick)="hideSearchResults()">
+</aio-search-results>
 
 <mat-sidenav-container class="sidenav-container" [class.no-animations]="disableAnimations" [class.has-floating-toc]="hasFloatingToc">
 

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -297,7 +297,7 @@ export class AppComponent implements OnInit {
           // the user is focusing backward from the search input,
           // loop it back to the results' close button
           const closeBtn: HTMLButtonElement =
-            this.searchResultsView.nativeElement.querySelector('button.close-btn');
+            this.searchResultsView.nativeElement.querySelector('button.close-button');
           closeBtn.focus();
         }
       }

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -295,13 +295,10 @@ export class AppComponent implements OnInit {
           this.focusSearchBox();
         } else {
           // the user is focusing backward from the search input,
-          // loop it back to the last search result item
-          const anchors: HTMLAnchorElement[] = Array.from(
-            this.searchResultsView.nativeElement.querySelectorAll('a.search-result-item'),
-          );
-          if (anchors.length) {
-            anchors[anchors.length - 1].focus();
-          }
+          // loop it back to the results' close button
+          const closeBtn: HTMLButtonElement =
+            this.searchResultsView.nativeElement.querySelector('button.close-btn');
+          closeBtn.focus();
         }
       }
     }

--- a/aio/src/app/app.module.ts
+++ b/aio/src/app/app.module.ts
@@ -7,7 +7,7 @@ import { ServiceWorkerModule } from '@angular/service-worker';
 import { Location, LocationStrategy, PathLocationStrategy } from '@angular/common';
 
 import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
+import { MatIconRegistry } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -150,7 +150,6 @@ export const svgIconProviders = [
     CustomElementsModule,
     HttpClientModule,
     MatButtonModule,
-    MatIconModule,
     MatProgressBarModule,
     MatSidenavModule,
     MatToolbarModule,

--- a/aio/src/app/layout/notification/notification.component.html
+++ b/aio/src/app/layout/notification/notification.component.html
@@ -2,6 +2,6 @@
   <ng-content></ng-content>
 </span>
 
-<button mat-icon-button class="close-button" aria-label="Close" (click)="dismiss()">
-  <mat-icon svgIcon="close" aria-label="Dismiss notification"></mat-icon>
+<button mat-icon-button class="close-button" aria-label="Dismiss notification" (click)="dismiss()">
+  <mat-icon svgIcon="close"></mat-icon>
 </button>

--- a/aio/src/app/shared/search-results/search-results.component.html
+++ b/aio/src/app/shared/search-results/search-results.component.html
@@ -52,6 +52,12 @@
       </ul>
     </div>
   </ng-container>
+
+  <div class="close-btn-wrapper">
+    <button class="close-btn" aria-label="Close search results panel" (click)="onCloseClicked()">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
 </div>
 
 

--- a/aio/src/app/shared/search-results/search-results.component.html
+++ b/aio/src/app/shared/search-results/search-results.component.html
@@ -53,11 +53,9 @@
     </div>
   </ng-container>
 
-  <div class="close-button-wrapper">
-    <button mat-icon-button class="close-button" aria-label="Close search results panel" (click)="onCloseClicked()">
-      <mat-icon svgIcon="close"></mat-icon>
-    </button>
-  </div>
+  <button mat-icon-button class="close-button" aria-label="Close search results panel" (click)="onCloseClicked()">
+    <mat-icon svgIcon="close"></mat-icon>
+  </button>
 </div>
 
 

--- a/aio/src/app/shared/search-results/search-results.component.html
+++ b/aio/src/app/shared/search-results/search-results.component.html
@@ -55,7 +55,7 @@
 
   <div class="close-button-wrapper">
     <button mat-icon-button class="close-button" aria-label="Close search results panel" (click)="onCloseClicked()">
-      <mat-icon svgIcon="close" aria-label="Dismiss notification"></mat-icon>
+      <mat-icon svgIcon="close"></mat-icon>
     </button>
   </div>
 </div>

--- a/aio/src/app/shared/search-results/search-results.component.html
+++ b/aio/src/app/shared/search-results/search-results.component.html
@@ -53,9 +53,9 @@
     </div>
   </ng-container>
 
-  <div class="close-btn-wrapper">
-    <button class="close-btn" aria-label="Close search results panel" (click)="onCloseClicked()">
-      <mat-icon>close</mat-icon>
+  <div class="close-button-wrapper">
+    <button mat-icon-button class="close-button" aria-label="Close search results panel" (click)="onCloseClicked()">
+      <mat-icon svgIcon="close" aria-label="Dismiss notification"></mat-icon>
     </button>
   </div>
 </div>

--- a/aio/src/app/shared/search-results/search-results.component.ts
+++ b/aio/src/app/shared/search-results/search-results.component.ts
@@ -28,6 +28,12 @@ export class SearchResultsComponent implements OnChanges {
   @Output()
   resultSelected = new EventEmitter<SearchResult>();
 
+  /**
+   * Emitted when the user clicks the close button
+   */
+  @Output()
+  closeButtonClick = new EventEmitter<void>();
+
   searchState: SearchState = SearchState.InProgress;
   readonly defaultArea = 'other';
   readonly folderToAreaMap: Record<string, string> = {
@@ -57,6 +63,10 @@ export class SearchResultsComponent implements OnChanges {
     if (event.button === 0 && !event.ctrlKey && !event.metaKey) {
       this.resultSelected.emit(page);
     }
+  }
+
+  onCloseClicked() {
+    this.closeButtonClick.emit();
   }
 
   // Map the search results into groups by area

--- a/aio/src/app/shared/shared.module.ts
+++ b/aio/src/app/shared/shared.module.ts
@@ -2,10 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SearchResultsComponent } from './search-results/search-results.component';
 import { SelectComponent } from './select/select.component';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
   imports: [
-    CommonModule
+    CommonModule,
+    MatIconModule,
   ],
   exports: [
     SearchResultsComponent,

--- a/aio/src/app/shared/shared.module.ts
+++ b/aio/src/app/shared/shared.module.ts
@@ -11,7 +11,8 @@ import { MatIconModule } from '@angular/material/icon';
   ],
   exports: [
     SearchResultsComponent,
-    SelectComponent
+    SelectComponent,
+    MatIconModule,
   ],
   declarations: [
     SearchResultsComponent,

--- a/aio/src/styles/2-modules/notification/_notification.scss
+++ b/aio/src/styles/2-modules/notification/_notification.scss
@@ -82,7 +82,7 @@ aio-notification {
   }
 
   .search-results {
-    padding-top: $notificationHeight;
+    border-top-width: 68px + $notificationHeight;
   }
 
   mat-sidenav-container.sidenav-container {

--- a/aio/src/styles/2-modules/notification/_notification.scss
+++ b/aio/src/styles/2-modules/notification/_notification.scss
@@ -83,6 +83,10 @@ aio-notification {
 
   .search-results {
     padding-top: $notificationHeight;
+
+    .close-btn-wrapper {
+      top: 6.5rem;
+    }
   }
 
   mat-sidenav-container.sidenav-container {

--- a/aio/src/styles/2-modules/notification/_notification.scss
+++ b/aio/src/styles/2-modules/notification/_notification.scss
@@ -84,7 +84,7 @@ aio-notification {
   .search-results {
     padding-top: $notificationHeight;
 
-    .close-btn-wrapper {
+    .close-button-wrapper {
       top: 6.5rem;
     }
   }

--- a/aio/src/styles/2-modules/notification/_notification.scss
+++ b/aio/src/styles/2-modules/notification/_notification.scss
@@ -85,7 +85,7 @@ aio-notification {
     padding-top: $notificationHeight;
 
     .close-button-wrapper {
-      top: 6.5rem;
+      top: $notificationHeight;
     }
   }
 

--- a/aio/src/styles/2-modules/notification/_notification.scss
+++ b/aio/src/styles/2-modules/notification/_notification.scss
@@ -84,7 +84,7 @@ aio-notification {
   .search-results {
     padding-top: $notificationHeight;
 
-    .close-button-wrapper {
+    .close-button {
       top: $notificationHeight;
     }
   }

--- a/aio/src/styles/2-modules/notification/_notification.scss
+++ b/aio/src/styles/2-modules/notification/_notification.scss
@@ -83,10 +83,6 @@ aio-notification {
 
   .search-results {
     padding-top: $notificationHeight;
-
-    .close-button {
-      top: $notificationHeight;
-    }
   }
 
   mat-sidenav-container.sidenav-container {

--- a/aio/src/styles/2-modules/search-results/_search-results-theme.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results-theme.scss
@@ -12,6 +12,8 @@
       background-color: constants.$darkgray;
       box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3);
 
+      $item-color: if($is-dark-theme, constants.$offwhite, constants.$lightgray);
+
       .search-area {
         .search-section-header {
           color: constants.$white;
@@ -19,7 +21,7 @@
 
         ul {
           .search-result-item {
-            color: if($is-dark-theme, constants.$offwhite, constants.$lightgray);
+            color: $item-color;
 
             &:hover {
               color: constants.$white;
@@ -34,6 +36,10 @@
 
       a {
         color: mat.get-color-from-palette($foreground, text);
+      }
+
+      .close-button {
+        color: $item-color;
       }
     }
 

--- a/aio/src/styles/2-modules/search-results/_search-results.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results.scss
@@ -1,5 +1,5 @@
-@use '../../mixins';
 @use '../../constants';
+@use '../../mixins';
 
 aio-search-results {
   z-index: 10;

--- a/aio/src/styles/2-modules/search-results/_search-results.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results.scss
@@ -80,21 +80,18 @@ aio-search-results {
       right: $offset;
       border: none;
       padding: 0;
-      margin: 0;
+      margin: 3px;
       display: flex;
       opacity: 0;
-      height: 0;
       width: 0;
       color: constants.$white;
-      background-color: constants.$darkgray;
+      background-color: inherit;
       cursor: pointer;
       transition: 100ms opacity;
 
       &:focus {
         opacity: 1;
-        height: auto;
         width: auto;
-        margin: 3px;
       }
     }
   }

--- a/aio/src/styles/2-modules/search-results/_search-results.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results.scss
@@ -73,14 +73,14 @@ aio-search-results {
       display: block;
     }
 
-    .close-btn-wrapper {
+    .close-button-wrapper {
       position: absolute;
       $offset: 1rem;
       top: $offset;
       right: $offset;
       overflow: hidden;
 
-      .close-btn {
+      .close-button {
         background-color: constants.$darkgray;
         border: none;
         padding: 0;

--- a/aio/src/styles/2-modules/search-results/_search-results.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results.scss
@@ -1,4 +1,3 @@
-@use '../../constants';
 @use '../../mixins';
 
 aio-search-results {

--- a/aio/src/styles/2-modules/search-results/_search-results.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results.scss
@@ -1,4 +1,5 @@
 @use '../../mixins';
+@use '../../constants';
 
 aio-search-results {
   z-index: 10;
@@ -70,6 +71,36 @@ aio-search-results {
 
     @media (max-width: 600px) {
       display: block;
+    }
+
+    .close-btn-wrapper {
+      position: absolute;
+      $offset: 1rem;
+      top: $offset;
+      right: $offset;
+      overflow: hidden;
+
+      .close-btn {
+        background-color: constants.$darkgray;
+        border: none;
+        padding: 0;
+        display: flex;
+        transition: 100ms opacity;
+        opacity: 0;
+        transform: translateX(5rem);
+        height: 0;
+        width: 0;
+        color: constants.$white;
+        cursor: pointer;
+
+        &:focus {
+          opacity: 1;
+          transform: translateX(0);
+          height: auto;
+          width: auto;
+          margin: 3px;
+        }
+      }
     }
   }
 

--- a/aio/src/styles/2-modules/search-results/_search-results.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results.scss
@@ -84,7 +84,6 @@ aio-search-results {
       display: flex;
       opacity: 0;
       width: 0;
-      color: constants.$white;
       background-color: inherit;
       cursor: pointer;
       transition: 100ms opacity;

--- a/aio/src/styles/2-modules/search-results/_search-results.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results.scss
@@ -73,33 +73,28 @@ aio-search-results {
       display: block;
     }
 
-    .close-button-wrapper {
+    .close-button {
       position: absolute;
       $offset: 1rem;
       top: $offset;
       right: $offset;
-      overflow: hidden;
+      border: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      opacity: 0;
+      height: 0;
+      width: 0;
+      color: constants.$white;
+      background-color: constants.$darkgray;
+      cursor: pointer;
+      transition: 100ms opacity;
 
-      .close-button {
-        background-color: constants.$darkgray;
-        border: none;
-        padding: 0;
-        display: flex;
-        transition: 100ms opacity;
-        opacity: 0;
-        transform: translateX(5rem);
-        height: 0;
-        width: 0;
-        color: constants.$white;
-        cursor: pointer;
-
-        &:focus {
-          opacity: 1;
-          transform: translateX(0);
-          height: auto;
-          width: auto;
-          margin: 3px;
-        }
+      &:focus {
+        opacity: 1;
+        height: auto;
+        width: auto;
+        margin: 3px;
       }
     }
   }

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -3,9 +3,9 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 450884,
+        "main": 451545,
         "polyfills": 33869,
-        "styles": 71137,
+        "styles": 71714,
         "light-theme": 78213,
         "dark-theme": 78318
       }
@@ -15,9 +15,9 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 451472,
+        "main": 452249,
         "polyfills": 33980,
-        "styles": 71137,
+        "styles": 71714,
         "light-theme": 78213,
         "dark-theme": 78318
       }


### PR DESCRIPTION
add a close button to the search-results aio panel so that the user can
conveniently close it via keyboard

this complements the focus trap implemented in PR #44989
(more here: https://github.com/angular/angular/pull/44989#issuecomment-1037287678)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A

## Change
![Peek 2022-04-09 20-42](https://user-images.githubusercontent.com/61631103/162589370-e585c91b-d87c-4a27-8fd1-819ae09fdcba.gif)


![Peek 2022-04-09 20-43](https://user-images.githubusercontent.com/61631103/162589366-5b0fa183-eafc-467f-b148-a821dda85ec9.gif)



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - @gkalpak :smiley: 