### PR TITLE
feat(common): add getState method to LocationStrategy interface

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -210,6 +210,8 @@ export class HashLocationStrategy extends LocationStrategy implements OnDestroy 
     // (undocumented)
     getBaseHref(): string;
     // (undocumented)
+    getState(): unknown;
+    // (undocumented)
     historyGo(relativePosition?: number): void;
     // (undocumented)
     ngOnDestroy(): void;
@@ -309,7 +311,7 @@ export class KeyValuePipe implements PipeTransform {
 
 // @public
 class Location_2 implements OnDestroy {
-    constructor(platformStrategy: LocationStrategy, platformLocation: PlatformLocation);
+    constructor(locationStrategy: LocationStrategy);
     back(): void;
     forward(): void;
     getState(): unknown;
@@ -359,6 +361,8 @@ export abstract class LocationStrategy {
     abstract forward(): void;
     // (undocumented)
     abstract getBaseHref(): string;
+    // (undocumented)
+    abstract getState(): unknown;
     // (undocumented)
     historyGo?(relativePosition: number): void;
     // (undocumented)
@@ -635,6 +639,8 @@ export class PathLocationStrategy extends LocationStrategy implements OnDestroy 
     forward(): void;
     // (undocumented)
     getBaseHref(): string;
+    // (undocumented)
+    getState(): unknown;
     // (undocumented)
     historyGo(relativePosition?: number): void;
     // (undocumented)

--- a/packages/common/src/location/hash_location_strategy.ts
+++ b/packages/common/src/location/hash_location_strategy.ts
@@ -100,6 +100,10 @@ export class HashLocationStrategy extends LocationStrategy implements OnDestroy 
     this._platformLocation.back();
   }
 
+  override getState(): unknown {
+    return this._platformLocation.getState();
+  }
+
   override historyGo(relativePosition: number = 0): void {
     this._platformLocation.historyGo?.(relativePosition);
   }

--- a/packages/common/src/location/location_strategy.ts
+++ b/packages/common/src/location/location_strategy.ts
@@ -34,6 +34,7 @@ import {joinWithSlash, normalizeQueryParams} from './util';
 export abstract class LocationStrategy {
   abstract path(includeHash?: boolean): string;
   abstract prepareExternalUrl(internal: string): string;
+  abstract getState(): unknown;
   abstract pushState(state: any, title: string, url: string, queryParams: string): void;
   abstract replaceState(state: any, title: string, url: string, queryParams: string): void;
   abstract forward(): void;
@@ -45,7 +46,7 @@ export abstract class LocationStrategy {
   abstract getBaseHref(): string;
 }
 
-export function provideLocationStrategy(platformLocation: PlatformLocation) {
+export function provideLocationStrategy() {
   // See #23917
   const location = ɵɵinject(DOCUMENT).location;
   return new PathLocationStrategy(
@@ -174,6 +175,10 @@ export class PathLocationStrategy extends LocationStrategy implements OnDestroy 
 
   override back(): void {
     this._platformLocation.back();
+  }
+
+  override getState(): unknown {
+    return this._platformLocation.getState();
   }
 
   override historyGo(relativePosition: number = 0): void {

--- a/packages/common/testing/src/location_mock.ts
+++ b/packages/common/testing/src/location_mock.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Location, LocationStrategy, PlatformLocation} from '@angular/common';
+import {Location, LocationStrategy} from '@angular/common';
 import {EventEmitter, Injectable} from '@angular/core';
 import {SubscriptionLike} from 'rxjs';
 
@@ -27,9 +27,7 @@ export class SpyLocation implements Location {
   /** @internal */
   _baseHref: string = '';
   /** @internal */
-  _platformStrategy: LocationStrategy = null!;
-  /** @internal */
-  _platformLocation: PlatformLocation = null!;
+  _locationStrategy: LocationStrategy = null!;
   /** @internal */
   _urlChangeListeners: ((url: string, state: unknown) => void)[] = [];
   /** @internal */


### PR DESCRIPTION
Add getState to LocationStrategy interface as it suppose to be the place to control all window.location interactions

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #34603


## What is the new behavior?

LocationStrategy implements getState() method which will eventually call  _window.history_ to access current history state.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Only classes that implement Abstract `LocationStrategy` are `PathLocationStrategy` (test already present) and `HashLocationStrategy`. Currently there are no tests for `HashLocationStrategy`, if you find them necessary for this PR to merge let me know.