### PR TITLE
refactor(core): delegate ApplicationRef.destroy logic to an Injector

### DIFF
--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -90,6 +90,12 @@ export abstract class EnvironmentInjector implements Injector {
   abstract destroy(): void;
 
   /**
+   * Flag indicating that this injector was previously destroyed.
+   * @internal
+   */
+  abstract readonly destroyed: boolean;
+
+  /**
    * @internal
    */
   abstract onDestroy(callback: () => void): void;
@@ -113,7 +119,7 @@ export class R3Injector extends EnvironmentInjector {
   /**
    * Flag indicating that this injector was previously destroyed.
    */
-  get destroyed(): boolean {
+  override get destroyed(): boolean {
     return this._destroyed;
   }
   private _destroyed = false;

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -43,6 +43,14 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
   override instance: T;
   destroyCbs: (() => void)[]|null = [];
 
+  /**
+   * Indicates whether this instance was destroyed.
+   * @internal
+   */
+  get destroyed(): boolean {
+    return this._r3Injector.destroyed;
+  }
+
   // When bootstrapping a module we have a dependency graph that looks like this:
   // ApplicationRef -> ComponentFactoryResolver -> NgModuleRef. The problem is that if the
   // module being resolved tries to inject the ComponentFactoryResolver, it'll create a

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -287,30 +287,6 @@ class SomeComponent {
                       expect(onDestroyB).toHaveBeenCalledTimes(1);
                     }))));
 
-      it('should allow to unsubscribe a registered `onDestroy` callback (internal API)',
-         withModule({providers}, waitForAsync(inject([Injector], (parentInjector: Injector) => {
-                      createRootEl();
-
-                      const appRef =
-                          createApplicationRef(parentInjector) as unknown as ApplicationRef &
-                          {onDestroy: Function};
-                      appRef.bootstrap(SomeComponent);
-
-                      const onDestroyA = jasmine.createSpy('onDestroyA');
-                      const onDestroyB = jasmine.createSpy('onDestroyB');
-                      const unsubscribeOnDestroyA = appRef.onDestroy(onDestroyA);
-                      const unsubscribeOnDestroyB = appRef.onDestroy(onDestroyB);
-
-                      // Unsubscribe registered listeners.
-                      unsubscribeOnDestroyA();
-                      unsubscribeOnDestroyB();
-
-                      appRef.destroy();
-
-                      expect(onDestroyA).not.toHaveBeenCalled();
-                      expect(onDestroyB).not.toHaveBeenCalled();
-                    }))));
-
       it('should correctly update the `destroyed` flag',
          withModule({providers}, waitForAsync(inject([Injector], (parentInjector: Injector) => {
                       createRootEl();


### PR DESCRIPTION
This commit updates an internal logic of the `ApplicationRef.destroy` to delegate the status and `onDestroy` callbacks management to the underlying injector, since the destroy lifecycle of the `ApplicationRef` fully depends on the underlying Injector instance.

## PR Type
What kind of change does this PR introduce?
- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No