### PR TITLE
Fix importProvidersFrom interaction with ModuleWithProviders

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -578,7 +578,10 @@ export interface HostListenerDecorator {
 }
 
 // @public
-export function importProvidersFrom(...types: Array<Type<unknown>>): Provider[];
+export function importProvidersFrom(...sources: ImportProvidersSource[]): Provider[];
+
+// @public
+export type ImportProvidersSource = Type<unknown> | ModuleWithProviders<unknown> | Array<ImportProvidersSource>;
 
 // @public
 export interface Inject {

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -25,7 +25,7 @@ export {ProviderToken} from './provider_token';
 export {ɵɵinject, inject, ɵɵinvalidFactoryDep} from './injector_compatibility';
 export {INJECTOR} from './injector_token';
 export {ReflectiveInjector} from './reflective_injector';
-export {ClassProvider, ClassSansProvider, ConstructorProvider, ConstructorSansProvider, ExistingProvider, ExistingSansProvider, FactoryProvider, FactorySansProvider, Provider, StaticClassProvider, StaticClassSansProvider, StaticProvider, TypeProvider, ValueProvider, ValueSansProvider} from './interface/provider';
+export {ClassProvider, ModuleWithProviders, ClassSansProvider, ConstructorProvider, ConstructorSansProvider, ExistingProvider, ExistingSansProvider, FactoryProvider, FactorySansProvider, Provider, StaticClassProvider, StaticClassSansProvider, StaticProvider, TypeProvider, ValueProvider, ValueSansProvider} from './interface/provider';
 export {ResolvedReflectiveFactory, ResolvedReflectiveProvider} from './reflective_provider';
 export {ReflectiveKey} from './reflective_key';
 export {InjectionToken} from './injection_token';

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -19,7 +19,7 @@ export {forwardRef, resolveForwardRef, ForwardRefFn} from './forward_ref';
 export {Injectable, InjectableDecorator, InjectableProvider} from './injectable';
 export {Injector} from './injector';
 export {EnvironmentInjector} from './r3_injector';
-export {importProvidersFrom} from './provider_collection';
+export {importProvidersFrom, ImportProvidersSource} from './provider_collection';
 export {INJECTOR_INITIALIZER} from './initializer_token';
 export {ProviderToken} from './provider_token';
 export {ɵɵinject, inject, ɵɵinvalidFactoryDep} from './injector_compatibility';

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -337,3 +337,17 @@ export type Provider = TypeProvider|ValueProvider|ClassProvider|ConstructorProvi
  * overrides).
  */
 export type ProcessProvidersFunction = (providers: Provider[]) => Provider[];
+
+
+/**
+ * A wrapper around an NgModule that associates it with [providers](guide/glossary#provider
+ * "Definition"). Usage without a generic type is deprecated.
+ *
+ * @see [Deprecations](guide/deprecations#modulewithproviders-type-without-a-generic)
+ *
+ * @publicApi
+ */
+export interface ModuleWithProviders<T> {
+  ngModule: Type<T>;
+  providers?: Provider[];
+}

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -17,6 +17,6 @@ export {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, 
 export {ANALYZE_FOR_ENTRY_COMPONENTS, ContentChild, ContentChildDecorator, ContentChildren, ContentChildrenDecorator, Query, ViewChild, ViewChildDecorator, ViewChildren, ViewChildrenDecorator} from './metadata/di';
 export {Component, ComponentDecorator, Directive, DirectiveDecorator, HostBinding, HostBindingDecorator, HostListener, HostListenerDecorator, Input, InputDecorator, Output, OutputDecorator, Pipe, PipeDecorator} from './metadata/directives';
 export {DoBootstrap} from './metadata/do_boostrap';
-export {ModuleWithProviders, NgModule, NgModuleDecorator} from './metadata/ng_module';
+export {NgModule, NgModuleDecorator} from './metadata/ng_module';
 export {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SchemaMetadata} from './metadata/schema';
 export {ViewEncapsulation} from './metadata/view';

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -6,25 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Provider} from '../di/interface/provider';
+import {ModuleWithProviders, Provider} from '../di/interface/provider';
 import {Type} from '../interface/type';
 import {SchemaMetadata} from '../metadata/schema';
 import {compileNgModule} from '../render3/jit/module';
 import {makeDecorator, TypeDecorator} from '../util/decorators';
