### PR TITLE
build(bazel): add an aio fast serve target

### DIFF
--- a/aio/BUILD.bazel
+++ b/aio/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@aio_npm//@angular-devkit/architect-cli:index.bzl", "architect", "architect_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "npm_package_bin")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary", "npm_package_bin")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 
 # The write_source_files macro is used to write bazel outputs to the source tree and test that they are up to date.
@@ -55,6 +55,14 @@ DGENI_FILES = [
     "//aio/content/examples",
     "//aio/src/assets",
     "//aio/tools/transforms",
+    "//:package.json",
+    "//packages:files_for_docgen",
+]
+
+# Sources needed to produce a fast low-fi dgeni build
+DGENI_FASTSERVE_FILES = [
+    "//aio/content",
+    "//aio/content/examples",
     "//:package.json",
     "//packages:files_for_docgen",
 ]
@@ -217,6 +225,7 @@ architect_test(
     data = TEST_FILES + TEST_DEPS,
 )
 
+# Build and serve the app. Run with ibazel to watch for changes and re-serve.
 architect(
     name = "serve",
     args = [
@@ -225,4 +234,26 @@ architect(
     chdir = package_name(),
     data = APPLICATION_DEPS + APPLICATION_FILES,
     tags = ["ibazel_notify_changes"],
+)
+
+# Build and serve the app, watch for changes, and run a fast but low-fidelity
+# rebuild when docs change. Watching and serving is a part of the node script,
+# so there is no need to run with ibazel, which would be slow as it would redo
+# the full dgeni build on each change.
+nodejs_binary(
+    name = "fast-serve",
+    chdir = package_name(),
+    data = APPLICATION_DEPS + APPLICATION_FILES + DGENI_FASTSERVE_FILES + [
+        "//aio/scripts:fast-serve-and-watch",
+    ],
+    entry_point = "//aio/scripts:fast-serve-and-watch.js",
+    env = {
+        # Have the authors package output its low-fi dgeni build
+        # to a different directory in the runfiles tree because bazel
+        # write-protects original dgeni runfiles. Then in angular.json
+        # we list this folder last under assets so that it will
+        # take precedence over the original dgeni assets, effectively
+        # overwriting select sources and then serving them.
+        "BAZEL_DGENI_OUTPUT_PATH": "dgeni-fast",
+    },
 )

--- a/aio/angular.json
+++ b/aio/angular.json
@@ -51,17 +51,22 @@
               "src/pwa-manifest.json",
               "src/google385281288605d160.html",
               {
-                "input": "dgeni/generated",
-                "output": "generated",
-                "glob": "**"
-              },
-              {
                 "input": "stackblitz/generated",
                 "output": "generated",
                 "glob": "**"
               },
               {
                 "input": "example-zips/generated",
+                "output": "generated",
+                "glob": "**"
+              },
+              {
+                "input": "dgeni/generated",
+                "output": "generated",
+                "glob": "**"
+              },
+              {
+                "input": "dgeni-fast/generated",
                 "output": "generated",
                 "glob": "**"
               }

--- a/aio/scripts/BUILD.bazel
+++ b/aio/scripts/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library", "nodejs_binary")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -11,4 +11,15 @@ nodejs_binary(
         "@aio_npm//json5",
     ],
     entry_point = "build-ngsw-config.js",
+)
+
+js_library(
+    name = "fast-serve-and-watch",
+    srcs = [
+        "fast-serve-and-watch.js",
+    ],
+    deps = [
+        "//aio/tools/transforms/authors-package:watchdocs",
+        "@aio_npm//@angular-devkit/architect-cli",
+    ],
 )

