### PR TITLE
Revert "refactor(router): Add warning for `relativeLinkResolution: 'legacy'` (#45523)"

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -321,8 +321,6 @@ The `relativeLinkResolution` option is deprecated and being removed.
 In version 11, the default behavior was changed to the correct one.
 After `relativeLinkResolution` is removed, the correct behavior is always used without an option to use the broken behavior.
 
-A dev mode warning was added in v14 to warn if a created `UrlTree` relies on the `relativeLinkResolution: 'legacy'` option.
-
 <a id="loadChildren"></a>
 
 ### loadChildren string syntax

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -284,13 +284,6 @@ export class ActivatedRouteSnapshot {
   _urlSegment: UrlSegmentGroup;
   /** @internal */
   _lastPathIndex: number;
-  /**
-   * @internal
-   *
-   * Used only in dev mode to detect if application relies on `relativeLinkResolution: 'legacy'`
-   * Should be removed in v16.
-   */
-  _correctedLastPathIndex: number;
   /** @internal */
   _resolve: ResolveData;
   /** @internal */
@@ -340,11 +333,10 @@ export class ActivatedRouteSnapshot {
       public outlet: string,
       /** The component of the route */
       public component: Type<any>|string|null, routeConfig: Route|null, urlSegment: UrlSegmentGroup,
-      lastPathIndex: number, resolve: ResolveData, correctedLastPathIndex?: number) {
+      lastPathIndex: number, resolve: ResolveData) {
     this.routeConfig = routeConfig;
     this._urlSegment = urlSegment;
     this._lastPathIndex = lastPathIndex;
-    this._correctedLastPathIndex = correctedLastPathIndex ?? lastPathIndex;
     this._resolve = resolve;
   }
 

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -227,13 +227,6 @@ export class UrlSegmentGroup {
   _sourceSegment?: UrlSegmentGroup;
   /** @internal */
   _segmentIndexShift?: number;
-  /**
-   * @internal
-   *
-   * Used only in dev mode to detect if application relies on `relativeLinkResolution: 'legacy'`
-   * Should be removed in when `relativeLinkResolution` is removed.
-   */
-  _segmentIndexShiftCorrected?: number;
   /** The parent node in the url tree */
   parent: UrlSegmentGroup|null = null;
 

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -111,9 +111,6 @@ function addEmptyPathsToChildrenIfNeeded(
       s._sourceSegment = segmentGroup;
       if (relativeLinkResolution === 'legacy') {
         s._segmentIndexShift = segmentGroup.segments.length;
-        if (typeof ngDevMode === 'undefined' || !!ngDevMode) {
-          s._segmentIndexShiftCorrected = consumedSegments.length;
-        }
       } else {
         s._segmentIndexShift = consumedSegments.length;
       }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -87,7 +87,6 @@ describe('Integration', () => {
 
       it('should not ignore empty paths in legacy mode',
          fakeAsync(inject([Router], (router: Router) => {
-           const warnSpy = spyOn(console, 'warn');
            router.relativeLinkResolution = 'legacy';
 
            const fixture = createRoot(router, RootCmp);
@@ -97,10 +96,6 @@ describe('Integration', () => {
 
            const link = fixture.nativeElement.querySelector('a');
            expect(link.getAttribute('href')).toEqual('/foo/bar/simple');
-           expect(warnSpy.calls.first().args[0])
-               .toContain('/foo/bar/simple will change to /foo/simple');
-           expect(warnSpy.calls.first().args[0])
-               .toContain('relativeLinkResolution: \'legacy\' is deprecated');
          })));
 
       it('should ignore empty paths in corrected mode',
@@ -5893,7 +5888,6 @@ describe('Integration', () => {
 
       it('should not ignore empty path when in legacy mode',
          fakeAsync(inject([Router], (router: Router) => {
-           const warnSpy = spyOn(console, 'warn');
            router.relativeLinkResolution = 'legacy';
 
            const fixture = createRoot(router, RootCmp);
@@ -5905,10 +5899,6 @@ describe('Integration', () => {
 
            const link = fixture.nativeElement.querySelector('a');
            expect(link.getAttribute('href')).toEqual('/lazy/foo/bar/simple');
-           expect(warnSpy.calls.first().args[0])
-               .toContain('/lazy/foo/bar/simple will change to /lazy/foo/simple');
-           expect(warnSpy.calls.first().args[0])
-               .toContain('relativeLinkResolution: \'legacy\' is deprecated');
          })));
 
       it('should ignore empty path when in corrected mode',


### PR DESCRIPTION
This reverts commit d180db15bf7aef83335ec152002e58a1d9e3031e.