-
-
-/**
- * A wrapper around an NgModule that associates it with [providers](guide/glossary#provider
- * "Definition"). Usage without a generic type is deprecated.
- *
- * @see [Deprecations](guide/deprecations#modulewithproviders-type-without-a-generic)
- *
- * @publicApi
- */
-export interface ModuleWithProviders<T> {
-  ngModule: Type<T>;
-  providers?: Provider[];
-}
 
 
 /**

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -9,11 +9,12 @@
 import {getCompilerFacade, JitCompilerUsage, R3InjectorMetadataFacade} from '../../compiler/compiler_facade';
 import {resolveForwardRef} from '../../di/forward_ref';
 import {NG_INJ_DEF} from '../../di/interface/defs';
+import {ModuleWithProviders} from '../../di/interface/provider';
 import {reflectDependencies} from '../../di/jit/util';
 import {Type} from '../../interface/type';
 import {registerNgModuleType} from '../../linker/ng_module_registration';
 import {Component} from '../../metadata/directives';
-import {ModuleWithProviders, NgModule} from '../../metadata/ng_module';
+import {NgModule} from '../../metadata/ng_module';
 import {NgModuleDef, NgModuleTransitiveScopes, NgModuleType} from '../../metadata/ng_module_def';
 import {deepForEach, flatten} from '../../util/array_utils';
 import {assertDefined} from '../../util/assert';

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -58,6 +58,20 @@ describe('importProvidersFrom', () => {
     // Expect 2 `INJECTOR_INITIALIZER` providers: one for `MyModule`, another was `MyModule2`
     expect(collectInjectorInitializerProviders(providers).length).toBe(2);
   });
+
+  it('should work for directly imported ModuleWithProviders', () => {
+    const A = new InjectionToken('A');
+
+    @NgModule({})
+    class Module {
+    }
+
+    const providers = importProvidersFrom({
+      ngModule: Module,
+      providers: [{provide: A, useValue: 'A'}],
+    });
+    expect(hasProviderWithToken(providers, A)).toBe(true);
+  });
 });
 
 describe('di', () => {

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -7,24 +7,30 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Attribute, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, Directive, ElementRef, EventEmitter, forwardRef, Host, HostBinding, importProvidersFrom, Inject, Injectable, InjectFlags, InjectionToken, INJECTOR, Injector, INJECTOR_INITIALIZER, Input, LOCALE_ID, NgModule, NgZone, Optional, Output, Pipe, PipeTransform, Provider, Self, SkipSelf, TemplateRef, ViewChild, ViewContainerRef, ViewRef, ɵcreateInjector as createInjector, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵINJECTOR_SCOPE} from '@angular/core';
+import {Attribute, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, Directive, ElementRef, EventEmitter, forwardRef, Host, HostBinding, importProvidersFrom, Inject, Injectable, InjectFlags, InjectionToken, INJECTOR, Injector, INJECTOR_INITIALIZER, Input, LOCALE_ID, ModuleWithProviders, NgModule, NgZone, Optional, Output, Pipe, PipeTransform, Provider, Self, SkipSelf, TemplateRef, Type, ViewChild, ViewContainerRef, ViewRef, ɵcreateInjector as createInjector, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵINJECTOR_SCOPE} from '@angular/core';
 import {ViewRef as ViewRefInternal} from '@angular/core/src/render3/view_ref';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {BehaviorSubject} from 'rxjs';
 
+const getProvidersByToken =
+    (providers: Provider[], token: Type<unknown>|InjectionToken<unknown>): Provider[] =>
+        providers.filter(provider => (provider as any).provide === token);
+
 const hasProviderWithToken = (providers: Provider[], token: InjectionToken<unknown>): boolean =>
-    providers.some(provider => (provider as any).provide === token);
+    getProvidersByToken(providers, token).length > 0;
 
 const collectInjectorInitializerProviders = (providers: Provider[]) =>
-    providers.filter(provider => (provider as any).provide === INJECTOR_INITIALIZER);
+    getProvidersByToken(providers, INJECTOR_INITIALIZER);
 
 describe('importProvidersFrom', () => {
-  it('should work for NgModules', () => {
-    const A = new InjectionToken('A');
-    const B = new InjectionToken('B');
-    const C = new InjectionToken('C');
-    const D = new InjectionToken('D');
+  // Set of tokens used in various tests.
+  const A = new InjectionToken('A');
+  const B = new InjectionToken('B');
+  const C = new InjectionToken('C');
+  const D = new InjectionToken('D');
+
+  it('should collect providers from NgModules', () => {
     @NgModule({
       providers: [
         {provide: C, useValue: 'C'},
@@ -59,9 +65,7 @@ describe('importProvidersFrom', () => {
     expect(collectInjectorInitializerProviders(providers).length).toBe(2);
   });
 
-  it('should work for directly imported ModuleWithProviders', () => {
-    const A = new InjectionToken('A');
-
+  it('should collect providers from directly imported ModuleWithProviders', () => {
     @NgModule({})
     class Module {
     }
@@ -72,6 +76,105 @@ describe('importProvidersFrom', () => {
     });
     expect(hasProviderWithToken(providers, A)).toBe(true);
   });
+
+  it('should collect all providers when a module is used twice with different providers (via ModuleWithProviders)',
+     () => {
+       @NgModule({
+         providers: [
+           {provide: A, useValue: 'A'}  //
+         ]
+       })
+       class ModuleA {
+       }
+
+       @NgModule({imports: [ModuleA]})
+       class ModuleB {
+         static forRoot(): ModuleWithProviders<ModuleB> {
+           return {ngModule: ModuleB, providers: [{provide: B, useValue: 'B'}]};
+         }
+         static forChild(): ModuleWithProviders<ModuleB> {
+           return {ngModule: ModuleB, providers: [{provide: C, useValue: 'C'}]};
+         }
+       }
+
+       const providers = importProvidersFrom(ModuleB.forRoot(), ModuleB.forChild());
+
+       // Expect 2 `INJECTOR_INITIALIZER` providers: one for `ModuleA`, another one for `ModuleB`
+       expect(collectInjectorInitializerProviders(providers).length).toBe(2);
+
+       // Expect exactly 1 provider for each module: `ModuleA` and `ModuleB`
+       expect(getProvidersByToken(providers, ModuleA).length).toBe(1);
+       expect(getProvidersByToken(providers, ModuleB).length).toBe(1);
+
+       // Expect all tokens to be collected.
+       expect(hasProviderWithToken(providers, A)).toBe(true);
+       expect(hasProviderWithToken(providers, B)).toBe(true);
+       expect(hasProviderWithToken(providers, C)).toBe(true);
+     });
+
+  it('should process nested arrays within a provider set of ModuleWithProviders type', () => {
+    @NgModule()
+    class ModuleA {
+      static forRoot(): ModuleWithProviders<ModuleA> {
+        return {
+          ngModule: ModuleA,
+          providers: [
+            {provide: A, useValue: 'A'},
+            // Nested arrays inside the list of providers:
+            [{provide: B, useValue: 'B'}, [{provide: C, useValue: 'C'}]]
+          ]
+        };
+      }
+    }
+
+    const providers = importProvidersFrom(ModuleA.forRoot());
+
+    // Expect 1 `INJECTOR_INITIALIZER` provider (for `ModuleA`)
+    expect(collectInjectorInitializerProviders(providers).length).toBe(1);
+
+    // Expect exactly 1 provider for `ModuleA`
+    expect(getProvidersByToken(providers, ModuleA).length).toBe(1);
+
+    // Expect all tokens to be collected.
+    expect(hasProviderWithToken(providers, A)).toBe(true);
+    expect(hasProviderWithToken(providers, B)).toBe(true);
+    expect(hasProviderWithToken(providers, C)).toBe(true);
+  });
+
+  it('should process nested arrays within provider set of an imported ModuleWithProviders type',
+     () => {
+       @NgModule()
+       class ModuleA {
+         static forRoot(): ModuleWithProviders<ModuleA> {
+           return {
+             ngModule: ModuleA,
+             providers: [
+               {provide: A, useValue: 'A'},
+               // Nested arrays inside the list of providers:
+               [{provide: B, useValue: 'B'}, [{provide: C, useValue: 'C'}]]
+             ]
+           };
+         }
+       }
+
+       @NgModule({imports: [ModuleA.forRoot()]})
+       class ModuleB {
+       }
+
+       const providers = importProvidersFrom(ModuleB);
+
+       // Expect 2 `INJECTOR_INITIALIZER` providers: one for `ModuleA`, another one for `ModuleB`
+       expect(collectInjectorInitializerProviders(providers).length).toBe(2);
+
+       // Expect exactly 1 provider for each module: `ModuleA` and `ModuleB`
+       expect(getProvidersByToken(providers, ModuleA).length).toBe(1);
+       expect(getProvidersByToken(providers, ModuleB).length).toBe(1);
+
+       // Expect all tokens to be collected.
+       expect(hasProviderWithToken(providers, A)).toBe(true);
+       expect(hasProviderWithToken(providers, B)).toBe(true);
+       expect(hasProviderWithToken(providers, C)).toBe(true);
+     });
 });
 
 describe('di', () => {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1005,12 +1005,6 @@
     "name": "isElementNode"
   },
   {
-    "name": "isExistingProvider"
-  },
-  {
-    "name": "isFactoryProvider"
-  },
-  {
     "name": "isFunction"
   },
   {
@@ -1177,6 +1171,9 @@
   },
   {
     "name": "platformCore"
+  },
+  {
+    "name": "processInjectorTypesWithProviders"
   },
   {
     "name": "promise"
@@ -1360,9 +1357,6 @@
   },
   {
     "name": "urlParsingNode"
-  },
-  {
-    "name": "validateProvider"
   },
   {
     "name": "viewAttachedToChangeDetector"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1101,12 +1101,6 @@
     "name": "isEmptyInputValue"
   },
   {
-    "name": "isExistingProvider"
-  },
-  {
-    "name": "isFactoryProvider"
-  },
-  {
     "name": "isFormControlState"
   },
   {
@@ -1323,6 +1317,9 @@
     "name": "platformCore"
   },
   {
+    "name": "processInjectorTypesWithProviders"
+  },
+  {
     "name": "promise"
   },
   {
@@ -1525,9 +1522,6 @@
   },
   {
     "name": "urlParsingNode"
-  },
-  {
-    "name": "validateProvider"
   },
   {
     "name": "viewAttachedToChangeDetector"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1065,12 +1065,6 @@
     "name": "isDirectiveHost"
   },
   {
-    "name": "isExistingProvider"
-  },
-  {
-    "name": "isFactoryProvider"
-  },
-  {
     "name": "isFormControlState"
   },
   {
@@ -1293,6 +1287,9 @@
     "name": "platformCore"
   },
   {
+    "name": "processInjectorTypesWithProviders"
+  },
+  {
     "name": "promise"
   },
   {
@@ -1507,9 +1504,6 @@
   },
   {
     "name": "urlParsingNode"
-  },
-  {
-    "name": "validateProvider"
   },
   {
     "name": "viewAttachedToChangeDetector"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -123,12 +123,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "isExistingProvider"
-  },
-  {
-    "name": "isFactoryProvider"
-  },
-  {
     "name": "isTypeProvider"
   },
   {
@@ -136,6 +130,9 @@
   },
   {
     "name": "makeRecord"
+  },
+  {
+    "name": "processInjectorTypesWithProviders"
   },
   {
     "name": "resolveForwardRef"
@@ -148,9 +145,6 @@
   },
   {
     "name": "stringify"
-  },
-  {
-    "name": "validateProvider"
   },
   {
     "name": "walkProviderTree"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1440,12 +1440,6 @@
     "name": "isDirectiveHost"
   },
   {
-    "name": "isExistingProvider"
-  },
-  {
-    "name": "isFactoryProvider"
-  },
-  {
     "name": "isFunction"
   },
   {
@@ -1675,6 +1669,9 @@
   },
   {
     "name": "prioritizedGuardValue"
+  },
+  {
+    "name": "processInjectorTypesWithProviders"
   },
   {
     "name": "promise"
@@ -1933,9 +1930,6 @@
   },
   {
     "name": "urlParsingNode"
-  },
-  {
-    "name": "validateProvider"
   },
   {
     "name": "viewAttachedToChangeDetector"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -648,12 +648,6 @@
     "name": "isComponentDef"
   },
   {
-    "name": "isExistingProvider"
-  },
-  {
-    "name": "isFactoryProvider"
-  },
-  {
     "name": "isFunction"
   },
   {
@@ -751,6 +745,9 @@
   },
   {
     "name": "onLeave"
+  },
+  {
+    "name": "processInjectorTypesWithProviders"
   },
   {
     "name": "promise"
@@ -883,9 +880,6 @@
   },
   {
     "name": "urlParsingNode"
-  },
-  {
-    "name": "validateProvider"
   },
   {
     "name": "viewAttachedToChangeDetector"


### PR DESCRIPTION
There were two problems with the `importProvidersFrom` function related to
`ModuleWithProviders` values:

* The public type did not accept `ModuleWithProviders` values directly.
* The implementation of `walkProviderTree` delegates collection of MWP providers
  to its caller, in order for the ordering of such providers to be correct.
  However, `importProvidersFrom` was not performing that collection, causing MWP
  providers passed in at the top level to be dropped.