### PR TITLE
refactor(router): Use `EnvironmentInjector` for lazy loading APIs

### DIFF
--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector, NgModuleFactory, NgModuleRef, Type} from '@angular/core';
+import {EnvironmentInjector, NgModuleFactory, Type} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
@@ -489,7 +489,7 @@ export interface Route {
    * Filled for routes with `loadChildren` once the routes are loaded
    * @internal
    */
-  _loadedInjector?: Injector;
+  _loadedInjector?: EnvironmentInjector;
 
   /**
    * Filled for routes with `loadChildren` during load
@@ -500,7 +500,7 @@ export interface Route {
 
 export interface LoadedRouterConfig {
   routes: Route[];
-  injector: Injector|undefined;
+  injector: EnvironmentInjector|undefined;
 }
 
 /**

--- a/packages/router/src/operators/apply_redirects.ts
+++ b/packages/router/src/operators/apply_redirects.ts
@@ -17,9 +17,10 @@ import {RouterConfigLoader} from '../router_config_loader';
 import {UrlSerializer} from '../url_tree';
 
 export function applyRedirects(
-    moduleInjector: EnvironmentInjector, configLoader: RouterConfigLoader,
+    environmentInjector: EnvironmentInjector, configLoader: RouterConfigLoader,
     urlSerializer: UrlSerializer, config: Routes): MonoTypeOperatorFunction<NavigationTransition> {
   return switchMap(
-      t => applyRedirectsFn(moduleInjector, configLoader, urlSerializer, t.extractedUrl, config)
-               .pipe(map(urlAfterRedirects => ({...t, urlAfterRedirects}))));
+      t =>
+          applyRedirectsFn(environmentInjector, configLoader, urlSerializer, t.extractedUrl, config)
+              .pipe(map(urlAfterRedirects => ({...t, urlAfterRedirects}))));
 }

--- a/packages/router/src/operators/apply_redirects.ts
+++ b/packages/router/src/operators/apply_redirects.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector} from '@angular/core';
+import {EnvironmentInjector} from '@angular/core';
 import {MonoTypeOperatorFunction} from 'rxjs';
 import {map, switchMap} from 'rxjs/operators';
 
@@ -17,8 +17,8 @@ import {RouterConfigLoader} from '../router_config_loader';
 import {UrlSerializer} from '../url_tree';
 
 export function applyRedirects(
-    moduleInjector: Injector, configLoader: RouterConfigLoader, urlSerializer: UrlSerializer,
-    config: Routes): MonoTypeOperatorFunction<NavigationTransition> {
+    moduleInjector: EnvironmentInjector, configLoader: RouterConfigLoader,
+    urlSerializer: UrlSerializer, config: Routes): MonoTypeOperatorFunction<NavigationTransition> {
   return switchMap(
       t => applyRedirectsFn(moduleInjector, configLoader, urlSerializer, t.extractedUrl, config)
                .pipe(map(urlAfterRedirects => ({...t, urlAfterRedirects}))));

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injector} from '@angular/core';
+import {EnvironmentInjector, Injector} from '@angular/core';
 
 import {EmptyOutletComponent} from '../components/empty_outlet';
 import {LoadedRouterConfig, Route, Routes} from '../models';
@@ -153,7 +153,8 @@ export function sortByMatchingOutlets(routes: Routes, outletName: string): Route
  * Generally used for retrieving the injector to use for getting tokens for guards/resolvers and
  * also used for getting the correct injector to use for creating components.
  */
-export function getClosestLoadedInjector(snapshot: ActivatedRouteSnapshot): Injector|null {
+export function getClosestLoadedInjector(snapshot: ActivatedRouteSnapshot): EnvironmentInjector|
+    null {
   if (!snapshot) return null;
 
   for (let s = snapshot.parent; s; s = s.parent) {

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModuleRef} from '@angular/core';
+import {EnvironmentInjector, NgModuleRef} from '@angular/core';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {ActivatedRouteSnapshot} from '@angular/router';
 import {TreeNode} from '@angular/router/src/utils/tree';
@@ -1185,7 +1185,8 @@ describe('applyRedirects', () => {
 });
 
 function checkRedirect(config: Routes, url: string, callback: any): void {
-  applyRedirects(TestBed, null!, new DefaultUrlSerializer(), tree(url), config)
+  applyRedirects(
+      TestBed.inject(EnvironmentInjector), null!, new DefaultUrlSerializer(), tree(url), config)
       .subscribe(callback, e => {
         throw e;
       });


### PR DESCRIPTION
The `EnvironmentInjector` should be used instead of `Injector` for the
lazy loading. A future refactor will further update `RouterOutlet` to
use this injector to create the component rather the deprecated
`ComponentFactoryResolver`.
