### PR TITLE
refactor(core): make `Testability` compatible with tree-shaking

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1272,7 +1272,7 @@ export abstract class TemplateRef<C> {
 
 // @public
 export class Testability implements PublicTestability {
-    constructor(_ngZone: NgZone);
+    constructor(_ngZone: NgZone, registry: TestabilityRegistry, testabilityGetter: GetTestability);
     // @deprecated
     decreasePendingRequestCount(): number;
     findProviders(using: any, provider: string, exactMatch: boolean): any[];
@@ -1290,7 +1290,6 @@ export class Testability implements PublicTestability {
 
 // @public
 export class TestabilityRegistry {
-    constructor();
     findTestabilityInTree(elem: Node, findInAncestors?: boolean): Testability | null;
     getAllRootElements(): any[];
     getAllTestabilities(): Testability[];

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4343,
-      "main": 454248,
+      "main": 454794,
       "polyfills": 33980,
       "styles": 71714,
       "light-theme": 78213,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,7 +2,7 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 1083,
-      "main": 126738,
+      "main": 126542,
       "polyfills": 33824
     }
   },
@@ -19,7 +19,7 @@
   "cli-hello-world-ivy-compat": {
     "uncompressed": {
       "runtime": 1102,
-      "main": 133348,
+      "main": 133968,
       "polyfills": 33957
     }
   },
@@ -41,7 +41,7 @@
   "forms": {
     "uncompressed": {
       "runtime": 1063,
-      "main": 158922,
+      "main": 159280,
       "polyfills": 33804
     }
   },

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -40,7 +40,7 @@ import {setJitOptions} from './render3/jit/jit_options';
 import {isStandalone} from './render3/jit/module';
 import {createEnvironmentInjector, NgModuleFactory as R3NgModuleFactory} from './render3/ng_module_ref';
 import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from './render3/util/global_utils';
-import {Testability, TestabilityRegistry} from './testability/testability';
+import {TESTABILITY} from './testability/testability';
 import {isPromise} from './util/lang';
 import {scheduleMicroTask} from './util/microtask';
 import {stringify} from './util/stringify';
@@ -944,18 +944,13 @@ export class ApplicationRef {
     const selectorOrNode = rootSelectorOrNode || componentFactory.selector;
     const compRef = componentFactory.create(Injector.NULL, [], selectorOrNode, ngModule);
     const nativeElement = compRef.location.nativeElement;
-    const testability = compRef.injector.get(Testability, null);
-    const testabilityRegistry = testability && compRef.injector.get(TestabilityRegistry);
-    if (testability && testabilityRegistry) {
-      testabilityRegistry.registerApplication(nativeElement, testability);
-    }
+    const testability = compRef.injector.get(TESTABILITY, null);
+    testability?.registerApplication(nativeElement);
 
     compRef.onDestroy(() => {
       this.detachView(compRef.hostView);
       remove(this.components, compRef);
-      if (testabilityRegistry) {
-        testabilityRegistry.unregisterApplication(nativeElement);
-      }
+      testability?.unregisterApplication(nativeElement);
     });
 
     this._loadComponent(compRef);

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -24,6 +24,7 @@ export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/r
 export {allowSanitizationBypassAndThrow as ɵallowSanitizationBypassAndThrow, BypassType as ɵBypassType, getSanitizationBypassType as ɵgetSanitizationBypassType, SafeHtml as ɵSafeHtml, SafeResourceUrl as ɵSafeResourceUrl, SafeScript as ɵSafeScript, SafeStyle as ɵSafeStyle, SafeUrl as ɵSafeUrl, SafeValue as ɵSafeValue, unwrapSafeValue as ɵunwrapSafeValue} from './sanitization/bypass';
 export {_sanitizeHtml as ɵ_sanitizeHtml} from './sanitization/html_sanitizer';
 export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';
+export {TESTABILITY as ɵTESTABILITY, TESTABILITY_GETTER as ɵTESTABILITY_GETTER} from './testability/testability';
 export {coerceToBoolean as ɵcoerceToBoolean} from './util/coercion';
 export {devModeEqual as ɵdevModeEqual} from './util/comparison';
 export {makeDecorator as ɵmakeDecorator} from './util/decorators';

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -96,9 +96,6 @@
     "name": "BrowserDomAdapter"
   },
   {
-    "name": "BrowserGetTestability"
-  },
-  {
     "name": "BrowserModule"
   },
   {
@@ -445,6 +442,15 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "TESTABILITY"
+  },
+  {
+    "name": "TESTABILITY_GETTER"
+  },
+  {
+    "name": "TESTABILITY_PROVIDERS"
   },
   {
     "name": "THROW_IF_NOT_FOUND"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -48,9 +48,6 @@
     "name": "BrowserDomAdapter"
   },
   {
-    "name": "BrowserGetTestability"
-  },
-  {
     "name": "BrowserModule"
   },
   {
@@ -457,6 +454,15 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "TESTABILITY"
+  },
+  {
+    "name": "TESTABILITY_GETTER"
+  },
+  {
+    "name": "TESTABILITY_PROVIDERS"
   },
   {
     "name": "THROW_IF_NOT_FOUND"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -51,9 +51,6 @@
     "name": "BrowserDomAdapter"
   },
   {
-    "name": "BrowserGetTestability"
-  },
-  {
     "name": "BrowserModule"
   },
   {
@@ -448,6 +445,15 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "TESTABILITY"
+  },
+  {
+    "name": "TESTABILITY_GETTER"
+  },
+  {
+    "name": "TESTABILITY_PROVIDERS"
   },
   {
     "name": "THROW_IF_NOT_FOUND"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -54,9 +54,6 @@
     "name": "BrowserDomAdapter"
   },
   {
-    "name": "BrowserGetTestability"
-  },
-  {
     "name": "BrowserModule"
   },
   {
@@ -640,6 +637,15 @@
   },
   {
     "name": "SwitchMapSubscriber"
+  },
+  {
+    "name": "TESTABILITY"
+  },
+  {
+    "name": "TESTABILITY_GETTER"
+  },
+  {
+    "name": "TESTABILITY_PROVIDERS"
   },
   {
     "name": "THROW_IF_NOT_FOUND"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -24,9 +24,6 @@
     "name": "BrowserDomAdapter"
   },
   {
-    "name": "BrowserGetTestability"
-  },
-  {
     "name": "BrowserXhr"
   },
   {
@@ -70,6 +67,9 @@
   },
   {
     "name": "DefaultDomRenderer2"
+  },
+  {
+    "name": "DomEventsPlugin"
   },
   {
     "name": "DomRendererFactory2"
@@ -136,6 +136,9 @@
   },
   {
     "name": "Injector"
+  },
+  {
+    "name": "KeyEventsPlugin"
   },
   {
     "name": "LOCALE_ID2"
@@ -289,6 +292,15 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "TESTABILITY"
+  },
+  {
+    "name": "TESTABILITY_GETTER"
+  },
+  {
+    "name": "TESTABILITY_PROVIDERS"
   },
   {
     "name": "THROW_IF_NOT_FOUND"

--- a/packages/platform-browser/src/browser/testability.ts
+++ b/packages/platform-browser/src/browser/testability.ts
@@ -7,13 +7,9 @@
  */
 
 import {ɵgetDOM as getDOM} from '@angular/common';
-import {GetTestability, setTestabilityGetter, Testability, TestabilityRegistry, ɵglobal as global} from '@angular/core';
+import {GetTestability, Testability, TestabilityRegistry, ɵglobal as global} from '@angular/core';
 
 export class BrowserGetTestability implements GetTestability {
-  static init() {
-    setTestabilityGetter(new BrowserGetTestability());
-  }
-
   addToWindow(registry: TestabilityRegistry): void {
     global['getAngularTestability'] = (elem: any, findInAncestors: boolean = true) => {
       const testability = registry.findTestabilityInTree(elem, findInAncestors);

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -7,11 +7,10 @@
  */
 
 import {DOCUMENT, isPlatformBrowser, ɵgetDOM as getDOM} from '@angular/common';
-import {APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, Inject, InjectionToken, Injector, Input, LOCALE_ID, NgModule, OnDestroy, Pipe, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Type, VERSION} from '@angular/core';
+import {APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, Inject, InjectionToken, Injector, Input, LOCALE_ID, NgModule, OnDestroy, Pipe, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Testability, TestabilityRegistry, Type, VERSION} from '@angular/core';
 import {ApplicationRef, destroyPlatform} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
-import {Testability, TestabilityRegistry} from '@angular/core/src/testability/testability';
 import {inject, TestBed} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 import {BrowserModule} from '@angular/platform-browser';

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -9,7 +9,7 @@
 import {ɵAnimationEngine} from '@angular/animations/browser';
 import {DOCUMENT, PlatformLocation, ViewportScroller, ɵgetDOM as getDOM, ɵNullViewportScroller as NullViewportScroller, ɵPLATFORM_SERVER_ID as PLATFORM_SERVER_ID} from '@angular/common';
 import {HttpClientModule} from '@angular/common/http';
-import {createPlatformFactory, Injector, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, StaticProvider, Testability, ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS, ɵsetDocument} from '@angular/core';
+import {createPlatformFactory, Injector, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, StaticProvider, Testability, ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS, ɵsetDocument, ɵTESTABILITY as TESTABILITY} from '@angular/core';
 import {BrowserModule, EVENT_MANAGER_PLUGINS, ɵSharedStylesHost as SharedStylesHost} from '@angular/platform-browser';
 import {ɵplatformCoreDynamic as platformCoreDynamic} from '@angular/platform-browser-dynamic';
 import {NoopAnimationsModule, ɵAnimationRendererFactory} from '@angular/platform-browser/animations';
@@ -22,10 +22,6 @@ import {ServerEventManagerPlugin} from './server_events';
 import {ServerRendererFactory2} from './server_renderer';
 import {ServerStylesHost} from './styles_host';
 import {INITIAL_CONFIG, PlatformConfig} from './tokens';
-
-function notSupported(feature: string): Error {
-  throw new Error(`platform-server does not support '${feature}'.`);
-}
 
 export const INTERNAL_SERVER_PLATFORM_PROVIDERS: StaticProvider[] = [
   {provide: DOCUMENT, useFactory: _document, deps: [Injector]},
@@ -74,7 +70,8 @@ export const SERVER_RENDER_PROVIDERS: Provider[] = [
   providers: [
     SERVER_RENDER_PROVIDERS,
     SERVER_HTTP_PROVIDERS,
-    {provide: Testability, useValue: null},
+    {provide: Testability, useValue: null},  // Keep for backwards-compatibility.
+    {provide: TESTABILITY, useValue: null},
     {provide: ViewportScroller, useClass: NullViewportScroller},
   ],
 })


### PR DESCRIPTION
This PR refactors the `Testability`-related logic to extract the necessary providers into a separate array, so that it can later become it's own NgModule (or exposed as an array of providers) and be excluded from the new APIs by default.