### PR TITLE
fix(language-service): two-way binding completion should not remove t…

### DIFF
--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -336,6 +336,15 @@ class TemplateTargetVisitor implements t.Visitor {
   visitElementOrTemplate(element: t.Template|t.Element) {
     this.visitAll(element.attributes);
     this.visitAll(element.inputs);
+    // We allow the path to contain both the `t.BoundAttribute` and `t.BoundEvent` for two-way
+    // bindings but do not want the path to contain both the `t.BoundAttribute` with its
+    // children when the position is in the value span because we would then logically create a path
+    // that also contains the `PropertyWrite` from the `t.BoundEvent`. This early return condition
+    // ensures we target just `t.BoundAttribute` for this case and exclude `t.BoundEvent` children.
+    if (this.path[this.path.length - 1] !== element &&
+        !(this.path[this.path.length - 1] instanceof t.BoundAttribute)) {
+      return;
+    }
     this.visitAll(element.outputs);
     if (element instanceof t.Template) {
       this.visitAll(element.templateAttrs);

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -241,6 +241,14 @@ describe('completions', () => {
       expectContain(completions, ts.ScriptElementKind.memberVariableElement, ['title']);
     });
 
+    it('should not include the trailing quote inside the RHS of a two-way binding', () => {
+      const {templateFile} = setup(`<h1 [(model)]="title."></h1>`, `title!: string;`);
+      templateFile.moveCursorToText('[(model)]="title.¦"');
+      const completions = templateFile.getCompletionsAtPosition();
+      expectContain(completions, ts.ScriptElementKind.memberFunctionElement, ['charAt']);
+      expectReplacementText(completions, templateFile.contents, '');
+    });
+
     it('should return completions inside an empty RHS of a two-way binding', () => {
       const {templateFile} = setup(`<h1 [(model)]=""></h1>`, `title!: string;`);
       templateFile.moveCursorToText('[(model)]="¦"');


### PR DESCRIPTION
…he trailing quote

For two-way binding syntax, the Angular compiler will append the ` =$event` to the expression of
`BoundEvent`.
https://github.com/angular/angular/blob/e0ac61412137144a43dc5a2134b4cd620bb4c30f/packages/compiler/src/render3/r3_template_transform.ts#L493
For example, the `[(model)]="title.¦"`, the expression of `BoundEvent` will be converted to
`title.¦ =$event`.
--------^------ this blank will be included in the `replacementSpan` of completion item.
When the user selects an item, the trailing quote will be removed.

Now the paths include `BoundAttribute` and `BoundEvent` for the two-way binding syntax. So the
`BoundEvent` should be removed from the paths and use the `BoundAttribute` instead.

Fixes https://github.com/angular/vscode-ng-language-service/issues/1626

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
