### PR TITLE
docs(docs-infra): improve clarity of toh-pt2 click code snippet

### DIFF
--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.1.html
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.1.html
@@ -14,6 +14,7 @@
 <!-- #docregion selectedHero-click -->
 <li *ngFor="let hero of heroes">
   <button type="button" (click)="onSelect(hero)">
+  <!-- ... -->
 <!-- #enddocregion selectedHero-click -->
 
 <!-- #docregion class-selected -->

--- a/aio/content/tutorial/toh-pt2.md
+++ b/aio/content/tutorial/toh-pt2.md
@@ -109,7 +109,7 @@ In this section, you'll listen for the hero item click event and update the hero
 
 ### Add a click event binding
 
-Add a `<button>` with a click event binding in the `<li>` like this:
+Start creating a `<button>` with a click event binding in the `<li>` like this:
 
 <code-example header="heroes.component.html (template excerpt)" path="toh-pt2/src/app/heroes/heroes.component.1.html" region="selectedHero-click"></code-example>
 


### PR DESCRIPTION
make clearer that the click code snippet present in the tour of heroes
part 2 guide is not complete but adding ellipsis at the end of the
snippet and also by slightly tweaking the text introducing the snippet

resolves #45758

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: #45758

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

