### PR TITLE
feat(docs-infra): add group role and label for aio-notification

### DIFF
--- a/aio/.eslintrc.json
+++ b/aio/.eslintrc.json
@@ -48,6 +48,7 @@
         "@typescript-eslint/naming-convention": "off",
         "no-console": ["error", {"allow": ["log", "warn", "error"]}],
         "no-empty-function": "off",
+        "@angular-eslint/no-host-metadata-property": "off",
         "no-restricted-syntax": [
           "error",
           {

--- a/aio/src/app/layout/notification/notification.component.ts
+++ b/aio/src/app/layout/notification/notification.component.ts
@@ -17,7 +17,8 @@ const LOCAL_STORAGE_NAMESPACE = 'aio-notification/';
       // - aio/src/app/app.component.ts : notificationDismissed()
       transition('show => hide', animate(250))
     ])
-  ]
+  ],
+  host: {role: 'group', 'aria-label': 'Notification'}
 })
 export class NotificationComponent implements OnInit {
   @Input() dismissOnContentClick: boolean;

--- a/aio/src/app/layout/notification/notification.component.ts
+++ b/aio/src/app/layout/notification/notification.component.ts
@@ -18,6 +18,7 @@ const LOCAL_STORAGE_NAMESPACE = 'aio-notification/';
       transition('show => hide', animate(250))
     ])
   ],
+  host: { role: 'group', 'aria-label': 'Notification' }
 })
 export class NotificationComponent implements OnInit {
   @Input() dismissOnContentClick: boolean;
@@ -27,9 +28,6 @@ export class NotificationComponent implements OnInit {
 
   @HostBinding('@hideAnimation')
   showNotification: 'show'|'hide';
-
-  @HostBinding('attr.role') attrRole = 'group';
-  @HostBinding('attr.aria-label') attrAriaLabel = 'Notification';
 
   constructor(@Inject(LocalStorage) private storage: Storage, @Inject(CurrentDateToken) private currentDate: Date) {}
 

--- a/aio/src/app/layout/notification/notification.component.ts
+++ b/aio/src/app/layout/notification/notification.component.ts
@@ -18,7 +18,6 @@ const LOCAL_STORAGE_NAMESPACE = 'aio-notification/';
       transition('show => hide', animate(250))
     ])
   ],
-  host: {role: 'group', 'aria-label': 'Notification'}
 })
 export class NotificationComponent implements OnInit {
   @Input() dismissOnContentClick: boolean;
@@ -28,6 +27,9 @@ export class NotificationComponent implements OnInit {
 
   @HostBinding('@hideAnimation')
   showNotification: 'show'|'hide';
+
+  @HostBinding('attr.role') attrRole = 'group';
+  @HostBinding('attr.aria-label') attrAriaLabel = 'Notification';
 
   constructor(@Inject(LocalStorage) private storage: Storage, @Inject(CurrentDateToken) private currentDate: Date) {}
 


### PR DESCRIPTION
add a role and an aria-label to the aio-notification component so that
it can be handled better by assistive technologies

resolves #44345

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #44345


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

@jelbourn :smile: 

This is the effect in voiceOver:
https://user-images.githubusercontent.com/61631103/165389941-fcb31a81-17c6-46ed-b667-bdbc97120bf2.mp4

I also tested it with Orca and Chomevox but I didn't really manage to record the thing there (but the best result I got is from voiceOver anyways :grin:)

