### PR TITLE
fix(core): Ensure the `StandaloneService` is retained after closure m…

### DIFF
--- a/packages/core/src/render3/features/standalone_feature.ts
+++ b/packages/core/src/render3/features/standalone_feature.ts
@@ -56,6 +56,7 @@ export class StandaloneService implements OnDestroy {
     }
   }
 
+  /** @nocollapse */
   static ɵprov = /** @pureOrBreakMyCode */ defineInjectable({
     token: StandaloneService,
     providedIn: 'environment',


### PR DESCRIPTION
…inification

In order to survive closure minification correctly, static properties need to
be annotated with @nocollapse.

For more history, see https://github.com/angular/angular/pull/28050