### PR TITLE
fix(router): Ensure failed initial navigation does not block app load

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -493,7 +493,7 @@ export class Router {
     errorHandler: ErrorHandler;
     readonly events: Observable<Event_2>;
     getCurrentNavigation(): Navigation | null;
-    initialNavigation(): void;
+    initialNavigation(): Promise<boolean | null>;
     // @deprecated
     isActive(url: string | UrlTree, exact: boolean): boolean;
     isActive(url: string | UrlTree, matchOptions: IsActiveMatchOptions): boolean;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1035,12 +1035,19 @@ export class Router {
 
   /**
    * Sets up the location change listener and performs the initial navigation.
+   *
+   * @see Router.navigateByUrl()
+   * @returns If a navigation is triggered, returns a Promise that resolves to 'true' when
+   *     navigation succeeds, to 'false' when navigation fails, or is rejected on error. If no
+   * navigation was triggered as a result of calling this function, a `Promise` that immediately
+   * resolves with `null` is returned.
    */
-  initialNavigation(): void {
+  initialNavigation(): Promise<boolean|null> {
     this.setUpLocationChangeListener();
     if (this.navigationId === 0) {
-      this.navigateByUrl(this.location.path(true), {replaceUrl: true});
+      return this.navigateByUrl(this.location.path(true), {replaceUrl: true});
     }
+    return Promise.resolve(null);
   }
 
   /**

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -551,7 +551,7 @@ export class RouterInitializer implements OnDestroy {
       }
 
       let resolve: Function = null!;
-      const res = new Promise(r => resolve = r);
+      const res = new Promise<true>(r => resolve = r);
       const router = this.injector.get(Router);
       const opts = this.injector.get(ROUTER_CONFIGURATION);
 
@@ -573,7 +573,20 @@ export class RouterInitializer implements OnDestroy {
             return of(null) as any;
           }
         };
-        router.initialNavigation();
+        router
+            .initialNavigation()
+            // If the initial navigation failed or did not trigger for some reason, we need to
+            // resolve the app initializer here. Otherwise, it will never be resolved and cause
+            // the application to hang indefinitely.
+            .then(result => {
+              if (result !== true) {
+                resolve(true);
+              }
+            })
+            .catch((e) => {
+              resolve(true);
+              throw e;
+            });
       } else {
         resolve(true);
       }


### PR DESCRIPTION
Previously, if initialNavigation were set to `enabledBlocking`, the
Router's `APP_INITIALIZER` would never resolve if that initial
navigation failed. This results in the application load hanging and
never completing.

fixes #44355
