### PR TITLE
docs: modify header and path of code-example to improve docs readability

### DIFF
--- a/aio/content/examples/content-projection/src/app/app.component.ts
+++ b/aio/content/examples/content-projection/src/app/app.component.ts
@@ -1,42 +1,7 @@
-import { Component, Directive, Input, TemplateRef, ContentChild, HostBinding, HostListener } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html'
 })
 export class AppComponent {}
-
-@Directive({
-  selector: 'button[appExampleZippyToggle]',
-})
-export class ZippyToggleDirective {
-  @HostBinding('attr.aria-expanded') ariaExpanded = this.zippy.expanded;
-  @HostBinding('attr.aria-controls') ariaControls = this.zippy.contentId;
-  @HostListener('click') toggleZippy() {
-    this.zippy.expanded = !this.zippy.expanded;
-  }
-  constructor(public zippy: ZippyComponent) {}
-}
-
-// #docregion zippycontentdirective
-@Directive({
-  selector: '[appExampleZippyContent]'
-})
-export class ZippyContentDirective {
-  constructor(public templateRef: TemplateRef<unknown>) {}
-}
-// #enddocregion zippycontentdirective
-
-let nextId = 0;
-
-@Component({
-  selector: 'app-example-zippy',
-  templateUrl: 'example-zippy.template.html',
-})
-export class ZippyComponent {
-  contentId = `zippy-${nextId++}`;
-  @Input() expanded = false;
-  // #docregion contentchild
-  @ContentChild(ZippyContentDirective) content!: ZippyContentDirective;
-  // #enddocregion contentchild
-}

--- a/aio/content/examples/content-projection/src/app/app.module.ts
+++ b/aio/content/examples/content-projection/src/app/app.module.ts
@@ -2,12 +2,12 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
 
+import { AppComponent } from './app.component';
 import {
-  AppComponent,
   ZippyComponent,
   ZippyContentDirective,
   ZippyToggleDirective,
-} from './app.component';
+} from './example-zippy.component';
 import { ZippyBasicComponent } from './zippy-basic/zippy-basic.component';
 import { ZippyMultislotComponent } from './zippy-multislot/zippy-multislot.component';
 import { ZippyNgprojectasComponent } from './zippy-ngprojectas/zippy-ngprojectas.component';

--- a/aio/content/examples/content-projection/src/app/example-zippy.component.ts
+++ b/aio/content/examples/content-projection/src/app/example-zippy.component.ts
@@ -1,0 +1,24 @@
+import { Component, Directive, Input, TemplateRef, ContentChild} from '@angular/core';
+
+let nextId = 0;
+
+// #docregion zippycontentdirective
+@Directive({
+  selector: '[appExampleZippyContent]'
+})
+export class ZippyContentDirective {
+  constructor(public templateRef: TemplateRef<unknown>) {}
+}
+// #enddocregion zippycontentdirective
+
+@Component({
+  selector: 'app-example-zippy',
+  templateUrl: 'example-zippy.template.html',
+})
+export class ZippyComponent {
+  contentId = `zippy-${nextId++}`;
+  @Input() expanded = false;
+  // #docregion contentchild
+  @ContentChild(ZippyContentDirective) content!: ZippyContentDirective;
+  // #enddocregion contentchild
+}

--- a/aio/content/examples/content-projection/src/app/example-zippy.component.ts
+++ b/aio/content/examples/content-projection/src/app/example-zippy.component.ts
@@ -1,4 +1,16 @@
-import { Component, Directive, Input, TemplateRef, ContentChild} from '@angular/core';
+import { Component, Directive, Input, TemplateRef, ContentChild, HostBinding, HostListener } from '@angular/core';
+
+@Directive({
+  selector: 'button[appExampleZippyToggle]',
+})
+export class ZippyToggleDirective {
+  @HostBinding('attr.aria-expanded') ariaExpanded = this.zippy.expanded;
+  @HostBinding('attr.aria-controls') ariaControls = this.zippy.contentId;
+  @HostListener('click') toggleZippy() {
+    this.zippy.expanded = !this.zippy.expanded;
+  }
+  constructor(public zippy: ZippyComponent) {}
+}
 
 let nextId = 0;
 

--- a/aio/content/guide/content-projection.md
+++ b/aio/content/guide/content-projection.md
@@ -129,7 +129,7 @@ The following steps demonstrate a typical implementation of conditional content 
 
 1.  In the component you want to project content into, use `@ContentChild` to get the template of the projected content.
 
-    <code-example header="content-projection/src/app/app.component.ts" path="content-projection/src/app/app.component.ts" region="contentchild"></code-example>
+    <code-example header="content-projection/src/app/example-zippy.component.ts" path="content-projection/src/app/example-zippy.component.ts" region="contentchild"></code-example>
 
     Prior to this step, your application has a component that instantiates a template when certain conditions are met.
     You've also created a directive that provides a reference to that template.

--- a/aio/content/guide/content-projection.md
+++ b/aio/content/guide/content-projection.md
@@ -121,7 +121,7 @@ The following steps demonstrate a typical implementation of conditional content 
 1.  [Create an attribute directive](guide/attribute-directives#building-an-attribute-directive) with a selector that matches the custom attribute for your template.
     In this directive, inject a `TemplateRef` instance.
 
-    <code-example header="content-projection/src/app/app.component.ts" path="content-projection/src/app/app.component.ts" region="zippycontentdirective"></code-example>
+    <code-example header="content-projection/src/app/example-zippy.component.ts" path="content-projection/src/app/example-zippy.component.ts" region="zippycontentdirective"></code-example>
 
     In the previous step, you added an `<ng-template>` element with a custom attribute, `appExampleZippyContent`.
     This code provides the logic that Angular will use when it encounters that custom attribute.


### PR DESCRIPTION
In this part of the [docs](https://angular.io/guide/content-projection#conditional-content-projection), without opening live example, `@ContentChild(ZippyContentDirective) content!: ZippyContentDirective;` seems to be used in `app.component.ts`.

Moving Component and Directives from `app.component.ts` to a separate file (`example-zippy.component.ts`) improves docs readability.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [x] No
