### PR TITLE
build(bazel): change ngc-wrapped to use new bazelOpts.devmode

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -8,7 +8,7 @@
 
 // `tsc-wrapped` helpers are not exposed in the primary `@bazel/concatjs` entry-point.
 // TODO: Update when https://github.com/bazelbuild/rules_nodejs/pull/3286 is available.
-import {BazelOptions, CachedFileLoader, CompilerHost, constructManifest, debug, FileCache, FileLoader, parseTsconfig, resolveNormalizedPath, runAsWorker, runWorkerLoop, UncachedFileLoader} from '@bazel/concatjs/internal/tsc_wrapped';
+import {BazelOptions as ExternalBazelOptions, CachedFileLoader, CompilerHost, constructManifest, debug, FileCache, FileLoader, parseTsconfig, resolveNormalizedPath, runAsWorker, runWorkerLoop, UncachedFileLoader} from '@bazel/concatjs/internal/tsc_wrapped';
 
 import type {AngularCompilerOptions, CompilerHost as NgCompilerHost, TsEmitCallback, Program, CompilerOptions} from '@angular/compiler-cli';
 import * as fs from 'fs';
@@ -19,6 +19,11 @@ import {pathToFileURL} from 'url';
 
 type CompilerCliModule =
     typeof import('@angular/compiler-cli')&typeof import('@angular/compiler-cli/private/bazel');
+
+// Add devmode for blaze internal
+interface BazelOptions extends ExternalBazelOptions {
+  devmode?: boolean;
+}
 
 /**
  * Reference to the previously loaded `compiler-cli` module exports. We cache the exports
@@ -301,7 +306,7 @@ export function compile({
   // Though, if we are building inside `google3`, closure annotations are desired for
   // prodmode output, so we enable it by default. The defaults can be overridden by
   // setting the `annotateForClosureCompiler` compiler option in the user tsconfig.
-  if (!bazelOpts.es5Mode) {
+  if (!bazelOpts.es5Mode && !bazelOpts.devmode) {
     if (bazelOpts.workspaceName === 'google3') {
       compilerOpts.annotateForClosureCompiler = true;
       // Enable the tsickle decorator transform in google3 with Ivy mode enabled. The tsickle

--- a/packages/bazel/test/ngc-wrapped/tsconfig_template.ts
+++ b/packages/bazel/test/ngc-wrapped/tsconfig_template.ts
@@ -61,6 +61,7 @@ export function createTsConfig(options: TsConfigOptions) {
       'target': options.target,
       // we have to set this as the default tsconfig is made of es6 mode
       'es5Mode': true,
+      'devmode': true,
       'manifest': createManifestPath(options),
       'compilationTargetSrc': options.compilationTargetSrc,
       // Override this property from the real tsconfig we read


### PR DESCRIPTION
bazelOpts.es5Mode is being removed and replaced with devmode. Adding a
check for either will allow a smooth migration. 

Required for internal Blaze infrastructure changes.

May depend on a release of https://github.com/bazelbuild/rules_nodejs/pull/3433 because of the expanded type definition for BazelOpts. 

