### PR TITLE
refactor(animations): Break out some of _flushAnimations into smaller chunks

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4343,
-      "main": 454248,
+      "main": 455140,
       "polyfills": 33980,
       "styles": 71714,
       "light-theme": 78213,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -48,7 +48,7 @@
   "animations": {
     "uncompressed": {
       "runtime": 1070,
-      "main": 158703,
+      "main": 159301,
       "polyfills": 33925
     }
   },

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -48,8 +48,8 @@
   "animations": {
     "uncompressed": {
       "runtime": 1070,
-      "main": 157739,
-      "polyfills": 33814
+      "main": 157555,
+      "polyfills": 33925
     }
   },
   "standalone-bootstrap": {

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -48,7 +48,7 @@
   "animations": {
     "uncompressed": {
       "runtime": 1070,
-      "main": 157555,
+      "main": 158703,
       "polyfills": 33925
     }
   },

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -369,6 +369,12 @@
     "name": "PlatformRef"
   },
   {
+    "name": "QueuedTransition"
+  },
+  {
+    "name": "QueuedTransitionType"
+  },
+  {
     "name": "R3Injector"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -372,9 +372,6 @@
     "name": "QueuedTransition"
   },
   {
-    "name": "QueuedTransitionType"
-  },
-  {
     "name": "R3Injector"
   },
   {


### PR DESCRIPTION
_flushAnimations is the central point of the animation package, and this starts to break it apart into more manageable chunks and remove side effects that are present throughout.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
