### PR TITLE
docs(service-worker): fix alert closing tag

### DIFF
--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -239,7 +239,7 @@ This version hash is the "latest manifest hash" listed above.
 Both clients are on the latest version.
 Each client is listed by its ID from the `Clients` API in the browser.
 
-</div
+</div>
 
 #### Idle task queue
 


### PR DESCRIPTION
This also allows correctly parsing other tags further below (such as the `@reviewed` tag at the end).
