### PR TITLE
docs: fix `schematicCollections` option

### DIFF
--- a/aio/content/guide/workspace-config.md
+++ b/aio/content/guide/workspace-config.md
@@ -58,7 +58,7 @@ The following configuration properties are a set of options that customize the A
 | `analytics`           | Share anonymous [usage data](cli/usage-analytics-gathering) with the Angular Team.            | `boolean` &verbar; `ci`                                 |
 | `analyticsSharing`    | A set of analytics sharing options.                                                           | [Analytics sharing options](#analytics-sharing-options) |
 | `cache`               | Control [persistent disk cache](cli/cache) used by [Angular CLI Builders](guide/cli-builder). | [Cache options](#cache-options)                         |
-| `schematicCollection` | A list of default schematics collection to use.                                               | `string`                                                |
+| `schematicCollections`| A list of default schematics collections to use.                                              | `string[]`                                              |
 | `packageManager`      | The preferred package manager tool to use.                                                    | `npm` &verbar; `cnpm` &verbar; `pnpm` &verbar;`yarn`    |
 | `warnings`            | Control CLI specific console warnings.                                                        | [Warnings options](#warnings-options)                   |
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The newly added `schematicCollections` configuration property in the Angular CLI (for v14) was [recently changed](https://github.com/angular/angular/pull/45325/files#diff-7a7f93b1816aebf99d12619000e3a1459c91771057c687ce51fa94a984018d95R61) in the docs to describe a `string` property while in the source code that property actually has a `string[]` type.

Issue Number: N/A

## What is the new behavior?
The `schematicCollections` configuration property is correctly documented.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
