### PR TITLE
refactor(core): rename `INJECTOR_INITIALIZER` -> `ENVIRONMENT_INITIALIZER`

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -453,6 +453,9 @@ export abstract class EmbeddedViewRef<C> extends ViewRef {
 export function enableProdMode(): void;
 
 // @public
+export const ENVIRONMENT_INITIALIZER: InjectionToken<() => void>;
+
+// @public
 export abstract class EnvironmentInjector implements Injector {
     // (undocumented)
     abstract destroy(): void;
@@ -679,9 +682,6 @@ export abstract class Injector {
     // (undocumented)
     static ɵprov: unknown;
 }
-
-// @public
-export const INJECTOR_INITIALIZER: InjectionToken<() => void>;
 
 // @public
 export interface InjectorType<T> extends Type<T> {

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -20,7 +20,7 @@ export {Injectable, InjectableDecorator, InjectableProvider} from './injectable'
 export {Injector} from './injector';
 export {EnvironmentInjector} from './r3_injector';
 export {importProvidersFrom, ImportProvidersSource} from './provider_collection';
-export {INJECTOR_INITIALIZER} from './initializer_token';
+export {ENVIRONMENT_INITIALIZER} from './initializer_token';
 export {ProviderToken} from './provider_token';
 export {ɵɵinject, inject, ɵɵinvalidFactoryDep} from './injector_compatibility';
 export {INJECTOR} from './injector_token';

--- a/packages/core/src/di/initializer_token.ts
+++ b/packages/core/src/di/initializer_token.ts
@@ -9,9 +9,9 @@
 import {InjectionToken} from './injection_token';
 
 /**
- * A multi-provider token for initialization functions that will run upon construction of a
- * non-view injector.
+ * A multi-provider token for initialization functions that will run upon construction of an
+ * environment injector.
  *
  * @publicApi
  */
-export const INJECTOR_INITIALIZER = new InjectionToken<() => void>('INJECTOR_INITIALIZER');
+export const ENVIRONMENT_INITIALIZER = new InjectionToken<() => void>('ENVIRONMENT_INITIALIZER');

--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -16,7 +16,7 @@ import {stringify} from '../util/stringify';
 import {EMPTY_ARRAY} from '../view';
 
 import {resolveForwardRef} from './forward_ref';
-import {INJECTOR_INITIALIZER} from './initializer_token';
+import {ENVIRONMENT_INITIALIZER} from './initializer_token';
 import {ɵɵinject as inject} from './injector_compatibility';
 import {getInjectorDef, InjectorType, InjectorTypeWithProviders} from './interface/defs';
 import {ClassProvider, ConstructorProvider, ExistingProvider, FactoryProvider, ModuleWithProviders, Provider, StaticClassProvider, TypeProvider, ValueProvider} from './interface/provider';
@@ -191,8 +191,8 @@ export function walkProviderTree(
           // Make this `defType` available to an internal logic that calculates injector scope.
           {provide: INJECTOR_DEF_TYPES, useValue: defType, multi: true},
 
-          // Provider to eagerly instantiate `defType` via `INJECTOR_INITIALIZER`.
-          {provide: INJECTOR_INITIALIZER, useValue: () => inject(defType!), multi: true}  //
+          // Provider to eagerly instantiate `defType` via `ENVIRONMENT_INITIALIZER`.
+          {provide: ENVIRONMENT_INITIALIZER, useValue: () => inject(defType!), multi: true}  //
       );
     }
 

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -19,7 +19,7 @@ import {EMPTY_ARRAY} from '../util/empty';
 import {stringify} from '../util/stringify';
 
 import {resolveForwardRef} from './forward_ref';
-import {INJECTOR_INITIALIZER} from './initializer_token';
+import {ENVIRONMENT_INITIALIZER} from './initializer_token';
 import {setInjectImplementation} from './inject_switch';
 import {InjectionToken} from './injection_token';
 import {Injector} from './injector';
@@ -246,7 +246,7 @@ export class R3Injector extends EnvironmentInjector {
     const previousInjector = setCurrentInjector(this);
     const previousInjectImplementation = setInjectImplementation(undefined);
     try {
-      const initializers = this.get(INJECTOR_INITIALIZER.multi, EMPTY_ARRAY, InjectFlags.Self);
+      const initializers = this.get(ENVIRONMENT_INITIALIZER.multi, EMPTY_ARRAY, InjectFlags.Self);
       for (const initializer of initializers) {
         initializer();
       }

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Attribute, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, createEnvironmentInjector, Directive, ElementRef, EventEmitter, forwardRef, Host, HostBinding, importProvidersFrom, Inject, Injectable, InjectFlags, InjectionToken, INJECTOR, Injector, INJECTOR_INITIALIZER, Input, LOCALE_ID, ModuleWithProviders, NgModule, NgZone, Optional, Output, Pipe, PipeTransform, Provider, Self, SkipSelf, TemplateRef, Type, ViewChild, ViewContainerRef, ViewRef, ɵcreateInjector as createInjector, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵINJECTOR_SCOPE} from '@angular/core';
+import {Attribute, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, createEnvironmentInjector, Directive, ElementRef, ENVIRONMENT_INITIALIZER, EventEmitter, forwardRef, Host, HostBinding, importProvidersFrom, Inject, Injectable, InjectFlags, InjectionToken, INJECTOR, Injector, Input, LOCALE_ID, ModuleWithProviders, NgModule, NgZone, Optional, Output, Pipe, PipeTransform, Provider, Self, SkipSelf, TemplateRef, Type, ViewChild, ViewContainerRef, ViewRef, ɵcreateInjector as createInjector, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵINJECTOR_SCOPE} from '@angular/core';
 import {ViewRef as ViewRefInternal} from '@angular/core/src/render3/view_ref';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -20,8 +20,8 @@ const getProvidersByToken =
 const hasProviderWithToken = (providers: Provider[], token: InjectionToken<unknown>): boolean =>
     getProvidersByToken(providers, token).length > 0;
 
-const collectInjectorInitializerProviders = (providers: Provider[]) =>
-    getProvidersByToken(providers, INJECTOR_INITIALIZER);
+const collectEnvironmentInitializerProviders = (providers: Provider[]) =>
+    getProvidersByToken(providers, ENVIRONMENT_INITIALIZER);
 
 describe('importProvidersFrom', () => {
   // Set of tokens used in various tests.
@@ -53,7 +53,7 @@ describe('importProvidersFrom', () => {
     // 4 tokens (A, B, C, D) + 2 providers for each NgModule:
     // - the definition type itself
     // - `INJECTOR_DEF_TYPES`
-    // - `INJECTOR_INITIALIZER`
+    // - `ENVIRONMENT_INITIALIZER`
     expect(providers.length).toBe(10);
 
     expect(hasProviderWithToken(providers, A)).toBe(true);
@@ -61,8 +61,8 @@ describe('importProvidersFrom', () => {
     expect(hasProviderWithToken(providers, C)).toBe(true);
     expect(hasProviderWithToken(providers, D)).toBe(true);
 
-    // Expect 2 `INJECTOR_INITIALIZER` providers: one for `MyModule`, another was `MyModule2`
-    expect(collectInjectorInitializerProviders(providers).length).toBe(2);
+    // Expect 2 `ENVIRONMENT_INITIALIZER` providers: one for `MyModule`, another was `MyModule2`
+    expect(collectEnvironmentInitializerProviders(providers).length).toBe(2);
   });
 
   it('should collect providers from directly imported ModuleWithProviders', () => {
@@ -99,8 +99,8 @@ describe('importProvidersFrom', () => {
 
        const providers = importProvidersFrom(ModuleB.forRoot(), ModuleB.forChild());
 
-       // Expect 2 `INJECTOR_INITIALIZER` providers: one for `ModuleA`, another one for `ModuleB`
-       expect(collectInjectorInitializerProviders(providers).length).toBe(2);
+       // Expect 2 `ENVIRONMENT_INITIALIZER` providers: one for `ModuleA`, another one for `ModuleB`
+       expect(collectEnvironmentInitializerProviders(providers).length).toBe(2);
 
        // Expect exactly 1 provider for each module: `ModuleA` and `ModuleB`
        expect(getProvidersByToken(providers, ModuleA).length).toBe(1);
@@ -129,8 +129,8 @@ describe('importProvidersFrom', () => {
 
     const providers = importProvidersFrom(ModuleA.forRoot());
 
-    // Expect 1 `INJECTOR_INITIALIZER` provider (for `ModuleA`)
-    expect(collectInjectorInitializerProviders(providers).length).toBe(1);
+    // Expect 1 `ENVIRONMENT_INITIALIZER` provider (for `ModuleA`)
+    expect(collectEnvironmentInitializerProviders(providers).length).toBe(1);
 
     // Expect exactly 1 provider for `ModuleA`
     expect(getProvidersByToken(providers, ModuleA).length).toBe(1);
@@ -163,8 +163,8 @@ describe('importProvidersFrom', () => {
 
        const providers = importProvidersFrom(ModuleB);
 
-       // Expect 2 `INJECTOR_INITIALIZER` providers: one for `ModuleA`, another one for `ModuleB`
-       expect(collectInjectorInitializerProviders(providers).length).toBe(2);
+       // Expect 2 `ENVIRONMENT_INITIALIZER` providers: one for `ModuleA`, another one for `ModuleB`
+       expect(collectEnvironmentInitializerProviders(providers).length).toBe(2);
 
        // Expect exactly 1 provider for each module: `ModuleA` and `ModuleB`
        expect(getProvidersByToken(providers, ModuleA).length).toBe(1);

--- a/packages/core/test/acceptance/environment_injector_spec.ts
+++ b/packages/core/test/acceptance/environment_injector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ComponentFactoryResolver, createEnvironmentInjector, EnvironmentInjector, InjectionToken, INJECTOR, Injector, INJECTOR_INITIALIZER, NgModuleRef} from '@angular/core';
+import {Component, ComponentFactoryResolver, createEnvironmentInjector, ENVIRONMENT_INITIALIZER, EnvironmentInjector, InjectionToken, INJECTOR, Injector, NgModuleRef} from '@angular/core';
 import {R3Injector} from '@angular/core/src/di/r3_injector';
 
 describe('environment injector', () => {
@@ -86,10 +86,10 @@ describe('environment injector', () => {
        expect(cRef.instance.service).toBeInstanceOf(Service);
      });
 
-  it('should support the INJECTOR_INITIALIZER muli-token', () => {
+  it('should support the ENVIRONMENT_INITIALIZER muli-token', () => {
     let initialized = false;
     createEnvironmentInjector([{
-      provide: INJECTOR_INITIALIZER,
+      provide: ENVIRONMENT_INITIALIZER,
       useValue: () => initialized = true,
       multi: true,
     }]);

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -189,6 +189,9 @@
     "name": "ENTER_TOKEN_REGEX"
   },
   {
+    "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
     "name": "EVENT_MANAGER_PLUGINS"
   },
   {
@@ -223,9 +226,6 @@
   },
   {
     "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_INITIALIZER"
   },
   {
     "name": "INJECTOR_SCOPE"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -147,6 +147,9 @@
     "name": "EMPTY_PAYLOAD"
   },
   {
+    "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
     "name": "EVENT_MANAGER_PLUGINS"
   },
   {
@@ -202,9 +205,6 @@
   },
   {
     "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_INITIALIZER"
   },
   {
     "name": "INJECTOR_SCOPE"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -150,6 +150,9 @@
     "name": "EMPTY_PAYLOAD"
   },
   {
+    "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
     "name": "EVENT_MANAGER_PLUGINS"
   },
   {
@@ -190,9 +193,6 @@
   },
   {
     "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_INITIALIZER"
   },
   {
     "name": "INJECTOR_SCOPE"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -6,6 +6,9 @@
     "name": "EMPTY_ARRAY"
   },
   {
+    "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
     "name": "EnvironmentInjector"
   },
   {
@@ -13,9 +16,6 @@
   },
   {
     "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_INITIALIZER"
   },
   {
     "name": "INJECTOR_SCOPE"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -183,6 +183,9 @@
     "name": "EMPTY_PAYLOAD"
   },
   {
+    "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
     "name": "EVENT_MANAGER_PLUGINS"
   },
   {
@@ -241,9 +244,6 @@
   },
   {
     "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_INITIALIZER"
   },
   {
     "name": "INJECTOR_SCOPE"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -87,6 +87,9 @@
     "name": "EMPTY_PAYLOAD"
   },
   {
+    "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
     "name": "EVENT_MANAGER_PLUGINS"
   },
   {
@@ -118,9 +121,6 @@
   },
   {
     "name": "INJECTOR_DEF_TYPES"
-  },
-  {
-    "name": "INJECTOR_INITIALIZER"
   },
   {
     "name": "INJECTOR_SCOPE"

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -190,7 +190,7 @@ class SportsCar extends Car {
     it('should work', () => {
       expect(Injector.create([Engine.PROVIDER, {provide: BrokenEngine, useValue: null}]).toString())
           .toEqual(
-              'R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR, InjectionToken INJECTOR_DEF_TYPES, InjectionToken INJECTOR_INITIALIZER]');
+              'R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR, InjectionToken INJECTOR_DEF_TYPES, InjectionToken ENVIRONMENT_INITIALIZER]');
     });
   });
 }


### PR DESCRIPTION
This commit renames the `INJECTOR_INITIALIZER` to `ENVIRONMENT_INITIALIZER` to better represent the intention of the token.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (*)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (*)

(*) - since the API is not release yet, this change is not breaking and can be considered a refactoring.