### PR TITLE
refactor(core): disallow standalone components in importProvidersFrom calls

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -31,6 +31,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     EXPRESSION_CHANGED_AFTER_CHECKED = -100,
     // (undocumented)
+    IMPORT_PROVIDERS_FROM_STANDALONE = 800,
+    // (undocumented)
     INJECTOR_ALREADY_DESTROYED = 205,
     // (undocumented)
     INVALID_DIFFER_INPUT = 900,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -26,7 +26,7 @@
   "cli-hello-world-ivy-i18n": {
     "uncompressed": {
       "runtime": 926,
-      "main": 125862,
+      "main": 126372,
       "polyfills": 35252
     }
   },

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -57,6 +57,9 @@ export const enum RuntimeErrorCode {
   // i18n Errors
   INVALID_I18N_STRUCTURE = 700,
 
+  // standalone errors
+  IMPORT_PROVIDERS_FROM_STANDALONE = 800,
+
   // JIT Compilation Errors
   // Other
   INVALID_DIFFER_INPUT = 900,

--- a/packages/core/src/render3/features/standalone_feature.ts
+++ b/packages/core/src/render3/features/standalone_feature.ts
@@ -7,7 +7,7 @@
  */
 import {ɵɵinject as inject} from '../../di/injector_compatibility';
 import {ɵɵdefineInjectable as defineInjectable} from '../../di/interface/defs';
-import {importProvidersFrom} from '../../di/provider_collection';
+import {internalImportProvidersFrom} from '../../di/provider_collection';
 import {EnvironmentInjector} from '../../di/r3_injector';
 import {OnDestroy} from '../../interface/lifecycle_hooks';
 import {ComponentDef} from '../interfaces/definition';
@@ -29,8 +29,8 @@ class StandaloneService implements OnDestroy {
     }
 
     if (!this.cachedInjectors.has(componentDef)) {
-      const providers = importProvidersFrom(componentDef.type);
-      const standaloneInjector = providers.ɵproviders.length > 0 ?
+      const providers = internalImportProvidersFrom(false, componentDef.type);
+      const standaloneInjector = providers.length > 0 ?
           createEnvironmentInjector(
               [providers], this._injector, `Standalone[${componentDef.type.name}]`) :
           null;

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -238,6 +238,41 @@ describe('importProvidersFrom', () => {
       TestBed.createComponent(Cmp);
     }).toThrowError(/NG0207/);
   });
+
+  it('should import providers from an array of NgModules (may be nested)', () => {
+    @NgModule({providers: [{provide: A, useValue: 'A'}]})
+    class ModuleA {
+    }
+
+    @NgModule({providers: [{provide: B, useValue: 'B'}]})
+    class ModuleB {
+    }
+
+    const providers = unwrappedImportProvidersFrom([ModuleA, [ModuleB]]);
+
+    expect(hasProviderWithToken(providers, A)).toBeTrue();
+    expect(hasProviderWithToken(providers, B)).toBeTrue();
+  });
+
+  it('should throw when trying to import providers from standalone components', () => {
+    @NgModule({providers: [{provide: A, useValue: 'A'}]})
+    class ModuleA {
+    }
+
+    @Component({
+      standalone: true,
+      template: '',
+      imports: [ModuleA],
+    })
+    class StandaloneCmp {
+    }
+
+    expect(() => {
+      importProvidersFrom(StandaloneCmp);
+    })
+        .toThrowError(
+            'NG0800: Importing providers supports NgModule or ModuleWithProviders but got a standalone component "StandaloneCmp"');
+  });
 });
 
 describe('di', () => {

--- a/packages/core/test/acceptance/env_injector_standalone_spec.ts
+++ b/packages/core/test/acceptance/env_injector_standalone_spec.ts
@@ -8,7 +8,9 @@
 
 import {Component, createEnvironmentInjector, importProvidersFrom, InjectionToken, NgModule} from '@angular/core';
 
-describe('environement injector and standalone components', () => {
+import {internalImportProvidersFrom} from '../../src/di/provider_collection';
+
+describe('environment injector and standalone components', () => {
   it('should see providers from modules imported by standalone components', () => {
     class ModuleService {}
 
@@ -20,7 +22,8 @@ describe('environement injector and standalone components', () => {
     class StandaloneComponent {
     }
 
-    const envInjector = createEnvironmentInjector([importProvidersFrom(StandaloneComponent)]);
+    const envInjector =
+        createEnvironmentInjector(internalImportProvidersFrom(false, StandaloneComponent));
     expect(envInjector.get(ModuleService)).toBeInstanceOf(ModuleService);
   });
 

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -960,6 +960,9 @@
     "name": "instructionState"
   },
   {
+    "name": "internalImportProvidersFrom"
+  },
+  {
     "name": "interpolateParams"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1065,6 +1065,9 @@
     "name": "instructionState"
   },
   {
+    "name": "internalImportProvidersFrom"
+  },
+  {
     "name": "invertObject"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1032,6 +1032,9 @@
     "name": "instructionState"
   },
   {
+    "name": "internalImportProvidersFrom"
+  },
+  {
     "name": "invertObject"
   },
   {

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -123,6 +123,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "internalImportProvidersFrom"
+  },
+  {
     "name": "isImportedNgModuleProviders"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1404,6 +1404,9 @@
     "name": "instructionState"
   },
   {
+    "name": "internalImportProvidersFrom"
+  },
+  {
     "name": "invertObject"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -636,6 +636,9 @@
     "name": "instructionState"
   },
   {
+    "name": "internalImportProvidersFrom"
+  },
+  {
     "name": "invertObject"
   },
   {


### PR DESCRIPTION
This commit narrows down acceptable argument types of the
`importProvidersFrom` function. More specifically, it rejects
standalone components as a source of imports.

Based on the discussion from https://github.com/angular/angular/pull/45766/files#r858684934