### PR TITLE
build: only allow renovate to run on Monday nights

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,14 +3,14 @@
   "semanticCommits": true,
   "semanticPrefix": "build",
   "separateMajorMinor": false,
-  "prHourlyLimit": 2,
+  "prHourlyLimit": 1,
   "stopUpdatingLabel": "action: merge",
   "labels": ["target: patch", "comp: build & ci", "action: review"],
   "timezone": "America/Tijuana",
   "lockFileMaintenance": {
     "enabled": true
   },
-  "schedule": ["after 10pm every weekday", "before 4am every weekday", "every weekend"],
+  "schedule": ["after 10pm every monday", "before 4am every tuesday"],
   "baseBranches": ["master"],
   "ignoreDeps": [
     "@angular/animations-12",


### PR DESCRIPTION
By running renovate once a week, we can consolidate all the updates into a single weekly PR, and merge them Tuesday before each Wednesday release. That will significantly reduce the burden on caretakers, and make patch ports less onerous.