### PR TITLE
feat(forms): Remove deprecated FormBuilder.group signature.

### DIFF
--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -74,19 +74,20 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
     const ast =
         <Ast<AnimationMetadataType>>visitDslNode(this, normalizeAnimationEntry(metadata), context);
 
-    if (context.unsupportedCSSPropertiesFound.size) {
-      pushUnrecognizedPropertiesWarning(
-          warnings,
-          [...context.unsupportedCSSPropertiesFound.keys()],
-      );
-    }
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      if (context.unsupportedCSSPropertiesFound.size) {
+        pushUnrecognizedPropertiesWarning(
+            warnings,
+            [...context.unsupportedCSSPropertiesFound.keys()],
+        );
+      }
 
-    if ((typeof ngDevMode === 'undefined' || ngDevMode) &&
-        context.nonAnimatableCSSPropertiesFound.size) {
-      pushNonAnimatablePropertiesWarning(
-          warnings,
-          [...context.nonAnimatableCSSPropertiesFound.keys()],
-      );
+      if (context.nonAnimatableCSSPropertiesFound.size) {
+        pushNonAnimatablePropertiesWarning(
+            warnings,
+            [...context.nonAnimatableCSSPropertiesFound.keys()],
+        );
+      }
     }
 
     return ast;

--- a/packages/animations/browser/src/warning_helpers.ts
+++ b/packages/animations/browser/src/warning_helpers.ts
@@ -35,7 +35,7 @@ export function triggerParsingWarnings(name: string, warnings: string[]): void {
 }
 
 export function pushUnrecognizedPropertiesWarning(warnings: string[], props: string[]): void {
-  if (ngDevMode && props.length) {
+  if (props.length) {
     warnings.push(`The following provided properties are not recognized: ${props.join(', ')}`);
   }
 }

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -54,33 +54,7 @@ export class FormBuilder {
       controlsConfig: {[key: string]: any},
       options?: AbstractControlOptions|null,
       ): FormGroup;
-  /**
-   * @description
-   * Construct a new `FormGroup` instance.
-   *
-   * @deprecated This API is not typesafe and can result in issues with Closure Compiler renaming.
-   * Use the `FormBuilder#group` overload with `AbstractControlOptions` instead.
-   * Note that `AbstractControlOptions` expects `validators` and `asyncValidators` to be valid
-   * validators. If you have custom validators, make sure their validation function parameter is
-   * `AbstractControl` and not a sub-class, such as `FormGroup`. These functions will be called with
-   * an object of type `AbstractControl` and that cannot be automatically downcast to a subclass, so
-   * TypeScript sees this as an error. For example, change the `(group: FormGroup) =>
-   * ValidationErrors|null` signature to be `(group: AbstractControl) => ValidationErrors|null`.
-   *
-   * @param controlsConfig A collection of child controls. The key for each child is the name
-   * under which it is registered.
-   *
-   * @param options Configuration options object for the `FormGroup`. The legacy configuration
-   * object consists of:
-   * * `validator`: A synchronous validator function, or an array of validator functions
-   * * `asyncValidator`: A single async validator or array of async validator functions
-   * Note: the legacy format is deprecated and might be removed in one of the next major versions
-   * of Angular.
-   */
-  group(
-      controlsConfig: {[key: string]: any},
-      options: {[key: string]: any},
-      ): FormGroup;
+
   group(
       controlsConfig: {[key: string]: any},
       options: AbstractControlOptions|{[key: string]: any}|null = null): FormGroup {
@@ -195,13 +169,7 @@ export class UntypedFormBuilder extends FormBuilder {
       controlsConfig: {[key: string]: any},
       options?: AbstractControlOptions|null,
       ): UntypedFormGroup;
-  /**
-   * @deprecated
-   */
-  override group(
-      controlsConfig: {[key: string]: any},
-      options: {[key: string]: any},
-      ): UntypedFormGroup;
+
   override group(
       controlsConfig: {[key: string]: any},
       options: AbstractControlOptions|{[key: string]: any}|null = null): UntypedFormGroup {


### PR DESCRIPTION
Forms previously provided a signature for `FormBuilder.group` which accepted an unconstrained map as the options argument. It was deprecated in v11.1. This signature is now removed.

BREAKING CHANGE: Code providing incorrect options to FormBuilder.group may be broken.

The open-ended options signature for `FormBuilder.group` has been deleted.