### PR TITLE
perf(router): cancel the navigation instantly if at least one resolver doesn't emit any value

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -291,6 +291,9 @@
     "name": "MapSubscriber"
   },
   {
+    "name": "MapToSubscriber"
+  },
+  {
     "name": "MergeMapOperator"
   },
   {
@@ -1170,9 +1173,6 @@
     "name": "getData"
   },
   {
-    "name": "getDataKeys"
-  },
-  {
     "name": "getDeclarationTNode"
   },
   {
@@ -1720,6 +1720,9 @@
   },
   {
     "name": "resetPreOrderHookFlags"
+  },
+  {
+    "name": "resolveData"
   },
   {
     "name": "resolveForwardRef"

--- a/packages/router/test/operators/resolve_data.spec.ts
+++ b/packages/router/test/operators/resolve_data.spec.ts
@@ -8,7 +8,7 @@
 
 import {Injector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {EMPTY, interval, of} from 'rxjs';
+import {EMPTY, interval, NEVER, of} from 'rxjs';
 import {TestScheduler} from 'rxjs/testing';
 
 import {resolveData} from '../../src/operators/resolve_data';
@@ -24,6 +24,7 @@ describe('resolveData operator', () => {
         {provide: 'resolveFour', useValue: (a: any, b: any) => 4},
         {provide: 'resolveEmpty', useValue: (a: any, b: any) => EMPTY},
         {provide: 'resolveInterval', useValue: (a: any, b: any) => interval()},
+        {provide: 'resolveNever', useValue: (a: any, b: any) => NEVER},
       ]
     });
   });
@@ -89,6 +90,15 @@ describe('resolveData operator', () => {
   it('should not emit if at least one resolver doesn\'t emit', () => {
     testScheduler.run(({hot, cold, expectObservable}) => {
       const transition: any = createTransition({e1: 'resolveTwo'}, {e2: 'resolveEmpty'});
+      const source = cold('-(t|)', {t: deepClone(transition)});
+      const expected = '-|';
+      expectObservable(source.pipe(resolveData('emptyOnly', injector))).toBe(expected);
+    });
+  });
+
+  it('should complete instantly if at least one resolver doesn\'t emit', () => {
+    testScheduler.run(({cold, expectObservable}) => {
+      const transition: any = createTransition({e1: 'resolveEmpty', e2: 'resolveNever'});
       const source = cold('-(t|)', {t: deepClone(transition)});
       const expected = '-|';
       expectObservable(source.pipe(resolveData('emptyOnly', injector))).toBe(expected);


### PR DESCRIPTION
Recently the navigation was on hold even at least one resolver didn't emit any value and completed, but another ones still are in progress to resolve any value. The changes cancel the navigation instantly if at least one resolver doesn't emit any value and completed.
