### PR TITLE
docs(upgrade): move import back into docregion in `rollup-config.js`

### DIFF
--- a/aio/content/examples/upgrade-phonecat-2-hybrid/rollup-config.js
+++ b/aio/content/examples/upgrade-phonecat-2-hybrid/rollup-config.js
@@ -1,5 +1,5 @@
-import commonjs from '@rollup/plugin-commonjs';
 // #docregion
+import commonjs from '@rollup/plugin-commonjs';
 import {nodeResolve} from '@rollup/plugin-node-resolve'
 import {terser} from 'rollup-plugin-terser'
 


### PR DESCRIPTION
This was accidentally broken in #45405.
