### PR TITLE
refactor(core): create a standalone injector during applicationBootstrap

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -15,7 +15,6 @@ import {ApplicationInitStatus} from './application_init';
 import {APP_BOOTSTRAP_LISTENER, PLATFORM_INITIALIZER} from './application_tokens';
 import {getCompilerFacade, JitCompilerUsage} from './compiler/compiler_facade';
 import {Console} from './console';
-import {importProvidersFrom} from './di';
 import {Injectable} from './di/injectable';
 import {InjectionToken} from './di/injection_token';
 import {Injector} from './di/injector';
@@ -35,9 +34,7 @@ import {InternalViewRef, ViewRef} from './linker/view_ref';
 import {isComponentResourceResolutionQueueEmpty, resolveComponentResources} from './metadata/resource_loading';
 import {assertNgModuleType} from './render3/assert';
 import {ComponentFactory as R3ComponentFactory} from './render3/component_ref';
-import {getComponentDef} from './render3/definition';
 import {assertStandaloneComponentType} from './render3/errors';
-import {StandaloneService} from './render3/features/standalone_feature';
 import {setLocaleId} from './render3/i18n/i18n_locale_id';
 import {setJitOptions} from './render3/jit/jit_options';
 import {isStandalone} from './render3/jit/module';
@@ -206,18 +203,9 @@ export function bootstrapApplication(config: {
     const allAppProviders = [
       {provide: NgZone, useValue: ngZone},  //
       ...(appProviders || []),              //
-      // Collect providers from the root standalone component
-      // and all of its dependencies (NgModule, other standalone Components)
-      // and make those providers available in the DI tree.
-      ...importProvidersFrom(rootComponent),
     ];
     const appInjector = createEnvironmentInjector(
         allAppProviders, platformInjector as EnvironmentInjector, 'Environment Injector');
-
-    // Instruct `StandaloneService` to use the `appInjector` as an injector for this
-    // root component, so that there is no extra injector instance created.
-    const componentDef = getComponentDef(rootComponent)!;
-    appInjector.get(StandaloneService).setInjector(componentDef, appInjector);
 
     const exceptionHandler: ErrorHandler|null = appInjector.get(ErrorHandler, null);
     if (NG_DEV_MODE && !exceptionHandler) {

--- a/packages/core/src/render3/features/standalone_feature.ts
+++ b/packages/core/src/render3/features/standalone_feature.ts
@@ -18,7 +18,7 @@ import {createEnvironmentInjector} from '../ng_module_ref';
  * created on demand in case of dynamic component instantiation and contain ambient providers
  * collected from the imports graph rooted at a given standalone component.
  */
-export class StandaloneService implements OnDestroy {
+class StandaloneService implements OnDestroy {
   cachedInjectors = new Map<ComponentDef<unknown>, EnvironmentInjector|null>();
 
   constructor(private _injector: EnvironmentInjector) {}

--- a/packages/core/src/render3/features/standalone_feature.ts
+++ b/packages/core/src/render3/features/standalone_feature.ts
@@ -23,10 +23,6 @@ class StandaloneService implements OnDestroy {
 
   constructor(private _injector: EnvironmentInjector) {}
 
-  setInjector(componentDef: ComponentDef<unknown>, injector: EnvironmentInjector) {
-    this.cachedInjectors.set(componentDef, injector);
-  }
-
   getOrCreateStandaloneInjector(componentDef: ComponentDef<unknown>): EnvironmentInjector|null {
     if (!componentDef.standalone) {
       return null;
@@ -47,7 +43,7 @@ class StandaloneService implements OnDestroy {
   ngOnDestroy() {
     try {
       for (const injector of this.cachedInjectors.values()) {
-        if (injector !== null && injector !== this._injector) {
+        if (injector !== null) {
           injector.destroy();
         }
       }

--- a/packages/platform-browser/test/browser/bootstrap_standalone_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_standalone_spec.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
+import {Component, destroyPlatform, Inject, Injectable, InjectionToken, NgModule} from '@angular/core';
+import {inject} from '@angular/core/testing';
+
+import {bootstrapApplication} from '../../src/browser';
+
+describe('bootstrapApplication for standalone components', () => {
+  let rootEl: HTMLUnknownElement;
+  beforeEach(inject([DOCUMENT], (doc: any) => {
+    rootEl = getDOM().createElement('test-app', doc);
+    getDOM().getDefaultDocument().body.appendChild(rootEl);
+  }));
+
+  afterEach(() => {
+    destroyPlatform();
+    rootEl.remove();
+  });
+
+  it('should create injector where ambient providers shadow explicit providers', async () => {
+    const testToken = new InjectionToken('test token');
+
+    @NgModule({
+      providers: [
+        {provide: testToken, useValue: 'Ambient'},
+      ]
+    })
+    class AmbientModule {
+    }
+
+    @Component({
+      selector: 'test-app',
+      standalone: true,
+      template: `({{testToken}})`,
+      imports: [AmbientModule]
+    })
+    class StandaloneCmp {
+      constructor(@Inject(testToken) readonly testToken: String) {}
+    }
+
+    const appRef = await bootstrapApplication(StandaloneCmp, {
+      providers: [
+        {provide: testToken, useValue: 'Bootstrap'},
+      ]
+    });
+
+    appRef.tick();
+
+    // make sure that ambient providers "shadow" ones explicitly provided during bootstrap
+    expect(rootEl.textContent).toBe('(Ambient)');
+  });
+
+  /*
+    This test verifies that ambient providers for the standalone component being bootstrapped
+    (providers collected from the import graph of a standalone component) are instantiated in a
+    dedicated standalone injector. As the result we are ending up with the following injectors
+    hierarchy:
+    - platform injector (platform specific providers go here);
+    - application injector (providers specified in the bootstrap options go here);
+    - standalone injector (ambient providers go here);
+  */
+  it('should create a standalone injector for standalone components with ambient providers',
+     async () => {
+       const ambientToken = new InjectionToken('ambient token');
+
+       @NgModule({
+         providers: [
+           {provide: ambientToken, useValue: 'Only in AmbientNgModule'},
+         ]
+       })
+       class AmbientModule {
+       }
+
+       @Injectable()
+       class NeedsAmbientProvider {
+         constructor(@Inject(ambientToken) readonly ambientToken: String) {}
+       }
+
+       @Component({
+         selector: 'test-app',
+         template: `({{service.ambientToken}})`,
+         standalone: true,
+         imports: [AmbientModule]
+       })
+       class StandaloneCmp {
+         constructor(readonly service: NeedsAmbientProvider) {}
+       }
+
+       try {
+         await bootstrapApplication(
+             StandaloneCmp,
+             {providers: [NeedsAmbientProvider]},
+         );
+
+         // we expect the bootstrap process to fail since the "NeedsAmbientProvider" service
+         // (located in the application injector) can't "see" ambient providers (located in a
+         // standalone injector that is a child of the application injector).
+         fail('Expected to throw');
+       } catch (e: unknown) {
+         expect(e).toBeInstanceOf(Error);
+         expect((e as Error).message).toContain('No provider for InjectionToken ambient token!');
+       }
+     });
+});


### PR DESCRIPTION
This commit changes the injectors hierarchy created during applicationBootstrap.
From now on a standalone injector (holding all the ambient providers of a
standalone component) is create as a child of the application injector.
This change aligns injectors hierarchy for bootstrapped and dynamically
created standalone components.
