### PR TITLE
build: update ng-dev with updated clang-format version to fix formatting

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-      - uses: angular/dev-infra/github-actions/commit-message-based-labels@93fef044b38a3818d292be5bad0817ca6578f3e5
+      - uses: angular/dev-infra/github-actions/commit-message-based-labels@a7d07a6f66c05791fdde2dd372da4ba55c1d524b
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/feature-requests.yml
+++ b/.github/workflows/feature-requests.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.repository == 'angular/angular'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/feature-request@93fef044b38a3818d292be5bad0817ca6578f3e5
+      - uses: angular/dev-infra/github-actions/feature-request@a7d07a6f66c05791fdde2dd372da4ba55c1d524b
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.repository == 'angular/angular'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@93fef044b38a3818d292be5bad0817ca6578f3e5
+      - uses: angular/dev-infra/github-actions/lock-closed@a7d07a6f66c05791fdde2dd372da4ba55c1d524b
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
   },
   "// 2": "devDependencies are not used under Bazel. Many can be removed after test.sh is deleted.",
   "devDependencies": {
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#0026ddaac15d7717152c8e113b9f7e1a7075ee82",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#335aad1b04b3d95cd4cb1d719e73b93d4e90cce3",
     "@bazel/bazelisk": "^1.7.5",
     "@bazel/buildifier": "^5.0.0",
     "@bazel/ibazel": "^0.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -322,20 +322,20 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#0026ddaac15d7717152c8e113b9f7e1a7075ee82":
-  version "0.0.0-93fef044b38a3818d292be5bad0817ca6578f3e5"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#0026ddaac15d7717152c8e113b9f7e1a7075ee82"
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#335aad1b04b3d95cd4cb1d719e73b93d4e90cce3":
+  version "0.0.0-a7d07a6f66c05791fdde2dd372da4ba55c1d524b"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#335aad1b04b3d95cd4cb1d719e73b93d4e90cce3"
   dependencies:
     "@angular-devkit/build-angular" "14.0.0-next.12"
     "@angular/benchpress" "0.3.0"
     "@babel/core" "^7.16.0"
     "@bazel/buildifier" "5.1.0"
-    "@bazel/concatjs" "5.4.1"
-    "@bazel/esbuild" "5.4.1"
-    "@bazel/protractor" "5.4.1"
-    "@bazel/runfiles" "5.4.1"
-    "@bazel/terser" "5.4.1"
-    "@bazel/typescript" "5.4.1"
+    "@bazel/concatjs" "5.4.2"
+    "@bazel/esbuild" "5.4.2"
+    "@bazel/protractor" "5.4.2"
+    "@bazel/runfiles" "5.4.2"
+    "@bazel/terser" "5.4.2"
+    "@bazel/typescript" "5.4.2"
     "@microsoft/api-extractor" "7.23.0"
     "@types/browser-sync" "^2.26.3"
     "@types/node" "16.10.9"
@@ -347,7 +347,7 @@
     "@types/yargs" "^17.0.0"
     browser-sync "^2.27.7"
     chalk "^4.1.0"
-    clang-format "1.7.0"
+    clang-format "1.8.0"
     node-fetch "^2.6.1"
     prettier "2.6.2"
     protractor "^7.0.0"
@@ -1394,10 +1394,24 @@
     source-map-support "0.5.9"
     tsutils "3.21.0"
 
+"@bazel/concatjs@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@bazel/concatjs/-/concatjs-5.4.2.tgz#2ec0943b50e229a163a277a6de2cc38aeb852e14"
+  integrity sha512-MoQfmY+6N8RCgqDI2+bRuD+I0p3CLI1JCYZZNSnbZySv1SnT5oQHxoerojEYwyOmsS5sUt2sR8uGtMYZSdoycQ==
+  dependencies:
+    protobufjs "6.8.8"
+    source-map-support "0.5.9"
+    tsutils "3.21.0"
+
 "@bazel/esbuild@5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@bazel/esbuild/-/esbuild-5.4.1.tgz#e2d1e66d2cf2e5d64d35dccce21a210b1082a7c4"
   integrity sha512-6kdjyJL3vPdQ/HJUoVhl3JJm4DarQfXQdycoSKsP0Snq4J71T2M2yCw2zY4hlQFsQdLhXzrPe9ZQ9dkUtobnSA==
+
+"@bazel/esbuild@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@bazel/esbuild/-/esbuild-5.4.2.tgz#07b46fd7b10667b6e56b94df2c316c19de17ab33"
+  integrity sha512-k1ZJzFlpfzTcJyHvVxSoOmiPwWNmJSVE0A2ygtXlyB4/dTnGAC6vcX03ECXovd+wk8py/DuFQDb6Xpv6RnWtAg==
 
 "@bazel/ibazel@^0.16.0":
   version "0.16.2"
@@ -1417,6 +1431,11 @@
   resolved "https://registry.yarnpkg.com/@bazel/protractor/-/protractor-5.4.1.tgz#f246f5e1fbcc5ed36e6d48824009bb29482e1660"
   integrity sha512-uYIrYuxyZMplpov7pkjNF2igQA3CrnHOF4W68xJlHWhw3tjbacWHd4OJJ1BYrpPoYShaiKYxuVnzRVF9/0f7Bg==
 
+"@bazel/protractor@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@bazel/protractor/-/protractor-5.4.2.tgz#4b29920445ab2d87769340551df92e70b43e33a3"
+  integrity sha512-uW4aDbQZfa+Y2qCbg59sndZROMpcv7Hg0i1ijkU98GiWS+vYaJyWQQUzyWPL3jWZXf8UIJbgyIEmneB4s13gjw==
+
 "@bazel/rollup@5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@bazel/rollup/-/rollup-5.4.1.tgz#3a79e6fd58e0afb540d2b975ecc2b8cb97374a07"
@@ -1429,17 +1448,27 @@
   resolved "https://registry.yarnpkg.com/@bazel/runfiles/-/runfiles-5.4.1.tgz#d85f3f5d5bd0b7b3f15ee9a5d3ad822cfb98c5f8"
   integrity sha512-P3ieXEcUKsycQcSfh6WqrESxvdd3eVwByQtK9wD0Xq2gvdBQlbl5tSNwyhKf41fWKyS6n4ZCLv7TXhFfMxZj9Q==
 
+"@bazel/runfiles@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@bazel/runfiles/-/runfiles-5.4.2.tgz#85d6ee8ab99c8a1ebe7b320b2bc452135c2ff30f"
+  integrity sha512-FfX+GeoeBcFP7JfsZN0T3cfFOpi80Nf9W9/g2U5pjcYay2Q06fmj3Fi3SVg+iyzjo+cbW9Sw/F3otCsvvZYPiw==
+
 "@bazel/terser@5.4.1":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@bazel/terser/-/terser-5.4.1.tgz#1a863c53f89f9882dcb489ec6ee1d1e64de8dd78"
   integrity sha512-osQkFkQU0gHUjlhhcbu7SXEKJ7bNGUr75eo7WLhMAnTtoHSzMP+9Fn/gbSNiGv1ekLjW71SRABt9xQNG3hl14g==
 
-"@bazel/typescript@5.4.1":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-5.4.1.tgz#c708ab2a0436620e28371fcedbf86abb1cf8abdd"
-  integrity sha512-LB/JbjPmj4/7R7fkZnWp2wc6tBEFT/5As+FqqJoAzS+YVhtp8sSmJXxZT1aq8/GO0DdA0uX2HZwlFUAzcF3VQQ==
+"@bazel/terser@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@bazel/terser/-/terser-5.4.2.tgz#c3ecf9be0c6c589bc981e67d0af2457d5a596e2a"
+  integrity sha512-bQFbsxaUTu0vhVCX+P6yY1t/Fg9vo/irOcB3OzX1iTBBS1eDK36fChMx6sFQu6QD5yq7zZxzpb6YH3RyPyri9w==
+
+"@bazel/typescript@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@bazel/typescript/-/typescript-5.4.2.tgz#73ff56d124841eeb3e55aa10c146d9cc25b0e973"
+  integrity sha512-QtCNPJHEeJhVGnRijRxzA3bUaY5mpURJ/Ss4QCjNTyJXbJAQ+F05LiEeFmxlhvouRXy4lW4/4EIhfucZ9YG5tw==
   dependencies:
-    "@bazel/worker" "5.4.1"
+    "@bazel/worker" "5.4.2"
     protobufjs "6.8.8"
     semver "5.6.0"
     source-map-support "0.5.9"
@@ -1449,6 +1478,13 @@
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-5.4.1.tgz#7b7fbc329b81f8aef308c14999618be67a741b19"
   integrity sha512-0tfP/ASibVAU+ksnTRmPjib3nBXW6cqyCMzVsx3i/eQu5JpyBZLSOxQZq4KrnKBLvp3UbgI599DqQVbMaJhbEw==
+  dependencies:
+    google-protobuf "^3.6.1"
+
+"@bazel/worker@5.4.2":
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@bazel/worker/-/worker-5.4.2.tgz#b5229140c2087b7f3977ee671624f3c65c6a46a4"
+  integrity sha512-wQZ1ybgiCPkuITaiPfh91zB/lBYqBglf1XYh9hJZCQnWZ+oz9krCnZcywI/i1U9/E9p3A+4Y1ni5akAwTMmfUA==
   dependencies:
     google-protobuf "^3.6.1"
 
@@ -4504,10 +4540,10 @@ cjson@^0.3.1:
   dependencies:
     json-parse-helpfulerror "^1.0.3"
 
-clang-format@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.7.0.tgz#c06c63ec1ae2a2590d8eac2562daeb877ca30d44"
-  integrity sha512-BNuK+rXAK/Fk0rOQ1DW6bpSQUAZz6tpbZHTQn6m4PsgEkE1SNr6AQ/hhFK/b4KJrl4zjcl68molP+rEaKSZRAQ==
+clang-format@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/clang-format/-/clang-format-1.8.0.tgz#7779df1c5ce1bc8aac1b0b02b4e479191ef21d46"
+  integrity sha512-pK8gzfu55/lHzIpQ1givIbWfn3eXnU7SfxqIwVgnn5jEM6j4ZJYjpFqFs4iSBPNedzRMmfjYjuQhu657WAXHXw==
   dependencies:
     async "^3.2.3"
     glob "^7.0.0"


### PR DESCRIPTION
Updates ng-dev to the latest clang-format version which fixes the AMD
x64 binaries.