### PR TITLE
test: reset counters before running a styling test

### DIFF
--- a/packages/core/test/render3/instructions/styling_spec.ts
+++ b/packages/core/test/render3/instructions/styling_spec.ts
@@ -98,6 +98,7 @@ describe('styling', () => {
   });
 
   it('should set class based on priority', () => {
+    ngDevModeResetPerfCounters();
     ɵɵclassProp('foo', false);
     ɵɵclassProp('foo', true);  // Higher priority, should win.
     expectClass(div).toEqual({foo: true});


### PR DESCRIPTION
This commit updates one of the styling tests to reset perf counters, making it order-independent and non-flaky (previously the test got random failures depending on whether there are other tests invoked before).

## PR Type
What kind of change does this PR introduce?
- [x] Other... Please describe: update to the test logic

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No