### PR TITLE
docs(forms): Add JSDoc content for typed forms.

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -283,7 +283,6 @@ export class FormBuilder {
     }): FormControl<T>;
     // (undocumented)
     control<T>(formState: T | FormControlState<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl<T | null>;
-    // (undocumented)
     group<T extends {}>(controls: T, options?: AbstractControlOptions | null): FormGroup<{
         [K in keyof T]: ɵElement<T[K]>;
     }>;

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -75,6 +75,21 @@ export type ɵElement<T> =
  */
 @Injectable({providedIn: ReactiveFormsModule})
 export class FormBuilder {
+  /**
+   * @description
+   * Construct a new `FormGroup` instance. Accepts a single generic argument, which is an object
+   * containing all the keys and corresponding inner control types.
+   *
+   * @param controls A collection of child controls. The key for each child is the name
+   * under which it is registered.
+   *
+   * @param options Configuration options object for the `FormGroup`. The object should have the
+   * `AbstractControlOptions` type and might contain the following fields:
+   * * `validators`: A synchronous validator function, or an array of validator functions.
+   * * `asyncValidators`: A single async validator or array of async validator functions.
+   * * `updateOn`: The event upon which the control should be updated (options: 'change' | 'blur'
+   * | submit').
+   */
   group<T extends {}>(
       controls: T,
       options?: AbstractControlOptions|null,
@@ -108,20 +123,6 @@ export class FormBuilder {
       options: {[key: string]: any},
       ): FormGroup;
 
-  /**
-   * @description
-   * Construct a new `FormGroup` instance.
-   *
-   * @param controls A collection of child controls. The key for each child is the name
-   * under which it is registered.
-   *
-   * @param options Configuration options object for the `FormGroup`. The object should have the
-   * `AbstractControlOptions` type and might contain the following fields:
-   * * `validators`: A synchronous validator function, or an array of validator functions.
-   * * `asyncValidators`: A single async validator or array of async validator functions.
-   * * `updateOn`: The event upon which the control should be updated (options: 'change' | 'blur'
-   * | submit').
-   */
   group(controls: {[key: string]: any}, options: AbstractControlOptions|{[key: string]:
                                                                              any}|null = null):
       FormGroup {
@@ -162,7 +163,8 @@ export class FormBuilder {
    * @description
    * Construct a new `FormControl` with the given state, validators and options. Set
    * `{initialValueIsDefault: true}` in the options to get a non-nullable control. Otherwise, the
-   * control will be nullable.
+   * control will be nullable. Accepts a single generic argument, which is the type  of the
+   * control's value.
    *
    * @param formState Initializes the control with an initial state value, or
    * with an object that contains both a value and a disabled status.
@@ -192,7 +194,8 @@ export class FormBuilder {
 
   /**
    * Constructs a new `FormArray` from the given array of configurations,
-   * validators and options.
+   * validators and options. Accepts a single generic argument, which is the type of each control
+   * inside the array.
    *
    * @param controls An array of child controls or control configs. Each child control is given an
    *     index when it is registered.

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -37,8 +37,11 @@ export type ɵFormArrayRawValue<T extends AbstractControl<any>> =
  * It calculates its status by reducing the status values of its children. For example, if one of
  * the controls in a `FormArray` is invalid, the entire array becomes invalid.
  *
- * `FormArray` is one of the three fundamental building blocks used to define forms in Angular,
- * along with `FormControl` and `FormGroup`.
+ * `FormArray` accepts one generic argument, which is the type of the controls inside.
+ * If you need a heterogenous array, use {@see UntypedFormArray}.
+ *
+ * `FormArray` is one of the four fundamental building blocks used to define forms in Angular,
+ * along with `FormControl`, `FormGroup`, and `FormRecord`.
  *
  * @usageNotes
  *
@@ -520,9 +523,8 @@ interface UntypedFormArrayCtor {
 }
 
 /**
- * UntypedFormArray is a non-strongly-typed version of @see FormArray.
- * Note: this is used for migration purposes only. Please avoid using it directly in your code and
- * prefer `FormControl` instead, unless you have been migrated to it automatically.
+ * UntypedFormArray is a non-strongly-typed version of @see FormArray, which
+ * permits heterogenous controls.
  */
 export type UntypedFormArray = FormArray<any>;
 

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -43,10 +43,16 @@ export interface FormControlOptions extends AbstractControlOptions {
 /**
  * Tracks the value and validation status of an individual form control.
  *
- * This is one of the three fundamental building blocks of Angular forms, along with
- * `FormGroup` and `FormArray`. It extends the `AbstractControl` class that
+ * This is one of the four fundamental building blocks of Angular forms, along with
+ * `FormGroup`, `FormArray` and `FormRecord`. It extends the `AbstractControl` class that
  * implements most of the base functionality for accessing the value, validation status,
- * user interactions and events. See [usage examples below](#usage-notes).
+ * user interactions and events.
+ *
+ * `FormControl` takes a single generic argument, which describes the type of its value. This
+ * argument always implicitly includes `null` because the control can be reset. To change this
+ * behavior, set `initialValueIsDefault` or see the usage notes below.
+ *
+ * See [usage examples below](#usage-notes).
  *
  * @see `AbstractControl`
  * @see [Reactive Forms Guide](guide/reactive-forms)
@@ -93,6 +99,23 @@ export interface FormControlOptions extends AbstractControlOptions {
  * });
  * ```
  *
+ * ### The single type argument
+ *
+ * `FormControl` accepts a generic argument, which describes the type of its value.
+ * In most cases, this argument will be inferred.
+ *
+ * If you are initializing the control to `null`, or you otherwise wish to provide a
+ * wider type, you may specify the argument explicitly:
+ *
+ * ```
+ * let fc = new FormControl<string|null>(null);
+ * fc.setValue('foo');
+ * ```
+ *
+ * You might notice that `null` is always added to the type of the control.
+ * This is because the control will become `null` if you call `reset`. You can change
+ * this  behavior by setting `{initialValueIsDefault: true}`.
+ *
  * ### Configure the control to update on a blur event
  *
  * Set the `updateOn` option to `'blur'` to update on the blur `event`.
@@ -109,7 +132,7 @@ export interface FormControlOptions extends AbstractControlOptions {
  * const control = new FormControl('', { updateOn: 'submit' });
  * ```
  *
- * ### Reset the control back to an initial value
+ * ### Reset the control back to a specific value
  *
  * You reset to a specific form state by passing through a standalone
  * value or a form state object that contains both a value and a disabled state
@@ -123,6 +146,21 @@ export interface FormControlOptions extends AbstractControlOptions {
  * control.reset('Drew');
  *
  * console.log(control.value); // 'Drew'
+ * ```
+ *
+ * ### Reset the control to its initial value
+ *
+ * If you wish to always reset the control to its initial value (instead of null),
+ * you can pass the `initialValueIsDefault` option:
+ *
+ * ```
+ * const control = new FormControl('Nancy', {initialValueIsDefault: true});
+ *
+ * console.log(control.value); // 'Nancy'
+ *
+ * control.reset();
+ *
+ * console.log(control.value); // 'Nancy'
  * ```
  *
  * ### Reset the control back to an initial value and disabled
@@ -498,8 +536,6 @@ interface UntypedFormControlCtor {
 
 /**
  * UntypedFormControl is a non-strongly-typed version of @see FormControl.
- * Note: this is used for migration purposes only. Please avoid using it directly in your code and
- * prefer `FormControl` instead, unless you have been migrated to it automatically.
  */
 export type UntypedFormControl = FormControl<any>;
 

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -49,11 +49,14 @@ export type ɵOptionalKeys<T> = {
  * of its children. For example, if one of the controls in a group is invalid, the entire
  * group becomes invalid.
  *
- * `FormGroup` is one of the three fundamental building blocks used to define forms in Angular,
- * along with `FormControl` and `FormArray`.
+ * `FormGroup` is one of the four fundamental building blocks used to define forms in Angular,
+ * along with `FormControl`, `FormArray`, and `FormRecord`.
  *
  * When instantiating a `FormGroup`, pass in a collection of child controls as the first
  * argument. The key for each child registers the name for the control.
+ *
+ * `FormGroup` is intended for use cases where the keys are known ahead of time.
+ * If you need to dynamically add and remove controls, use {@see FormRecord} instead.
  *
  * `FormGroup` accepts an optional type parameter `TControl`, which is an object type with inner
  * control types as values.
@@ -70,6 +73,26 @@ export type ɵOptionalKeys<T> = {
  *
  * console.log(form.value);   // {first: 'Nancy', last; 'Drew'}
  * console.log(form.status);  // 'VALID'
+ * ```
+ *
+ * ### The type argument, and optional controls
+ *
+ * `FormGroup` accepts one generic argument, which is an object containing its inner controls.
+ * This type will usually be inferred automatically, but you can always specify it explicitly if you
+ * wish.
+ *
+ * If you have controls that are optional (i.e. they can be removed, you can use the `?` in the
+ * type):
+ *
+ * ```
+ * const form = new FormGroup<{
+ *   first: FormControl<string|null>,
+ *   middle?: FormControl<string|null>, // Middle name is optional.
+ *   last: FormControl<string|null>,
+ * }>({
+ *   first: new FormControl('Nancy'),
+ *   last: new FormControl('Drew'),
+ * });
  * ```
  *
  * ### Create a form group with a group-level validator
@@ -576,8 +599,6 @@ interface UntypedFormGroupCtor {
 
 /**
  * UntypedFormGroup is a non-strongly-typed version of @see FormGroup.
- * Note: this is used for migration purposes only. Please avoid using it directly in your code and
- * prefer `FormControl` instead, unless you have been migrated to it automatically.
  */
 export type UntypedFormGroup = FormGroup<any>;
 
@@ -593,8 +614,18 @@ export class FormRecord<TControl extends AbstractControl<ɵValue<TControl>, ɵRa
  * Tracks the value and validity state of a collection of `FormControl` instances, each of which has
  * the same value type.
  *
- * `FormRecord` is very similar to {@see FormGroup}, except it enforces that all controls in the group have the same type,
- * and can be used with an open-ended, dynamically changing set of controls.
+ * `FormRecord` is very similar to {@see FormGroup}, except it can be used with a dynamic keys,
+ * with controls added and removed as needed.
+ *
+ * `FormRecord` accepts one generic argument, which describes the type of the controls it contains.
+ *
+ * @usageNotes
+ *
+ * ```
+ * let numbers = new FormRecord({bill: '415-123-456'});
+ * numbers.addControl('bob', '415-234-567');
+ * numbers.removeControl('bill');
+ * ```
  *
  * @publicApi
  */


### PR DESCRIPTION
Update the JSDoc on forms model classes with more specific information about the new types.

(`public-api` review is spurious; no actual API changes were made.)

Issue: https://github.com/angular/angular/issues/13721