### PR TITLE
build: updates to account for github primary branch rename

### DIFF
--- a/.ng-dev/github.ts
+++ b/.ng-dev/github.ts
@@ -7,5 +7,5 @@ import {GithubConfig} from '@angular/dev-infra-private/ng-dev';
 export const github: GithubConfig = {
   owner: 'angular',
   name: 'angular',
-  mainBranchName: 'master',
+  mainBranchName: 'main',
 };

--- a/.ng-dev/pullRequest.ts
+++ b/.ng-dev/pullRequest.ts
@@ -10,10 +10,10 @@ export const pullRequest: PullRequestConfig = {
   caretakerNoteLabel: /^(action: merge-assistance)|(PullApprove: disable)/,
   commitMessageFixupLabel: 'commit message fixup',
   requiredBaseCommits: {
-    // PRs that target either `master` or the patch branch, need to be rebased
+    // PRs that target either `main` or the patch branch, need to be rebased
     // on top of the latest commit message validation fix.
     // These SHAs are the commits that update the required license text in the header.
-    'master': '5aeb9a4124922d8ac08eb73b8f322905a32b0b3a',
+    'main': '5aeb9a4124922d8ac08eb73b8f322905a32b0b3a',
     '10.0.x': '27b95ba64a5d99757f4042073fd1860e20e3ed24',
   },
   // `dev-infra` and `docs-infra` are not affecting the public NPM packages. Similarly,

--- a/aio/scripts/deploy-to-firebase/index.mjs
+++ b/aio/scripts/deploy-to-firebase/index.mjs
@@ -27,7 +27,7 @@
  * | deploying | RC     | -                               | rc                              |
  * | from?     |        |                                 | redirectVersionDomainToRc(*)    |
  * |           |--------|---------------------------------|---------------------------------|
- * |           | MASTER | next                            | next                            |
+ * |           | main   | next                            | next                            |
  * |           |        | redirectVersionDomainToNext(**) | redirectVersionDomainToNext(**) |
  * |-----------|--------|---------------------------------|---------------------------------|
  *
@@ -36,7 +36,7 @@
  *
  * NOTES:
  *   - The `v<X>-angular-io-site` Firebase site should be created (and connected to the
- *     `v<X>.angular.io` subdomain) before the version in the `master` branch's `package.json` is
+ *     `v<X>.angular.io` subdomain) before the version in the `main` branch's `package.json` is
  *     updated to a new major.
  *   - When a new major version is released, the deploy CI jobs for the new stable branch (prev. RC
  *     or next) and the old stable branch must be run AFTER the new stable version has been
