### PR TITLE
feat(router): Allow loadChildren to return a Route array

### DIFF
--- a/aio/content/guide/router-tutorial-toh.md
+++ b/aio/content/guide/router-tutorial-toh.md
@@ -2255,13 +2255,6 @@ Finally, it loads the requested route to the destination admin component.
 
 The lazy loading and re-configuration happen just once, when the route is first requested; the module and routes are available immediately for subsequent requests.
 
-<div class="alert is-helpful">
-
-Angular provides a built-in module loader that supports SystemJS to load modules asynchronously.
-If you were using another bundling tool, such as Webpack, you would use the Webpack mechanism for asynchronously loading modules.
-
-</div>
-
 Take the final step and detach the admin feature set from the main application.
 The root `AppModule` must neither load nor reference the `AdminModule` or its files.
 

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -263,7 +263,7 @@ export interface IsActiveMatchOptions {
 export type LoadChildren = LoadChildrenCallback;
 
 // @public
-export type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Observable<Type<any>> | Promise<NgModuleFactory<any> | Type<any>>;
+export type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Routes | Observable<Type<any> | Routes> | Promise<NgModuleFactory<any> | Type<any> | Routes>;
 
 // @public
 export interface Navigation {

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -251,6 +251,9 @@ export {
 export {
   compilePipe as ɵcompilePipe,
 } from './render3/jit/pipe';
+export {
+  isStandalone as ɵisStandalone,
+} from './render3/jit/module';
 export { Profiler as ɵProfiler, ProfilerEvent as ɵProfilerEvent } from './render3/profiler';
 export {
   publishDefaultGlobalUtils as ɵpublishDefaultGlobalUtils

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -195,7 +195,7 @@ export function compileNgModuleDefs(
   });
 }
 
-function isStandalone<T>(type: Type<T>) {
+export function isStandalone<T>(type: Type<T>) {
   const def = getComponentDef(type) || getDirectiveDef(type) || getPipeDef(type);
   return def !== null ? def.standalone : false;
 }

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -93,6 +93,8 @@ export type ResolveData = {
  * A function that is called to resolve a collection of lazy-loaded routes.
  * Must be an arrow function of the following form:
  * `() => import('...').then(mod => mod.MODULE)`
+ * or
+ * `() => import('...').then(mod => mod.ROUTES)`
  *
  * For example:
  *
@@ -102,12 +104,19 @@ export type ResolveData = {
  *   loadChildren: () => import('./lazy-route/lazy.module').then(mod => mod.LazyModule),
  * }];
  * ```
+ * or
+ * ```
+ * [{
+ *   path: 'lazy',
+ *   loadChildren: () => import('./lazy-route/lazy.routes').then(mod => mod.ROUTES),
+ * }];
+ * ```
  *
  * @see [Route.loadChildren](api/router/Route#loadChildren)
  * @publicApi
  */
-export type LoadChildrenCallback = () =>
-    Type<any>|NgModuleFactory<any>|Observable<Type<any>>|Promise<NgModuleFactory<any>|Type<any>>;
+export type LoadChildrenCallback = () => Type<any>|NgModuleFactory<any>|Routes|
+    Observable<Type<any>|Routes>|Promise<NgModuleFactory<any>|Type<any>|Routes>;
 
 /**
  *

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector} from '@angular/core';
+import {EnvironmentInjector, ɵisStandalone as isStandalone} from '@angular/core';
 
 import {EmptyOutletComponent} from '../components/empty_outlet';
 import {Route, Routes} from '../models';
@@ -25,16 +25,17 @@ export function getProvidersInjector(route: Route): EnvironmentInjector|undefine
   return route._injector;
 }
 
-export function validateConfig(config: Routes, parentPath: string = ''): void {
+export function validateConfig(
+    config: Routes, parentPath: string = '', requireStandaloneComponents = false): void {
   // forEach doesn't iterate undefined values
   for (let i = 0; i < config.length; i++) {
     const route: Route = config[i];
     const fullPath: string = getFullPath(parentPath, route);
-    validateNode(route, fullPath);
+    validateNode(route, fullPath, requireStandaloneComponents);
   }
 }
 
-function validateNode(route: Route, fullPath: string): void {
+function validateNode(route: Route, fullPath: string, requireStandaloneComponents: boolean): void {
   if (typeof ngDevMode === 'undefined' || ngDevMode) {
     if (!route) {
       throw new Error(`
@@ -101,9 +102,13 @@ function validateNode(route: Route, fullPath: string): void {
       throw new Error(`Invalid configuration of route '{path: "${fullPath}", redirectTo: "${
           route.redirectTo}"}': please provide 'pathMatch'. ${exp}`);
     }
+    if (requireStandaloneComponents && route.component && !isStandalone(route.component)) {
+      throw new Error(
+          `Invalid configuration of route '${fullPath}'. The component must be standalone.`);
+    }
   }
   if (route.children) {
-    validateConfig(route.children, fullPath);
+    validateConfig(route.children, fullPath, requireStandaloneComponents);
   }
 }
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -5567,7 +5567,7 @@ describe('Integration', () => {
 
          expect(recordedError.message)
              .toEqual(
-                 `Invalid configuration of route 'loaded'. One of the following must be provided: component, redirectTo, children or loadChildren`);
+                 `Invalid configuration of route 'lazy/loaded'. One of the following must be provided: component, redirectTo, children or loadChildren`);
        }));
 
     it('should work with complex redirect rules',


### PR DESCRIPTION
This commit expands the `LoadChildrenCallback` to accept returning `Routes`
in addition to the existing `NgModule` type. In addition, it adds a
check to ensure these loaded routes all use standalone components.
The components must be standalone because if they were not,
we would not have the required `NgModule` which the component is declared in.

Existing API:
```
{path: 'lazy/route', loadChildren: import('./lazy').then(m => m.LazyModule)}

@NgModule({
  imports: [
    ExtraCmpModule,
    RouterModule.forChild([
      {path: 'extra/route', component: ExtraCmp},
    ]),
  ],
})
export class LazyModule {}
```

The new API for lazy loading route configs with standalone components
(no NgModule) is to expand `loadChildren` to allow returning simply a `Routes` array.

```
// parent.ts
{
  path: 'parent',
  loadChildren: () => import('./children').then(m => m.ROUTES),
}

// children.ts
export const ROUTES: Route[] = [
  {path: 'child', component: ChildCmp},
];
```

Note that this includes minimal documentation updates. We need to
include a holistic update to the documentation for standalone components
in the future that includes this feature.