### PR TITLE
fix(ngcc): cope with packages following APF v14+

### DIFF
--- a/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
@@ -137,7 +137,7 @@ export class ModuleResolver {
    *
    * This is achieved by checking for the existence of `${modulePath}/package.json`.
    * If there is no `package.json`, we check whether this is an APF v14+ secondary entry-point,
-   * which does not have each own `package.json` but has an `exports` entry in the package's primary
+   * which does not have its own `package.json` but has an `exports` entry in the package's primary
    * `package.json`.
    */
   private isEntryPoint(modulePath: AbsoluteFsPath): boolean {

--- a/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
+++ b/packages/compiler-cli/ngcc/src/dependencies/module_resolver.ts
@@ -7,7 +7,7 @@
  */
 import {AbsoluteFsPath, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 import {PathMappings} from '../path_mappings';
-import {isRelativePath, resolveFileWithPostfixes} from '../utils';
+import {isRelativePath, loadJson, loadSecondaryEntryPointInfoForApfV14, resolveFileWithPostfixes} from '../utils';
 
 /**
  * This is a very cut-down implementation of the TypeScript module resolution strategy.
@@ -110,8 +110,8 @@ export class ModuleResolver {
    * Try to resolve the `moduleName` as an external entry-point by searching the `node_modules`
    * folders up the tree for a matching `.../node_modules/${moduleName}`.
    *
-   * If a folder is found but the path does not contain a `package.json` then it is marked as a
-   * "deep-import".
+   * If a folder is found but the path is not considered an entry-point (see `isEntryPoint()`) then
+   * it is marked as a "deep-import".
    */
   private resolveAsEntryPoint(moduleName: string, fromPath: AbsoluteFsPath): ResolvedModule|null {
     let folder = fromPath;
@@ -136,9 +136,25 @@ export class ModuleResolver {
    * Can we consider the given path as an entry-point to a package?
    *
    * This is achieved by checking for the existence of `${modulePath}/package.json`.
+   * If there is no `package.json`, we check whether this is an APF v14+ secondary entry-point,
+   * which does not have each own `package.json` but has an `exports` entry in the package's primary
+   * `package.json`.
    */
   private isEntryPoint(modulePath: AbsoluteFsPath): boolean {
-    return this.fs.exists(this.fs.join(modulePath, 'package.json'));
+    if (this.fs.exists(this.fs.join(modulePath, 'package.json'))) {
+      return true;
+    }
+
+    const packagePath = this.findPackagePath(modulePath);
+    if (packagePath === null) {
+      return false;
+    }
+
+    const packagePackageJson = loadJson(this.fs, this.fs.join(packagePath, 'package.json'));
+    const entryPointInfoForApfV14 =
+        loadSecondaryEntryPointInfoForApfV14(this.fs, packagePackageJson, packagePath, modulePath);
+
+    return entryPointInfoForApfV14 !== null;
   }
 
   /**

--- a/packages/compiler-cli/ngcc/src/execution/cluster/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/api.ts
@@ -7,7 +7,7 @@
  */
 
 import {AbsoluteFsPath} from '../../../../src/ngtsc/file_system';
-import {JsonObject} from '../../packages/entry_point';
+import {JsonObject} from '../../utils';
 import {PackageJsonChange} from '../../writing/package_json_updater';
 import {Task, TaskProcessingOutcome} from '../tasks/api';
 

--- a/packages/compiler-cli/ngcc/src/execution/cluster/package_json_updater.ts
+++ b/packages/compiler-cli/ngcc/src/execution/cluster/package_json_updater.ts
@@ -11,7 +11,7 @@
 import cluster from 'cluster';
 
 import {AbsoluteFsPath} from '../../../../src/ngtsc/file_system';
-import {JsonObject} from '../../packages/entry_point';
+import {JsonObject} from '../../utils';
 import {applyChange, PackageJsonChange, PackageJsonUpdate, PackageJsonUpdater} from '../../writing/package_json_updater';
 
 import {sendMessageToMaster} from './utils';

--- a/packages/compiler-cli/ngcc/src/execution/create_compile_function.ts
+++ b/packages/compiler-cli/ngcc/src/execution/create_compile_function.ts
@@ -12,7 +12,7 @@ import {replaceTsWithNgInErrors} from '../../../src/ngtsc/diagnostics';
 import {FileSystem} from '../../../src/ngtsc/file_system';
 import {Logger} from '../../../src/ngtsc/logging';
 import {ParsedConfiguration} from '../../../src/perform_compile';
-import {EntryPointPackageJson, getEntryPointFormat} from '../packages/entry_point';
+import {getEntryPointFormat} from '../packages/entry_point';
 import {makeEntryPointBundle} from '../packages/entry_point_bundle';
 import {createModuleResolutionCache, SharedFileCache} from '../packages/source_file_cache';
 import {Transformer} from '../packages/transformer';

--- a/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
+++ b/packages/compiler-cli/ngcc/src/execution/tasks/api.ts
@@ -5,8 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {EntryPoint, EntryPointJsonProperty, JsonObject} from '../../packages/entry_point';
-import {PartiallyOrderedList} from '../../utils';
+import {EntryPoint, EntryPointJsonProperty} from '../../packages/entry_point';
+import {JsonObject, PartiallyOrderedList} from '../../utils';
 
 /**
  * Represents a unit of work to be undertaken by an `Executor`.

--- a/packages/compiler-cli/ngcc/src/packages/source_file_cache.ts
+++ b/packages/compiler-cli/ngcc/src/packages/source_file_cache.ts
@@ -9,8 +9,6 @@ import ts from 'typescript';
 
 import {AbsoluteFsPath, ReadonlyFileSystem} from '../../../src/ngtsc/file_system';
 
-import {adjustElementAccessExports} from './adjust_cjs_umd_exports';
-
 /**
  * A cache that holds on to source files that can be shared for processing all entry-points in a
  * single invocation of ngcc. In particular, the following files are shared across all entry-points

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -10,6 +10,13 @@ import ts from 'typescript';
 import {absoluteFrom, AbsoluteFsPath, isRooted, ReadonlyFileSystem} from '../../src/ngtsc/file_system';
 import {DeclarationNode, KnownDeclaration} from '../../src/ngtsc/reflection';
 
+export type JsonPrimitive = string|number|boolean|null;
+export type JsonValue = JsonPrimitive|JsonArray|JsonObject|undefined;
+export interface JsonArray extends Array<JsonValue> {}
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+
 /**
  * A list (`Array`) of partially ordered `T` items.
  *
@@ -163,4 +170,19 @@ export function stripDollarSuffix(value: string): string {
 
 export function stripExtension(fileName: string): string {
   return fileName.replace(/\..+$/, '');
+}
+
+/**
+ * Parse the JSON from a `package.json` file.
+ *
+ * @param packageJsonPath The absolute path to the `package.json` file.
+ * @returns JSON from the `package.json` file if it exists and is valid, `null` otherwise.
+ */
+export function loadJson<T extends JsonObject = JsonObject>(
+    fs: ReadonlyFileSystem, packageJsonPath: AbsoluteFsPath): T|null {
+  try {
+    return JSON.parse(fs.readFile(packageJsonPath)) as T;
+  } catch {
+    return null;
+  }
 }

--- a/packages/compiler-cli/ngcc/src/utils.ts
+++ b/packages/compiler-cli/ngcc/src/utils.ts
@@ -186,3 +186,33 @@ export function loadJson<T extends JsonObject = JsonObject>(
     return null;
   }
 }
+
+/**
+ * Given the parsed JSON of a `package.json` file, try to extract info for a secondary entry-point
+ * from the `exports` property. Such info will only be present for packages following Angular
+ * Package Format v14+.
+ *
+ * @param primaryPackageJson The parsed JSON of the primary `package.json` (or `null` if it failed
+ *     to be loaded).
+ * @param packagePath The absolute path to the containing npm package.
+ * @param entryPointPath The absolute path to the secondary entry-point.
+ * @returns The `exports` info for the specified entry-point if it exists, `null` otherwise.
+ */
+export function loadSecondaryEntryPointInfoForApfV14(
+    fs: ReadonlyFileSystem, primaryPackageJson: JsonObject|null, packagePath: AbsoluteFsPath,
+    entryPointPath: AbsoluteFsPath): JsonObject|null {
+  // Check if primary `package.json` has been loaded and has an `exports` property.
+  if (primaryPackageJson?.exports === undefined) {
+    return null;
+  }
+
+  // Find the `exports` key for the secondary entry-point.
+  const relativeEntryPointPath = fs.relative(packagePath, entryPointPath);
+  const exportsKey = `./${relativeEntryPointPath}`;
+
+  // Read the data (if it exists).
+  const exportsData =
+      (primaryPackageJson.exports as JsonObject)[exportsKey] as JsonObject | undefined;
+
+  return exportsData ?? null;
+}

--- a/packages/compiler-cli/ngcc/src/writing/package_json_updater.ts
+++ b/packages/compiler-cli/ngcc/src/writing/package_json_updater.ts
@@ -7,7 +7,7 @@
  */
 
 import {AbsoluteFsPath, dirname, FileSystem} from '../../../src/ngtsc/file_system';
-import {JsonObject, JsonValue} from '../packages/entry_point';
+import {JsonObject, JsonValue} from '../utils';
 
 
 export type PackageJsonChange = [string[], JsonValue, PackageJsonPropertyPositioning];

--- a/packages/compiler-cli/ngcc/src/writing/package_json_updater.ts
+++ b/packages/compiler-cli/ngcc/src/writing/package_json_updater.ts
@@ -101,6 +101,7 @@ export class PackageJsonUpdate {
    */
   writeChanges(packageJsonPath: AbsoluteFsPath, parsedJson?: JsonObject): void {
     this.ensureNotApplied();
+    this.ensureNotSynthesized(parsedJson);
     this.writeChangesImpl(this.changes, packageJsonPath, parsedJson);
     this.applied = true;
   }
@@ -108,6 +109,15 @@ export class PackageJsonUpdate {
   private ensureNotApplied() {
     if (this.applied) {
       throw new Error('Trying to apply a `PackageJsonUpdate` that has already been applied.');
+    }
+  }
+
+  private ensureNotSynthesized(parsedJson?: JsonObject) {
+    if (parsedJson?.synthesized) {
+      // Theoretically, this should never happen, because synthesized `package.json` files should
+      // only be created for libraries following the Angular Package Format v14+, which means they
+      // should already be in Ivy format and not require processing by `ngcc`.
+      throw new Error('Trying to update a non-existent (synthesized) `package.json` file.');
     }
   }
 }

--- a/packages/compiler-cli/ngcc/test/dependencies/module_resolver_spec.ts
+++ b/packages/compiler-cli/ngcc/test/dependencies/module_resolver_spec.ts
@@ -64,6 +64,25 @@ runInEachFileSystem(() => {
           name: _('/node_modules/top-package/package.json'),
           contents: 'PACKAGE.JSON for top-package'
         },
+        {
+          name: _('/node_modules/apf-v14-package/package.json'),
+          contents: `{
+            "name": "apf-v14-package",
+            "exports": {
+              "./second/ary": {
+                "main": "./second/ary/index.js"
+              }
+            }
+          }`,
+        },
+        {
+          name: _('/node_modules/apf-v14-package/index.js'),
+          contents: `export const type = 'primary';`,
+        },
+        {
+          name: _('/node_modules/apf-v14-package/second/ary/index.js'),
+          contents: `export const type = 'secondary';`,
+        },
       ]);
     });
 
@@ -143,6 +162,17 @@ runInEachFileSystem(() => {
                      'package-1/sub-folder', _('/libs/local-package/index.js')))
               .toEqual(new ResolvedDeepImport(
                   _('/libs/local-package/node_modules/package-1/sub-folder')));
+        });
+
+        it('should resolve to APF v14+ secondary entry-points', () => {
+          const resolver = new ModuleResolver(getFileSystem());
+
+          expect(resolver.resolveModuleImport(
+                     'apf-v14-package/second/ary', _('/libs/local-package/index.js')))
+              .toEqual(new ResolvedExternalModule(_('/node_modules/apf-v14-package/second/ary')));
+          expect(resolver.resolveModuleImport(
+                     'apf-v14-package/second/ary', _('/libs/local-package/sub-folder/index.js')))
+              .toEqual(new ResolvedExternalModule(_('/node_modules/apf-v14-package/second/ary')));
         });
       });
 
