### PR TITLE
Introducing EnvInjector!

### DIFF
--- a/aio/tests/e2e/src/api-pages.e2e-spec.ts
+++ b/aio/tests/e2e/src/api-pages.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { ApiPage } from './api.po';
+import {ApiPage} from './api.po';
 
 describe('Api pages', () => {
   let page: ApiPage;
@@ -13,16 +13,8 @@ describe('Api pages', () => {
   it('should show direct and indirect subclasses of a class', async () => {
     await page.navigateTo('api/forms/AbstractControlDirective');
     expect(await page.getDescendants('class')).toEqual([
-      'ControlContainer',
-      'AbstractFormGroupDirective',
-      'NgModelGroup',
-      'FormGroupName',
-      'NgForm',
-      'FormGroupDirective',
-      'FormArrayName',
-      'NgControl',
-      'NgModel',
-      'FormControlDirective',
+      'ControlContainer', 'AbstractFormGroupDirective', 'NgModelGroup', 'FormGroupName', 'NgForm',
+      'FormGroupDirective', 'FormArrayName', 'NgControl', 'NgModel', 'FormControlDirective',
       'FormControlName'
     ]);
   });
@@ -34,7 +26,9 @@ describe('Api pages', () => {
 
   it('should show classes that implement an interface', async () => {
     await page.navigateTo('api/animations/AnimationPlayer');
-    expect(await page.getDescendants('class')).toEqual(['NoopAnimationPlayer', 'MockAnimationPlayer']);
+    expect(await page.getDescendants('class')).toEqual([
+      'NoopAnimationPlayer', 'MockAnimationPlayer'
+    ]);
   });
 
   it('should show type params of type-aliases', async () => {
@@ -44,12 +38,13 @@ describe('Api pages', () => {
 
   it('should not show parenthesis for getters', async () => {
     await page.navigateTo('api/core/NgModuleRef');
-    expect(await page.getOverview('class').getText()).toContain('injector: Injector');
+    expect(await page.getOverview('class').getText()).toContain('injector: EnvironmentInjector');
   });
 
   it('should show both type and initializer if set', async () => {
     await page.navigateTo('api/common/HashLocationStrategy');
-    expect(await page.getOverview('class').getText()).toContain('path(includeHash: boolean = false): string');
+    expect(await page.getOverview('class').getText())
+        .toContain('path(includeHash: boolean = false): string');
   });
 
   it('should show a "Properties" section if there are public properties', async () => {
@@ -71,9 +66,11 @@ describe('Api pages', () => {
     await page.navigateTo('api/core/EventEmitter');
     /* eslint-disable max-len */
     expect(await page.ghLinks.get(0).getAttribute('href'))
-      .toMatch(/https:\/\/github\.com\/angular\/angular\/edit\/master\/packages\/core\/src\/event_emitter\.ts\?message=docs\(core\)%3A%20describe%20your%20change\.\.\.#L\d+-L\d+/);
+        .toMatch(
+            /https:\/\/github\.com\/angular\/angular\/edit\/master\/packages\/core\/src\/event_emitter\.ts\?message=docs\(core\)%3A%20describe%20your%20change\.\.\.#L\d+-L\d+/);
     expect(await page.ghLinks.get(1).getAttribute('href'))
-      .toMatch(/https:\/\/github\.com\/angular\/angular\/tree\/[^/]+\/packages\/core\/src\/event_emitter\.ts#L\d+-L\d+/);
+        .toMatch(
+            /https:\/\/github\.com\/angular\/angular\/tree\/[^/]+\/packages\/core\/src\/event_emitter\.ts#L\d+-L\d+/);
     /* eslint-enable max-len */
   });
 

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1430,7 +1430,7 @@ export abstract class ViewRef extends ChangeDetectorRef {
 // @public
 export function ɵɵdefineInjectable<T>(opts: {
     token: unknown;
-    providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
+    providedIn?: Type<any> | 'root' | 'platform' | 'any' | 'env' | null;
     factory: () => T;
 }): unknown;
 

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -200,7 +200,7 @@ export interface ComponentDecorator {
 // @public @deprecated
 export abstract class ComponentFactory<C> {
     abstract get componentType(): Type<any>;
-    abstract create(injector: Injector, projectableNodes?: any[][], rootSelectorOrNode?: string | any, ngModule?: NgModuleRef<any>): ComponentRef<C>;
+    abstract create(injector: Injector, projectableNodes?: any[][], rootSelectorOrNode?: string | any, environmentInjector?: EnvironmentInjector | NgModuleRef<any>): ComponentRef<C>;
     abstract get inputs(): {
         propName: string;
         templateName: string;
@@ -282,6 +282,9 @@ export interface ContentChildrenDecorator {
         read?: any;
     }): Query;
 }
+
+// @public
+export function createEnvironmentInjector(providers: Provider[], parent?: EnvironmentInjector | null, debugName?: string | null): EnvironmentInjector;
 
 // @public
 export function createNgModuleRef<T>(ngModule: Type<T>, parentInjector?: Injector): NgModuleRef<T>;
@@ -437,6 +440,15 @@ export abstract class EmbeddedViewRef<C> extends ViewRef {
 
 // @public
 export function enableProdMode(): void;
+
+// @public
+export abstract class EnvironmentInjector implements Injector {
+    // (undocumented)
+    abstract destroy(): void;
+    abstract get<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
+    // @deprecated (undocumented)
+    abstract get(token: any, notFoundValue?: any): any;
+}
 
 // @public
 export class ErrorHandler {
@@ -652,6 +664,9 @@ export abstract class Injector {
 }
 
 // @public
+export const INJECTOR_INITIALIZER: InjectionToken<() => void>;
+
+// @public
 export interface InjectorType<T> extends Type<T> {
     // (undocumented)
     ɵfac?: unknown;
@@ -837,7 +852,7 @@ export abstract class NgModuleRef<T> {
     // @deprecated
     abstract get componentFactoryResolver(): ComponentFactoryResolver;
     abstract destroy(): void;
-    abstract get injector(): Injector;
+    abstract get injector(): EnvironmentInjector;
     abstract get instance(): T;
     abstract onDestroy(callback: () => void): void;
 }
@@ -1375,10 +1390,11 @@ export abstract class ViewContainerRef {
         index?: number;
         injector?: Injector;
         ngModuleRef?: NgModuleRef<unknown>;
+        environmentInjector?: EnvironmentInjector | NgModuleRef<unknown>;
         projectableNodes?: Node[][];
     }): ComponentRef<C>;
     // @deprecated
-    abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], ngModuleRef?: NgModuleRef<any>): ComponentRef<C>;
+    abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], environmentInjector?: EnvironmentInjector | NgModuleRef<any>): ComponentRef<C>;
     abstract createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, options?: {
         index?: number;
         injector?: Injector;

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,7 +15,7 @@
     "master": {
       "uncompressed": {
         "runtime": 4343,
-        "main": 452249,
+        "main": 452837,
         "polyfills": 33980,
         "styles": 71714,
         "light-theme": 78213,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -3,7 +3,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1083,
-        "main": 125129,
+        "main": 125851,
         "polyfills": 33824
       }
     }
@@ -33,7 +33,7 @@
     "master": {
       "uncompressed": {
         "runtime": 929,
-        "main": 124544,
+        "main": 125387,
         "polyfills": 34530
       }
     }
@@ -42,7 +42,7 @@
     "master": {
       "uncompressed": {
         "runtime": 2835,
-        "main": 233375,
+        "main": 234131,
         "polyfills": 33842,
         "src_app_lazy_lazy_module_ts": 795
       }
@@ -52,7 +52,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1063,
-        "main": 157357,
+        "main": 158031,
         "polyfills": 33804
       }
     }
@@ -61,7 +61,7 @@
     "master": {
       "uncompressed": {
         "runtime": 1070,
-        "main": 156290,
+        "main": 156852,
         "polyfills": 33814
       }
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -79,6 +79,11 @@ export class DirectiveDecoratorHandler implements
     // been processed, but we want to enforce a consistent decorator mental model.
     // See: https://v9.angular.io/guide/migration-undecorated-classes.
     if (this.compileUndecoratedClassesWithAngularFeatures === false && decorator === null) {
+      // If compiling @angular/core, skip the diagnostic as core occasionally hand-writes
+      // definitions.
+      if (this.isCore) {
+        return {};
+      }
       return {diagnostics: [getUndecoratedClassWithAngularFeaturesDiagnostic(node)]};
     }
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -36,7 +36,7 @@ export * from './core_private_export';
 export * from './core_render3_private_export';
 export {SecurityContext} from './sanitization/security';
 export {Sanitizer} from './sanitization/sanitizer';
-export {createNgModuleRef} from './render3/ng_module_ref';
+export {createNgModuleRef, createEnvironmentInjector} from './render3/ng_module_ref';
 
 import {global} from './util/global';
 if (typeof ngDevMode !== 'undefined' && ngDevMode) {

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -18,6 +18,7 @@ export {ɵɵdefineInjectable, defineInjectable, ɵɵdefineInjector, InjectableTy
 export {forwardRef, resolveForwardRef, ForwardRefFn} from './forward_ref';
 export {Injectable, InjectableDecorator, InjectableProvider} from './injectable';
 export {Injector} from './injector';
+export {EnvironmentInjector, INJECTOR_INITIALIZER} from '../di/r3_injector';
 export {ProviderToken} from './provider_token';
 export {ɵɵinject, inject, ɵɵinvalidFactoryDep} from './injector_compatibility';
 export {INJECTOR} from './injector_token';

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -83,6 +83,13 @@ export class InjectionToken<T> {
     }
   }
 
+  /**
+   * @internal
+   */
+  get multi(): InjectionToken<Array<T>> {
+    return this as InjectionToken<Array<T>>;
+  }
+
   toString(): string {
     return `InjectionToken ${this._desc}`;
   }

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -8,6 +8,7 @@
 
 import {Type} from '../../interface/type';
 import {getClosureSafeProperty} from '../../util/property';
+
 import {ClassProvider, ConstructorProvider, ExistingProvider, FactoryProvider, StaticClassProvider, ValueProvider} from './provider';
 
 
@@ -36,7 +37,7 @@ export interface ɵɵInjectableDeclaration<T> {
    * - `null`, does not belong to any injector. Must be explicitly listed in the injector
    *   `providers`.
    */
-  providedIn: InjectorType<any>|'root'|'platform'|'any'|null;
+  providedIn: InjectorType<any>|'root'|'platform'|'any'|'environment'|null;
 
   /**
    * The token to which this definition belongs.
@@ -141,7 +142,7 @@ export interface InjectorTypeWithProviders<T> {
  */
 export function ɵɵdefineInjectable<T>(opts: {
   token: unknown,
-  providedIn?: Type<any>|'root'|'platform'|'any'|null, factory: () => T,
+  providedIn?: Type<any>|'root'|'platform'|'any'|'env'|null, factory: () => T,
 }): unknown {
   return {
     token: opts.token,

--- a/packages/core/src/di/scope.ts
+++ b/packages/core/src/di/scope.ts
@@ -9,9 +9,11 @@
 import {InjectionToken} from './injection_token';
 
 
+export type InjectorScope = 'root'|'platform'|'environment';
+
 /**
  * An internal token whose presence in an injector indicates that the injector should treat itself
  * as a root scoped injector when processing requests for unknown tokens which may indicate
  * they are provided in the root scope.
  */
-export const INJECTOR_SCOPE = new InjectionToken<'root'|'platform'|null>('Set Injector scope.');
+export const INJECTOR_SCOPE = new InjectionToken<InjectorScope|null>('Set Injector scope.');

--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -8,6 +8,7 @@
 
 import {ChangeDetectorRef} from '../change_detection/change_detection';
 import {Injector} from '../di/injector';
+import {EnvironmentInjector} from '../di/r3_injector';
 import {Type} from '../interface/type';
 
 import {ElementRef} from './element_ref';
@@ -105,5 +106,5 @@ export abstract class ComponentFactory<C> {
    */
   abstract create(
       injector: Injector, projectableNodes?: any[][], rootSelectorOrNode?: string|any,
-      ngModule?: NgModuleRef<any>): ComponentRef<C>;
+      environmentInjector?: EnvironmentInjector|NgModuleRef<any>): ComponentRef<C>;
 }

--- a/packages/core/src/linker/ng_module_factory.ts
+++ b/packages/core/src/linker/ng_module_factory.ts
@@ -7,6 +7,7 @@
  */
 
 import {Injector} from '../di/injector';
+import {EnvironmentInjector} from '../di/r3_injector';
 import {Type} from '../interface/type';
 
 import {ComponentFactoryResolver} from './component_factory_resolver';
@@ -22,7 +23,7 @@ export abstract class NgModuleRef<T> {
   /**
    * The injector that contains all of the providers of the `NgModule`.
    */
-  abstract get injector(): Injector;
+  abstract get injector(): EnvironmentInjector;
 
   /**
    * The resolver that can retrieve component factories in a context of this module.

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -10,6 +10,7 @@ import {ChangeDetectorRef as ViewEngine_ChangeDetectorRef} from '../change_detec
 import {Injector} from '../di/injector';
 import {InjectFlags} from '../di/interface/injector';
 import {ProviderToken} from '../di/provider_token';
+import {EnvironmentInjector} from '../di/r3_injector';
 import {Type} from '../interface/type';
 import {ComponentFactory as viewEngine_ComponentFactory, ComponentRef as viewEngine_ComponentRef} from '../linker/component_factory';
 import {ComponentFactoryResolver as viewEngine_ComponentFactoryResolver} from '../linker/component_factory_resolver';
@@ -126,10 +127,16 @@ export class ComponentFactory<T> extends viewEngine_ComponentFactory<T> {
 
   override create(
       injector: Injector, projectableNodes?: any[][]|undefined, rootSelectorOrNode?: any,
-      ngModule?: viewEngine_NgModuleRef<any>|undefined): viewEngine_ComponentRef<T> {
-    ngModule = ngModule || this.ngModule;
+      environmentInjector?: viewEngine_NgModuleRef<any>|EnvironmentInjector|
+      undefined): viewEngine_ComponentRef<T> {
+    environmentInjector = environmentInjector || this.ngModule;
 
-    const rootViewInjector = ngModule ? new ChainedInjector(injector, ngModule.injector) : injector;
+    let realEnvironmentInjector = environmentInjector instanceof EnvironmentInjector ?
+        environmentInjector :
+        environmentInjector?.injector;
+
+    const rootViewInjector =
+        realEnvironmentInjector ? new ChainedInjector(injector, realEnvironmentInjector) : injector;
 
     const rendererFactory =
         rootViewInjector.get(RendererFactory2, domRendererFactory3 as RendererFactory2) as

--- a/packages/core/src/render3/errors_di.ts
+++ b/packages/core/src/render3/errors_di.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Type} from '../core';
 import {InjectorType} from '../di/interface/defs';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {stringify} from '../util/stringify';
@@ -26,7 +27,7 @@ export function throwMixedMultiProviderError() {
 }
 
 export function throwInvalidProviderError(
-    ngModuleType?: InjectorType<any>, providers?: any[], provider?: any) {
+    ngModuleType?: Type<unknown>, providers?: any[], provider?: any) {
   let ngModuleDetail = '';
   if (ngModuleType && providers) {
     const providerDetail = providers.map(v => v == provider ? '?' + provider + '?' : '...');

--- a/packages/core/src/render3/errors_di.ts
+++ b/packages/core/src/render3/errors_di.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type} from '../core';
-import {InjectorType} from '../di/interface/defs';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
+import {Type} from '../interface/type';
 import {stringify} from '../util/stringify';
 
 import {stringifyForError} from './util/stringify_utils';

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -138,7 +138,7 @@ export {CssSelectorList, ProjectionSlots} from './interfaces/projection';
 export {
   setClassMetadata,
 } from './metadata';
-export {NgModuleFactory, NgModuleRef} from './ng_module_ref';
+export {NgModuleFactory, NgModuleRef, createEnvironmentInjector} from './ng_module_ref';
 export {
   ɵɵpipe,
   ɵɵpipeBind1,

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -71,7 +71,7 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
     // We need to resolve the injector types separately from the injector creation, because
     // the module might be trying to use this ref in its constructor for DI which will cause a
     // circular error that will eventually error out, because the injector isn't created yet.
-    this._r3Injector._resolveInjectorDefTypes();
+    this._r3Injector.resolveInjectorInitializers();
     this.instance = this.get(ngModuleType);
   }
 

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -68,7 +68,7 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
                                useValue: this.componentFactoryResolver
                              }
                            ],
-                           stringify(ngModuleType)) as R3Injector;
+                           stringify(ngModuleType), new Set(['environment'])) as R3Injector;
 
     // We need to resolve the injector types separately from the injector creation, because
     // the module might be trying to use this ref in its constructor for DI which will cause a
@@ -122,7 +122,7 @@ class EnvironmentNgModuleRefAdapter extends viewEngine_NgModuleRef<null> {
           {provide: viewEngine_NgModuleRef, useValue: this},
           {provide: viewEngine_ComponentFactoryResolver, useValue: this.componentFactoryResolver},
         ],
-        parent || getNullInjector(), source);
+        parent || getNullInjector(), source, new Set(['environment']));
     this.injector = injector;
     injector.resolveInjectorInitializers();
   }

--- a/packages/core/test/acceptance/environment_injector_spec.ts
+++ b/packages/core/test/acceptance/environment_injector_spec.ts
@@ -1,0 +1,108 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ComponentFactoryResolver, createEnvironmentInjector, EnvironmentInjector, InjectionToken, INJECTOR, Injector, INJECTOR_INITIALIZER, NgModuleRef} from '@angular/core';
+import {R3Injector} from '@angular/core/src/di/r3_injector';
+
+describe('environment injector', () => {
+  it('should create and destroy an environment injector', () => {
+    class Service {}
+
+    let destroyed = false;
+    const envInjector = createEnvironmentInjector([Service]) as R3Injector;
+    envInjector.onDestroy(() => destroyed = true);
+
+    const service = envInjector.get(Service);
+    expect(service).toBeInstanceOf(Service);
+
+    envInjector.destroy();
+    expect(destroyed).toBeTrue();
+  });
+
+  it('should see providers from a parent EnvInjector', () => {
+    class Service {}
+
+    const envInjector = createEnvironmentInjector([], createEnvironmentInjector([Service]));
+    expect(envInjector.get(Service)).toBeInstanceOf(Service);
+  });
+
+  it('should shadow providers from the parent EnvInjector', () => {
+    const token = new InjectionToken('token');
+
+    const envInjector = createEnvironmentInjector(
+        [{provide: token, useValue: 'child'}],
+        createEnvironmentInjector([{provide: token, useValue: 'parent'}]));
+    expect(envInjector.get(token)).toBe('child');
+  });
+
+  it('should expose the Injector token', () => {
+    const envInjector = createEnvironmentInjector([]);
+    expect(envInjector.get(Injector)).toBe(envInjector);
+    expect(envInjector.get(INJECTOR)).toBe(envInjector);
+  });
+
+  it('should expose the EnvInjector token', () => {
+    const envInjector = createEnvironmentInjector([]);
+    expect(envInjector.get(EnvironmentInjector)).toBe(envInjector);
+  });
+
+  it('should expose the same object as both the Injector and EnvInjector token', () => {
+    const envInjector = createEnvironmentInjector([]);
+    expect(envInjector.get(Injector)).toBe(envInjector.get(EnvironmentInjector));
+  });
+
+  it('should expose the NgModuleRef token', () => {
+    class Service {}
+    const envInjector = createEnvironmentInjector([Service]);
+
+    const ngModuleRef = envInjector.get(NgModuleRef);
+
+    expect(ngModuleRef).toBeInstanceOf(NgModuleRef);
+    // NgModuleRef proxies to an Injector holding supplied providers
+    expect(ngModuleRef.injector.get(Service)).toBeInstanceOf(Service);
+    // There is no actual instance of @NgModule-annotated class
+    expect(ngModuleRef.instance).toBeNull();
+  });
+
+  it('should expose the ComponentFactoryResolver token bound to env injector with specified providers',
+     () => {
+       class Service {}
+
+       @Component({selector: 'test-cmp'})
+       class TestComponent {
+         constructor(readonly service: Service) {}
+       }
+
+       const envInjector = createEnvironmentInjector([Service]);
+       const cfr = envInjector.get(ComponentFactoryResolver);
+       const cf = cfr.resolveComponentFactory(TestComponent);
+       const cRef = cf.create(Injector.NULL);
+
+       expect(cRef.instance.service).toBeInstanceOf(Service);
+     });
+
+  it('should support the INJECTOR_INITIALIZER muli-token', () => {
+    let initialized = false;
+    createEnvironmentInjector([{
+      provide: INJECTOR_INITIALIZER,
+      useValue: () => initialized = true,
+      multi: true,
+    }]);
+
+    expect(initialized).toBeTrue();
+  });
+
+  it('should adopt env-scoped providers', () => {
+    const injector = createEnvironmentInjector([]);
+    const EnvScopedToken = new InjectionToken('env-scoped token', {
+      providedIn: 'env' as any,
+      factory: () => true,
+    });
+    expect(injector.get(EnvScopedToken, false)).toBeTrue();
+  });
+});

--- a/packages/core/test/acceptance/environment_injector_spec.ts
+++ b/packages/core/test/acceptance/environment_injector_spec.ts
@@ -97,10 +97,10 @@ describe('environment injector', () => {
     expect(initialized).toBeTrue();
   });
 
-  it('should adopt env-scoped providers', () => {
+  it('should adopt environment-scoped providers', () => {
     const injector = createEnvironmentInjector([]);
     const EnvScopedToken = new InjectionToken('env-scoped token', {
-      providedIn: 'env' as any,
+      providedIn: 'environment' as any,
       factory: () => true,
     });
     expect(injector.get(EnvScopedToken, false)).toBeTrue();

--- a/packages/core/test/application_module_spec.ts
+++ b/packages/core/test/application_module_spec.ts
@@ -9,12 +9,17 @@
 import {DEFAULT_CURRENCY_CODE, LOCALE_ID} from '@angular/core';
 import {inject} from '@angular/core/testing';
 
-import {getLocaleId} from '../src/render3';
+import {DEFAULT_LOCALE_ID} from '../src/i18n/localization';
+import {getLocaleId, setLocaleId} from '../src/render3';
 import {global} from '../src/util/global';
 import {TestBed} from '../testing';
 
 {
   describe('Application module', () => {
+    beforeEach(() => {
+      setLocaleId(DEFAULT_LOCALE_ID);
+    });
+
     it('should set the default locale to "en-US"', inject([LOCALE_ID], (defaultLocale: string) => {
          expect(defaultLocale).toEqual('en-US');
        }));

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -201,6 +201,9 @@
     "name": "EmulatedEncapsulationDomRenderer2"
   },
   {
+    "name": "EnvironmentInjector"
+  },
+  {
     "name": "ErrorHandler"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -219,6 +219,12 @@
     "name": "INJECTOR2"
   },
   {
+    "name": "INJECTOR_DEF_TYPES"
+  },
+  {
+    "name": "INJECTOR_INITIALIZER"
+  },
+  {
     "name": "INJECTOR_SCOPE"
   },
   {
@@ -774,6 +780,9 @@
     "name": "findAttrIndexInNode"
   },
   {
+    "name": "flatten"
+  },
+  {
     "name": "flattenStyles"
   },
   {
@@ -921,6 +930,9 @@
     "name": "identity"
   },
   {
+    "name": "importProvidersFrom"
+  },
+  {
     "name": "includeViewProviders"
   },
   {
@@ -997,6 +1009,12 @@
   },
   {
     "name": "isElementNode"
+  },
+  {
+    "name": "isExistingProvider"
+  },
+  {
+    "name": "isFactoryProvider"
   },
   {
     "name": "isFunction"
@@ -1347,10 +1365,16 @@
     "name": "urlParsingNode"
   },
   {
+    "name": "validateProvider"
+  },
+  {
     "name": "viewAttachedToChangeDetector"
   },
   {
     "name": "visitDslNode"
+  },
+  {
+    "name": "walkProviderTree"
   },
   {
     "name": "writeDirectClass"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -198,6 +198,12 @@
     "name": "INJECTOR2"
   },
   {
+    "name": "INJECTOR_DEF_TYPES"
+  },
+  {
+    "name": "INJECTOR_INITIALIZER"
+  },
+  {
     "name": "INJECTOR_SCOPE"
   },
   {
@@ -798,6 +804,9 @@
     "name": "findStylingValue"
   },
   {
+    "name": "flatten"
+  },
+  {
     "name": "flattenStyles"
   },
   {
@@ -1008,6 +1017,9 @@
     "name": "identity"
   },
   {
+    "name": "importProvidersFrom"
+  },
+  {
     "name": "includeViewProviders"
   },
   {
@@ -1093,6 +1105,12 @@
   },
   {
     "name": "isEmptyInputValue"
+  },
+  {
+    "name": "isExistingProvider"
+  },
+  {
+    "name": "isFactoryProvider"
   },
   {
     "name": "isFormControlState"
@@ -1512,7 +1530,13 @@
     "name": "urlParsingNode"
   },
   {
+    "name": "validateProvider"
+  },
+  {
     "name": "viewAttachedToChangeDetector"
+  },
+  {
+    "name": "walkProviderTree"
   },
   {
     "name": "wrapListener"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -156,6 +156,9 @@
     "name": "EmulatedEncapsulationDomRenderer2"
   },
   {
+    "name": "EnvironmentInjector"
+  },
+  {
     "name": "ErrorHandler"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -186,6 +186,12 @@
     "name": "INJECTOR2"
   },
   {
+    "name": "INJECTOR_DEF_TYPES"
+  },
+  {
+    "name": "INJECTOR_INITIALIZER"
+  },
+  {
     "name": "INJECTOR_SCOPE"
   },
   {
@@ -771,6 +777,9 @@
     "name": "findStylingValue"
   },
   {
+    "name": "flatten"
+  },
+  {
     "name": "flattenStyles"
   },
   {
@@ -972,6 +981,9 @@
     "name": "identity"
   },
   {
+    "name": "importProvidersFrom"
+  },
+  {
     "name": "includeViewProviders"
   },
   {
@@ -1057,6 +1069,12 @@
   },
   {
     "name": "isDirectiveHost"
+  },
+  {
+    "name": "isExistingProvider"
+  },
+  {
+    "name": "isFactoryProvider"
   },
   {
     "name": "isFormControlState"
@@ -1494,7 +1512,13 @@
     "name": "urlParsingNode"
   },
   {
+    "name": "validateProvider"
+  },
+  {
     "name": "viewAttachedToChangeDetector"
+  },
+  {
+    "name": "walkProviderTree"
   },
   {
     "name": "wrapListener"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -159,6 +159,9 @@
     "name": "EmulatedEncapsulationDomRenderer2"
   },
   {
+    "name": "EnvironmentInjector"
+  },
+  {
     "name": "ErrorHandler"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -6,6 +6,9 @@
     "name": "EMPTY_ARRAY"
   },
   {
+    "name": "EnvironmentInjector"
+  },
+  {
     "name": "INJECTOR2"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -9,6 +9,12 @@
     "name": "INJECTOR2"
   },
   {
+    "name": "INJECTOR_DEF_TYPES"
+  },
+  {
+    "name": "INJECTOR_INITIALIZER"
+  },
+  {
     "name": "INJECTOR_SCOPE"
   },
   {
@@ -72,6 +78,9 @@
     "name": "deepForEach"
   },
   {
+    "name": "flatten"
+  },
+  {
     "name": "forwardRef"
   },
   {
@@ -93,6 +102,12 @@
     "name": "getOwnDefinition"
   },
   {
+    "name": "importProvidersFrom"
+  },
+  {
+    "name": "inject"
+  },
+  {
     "name": "injectArgs"
   },
   {
@@ -103,6 +118,12 @@
   },
   {
     "name": "injectableDefOrInjectorDefFactory"
+  },
+  {
+    "name": "isExistingProvider"
+  },
+  {
+    "name": "isFactoryProvider"
   },
   {
     "name": "isTypeProvider"
@@ -124,6 +145,12 @@
   },
   {
     "name": "stringify"
+  },
+  {
+    "name": "validateProvider"
+  },
+  {
+    "name": "walkProviderTree"
   },
   {
     "name": "ɵɵdefineInjectable"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -228,6 +228,12 @@
     "name": "INJECTOR2"
   },
   {
+    "name": "INJECTOR_DEF_TYPES"
+  },
+  {
+    "name": "INJECTOR_INITIALIZER"
+  },
+  {
     "name": "INJECTOR_SCOPE"
   },
   {
@@ -1341,6 +1347,9 @@
     "name": "identity"
   },
   {
+    "name": "importProvidersFrom"
+  },
+  {
     "name": "includeViewProviders"
   },
   {
@@ -1426,6 +1435,12 @@
   },
   {
     "name": "isDirectiveHost"
+  },
+  {
+    "name": "isExistingProvider"
+  },
+  {
+    "name": "isFactoryProvider"
   },
   {
     "name": "isFunction"
@@ -1914,7 +1929,13 @@
     "name": "urlParsingNode"
   },
   {
+    "name": "validateProvider"
+  },
+  {
     "name": "viewAttachedToChangeDetector"
+  },
+  {
+    "name": "walkProviderTree"
   },
   {
     "name": "wrapIntoObservable"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -192,6 +192,9 @@
     "name": "EmulatedEncapsulationDomRenderer2"
   },
   {
+    "name": "EnvironmentInjector"
+  },
+  {
     "name": "ErrorHandler"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -21,6 +21,9 @@
     "name": "ElementRef"
   },
   {
+    "name": "EnvironmentInjector"
+  },
+  {
     "name": "InjectFlags"
   },
   {

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -189,7 +189,8 @@ class SportsCar extends Car {
   describe('displayName', () => {
     it('should work', () => {
       expect(Injector.create([Engine.PROVIDER, {provide: BrokenEngine, useValue: null}]).toString())
-          .toEqual('R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR]');
+          .toEqual(
+              'R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR, InjectionToken INJECTOR_DEF_TYPES, InjectionToken INJECTOR_INITIALIZER]');
     });
   });
 }

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -190,7 +190,7 @@ class SportsCar extends Car {
     it('should work', () => {
       expect(Injector.create([Engine.PROVIDER, {provide: BrokenEngine, useValue: null}]).toString())
           .toEqual(
-              'R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR, InjectionToken INJECTOR_DEF_TYPES, InjectionToken INJECTOR_INITIALIZER]');
+              'R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR, EnvironmentInjector, InjectionToken INJECTOR_DEF_TYPES, InjectionToken INJECTOR_INITIALIZER]');
     });
   });
 }

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -190,7 +190,7 @@ class SportsCar extends Car {
     it('should work', () => {
       expect(Injector.create([Engine.PROVIDER, {provide: BrokenEngine, useValue: null}]).toString())
           .toEqual(
-              'R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR, EnvironmentInjector, InjectionToken INJECTOR_DEF_TYPES, InjectionToken INJECTOR_INITIALIZER]');
+              'R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR, InjectionToken INJECTOR_DEF_TYPES, InjectionToken INJECTOR_INITIALIZER]');
     });
   });
 }


### PR DESCRIPTION
This PR includes a couple commits which introduce the new `EnvInjector` concept. `EnvInjector` is a generalized version of `NgModuleRef` which represents the "module injector" (now renamed to "environment injector"). It's one of the primitives needed to support upcoming standalone components APIs.