--- a/aio/scripts/fast-serve-and-watch.js
+++ b/aio/scripts/fast-serve-and-watch.js
@@ -1,0 +1,21 @@
+/*
+    This script serves the aio app, watches for changes,
+    and runs a fast dgeni build on any changed files.
+*/
+
+const spawn = require("cross-spawn");
+const watchr = require("../tools/transforms/authors-package/watchr.js");
+const architectCli = require.resolve("@angular-devkit/architect-cli/bin/architect");
+
+const serve = spawn(architectCli, ["site:serve"], {stdio: "inherit"});
+serve.on("error", error => {
+    console.error("architect serve script failed");
+    console.error(error);
+    process.exit(1);
+});
+serve.on("close", code => {
+    console.error(`architect serve script exited with code ${code}`);
+    process.exit(1);
+})
+
+watchr.watch(true);

--- a/aio/tools/transforms/BUILD.bazel
+++ b/aio/tools/transforms/BUILD.bazel
@@ -12,8 +12,6 @@ filegroup(
         exclude = [
             "test.js",
             "**/*.spec.js",
-            # Used only for fast dgeni builds, not required for the high-fidelity dgeni build
-            "authors-package",
         ],
     ),
 )

--- a/aio/tools/transforms/authors-package/BUILD.bazel
+++ b/aio/tools/transforms/authors-package/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+
+package(default_visibility = ["//visibility:public"])
+
+js_library(
+    name = "watchdocs",
+    srcs = [
+        "api-package.js",
+        "base-authoring-package.js",
+        "errors-package.js",
+        "extended-diagnostics-package.js",
+        "getting-started-package.js",
+        "guide-package.js",
+        "index.js",
+        "marketing-package.js",
+        "tutorial-package.js",
+        "utils.js",
+        "watchr.js",
+    ],
+    deps = [
+        "//aio/tools/transforms",
+        "@aio_npm//canonical-path",
+        "@aio_npm//dgeni",
+        "@aio_npm//watchr",
+    ],
+)

--- a/aio/tools/transforms/authors-package/watchr.js
+++ b/aio/tools/transforms/authors-package/watchr.js
@@ -20,32 +20,16 @@ function next(error) {
   }
 }
 
-let p = Promise.resolve();
+function watch() {
+    console.log('============================================================================');
+    console.log('Started watching files in:');
+    console.log(' - ', CONTENTS_PATH);
+    console.log(' - ', API_SOURCE_PATH);
+    console.log('Doc gen will automatically run on any change to a file in either directory.');
+    console.log('============================================================================');
 
-if (process.argv.indexOf('--watch-only') === -1) {
-  console.log('================================================================');
-  console.log('Running initial doc generation');
-  console.log('----------------------------------------------------------------');
-  console.log('Skip the full doc-gen by running: `yarn docs-watch --watch-only`');
-  console.log('================================================================');
-  const {Dgeni} = require('dgeni');
-  const dgeni = new Dgeni([
-    // The base-authoring-package will turn off potential failures for this doc-gen one-off run.
-    // This enables authors to run `docs-watch` while the docs are still in an unstable state.
-    require('./base-authoring-package'),
-    require('../angular.io-package')]);
-  p = dgeni.generate();
+    watchr.open(CONTENTS_PATH, listener, next);
+    watchr.open(API_SOURCE_PATH, listener, next);
 }
 
-p.then(() => {
-  console.log('===================================================================');
-  console.log('Started watching files in:');
-  console.log(' - ', CONTENTS_PATH);
-  console.log(' - ', API_SOURCE_PATH);
-  console.log('Doc gen will run when you change a file in either of these folders.');
-  console.log('===================================================================');
-
-  watchr.open(CONTENTS_PATH, listener, next);
-  watchr.open(API_SOURCE_PATH, listener, next);
-
-});
+exports.watch = watch;


### PR DESCRIPTION
@gkalpak @devversion @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

I added a bazel executable target that mimics the fast `docs-watch` script for quick documentation editing. Calling
```
bazel run //aio:fast-serve
```
will do the full dgeni build (if it's not cached) and serve the app, then run a watcher that quickly rebuilds any docs changes.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## Other information
