### PR TITLE
fix(dev-infra): Fix pullapprove by commenting out the empty availability

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -62,8 +62,8 @@
 
 version: 3
 
-availability:
-  users_unavailable:
+#availability:
+#  users_unavailable:
 #    - username
 
 # Meta field that goes unused by PullApprove to allow for defining aliases to be


### PR DESCRIPTION
Fixes invalid yml caused by https://github.com/angular/angular/commit/509cab9972dc9ee3366649324e0b19ec9277d7f8
