### PR TITLE
fix(router): Remove unused string type for ActivatedRoute.component

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -33,7 +33,7 @@ import { ViewContainerRef } from '@angular/core';
 // @public
 export class ActivatedRoute {
     get children(): ActivatedRoute[];
-    component: Type<any> | string | null;
+    component: Type<any> | null;
     data: Observable<Data>;
     get firstChild(): ActivatedRoute | null;
     fragment: Observable<string | null>;
@@ -55,7 +55,7 @@ export class ActivatedRoute {
 // @public
 export class ActivatedRouteSnapshot {
     get children(): ActivatedRouteSnapshot[];
-    component: Type<any> | string | null;
+    component: Type<any> | null;
     data: Data;
     get firstChild(): ActivatedRouteSnapshot | null;
     fragment: string | null;

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -136,8 +136,7 @@ export class ActivatedRoute {
       /** The outlet name of the route, a constant. */
       public outlet: string,
       /** The component of the route, a constant. */
-      // TODO(vsavkin): remove |string
-      public component: Type<any>|string|null, futureSnapshot: ActivatedRouteSnapshot) {
+      public component: Type<any>|null, futureSnapshot: ActivatedRouteSnapshot) {
     this._futureSnapshot = futureSnapshot;
   }
 
@@ -339,7 +338,7 @@ export class ActivatedRouteSnapshot {
       /** The outlet name of the route */
       public outlet: string,
       /** The component of the route */
-      public component: Type<any>|string|null, routeConfig: Route|null, urlSegment: UrlSegmentGroup,
+      public component: Type<any>|null, routeConfig: Route|null, urlSegment: UrlSegmentGroup,
       lastPathIndex: number, resolve: ResolveData, correctedLastPathIndex?: number) {
     this.routeConfig = routeConfig;
     this._urlSegment = urlSegment;


### PR DESCRIPTION
The type of `component` on `ActivatedRoute` and `ActivatedRouteSnapshot`
includes `string`. In reality, this is not the case. The component
cannot be anything other than a component class.

Reviewers note: It's unlikely that this is actually a breaking change but I will run TGP to confirm.