### PR TITLE
feat(forms): Add `FormBuilder.nonNullable`.

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -276,7 +276,7 @@ export class FormArrayName extends ControlContainer implements OnInit, OnDestroy
 
 // @public
 export class FormBuilder {
-    array<T>(controls: Array<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormArray<ɵElement<T>>;
+    array<T>(controls: Array<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormArray<ɵElement<T, null>>;
     // (undocumented)
     control<T>(formState: T | FormControlState<T>, opts: FormControlOptions & {
         initialValueIsDefault: true;
@@ -284,7 +284,7 @@ export class FormBuilder {
     // (undocumented)
     control<T>(formState: T | FormControlState<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl<T | null>;
     group<T extends {}>(controls: T, options?: AbstractControlOptions | null): FormGroup<{
-        [K in keyof T]: ɵElement<T[K]>;
+        [K in keyof T]: ɵElement<T[K], null>;
     }>;
     // @deprecated
     group(controls: {
@@ -292,6 +292,7 @@ export class FormBuilder {
     }, options: {
         [key: string]: any;
     }): FormGroup;
+    get nonNullable(): NonNullableFormBuilder;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FormBuilder, never>;
     // (undocumented)
@@ -705,6 +706,15 @@ export class NgSelectOption implements OnDestroy {
 }
 
 // @public
+export interface NonNullableFormBuilder {
+    array<T>(controls: Array<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormArray<ɵElement<T, never>>;
+    control<T>(formState: T | FormControlState<T>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): FormControl<T>;
+    group<T extends {}>(controls: T, options?: AbstractControlOptions | null): FormGroup<{
+        [K in keyof T]: ɵElement<T[K], never>;
+    }>;
+}
+
+// @public
 export class NumberValueAccessor extends BuiltInControlValueAccessor implements ControlValueAccessor {
     registerOnChange(fn: (_: number | null) => void): void;
     writeValue(value: number): void;
@@ -810,11 +820,8 @@ export const UntypedFormArray: UntypedFormArrayCtor;
 
 // @public
 export class UntypedFormBuilder extends FormBuilder {
-    // (undocumented)
     array(controlsConfig: any[], validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): UntypedFormArray;
-    // (undocumented)
     control(formState: any, validatorOrOpts?: ValidatorFn | ValidatorFn[] | FormControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null): UntypedFormControl;
-    // (undocumented)
     group(controlsConfig: {
         [key: string]: any;
     }, options?: AbstractControlOptions | null): UntypedFormGroup;

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1077,6 +1077,9 @@
     "name": "invokeHostBindingsInCreationMode"
   },
   {
+    "name": "isAbstractControlOptions"
+  },
+  {
     "name": "isAnimationProp"
   },
   {

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -41,7 +41,7 @@ export {FormArrayName, FormGroupName} from './directives/reactive_directives/for
 export {NgSelectOption, SelectControlValueAccessor} from './directives/select_control_value_accessor';
 export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
-export {FormBuilder, UntypedFormBuilder, ɵElement} from './form_builder';
+export {FormBuilder, NonNullableFormBuilder, UntypedFormBuilder, ɵElement} from './form_builder';
 export {AbstractControl, AbstractControlOptions, FormControlStatus, ɵCoerceStrArrToNumArr, ɵGetProperty, ɵNavigate, ɵRawValue, ɵTokenize, ɵTypedOrUntyped, ɵValue, ɵWriteable} from './model/abstract_model';
 export {FormArray, UntypedFormArray, ɵFormArrayRawValue, ɵFormArrayValue} from './model/form_array';
 export {FormControl, FormControlOptions, FormControlState, UntypedFormControl, ɵFormControlCtor} from './model/form_control';

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -9,7 +9,7 @@
 // These tests mainly check the types of strongly typed form controls, which is generally enforced
 // at compile time.
 
-import {FormBuilder, UntypedFormBuilder} from '../src/form_builder';
+import {FormBuilder, NonNullableFormBuilder, UntypedFormBuilder} from '../src/form_builder';
 import {AbstractControl, FormArray, FormControl, FormGroup, UntypedFormArray, UntypedFormControl, UntypedFormGroup, Validators} from '../src/forms';
 import {FormRecord} from '../src/model/form_group';
 
@@ -1268,6 +1268,191 @@ describe('Typed Class', () => {
         let t1 = myParty.controls;
         t1 = null as unknown as ControlType;
       }
+    });
+  });
+
+  describe('NonNullFormBuilder', () => {
+    let fb: NonNullableFormBuilder;
+
+    beforeEach(() => {
+      fb = new FormBuilder().nonNullable;
+    });
+
+    describe('should build FormControls', () => {
+      it('non-nullably from values', () => {
+        const c = fb.control('foo');
+        {
+          type RawValueType = string;
+          let t: RawValueType = c.getRawValue();
+          let t1 = c.getRawValue();
+          t1 = null as unknown as RawValueType;
+        }
+        c.reset();
+        expect(c.value).not.toBeNull;
+      });
+    });
+
+    describe('should build FormGroups', () => {
+      it('from objects with plain values', () => {
+        const c = fb.group({foo: 'bar'});
+        {
+          type ControlsType = {foo: FormControl<string>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual({foo: 'bar'});
+      });
+
+      it('from objects with FormControlState', () => {
+        const c = fb.group({foo: {value: 'bar', disabled: false}});
+        {
+          type ControlsType = {foo: FormControl<string>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual({foo: 'bar'});
+      });
+
+      it('from objects with ControlConfigs', () => {
+        const c = fb.group({foo: ['bar']});
+        {
+          type ControlsType = {foo: FormControl<string>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual({foo: 'bar'});
+      });
+
+      it('from objects with ControlConfigs and validators', () => {
+        const c = fb.group({foo: ['bar', Validators.required]});
+        {
+          type ControlsType = {foo: FormControl<string>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual({foo: 'bar'});
+      });
+
+      it('from objects with ControlConfigs and validator lists', () => {
+        const c = fb.group({foo: ['bar', [Validators.required, Validators.email]]});
+        {
+          type ControlsType = {foo: FormControl<string>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual({foo: 'bar'});
+      });
+
+      it('from objects with ControlConfigs and explicit types', () => {
+        const c: FormGroup<{foo: FormControl<string>}> =
+            fb.group({foo: ['bar', [Validators.required, Validators.email]]});
+        {
+          type ControlsType = {foo: FormControl<string>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual({foo: 'bar'});
+      });
+
+      describe('from objects with FormControls', () => {
+        it('from objects with builder FormGroups', () => {
+          const c = fb.group({foo: fb.group({baz: 'bar'})});
+          {
+            type ControlsType = {foo: FormGroup<{baz: FormControl<string>}>};
+            let t: ControlsType = c.controls;
+            let t1 = c.controls;
+            t1 = null as unknown as ControlsType;
+          }
+          c.reset();
+          expect(c.value).toEqual({foo: {baz: 'bar'}});
+        });
+
+        it('from objects with builder FormArrays', () => {
+          const c = fb.group({foo: fb.array(['bar'])});
+          {
+            type ControlsType = {foo: FormArray<FormControl<string>>};
+            let t: ControlsType = c.controls;
+            let t1 = c.controls;
+            t1 = null as unknown as ControlsType;
+          }
+          c.reset();
+          expect(c.value).toEqual({foo: ['bar']});
+        });
+      });
+    });
+
+    describe('should build FormArrays', () => {
+      it('from arrays with plain values', () => {
+        const c = fb.array(['foo']);
+        {
+          type ControlsType = Array<FormControl<string>>;
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual(['foo']);
+      });
+
+      it('from arrays with FormControlStates', () => {
+        const c = fb.array([{value: 'foo', disabled: false}]);
+        {
+          type ControlsType = Array<FormControl<string>>;
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual(['foo']);
+      });
+
+      it('from arrays with ControlConfigs', () => {
+        const c = fb.array([['foo']]);
+        {
+          type ControlsType = Array<FormControl<string>>;
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual(['foo']);
+      });
+
+      it('from arrays with builder FormArrays', () => {
+        const c = fb.array([fb.array(['foo'])]);
+        {
+          type ControlsType = Array<FormArray<FormControl<string>>>;
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual([['foo']]);
+      });
+
+      it('from arrays with builder FormGroups', () => {
+        const c = fb.array([fb.group({bar: 'foo'})]);
+        {
+          type ControlsType = Array<FormGroup<{bar: FormControl<string>}>>;
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        c.reset();
+        expect(c.value).toEqual([{bar: 'foo'}]);
+      });
     });
   });
 });


### PR DESCRIPTION
With typed forms, all `FormControl`s are nullable by default, because they can be reset to `null`. This behavior is possible to change by passing the option `initialValueIsDefault: true`. However, in a large form, this is extremely cumbersome, as the option must be repeated over and over. Additionally, it is not possible to take full advantage of `FormBuilder`, since `FormBuilder.group` and `FormBuilder.array` will produce nullable controls.

This PR introduces a new accessor `FormBuilder.nonNullable`, which produces *non-nullable* controls. Specifically, any call to `.control` will produce controls with `{initialValueIsDefault: true}`, and calls to `.array` or `.group` that implicitly build inner controls will have the same effect.

```ts
let nfb = new FormBuilder().nonNullable;
let name = nfb.group({who: 'Alex'}); // FormGroup<{who: FormControl<string>}>
name.reset();
console.log(name); // {who: 'Alex'}
```



Issue: https://github.com/angular/angular/issues/13721