### PR TITLE
refactor(docs-infra): remove unnecessary types for stemmer dependency

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -117,7 +117,6 @@
     "@types/jasmine": "~3.10.0",
     "@types/lunr": "^2.3.3",
     "@types/node": "^12.7.9",
-    "@types/stemmer": "^1.0.2",
     "@types/trusted-types": "^2.0.2",
     "@types/xregexp": "^4.3.0",
     "@typescript-eslint/eslint-plugin": "5.19.0",

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -2164,11 +2164,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/stemmer@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/stemmer/-/stemmer-1.0.2.tgz#bd8354f50b3c9b87c351d169240e45cf1fa1f5e8"
-  integrity sha512-2gWEIFqVZjjZxo8/TcugCAl7nW9Jd9ArEDpTAc5nH7d+ZUkreHA7GzuFcLZ0sflLrA5b1PZ+2yDyHJcuP9KWWw==
-
 "@types/trusted-types@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"


### PR DESCRIPTION
NOTE:
Since version 2.0.0 stemmer includes its own typings (see https://github.com/words/stemmer/commit/cd6fd9a0319bd7f44dc09ed40614fa807fe28535)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There are two versions for the `stemmer` dependency types: 
- `@types/stemmer` for version < 2.0.0
- `stemmer` for version 2.0.0


Issue Number: N/A

## What is the new behavior?
The types bundled with the `stemmer` package are used.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
When updating stemmer to version 2.0.0 (see https://github.com/angular/angular/pull/41724) the types where not updated. 