@@ -256,6 +286,20 @@ runInEachFileSystem(() => {
                         'package-4/secondary-entry-point', _('/dist/package-4/index.js')))
                  .toEqual(new ResolvedExternalModule(_('/dist/package-4/secondary-entry-point')));
            });
+
+        it('should resolve APF v14+ secondary entry-points', () => {
+          const resolver = new ModuleResolver(getFileSystem(), {
+            baseUrl: '/node_modules',
+            paths: {'package-42': ['apf-v14-package'], 'package-42/*': ['apf-v14-package/*']},
+          });
+
+          expect(resolver.resolveModuleImport(
+                     'package-42/second/ary', _('/libs/local-package/index.js')))
+              .toEqual(new ResolvedExternalModule(_('/node_modules/apf-v14-package/second/ary')));
+          expect(resolver.resolveModuleImport(
+                     'package-42/second/ary', _('/libs/local-package/sub-folder/index.js')))
+              .toEqual(new ResolvedExternalModule(_('/node_modules/apf-v14-package/second/ary')));
+        });
       });
 
       describe('with mapped path relative paths', () => {

--- a/packages/compiler-cli/ngcc/test/execution/cluster/package_json_updater_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/package_json_updater_spec.ts
@@ -13,7 +13,7 @@ import cluster from 'cluster';
 import {absoluteFrom as _} from '../../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../../src/ngtsc/file_system/testing';
 import {ClusterWorkerPackageJsonUpdater} from '../../../src/execution/cluster/package_json_updater';
-import {JsonObject} from '../../../src/packages/entry_point';
+import {JsonObject} from '../../../src/utils';
 import {PackageJsonPropertyPositioning, PackageJsonUpdate, PackageJsonUpdater} from '../../../src/writing/package_json_updater';
 import {mockProperty} from '../../helpers/spy_utils';
 

--- a/packages/compiler-cli/ngcc/test/execution/cluster/package_json_updater_spec.ts
+++ b/packages/compiler-cli/ngcc/test/execution/cluster/package_json_updater_spec.ts
@@ -197,6 +197,14 @@ runInEachFileSystem(() => {
         expect(() => update.writeChanges(_('/bar/package.json')))
             .toThrowError('Trying to apply a `PackageJsonUpdate` that has already been applied.');
       });
+
+      it('should throw, if trying to update a synthesized `package.json` file', () => {
+        const update = updater.createUpdate().addChange(['foo'], 'updated');
+
+        expect(() => update.writeChanges(_('/foo/package.json'), {
+          synthesized: true
+        })).toThrowError('Trying to update a non-existent (synthesized) `package.json` file.');
+      });
     });
   });
 

