### PR TITLE
fix(compiler-cli): report invalid imports in standalone components during resolve phase

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -276,16 +276,6 @@ export class ComponentDecoratorHandler implements
         }
         diagnostics.push(...importDiagnostics);
       }
-
-      const validationDiagnostics =
-          validateStandaloneImports(resolvedImports, rawImports, this.metaReader, this.scopeReader);
-      if (validationDiagnostics.length > 0) {
-        isPoisoned = true;
-        if (diagnostics === undefined) {
-          diagnostics = [];
-        }
-        diagnostics.push(...validationDiagnostics);
-      }
     }
 
     let schemas: SchemaMetadata[]|null = null;
@@ -799,6 +789,12 @@ export class ComponentDecoratorHandler implements
               relatedMessages);
         }
       }
+    }
+
+    if (analysis.resolvedImports !== null && analysis.rawImports !== null) {
+      const standaloneDiagnostics = validateStandaloneImports(
+          analysis.resolvedImports, analysis.rawImports, this.metaReader, this.scopeReader);
+      diagnostics.push(...standaloneDiagnostics);
     }
 
     if (analysis.providersRequiringFactory !== null &&

--- a/packages/compiler-cli/src/ngtsc/scope/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/util.ts
@@ -31,7 +31,7 @@ export function makeNotStandaloneDiagnostic(
 
   let message = `The ${kind} '${
       ref.node.name
-          .text}' appears in 'imports', but is not standalone and cannot be imported directly`;
+          .text}' appears in 'imports', but is not standalone and cannot be imported directly.`;
   let relatedInformation: ts.DiagnosticRelatedInformation[]|undefined = undefined;
   if (scope !== null && scope.kind === ComponentScopeKind.NgModule) {
     // The directive/pipe in question is declared in an NgModule. Check if it's also exported.


### PR DESCRIPTION
The analysis phase of the compiler should operate on individual classes, independently
of other the analysis of other classes. The validation that `Component.imports` only
contains standalone entities or NgModules however did happen during the analysis phase,
introducing a dependency on other classes and causing inconsistencies due to ordering
and/or asynchronous timing differences.

This commit fixes the issue by moving the validation to the resolve phase, which occurs
after all classes have been analyzed.

Fixes #45819