### PR TITLE
build: update tsec and drop corresponding postinstall patch

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -177,7 +177,7 @@
     "timezone-mock": "^1.1.3",
     "tree-kill": "^1.1.0",
     "ts-node": "^10.0.0",
-    "tsec": "^0.2.0",
+    "tsec": "^0.2.2",
     "tslint": "~6.1.3",
     "typescript": "~4.6.2",
     "uglify-js": "^3.13.3",

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -12006,7 +12006,7 @@ tsconfig-paths@^3.14.1, tsconfig-paths@^3.9.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tsec@^0.2.0:
+tsec@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/tsec/-/tsec-0.2.2.tgz#d86d771215fb09a5e226f2b252a1c038c7fa17ca"
   integrity sha512-gKm+nnIKcE9xtrJw2cIJFjfuDGK0AvH3r4RayTEIkUvja/s9z9GPFgcSdEaapm6N10KrmWWcLjsHlKmH2tqzMw==

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
     "semver": "^7.3.5",
     "send": "^0.18.0",
     "ts-node": "^10.0.0",
-    "tsec": "0.2.1",
+    "tsec": "0.2.2",
     "tslint-eslint-rules": "5.4.0",
     "tslint-no-toplevel-property-access": "0.0.2",
     "typed-graphqlify": "^3.1.1",

--- a/tools/postinstall-patches.js
+++ b/tools/postinstall-patches.js
@@ -139,10 +139,6 @@ for (const [fileName, patches] of ngDevPatches.entries()) {
   }
 }
 
-// Workaround until tsec is compatible with `rules_nodejs` v5.
-// TODO: Remove when https://github.com/google/tsec/pull/25 is available.
-sed('-i', '@bazel/typescript', '@bazel/concatjs', 'node_modules/tsec/index.bzl');
-
 log('\n# patch: delete d.ts files referring to rxjs-compat');
 // more info in https://github.com/angular/angular/pull/33786
 rm('-rf', [

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,7 +318,6 @@
 
 "@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#3ff6a9e935cf0d1a8694e7f5842e5e538da64030":
   version "0.0.0-129a5ccbcc73d7ca960d8c166d7400bf2e94cd3d"
-  uid "3ff6a9e935cf0d1a8694e7f5842e5e538da64030"
   resolved "https://github.com/angular/dev-infra-private-builds.git#3ff6a9e935cf0d1a8694e7f5842e5e538da64030"
   dependencies:
     "@angular-devkit/build-angular" "14.0.0-next.6"
@@ -13734,7 +13733,6 @@ sass@1.49.9:
 
 "sauce-connect@https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz":
   version "0.0.0"
-  uid e5d7f82ad98251a653d1b0537f1103e49eda5e11
   resolved "https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz#e5d7f82ad98251a653d1b0537f1103e49eda5e11"
 
 saucelabs@7.1.3, saucelabs@^1.5.0, saucelabs@^4.6.3:
@@ -15257,10 +15255,10 @@ ts-node@^10.0.0:
     v8-compile-cache-lib "^3.0.0"
     yn "3.1.1"
 
-tsec@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/tsec/-/tsec-0.2.1.tgz#017423174b2be54f26da5cb7591dc7035996086b"
-  integrity sha512-RP9vhbRbRI9VH4CfOlQvo5W9HdfiPKq0gdiUOWI5oKmLaZKNFN8CsPwBfT5ySmhnKNwmmAS/BtY3WoTfABwwig==
+tsec@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/tsec/-/tsec-0.2.2.tgz#d86d771215fb09a5e226f2b252a1c038c7fa17ca"
+  integrity sha512-gKm+nnIKcE9xtrJw2cIJFjfuDGK0AvH3r4RayTEIkUvja/s9z9GPFgcSdEaapm6N10KrmWWcLjsHlKmH2tqzMw==
   dependencies:
     glob "^7.1.1"
     minimatch "^3.0.3"


### PR DESCRIPTION
Updates tsec and drops the corresponding postinstall patch that
we added when we updated to Bazel v5. See: https://github.com/google/tsec/pull/25