### PR TITLE
docs(core): add public API for standalone entities

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -181,14 +181,11 @@ export interface Component extends Directive {
     encapsulation?: ViewEncapsulation;
     // @deprecated
     entryComponents?: Array<Type<any> | any[]>;
-    // (undocumented)
     imports?: (Type<any> | any[])[];
     interpolation?: [string, string];
     moduleId?: string;
     preserveWhitespaces?: boolean;
-    // (undocumented)
     schemas?: SchemaMetadata[];
-    // (undocumented)
     standalone?: boolean;
     styles?: string[];
     styleUrls?: string[];
@@ -413,7 +410,6 @@ export interface Directive {
         [key: string]: any;
     };
     selector?: string;
-    // (undocumented)
     standalone?: boolean;
 }
 
@@ -965,7 +961,6 @@ export const PACKAGE_ROOT_URL: InjectionToken<string>;
 export interface Pipe {
     name: string;
     pure?: boolean;
-    // (undocumented)
     standalone?: boolean;
 }
 

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -289,6 +289,11 @@ export interface Directive {
    */
   jit?: true;
 
+  /**
+   * Angular directives marked as `standalone` do not need to be declared in an NgModule. Such
+   * directives don't depend on any "intermediate context" of an NgModule (ex. configured
+   * providers).
+   */
   standalone?: boolean;
 }
 
@@ -557,11 +562,30 @@ export interface Component extends Directive {
    */
   preserveWhitespaces?: boolean;
 
+  /**
+   * Angular components marked as `standalone` do not need to be declared in an NgModule. Such
+   * components directly manage their own template dependencies (components, directives and pipes
+   * used in a template) via the imports property.
+   */
   standalone?: boolean;
 
-  // TODO: better type here!
+  /**
+   * The imports property specifies the standalone component's template dependencies — those
+   * directives, components, and pipes that can be used within its template. Standalone components
+   * can import other standalone components, directives and pipes as well as existing NgModules.
+   *
+   * This property is only available for standalone components - specifying it for components
+   * declared in an NgModule generates a compilation error.
+   */
   imports?: (Type<any>|any[])[];
 
+  /**
+   * The set of schemas that declare elements to be allowed in a standalone component. Elements and
+   * properties that are neither Angular components nor directives must be declared in a schema.
+   *
+   * This property is only available for standalone components - specifying it for components
+   * declared in an NgModule generates a compilation error.
+   */
   schemas?: SchemaMetadata[];
 }
 
@@ -635,6 +659,10 @@ export interface Pipe {
    */
   pure?: boolean;
 
+  /**
+   * Angular pipes marked as `standalone` do not need to be declared in an NgModule. Such
+   * pipes don't depend on any "intermediate context" of an NgModule (ex. configured providers).
+   */
   standalone?: boolean;
 }
 


### PR DESCRIPTION
This commit adds public API docs for standalone components,
directives and pipes.
