### PR TITLE
Optimizations for injector emit with standalone

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/util.ts
@@ -43,22 +43,20 @@ export function isAngularAnimationsReference(reference: Reference, symbolName: s
       reference.debugName === symbolName;
 }
 
-export const animationTriggerResolver: ForeignFunctionResolver = (ref, args) => {
-  const animationTriggerMethodName = 'trigger';
-  if (!isAngularAnimationsReference(ref, animationTriggerMethodName)) {
-    return null;
-  }
-  const triggerNameExpression = args[0];
-  if (!triggerNameExpression) {
-    return null;
-  }
-  const factory = ts.factory;
-  return factory.createObjectLiteralExpression(
-      [
-        factory.createPropertyAssignment(factory.createIdentifier('name'), triggerNameExpression),
-      ],
-      true);
-};
+export const animationTriggerResolver: ForeignFunctionResolver =
+    (fn, node, resolve, unresolvable) => {
+      const animationTriggerMethodName = 'trigger';
+      if (!isAngularAnimationsReference(fn, animationTriggerMethodName)) {
+        return unresolvable;
+      }
+      const triggerNameExpression = node.arguments[0];
+      if (!triggerNameExpression) {
+        return unresolvable;
+      }
+      const res = new Map<string, ResolvedValue>();
+      res.set('name', resolve(triggerNameExpression));
+      return res;
+    };
 
 export function validateAndFlattenComponentImports(imports: ResolvedValue, expr: ts.Expression): {
   imports: Reference<ClassDeclaration>[],

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -24,13 +24,14 @@ import {combineResolvers, compileDeclareFactory, compileNgFactoryDefField, creat
 
 export interface NgModuleAnalysis {
   mod: R3NgModuleMetadata;
-  inj: R3InjectorMetadata;
+  inj: Omit<R3InjectorMetadata, 'imports'>;
   fac: R3FactoryMetadata;
   classMetadata: R3ClassMetadata|null;
   declarations: Reference<ClassDeclaration>[];
   rawDeclarations: ts.Expression|null;
   schemas: SchemaMetadata[];
-  imports: Reference<ClassDeclaration>[];
+  imports: TopLevelImportedExpression[];
+  importRefs: Reference<ClassDeclaration>[];
   rawImports: ts.Expression|null;
   exports: Reference<ClassDeclaration>[];
   rawExports: ts.Expression|null;
@@ -191,7 +192,8 @@ export class NgModuleDecoratorHandler implements
       rawDeclarations = ngModule.get('declarations')!;
       const declarationMeta = this.evaluator.evaluate(rawDeclarations, forwardRefResolver);
       declarationRefs =
-          this.resolveTypeList(rawDeclarations, declarationMeta, name, 'declarations');
+          this.resolveTypeList(rawDeclarations, declarationMeta, name, 'declarations', 0)
+              .references;
 
       // Look through the declarations to make sure they're all a part of the current compilation.
       for (const ref of declarationRefs) {
@@ -218,21 +220,21 @@ export class NgModuleDecoratorHandler implements
     if (ngModule.has('imports')) {
       rawImports = ngModule.get('imports')!;
       const importsMeta = this.evaluator.evaluate(rawImports, moduleResolvers);
-      importRefs = this.resolveTypeList(rawImports, importsMeta, name, 'imports');
+      importRefs = this.resolveTypeList(rawImports, importsMeta, name, 'imports', 0).references;
     }
     let exportRefs: Reference<ClassDeclaration>[] = [];
     let rawExports: ts.Expression|null = null;
     if (ngModule.has('exports')) {
       rawExports = ngModule.get('exports')!;
       const exportsMeta = this.evaluator.evaluate(rawExports, moduleResolvers);
-      exportRefs = this.resolveTypeList(rawExports, exportsMeta, name, 'exports');
+      exportRefs = this.resolveTypeList(rawExports, exportsMeta, name, 'exports', 0).references;
       this.referencesRegistry.add(node, ...exportRefs);
     }
     let bootstrapRefs: Reference<ClassDeclaration>[] = [];
     if (ngModule.has('bootstrap')) {
       const expr = ngModule.get('bootstrap')!;
       const bootstrapMeta = this.evaluator.evaluate(expr, forwardRefResolver);
-      bootstrapRefs = this.resolveTypeList(expr, bootstrapMeta, name, 'bootstrap');
+      bootstrapRefs = this.resolveTypeList(expr, bootstrapMeta, name, 'bootstrap', 0).references;
     }
 
     const schemas: SchemaMetadata[] = [];
@@ -340,20 +342,47 @@ export class NgModuleDecoratorHandler implements
                                               rawProviders) :
         null;
 
-    // At this point, only add the module's imports as the injectors' imports. Any exported modules
-    // are added during `resolve`, as we need scope information to be able to filter out directives
-    // and pipes from the module exports.
-    const injectorImports: WrappedNodeExpr<ts.Expression>[] = [];
+    const topLevelImports: TopLevelImportedExpression[] = [];
     if (ngModule.has('imports')) {
-      injectorImports.push(new WrappedNodeExpr(ngModule.get('imports')!));
+      const rawImports = unwrapExpression(ngModule.get('imports')!);
+
+      let topLevelExpressions: ts.Expression[] = [];
+      if (ts.isArrayLiteralExpression(rawImports)) {
+        for (const element of rawImports.elements) {
+          if (ts.isSpreadElement(element)) {
+            // Because `imports` allows nested arrays anyway, a spread expression (`...foo`) can be
+            // treated the same as a direct reference to `foo`.
+            topLevelExpressions.push(element.expression);
+            continue;
+          }
+          topLevelExpressions.push(element);
+        }
+      } else {
+        // Treat the whole `imports` expression as top-level.
+        topLevelExpressions.push(rawImports);
+      }
+
+      let absoluteIndex = 0;
+      for (const importExpr of topLevelExpressions) {
+        const resolved = this.evaluator.evaluate(importExpr, moduleResolvers);
+
+        const {references, hasModuleWithProviders} =
+            this.resolveTypeList(importExpr, [resolved], node.name.text, 'imports', absoluteIndex);
+        absoluteIndex += references.length;
+
+        topLevelImports.push({
+          expression: importExpr,
+          resolvedReferences: references,
+          hasModuleWithProviders,
+        });
+      }
     }
 
-    const injectorMetadata: R3InjectorMetadata = {
+    const injectorMetadata: Omit<R3InjectorMetadata, 'imports'> = {
       name,
       type,
       internalType,
       providers: wrapperProviders,
-      imports: injectorImports,
     };
 
     const factoryMetadata: R3FactoryMetadata = {
@@ -375,8 +404,9 @@ export class NgModuleDecoratorHandler implements
         fac: factoryMetadata,
         declarations: declarationRefs,
         rawDeclarations,
-        imports: importRefs,
+        imports: topLevelImports,
         rawImports,
+        importRefs,
         exports: exportRefs,
         rawExports,
         providers: rawProviders,
@@ -403,7 +433,7 @@ export class NgModuleDecoratorHandler implements
       ref: new Reference(node),
       schemas: analysis.schemas,
       declarations: analysis.declarations,
-      imports: analysis.imports,
+      imports: analysis.importRefs,
       exports: analysis.exports,
       rawDeclarations: analysis.rawDeclarations,
       rawImports: analysis.rawImports,
@@ -438,6 +468,11 @@ export class NgModuleDecoratorHandler implements
     const data: NgModuleResolution = {
       injectorImports: [],
     };
+
+    // Add all top-level imports from the `imports` field to the injector imports.
+    for (const topLevelImport of analysis.imports) {
+      data.injectorImports.push(new WrappedNodeExpr(topLevelImport.expression));
+    }
 
     if (scope !== null && !scope.compilation.isPoisoned) {
       // Using the scope information, extend the injector's imports using the modules that are
@@ -487,7 +522,10 @@ export class NgModuleDecoratorHandler implements
       {inj, mod, fac, classMetadata, declarations}: Readonly<NgModuleAnalysis>,
       {injectorImports}: Readonly<NgModuleResolution>): CompileResult[] {
     const factoryFn = compileNgFactoryDefField(fac);
-    const ngInjectorDef = compileInjector(this.mergeInjectorImports(inj, injectorImports));
+    const ngInjectorDef = compileInjector({
+      ...inj,
+      imports: injectorImports,
+    });
     const ngModuleDef = compileNgModule(mod);
     const statements = ngModuleDef.statements;
     const metadata = classMetadata !== null ? compileClassMetadata(classMetadata) : null;
@@ -501,22 +539,15 @@ export class NgModuleDecoratorHandler implements
       node: ClassDeclaration, {inj, fac, mod, classMetadata}: Readonly<NgModuleAnalysis>,
       {injectorImports}: Readonly<NgModuleResolution>): CompileResult[] {
     const factoryFn = compileDeclareFactory(fac);
-    const injectorDef =
-        compileDeclareInjectorFromMetadata(this.mergeInjectorImports(inj, injectorImports));
+    const injectorDef = compileDeclareInjectorFromMetadata({
+      ...inj,
+      imports: injectorImports,
+    });
     const ngModuleDef = compileDeclareNgModuleFromMetadata(mod);
     const metadata = classMetadata !== null ? compileDeclareClassMetadata(classMetadata) : null;
     this.insertMetadataStatement(ngModuleDef.statements, metadata);
     // NOTE: no remote scoping required as this is banned in partial compilation.
     return this.compileNgModule(factoryFn, injectorDef, ngModuleDef);
-  }
-
-  /**
-   *  Merge the injector imports (which are 'exports' that were later found to be NgModules)
-   *  computed during resolution with the ones from analysis.
-   */
-  private mergeInjectorImports(inj: R3InjectorMetadata, injectorImports: Expression[]):
-      R3InjectorMetadata {
-    return {...inj, imports: [...inj.imports, ...injectorImports]};
   }
 
   /**
@@ -714,8 +745,10 @@ export class NgModuleDecoratorHandler implements
    * Compute a list of `Reference`s from a resolved metadata value.
    */
   private resolveTypeList(
-      expr: ts.Node, resolvedList: ResolvedValue, className: string,
-      arrayName: string): Reference<ClassDeclaration>[] {
+      expr: ts.Node, resolvedList: ResolvedValue, className: string, arrayName: string,
+      absoluteIndex: number):
+      {references: Reference<ClassDeclaration>[], hasModuleWithProviders: boolean} {
+    let hasModuleWithProviders = false;
     const refList: Reference<ClassDeclaration>[] = [];
     if (!Array.isArray(resolvedList)) {
       throw createValueHasWrongTypeError(
@@ -729,31 +762,41 @@ export class NgModuleDecoratorHandler implements
       // resolution was able to descend into the function and return an object literal, a Map).
       if (entry instanceof SyntheticValue && isResolvedModuleWithProviders(entry)) {
         entry = entry.value.ngModule;
+        hasModuleWithProviders = true;
       } else if (entry instanceof Map && entry.has('ngModule')) {
         entry = entry.get('ngModule')!;
+        hasModuleWithProviders = true;
       }
 
       if (Array.isArray(entry)) {
         // Recurse into nested arrays.
-        refList.push(...this.resolveTypeList(expr, entry, className, arrayName));
+        const recursiveResult =
+            this.resolveTypeList(expr, entry, className, arrayName, absoluteIndex);
+        refList.push(...recursiveResult.references);
+        absoluteIndex += recursiveResult.references.length;
+        hasModuleWithProviders = hasModuleWithProviders || recursiveResult.hasModuleWithProviders;
       } else if (entry instanceof Reference) {
         if (!this.isClassDeclarationReference(entry)) {
           throw createValueHasWrongTypeError(
               entry.node, entry,
-              `Value at position ${idx} in the NgModule.${arrayName} of ${
+              `Value at position ${absoluteIndex} in the NgModule.${arrayName} of ${
                   className} is not a class`);
         }
         refList.push(entry);
+        absoluteIndex += 1;
       } else {
         // TODO(alxhub): Produce a better diagnostic here - the array index may be an inner array.
         throw createValueHasWrongTypeError(
             expr, entry,
-            `Value at position ${idx} in the NgModule.${arrayName} of ${
+            `Value at position ${absoluteIndex} in the NgModule.${arrayName} of ${
                 className} is not a reference`);
       }
     }
 
-    return refList;
+    return {
+      references: refList,
+      hasModuleWithProviders,
+    };
   }
 }
 
@@ -772,6 +815,12 @@ function isModuleIdExpression(expr: ts.Expression): boolean {
 interface ResolvedModuleWithProviders {
   ngModule: Reference<ClassDeclaration>;
   mwpCall: ts.CallExpression;
+}
+
+export interface TopLevelImportedExpression {
+  expression: ts.Expression;
+  resolvedReferences: Array<Reference<ClassDeclaration>>;
+  hasModuleWithProviders: boolean;
 }
 
 function isResolvedModuleWithProviders(sv: SyntheticValue<unknown>):

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/index.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/index.ts
@@ -11,3 +11,4 @@ export {DynamicValue} from './src/dynamic';
 export {ForeignFunctionResolver, PartialEvaluator} from './src/interface';
 export {StaticInterpreter} from './src/interpreter';
 export {EnumValue, KnownFn, ResolvedValue, ResolvedValueArray, ResolvedValueMap} from './src/result';
+export {SyntheticValue} from './src/synthetic';

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/diagnostics.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/diagnostics.ts
@@ -11,8 +11,10 @@ import ts from 'typescript';
 import {makeRelatedInformation} from '../../diagnostics';
 import {Reference} from '../../imports';
 import {FunctionDefinition} from '../../reflection';
+
 import {DynamicValue, DynamicValueVisitor} from './dynamic';
 import {EnumValue, KnownFn, ResolvedModule, ResolvedValue} from './result';
+import {SyntheticValue} from './synthetic';
 
 /**
  * Derives a type representation from a resolved value to be reported in a diagnostic.
@@ -88,6 +90,11 @@ class TraceDynamicValueVisitor implements DynamicValueVisitor<ts.DiagnosticRelat
       trace.unshift(info);
     }
     return trace;
+  }
+
+  visitSyntheticInput(value: DynamicValue<SyntheticValue<unknown>>):
+      ts.DiagnosticRelatedInformation[] {
+    return [makeRelatedInformation(value.node, 'Unable to evaluate this expression further.')];
   }
 
   visitDynamicString(value: DynamicValue): ts.DiagnosticRelatedInformation[] {

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interface.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interface.ts
@@ -12,12 +12,14 @@ import {Reference} from '../../imports';
 import {DependencyTracker} from '../../incremental/api';
 import {ReflectionHost} from '../../reflection';
 
+import {DynamicValue} from './dynamic';
 import {StaticInterpreter} from './interpreter';
 import {ResolvedValue} from './result';
 
 export type ForeignFunctionResolver =
-    (node: Reference<ts.FunctionDeclaration|ts.MethodDeclaration|ts.FunctionExpression>,
-     args: ReadonlyArray<ts.Expression>) => ts.Expression|null;
+    (fn: Reference<ts.FunctionDeclaration|ts.MethodDeclaration|ts.FunctionExpression>,
+     callExpr: ts.CallExpression, resolve: (expr: ts.Expression) => ResolvedValue,
+     unresolvable: DynamicValue) => ResolvedValue;
 
 export class PartialEvaluator {
   constructor(

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/result.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/result.ts
@@ -12,6 +12,7 @@ import {Reference} from '../../imports';
 import {Declaration} from '../../reflection';
 
 import {DynamicValue} from './dynamic';
+import {SyntheticValue} from './synthetic';
 
 
 /**
@@ -21,8 +22,9 @@ import {DynamicValue} from './dynamic';
  * non-primitive value, or a special `DynamicValue` type which indicates the value was not
  * available statically.
  */
-export type ResolvedValue = number|boolean|string|null|undefined|Reference|EnumValue|
-    ResolvedValueArray|ResolvedValueMap|ResolvedModule|KnownFn|DynamicValue<unknown>;
+export type ResolvedValue =
+    number|boolean|string|null|undefined|Reference|EnumValue|ResolvedValueArray|ResolvedValueMap|
+    ResolvedModule|KnownFn|SyntheticValue<unknown>|DynamicValue<unknown>;
 
 /**
  * An array of `ResolvedValue`s.

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/synthetic.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/synthetic.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * A value produced which originated in a `ForeignFunctionResolver` and doesn't come from the
+ * template itself.
+ *
+ * Synthetic values cannot be further evaluated, and attempts to do so produce `DynamicValue`s
+ * instead.
+ */
+export class SyntheticValue<T> {
+  constructor(readonly value: T) {}
+}

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/test/utils.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/test/utils.ts
@@ -58,18 +58,18 @@ export function owningModuleOf(ref: Reference): string|null {
 }
 
 export function firstArgFfr(
-    node: Reference<ts.FunctionDeclaration|ts.MethodDeclaration|ts.FunctionExpression>,
-    args: ReadonlyArray<ts.Expression>): ts.Expression {
-  return args[0];
+    fn: Reference<ts.FunctionDeclaration|ts.MethodDeclaration|ts.FunctionExpression>,
+    expr: ts.CallExpression, resolve: (expr: ts.Expression) => ResolvedValue): ResolvedValue {
+  return resolve(expr.arguments[0]);
 }
 
-export const arrowReturnValueFfr: ForeignFunctionResolver = (_ref, args) => {
+export const arrowReturnValueFfr: ForeignFunctionResolver = (_fn, node, resolve) => {
   // Extracts the `Foo` from `() => Foo`.
-  return (args[0] as ts.ArrowFunction).body as ts.Expression;
+  return resolve((node.arguments[0] as ts.ArrowFunction).body as ts.Expression);
 };
 
-export const returnTypeFfr: ForeignFunctionResolver = (ref) => {
+export const returnTypeFfr: ForeignFunctionResolver = (fn, node, resolve) => {
   // Extract the `Foo` from the return type of the `external` function declaration.
-  return ((ref.node as ts.FunctionDeclaration).type as ts.TypeReferenceNode).typeName as
-      ts.Identifier;
+  return resolve(
+      ((fn.node as ts.FunctionDeclaration).type as ts.TypeReferenceNode).typeName as ts.Identifier);
 };

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/GOLDEN_PARTIAL.js
@@ -596,7 +596,7 @@ export class TestModule {
 }
 TestModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
 TestModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestModule, declarations: [TestComponent], imports: [LibModule] });
-TestModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestModule, imports: [[LibModule]] });
+TestModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestModule, imports: [LibModule] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestModule, decorators: [{
             type: NgModule,
             args: [{

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
@@ -155,7 +155,7 @@ export class SomeModule {
 }
 SomeModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
 SomeModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeModule, imports: [IndirectDir, IndirectPipe], exports: [NotStandaloneStuffModule, IndirectDir, IndirectPipe] });
-SomeModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeModule, imports: [[IndirectDir, IndirectPipe], NotStandaloneStuffModule] });
+SomeModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeModule, imports: [IndirectDir, IndirectPipe, NotStandaloneStuffModule] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeModule, decorators: [{
             type: NgModule,
             args: [{

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
@@ -155,7 +155,7 @@ export class SomeModule {
 }
 SomeModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
 SomeModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeModule, imports: [IndirectDir, IndirectPipe], exports: [NotStandaloneStuffModule, IndirectDir, IndirectPipe] });
-SomeModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeModule, imports: [IndirectDir, IndirectPipe, NotStandaloneStuffModule] });
+SomeModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeModule, imports: [NotStandaloneStuffModule] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: SomeModule, decorators: [{
             type: NgModule,
             args: [{
@@ -284,5 +284,60 @@ import * as i0 from "@angular/core";
 export declare class RecursiveComponent {
     static ɵfac: i0.ɵɵFactoryDeclaration<RecursiveComponent, never>;
     static ɵcmp: i0.ɵɵComponentDeclaration<RecursiveComponent, "recursive-cmp", never, {}, {}, never, never, true>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: module_optimization.js
+ ****************************************************************************************************/
+import { Component, Directive, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class StandaloneCmp {
+}
+StandaloneCmp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: StandaloneCmp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+StandaloneCmp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: StandaloneCmp, isStandalone: true, selector: "standalone-cmp", ngImport: i0, template: '', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: StandaloneCmp, decorators: [{
+            type: Component,
+            args: [{
+                    standalone: true,
+                    selector: 'standalone-cmp',
+                    template: '',
+                }]
+        }] });
+export class StandaloneDir {
+}
+StandaloneDir.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: StandaloneDir, deps: [], target: i0.ɵɵFactoryTarget.Directive });
+StandaloneDir.ɵdir = i0.ɵɵngDeclareDirective({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", type: StandaloneDir, isStandalone: true, ngImport: i0 });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: StandaloneDir, decorators: [{
+            type: Directive,
+            args: [{ standalone: true }]
+        }] });
+export class Module {
+}
+Module.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Module, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+Module.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Module, imports: [StandaloneCmp, StandaloneDir] });
+Module.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Module, imports: [StandaloneCmp] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Module, decorators: [{
+            type: NgModule,
+            args: [{
+                    imports: [StandaloneCmp, StandaloneDir],
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: module_optimization.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class StandaloneCmp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<StandaloneCmp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<StandaloneCmp, "standalone-cmp", never, {}, {}, never, never, true>;
+}
+export declare class StandaloneDir {
+    static ɵfac: i0.ɵɵFactoryDeclaration<StandaloneDir, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<StandaloneDir, never, never, {}, {}, never, never, true>;
+}
+export declare class Module {
+    static ɵfac: i0.ɵɵFactoryDeclaration<Module, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<Module, never, [typeof StandaloneCmp, typeof StandaloneDir], never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<Module>;
 }
 

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/TEST_CASES.json
@@ -70,6 +70,20 @@
           ]
         }
       ]
+    },
+    {
+      "description": "should optimize injector imports",
+      "inputFiles": [
+        "module_optimization.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Injector imports not optimized",
+          "files": [
+            "module_optimization.js"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/module_optimization.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/module_optimization.js
@@ -1,0 +1,1 @@
+Module.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [StandaloneCmp] });

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/module_optimization.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/module_optimization.ts
@@ -1,0 +1,19 @@
+import {Component, Directive, NgModule} from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'standalone-cmp',
+  template: '',
+})
+export class StandaloneCmp {
+}
+
+@Directive({standalone: true})
+export class StandaloneDir {
+}
+
+@NgModule({
+  imports: [StandaloneCmp, StandaloneDir],
+})
+export class Module {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/GOLDEN_PARTIAL.js
@@ -320,7 +320,7 @@ export class AppModule {
 }
 AppModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AppModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
 AppModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AppModule, imports: [BModule] });
-AppModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AppModule, imports: [[BModule]] });
+AppModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AppModule, imports: [BModule] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AppModule, decorators: [{
             type: NgModule,
             args: [{ imports: [BModule] }]
@@ -421,7 +421,7 @@ export class AppModule {
 }
 AppModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AppModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
 AppModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AppModule, imports: [BModule] });
-AppModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AppModule, imports: [[BModule]] });
+AppModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AppModule, imports: [BModule] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: AppModule, decorators: [{
             type: NgModule,
             args: [{ imports: [BModule] }]
@@ -553,7 +553,7 @@ export class TestModule {
 }
 TestModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
 TestModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestModule, imports: function () { return [ForwardModule]; } });
-TestModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestModule, imports: [[provideModule()]] });
+TestModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestModule, imports: [provideModule()] });
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestModule, decorators: [{
             type: NgModule,
             args: [{ imports: [provideModule()] }]

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/forward_refs.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/forward_refs.js
@@ -5,7 +5,7 @@ export function provideModule() {
 export class TestModule {}
 TestModule.ɵfac = function TestModule_Factory(t) { return new (t || TestModule)(); };
 TestModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: TestModule, imports: function () { return [ForwardModule]; } });
-TestModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [[provideModule()]] });
+TestModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [provideModule()] });
 …
 export class ForwardModule {}
 ForwardModule.ɵfac = function ForwardModule_Factory(t) { return new (t || ForwardModule)(); };

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports.js
@@ -23,7 +23,7 @@ BModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [AModule] });
 export class AppModule {}
 AppModule.ɵfac = function AppModule_Factory(t) { return new (t || AppModule)(); };
 AppModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AppModule });
-AppModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [[BModule]] });
+AppModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [BModule] });
 …
 (function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppModule, [{
   type: NgModule,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports_jit_mode.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/imports_exports_jit_mode.js
@@ -23,7 +23,7 @@ BModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [AModule] });
 export class AppModule {}
 AppModule.ɵfac = function AppModule_Factory(t) { return new (t || AppModule)(); };
 AppModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: AppModule, imports: [BModule] });
-AppModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [[BModule]] });
+AppModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [BModule] });
 …
 (function () { (typeof ngDevMode === "undefined" || ngDevMode) && i0.ɵsetClassMetadata(AppModule, [{
   type: NgModule,

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1329,7 +1329,7 @@ function allTests(os: string) {
               'TestModule.ɵfac = function TestModule_Factory(t) { return new (t || TestModule)(); }');
       expect(jsContents)
           .toContain(
-              'i0.ɵɵdefineInjector({ imports: [[OtherModule, RouterModule.forRoot()],' +
+              'i0.ɵɵdefineInjector({ imports: [OtherModule, RouterModule.forRoot(),' +
               ' OtherModule, RouterModule] });');
     });
 
@@ -1367,7 +1367,7 @@ function allTests(os: string) {
           .toContain(
               `TestModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ ` +
               `providers: [{ provide: Token, useValue: 'test' }], ` +
-              `imports: [[OtherModule]] });`);
+              `imports: [OtherModule] });`);
 
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
@@ -1410,7 +1410,7 @@ function allTests(os: string) {
           .toContain(
               `TestModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ ` +
               `providers: [{ provide: Token, useFactory: () => new Token() }], ` +
-              `imports: [[OtherModule]] });`);
+              `imports: [OtherModule] });`);
 
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
@@ -1457,7 +1457,7 @@ function allTests(os: string) {
           .toContain(
               `TestModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ ` +
               `providers: [{ provide: Token, useFactory: (dep) => new Token(dep), deps: [Dep] }], ` +
-              `imports: [[OtherModule]] });`);
+              `imports: [OtherModule] });`);
 
       const dtsContents = env.getContents('test.d.ts');
       expect(dtsContents)
@@ -2938,7 +2938,7 @@ function allTests(os: string) {
         env.driveMain();
 
         const jsContents = env.getContents('test.js');
-        expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
+        expect(jsContents).toContain('imports: [RouterModule.forRoot()]');
 
         const dtsContents = env.getContents('test.d.ts');
         expect(dtsContents).toContain(`import * as i1 from "router";`);
@@ -3002,7 +3002,7 @@ function allTests(os: string) {
         env.driveMain();
 
         const jsContents = env.getContents('test.js');
-        expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
+        expect(jsContents).toContain('imports: [RouterModule.forRoot()]');
 
         const dtsContents = env.getContents('test.d.ts');
         expect(dtsContents).toContain(`import * as i1 from "router";`);
@@ -3037,7 +3037,7 @@ function allTests(os: string) {
            env.driveMain();
 
            const jsContents = env.getContents('test.js');
-           expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
+           expect(jsContents).toContain('imports: [RouterModule.forRoot()]');
 
            const dtsContents = env.getContents('test.d.ts');
            expect(dtsContents).toContain(`import * as i1 from "router2";`);
@@ -3100,7 +3100,7 @@ function allTests(os: string) {
          env.driveMain();
 
          const jsContents = env.getContents('test.js');
-         expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
+         expect(jsContents).toContain('imports: [RouterModule.forRoot()]');
 
          const dtsContents = env.getContents('test.d.ts');
          expect(dtsContents).toContain(`import * as i1 from "router";`);
@@ -3132,7 +3132,7 @@ function allTests(os: string) {
          env.driveMain();
 
          const jsContents = env.getContents('test.js');
-         expect(jsContents).toContain('imports: [[RouterModule.forRoot()]]');
+         expect(jsContents).toContain('imports: [RouterModule.forRoot()]');
 
          const dtsContents = env.getContents('test.d.ts');
          expect(dtsContents).toContain(`import * as i1 from "router";`);


### PR DESCRIPTION
Before standalone, everything that could appear in an NgModule's `imports` was relevant to DI, and needed to be emitted in the `imports` of the generated `InjectorDef` definition. With the introduction of standalone types, NgModule `imports` can now contain components, directives, and pipes which are standalone. Only standalone components need to be included in the `imports` of the generated injector definition - directives and pipes have no effect on DI. Having them present doesn't cause any errors in the runtime (they're filtered out by the injector itself) but it does prevent tree-shaking.

With this commit, the generation of `InjectorDef` now filters the `imports` to exclude directives and pipes as much as possible. It's not _always_ possible because an expression in `imports` may pull in both a directive and a `ModuleWithProviders` reference, and we have no way of referencing just the MWP part of that expression. Therefore this is an optimization, not a rule of `InjectorDef` compilation.
