### PR TITLE
docs: fix ellipsis in code-snippet in `creating-libraries` guide

### DIFF
--- a/aio/content/examples/angular-linker-plugin/webpack.config.mjs
+++ b/aio/content/examples/angular-linker-plugin/webpack.config.mjs
@@ -1,4 +1,4 @@
-// #docplaster &hellip;
+// #docplaster ...
 // #docregion webpack-config
 import linkerPlugin from '@angular/compiler-cli/linker/babel';
 


### PR DESCRIPTION
When hard-coding content in a `<code-example>` tag inside an `.md` file, the content is treated as HTML by the Markdown processor and thus any characters with special meaning in HTML have to be encoded (or replaced with HTML entities).

However, the content that is embedded into `<code-example>` tags via docregions is treated as text (since it is not parsed by the Markdown processor) and thus should not have encoded characters or HTML entities.

##
You can see the issue and the fix in action in this code-snippet of the "Creating Libraries" guide:
- Before: https://angular.io/guide/creating-libraries#consuming-partial-ivy-code-outside-the-angular-cli
- After: https://pr45820-d4f3270.ngbuilds.io/guide/creating-libraries#consuming-partial-ivy-code-outside-the-angular-cli
