### PR TITLE
feat(core): allow to throw on unknown properties in tests

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -216,6 +216,7 @@ export class TestComponentRenderer {
 // @public (undocumented)
 export interface TestEnvironmentOptions {
     errorOnUnknownElements?: boolean;
+    errorOnUnknownProperties?: boolean;
     teardown?: ModuleTeardownOptions;
 }
 
@@ -227,6 +228,7 @@ export type TestModuleMetadata = {
     schemas?: Array<SchemaMetadata | any[]>;
     teardown?: ModuleTeardownOptions;
     errorOnUnknownElements?: boolean;
+    errorOnUnknownProperties?: boolean;
 };
 
 // @public

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -210,7 +210,9 @@ export {
   ɵɵtextInterpolateV,
   ɵɵviewQuery,
   ɵgetUnknownElementStrictMode,
-  ɵsetUnknownElementStrictMode
+  ɵsetUnknownElementStrictMode,
+  ɵgetUnknownPropertyStrictMode,
+  ɵsetUnknownPropertyStrictMode
 } from './render3/index';
 export {
   LContext as ɵLContext,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -130,7 +130,9 @@ export {
   ɵɵtextInterpolate8,
   ɵɵtextInterpolateV,
   ɵgetUnknownElementStrictMode,
-  ɵsetUnknownElementStrictMode
+  ɵsetUnknownElementStrictMode,
+  ɵgetUnknownPropertyStrictMode,
+  ɵsetUnknownPropertyStrictMode
 } from './instructions/all';
 export {ɵɵi18n, ɵɵi18nApply, ɵɵi18nAttributes, ɵɵi18nEnd, ɵɵi18nExp,ɵɵi18nPostprocess, ɵɵi18nStart} from './instructions/i18n';
 export {RenderFlags} from './interfaces/definition';

--- a/packages/core/src/render3/instructions/all.ts
+++ b/packages/core/src/render3/instructions/all.ts
@@ -50,3 +50,4 @@ export * from './style_map_interpolation';
 export * from './style_prop_interpolation';
 export * from './host_property';
 export * from './i18n';
+export {ɵgetUnknownPropertyStrictMode, ɵsetUnknownPropertyStrictMode} from './shared';

--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -227,7 +227,7 @@ describe('NgModule', () => {
   });
 
   describe('schemas', () => {
-    it('should throw on unknown props if NO_ERRORS_SCHEMA is absent', () => {
+    it('should log an error on unknown props if NO_ERRORS_SCHEMA is absent', () => {
       @Component({
         selector: 'my-comp',
         template: `
@@ -255,6 +255,36 @@ describe('NgModule', () => {
       expect(spy.calls.mostRecent().args[0])
           .toMatch(/Can't bind to 'unknown-prop' since it isn't a known property of 'div'/);
     });
+    it('should throw an error with errorOnUnknownProperties on unknown props if NO_ERRORS_SCHEMA is absent',
+       () => {
+         @Component({
+           selector: 'my-comp',
+           template: `
+              <ng-container *ngIf="condition">
+                <div [unknown-prop]="true"></div>
+              </ng-container>
+            `,
+         })
+         class MyComp {
+           condition = true;
+         }
+
+         @NgModule({
+           imports: [CommonModule],
+           declarations: [MyComp],
+         })
+         class MyModule {
+         }
+
+         TestBed.configureTestingModule({imports: [MyModule], errorOnUnknownProperties: true});
+
+         expect(() => {
+           const fixture = TestBed.createComponent(MyComp);
+           fixture.detectChanges();
+         })
+             .toThrowError(
+                 /NG0303: Can't bind to 'unknown-prop' since it isn't a known property of 'div'/g);
+       });
 
     it('should not throw on unknown props if NO_ERRORS_SCHEMA is present', () => {
       @Component({
@@ -284,6 +314,36 @@ describe('NgModule', () => {
         fixture.detectChanges();
       }).not.toThrow();
     });
+
+    it('should not throw on unknown props with errorOnUnknownProperties if NO_ERRORS_SCHEMA is present',
+       () => {
+         @Component({
+           selector: 'my-comp',
+           template: `
+          <ng-container *ngIf="condition">
+            <div [unknown-prop]="true"></div>
+          </ng-container>
+        `,
+         })
+         class MyComp {
+           condition = true;
+         }
+
+         @NgModule({
+           imports: [CommonModule],
+           schemas: [NO_ERRORS_SCHEMA],
+           declarations: [MyComp],
+         })
+         class MyModule {
+         }
+
+         TestBed.configureTestingModule({imports: [MyModule], errorOnUnknownProperties: true});
+
+         expect(() => {
+           const fixture = TestBed.createComponent(MyComp);
+           fixture.detectChanges();
+         }).not.toThrow();
+       });
 
     it('should log an error about unknown element without CUSTOM_ELEMENTS_SCHEMA for element with dash in tag name',
        () => {
@@ -384,6 +444,21 @@ describe('NgModule', () => {
           .toMatch(/Can't bind to 'unknownProp' since it isn't a known property of 'ng-content'/);
     });
 
+    it('should throw an error on unknown property bindings on ng-content when errorOnUnknownProperties is enabled',
+       () => {
+         @Component({template: `<ng-content *unknownProp="123"></ng-content>`})
+         class App {
+         }
+
+         TestBed.configureTestingModule({declarations: [App], errorOnUnknownProperties: true});
+         expect(() => {
+           const fixture = TestBed.createComponent(App);
+           fixture.detectChanges();
+         })
+             .toThrowError(
+                 /NG0303: Can't bind to 'unknownProp' since it isn't a known property of 'ng-content'/g);
+       });
+
     it('should report unknown property bindings on ng-container', () => {
       @Component({template: `<ng-container [unknown-prop]="123"></ng-container>`})
       class App {
@@ -398,6 +473,21 @@ describe('NgModule', () => {
           .toMatch(
               /Can't bind to 'unknown-prop' since it isn't a known property of 'ng-container'/);
     });
+
+    it('should throw error on unknown property bindings on ng-container when errorOnUnknownProperties is enabled',
+       () => {
+         @Component({template: `<ng-container [unknown-prop]="123"></ng-container>`})
+         class App {
+         }
+
+         TestBed.configureTestingModule({declarations: [App], errorOnUnknownProperties: true});
+         expect(() => {
+           const fixture = TestBed.createComponent(App);
+           fixture.detectChanges();
+         })
+             .toThrowError(
+                 /NG0303: Can't bind to 'unknown-prop' since it isn't a known property of 'ng-container'/g);
+       });
 
     describe('AOT-compiled components', () => {
       function createComponent(

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -13,7 +13,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {getNgModuleById} from '../public_api';
 import {TestBedRender3} from '../testing/src/r3_test_bed';
-import {TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT, THROW_ON_UNKNOWN_ELEMENTS_DEFAULT} from '../testing/src/test_bed_common';
+import {TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT, THROW_ON_UNKNOWN_ELEMENTS_DEFAULT, THROW_ON_UNKNOWN_PROPERTIES_DEFAULT} from '../testing/src/test_bed_common';
 
 const NAME = new InjectionToken<string>('name');
 
@@ -1991,5 +1991,36 @@ describe('TestBed module `errorOnUnknownElements`', () => {
     expect(TestBed.shouldThrowErrorOnUnknownElements()).toBe(true);
     TestBed.resetTestingModule();
     expect(TestBed.shouldThrowErrorOnUnknownElements()).toBe(false);
+  });
+});
+
+describe('TestBed module `errorOnUnknownProperties`', () => {
+  // Cast the `TestBed` to the internal data type since we're testing private APIs.
+  let TestBed: TestBedRender3;
+
+  beforeEach(() => {
+    TestBed = getTestBed() as unknown as TestBedRender3;
+    TestBed.resetTestingModule();
+  });
+
+  it('should not throw based on the default behavior', () => {
+    expect(TestBed.shouldThrowErrorOnUnknownProperties()).toBe(THROW_ON_UNKNOWN_PROPERTIES_DEFAULT);
+  });
+
+  it('should not throw if the option is omitted', () => {
+    TestBed.configureTestingModule({});
+    expect(TestBed.shouldThrowErrorOnUnknownProperties()).toBe(false);
+  });
+
+  it('should be able to configure the option', () => {
+    TestBed.configureTestingModule({errorOnUnknownProperties: true});
+    expect(TestBed.shouldThrowErrorOnUnknownProperties()).toBe(true);
+  });
+
+  it('should reset the option back to the default when TestBed is reset', () => {
+    TestBed.configureTestingModule({errorOnUnknownProperties: true});
+    expect(TestBed.shouldThrowErrorOnUnknownProperties()).toBe(true);
+    TestBed.resetTestingModule();
+    expect(TestBed.shouldThrowErrorOnUnknownProperties()).toBe(false);
   });
 });

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -18,6 +18,9 @@ export const TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT = true;
 /** Whether unknown elements in templates should throw by default. */
 export const THROW_ON_UNKNOWN_ELEMENTS_DEFAULT = false;
 
+/** Whether unknown properties in templates should throw by default. */
+export const THROW_ON_UNKNOWN_PROPERTIES_DEFAULT = false;
+
 /**
  * An abstract class for inserting the root test component element in a platform independent way.
  *
@@ -49,12 +52,19 @@ export type TestModuleMetadata = {
   schemas?: Array<SchemaMetadata|any[]>,
   teardown?: ModuleTeardownOptions;
   /**
-   * Whether NG0304 runtime errors should be thrown on unknown elements.
-   * Defaults to `false`, where the error is simply logged.
-   * If sets to `true`, the error is thrown.
+   * Whether NG0304 runtime errors should be thrown when unknown elements are present in component's
+   * template. Defaults to `false`, where the error is simply logged. If set to `true`, the error is
+   * thrown.
    * @see https://angular.io/errors/NG8001 for the description of the problem and how to fix it
    */
   errorOnUnknownElements?: boolean;
+  /**
+   * Whether errors should be thrown when unknown properties are present in component's template.
+   * Defaults to `false`, where the error is simply logged.
+   * If set to `true`, the error is thrown.
+   * @see https://angular.io/errors/NG8002 for the description of the error and how to fix it
+   */
+  errorOnUnknownProperties?: boolean;
 };
 
 /**
@@ -66,12 +76,19 @@ export interface TestEnvironmentOptions {
    */
   teardown?: ModuleTeardownOptions;
   /**
-   * Whether errors should be thrown on unknown elements.
+   * Whether errors should be thrown when unknown elements are present in component's template.
    * Defaults to `false`, where the error is simply logged.
-   * If sets to `true`, the error is thrown.
+   * If set to `true`, the error is thrown.
    * @see https://angular.io/errors/NG8001 for the description of the error and how to fix it
    */
   errorOnUnknownElements?: boolean;
+  /**
+   * Whether errors should be thrown when unknown properties are present in component's template.
+   * Defaults to `false`, where the error is simply logged.
+   * If set to `true`, the error is thrown.
+   * @see https://angular.io/errors/NG8002 for the description of the error and how to fix it
+   */
+  errorOnUnknownProperties?: boolean;
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Feature

## What is the current behavior?

In a test, when using an unknown property in a template, we just get a console error.

This is similar to PR #45479 which introduced an `errorOnUnknownElements` option.

Issue Number: https://github.com/angular/angular/issues/36430


## What is the new behavior?
Allows to provide a TestBed option to throw on unknown properties in templates:

```ts
getTestBed().initTestEnvironment(
  BrowserDynamicTestingModule,
  platformBrowserDynamicTesting(), {
    errorOnUnknownProperties: true
  }
);
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The default value of `errorOnUnknownProperties` is `false`, so this is not a breaking change.


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
