### PR TITLE
feat(router): Add ability to specify providers on a Route

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -694,7 +694,7 @@ export interface RouterOutletContract {
 
 // @public
 export class RouterPreloader implements OnDestroy {
-    constructor(router: Router, compiler: Compiler, injector: Injector, preloadingStrategy: PreloadingStrategy, loader: RouterConfigLoader);
+    constructor(router: Router, compiler: Compiler, injector: EnvironmentInjector, preloadingStrategy: PreloadingStrategy, loader: RouterConfigLoader);
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -23,6 +23,7 @@ import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
+import { Provider } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
@@ -452,6 +453,7 @@ export interface Route {
     outlet?: string;
     path?: string;
     pathMatch?: 'prefix' | 'full';
+    providers?: Provider[];
     redirectTo?: string;
     resolve?: ResolveData;
     runGuardsAndResolvers?: RunGuardsAndResolvers;

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4343,
-      "main": 453341,
+      "main": 453737,
       "polyfills": 33980,
       "styles": 71714,
       "light-theme": 78213,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -33,7 +33,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2835,
-      "main": 234960,
+      "main": 235837,
       "polyfills": 33842,
       "src_app_lazy_lazy_module_ts": 795
     }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -195,6 +195,9 @@
     "name": "EnvironmentInjector"
   },
   {
+    "name": "EnvironmentNgModuleRefAdapter"
+  },
+  {
     "name": "ErrorHandler"
   },
   {
@@ -1152,7 +1155,7 @@
     "name": "getChildRouteGuards"
   },
   {
-    "name": "getClosestLoadedInjector"
+    "name": "getClosestRouteInjector"
   },
   {
     "name": "getClosureSafeProperty"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -927,6 +927,9 @@
     "name": "createEmptyState"
   },
   {
+    "name": "createEnvironmentInjector"
+  },
+  {
     "name": "createInjector"
   },
   {

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -7,6 +7,7 @@
  */
 
 import {EnvironmentInjector} from '@angular/core';
+import {createEnvironmentInjector} from '@angular/core/src/render3/ng_module_ref';
 import {EmptyError, from, Observable, Observer, of, throwError} from 'rxjs';
 import {catchError, concatMap, first, last, map, mergeMap, scan, tap} from 'rxjs/operators';
 
@@ -182,9 +183,18 @@ class ApplyRedirects {
       segments: UrlSegment[], outlet: string,
       allowRedirects: boolean): Observable<UrlSegmentGroup> {
     return from(routes).pipe(
-        concatMap((r: any) => {
+        concatMap(r => {
+          if (r.providers && !r._injector) {
+            r._injector = createEnvironmentInjector(r.providers, injector);
+          }
+          // We specifically _do not_ want to include the _loadedInjector here. The loaded injector
+          // only applies to the route's children, not the route itself. Note that this distinction
+          // only applies here to any tokens we try to retrieve during this phase. At the moment,
+          // that only includes `canLoad`, which won't run again once the child module is loaded. As
+          // a result, this makes no difference right now, but could in the future if there are more
+          // actions here that need DI (for example, a canMatch guard).
           const expanded$ = this.expandSegmentAgainstRoute(
-              injector, segmentGroup, routes, r, segments, outlet, allowRedirects);
+              r._injector ?? injector, segmentGroup, routes, r, segments, outlet, allowRedirects);
           return expanded$.pipe(catchError((e: any) => {
             if (e instanceof NoMatch) {
               return of(null);

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector} from '@angular/core';
-import {createEnvironmentInjector} from '@angular/core/src/render3/ng_module_ref';
+import {createEnvironmentInjector, EnvironmentInjector} from '@angular/core';
 import {EmptyError, from, Observable, Observer, of, throwError} from 'rxjs';
 import {catchError, concatMap, first, last, map, mergeMap, scan, tap} from 'rxjs/operators';
 
@@ -185,7 +184,7 @@ class ApplyRedirects {
     return from(routes).pipe(
         concatMap(r => {
           if (r.providers && !r._injector) {
-            r._injector = createEnvironmentInjector(r.providers, injector);
+            r._injector = createEnvironmentInjector(r.providers, injector, `Route: ${r.path}`);
           }
           // We specifically _do not_ want to include the _loadedInjector here. The loaded injector
           // only applies to the route's children, not the route itself. Note that this distinction

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Attribute, ChangeDetectorRef, ComponentFactoryResolver, ComponentRef, Directive, EventEmitter, Injector, OnDestroy, OnInit, Output, ViewContainerRef,} from '@angular/core';
+import {Attribute, ChangeDetectorRef, ComponentFactoryResolver, ComponentRef, Directive, EventEmitter, Injector, OnDestroy, OnInit, Output, ViewContainerRef} from '@angular/core';
 
 import {Data} from '../models';
 import {ChildrenOutletContexts} from '../router_outlet_context';

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, NgModuleFactory, Type} from '@angular/core';
+import {EnvironmentInjector, NgModuleFactory, Provider, Type} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
@@ -478,6 +478,22 @@ export interface Route {
    * parameters of the route change.
    */
   runGuardsAndResolvers?: RunGuardsAndResolvers;
+
+  /**
+   * A `Provider` array to use for this `Route` and its `children`.
+   *
+   * The `Router` will create a new `EnvironmentInjector` for this
+   * `Route` and use it for this `Route` and its `children`. If this
+   * route also has a `loadChildren` function which returns an `NgModuleRef`, this injector will be
+   * used as the parent of the lazy loaded module.
+   */
+  providers?: Provider[];
+
+  /**
+   * Injector created from the static route providers
+   * @internal
+   */
+  _injector?: EnvironmentInjector;
 
   /**
    * Filled for routes with `loadChildren` once the routes are loaded.

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {NgModuleRef} from '@angular/core';
+import {ComponentFactoryResolver, EnvironmentInjector, NgModuleRef} from '@angular/core';
 import {MonoTypeOperatorFunction} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -16,7 +16,7 @@ import {NavigationTransition} from '../router';
 import {ChildrenOutletContexts} from '../router_outlet_context';
 import {ActivatedRoute, advanceActivatedRoute, RouterState} from '../router_state';
 import {forEach} from '../utils/collection';
-import {getClosestLoadedInjector} from '../utils/config';
+import {getClosestRouteInjector} from '../utils/config';
 import {nodeChildrenAsMap, TreeNode} from '../utils/tree';
 
 export const activateRoutes =
@@ -193,9 +193,8 @@ export class ActivateRoutes {
           advanceActivatedRoute(stored.route.value);
           this.activateChildRoutes(futureNode, null, context.children);
         } else {
-          const injector = getClosestLoadedInjector(future.snapshot);
-          const cmpFactoryResolver = injector?.get(NgModuleRef)?.componentFactoryResolver ?? null;
-
+          const injector = getClosestRouteInjector(future.snapshot);
+          const cmpFactoryResolver = injector?.get(ComponentFactoryResolver) ?? null;
           context.attachRef = null;
           context.route = future;
           context.resolver = cmpFactoryResolver;

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentFactoryResolver, ComponentRef} from '@angular/core';
+import {ComponentFactoryResolver, ComponentRef, EnvironmentInjector} from '@angular/core';
 
 import {RouterOutletContract} from './directives/router_outlet';
 import {ActivatedRoute} from './router_state';

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, Injector} from '@angular/core';
+import {EnvironmentInjector} from '@angular/core';
 
 import {EmptyOutletComponent} from '../components/empty_outlet';
-import {LoadedRouterConfig, Route, Routes} from '../models';
+import {Route, Routes} from '../models';
 import {ActivatedRouteSnapshot} from '../router_state';
 import {PRIMARY_OUTLET} from '../shared';
 
@@ -17,7 +17,7 @@ export function getLoadedRoutes(route: Route): Route[]|undefined {
   return route._loadedRoutes;
 }
 
-export function getLoadedInjector(route: Route): Injector|undefined {
+export function getLoadedInjector(route: Route): EnvironmentInjector|undefined {
   return route._loadedInjector;
 }
 
@@ -146,20 +146,32 @@ export function sortByMatchingOutlets(routes: Routes, outletName: string): Route
 }
 
 /**
- * Gets the first loaded injector in the snapshot's parent tree.
+ * Gets the first injector in the snapshot's parent tree.
  *
- * Returns `null` if there is no parent lazy loaded injector.
+ * If the `Route` has a static list of providers, the returned injector will be the one created from
+ * those. If it does not exist, the returned injector may come from the parents, which may be from a
+ * loaded config or their static providers.
+ *
+ * Returns `null` if there is neither this nor any parents have a stored injector.
  *
  * Generally used for retrieving the injector to use for getting tokens for guards/resolvers and
  * also used for getting the correct injector to use for creating components.
  */
-export function getClosestLoadedInjector(snapshot: ActivatedRouteSnapshot): EnvironmentInjector|
+export function getClosestRouteInjector(snapshot: ActivatedRouteSnapshot): EnvironmentInjector|
     null {
   if (!snapshot) return null;
+
+  // If the current route has its own injector, which is created from the static providers on the
+  // route itself, we should use that. Otherwise, we start at the parent since we do not want to
+  // include the lazy loaded injector from this route.
+  if (snapshot.routeConfig && snapshot.routeConfig._injector) {
+    return snapshot.routeConfig._injector;
+  }
 
   for (let s = snapshot.parent; s; s = s.parent) {
     const route = s.routeConfig;
     if (route && route._loadedInjector) return route._loadedInjector;
+    if (route && route._injector) return route._injector;
   }
 
   return null;

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -164,14 +164,18 @@ export function getClosestRouteInjector(snapshot: ActivatedRouteSnapshot): Envir
   // If the current route has its own injector, which is created from the static providers on the
   // route itself, we should use that. Otherwise, we start at the parent since we do not want to
   // include the lazy loaded injector from this route.
-  if (snapshot.routeConfig && snapshot.routeConfig._injector) {
+  if (snapshot.routeConfig?._injector) {
     return snapshot.routeConfig._injector;
   }
 
   for (let s = snapshot.parent; s; s = s.parent) {
     const route = s.routeConfig;
-    if (route && route._loadedInjector) return route._loadedInjector;
-    if (route && route._injector) return route._injector;
+    // Note that the order here is important. `_loadedInjector` stored on the route with
+    // `loadChildren: () => NgModule` so it applies to child routes with priority. The `_injector`
+    // is created from the static providers on that parent route, so it applies to the children as
+    // well, but only if there is no lazy loaded NgModuleRef injector.
+    if (route?._loadedInjector) return route._loadedInjector;
+    if (route?._injector) return route._injector;
   }
 
   return null;

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -21,6 +21,10 @@ export function getLoadedInjector(route: Route): EnvironmentInjector|undefined {
   return route._loadedInjector;
 }
 
+export function getProvidersInjector(route: Route): EnvironmentInjector|undefined {
+  return route._injector;
+}
+
 export function validateConfig(config: Routes, parentPath: string = ''): void {
   // forEach doesn't iterate undefined values
   for (let i = 0; i < config.length; i++) {

--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -13,7 +13,7 @@ import {ChildrenOutletContexts, OutletContext} from '../router_outlet_context';
 import {ActivatedRouteSnapshot, equalParamsAndUrlSegments, RouterStateSnapshot} from '../router_state';
 import {equalPath} from '../url_tree';
 import {forEach, shallowEqual} from '../utils/collection';
-import {getClosestLoadedInjector} from '../utils/config';
+import {getClosestRouteInjector} from '../utils/config';
 import {nodeChildrenAsMap, TreeNode} from '../utils/tree';
 
 export class CanActivate {
@@ -50,7 +50,7 @@ export function getCanActivateChild(p: ActivatedRouteSnapshot):
 
 export function getToken(
     token: any, snapshot: ActivatedRouteSnapshot, fallbackInjector: Injector): any {
-  const routeInjector = getClosestLoadedInjector(snapshot);
+  const routeInjector = getClosestRouteInjector(snapshot);
   const injector = routeInjector ?? fallbackInjector;
   return injector.get(token);
 }

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -8,13 +8,11 @@
 
 import {EnvironmentInjector, NgModuleRef} from '@angular/core';
 import {fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {ActivatedRouteSnapshot} from '@angular/router';
-import {TreeNode} from '@angular/router/src/utils/tree';
 import {Observable, of} from 'rxjs';
 import {delay, tap} from 'rxjs/operators';
 
 import {applyRedirects} from '../src/apply_redirects';
-import {LoadedRouterConfig, Route, Routes} from '../src/models';
+import {Route, Routes} from '../src/models';
 import {DefaultUrlSerializer, equalSegments, UrlSegment, UrlSegmentGroup, UrlTree} from '../src/url_tree';
 import {getLoadedRoutes} from '../src/utils/config';
 

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, Injectable, NgModule} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {Router} from '@angular/router';
+import {RouterTestingModule} from '@angular/router/testing';
+
+import {RouterModule} from '../src';
+
+@Component({template: '<div>simple standalone</div>'})
+export class SimpleStandaloneComponent {
+}
+
+@Component({template: '<router-outlet></router-outlet>'})
+export class RootCmp {
+}
+
+describe('standalone in Router API', () => {
+  describe('route providers', () => {
+    it('can provide a guard on a route', fakeAsync(() => {
+         @Injectable()
+         class ConfigurableGuard {
+           static canActivateValue = false;
+           canActivate() {
+             return ConfigurableGuard.canActivateValue;
+           }
+         }
+
+         TestBed.configureTestingModule({
+           imports: [
+             RouterTestingModule.withRoutes([{
+               path: 'simple',
+               providers: [ConfigurableGuard],
+               canActivate: [ConfigurableGuard],
+               component: SimpleStandaloneComponent
+             }]),
+           ],
+           declarations: [RootCmp],
+         });
+         const root = TestBed.createComponent(RootCmp);
+
+         ConfigurableGuard.canActivateValue = false;
+         const router = TestBed.inject(Router);
+         router.navigateByUrl('/simple');
+         advance(root);
+         expect(root.nativeElement.innerHTML).not.toContain('simple standalone');
+         expect(router.url).not.toContain('simple');
+
+         ConfigurableGuard.canActivateValue = true;
+         router.navigateByUrl('/simple');
+         advance(root);
+         expect(root.nativeElement.innerHTML).toContain('simple standalone');
+         expect(router.url).toContain('simple');
+       }));
+
+    it('can inject provider on a route into component', fakeAsync(() => {
+         @Injectable()
+         class Service {
+           value = 'my service';
+         }
+
+         @Component({template: `{{service.value}}`})
+         class MyComponent {
+           constructor(readonly service: Service) {}
+         }
+
+         TestBed.configureTestingModule({
+           imports: [
+             RouterTestingModule.withRoutes(
+                 [{path: 'home', providers: [Service], component: MyComponent}]),
+           ],
+           declarations: [RootCmp, MyComponent],
+         });
+         const root = TestBed.createComponent(RootCmp);
+
+         const router = TestBed.inject(Router);
+         router.navigateByUrl('/home');
+         advance(root);
+         expect(root.nativeElement.innerHTML).toContain('my service');
+         expect(router.url).toContain('home');
+       }));
+
+    it('can not inject provider in lazy loaded ngModule from component on same level',
+       fakeAsync(() => {
+         @Injectable()
+         class Service {
+           value = 'my service';
+         }
+
+         @NgModule({providers: [Service]})
+         class LazyModule {
+         }
+
+         @Component({template: `{{service.value}}`})
+         class MyComponent {
+           constructor(readonly service: Service) {}
+         }
+
+         TestBed.configureTestingModule({
+           imports: [
+             RouterTestingModule.withRoutes(
+                 [{path: 'home', loadChildren: () => LazyModule, component: MyComponent}]),
+           ],
+           declarations: [RootCmp, MyComponent],
+         });
+         const root = TestBed.createComponent(RootCmp);
+
+         const router = TestBed.inject(Router);
+         router.navigateByUrl('/home');
+         expect(() => advance(root)).toThrowError();
+       }));
+
+    it('component from lazy module can inject provider from parent route', fakeAsync(() => {
+         @Injectable()
+         class Service {
+           value = 'my service';
+         }
+
+         @Component({template: `{{service.value}}`})
+         class MyComponent {
+           constructor(readonly service: Service) {}
+         }
+         @NgModule({
+           providers: [Service],
+           declarations: [MyComponent],
+           imports: [RouterModule.forChild([{path: '', component: MyComponent}])]
+         })
+         class LazyModule {
+         }
+
+
+         TestBed.configureTestingModule({
+           imports: [
+             RouterTestingModule.withRoutes([{path: 'home', loadChildren: () => LazyModule}]),
+           ],
+           declarations: [RootCmp],
+         });
+         const root = TestBed.createComponent(RootCmp);
+
+         const router = TestBed.inject(Router);
+         router.navigateByUrl('/home');
+         advance(root);
+         expect(root.nativeElement.innerHTML).toContain('my service');
+       }));
+
+    it('gets the correct injector for guards and components when combining lazy modules and route providers',
+       fakeAsync(() => {
+         const canActivateLog: string[] = [];
+         abstract class ServiceBase {
+           abstract name: string;
+           canActivate() {
+             canActivateLog.push(this.name);
+             return true;
+           }
+         }
+
+         @Injectable()
+         class Service1 extends ServiceBase {
+           override name = 'service1';
+         }
+
+         @Injectable()
+         class Service2 extends ServiceBase {
+           override name = 'service2';
+         }
+
+         @Injectable()
+         class Service3 extends ServiceBase {
+           override name = 'service3';
+         }
+
+         @Component({template: `parent<router-outlet></router-outlet>`})
+         class ParentCmp {
+           constructor(readonly service: ServiceBase) {}
+         }
+         @Component({template: `child`})
+         class ChildCmp {
+           constructor(readonly service: ServiceBase) {}
+         }
+
+         @Component({template: `child2`})
+         class ChildCmp2 {
+           constructor(readonly service: ServiceBase) {}
+         }
+         @NgModule({
+           providers: [{provide: ServiceBase, useClass: Service2}],
+           declarations: [ChildCmp, ChildCmp2],
+           imports: [RouterModule.forChild([
+             {
+               path: '',
+               // This component and guard should get Service2 since it's provided in this module
+               component: ChildCmp,
+               canActivate: [ServiceBase],
+             },
+             {
+               path: 'child2',
+               providers: [{provide: ServiceBase, useFactory: () => new Service3()}],
+               // This component and guard should get Service3 since it's provided on this route
+               component: ChildCmp2,
+               canActivate: [ServiceBase],
+             },
+           ])]
+         })
+         class LazyModule {
+         }
+
+
+         TestBed.configureTestingModule({
+           imports: [
+             RouterTestingModule.withRoutes([{
+               path: 'home',
+               // This component and guard should get Service1 since it's provided on this route
+               component: ParentCmp,
+               canActivate: [ServiceBase],
+               providers: [{provide: ServiceBase, useFactory: () => new Service1()}],
+               loadChildren: () => LazyModule
+             }]),
+           ],
+           declarations: [RootCmp, ParentCmp],
+         });
+         const root = TestBed.createComponent(RootCmp);
+
+         const router = TestBed.inject(Router);
+         router.navigateByUrl('/home');
+         advance(root);
+         expect(canActivateLog).toEqual(['service1', 'service2']);
+         expect(root.debugElement.query(By.directive(ParentCmp)).componentInstance.service.name)
+             .toEqual('service1');
+         expect(root.debugElement.query(By.directive(ChildCmp)).componentInstance.service.name)
+             .toEqual('service2');
+
+         router.navigateByUrl('/home/child2');
+         advance(root);
+         expect(canActivateLog).toEqual(['service1', 'service2', 'service3']);
+         expect(root.debugElement.query(By.directive(ChildCmp2)).componentInstance.service.name)
+             .toEqual('service3');
+       }));
+  });
+});
+
+function advance(fixture: ComponentFixture<unknown>) {
+  tick();
+  fixture.detectChanges();
+}


### PR DESCRIPTION
Currently, the only way to specify new providers for a `Route` and the
children is to create a new `NgModule` with those providers and use the
`loadChildren` feature. This is pretty confusing and a wholly indirect
way of accomplishing this task. With this commit, developers will be
able to specify a list of providers directly on the `Route` itself.
These providers will apply the that route and its children.

This feature was inspired by the upcoming standalone components feature.
This ties in there because, as mentioned before, the prior art for lazy
loading configs was to load an `NgModule`. This loaded module contained
new route configs _and_ could specify new providers. Separating those
two concepts, there should be a way to load _just_ some new routes, but
there should also be a way to specify new providers as well (something
you could do in the `NgModule` world and now will be able to do in the
world without any `NgModule` through this feature).