--- a/packages/compiler-cli/ngcc/test/utils_spec.ts
+++ b/packages/compiler-cli/ngcc/test/utils_spec.ts
@@ -283,7 +283,7 @@ runInEachFileSystem(() => {
   beforeEach(() => fs = getFileSystem());
 
   describe('loadSecondaryEntryPointInfoForApfV14()', () => {
-    it('should return `null` of the primary `package.json` failed to be loaded', () => {
+    it('should return `null` if the primary `package.json` failed to be loaded', () => {
       expect(loadSecondaryEntryPointInfoForApfV14(fs, null, _abs('/foo'), _abs('/foo/bar')))
           .toBe(null);
     });
@@ -300,12 +300,39 @@ runInEachFileSystem(() => {
           .toBe(null);
     });
 
+    it('should return `null` if the primary `package.json`\'s `exports` property is a string',
+       () => {
+         const primaryPackageJson = {
+           name: 'some-package',
+           exports: './index.js',
+         };
+
+         expect(loadSecondaryEntryPointInfoForApfV14(
+                    fs, primaryPackageJson, _abs('/foo'), _abs('/foo/bar')))
+             .toBe(null);
+       });
+
+    it('should return `null` if the primary `package.json`\'s `exports` property is a string array',
+       () => {
+         const primaryPackageJson = {
+           name: 'some-package',
+           exports: [
+             './foo.js',
+             './bar.js',
+           ],
+         };
+
+         expect(loadSecondaryEntryPointInfoForApfV14(
+                    fs, primaryPackageJson, _abs('/foo'), _abs('/foo/bar')))
+             .toBe(null);
+       });
+
     it('should return `null` if there is no info for the specified entry-point', () => {
       const primaryPackageJson = {
         name: 'some-package',
         exports: {
           './baz': {
-            isBar: false,
+            main: './baz/index.js',
           },
         },
       };
@@ -315,19 +342,48 @@ runInEachFileSystem(() => {
           .toBe(null);
     });
 
-    it('should return the entry-point info if it exists', () => {
+    it('should return `null` if the entry-point info is a string', () => {
+      const primaryPackageJson = {
+        name: 'some-package',
+        exports: {
+          './bar': './bar/index.js',
+        },
+      };
+
+      expect(loadSecondaryEntryPointInfoForApfV14(
+                 fs, primaryPackageJson, _abs('/foo'), _abs('/foo/bar')))
+          .toBe(null);
+    });
+
+    it('should return `null` if the entry-point info is a string array', () => {
+      const primaryPackageJson = {
+        name: 'some-package',
+        exports: {
+          './bar': [
+            './bar/a.js',
+            './bar/b.js',
+          ],
+        },
+      };
+
+      expect(loadSecondaryEntryPointInfoForApfV14(
+                 fs, primaryPackageJson, _abs('/foo'), _abs('/foo/bar')))
+          .toBe(null);
+    });
+
+    it('should return the entry-point info if it exists and is an object', () => {
       const primaryPackageJson = {
         name: 'some-package',
         exports: {
           './bar': {
-            isBar: true,
+            main: './bar/index.js',
           },
         },
       };
 
       expect(loadSecondaryEntryPointInfoForApfV14(
                  fs, primaryPackageJson, _abs('/foo'), _abs('/foo/bar')))
-          .toEqual({isBar: true});
+          .toEqual({main: './bar/index.js'});
     });
   });
 });

--- a/packages/compiler-cli/ngcc/test/utils_spec.ts
+++ b/packages/compiler-cli/ngcc/test/utils_spec.ts
@@ -12,7 +12,7 @@ import {absoluteFrom as _abs, FileSystem, getFileSystem} from '../../src/ngtsc/f
 import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
 import {KnownDeclaration} from '../../src/ngtsc/reflection';
 import {loadTestFiles} from '../../src/ngtsc/testing';
-import {FactoryMap, getTsHelperFnFromDeclaration, getTsHelperFnFromIdentifier, isRelativePath, loadJson, stripExtension} from '../src/utils';
+import {FactoryMap, getTsHelperFnFromDeclaration, getTsHelperFnFromIdentifier, isRelativePath, loadJson, loadSecondaryEntryPointInfoForApfV14, stripExtension} from '../src/utils';
 
 describe('FactoryMap', () => {
   it('should return an existing value', () => {
@@ -273,6 +273,61 @@ runInEachFileSystem(() => {
       ]);
 
       expect(loadJson(fs, _abs('/foo/bar.json'))).toBeNull();
+    });
+  });
+});
+
+runInEachFileSystem(() => {
+  let fs: FileSystem;
+
+  beforeEach(() => fs = getFileSystem());
+
+  describe('loadSecondaryEntryPointInfoForApfV14()', () => {
+    it('should return `null` of the primary `package.json` failed to be loaded', () => {
+      expect(loadSecondaryEntryPointInfoForApfV14(fs, null, _abs('/foo'), _abs('/foo/bar')))
+          .toBe(null);
+    });
+
+    it('should return `null` if the primary `package.json` has no `exports` property', () => {
+      const primaryPackageJson = {
+        name: 'some-package',
+        version: '1.33.7',
+        main: './index.js',
+      };
+
+      expect(loadSecondaryEntryPointInfoForApfV14(
+                 fs, primaryPackageJson, _abs('/foo'), _abs('/foo/bar')))
+          .toBe(null);
+    });
+
+    it('should return `null` if there is no info for the specified entry-point', () => {
+      const primaryPackageJson = {
+        name: 'some-package',
+        exports: {
+          './baz': {
+            isBar: false,
+          },
+        },
+      };
+
+      expect(loadSecondaryEntryPointInfoForApfV14(
+                 fs, primaryPackageJson, _abs('/foo'), _abs('/foo/bar')))
+          .toBe(null);
+    });
+
+    it('should return the entry-point info if it exists', () => {
+      const primaryPackageJson = {
+        name: 'some-package',
+        exports: {
+          './bar': {
+            isBar: true,
+          },
+        },
+      };
+
+      expect(loadSecondaryEntryPointInfoForApfV14(
+                 fs, primaryPackageJson, _abs('/foo'), _abs('/foo/bar')))
+          .toEqual({isBar: true});
     });
   });
 });

--- a/packages/compiler-cli/ngcc/test/writing/package_json_updater_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/package_json_updater_spec.ts
@@ -153,6 +153,14 @@ runInEachFileSystem(() => {
           .toThrowError('Trying to apply a `PackageJsonUpdate` that has already been applied.');
     });
 
+    it('should throw, if trying to update a synthesized `package.json` file', () => {
+      const update = updater.createUpdate().addChange(['foo'], 'updated');
+
+      expect(() => update.writeChanges(_('/foo/package.json'), {
+        synthesized: true
+      })).toThrowError('Trying to update a non-existent (synthesized) `package.json` file.');
+    });
+
     describe('(property positioning)', () => {
       // Helpers
       const createJsonFile = (jsonObj: JsonObject) => {

--- a/packages/compiler-cli/ngcc/test/writing/package_json_updater_spec.ts
+++ b/packages/compiler-cli/ngcc/test/writing/package_json_updater_spec.ts
@@ -8,7 +8,7 @@
 import {absoluteFrom, AbsoluteFsPath, FileSystem, getFileSystem} from '../../../src/ngtsc/file_system';
 import {runInEachFileSystem} from '../../../src/ngtsc/file_system/testing';
 import {loadTestFiles} from '../../../src/ngtsc/testing';
-import {JsonObject} from '../../src/packages/entry_point';
+import {JsonObject} from '../../src/utils';
 import {DirectPackageJsonUpdater, PackageJsonUpdater} from '../../src/writing/package_json_updater';
 
 runInEachFileSystem(() => {


### PR DESCRIPTION
In PR #45405, the Angular Package Format (APF) was updated so that secondary entry-points (such as `@angular/common/http`) do not have their own `package.json` file, as they used to. Instead, the paths to their various formats and types are exposed via the primary `package.json` file's `exports` property. As an example, see the v13 [@angular/common/http/package.json][1] and compare it with the v14 [@angular/common/package.json > exports][2].

Previously, `ngcc` was not able to analyze such v14+ entry-points and would instead error as it considered such entry-points missing.

This commit addresses the issue by detecting this situation and synthesizing a `package.json` file for the secondary entry-points based on the `exports` property of the primary `package.json` file. This data is only used by `ngcc` in order to determine that the entry-point does not need further processing, since it is already in Ivy format.

##
FYI, I have tested this on `ngcc-validation` and it makes CI green: [CI run][3]

[1]: https://unpkg.com/browse/@angular/common@13.3.5/http/package.json
[2]: https://unpkg.com/browse/@angular/common@14.0.0-next.15/package.json
[3]: https://app.circleci.com/pipelines/github/angular/ngcc-validation/18407/workflows/36ae9514-3d96-4407-b104-a372a634e17c
