### PR TITLE
docs(common): fix links to locales in i18n guides

### DIFF
--- a/aio/content/guide/i18n-optional-import-global-variants.md
+++ b/aio/content/guide/i18n-optional-import-global-variants.md
@@ -11,7 +11,7 @@ ng build --localize
 </code-example>
 
 The `@angular/common` package on npm contains the locale data files.
-Global variants of the locale data are available in [`@angular/common/locales/global`][GithubAngularAngularTreeMasterPackagesCommonLocalesGlobal].
+Global variants of the locale data are available in [`@angular/common/locales/global`][UnpkgBrowseAngularCommonLocalesGlobal].
 
 ## `import` example for French
 
@@ -26,8 +26,7 @@ The following example imports the global variants for French \(`fr`\).
 
 <!-- external links -->
 
-[GithubAngularAngularTreeMasterPackagesCommonLocales]: https://github.com/angular/angular/tree/master/packages/common/locales "angular/packages/common/locales | angular/angular | GitHub"
-[GithubAngularAngularTreeMasterPackagesCommonLocalesGlobal]: https://github.com/angular/angular/tree/master/packages/common/locales/global "angular/packages/common/locales/global | angular/angular | GitHub"
+[UnpkgBrowseAngularCommonLocalesGlobal]: https://unpkg.com/browse/@angular/common/locales/global "@angular/common/locales/global | Unpkg"
 
 <!-- end links -->
 

--- a/aio/content/guide/i18n-optional-manual-runtime-locale.md
+++ b/aio/content/guide/i18n-optional-manual-runtime-locale.md
@@ -9,7 +9,7 @@ The [Angular CLI][AioCliMain] automatically includes the locale data and sets th
 
 To manually set the runtime locale of an application to one other than the automatic value, complete the following actions.
 
-1.  Search for the Unicode locale ID in the language-locale combination in [the Angular repository][GithubAngularAngularTreeMasterPackagesCommonLocales].
+1.  Search for the Unicode locale ID in the language-locale combination in the [`@angular/common/locales/`][UnpkgBrowseAngularCommonLocales] directory.
 1.  Set the [`LOCALE_ID`][AioApiCoreLocaleId] token.
 
 The following example sets the value of `LOCALE_ID` to `fr` for French.
@@ -25,7 +25,7 @@ The following example sets the value of `LOCALE_ID` to `fr` for French.
 
 <!-- external links -->
 
-[GithubAngularAngularTreeMasterPackagesCommonLocales]: https://github.com/angular/angular/tree/master/packages/common/locales "angular/packages/common/locales | angular/angular | GitHub"
+[UnpkgBrowseAngularCommonLocales]: https://unpkg.com/browse/@angular/common/locales "@angular/common/locales | Unpkg"
 
 <!-- end links -->
 


### PR DESCRIPTION
In PR #42230, the locale file generation process was modified so that generated locale files are no longer checked into the repository. Update a few links in the docs that pointed to the previously checked in files to point to other places where the files exist.
