### PR TITLE
ci: add more reviewers to the `docs-packaging-and-releasing` group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -914,12 +914,12 @@ groups:
           'aio/content/guide/migration-module-with-providers.md',
           'aio/content/guide/static-query-migration.md',
           'aio/content/guide/update-to-latest-version.md',
-          'aio/content/guide/ivy-compatibility.md',
-          'aio/content/guide/ivy-compatibility-examples.md'
           ])
     reviewers:
       users:
         - alxhub
+        - AndrewKushnir
+        - atscott
         - jelbourn
 
   # =========================================================


### PR DESCRIPTION
Currently that group has just 2 reviewers, but we often update the files that belong to that group during the deprecation period. Adding more people would allow to balance the reviews better.

Note to reviewers: Andrew S is ok to be added to the group (checked with Andrew offline).

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No