### PR TITLE
docs: fix final code review section codetabs path

### DIFF
--- a/aio/content/tutorial/toh-pt6.md
+++ b/aio/content/tutorial/toh-pt6.md
@@ -482,9 +482,9 @@ Here are the code files discussed on this page \(all in the `src/app/` folder\).
 ### `HeroService`, `InMemoryDataService`, `AppModule`
 
 <code-tabs>
-    <code-pane header="hero-search/hero-search.component.html" path="toh-pt6/src/app/hero-search/hero-search.component.html"></code-pane>
+    <code-pane header="hero.service.ts" path="toh-pt6/src/app/hero.service.ts"></code-pane>
     <code-pane header="in-memory-data.service.ts" path="toh-pt6/src/app/in-memory-data.service.ts"></code-pane>
-    <code-pane header="hero-search/hero-search.component.html" path="toh-pt6/src/app/hero-search/hero-search.component.html"></code-pane>
+    <code-pane header="app.module.ts" path="toh-pt6/src/app/app.module.ts"></code-pane>
 </code-tabs>
 
 <a id="heroescomponent"></a>
@@ -492,9 +492,9 @@ Here are the code files discussed on this page \(all in the `src/app/` folder\).
 ### `HeroesComponent`
 
 <code-tabs>
-    <code-pane header="hero-search/hero-search.component.html" path="toh-pt6/src/app/hero-search/hero-search.component.html"></code-pane>
+    <code-pane header="heroes/heroes.component.html" path="toh-pt6/src/app/hero-search/heroes.component.html"></code-pane>
     <code-pane header="heroes/heroes.component.ts" path="toh-pt6/src/app/heroes/heroes.component.ts"></code-pane>
-    <code-pane header="hero-search/hero-search.component.html" path="toh-pt6/src/app/hero-search/hero-search.component.html"></code-pane>
+    <code-pane header="heroes/heroes.component.css" path="toh-pt6/src/app/heroes/heroes.component.css"></code-pane>
 </code-tabs>
 
 <a id="herodetailcomponent"></a>
@@ -502,8 +502,9 @@ Here are the code files discussed on this page \(all in the `src/app/` folder\).
 ### `HeroDetailComponent`
 
 <code-tabs>
-    <code-pane header="hero-search/hero-search.component.html" path="toh-pt6/src/app/hero-search/hero-search.component.html"></code-pane>
+    <code-pane header="hero-detail/hero-detail.component.html" path="toh-pt6/src/app/hero-detail/hero-detail.component.html"></code-pane>
     <code-pane header="hero-detail/hero-detail.component.ts" path="toh-pt6/src/app/hero-detail/hero-detail.component.ts"></code-pane>
+    <code-pane header="hero-detail/hero-detail.component.css" path="toh-pt6/src/app/hero-detail/hero-detail.component.css"></code-pane>
 </code-tabs>
 
 <a id="dashboardcomponent"></a>
@@ -511,7 +512,9 @@ Here are the code files discussed on this page \(all in the `src/app/` folder\).
 ### `DashboardComponent`
 
 <code-tabs>
-    <code-pane header="hero-search/hero-search.component.html" path="toh-pt6/src/app/hero-search/hero-search.component.html"></code-pane>
+    <code-pane header="dashboard/dashboard.component.html" path="toh-pt6/src/app/dashboard/dashboard.component.html"></code-pane>
+    <code-pane header="dashboard/dashboard.component.ts" path="toh-pt6/src/app/dashboard/dashboard.component.ts"></code-pane>
+    <code-pane header="dashboard/dashboard.component.css" path="toh-pt6/src/app/dashboard/dashboard.component.css"></code-pane>
 </code-tabs>
 
 <a id="herosearchcomponent"></a>
@@ -521,7 +524,7 @@ Here are the code files discussed on this page \(all in the `src/app/` folder\).
 <code-tabs>
     <code-pane header="hero-search/hero-search.component.html" path="toh-pt6/src/app/hero-search/hero-search.component.html"></code-pane>
     <code-pane header="hero-search/hero-search.component.ts" path="toh-pt6/src/app/hero-search/hero-search.component.ts"></code-pane>
-    <code-pane header="hero-search/hero-search.component.html" path="toh-pt6/src/app/hero-search/hero-search.component.html"></code-pane>
+    <code-pane header="hero-search/hero-search.component.css" path="toh-pt6/src/app/hero-search/hero-search.component.css"></code-pane>
 </code-tabs>
 
 ## Summary

--- a/aio/content/tutorial/toh-pt6.md
+++ b/aio/content/tutorial/toh-pt6.md
@@ -492,7 +492,7 @@ Here are the code files discussed on this page \(all in the `src/app/` folder\).
 ### `HeroesComponent`
 
 <code-tabs>
-    <code-pane header="heroes/heroes.component.html" path="toh-pt6/src/app/hero-search/heroes.component.html"></code-pane>
+    <code-pane header="heroes/heroes.component.html" path="toh-pt6/src/app/heroes/heroes.component.html"></code-pane>
     <code-pane header="heroes/heroes.component.ts" path="toh-pt6/src/app/heroes/heroes.component.ts"></code-pane>
     <code-pane header="heroes/heroes.component.css" path="toh-pt6/src/app/heroes/heroes.component.css"></code-pane>
 </code-tabs>


### PR DESCRIPTION
Fix paths for codetabs in final review section messed up by this commit https://github.com/angular/angular/commit/42289f25c69ec7a36d2e3ef424d32f77bc7cd19a
They were all pointing to `heroes-search.component`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
