### PR TITLE
docs: remove angular component from angular install command

### DIFF
--- a/aio/content/guide/setup-local.md
+++ b/aio/content/guide/setup-local.md
@@ -43,7 +43,7 @@ To install the Angular CLI, open a terminal window and run the following command
 
 <code-example format="shell" language="shell">
 
-npm install -g &commat;angular/cli&lt;aio-angular-dist-tag class="pln"&gt;&lt;/aio-angular-dist-tag&gt;
+npm install -g &commat;angular/cli
 
 </code-example>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The install command code snippet on the [local setup](https://angular.io/guide/setup-local) page has an extra angular component in it.

Direct link: https://angular.io/guide/setup-local#install-the-angular-cli

Issue Number: N/A


## What is the new behavior?

With this PR, the extra angular component is removed from the code snippet

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
