### PR TITLE
fix(router): Remove deprecated initialNavigation option

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -249,7 +249,7 @@ export class GuardsCheckStart extends RouterEvent {
 }
 
 // @public
-export type InitialNavigation = 'disabled' | 'enabled' | 'enabledBlocking' | 'enabledNonBlocking';
+export type InitialNavigation = 'disabled' | 'enabledBlocking' | 'enabledNonBlocking';
 
 // @public
 export interface IsActiveMatchOptions {

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/root.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/root.ts
@@ -34,7 +34,7 @@ export function children(): any {
         [
           {path: '', pathMatch: 'prefix', loadChildren: children},
         ],
-        {initialNavigation: 'enabled'}),
+        {initialNavigation: 'enabledBlocking'}),
   ],
   declarations: [AppComponent],
   bootstrap: [AppComponent],

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -237,13 +237,11 @@ export function provideRoutes(routes: Routes): any {
  * The following values have been [deprecated](guide/releases#deprecation-practices) since v11,
  * and should not be used for new applications.
  *
- * * 'enabled' - This option is 1:1 replaceable with `enabledBlocking`.
- *
  * @see `forRoot()`
  *
  * @publicApi
  */
-export type InitialNavigation = 'disabled'|'enabled'|'enabledBlocking'|'enabledNonBlocking';
+export type InitialNavigation = 'disabled'|'enabledBlocking'|'enabledNonBlocking';
 
 /**
  * A set of configuration options for a router module, provided in the
@@ -558,9 +556,7 @@ export class RouterInitializer implements OnDestroy {
       if (opts.initialNavigation === 'disabled') {
         router.setUpLocationChangeListener();
         resolve(true);
-      } else if (
-          // TODO: enabled is deprecated as of v11, can be removed in v13
-          opts.initialNavigation === 'enabled' || opts.initialNavigation === 'enabledBlocking') {
+      } else if (opts.initialNavigation === 'enabledBlocking') {
         router.hooks.afterPreactivation = () => {
           // only the initial navigation should be delayed
           if (!this.initNavigation) {

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -76,43 +76,6 @@ describe('bootstrap', () => {
     }
   }));
 
-  it('should wait for resolvers to complete when initialNavigation = enabled', (done) => {
-    @Component({selector: 'test', template: 'test'})
-    class TestCmpEnabled {
-    }
-
-    @NgModule({
-      imports: [
-        BrowserModule,
-        RouterModule.forRoot(
-            [{path: '**', component: TestCmpEnabled, resolve: {test: TestResolver}}],
-            {useHash: true, initialNavigation: 'enabled'})
-      ],
-      declarations: [RootCmp, TestCmpEnabled],
-      bootstrap: [RootCmp],
-      providers: [...testProviders, TestResolver],
-      schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    })
-    class TestModule {
-      constructor(router: Router) {
-        log.push('TestModule');
-        router.events.subscribe(e => log.push(e.constructor.name));
-      }
-    }
-
-    platformBrowserDynamic([]).bootstrapModule(TestModule).then(res => {
-      const router = res.injector.get(Router);
-      const data = router.routerState.snapshot.root.firstChild!.data;
-      expect(data['test']).toEqual('test-data');
-      expect(log).toEqual([
-        'TestModule', 'NavigationStart', 'RoutesRecognized', 'GuardsCheckStart',
-        'ChildActivationStart', 'ActivationStart', 'GuardsCheckEnd', 'ResolveStart', 'ResolveEnd',
-        'RootCmp', 'ActivationEnd', 'ChildActivationEnd', 'NavigationEnd', 'Scroll'
-      ]);
-      done();
-    });
-  });
-
   it('should wait for resolvers to complete when initialNavigation = enabledBlocking', (done) => {
     @Component({selector: 'test', template: 'test'})
     class TestCmpEnabled {


### PR DESCRIPTION
BREAKING CHANGE:
`initialNavigation: 'enabled'` was deprecated in v11 and is replaced by
`initialNavigation: 'enabledBlocking'`.