### PR TITLE
refactor(common): change name of directive from NgImage => NgOptimizedImage

### DIFF
--- a/packages/common/src/directives/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Inject, InjectionToken, Input, NgModule, SimpleChanges, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {Directive, Inject, InjectionToken, Input, NgModule, OnInit, ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {RuntimeErrorCode} from '../errors';
 
@@ -56,7 +56,7 @@ export const IMAGE_LOADER = new InjectionToken<ImageLoader>('ImageLoader', {
     '[src]': 'getRewrittenSrc()',
   },
 })
-export class NgImage {
+export class NgOptimizedImage implements OnInit {
   constructor(@Inject(IMAGE_LOADER) private imageLoader: ImageLoader) {}
 
   // Private fields to keep normalized input values.
@@ -113,10 +113,6 @@ export class NgImage {
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    // TODO: react to input changes.
-  }
-
   getRewrittenSrc(): string {
     // If a loader is provided as an input - use it, otherwise fall back
     // to the loader configured globally using the `IMAGE_LOADER` token.
@@ -133,14 +129,14 @@ export class NgImage {
 }
 
 /**
- * Temporary NgModule that exports the NgImage directive.
+ * Temporary NgModule that exports the NgOptimizedImage directive.
  * The module should not be needed once the `standalone` flag is supported as a public API.
  */
 @NgModule({
-  declarations: [NgImage],
-  exports: [NgImage],
+  declarations: [NgOptimizedImage],
+  exports: [NgOptimizedImage],
 })
-export class NgImageModule {
+export class NgOptimizedImageModule {
 }
 
 /***** Helpers *****/
@@ -150,20 +146,20 @@ function inputToInteger(value: string|number|undefined): number|undefined {
   return typeof value === 'string' ? parseInt(value, 10) : value;
 }
 
-function imgDirectiveDetails(dir: NgImage) {
-  return `The NgImage directive (activated on an <img> element ` +
+function imgDirectiveDetails(dir: NgOptimizedImage) {
+  return `The NgOptimizedImage directive (activated on an <img> element ` +
       `with the \`raw-src="${dir.rawSrc}"\`)`;
 }
 
 /***** Assert functions *****/
 
 // Verifies that there is no `src` set on a host element.
-function assertExistingSrc(dir: NgImage) {
+function assertExistingSrc(dir: NgOptimizedImage) {
   if (dir.src) {
     throw new RuntimeError(
         RuntimeErrorCode.UNEXPECTED_SRC_ATTR,
         `${imgDirectiveDetails(dir)} detected that the \`src\` is also set (to \`${dir.src}\`). ` +
-            `Please remove the \`src\` attribute from this image. The NgImage directive will use ` +
+            `Please remove the \`src\` attribute from this image. The NgOptimizedImage directive will use ` +
             `the \`raw-src\` to compute the final image URL and set the \`src\` itself.`);
   }
 }

--- a/packages/common/src/private_export.ts
+++ b/packages/common/src/private_export.ts
@@ -6,6 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {IMAGE_LOADER as ɵIMAGE_LOADER, NgImage as ɵNgImage, NgImageModule as ɵNgImageModule} from './directives/ng_image';
+export {IMAGE_LOADER as ɵIMAGE_LOADER, NgOptimizedImage as ɵNgOptimizedImage, NgOptimizedImageModule as ɵNgOptimizedImageModule} from './directives/ng_optimized_image';
 export {DomAdapter as ɵDomAdapter, getDOM as ɵgetDOM, setRootDomAdapter as ɵsetRootDomAdapter} from './dom_adapter';
 export {BrowserPlatformLocation as ɵBrowserPlatformLocation} from './location/platform_location';

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {IMAGE_LOADER, ImageLoader, ImageLoaderConfig, NgImage} from '@angular/common/src/directives/ng_image';
+import {IMAGE_LOADER, ImageLoader, ImageLoaderConfig, NgOptimizedImage} from '@angular/common/src/directives/ng_optimized_image';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -64,9 +64,9 @@ describe('Image directive', () => {
         fixture.detectChanges();
       })
           .toThrowError(
-              'NG02950: The NgImage directive (activated on an <img> element with the ' +
+              'NG02950: The NgOptimizedImage directive (activated on an <img> element with the ' +
               '`raw-src="path/img.png"`) detected that the `src` is also set (to `path/img2.png`). ' +
-              'Please remove the `src` attribute from this image. The NgImage directive will use ' +
+              'Please remove the `src` attribute from this image. The NgOptimizedImage directive will use ' +
               'the `raw-src` to compute the final image URL and set the `src` itself.');
     });
   });
@@ -88,9 +88,9 @@ function setupTestingModule(config?: {imageLoader: ImageLoader}) {
   const providers =
       config?.imageLoader ? [{provide: IMAGE_LOADER, useValue: config?.imageLoader}] : [];
   TestBed.configureTestingModule({
-    // Note: the `NgImage` is a part of declarations for now,
+    // Note: the `NgOptimizedImage` is a part of declarations for now,
     // since it's experimental and not yet added to the `CommonModule`.
-    declarations: [TestComponent, NgImage],
+    declarations: [TestComponent, NgOptimizedImage],
     imports: [CommonModule],
     providers,
   });

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgImageModule as NgImageModule} from '@angular/common';
+import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImageModule as NgOptimizedImageModule} from '@angular/common';
 import {Component, NgModule} from '@angular/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
@@ -21,7 +21,7 @@ class RootComponent {
 
 @NgModule({
   declarations: [RootComponent],
-  imports: [BrowserModule, NgImageModule],
+  imports: [BrowserModule, NgOptimizedImageModule],
   bootstrap: [RootComponent],
   providers: [{provide: IMAGE_LOADER, useValue: () => 'b.png'}],
 })


### PR DESCRIPTION
We want it to be clear what benefits the image directive
confers over a normal <img> tag, and the `NgImage` name
didn't provide much information. `NgOptimizedImage` makes
it obvious that the new directive is intended to improve
performance.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features) -- N/A
- [ ] Docs have been added / updated (for bug fixes / features) -- N/A


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
N/A


## What is the new behavior?
N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
