### PR TITLE
refactor(router): refactor RouterLinkActive to use host

### DIFF
--- a/packages/router/src/directives/router_link_active.ts
+++ b/packages/router/src/directives/router_link_active.ts
@@ -209,11 +209,7 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
       if (this.isActive !== hasActiveLinks) {
         (this as any).isActive = hasActiveLinks;
         this.cdr.markForCheck();
-        if (hasActiveLinks) {
-          this._class = this.classes.join(' ');
-        } else {
-          this._class = null;
-        }
+        this._class = hasActiveLinks ? this.classes.join(' ') : null;
         if (hasActiveLinks && this.ariaCurrentWhenActive !== undefined) {
           this._ariaCurrent = this.ariaCurrentWhenActive.toString();
         } else {


### PR DESCRIPTION
refactor the RouterLinkActive directive to set its classes and
aria-current value via the `host` metadata instead of using on the
`renderer`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - @atscott as promised [here](https://github.com/angular/angular/pull/45167#discussion_r812873888) :smile: 