### PR TITLE
feat(router): Support lazy loading standalone components with `loadComponent`

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -451,6 +451,7 @@ export interface Route {
     component?: Type<any>;
     data?: Data;
     loadChildren?: LoadChildren;
+    loadComponent?: () => Type<unknown> | Observable<Type<unknown>> | Promise<Type<unknown>>;
     matcher?: UrlMatcher;
     outlet?: string;
     path?: string;

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -33,7 +33,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2835,
-      "main": 236444,
+      "main": 237828,
       "polyfills": 33842,
       "src_app_lazy_lazy_module_ts": 795
     }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -96,6 +96,9 @@
     "name": "ChildrenOutletContexts"
   },
   {
+    "name": "CombineLatestOperator"
+  },
+  {
     "name": "CombineLatestSubscriber"
   },
   {
@@ -865,6 +868,9 @@
   },
   {
     "name": "collectQueryResults"
+  },
+  {
+    "name": "combineLatest"
   },
   {
     "name": "compare"

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -283,7 +283,7 @@ class ApplyRedirects {
       if (route.loadChildren) {
         const loaded$ = route._loadedRoutes ?
             of({routes: route._loadedRoutes, injector: route._loadedInjector}) :
-            this.configLoader.load(injector, route);
+            this.configLoader.loadChildren(injector, route);
         return loaded$.pipe(map((cfg: LoadedRouterConfig) => {
           route._loadedRoutes = cfg.routes;
           route._loadedInjector = cfg.injector;
@@ -345,11 +345,11 @@ class ApplyRedirects {
       return this.runCanLoadGuards(injector, route, segments)
           .pipe(mergeMap((shouldLoadResult: boolean) => {
             if (shouldLoadResult) {
-              return this.configLoader.load(injector, route).pipe(map((cfg: LoadedRouterConfig) => {
-                route._loadedRoutes = cfg.routes;
-                route._loadedInjector = cfg.injector;
-                return cfg;
-              }));
+              return this.configLoader.loadChildren(injector, route)
+                  .pipe(tap((cfg: LoadedRouterConfig) => {
+                    route._loadedRoutes = cfg.routes;
+                    route._loadedInjector = cfg.injector;
+                  }));
             }
             return canLoadFails(route);
           }));

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -271,7 +271,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     this._activatedRoute = activatedRoute;
     const location = this.location;
     const snapshot = activatedRoute._futureSnapshot;
-    const component = <any>snapshot.routeConfig!.component;
+    const component = snapshot.component!;
     const childContexts = this.parentContexts.getOrCreateContext(this.name).children;
     const injector = new OutletInjector(activatedRoute, childContexts, location.injector);
 

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -422,6 +422,17 @@ export interface Route {
    * Can be empty if child routes specify components.
    */
   component?: Type<any>;
+
+  /**
+   * An object specifying a lazy-loaded component.
+   */
+  loadComponent?: () => Type<unknown>| Observable<Type<unknown>>| Promise<Type<unknown>>;
+  /**
+   * Filled for routes `loadComponent` once the component is loaded.
+   * @internal
+   */
+  _loadedComponent?: Type<unknown>;
+
   /**
    * A URL to redirect to when the path matches.
    *
@@ -479,6 +490,7 @@ export interface Route {
    * An object specifying lazy-loaded child routes.
    */
   loadChildren?: LoadChildren;
+
   /**
    * Defines when guards and resolvers will be run. One of
    * - `paramsOrQueryParamsChange` : Run when query parameters change.

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -164,8 +164,8 @@ export class Recognizer {
       const pathIndexShift = getPathIndexShift(rawSegment) + segments.length;
       snapshot = new ActivatedRouteSnapshot(
           segments, params, Object.freeze({...this.urlTree.queryParams}), this.urlTree.fragment,
-          getData(route), getOutlet(route), route.component!, route,
-          getSourceSegmentGroup(rawSegment), pathIndexShift, getResolve(route),
+          getData(route), getOutlet(route), route.component ?? route._loadedComponent ?? null,
+          route, getSourceSegmentGroup(rawSegment), pathIndexShift, getResolve(route),
           // NG_DEV_MODE is used to prevent the getCorrectedPathIndexShift function from affecting
           // production bundle size. This value is intended only to surface a warning to users
           // depending on `relativeLinkResolution: 'legacy'` in dev mode.
@@ -182,7 +182,8 @@ export class Recognizer {
 
       snapshot = new ActivatedRouteSnapshot(
           consumedSegments, result.parameters, Object.freeze({...this.urlTree.queryParams}),
-          this.urlTree.fragment, getData(route), getOutlet(route), route.component!, route,
+          this.urlTree.fragment, getData(route), getOutlet(route),
+          route.component ?? route._loadedComponent ?? null, route,
           getSourceSegmentGroup(rawSegment), pathIndexShift, getResolve(route),
           (NG_DEV_MODE ? getCorrectedPathIndexShift(rawSegment) + consumedSegments.length :
                          pathIndexShift));

--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -8,9 +8,9 @@
 
 import {Compiler, createEnvironmentInjector, EnvironmentInjector, Injectable, OnDestroy} from '@angular/core';
 import {from, Observable, of, Subscription} from 'rxjs';
-import {catchError, concatMap, filter, map, mergeAll, mergeMap} from 'rxjs/operators';
+import {catchError, concatMap, filter, map, mapTo, mergeAll, mergeMap, tap} from 'rxjs/operators';
 
-import {Event, NavigationEnd} from './events';
+import {Event, NavigationEnd, RouteConfigLoadEnd, RouteConfigLoadStart} from './events';
 import {LoadedRouterConfig, Route, Routes} from './models';
 import {Router} from './router';
 import {RouterConfigLoader} from './router_config_loader';
@@ -104,36 +104,46 @@ export class RouterPreloader implements OnDestroy {
         route._injector =
             createEnvironmentInjector(route.providers, injector, `Route: ${route.path}`);
       }
+
       const injectorForCurrentRoute = route._injector ?? injector;
       const injectorForChildren = route._loadedInjector ?? injectorForCurrentRoute;
-      // we already have the config loaded, just recurse
-      if (route.loadChildren && !route.canLoad && route._loadedRoutes) {
-        res.push(this.processRoutes(injectorForChildren, route._loadedRoutes));
 
-        // no config loaded, fetch the config
-      } else if (route.loadChildren && !route.canLoad) {
+      if ((route.loadChildren && !route._loadedRoutes) ||
+          (route.loadComponent && !route._loadedComponent)) {
         res.push(this.preloadConfig(injectorForCurrentRoute, route));
-
-        // recurse into children
-      } else if (route.children) {
-        res.push(this.processRoutes(injectorForChildren, route.children));
+      } else if (route.children || route._loadedRoutes) {
+        res.push(this.processRoutes(injectorForChildren, (route.children ?? route._loadedRoutes)!));
       }
     }
-    return from(res).pipe(mergeAll(), map((_) => void 0));
+    return from(res).pipe(mergeAll());
   }
 
   private preloadConfig(injector: EnvironmentInjector, route: Route): Observable<void> {
     return this.preloadingStrategy.preload(route, () => {
-      const loaded$ = route._loadedRoutes ?
-          of({routes: route._loadedRoutes, injector: route._loadedInjector}) :
-          this.loader.load(injector, route);
-      return loaded$.pipe(mergeMap((config: LoadedRouterConfig) => {
-        route._loadedRoutes = config.routes;
-        route._loadedInjector = config.injector;
-        // If the loaded config was a module, use that as the module/module injector going forward.
-        // Otherwise, continue using the current module/module injector.
-        return this.processRoutes(config.injector ?? injector, config.routes);
-      }));
+      let loadedChildren$: Observable<LoadedRouterConfig|null>;
+      if (route.loadChildren && route.canLoad === undefined) {
+        loadedChildren$ = this.loader.loadChildren(injector, route);
+      } else {
+        loadedChildren$ = of(null);
+      }
+
+      const recursiveLoadChildren$ =
+          loadedChildren$.pipe(mergeMap((config: LoadedRouterConfig|null) => {
+            if (config === null) {
+              return of(void 0);
+            }
+            route._loadedRoutes = config.routes;
+            route._loadedInjector = config.injector;
+            // If the loaded config was a module, use that as the module/module injector going
+            // forward. Otherwise, continue using the current module/module injector.
+            return this.processRoutes(config.injector ?? injector, config.routes);
+          }));
+      if (route.loadComponent && !route._loadedComponent) {
+        const loadComponent$ = this.loader.loadComponent(route);
+        return from([recursiveLoadChildren$, loadComponent$]).pipe(mergeAll());
+      } else {
+        return recursiveLoadChildren$;
+      }
     });
   }
 }

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -13,6 +13,7 @@ import {delay, tap} from 'rxjs/operators';
 
 import {applyRedirects} from '../src/apply_redirects';
 import {Route, Routes} from '../src/models';
+import {RouterConfigLoader} from '../src/router_config_loader';
 import {DefaultUrlSerializer, equalSegments, UrlSegment, UrlSegmentGroup, UrlTree} from '../src/url_tree';
 import {getLoadedRoutes} from '../src/utils/config';
 
@@ -195,8 +196,8 @@ describe('applyRedirects', () => {
         routes: [{path: 'b', component: ComponentB}],
         injector: testModule.injector
       };
-      const loader = {
-        load: (injector: any, p: any) => {
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => {
           if (injector !== testModule.injector) throw 'Invalid Injector';
           return of(loadedConfig);
         }
@@ -212,8 +213,9 @@ describe('applyRedirects', () => {
     });
 
     it('should handle the case when the loader errors', () => {
-      const loader = {
-        load: (p: any) => new Observable<any>((obs: any) => obs.error(new Error('Loading Error')))
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (p: any) =>
+            new Observable<any>((obs: any) => obs.error(new Error('Loading Error')))
       };
       const config =
           [{path: 'a', component: ComponentA, loadChildren: jasmine.createSpy('children')}];
@@ -229,7 +231,9 @@ describe('applyRedirects', () => {
         routes: [{path: 'b', component: ComponentB}],
         injector: testModule.injector
       };
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => of(loadedConfig)
+      };
 
       const guard = () => true;
       const injector = {
@@ -253,7 +257,9 @@ describe('applyRedirects', () => {
         routes: [{path: 'b', component: ComponentB}],
         injector: testModule.injector
       };
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => of(loadedConfig)
+      };
 
       const trueGuard = () => true;
       const falseGuard = () => false;
@@ -293,7 +299,9 @@ describe('applyRedirects', () => {
         routes: [{path: 'b', component: ComponentB}],
         injector: testModule.injector
       };
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => of(loadedConfig)
+      };
 
       const trueGuard = () => Promise.resolve(true);
       const falseGuard = () => Promise.reject('someError');
@@ -332,7 +340,9 @@ describe('applyRedirects', () => {
         routes: [{path: 'b', component: ComponentB}],
         injector: testModule.injector
       };
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => of(loadedConfig)
+      };
 
       const guard = {canLoad: () => Promise.resolve(true)};
       const injector = {get: (token: any) => token === 'guard' ? guard : {injector}};
@@ -359,7 +369,9 @@ describe('applyRedirects', () => {
         routes: [{path: 'b', component: ComponentB}],
         injector: testModule.injector
       };
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => of(loadedConfig)
+      };
 
       let passedUrlSegments: UrlSegment[];
 
@@ -394,7 +406,9 @@ describe('applyRedirects', () => {
         routes: [{path: 'b', component: ComponentB}],
         injector: testModule.injector
       };
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => of(loadedConfig)
+      };
 
       let passedUrlSegments: UrlSegment[];
 
@@ -432,7 +446,9 @@ describe('applyRedirects', () => {
         injector: testModule.injector
       };
 
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => of(loadedConfig)
+      };
 
       const config: Routes = [
         {path: '', pathMatch: 'full', redirectTo: '/a'},
@@ -452,8 +468,8 @@ describe('applyRedirects', () => {
       };
 
       let called = false;
-      const loader = {
-        load: (injector: any, p: any) => {
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => {
           if (called) throw new Error('Should not be called twice');
           called = true;
           return of(loadedConfig);
@@ -482,7 +498,9 @@ describe('applyRedirects', () => {
         injector: testModule.injector
       };
 
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => of(loadedConfig)
+      };
 
       const config: Routes = [{path: '**', loadChildren: jasmine.createSpy('children')}];
 
@@ -498,8 +516,9 @@ describe('applyRedirects', () => {
         injector: testModule.injector
       };
 
-      const loader = jasmine.createSpyObj('loader', ['load']);
-      loader.load.and.returnValue(of(loadedConfig).pipe(delay(0)));
+      const loader: jasmine.SpyObj<Pick<RouterConfigLoader, 'loadChildren'>> =
+          jasmine.createSpyObj('loader', ['loadChildren']);
+      loader.loadChildren.and.returnValue(of(loadedConfig).pipe(delay(0)));
 
       const config: Routes = [
         {path: '', loadChildren: jasmine.createSpy('matchChildren')},
@@ -507,8 +526,8 @@ describe('applyRedirects', () => {
       ];
 
       applyRedirects(testModule.injector, <any>loader, serializer, tree(''), config).forEach(r => {
-        expect(loader.load.calls.count()).toEqual(1);
-        expect(loader.load.calls.first().args).not.toContain(jasmine.objectContaining({
+        expect(loader.loadChildren.calls.count()).toEqual(1);
+        expect(loader.loadChildren.calls.first().args).not.toContain(jasmine.objectContaining({
           loadChildren: jasmine.createSpy('children')
         }));
       });
@@ -520,7 +539,9 @@ describe('applyRedirects', () => {
         injector: testModule.injector
       };
 
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => of(loadedConfig)
+      };
 
       const config: Routes = [
         {path: 'not-found', loadChildren: jasmine.createSpy('children')},
@@ -539,7 +560,9 @@ describe('applyRedirects', () => {
         injector: testModule.injector
       };
 
-      const loader = {load: (injector: any, p: any) => of(loadedConfig)};
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: any) => of(loadedConfig)
+      };
 
       const config: Routes = [
         {path: 'not-found', loadChildren: jasmine.createSpy('children')},
@@ -560,8 +583,8 @@ describe('applyRedirects', () => {
          };
          let loadCalls = 0;
          let loaded: string[] = [];
-         const loader = {
-           load: (injector: any, p: Route) => {
+         const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+           loadChildren: (injector: any, p: Route) => {
              loadCalls++;
              return of(loadedConfig)
                  .pipe(
@@ -593,8 +616,8 @@ describe('applyRedirects', () => {
          };
          let loadCalls = 0;
          let loaded: string[] = [];
-         const loader = {
-           load: (injector: any, p: Route) => {
+         const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+           loadChildren: (injector: any, p: Route) => {
              loadCalls++;
              return of(loadedConfig)
                  .pipe(
@@ -633,8 +656,8 @@ describe('applyRedirects', () => {
       };
       let loadCalls = 0;
       let loaded: string[] = [];
-      const loader = {
-        load: (injector: any, p: Route) => {
+      const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+        loadChildren: (injector: any, p: Route) => {
           loadCalls++;
           return of(loadedConfig)
               .pipe(
@@ -662,8 +685,8 @@ describe('applyRedirects', () => {
          let loaded: string[] = [];
          const rootDelay = 100;
          const auxDelay = 1;
-         const loader = {
-           load: (injector: any, p: Route) => {
+         const loader: Pick<RouterConfigLoader, 'loadChildren'> = {
+           loadChildren: (injector: any, p: Route) => {
              const delayMs =
                  (p.loadChildren! as jasmine.Spy).and.identity === 'aux' ? auxDelay : rootDelay;
              return of(loadedConfig)

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -62,7 +62,7 @@ describe('config', () => {
     it('should validate children and report full path', () => {
       expect(() => validateConfig([{path: 'a', children: [{path: 'b'}]}]))
           .toThrowError(
-              `Invalid configuration of route 'a/b'. One of the following must be provided: component, redirectTo, children or loadChildren`);
+              `Invalid configuration of route 'a/b'. One of the following must be provided: component, loadComponent, redirectTo, children or loadChildren`);
     });
 
     it('should properly report deeply nested path', () => {
@@ -71,7 +71,7 @@ describe('config', () => {
             {path: 'a', children: [{path: 'b', children: [{path: 'c', children: [{path: 'd'}]}]}]}
           ]))
           .toThrowError(
-              `Invalid configuration of route 'a/b/c/d'. One of the following must be provided: component, redirectTo, children or loadChildren`);
+              `Invalid configuration of route 'a/b/c/d'. One of the following must be provided: component, loadComponent, redirectTo, children or loadChildren`);
     });
 
     it('should throw when redirectTo and loadChildren are used together', () => {
@@ -95,7 +95,23 @@ describe('config', () => {
         validateConfig([{path: 'a', component: ComponentA, redirectTo: 'b'}]);
       })
           .toThrowError(
-              `Invalid configuration of route 'a': redirectTo and component cannot be used together`);
+              `Invalid configuration of route 'a': redirectTo and component/loadComponent cannot be used together`);
+    });
+
+    it('should throw when redirectTo and loadComponent are used together', () => {
+      expect(() => {
+        validateConfig([{path: 'a', redirectTo: 'b', loadComponent: () => ComponentA}]);
+      })
+          .toThrowError(
+              `Invalid configuration of route 'a': redirectTo and component/loadComponent cannot be used together`);
+    });
+
+    it('should throw when component and loadComponent are used together', () => {
+      expect(() => {
+        validateConfig([{path: 'a', component: ComponentA, loadComponent: () => ComponentA}]);
+      })
+          .toThrowError(
+              `Invalid configuration of route 'a': component and loadComponent cannot be used together`);
     });
 
     it('should throw when component and redirectTo are used together', () => {
@@ -128,7 +144,7 @@ describe('config', () => {
         validateConfig([{path: 'a'}]);
       })
           .toThrowError(
-              `Invalid configuration of route 'a'. One of the following must be provided: component, redirectTo, children or loadChildren`);
+              `Invalid configuration of route 'a'. One of the following must be provided: component, loadComponent, redirectTo, children or loadChildren`);
     });
 
     it('should throw when path starts with a slash', () => {

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -318,7 +318,7 @@ describe('recognize', () => {
 
            const s = recognize(config, 'parent/b');
            checkActivatedRoute(s.root, '', {}, RootComponent);
-           checkActivatedRoute(s.root.firstChild!, 'parent', {}, undefined!);
+           checkActivatedRoute(s.root.firstChild!, 'parent', {}, null);
 
            const cc = s.root.firstChild!.children;
            checkActivatedRoute(cc[0], '', {}, ComponentA);
@@ -674,7 +674,7 @@ describe('recognize', () => {
           }],
           'p/11;pp=22/(a;pa=33//aux:b;pb=44)');
       const p = s.root.firstChild!;
-      checkActivatedRoute(p, 'p/11', {id: '11', pp: '22'}, undefined!);
+      checkActivatedRoute(p, 'p/11', {id: '11', pp: '22'}, null);
 
       const c = p.children;
       checkActivatedRoute(c[0], 'a', {id: '11', pp: '22', pa: '33'}, ComponentA);
@@ -694,10 +694,10 @@ describe('recognize', () => {
           }],
           'p/11/a/victor/b/c');
       const p = s.root.firstChild!;
-      checkActivatedRoute(p, 'p/11', {id: '11'}, undefined!);
+      checkActivatedRoute(p, 'p/11', {id: '11'}, null);
 
       const a = p.firstChild!;
-      checkActivatedRoute(a, 'a/victor', {id: '11', name: 'victor'}, undefined!);
+      checkActivatedRoute(a, 'a/victor', {id: '11', name: 'victor'}, null);
 
       const b = a.firstChild!;
       checkActivatedRoute(b, 'b', {id: '11', name: 'victor'}, ComponentB);
@@ -831,7 +831,7 @@ function recognize(
 }
 
 function checkActivatedRoute(
-    actual: ActivatedRouteSnapshot, url: string, params: Params, cmp: Function,
+    actual: ActivatedRouteSnapshot, url: string, params: Params, cmp: Function|null,
     outlet: string = PRIMARY_OUTLET): void {
   if (actual === null) {
     expect(actual).not.toBeNull();

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -289,6 +289,57 @@ describe('standalone in Router API', () => {
              .toEqual('service3');
        }));
   });
+
+  describe('loadComponent', () => {
+    it('does not load component when canActivate returns false', fakeAsync(() => {
+         const loadComponentSpy = jasmine.createSpy();
+         @Injectable({providedIn: 'root'})
+         class Guard {
+           canActivate() {
+             return false;
+           }
+         }
+
+         TestBed.configureTestingModule({
+           imports: [RouterTestingModule.withRoutes([{
+             path: 'home',
+             loadComponent: loadComponentSpy,
+             canActivate: [Guard],
+           }])]
+         });
+
+         TestBed.inject(Router).navigateByUrl('/home');
+         tick();
+         expect(loadComponentSpy).not.toHaveBeenCalled();
+       }));
+
+    it('loads and renders lazy component', fakeAsync(() => {
+         TestBed.configureTestingModule({
+           imports: [RouterTestingModule.withRoutes([{
+             path: 'home',
+             loadComponent: () => SimpleStandaloneComponent,
+           }])],
+         });
+
+         const root = TestBed.createComponent(RootCmp);
+         TestBed.inject(Router).navigateByUrl('/home');
+         advance(root);
+         expect(root.nativeElement.innerHTML).toContain('simple standalone');
+       }));
+
+    it('throws error when loadComponent is not standalone', fakeAsync(() => {
+         TestBed.configureTestingModule({
+           imports: [RouterTestingModule.withRoutes([{
+             path: 'home',
+             loadComponent: () => NotStandaloneComponent,
+           }])],
+         });
+
+         const root = TestBed.createComponent(RootCmp);
+         TestBed.inject(Router).navigateByUrl('/home');
+         expect(() => advance(root)).toThrowError(/.*home.*component must be standalone/);
+       }));
+  });
 });
 
 function advance(fixture: ComponentFixture<unknown>) {


### PR DESCRIPTION
Note: this is rebased on top of #45700 which is rebased on the `standalone` branch

Similarly to the symmetry being strengthened between children and loadChildren,
a new loadComponent property will be introduced as the asynchronous version of component.
This will allow for direct single-component lazy loading:

```
{path: 'lazy/a', loadComponent:
  () => import('./lazy/a.component').then(m => m.ACmp)},
{path: 'lazy/b', loadComponent:
  () => import('./lazy/b.component').then(m => m.BCmp)},
```

This option requires that the component being loaded is standalone and
is implemented as a runtime check.

Other notes:
* Components are not loaded until all guards and resolvers complete.
* Loading the component is included in the function passed to the router
  preloading strategy
* `RouteConfigLoadStart` and `RouteConfigLoadEnd` events emit at the
  start and end of the component loading
* `CanLoad` guards _do not_ apply to `loadComponent`. `canActivate`
  should be used instead, just like you would do if it were simply
  `component` instead.