### PR TITLE
refactor(animations): include pushUnrecognizedPropertiesWarning in  ngDevMode check

### DIFF
--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -74,19 +74,20 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
     const ast =
         <Ast<AnimationMetadataType>>visitDslNode(this, normalizeAnimationEntry(metadata), context);
 
-    if (context.unsupportedCSSPropertiesFound.size) {
-      pushUnrecognizedPropertiesWarning(
-          warnings,
-          [...context.unsupportedCSSPropertiesFound.keys()],
-      );
-    }
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      if (context.unsupportedCSSPropertiesFound.size) {
+        pushUnrecognizedPropertiesWarning(
+            warnings,
+            [...context.unsupportedCSSPropertiesFound.keys()],
+        );
+      }
 
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) &&
-        context.nonAnimatableCSSPropertiesFound.size) {
-      pushNonAnimatablePropertiesWarning(
-          warnings,
-          [...context.nonAnimatableCSSPropertiesFound.keys()],
-      );
+      if (context.nonAnimatableCSSPropertiesFound.size) {
+        pushNonAnimatablePropertiesWarning(
+            warnings,
+            [...context.nonAnimatableCSSPropertiesFound.keys()],
+        );
+      }
     }
 
     return ast;

--- a/packages/animations/browser/src/warning_helpers.ts
+++ b/packages/animations/browser/src/warning_helpers.ts
@@ -35,7 +35,7 @@ export function triggerParsingWarnings(name: string, warnings: string[]): void {
 }
 
 export function pushUnrecognizedPropertiesWarning(warnings: string[], props: string[]): void {
-  if (ngDevMode && props.length) {
+  if (props.length) {
     warnings.push(`The following provided properties are not recognized: ${props.join(', ')}`);
   }
 }


### PR DESCRIPTION
the check for unsupported CSS properties has been made dev-mode-only in
PR #45570, so the check for the unsupportedCSSPRopertiesFound can be
moved inside a ngDevMode check so that more code can be treeshaken away

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue
Issue Number: N/A



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 @jessicajaniuk sorry I should have done this in PR #45570 :sweat: 