### PR TITLE
ci: update payload size golden file

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -41,7 +41,7 @@
   "forms": {
     "uncompressed": {
       "runtime": 1063,
-      "main": 158031,
+      "main": 158537,
       "polyfills": 33804
     }
   },


### PR DESCRIPTION
This commit updates the payload size for the Forms-related test app.
The CI started to fail after merging https://github.com/angular/angular/commit/ff3f5a8d12e3243620e311b690a050e26493e539. The payload size increase is most likely accumulated.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
