### PR TITLE
refactor(router): combine functions for getting loaded config

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1143,6 +1143,9 @@
     "name": "getChildRouteGuards"
   },
   {
+    "name": "getClosestLoadedConfig"
+  },
+  {
     "name": "getClosureSafeProperty"
   },
   {

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -16,6 +16,7 @@ import {NavigationTransition} from '../router';
 import {ChildrenOutletContexts} from '../router_outlet_context';
 import {ActivatedRoute, ActivatedRouteSnapshot, advanceActivatedRoute, RouterState} from '../router_state';
 import {forEach} from '../utils/collection';
+import {getClosestLoadedConfig} from '../utils/config';
 import {nodeChildrenAsMap, TreeNode} from '../utils/tree';
 
 export const activateRoutes =
@@ -192,7 +193,7 @@ export class ActivateRoutes {
           advanceActivatedRoute(stored.route.value);
           this.activateChildRoutes(futureNode, null, context.children);
         } else {
-          const config = parentLoadedConfig(future.snapshot);
+          const config = getClosestLoadedConfig(future.snapshot);
           const cmpFactoryResolver = config ? config.module.componentFactoryResolver : null;
 
           context.attachRef = null;
@@ -212,14 +213,4 @@ export class ActivateRoutes {
       }
     }
   }
-}
-
-function parentLoadedConfig(snapshot: ActivatedRouteSnapshot): LoadedRouterConfig|null {
-  for (let s = snapshot.parent; s; s = s.parent) {
-    const route = s.routeConfig;
-    if (route && route._loadedConfig) return route._loadedConfig;
-    if (route && route.component) return null;
-  }
-
-  return null;
 }

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -7,7 +7,8 @@
  */
 
 import {EmptyOutletComponent} from '../components/empty_outlet';
-import {Route, Routes} from '../models';
+import {LoadedRouterConfig, Route, Routes} from '../models';
+import {ActivatedRouteSnapshot} from '../router_state';
 import {PRIMARY_OUTLET} from '../shared';
 
 export function validateConfig(config: Routes, parentPath: string = ''): void {
@@ -132,4 +133,23 @@ export function sortByMatchingOutlets(routes: Routes, outletName: string): Route
   const sortedConfig = routes.filter(r => getOutlet(r) === outletName);
   sortedConfig.push(...routes.filter(r => getOutlet(r) !== outletName));
   return sortedConfig;
+}
+
+/**
+ * Gets the first loaded config in the snapshot's parent tree.
+ *
+ * Returns `null` if there is no parent lazy loaded config.
+ *
+ * Generally used for retrieving the injector to use for getting tokens for guards/resolvers and
+ * also used for getting the correct injector to use for creating components.
+ */
+export function getClosestLoadedConfig(snapshot: ActivatedRouteSnapshot): LoadedRouterConfig|null {
+  if (!snapshot) return null;
+
+  for (let s = snapshot.parent; s; s = s.parent) {
+    const route = s.routeConfig;
+    if (route && route._loadedConfig) return route._loadedConfig;
+  }
+
+  return null;
 }

--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -8,11 +8,12 @@
 
 import {Injector} from '@angular/core';
 
-import {LoadedRouterConfig, RunGuardsAndResolvers} from '../models';
+import {RunGuardsAndResolvers} from '../models';
 import {ChildrenOutletContexts, OutletContext} from '../router_outlet_context';
 import {ActivatedRouteSnapshot, equalParamsAndUrlSegments, RouterStateSnapshot} from '../router_state';
 import {equalPath} from '../url_tree';
 import {forEach, shallowEqual} from '../utils/collection';
+import {getClosestLoadedConfig} from '../utils/config';
 import {nodeChildrenAsMap, TreeNode} from '../utils/tree';
 
 export class CanActivate {
@@ -52,17 +53,6 @@ export function getToken(
   const config = getClosestLoadedConfig(snapshot);
   const injector = config ? config.module.injector : moduleInjector;
   return injector.get(token);
-}
-
-function getClosestLoadedConfig(snapshot: ActivatedRouteSnapshot): LoadedRouterConfig|null {
-  if (!snapshot) return null;
-
-  for (let s = snapshot.parent; s; s = s.parent) {
-    const route = s.routeConfig;
-    if (route && route._loadedConfig) return route._loadedConfig;
-  }
-
-  return null;
 }
 
 function getChildRouteGuards(


### PR DESCRIPTION
There are two functions which do the same thing and are meant to search
for the closest loaded config in the `ActivatedRouteSnapshot` parent
tree. These can be combined to reduce code duplication.

One difference in the current implementation is the early exit for the
implementation in `activate_routes` when `route.component` is defined.
This early exit takes advantage of the fact that the component must then
also have a `RouterOutlet`, which injects `ComponentFactoryResolver`,
which would end up being the same one as what would be found if we
continued to look up the parent tree. This is only a tiny optimization
that will actually break when we add `providers` as a feature to the
`Route` config. In this scenario, we _must_ find the correct injector
in the parent routes and cannot rely on a parent `RouterOutlet` since
there may be some route with a providers list in between.
