### PR TITLE
docs(core): add public API docs for the ApplicationRef

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -81,7 +81,6 @@ export class ApplicationRef {
     bootstrap<C>(componentFactory: ComponentFactory<C>, rootSelectorOrNode?: string | any): ComponentRef<C>;
     readonly components: ComponentRef<any>[];
     readonly componentTypes: Type<any>[];
-    // (undocumented)
     destroy(): void;
     get destroyed(): boolean;
     detachView(viewRef: ViewRef): void;

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -1072,6 +1072,11 @@ export class ApplicationRef {
     return () => remove(this._destroyListeners, callback);
   }
 
+  /**
+   * Destroys an Angular application represented by this `ApplicationRef`. Calling this function
+   * will destroy the associated environnement injectors as well as all the bootstrapped components
+   * with their views.
+   */
   destroy(): void {
     if (this._destroyed) {
       throw new RuntimeError(


### PR DESCRIPTION
This commits add the missing documentation for the ApplicationRef
destroy() method.
