### PR TITLE
fix(docs-infra): fix placement of "Edit source" button on errors and diagnostics pages

### DIFF
--- a/aio/tools/transforms/templates/error/error.template.html
+++ b/aio/tools/transforms/templates/error/error.template.html
@@ -1,28 +1,33 @@
 {% import "lib/githubLinks.html" as github -%}
 
-<h1>{$ doc.code $}: {$ doc.shortDescription $}</h1>
 <div class="github-links">
   {$ github.githubEditLink(doc, versionInfo) $}
 </div>
 
-{% if doc.videoUrl.length %}
-<div class="video-container">
-  <iframe
-  src="{$ doc.videoUrl $}"
-  frameborder="0"
-  allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen></iframe>
-</div>
-{% endif%}
-
-{% block content %}
 <div class="content">
-  <h2>Description</h2>
-  {$ doc.description | marked $}
+
+  <h1>{$ doc.code $}: {$ doc.shortDescription $}</h1>
+
+  {% if doc.videoUrl.length %}
+  <div class="video-container">
+    <iframe
+    src="{$ doc.videoUrl $}"
+    frameborder="0"
+    allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen></iframe>
+  </div>
+  {% endif%}
+
+  <div class="error-description">
+    <h2>Description</h2>
+    {$ doc.description | marked $}
+  </div>
+
+  <br>
+
+  <div class="debugging">
+    <h2>Debugging the error</h2>
+    {$ doc.debugging | marked $}
+  </div>
+
 </div>
-<br>
-<div class="debugging">
-  <h2>Debugging the error</h2>
-  {$ doc.debugging | marked $}
-</div>
-{% endblock %}

--- a/aio/tools/transforms/templates/extended-diagnostic/extended-diagnostic.template.html
+++ b/aio/tools/transforms/templates/extended-diagnostic/extended-diagnostic.template.html
@@ -1,12 +1,16 @@
 {% import "lib/githubLinks.html" as github -%}
 
-<h1>{$ doc.code $}: {$ doc.name $}</h1>
 <div class="github-links">
   {$ github.githubEditLink(doc, versionInfo) $}
 </div>
-{% block content %}
+
 <div class="content">
-  <h2>Description</h2>
-  {$ doc.description | marked $}
+
+  <h1>{$ doc.code $}: {$ doc.name $}</h1>
+
+  <div class="diagnostic-description">
+    <h2>Description</h2>
+    {$ doc.description | marked $}
+  </div>
+
 </div>
-{% endblock %}


### PR DESCRIPTION
This commit aligns the layout of errors and extended diagnostics pages more closely with other docs pages to ensure that the "Edit source" button is displayed correctly even when the heading is too long to fit on a single line. For error pages, in particular, this ensures that the button is not obscured by the error video.

**Before:**
![error-pages before][1]

**After:**
![error-pages after][2]

[1]: https://user-images.githubusercontent.com/8604205/163408291-7aebd029-891c-4045-8fa2-a8e2b2b06dab.png
[2]: https://user-images.githubusercontent.com/8604205/163408296-40e6df8e-aadc-4a82-978a-ab4d902b6f6e.png
