### PR TITLE
fix(docs-infra): include `tslib` into SystemJS config in `upgrade-module` example app

### DIFF
--- a/aio/content/examples/upgrade-module/src/systemjs.config.1.js
+++ b/aio/content/examples/upgrade-module/src/systemjs.config.1.js
@@ -28,6 +28,7 @@
       // other libraries
       'rxjs': 'npm:rxjs/dist/cjs',
       'rxjs/operators': 'npm:rxjs/dist/cjs/operators',
+      'tslib': 'npm:tslib/tslib.js',
       'angular-in-memory-web-api': 'npm:angular-in-memory-web-api/bundles/in-memory-web-api.umd.js',
 
       'plugin-babel': 'npm:systemjs-plugin-babel/plugin-babel.js',


### PR DESCRIPTION
This commit updates the SystemJS for one of the example apps (the `upgrade-module` one) to include a resolution rule for the `tslib`. This is needed in case `tslib` is referenced from the framework code (for example in case of downleveling of some operators). This makes it consistent with other example app configs.

This issue was causing [Protractor errors](https://app.circleci.com/pipelines/github/angular/angular/45248/workflows/02024625-4c06-4675-8aba-ccde3f086d70/jobs/1154963) in the PR #45674 when native async/await were used in the code and downlevelled to use `__awaiter` helper from `tslib`.

## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No