### PR TITLE
refactor(core): do not allow `standalone` flag overrides via TestBed APIs

### DIFF
--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -143,18 +143,31 @@ export class R3TestBedCompiler {
   }
 
   overrideComponent(component: Type<any>, override: MetadataOverride<Component>): void {
+    this.verifyNoStandaloneFlagOverrides(component, override);
     this.resolvers.component.addOverride(component, override);
     this.pendingComponents.add(component);
   }
 
   overrideDirective(directive: Type<any>, override: MetadataOverride<Directive>): void {
+    this.verifyNoStandaloneFlagOverrides(directive, override);
     this.resolvers.directive.addOverride(directive, override);
     this.pendingDirectives.add(directive);
   }
 
   overridePipe(pipe: Type<any>, override: MetadataOverride<Pipe>): void {
+    this.verifyNoStandaloneFlagOverrides(pipe, override);
     this.resolvers.pipe.addOverride(pipe, override);
     this.pendingPipes.add(pipe);
+  }
+
+  private verifyNoStandaloneFlagOverrides(
+      type: Type<any>, override: MetadataOverride<Component|Directive|Pipe>) {
+    if (override.add?.hasOwnProperty('standalone') || override.set?.hasOwnProperty('standalone') ||
+        override.remove?.hasOwnProperty('standalone')) {
+      throw new Error(
+          `An override for the ${type.name} class has the \`standalone\` flag. ` +
+          `Changing the \`standalone\` flag via TestBed overrides is not supported.`);
+    }
   }
 
   overrideProvider(


### PR DESCRIPTION
This commit adds a check into the TestBed APIs to throw an error if the `standalone` flag is overridden.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No