### PR TITLE
fix(docs-infra): fix wrong heading structure in aio resources page

### DIFF
--- a/aio/src/app/custom-elements/resource/resource-list.component.html
+++ b/aio/src/app/custom-elements/resource/resource-list.component.html
@@ -7,11 +7,11 @@
   </div>
   <div class="showcase">
     <div *ngFor="let subCategory of selectedCategory?.subCategories">
-      <h3 class="subcategory-title" id="{{subCategory.id}}">{{subCategory.title}}</h3>
+      <h2 class="subcategory-title" id="{{subCategory.id}}">{{subCategory.title}}</h2>
       <div *ngFor="let resource of subCategory.resources">
         <div class="resource-item">
           <a class="resource-row-link" rel="noopener" target="_blank" [href]="resource.url">
-            <h4>{{resource.title}}</h4>
+            <h3 class="resource-name">{{resource.title}}</h3>
             <p class="resource-description">{{resource.desc || 'No Description'}}</p>
           </a>
         </div>

--- a/aio/src/styles/2-modules/resources/_resources.scss
+++ b/aio/src/styles/2-modules/resources/_resources.scss
@@ -10,12 +10,13 @@ aio-resource-list {
   }
 
   .resource-item {
-    h4 {
+    .resource-name {
       margin: 0;
       @include mixins.line-height(24);
+      @include mixins.font-size(20);
     }
 
-    p {
+    .resource-description {
       margin: 0;
     }
   }
@@ -23,6 +24,7 @@ aio-resource-list {
   .subcategory-title {
     padding: 16px 23px;
     margin: 0;
+    @include mixins.font-size(24);
   }
 
   .resource-row-link {


### PR DESCRIPTION
in the aio resources page there is a main h1 heading and then the next
headings used are h3 and h4, thus h2 is being skipped, change such
headings so that there is no heading skipping (which is a bad practice
and can result to confusing experiences from screen reader users)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 Just a minor a11y improvement, the page should look exactly as it does now :slightly_smiling_face: 