@@ -250,8 +250,8 @@ function computeDeploymentsInfo(
   const rcBranch = (mostRecentMinorBranch !== stableBranch) ? mostRecentMinorBranch : null;
   const isRcActive = rcBranch !== null;
 
-  // If the current branch is `master`, deploy as `next`.
-  if (currentBranch === 'master') {
+  // If the current branch is `main`, deploy as `next`.
+  if (currentBranch === 'main') {
     // In order to determine whether to also deploy to `v<NEXT>-angular-io-site` we need to compare
     // `v<NEXT>` with either `v<RC>` (if there is an active RC) or `v<STABLE>`.
     const otherVersion = isRcActive ? u.computeMajorVersion(rcBranch) : stableBranchMajorVersion;
@@ -308,7 +308,7 @@ function computeDeploymentsInfo(
       ];
   }
 
-  // If we get here, it means that the current branch is neither `master`, nor the RC or stable
+  // If we get here, it means that the current branch is neither `main`, nor the RC or stable
   // branches. At this point, we may only deploy as `archive` and only if the following criteria are
   // met:
   //   1. The current branch must have the highest minor version among all branches with the same

--- a/aio/scripts/deploy-to-firebase/index.spec.mjs
+++ b/aio/scripts/deploy-to-firebase/index.spec.mjs
@@ -20,7 +20,7 @@ describe('deploy-to-firebase:', () => {
 
     mostRecentMinorBranch = u.getMostRecentMinorBranch();
     latestCommits = {
-      master: u.getLatestCommit('master'),
+      main: u.getLatestCommit('main'),
       '2.1.x': u.getLatestCommit('2.1.x'),
       '2.4.x': u.getLatestCommit('2.4.x'),
       '4.3.x': u.getLatestCommit('4.3.x'),
@@ -39,7 +39,7 @@ describe('deploy-to-firebase:', () => {
     return JSON.parse(JSON.stringify(deploymentsInfo, jsonFunctionReplacer));
   };
 
-  it('master - skip deploy - not angular', () => {
+  it('main - skip deploy - not angular', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'notangular',
@@ -52,7 +52,7 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('master - skip deploy - angular fork', () => {
+  it('main - skip deploy - angular fork', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'notangular',
       CI_REPO_NAME: 'angular',
@@ -65,7 +65,7 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('master - skip deploy - pull request', () => {
+  it('main - skip deploy - pull request', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
@@ -79,20 +79,20 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('master - deploy success - no active RC, major higher than stable', () => {
+  it('main - deploy success - no active RC, major higher than stable', () => {
     const mostRecentMajorVersion = u.computeMajorVersion(mostRecentMinorBranch);
-    const fakeMasterMajorVersion = mostRecentMajorVersion + 1;
+    const fakeMainMajorVersion = mostRecentMajorVersion + 1;
 
     // Fake the `package.json` version.
-    spyOn(u, 'loadJson').and.returnValue({version: `${fakeMasterMajorVersion}.0.0-next.42`});
+    spyOn(u, 'loadJson').and.returnValue({version: `${fakeMainMajorVersion}.0.0-next.42`});
 
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
-      CI_BRANCH: 'master',
+      CI_BRANCH: 'main',
       CI_STABLE_BRANCH: mostRecentMinorBranch,
-      CI_COMMIT: latestCommits.master,
+      CI_COMMIT: latestCommits.main,
     })).toEqual([
       {
         name: 'next',
@@ -109,15 +109,15 @@ describe('deploy-to-firebase:', () => {
         type: 'secondary',
         deployEnv: 'next',
         projectId: 'angular-io',
-        siteId: `v${fakeMasterMajorVersion}-angular-io-site`,
-        deployedUrl: `https://v${fakeMasterMajorVersion}.angular.io/`,
+        siteId: `v${fakeMainMajorVersion}-angular-io-site`,
+        deployedUrl: `https://v${fakeMainMajorVersion}.angular.io/`,
         preDeployActions: ['function:redirectAllToNext'],
         postDeployActions: ['function:undoRedirectAllToNext', 'function:testRedirectToNext'],
       },
     ]);
   });
 
-  it('master - deploy success - no active RC, major same as stable', () => {
+  it('main - deploy success - no active RC, major same as stable', () => {
     const mostRecentMajorVersion = u.computeMajorVersion(mostRecentMinorBranch);
 
     // Fake the `package.json` version.
@@ -127,9 +127,9 @@ describe('deploy-to-firebase:', () => {
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
-      CI_BRANCH: 'master',
+      CI_BRANCH: 'main',
       CI_STABLE_BRANCH: mostRecentMinorBranch,
-      CI_COMMIT: latestCommits.master,
+      CI_COMMIT: latestCommits.main,
     })).toEqual([
       {
         name: 'next',
@@ -144,20 +144,20 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('master - deploy success - active RC, major higher than RC and stable', () => {
+  it('main - deploy success - active RC, major higher than RC and stable', () => {
     const mostRecentMajorVersion = u.computeMajorVersion(mostRecentMinorBranch);
-    const fakeMasterMajorVersion = mostRecentMajorVersion + 1;
+    const fakeMainMajorVersion = mostRecentMajorVersion + 1;
 
     // Fake the `package.json` version.
-    spyOn(u, 'loadJson').and.returnValue({version: `${fakeMasterMajorVersion}.0.0-next.42`});
+    spyOn(u, 'loadJson').and.returnValue({version: `${fakeMainMajorVersion}.0.0-next.42`});
 
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
-      CI_BRANCH: 'master',
+      CI_BRANCH: 'main',
       CI_STABLE_BRANCH: '4.4.x',
-      CI_COMMIT: latestCommits.master,
+      CI_COMMIT: latestCommits.main,
     })).toEqual([
       {
         name: 'next',
@@ -174,15 +174,15 @@ describe('deploy-to-firebase:', () => {
         type: 'secondary',
         deployEnv: 'next',
         projectId: 'angular-io',
-        siteId: `v${fakeMasterMajorVersion}-angular-io-site`,
-        deployedUrl: `https://v${fakeMasterMajorVersion}.angular.io/`,
+        siteId: `v${fakeMainMajorVersion}-angular-io-site`,
+        deployedUrl: `https://v${fakeMainMajorVersion}.angular.io/`,
         preDeployActions: ['function:redirectAllToNext'],
         postDeployActions: ['function:undoRedirectAllToNext', 'function:testRedirectToNext'],
       },
     ]);
   });
 
-  it('master - deploy success - active RC, major same as RC and higher than stable', () => {
+  it('main - deploy success - active RC, major same as RC and higher than stable', () => {
     const mostRecentMajorVersion = u.computeMajorVersion(mostRecentMinorBranch);
 
     // Fake the `package.json` version.
@@ -192,9 +192,9 @@ describe('deploy-to-firebase:', () => {
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
-      CI_BRANCH: 'master',
+      CI_BRANCH: 'main',
       CI_STABLE_BRANCH: '4.4.x',
-      CI_COMMIT: latestCommits.master,
+      CI_COMMIT: latestCommits.main,
     })).toEqual([
       {
         name: 'next',
@@ -209,12 +209,12 @@ describe('deploy-to-firebase:', () => {
     ]);
   });
 
-  it('master - skip deploy - commit not HEAD', () => {
+  it('main - skip deploy - commit not HEAD', () => {
     expect(getDeploymentsInfoFor({
       CI_REPO_OWNER: 'angular',
       CI_REPO_NAME: 'angular',
       CI_PULL_REQUEST: 'false',
-      CI_BRANCH: 'master',
+      CI_BRANCH: 'main',
       CI_COMMIT: 'DUMMY_TEST_COMMIT',
     })).toEqual([
       {
@@ -222,7 +222,7 @@ describe('deploy-to-firebase:', () => {
         type: 'skipped',
         reason:
             'Skipping deploy because DUMMY_TEST_COMMIT is not the latest commit ' +
-            `(${latestCommits.master}).`,
+            `(${latestCommits.main}).`,
       },
     ]);
   });

--- a/aio/tests/e2e/src/api-pages.e2e-spec.ts
+++ b/aio/tests/e2e/src/api-pages.e2e-spec.ts
@@ -67,7 +67,7 @@ describe('Api pages', () => {
     /* eslint-disable max-len */
     expect(await page.ghLinks.get(0).getAttribute('href'))
         .toMatch(
-            /https:\/\/github\.com\/angular\/angular\/edit\/master\/packages\/core\/src\/event_emitter\.ts\?message=docs\(core\)%3A%20describe%20your%20change\.\.\.#L\d+-L\d+/);
+            /https:\/\/github\.com\/angular\/angular\/edit\/main\/packages\/core\/src\/event_emitter\.ts\?message=docs\(core\)%3A%20describe%20your%20change\.\.\.#L\d+-L\d+/);
     expect(await page.ghLinks.get(1).getAttribute('href'))
         .toMatch(
             /https:\/\/github\.com\/angular\/angular\/tree\/[^/]+\/packages\/core\/src\/event_emitter\.ts#L\d+-L\d+/);

--- a/aio/tests/e2e/src/app.e2e-spec.ts
+++ b/aio/tests/e2e/src/app.e2e-spec.ts
@@ -1,4 +1,5 @@
-import { browser, by, element, ElementFinder } from 'protractor';
+import { ElementFinder, browser, by, element } from 'protractor';
+
 import { SitePage } from './app.po';
 
 describe('site App', () => {
@@ -232,12 +233,12 @@ describe('site App', () => {
       expect(await page.ghLinks.count()).toEqual(1);
       /* eslint-disable max-len */
       expect(await page.ghLinks.get(0).getAttribute('href'))
-        .toMatch(/https:\/\/github\.com\/angular\/angular\/edit\/master\/aio\/content\/tutorial\/toh-pt1\.md\?message=docs%3A%20describe%20your%20change\.\.\./);
+        .toMatch(/https:\/\/github\.com\/angular\/angular\/edit\/main\/aio\/content\/tutorial\/toh-pt1\.md\?message=docs%3A%20describe%20your%20change\.\.\./);
 
       await page.navigateTo('guide/router');
       expect(await page.ghLinks.count()).toEqual(1);
       expect(await page.ghLinks.get(0).getAttribute('href'))
-        .toMatch(/https:\/\/github\.com\/angular\/angular\/edit\/master\/aio\/content\/guide\/router\.md\?message=docs%3A%20describe%20your%20change\.\.\./);
+        .toMatch(/https:\/\/github\.com\/angular\/angular\/edit\/main\/aio\/content\/guide\/router\.md\?message=docs%3A%20describe%20your%20change\.\.\./);
       /* eslint-enable max-len */
     });
 

--- a/aio/tools/transforms/templates/lib/githubLinks.html
+++ b/aio/tools/transforms/templates/lib/githubLinks.html
@@ -18,7 +18,7 @@ https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInf
 
 {% macro githubEditHref(doc, versionInfo, pathPrefix) -%}
 {% set lineInfo = doc.startingLine and ('#L' + (doc.startingLine + 1) + '-L' + (doc.endingLine + 1)) or '' -%}
-{$ githubBaseUrl(versionInfo) $}/edit/master/{$ projectRelativePath(doc.fileInfo) $}?message=docs
+{$ githubBaseUrl(versionInfo) $}/edit/main/{$ projectRelativePath(doc.fileInfo) $}?message=docs
   {%- if doc.moduleDoc %}({$ doc.moduleDoc.id.split('/')[0] $})
   {%- elseif doc.docType === 'module' %}({$ doc.id.split('/')[0] $})
   {%- elseif doc.docType === 'content' %}

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "enabled": true
   },
   "schedule": ["after 10pm every monday", "before 4am every tuesday"],
-  "baseBranches": ["master"],
+  "baseBranches": ["main"],
   "ignoreDeps": [
     "@angular/animations-12",
     "@angular/common-12",


### PR DESCRIPTION
This is the commit accounting for the Github primary branch
rename when we actually perform the update.

We have three change phases: Prepare (✅ ), Direct, Cleanup. This commit
is for the `direct` phase.