### PR TITLE
fix(service-worker): escape dollar sign in glob to regex conversion

### DIFF
--- a/packages/service-worker/config/src/glob.ts
+++ b/packages/service-worker/config/src/glob.ts
@@ -13,6 +13,7 @@ const WILD_OPEN = '(?:.+\\/)?';
 const TO_ESCAPE_BASE = [
   {replace: /\./g, with: '\\.'},
   {replace: /\+/g, with: '\\+'},
+  {replace: /\$/g, with: '\\$'},
   {replace: /\*/g, with: WILD_SINGLE},
 ];
 const TO_ESCAPE_WILDCARD_QM = [

--- a/packages/service-worker/config/test/generator_spec.ts
+++ b/packages/service-worker/config/test/generator_spec.ts
@@ -51,6 +51,7 @@ describe('Generator', () => {
           '/api/**',
           'relapi/**',
           'https://example.com/**/*?with+escaped+chars',
+          'https://example.com/$value',
         ],
         cacheConfig: {
           maxSize: 100,
@@ -100,6 +101,7 @@ describe('Generator', () => {
           '\\/api\\/.*',
           '\\/test\\/relapi\\/.*',
           'https:\\/\\/example\\.com\\/(?:.+\\/)?[^/]*\\?with\\+escaped\\+chars',
+          'https:\\/\\/example\\.com\\/\\$value',
         ],
         strategy: 'performance',
         maxSize: 100,


### PR DESCRIPTION
Escape the dollar sign ($) in the glob to regex conversion. The dollar sign in a regular expression matches the end-of-line. If a dollar sign appears in the middle of a regular expression, the resulting regexp is usually not matchable. For example "x$y" is unmatchable because no string can contain the letter "y" after the end of the string.

Fixes #45737 