### PR TITLE
refactor(router): deprecate no longer needed `resolver` fields

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -77,6 +77,8 @@ v14 - v17
 | `@angular/forms`                    | [`FormBuilder.group` legacy options parameter](api/forms/FormBuilder#group)                                | <!-- v11 --> v14         |
 | `@angular/platform-server`          | [`renderModuleFactory`](#platform-server)                                                                  | <!-- v13 --> v15         |
 | `@angular/router`                   | [`relativeLinkResolution`](#relativeLinkResolution)                                                        | <!-- v14 --> v16         |
+| `@angular/router`                     | [`resolver` argument in `RouterOutletContract.activateWith`](#router)                                                                        | <!-- v14 --> v16         |
+| `@angular/router`                     | [`resolver` field of the `OutletContext` class](#router)                                                                        | <!-- v14 --> v16         |
 | `@angular/service-worker`           | [`SwUpdate#activated`](api/service-worker/SwUpdate#activated)                                              | <!-- v13 --> v16         |
 | `@angular/service-worker`           | [`SwUpdate#available`](api/service-worker/SwUpdate#available)                                              | <!-- v13 --> v16         |
 | template syntax                     | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector)                                         | <!--  v7 --> unspecified |
@@ -146,6 +148,16 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 |:---                                                                                                      |:---                                                 |:---                   |:---     |
 | [`TestBed.get`](api/core/testing/TestBed#get)                                                            | [`TestBed.inject`](api/core/testing/TestBed#inject) | v9                    | Same behavior, but type safe.                 |
 | [`async`](api/core/testing/async)                                                                        | [`waitForAsync`](api/core/testing/waitForAsync)     | v10                   | Same behavior, but rename to avoid confusion. |
+
+<a id="router"></a>
+
+### &commat;angular/router
+
+| API                                        | Replacement                       | Deprecation announced | Details |
+|:---                                        |:---                               |:---                   |:---     |
+| [`resolver` argument in `RouterOutletContract.activateWith`](api/router/RouterOutletContract#activatewith) | No replacement needed | v14                   | Component factories are not required to create an instance of a component dynamically. Passing a factory resolver via `resolver` argument is no longer needed. |
+| [`resolver` field of the `OutletContext` class](api/router/OutletContext#resolver) | No replacement needed | v14                   | Component factories are not required to create an instance of a component dynamically. Passing a factory resolver via `resolver` class field is no longer needed. |
+
 
 <a id="platform-browser-dynamic"></a>
 

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -357,6 +357,8 @@ export class OutletContext {
     // (undocumented)
     children: ChildrenOutletContexts;
     // (undocumented)
+    injector: EnvironmentInjector | null;
+    // (undocumented)
     outlet: RouterOutletContract | null;
     // (undocumented)
     resolver: ComponentFactoryResolver | null;
@@ -645,7 +647,7 @@ export class RouterModule {
 
 // @public
 export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
-    constructor(parentContexts: ChildrenOutletContexts, location: ViewContainerRef, resolver: ComponentFactoryResolver, name: string, changeDetector: ChangeDetectorRef);
+    constructor(parentContexts: ChildrenOutletContexts, location: ViewContainerRef, name: string, changeDetector: ChangeDetectorRef, environmentInjector: EnvironmentInjector);
     // (undocumented)
     get activatedRoute(): ActivatedRoute;
     // (undocumented)
@@ -653,7 +655,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     // (undocumented)
     activateEvents: EventEmitter<any>;
     // (undocumented)
-    activateWith(activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver | null): void;
+    activateWith(activatedRoute: ActivatedRoute, resolverOrInjector?: ComponentFactoryResolver | EnvironmentInjector | null): void;
     attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute): void;
     attachEvents: EventEmitter<unknown>;
     // (undocumented)
@@ -673,7 +675,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<RouterOutlet, "router-outlet", ["outlet"], {}, { "activateEvents": "activate"; "deactivateEvents": "deactivate"; "attachEvents": "attach"; "detachEvents": "detach"; }, never, never, false>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<RouterOutlet, [null, null, null, { attribute: "name"; }, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<RouterOutlet, [null, null, { attribute: "name"; }, null, null]>;
 }
 
 // @public
@@ -681,6 +683,7 @@ export interface RouterOutletContract {
     activatedRoute: ActivatedRoute | null;
     activatedRouteData: Data;
     activateEvents?: EventEmitter<unknown>;
+    activateWith(activatedRoute: ActivatedRoute, environmnetInjector: EnvironmentInjector | null): void;
     activateWith(activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver | null): void;
     attach(ref: ComponentRef<unknown>, activatedRoute: ActivatedRoute): void;
     attachEvents?: EventEmitter<unknown>;

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -360,7 +360,7 @@ export class OutletContext {
     injector: EnvironmentInjector | null;
     // (undocumented)
     outlet: RouterOutletContract | null;
-    // (undocumented)
+    // @deprecated (undocumented)
     resolver: ComponentFactoryResolver | null;
     // (undocumented)
     route: ActivatedRoute | null;
@@ -684,6 +684,7 @@ export interface RouterOutletContract {
     activatedRouteData: Data;
     activateEvents?: EventEmitter<unknown>;
     activateWith(activatedRoute: ActivatedRoute, environmnetInjector: EnvironmentInjector | null): void;
+    // @deprecated
     activateWith(activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver | null): void;
     attach(ref: ComponentRef<unknown>, activatedRoute: ActivatedRoute): void;
     attachEvents?: EventEmitter<unknown>;

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -53,6 +53,9 @@ export interface RouterOutletContract {
   activateWith(activatedRoute: ActivatedRoute, environmnetInjector: EnvironmentInjector|null): void;
   /**
    * Called by the `Router` when the outlet should activate (create a component).
+   *
+   * @deprecated Passing a resolver to retrieve a component factory is not required and is
+   *     deprecated since v14.
    */
   activateWith(activatedRoute: ActivatedRoute, resolver: ComponentFactoryResolver|null): void;
 

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -198,10 +198,11 @@ export class ActivateRoutes {
           context.attachRef = null;
           context.route = future;
           context.resolver = cmpFactoryResolver;
+          context.injector = injector;
           if (context.outlet) {
             // Activate the outlet when it has already been instantiated
             // Otherwise it will get activated from its `ngOnInit` when instantiated
-            context.outlet.activateWith(future, cmpFactoryResolver);
+            context.outlet.activateWith(future, context.injector);
           }
 
           this.activateChildRoutes(futureNode, null, context.children);

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -20,6 +20,10 @@ import {ActivatedRoute} from './router_state';
 export class OutletContext {
   outlet: RouterOutletContract|null = null;
   route: ActivatedRoute|null = null;
+  /**
+   * @deprecated Passing a resolver to retrieve a component factory is not required and is
+   *     deprecated since v14.
+   */
   resolver: ComponentFactoryResolver|null = null;
   injector: EnvironmentInjector|null = null;
   children = new ChildrenOutletContexts();

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -21,6 +21,7 @@ export class OutletContext {
   outlet: RouterOutletContract|null = null;
   route: ActivatedRoute|null = null;
   resolver: ComponentFactoryResolver|null = null;
+  injector: EnvironmentInjector|null = null;
   children = new ChildrenOutletContexts();
   attachRef: ComponentRef<any>|null = null;
 }


### PR DESCRIPTION
DEPRECATED:

The `resolver` argument of the `RouterOutletContract.activateWith` function and the `resolver` field of the `OutletContext` class are deprecated. Passing component factory resolvers are no longer needed. The `ComponentFactoryResolver`-related symbols were deprecated in `@angular/core` package since v13.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: deprecation of no longer relevant APIs.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No