### PR TITLE
fix(compiler): add validations for custom placeholder expressions

### DIFF
--- a/packages/compiler/test/i18n/i18n_parser_spec.ts
+++ b/packages/compiler/test/i18n/i18n_parser_spec.ts
@@ -304,6 +304,51 @@ import {DEFAULT_INTERPOLATION_CONFIG} from '@angular/compiler/src/ml_parser/inte
           '',
         ]);
       });
+
+      it('should validate that custom placeholder is wrapped in quotes', () => {
+        expect(() => _extractMessages(`<div i18n>Hello, {{ name // i18n(ph = user name) }}</div>`))
+            .toThrowError(
+                'Custom placeholder must be wrapped in quotes in expression "{{ name // i18n(ph = user name) }}".');
+      });
+
+      it('should handle equals sign and parentheses in the custom placeholder string', () => {
+        expect(_humanizeMessages(
+                   `<div i18n>Hello, {{ name // i18n(ph = "Name (>= 5 characters)") }}</div>`))
+            .toEqual([[
+              [
+                '[Hello, , <ph name="NAME (>= 5 CHARACTERS)"> name // i18n(ph = "Name (>= 5 characters)") </ph>]'
+              ],
+              '', '', ''
+            ]]);
+      });
+
+      it('should validate that custom placeholder quotes match', () => {
+        expect(
+            () => _extractMessages(`<div i18n>Hello, {{ name // i18n(ph = "user name') }}</div>`))
+            .toThrowError(
+                `Custom placeholder must be a valid string in expression "{{ name // i18n(ph = "user name') }}".`);
+        expect(() => _extractMessages(`<div i18n>Hello, {{ name // i18n(ph = "user name) }}</div>`))
+            .toThrowError(
+                'Custom placeholder must be a valid string in expression "{{ name // i18n(ph = "user name) }}".');
+      });
+
+      it('should validate that custom placeholder does not contain new lines', () => {
+        expect(
+            () => _extractMessages(`<div i18n>Hello, {{ name // i18n(ph = "user\nname") }}</div>`))
+            .toThrowError(
+                'Custom placeholder cannot contain new lines in expression "{{ name // i18n(ph = "user\nname") }}".');
+        expect(
+            () =>
+                _extractMessages(`<div i18n>Hello, {{ name // i18n(ph = "user\r\nname") }}</div>`))
+            .toThrowError(
+                'Custom placeholder cannot contain new lines in expression "{{ name // i18n(ph = "user\nname") }}".');
+      });
+
+      it('should validate that custom placeholder is not empty', () => {
+        expect(() => _extractMessages(`<div i18n>Hello, {{ name // i18n(ph = "") }}</div>`))
+            .toThrowError(
+                'Custom placeholder cannot be empty in expression "{{ name // i18n(ph = "") }}".');
+      });
     });
   });
 }


### PR DESCRIPTION
Adds a few basic validations to custom placeholder expressions (e.g. `{{ foo // i18n(ph = "foo") }}`) in order to catch cases like newlines inside the placeholder and non-matching quotes.

Note that I've intentionally kept the validations somewhat basic for now, because the previous approach only used regex for the parsing which would've allowed other potentially invalid expressions. We can expand this approach if we run into more such cases in the future.

Fixes #45653.