### PR TITLE
fix(docs-infra): avoid internal symbols from being referenced during auto-linking

### DIFF
--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.js
@@ -126,7 +126,8 @@ module.exports = function autoLinkCode(getDocFromAlias) {
 
     var doc = docs[0];
 
-    const isInvalidDoc = doc.docType === 'member' && !keyword.includes('.');
+    const isInvalidDoc =
+        doc.internal || doc.privateExport || (doc.docType === 'member' && !keyword.includes('.'));
     if (isInvalidDoc) {
       return false;
     }

--- a/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
+++ b/aio/tools/transforms/angular-base-package/post-processors/auto-link-code.spec.js
@@ -221,6 +221,20 @@ describe('autoLinkCode post-processor', () => {
     expect(doc.renderedContent).toEqual('<code class="no-auto-link">MyClass</code>');
   });
 
+  it('should ignore symbols marked as internal', () => {
+    aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], internal: true});
+    const doc = {docType: 'test-doc', renderedContent: '<code>MyClass</code>'};
+    processor.$process([doc]);
+    expect(doc.renderedContent).toEqual('<code>MyClass</code>');
+  });
+
+  it('should ignore symbols marked as privately exported (that start with `ɵ`)', () => {
+    aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], privateExport: true});
+    const doc = {docType: 'test-doc', renderedContent: '<code>MyClass</code>'};
+    processor.$process([doc]);
+    expect(doc.renderedContent).toEqual('<code>MyClass</code>');
+  });
+
   it('should ignore code blocks that are marked with an "ignored" language', () => {
     aliasMap.addDoc({docType: 'class', id: 'MyClass', aliases: ['MyClass'], path: 'a/b/myclass'});
     const doc = {docType: 'test-doc', renderedContent: '<code language="bash">MyClass</code>'};


### PR DESCRIPTION
This commit adds extra logic to avoid internal and privately exported symbols from being referenced during auto-linking. Currently such symbols can be used for linking, thus resulting in a non-existing link and causing the linking process to fail.

Note: the issue was discovered while trying to privately export an experimental directive in #45688 ([see CI failure here](https://app.circleci.com/pipelines/github/angular/angular/45165/workflows/1c43d8d9-d115-4863-94a0-b37f610d225a/jobs/1153974)).

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No