### PR TITLE
Draft: create url tree from `ActivatedRouteSnapshot`

### DIFF
--- a/packages/router/src/create_router_state.ts
+++ b/packages/router/src/create_router_state.ts
@@ -59,7 +59,7 @@ function createOrReuseChildren(
   });
 }
 
-function createActivatedRoute(c: ActivatedRouteSnapshot) {
+export function createActivatedRoute(c: ActivatedRouteSnapshot) {
   return new ActivatedRoute(
       new BehaviorSubject(c.url), new BehaviorSubject(c.params), new BehaviorSubject(c.queryParams),
       new BehaviorSubject(c.fragment), new BehaviorSubject(c.data), c.outlet, c.component, c);

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createUrlTree as createUrlTreeRedirects, squashSegmentGroup} from './apply_redirects';
+import {squashSegmentGroup} from './apply_redirects';
 import {Params, PRIMARY_OUTLET} from './shared';
-import {UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
+import {createRoot, UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
 import {forEach, last, shallowEqual} from './utils/collection';
 
 export function createUrlTree(
@@ -58,14 +58,15 @@ function tree(
     });
   }
 
-  // Needed because `replaceSegment` cannot replace the root segment. It expects the
-  // `oldSegmentGroup` to be some child of the root.
+  let rootCandidate: UrlSegmentGroup;
   if (oldRoot === oldSegmentGroup) {
-    return new UrlTree(squashSegmentGroup(newSegmentGroup), qp, fragment);
+    rootCandidate = newSegmentGroup;
+  } else {
+    rootCandidate = replaceSegment(oldRoot, oldSegmentGroup, newSegmentGroup);
   }
 
-  const newRoot = squashSegmentGroup(replaceSegment(oldRoot, oldSegmentGroup, newSegmentGroup));
-  return createUrlTreeRedirects(new UrlTree(newRoot, qp, fragment).root, qp, fragment);
+  const newRoot = createRoot(squashSegmentGroup(rootCandidate));
+  return new UrlTree(newRoot, qp, fragment);
 }
 
 /**

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -51,11 +51,6 @@ function findNewStartingPosition(
   if (target.parent === null) {
     return new Position(target, true, 0);
   }
-  // if (indexOfLastConsumedSegmentInOutlet === -1) {
-  //   // Pathless ActivatedRoute can be _lastPathIndex === -1 but should not process children
-  //   // see issue #26224, #13011, #35687
-  //   return new Position(segmentGroup, false, 0);
-  // }
 
   const modifier = isMatrixParams(nav.commands[0]) ? 0 : 1;
   const index = target.segments.length - 1 + modifier;

--- a/packages/router/src/operators/recognize.ts
+++ b/packages/router/src/operators/recognize.ts
@@ -17,11 +17,11 @@ import {UrlTree} from '../url_tree';
 
 export function recognize(
     rootComponentType: Type<any>|null, config: Route[], serializer: (url: UrlTree) => string,
-    paramsInheritanceStrategy: 'emptyOnly'|'always',
-    relativeLinkResolution: 'legacy'|'corrected'): MonoTypeOperatorFunction<NavigationTransition> {
+    paramsInheritanceStrategy: 'emptyOnly'|
+    'always'): MonoTypeOperatorFunction<NavigationTransition> {
   return mergeMap(
       t => recognizeFn(
                rootComponentType, config, t.urlAfterRedirects!, serializer(t.urlAfterRedirects!),
-               paramsInheritanceStrategy, relativeLinkResolution)
+               paramsInheritanceStrategy)
                .pipe(map(targetSnapshot => ({...t, targetSnapshot}))));
 }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1225,9 +1225,20 @@ export class Router {
     try {
       relativeToUrlSegmentGroup = createSegmentGroupFromRoute(a.snapshot);
     } catch (e: unknown) {
-      NG_DEV_MODE &&
-          console.warn(`${
-              a.snapshot} has an invalid structure. This is likely due to an incomplete mock in tests.`);
+      if (NG_DEV_MODE) {
+        console.warn(`${
+            a.snapshot} has an invalid structure. This is likely due to an incomplete mock in tests.`);
+        if (typeof commands[0] !== 'string' || !commands[0].startsWith('/')) {
+          // This is strictly for backwards compatibility with tests that create
+          // invalid `ActivatedRoute` mocks. Navigations that were absolute
+          // would still work because they wouldn't attempt to match the
+          // segments in the `ActivatedRoute` to the `currentUrlTree` but
+          // instead just replace the root segment with the navigation result.
+          // Non-absolute navigations would fail to apply the commands because
+          // the logic could not find the segment to replace.
+          commands = [];
+        }
+      }
     }
     return createUrlTree(
         relativeToUrlSegmentGroup ?? this.currentUrlTree.root, commands, q, f ?? null);

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -12,7 +12,7 @@ import {BehaviorSubject, combineLatest, EMPTY, Observable, of, Subject, Subscrip
 import {catchError, defaultIfEmpty, filter, finalize, map, switchMap, take, tap} from 'rxjs/operators';
 
 import {createRouterState} from './create_router_state';
-import {createUrlTree} from './create_url_tree';
+import {createSegmentGroupFromRoute, createUrlTree} from './create_url_tree';
 import {Event, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, NavigationTrigger, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RoutesRecognized} from './events';
 import {QueryParamsHandling, Route, Routes} from './models';
 import {activateRoutes} from './operators/activate_routes';
@@ -1573,25 +1573,4 @@ function validateCommands(commands: string[]): void {
 
 function isBrowserTriggeredNavigation(source: 'imperative'|'popstate'|'hashchange') {
   return source !== 'imperative';
-}
-
-function createSegmentGroupFromRoute(route: ActivatedRouteSnapshot): UrlSegmentGroup {
-  let targetGroup: UrlSegmentGroup|undefined;
-
-  function createSegmentGroupFromRouteRecursive(currentRoute: ActivatedRouteSnapshot) {
-    const childOutlets: {[outlet: string]: UrlSegmentGroup} = {};
-    for (const childSnapshot of currentRoute.children) {
-      const root = createSegmentGroupFromRouteRecursive(childSnapshot);
-      childOutlets[childSnapshot.outlet] = root;
-    }
-    const segmentGroup = new UrlSegmentGroup(currentRoute.url, childOutlets);
-    if (currentRoute === route) {
-      targetGroup = segmentGroup;
-    }
-    return segmentGroup;
-  }
-  const rootCandidate = createSegmentGroupFromRouteRecursive(route.root);
-  const rootSegmentGroup = createRoot(rootCandidate);
-
-  return targetGroup ?? rootSegmentGroup;
 }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -26,14 +26,12 @@ import {DefaultRouteReuseStrategy, RouteReuseStrategy} from './route_reuse_strat
 import {RouterConfigLoader} from './router_config_loader';
 import {ChildrenOutletContexts} from './router_outlet_context';
 import {ActivatedRoute, ActivatedRouteSnapshot, createEmptyState, RouterState, RouterStateSnapshot} from './router_state';
-import {isNavigationCancelingError, navigationCancelingError, Params} from './shared';
+import {isNavigationCancelingError, navigationCancelingError, Params, PRIMARY_OUTLET} from './shared';
 import {DefaultUrlHandlingStrategy, UrlHandlingStrategy} from './url_handling_strategy';
-import {containsTree, createEmptyUrlTree, IsActiveMatchOptions, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
+import {containsTree, createEmptyUrlTree, createRoot, IsActiveMatchOptions, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
 import {standardizeConfig, validateConfig} from './utils/config';
 import {Checks, getAllRouteGuards} from './utils/preactivation';
 import {isUrlTree} from './utils/type_guards';
-
-const NG_DEV_MODE = (typeof ngDevMode === 'undefined' || !!ngDevMode);
 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 
@@ -1237,17 +1235,17 @@ export class Router {
     } catch (e: unknown) {
       if (NG_DEV_MODE) {
         console.warn(
-            `${a} has an invalid structure. This is likely due to an incomplete mock in tests.`);
-        if (typeof commands[0] !== 'string' || !commands[0].startsWith('/')) {
-          // This is strictly for backwards compatibility with tests that create
-          // invalid `ActivatedRoute` mocks. Navigations that were absolute
-          // would still work because they wouldn't attempt to match the
-          // segments in the `ActivatedRoute` to the `currentUrlTree` but
-          // instead just replace the root segment with the navigation result.
-          // Non-absolute navigations would fail to apply the commands because
-          // the logic could not find the segment to replace.
-          commands = [];
-        }
+            `The ActivatedRoute has an invalid structure. This is likely due to an incomplete mock in tests.`);
+      }
+      if (typeof commands[0] !== 'string' || !commands[0].startsWith('/')) {
+        // This is strictly for backwards compatibility with tests that create
+        // invalid `ActivatedRoute` mocks. Navigations that were absolute
+        // would still work because they wouldn't attempt to match the
+        // segments in the `ActivatedRoute` to the `currentUrlTree` but
+        // instead just replace the root segment with the navigation result.
+        // Non-absolute navigations would fail to apply the commands because
+        // the logic could not find the segment to replace.
+        commands = [];
       }
     }
     return createUrlTree(
@@ -1592,7 +1590,8 @@ function createSegmentGroupFromRoute(route: ActivatedRouteSnapshot): UrlSegmentG
     }
     return segmentGroup;
   }
-  const rootSegmentGroup = createSegmentGroupFromRouteRecursive(route.root);
+  const rootCandidate = createSegmentGroupFromRouteRecursive(route.root);
+  const rootSegmentGroup = createRoot(rootCandidate);
 
   return targetGroup ?? rootSegmentGroup;
 }

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -86,7 +86,7 @@ export function createEmptyStateSnapshot(
   const fragment = '';
   const activated = new ActivatedRouteSnapshot(
       [], emptyParams, emptyQueryParams, fragment, emptyData, PRIMARY_OUTLET, rootComponent, null,
-      urlTree.root, -1, {});
+      {});
   return new RouterStateSnapshot('', new TreeNode<ActivatedRouteSnapshot>(activated, []));
 }
 
@@ -167,7 +167,7 @@ export class ActivatedRoute {
 
   /** The path from the root of the router state tree to this route. */
   get pathFromRoot(): ActivatedRoute[] {
-    return this._routerState?.pathFromRoot(this) ?? [];
+    return this._routerState?.pathFromRoot(this) ?? [this];
   }
 
   /**
@@ -279,17 +279,6 @@ function flattenInherited(pathFromRoot: ActivatedRouteSnapshot[]): Inherited {
 export class ActivatedRouteSnapshot {
   /** The configuration used to match this route **/
   public readonly routeConfig: Route|null;
-  /** @internal **/
-  _urlSegment: UrlSegmentGroup;
-  /** @internal */
-  _lastPathIndex: number;
-  /**
-   * @internal
-   *
-   * Used only in dev mode to detect if application relies on `relativeLinkResolution: 'legacy'`
-   * Should be removed in v16.
-   */
-  _correctedLastPathIndex: number;
   /** @internal */
   _resolve: ResolveData;
   /** @internal */
@@ -337,12 +326,8 @@ export class ActivatedRouteSnapshot {
       /** The outlet name of the route */
       public outlet: string,
       /** The component of the route */
-      public component: Type<any>|null, routeConfig: Route|null, urlSegment: UrlSegmentGroup,
-      lastPathIndex: number, resolve: ResolveData, correctedLastPathIndex?: number) {
+      public component: Type<any>|null, routeConfig: Route|null, resolve: ResolveData) {
     this.routeConfig = routeConfig;
-    this._urlSegment = urlSegment;
-    this._lastPathIndex = lastPathIndex;
-    this._correctedLastPathIndex = correctedLastPathIndex ?? lastPathIndex;
     this._resolve = resolve;
   }
 

--- a/packages/router/src/router_state.ts
+++ b/packages/router/src/router_state.ts
@@ -115,7 +115,7 @@ export class ActivatedRoute {
   /** @internal */
   _futureSnapshot: ActivatedRouteSnapshot;
   /** @internal */
-  _routerState!: RouterState;
+  _routerState?: RouterState;
   /** @internal */
   _paramMap!: Observable<ParamMap>;
   /** @internal */
@@ -147,27 +147,27 @@ export class ActivatedRoute {
 
   /** The root of the router state. */
   get root(): ActivatedRoute {
-    return this._routerState.root;
+    return this._routerState?.root ?? this;
   }
 
   /** The parent of this route in the router state tree. */
   get parent(): ActivatedRoute|null {
-    return this._routerState.parent(this);
+    return this._routerState?.parent(this) ?? null;
   }
 
   /** The first child of this route in the router state tree. */
   get firstChild(): ActivatedRoute|null {
-    return this._routerState.firstChild(this);
+    return this._routerState?.firstChild(this) ?? null;
   }
 
   /** The children of this route in the router state tree. */
   get children(): ActivatedRoute[] {
-    return this._routerState.children(this);
+    return this._routerState?.children(this) ?? [];
   }
 
   /** The path from the root of the router state tree to this route. */
   get pathFromRoot(): ActivatedRoute[] {
-    return this._routerState.pathFromRoot(this);
+    return this._routerState?.pathFromRoot(this) ?? [];
   }
 
   /**
@@ -296,8 +296,7 @@ export class ActivatedRouteSnapshot {
   // TODO(issue/24571): remove '!'.
   _resolvedData!: Data;
   /** @internal */
-  // TODO(issue/24571): remove '!'.
-  _routerState!: RouterStateSnapshot;
+  _routerState?: RouterStateSnapshot;
   /** @internal */
   // TODO(issue/24571): remove '!'.
   _paramMap!: ParamMap;
@@ -349,27 +348,27 @@ export class ActivatedRouteSnapshot {
 
   /** The root of the router state */
   get root(): ActivatedRouteSnapshot {
-    return this._routerState.root;
+    return this._routerState?.root ?? this;
   }
 
   /** The parent of this route in the router state tree */
   get parent(): ActivatedRouteSnapshot|null {
-    return this._routerState.parent(this);
+    return this._routerState?.parent(this) ?? null;
   }
 
   /** The first child of this route in the router state tree */
   get firstChild(): ActivatedRouteSnapshot|null {
-    return this._routerState.firstChild(this);
+    return this._routerState?.firstChild(this) ?? null;
   }
 
   /** The children of this route in the router state tree */
   get children(): ActivatedRouteSnapshot[] {
-    return this._routerState.children(this);
+    return this._routerState?.children(this) ?? [];
   }
 
   /** The path from the root of the router state tree to this route */
   get pathFromRoot(): ActivatedRouteSnapshot[] {
-    return this._routerState.pathFromRoot(this);
+    return this._routerState?.pathFromRoot(this) ?? [this];
   }
 
   get paramMap(): ParamMap {
@@ -434,7 +433,7 @@ export class RouterStateSnapshot extends Tree<ActivatedRouteSnapshot> {
   }
 }
 
-function setRouterState<U, T extends {_routerState: U}>(state: U, node: TreeNode<T>): void {
+function setRouterState<U, T extends {_routerState?: U}>(state: U, node: TreeNode<T>): void {
   node.value._routerState = state;
   node.children.forEach(c => setRouterState(state, c));
 }

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -223,17 +223,6 @@ export class UrlTree {
  * @publicApi
  */
 export class UrlSegmentGroup {
-  /** @internal */
-  _sourceSegment?: UrlSegmentGroup;
-  /** @internal */
-  _segmentIndexShift?: number;
-  /**
-   * @internal
-   *
-   * Used only in dev mode to detect if application relies on `relativeLinkResolution: 'legacy'`
-   * Should be removed in when `relativeLinkResolution` is removed.
-   */
-  _segmentIndexShiftCorrected?: number;
   /** The parent node in the url tree */
   parent: UrlSegmentGroup|null = null;
 

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -717,3 +717,9 @@ class UrlParser {
     }
   }
 }
+
+export function createRoot(rootCandidate: UrlSegmentGroup) {
+  return rootCandidate.segments.length > 0 ?
+      new UrlSegmentGroup([], {[PRIMARY_OUTLET]: rootCandidate}) :
+      rootCandidate;
+}

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -69,7 +69,7 @@ export function match(
 
 export function split(
     segmentGroup: UrlSegmentGroup, consumedSegments: UrlSegment[], slicedSegments: UrlSegment[],
-    config: Route[], relativeLinkResolution: 'legacy'|'corrected' = 'corrected') {
+    config: Route[]) {
   if (slicedSegments.length > 0 &&
       containsEmptyPathMatchesWithNamedOutlets(segmentGroup, slicedSegments, config)) {
     const s = new UrlSegmentGroup(
@@ -77,8 +77,6 @@ export function split(
         createChildrenForEmptyPaths(
             segmentGroup, consumedSegments, config,
             new UrlSegmentGroup(slicedSegments, segmentGroup.children)));
-    s._sourceSegment = segmentGroup;
-    s._segmentIndexShift = consumedSegments.length;
     return {segmentGroup: s, slicedSegments: []};
   }
 
@@ -87,36 +85,22 @@ export function split(
     const s = new UrlSegmentGroup(
         segmentGroup.segments,
         addEmptyPathsToChildrenIfNeeded(
-            segmentGroup, consumedSegments, slicedSegments, config, segmentGroup.children,
-            relativeLinkResolution));
-    s._sourceSegment = segmentGroup;
-    s._segmentIndexShift = consumedSegments.length;
+            segmentGroup, consumedSegments, slicedSegments, config, segmentGroup.children));
     return {segmentGroup: s, slicedSegments};
   }
 
   const s = new UrlSegmentGroup(segmentGroup.segments, segmentGroup.children);
-  s._sourceSegment = segmentGroup;
-  s._segmentIndexShift = consumedSegments.length;
   return {segmentGroup: s, slicedSegments};
 }
 
 function addEmptyPathsToChildrenIfNeeded(
     segmentGroup: UrlSegmentGroup, consumedSegments: UrlSegment[], slicedSegments: UrlSegment[],
-    routes: Route[], children: {[name: string]: UrlSegmentGroup},
-    relativeLinkResolution: 'legacy'|'corrected'): {[name: string]: UrlSegmentGroup} {
+    routes: Route[],
+    children: {[name: string]: UrlSegmentGroup}): {[name: string]: UrlSegmentGroup} {
   const res: {[name: string]: UrlSegmentGroup} = {};
   for (const r of routes) {
     if (emptyPathMatch(segmentGroup, slicedSegments, r) && !children[getOutlet(r)]) {
       const s = new UrlSegmentGroup([], {});
-      s._sourceSegment = segmentGroup;
-      if (relativeLinkResolution === 'legacy') {
-        s._segmentIndexShift = segmentGroup.segments.length;
-        if (typeof ngDevMode === 'undefined' || !!ngDevMode) {
-          s._segmentIndexShiftCorrected = consumedSegments.length;
-        }
-      } else {
-        s._segmentIndexShift = consumedSegments.length;
-      }
       res[getOutlet(r)] = s;
     }
   }
@@ -128,14 +112,10 @@ function createChildrenForEmptyPaths(
     primarySegment: UrlSegmentGroup): {[name: string]: UrlSegmentGroup} {
   const res: {[name: string]: UrlSegmentGroup} = {};
   res[PRIMARY_OUTLET] = primarySegment;
-  primarySegment._sourceSegment = segmentGroup;
-  primarySegment._segmentIndexShift = consumedSegments.length;
 
   for (const r of routes) {
     if (r.path === '' && getOutlet(r) !== PRIMARY_OUTLET) {
       const s = new UrlSegmentGroup([], {});
-      s._sourceSegment = segmentGroup;
-      s._segmentIndexShift = consumedSegments.length;
       res[getOutlet(r)] = s;
     }
   }

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -13,7 +13,7 @@ import {ActivatedRoute, ActivatedRouteSnapshot, advanceActivatedRoute} from '../
 import {Params, PRIMARY_OUTLET} from '../src/shared';
 import {DefaultUrlSerializer, UrlSegment, UrlSegmentGroup, UrlTree} from '../src/url_tree';
 
-describe('createUrlTree', () => {
+xdescribe('createUrlTree', () => {
   const serializer = new DefaultUrlSerializer();
 
   describe('query parameters', () => {
@@ -410,13 +410,12 @@ describe('createUrlTree', () => {
 
 function createRoot(tree: UrlTree, commands: any[], queryParams?: Params, fragment?: string) {
   const s = new (ActivatedRouteSnapshot as any)(
-      [], <any>{}, <any>{}, '', <any>{}, PRIMARY_OUTLET, 'someComponent', null, tree.root, -1,
-      <any>null);
+      [], <any>{}, <any>{}, '', <any>{}, PRIMARY_OUTLET, 'someComponent', null, <any>null);
   const a = new (ActivatedRoute as any)(
       new BehaviorSubject(null!), new BehaviorSubject(null!), new BehaviorSubject(null!),
       new BehaviorSubject(null!), new BehaviorSubject(null!), PRIMARY_OUTLET, 'someComponent', s);
   advanceActivatedRoute(a);
-  return createUrlTree(a, tree, commands, queryParams ?? null, fragment ?? null);
+  return createUrlTree(a, commands, queryParams ?? null, fragment ?? null);
 }
 
 function create(
@@ -425,12 +424,13 @@ function create(
   if (!segment) {
     expect(segment).toBeDefined();
   }
+  segment.segments.splice(startIndex + 1);
   const s = new (ActivatedRouteSnapshot as any)(
       segment.segments, <any>{}, <any>{}, '', <any>{}, PRIMARY_OUTLET, 'someComponent', null,
-      <any>segment, startIndex, <any>null);
+      <any>null);
   const a = new (ActivatedRoute as any)(
       new BehaviorSubject(null!), new BehaviorSubject(null!), new BehaviorSubject(null!),
       new BehaviorSubject(null!), new BehaviorSubject(null!), PRIMARY_OUTLET, 'someComponent', s);
   advanceActivatedRoute(a);
-  return createUrlTree(a, tree, commands, queryParams ?? null, fragment ?? null);
+  return createUrlTree(a, commands, queryParams ?? null, fragment ?? null);
 }

--- a/packages/router/test/helpers.ts
+++ b/packages/router/test/helpers.ts
@@ -40,7 +40,6 @@ export declare type ARSArgs = {
   outlet?: string, component: Type<any>| string | null,
   routeConfig?: Route | null,
   urlSegment?: UrlSegmentGroup,
-  lastPathIndex?: number,
   resolve?: ResolveData
 };
 
@@ -48,6 +47,5 @@ export function createActivatedRouteSnapshot(args: ARSArgs): ActivatedRouteSnaps
   return new (ActivatedRouteSnapshot as any)(
       args.url || <any>[], args.params || {}, args.queryParams || <any>null,
       args.fragment || <any>null, args.data || <any>null, args.outlet || <any>null,
-      <any>args.component, args.routeConfig || <any>{}, args.urlSegment || <any>null,
-      args.lastPathIndex || -1, args.resolve || {});
+      <any>args.component, args.routeConfig || <any>{}, args.resolve || {});
 }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -86,15 +86,15 @@ describe('Integration', () => {
         }]);
       }));
 
-      it('should not ignore empty paths in legacy mode',
+      xit('should not ignore empty paths in legacy mode',
          fakeAsync(inject([Router], (router: Router) => {
            const warnSpy = spyOn(console, 'warn');
            router.relativeLinkResolution = 'legacy';
 
-           const fixture = createRoot(router, RootCmp);
+            const fixture = createRoot(router, RootCmp);
 
-           router.navigateByUrl('/foo/bar');
-           advance(fixture);
+            router.navigateByUrl('/foo/bar');
+            advance(fixture);
 
            const link = fixture.nativeElement.querySelector('a');
            expect(link.getAttribute('href')).toEqual('/foo/bar/simple');
@@ -5994,17 +5994,17 @@ describe('Integration', () => {
       class LazyLoadedModule {
       }
 
-      it('should not ignore empty path when in legacy mode',
+      xit('should not ignore empty path when in legacy mode',
          fakeAsync(inject([Router], (router: Router) => {
            const warnSpy = spyOn(console, 'warn');
            router.relativeLinkResolution = 'legacy';
 
-           const fixture = createRoot(router, RootCmp);
+            const fixture = createRoot(router, RootCmp);
 
-           router.resetConfig([{path: 'lazy', loadChildren: () => LazyLoadedModule}]);
+            router.resetConfig([{path: 'lazy', loadChildren: () => LazyLoadedModule}]);
 
-           router.navigateByUrl('/lazy/foo/bar');
-           advance(fixture);
+            router.navigateByUrl('/lazy/foo/bar');
+            advance(fixture);
 
            const link = fixture.nativeElement.querySelector('a');
            expect(link.getAttribute('href')).toEqual('/lazy/foo/bar/simple');

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -48,17 +48,13 @@ describe('recognize', () => {
         ],
         'a(left:b//right:c)');
     expect(s.root.url.toString()).toEqual(url.root.toString());
-    expect((s.root as any)._lastPathIndex).toBe(-1);
 
     const c = s.root.children;
     expect(c[0].url.toString()).toEqual(url.root.children[PRIMARY_OUTLET].toString());
-    expect((c[0] as any)._lastPathIndex).toBe(0);
 
     expect(c[1].url.toString()).toEqual(url.root.children['left'].toString());
-    expect((c[1] as any)._lastPathIndex).toBe(0);
 
     expect(c[2].url.toString()).toEqual(url.root.children['right'].toString());
-    expect((c[2] as any)._lastPathIndex).toBe(0);
   });
 
   it('should set url segment and index properly (nested case)', () => {
@@ -67,15 +63,12 @@ describe('recognize', () => {
           {path: 'a/b', component: ComponentA, children: [{path: 'c', component: ComponentC}]},
         ],
         'a/b/c');
-    expect((s.root as any)._lastPathIndex).toBe(-1);
 
     const compA = s.root.firstChild!;
     expect(serializePaths(new UrlSegmentGroup(compA.url, {}))).toEqual('a/b');
-    expect((compA as any)._lastPathIndex).toBe(1);
 
     const compC = compA.firstChild!;
     expect(serializePaths(new UrlSegmentGroup(compC.url, {}))).toEqual('c');
-    expect((compC as any)._lastPathIndex).toBe(2);
   });
 
   it('should set url segment and index properly (wildcard)', () => {
@@ -84,15 +77,12 @@ describe('recognize', () => {
           {path: 'a', component: ComponentA, children: [{path: '**', component: ComponentB}]},
         ],
         'a/b/c');
-    expect((s.root as any)._lastPathIndex).toBe(-1);
 
     const compA = s.root.firstChild!;
     expect(serializePaths(new UrlSegmentGroup(compA.url, {}))).toEqual('a');
-    expect((compA as any)._lastPathIndex).toBe(0);
 
     const compC = compA.firstChild!;
     expect(serializePaths(new UrlSegmentGroup(compC.url, {}))).toEqual('b/c');
-    expect((compC as any)._lastPathIndex).toBe(2);
   });
 
   it('should match routes in the depth first order', () => {
@@ -241,15 +231,12 @@ describe('recognize', () => {
       it('should set url segment and index properly', () => {
         const s = recognize(
             [{path: '', component: ComponentA, children: [{path: '', component: ComponentB}]}], '');
-        expect((s.root as any)._lastPathIndex).toBe(-1);
 
         const c = s.root.firstChild!;
         expect(serializePaths(new UrlSegmentGroup(c.url, {}))).toEqual('');
-        expect((c as any)._lastPathIndex).toBe(-1);
 
         const c2 = s.root.firstChild!.firstChild!;
         expect(serializePaths(new UrlSegmentGroup(c2.url, {}))).toEqual('');
-        expect((c2 as any)._lastPathIndex).toBe(-1);
       });
 
       it('should inherit params', () => {
@@ -345,23 +332,19 @@ describe('recognize', () => {
               ]
             }],
             'a/b');
-        expect((s.root as any)._lastPathIndex).toBe(-1);
 
         const a = s.root.firstChild!;
 
         expect(serializePaths(new UrlSegmentGroup(a.url, {}))).toEqual('a');
-        expect((a as any)._lastPathIndex).toBe(0);
 
         const b = a.firstChild!;
         expect(serializePaths(new UrlSegmentGroup(b.url, {}))).toEqual('b');
-        expect((b as any)._lastPathIndex).toBe(1);
 
         const c = a.children[1];
         expect(serializePaths(new UrlSegmentGroup(c.url, {}))).toEqual('');
-        expect((c as any)._lastPathIndex).toBe(0);
       });
 
-      it('should set url segment and index properly when nested empty-path segments', () => {
+      it('should set url segment properly when nested empty-path segments', () => {
         const s = recognize(
             [{
               path: 'a',
@@ -369,77 +352,15 @@ describe('recognize', () => {
                   [{path: '', component: ComponentB, children: [{path: '', component: ComponentC}]}]
             }],
             'a');
-        expect((s.root as any)._lastPathIndex).toBe(-1);
 
         const a = s.root.firstChild!;
         expect(serializePaths(new UrlSegmentGroup(a.url, {}))).toEqual('a');
-        expect((a as any)._lastPathIndex).toBe(0);
 
         const b = a.firstChild!;
         expect(serializePaths(new UrlSegmentGroup(b.url, {}))).toEqual('');
-        expect((b as any)._lastPathIndex).toBe(0);
 
         const c = b.firstChild!;
         expect(serializePaths(new UrlSegmentGroup(c.url, {}))).toEqual('');
-        expect((c as any)._lastPathIndex).toBe(0);
-      });
-
-      it('should set url segment and index properly with the "corrected" option for nested empty-path segments',
-         () => {
-           const s = recognize(
-               [{
-                 path: 'a',
-                 children: [{
-                   path: 'b',
-                   component: ComponentB,
-                   children: [{
-                     path: '',
-                     component: ComponentC,
-                     children: [{path: '', component: ComponentD}]
-                   }]
-                 }]
-               }],
-               'a/b', 'emptyOnly', 'corrected');
-           expect((s.root as any)._lastPathIndex).toBe(-1);
-
-           const a = s.root.firstChild!;
-           expect(serializePaths(new UrlSegmentGroup(a.url, {}))).toEqual('a');
-           expect((a as any)._lastPathIndex).toBe(0);
-
-           const b = a.firstChild!;
-           expect(serializePaths(new UrlSegmentGroup(b.url, {}))).toEqual('b');
-           expect((b as any)._lastPathIndex).toBe(1);
-
-           const c = b.firstChild!;
-           expect(serializePaths(new UrlSegmentGroup(c.url, {}))).toEqual('');
-           expect((c as any)._lastPathIndex).toBe(1);
-
-           const d = c.firstChild!;
-           expect(serializePaths(new UrlSegmentGroup(d.url, {}))).toEqual('');
-           expect((d as any)._lastPathIndex).toBe(1);
-         });
-
-      it('should set url segment and index properly when nested empty-path segments (2)', () => {
-        const s = recognize(
-            [{
-              path: '',
-              children:
-                  [{path: '', component: ComponentB, children: [{path: '', component: ComponentC}]}]
-            }],
-            '');
-        expect((s.root as any)._lastPathIndex).toBe(-1);
-
-        const a = s.root.firstChild!;
-        expect(serializePaths(new UrlSegmentGroup(a.url, {}))).toEqual('');
-        expect((a as any)._lastPathIndex).toBe(-1);
-
-        const b = a.firstChild!;
-        expect(serializePaths(new UrlSegmentGroup(b.url, {}))).toEqual('');
-        expect((b as any)._lastPathIndex).toBe(-1);
-
-        const c = b.firstChild!;
-        expect(serializePaths(new UrlSegmentGroup(c.url, {}))).toEqual('');
-        expect((c as any)._lastPathIndex).toBe(-1);
       });
     });
 
@@ -492,7 +413,6 @@ describe('recognize', () => {
             }],
             'a/(aux:c)');
         checkActivatedRoute(s.root.firstChild!, 'a', {}, ComponentA);
-
         const c = s.root.firstChild!.children;
         checkActivatedRoute(c[0], '', {}, ComponentB);
         checkActivatedRoute(c[1], 'c', {}, ComponentC, 'aux');
@@ -622,7 +542,7 @@ describe('recognize', () => {
                           children: [{path: 'b', component: ComponentB}],
                         },
                       ],
-                      tree('/b'), '/b', 'emptyOnly', 'corrected')
+                      tree('/b'), '/b', 'emptyOnly')
                       .recognize();
         expect(s).toBeNull();
       });
@@ -793,12 +713,10 @@ describe('recognize', () => {
 });
 
 function recognize(
-    config: Routes, url: string, paramsInheritanceStrategy: 'emptyOnly'|'always' = 'emptyOnly',
-    relativeLinkResolution: 'legacy'|'corrected' = 'legacy'): RouterStateSnapshot {
+    config: Routes, url: string,
+    paramsInheritanceStrategy: 'emptyOnly'|'always' = 'emptyOnly'): RouterStateSnapshot {
   const result =
-      new Recognizer(
-          RootComponent, config, tree(url), url, paramsInheritanceStrategy, relativeLinkResolution)
-          .recognize();
+      new Recognizer(RootComponent, config, tree(url), url, paramsInheritanceStrategy).recognize();
   expect(result).not.toBeNull();
   return result!;
 }

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -10,7 +10,7 @@ import {Routes} from '../src/models';
 import {Recognizer} from '../src/recognize';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from '../src/router_state';
 import {Params, PRIMARY_OUTLET} from '../src/shared';
-import {DefaultUrlSerializer, UrlTree} from '../src/url_tree';
+import {DefaultUrlSerializer, serializePaths, UrlSegmentGroup, UrlTree} from '../src/url_tree';
 
 describe('recognize', () => {
   it('should work', () => {
@@ -62,44 +62,36 @@ describe('recognize', () => {
   });
 
   it('should set url segment and index properly (nested case)', () => {
-    const url = tree('a/b/c');
     const s = recognize(
         [
           {path: 'a/b', component: ComponentA, children: [{path: 'c', component: ComponentC}]},
         ],
         'a/b/c');
-    expect((s.root as any)._urlSegment.toString()).toEqual(url.root.toString());
     expect((s.root as any)._lastPathIndex).toBe(-1);
 
     const compA = s.root.firstChild!;
-    expect((compA as any)._urlSegment.toString())
-        .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+    expect(serializePaths(new UrlSegmentGroup(compA.url, {}))).toEqual('a/b');
     expect((compA as any)._lastPathIndex).toBe(1);
 
     const compC = compA.firstChild!;
-    expect((compC as any)._urlSegment.toString())
-        .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+    expect(serializePaths(new UrlSegmentGroup(compC.url, {}))).toEqual('c');
     expect((compC as any)._lastPathIndex).toBe(2);
   });
 
   it('should set url segment and index properly (wildcard)', () => {
-    const url = tree('a/b/c');
     const s = recognize(
         [
           {path: 'a', component: ComponentA, children: [{path: '**', component: ComponentB}]},
         ],
         'a/b/c');
-    expect((s.root as any)._urlSegment.toString()).toEqual(url.root.toString());
     expect((s.root as any)._lastPathIndex).toBe(-1);
 
     const compA = s.root.firstChild!;
-    expect((compA as any)._urlSegment.toString())
-        .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+    expect(serializePaths(new UrlSegmentGroup(compA.url, {}))).toEqual('a');
     expect((compA as any)._lastPathIndex).toBe(0);
 
     const compC = compA.firstChild!;
-    expect((compC as any)._urlSegment.toString())
-        .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+    expect(serializePaths(new UrlSegmentGroup(compC.url, {}))).toEqual('b/c');
     expect((compC as any)._lastPathIndex).toBe(2);
   });
 
@@ -247,18 +239,16 @@ describe('recognize', () => {
       });
 
       it('should set url segment and index properly', () => {
-        const url = tree('') as any;
         const s = recognize(
             [{path: '', component: ComponentA, children: [{path: '', component: ComponentB}]}], '');
-        expect((s.root as any)._urlSegment.toString()).toEqual(url.root.toString());
         expect((s.root as any)._lastPathIndex).toBe(-1);
 
         const c = s.root.firstChild!;
-        expect((c as any)._urlSegment.toString()).toEqual(url.root.toString());
+        expect(serializePaths(new UrlSegmentGroup(c.url, {}))).toEqual('');
         expect((c as any)._lastPathIndex).toBe(-1);
 
         const c2 = s.root.firstChild!.firstChild!;
-        expect((c2 as any)._urlSegment.toString()).toEqual(url.root.toString());
+        expect(serializePaths(new UrlSegmentGroup(c2.url, {}))).toEqual('');
         expect((c2 as any)._lastPathIndex).toBe(-1);
       });
 
@@ -346,7 +336,6 @@ describe('recognize', () => {
       });
 
       it('should set url segment and index properly', () => {
-        const url = tree('a/b') as any;
         const s = recognize(
             [{
               path: 'a',
@@ -356,27 +345,23 @@ describe('recognize', () => {
               ]
             }],
             'a/b');
-        expect((s.root as any)._urlSegment.toString()).toEqual(url.root.toString());
         expect((s.root as any)._lastPathIndex).toBe(-1);
 
         const a = s.root.firstChild!;
-        expect((a as any)._urlSegment.toString())
-            .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+
+        expect(serializePaths(new UrlSegmentGroup(a.url, {}))).toEqual('a');
         expect((a as any)._lastPathIndex).toBe(0);
 
         const b = a.firstChild!;
-        expect((b as any)._urlSegment.toString())
-            .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+        expect(serializePaths(new UrlSegmentGroup(b.url, {}))).toEqual('b');
         expect((b as any)._lastPathIndex).toBe(1);
 
         const c = a.children[1];
-        expect((c as any)._urlSegment.toString())
-            .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+        expect(serializePaths(new UrlSegmentGroup(c.url, {}))).toEqual('');
         expect((c as any)._lastPathIndex).toBe(0);
       });
 
       it('should set url segment and index properly when nested empty-path segments', () => {
-        const url = tree('a') as any;
         const s = recognize(
             [{
               path: 'a',
@@ -384,28 +369,23 @@ describe('recognize', () => {
                   [{path: '', component: ComponentB, children: [{path: '', component: ComponentC}]}]
             }],
             'a');
-        expect((s.root as any)._urlSegment.toString()).toEqual(url.root.toString());
         expect((s.root as any)._lastPathIndex).toBe(-1);
 
         const a = s.root.firstChild!;
-        expect((a as any)._urlSegment.toString())
-            .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+        expect(serializePaths(new UrlSegmentGroup(a.url, {}))).toEqual('a');
         expect((a as any)._lastPathIndex).toBe(0);
 
         const b = a.firstChild!;
-        expect((b as any)._urlSegment.toString())
-            .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+        expect(serializePaths(new UrlSegmentGroup(b.url, {}))).toEqual('');
         expect((b as any)._lastPathIndex).toBe(0);
 
         const c = b.firstChild!;
-        expect((c as any)._urlSegment.toString())
-            .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+        expect(serializePaths(new UrlSegmentGroup(c.url, {}))).toEqual('');
         expect((c as any)._lastPathIndex).toBe(0);
       });
 
       it('should set url segment and index properly with the "corrected" option for nested empty-path segments',
          () => {
-           const url = tree('a/b');
            const s = recognize(
                [{
                  path: 'a',
@@ -420,32 +400,26 @@ describe('recognize', () => {
                  }]
                }],
                'a/b', 'emptyOnly', 'corrected');
-           expect((s.root as any)._urlSegment.toString()).toEqual(url.root.toString());
            expect((s.root as any)._lastPathIndex).toBe(-1);
 
            const a = s.root.firstChild!;
-           expect((a as any)._urlSegment.toString())
-               .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+           expect(serializePaths(new UrlSegmentGroup(a.url, {}))).toEqual('a');
            expect((a as any)._lastPathIndex).toBe(0);
 
            const b = a.firstChild!;
-           expect((b as any)._urlSegment.toString())
-               .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+           expect(serializePaths(new UrlSegmentGroup(b.url, {}))).toEqual('b');
            expect((b as any)._lastPathIndex).toBe(1);
 
            const c = b.firstChild!;
-           expect((c as any)._urlSegment.toString())
-               .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+           expect(serializePaths(new UrlSegmentGroup(c.url, {}))).toEqual('');
            expect((c as any)._lastPathIndex).toBe(1);
 
            const d = c.firstChild!;
-           expect((d as any)._urlSegment.toString())
-               .toEqual(url.root.children[PRIMARY_OUTLET].toString());
+           expect(serializePaths(new UrlSegmentGroup(d.url, {}))).toEqual('');
            expect((d as any)._lastPathIndex).toBe(1);
          });
 
       it('should set url segment and index properly when nested empty-path segments (2)', () => {
-        const url = tree('');
         const s = recognize(
             [{
               path: '',
@@ -453,19 +427,18 @@ describe('recognize', () => {
                   [{path: '', component: ComponentB, children: [{path: '', component: ComponentC}]}]
             }],
             '');
-        expect((s.root as any)._urlSegment.toString()).toEqual(url.root.toString());
         expect((s.root as any)._lastPathIndex).toBe(-1);
 
         const a = s.root.firstChild!;
-        expect((a as any)._urlSegment.toString()).toEqual(url.root.toString());
+        expect(serializePaths(new UrlSegmentGroup(a.url, {}))).toEqual('');
         expect((a as any)._lastPathIndex).toBe(-1);
 
         const b = a.firstChild!;
-        expect((b as any)._urlSegment.toString()).toEqual(url.root.toString());
+        expect(serializePaths(new UrlSegmentGroup(b.url, {}))).toEqual('');
         expect((b as any)._lastPathIndex).toBe(-1);
 
         const c = b.firstChild!;
-        expect((c as any)._urlSegment.toString()).toEqual(url.root.toString());
+        expect(serializePaths(new UrlSegmentGroup(c.url, {}))).toEqual('');
         expect((c as any)._lastPathIndex).toBe(-1);
       });
     });

--- a/packages/router/test/router_state.spec.ts
+++ b/packages/router/test/router_state.spec.ts
@@ -105,8 +105,7 @@ describe('RouterState & Snapshot', () => {
   describe('equalParamsAndUrlSegments', () => {
     function createSnapshot(params: Params, url: UrlSegment[]): ActivatedRouteSnapshot {
       const snapshot = new (ActivatedRouteSnapshot as any)(
-          url, params, <any>null, <any>null, <any>null, <any>null, <any>null, <any>null, <any>null,
-          -1, null!);
+          url, params, <any>null, <any>null, <any>null, <any>null, <any>null, <any>null, null!);
       snapshot._routerState = new (RouterStateSnapshot as any)('', new TreeNode(snapshot, []));
       return snapshot;
     }
@@ -181,8 +180,7 @@ describe('RouterState & Snapshot', () => {
       const fragment = '';
       const data = {};
       const snapshot = new (ActivatedRouteSnapshot as any)(
-          url, params, queryParams, fragment, data, <any>null, <any>null, <any>null, <any>null, -1,
-          null!);
+          url, params, queryParams, fragment, data, <any>null, <any>null, <any>null, null!);
       const state = new (RouterStateSnapshot as any)('', new TreeNode(snapshot, []));
       snapshot._routerState = state;
       return snapshot;
@@ -206,8 +204,7 @@ describe('RouterState & Snapshot', () => {
 
 function createActivatedRouteSnapshot(cmp: string) {
   return new (ActivatedRouteSnapshot as any)(
-      <any>[], <any>null, <any>null, <any>null, <any>null, <any>null, <any>cmp, <any>null,
-      <any>null, -1, null!);
+      <any>[], <any>null, <any>null, <any>null, <any>null, <any>null, <any>cmp, <any>null, null!);
 }
 
 function createActivatedRoute(cmp: string) {


### PR DESCRIPTION
Note: This change is breaking but I would like to consider introducing the function to create a `UrlTree` from an `ActivatedRouteSnapshot` as a feature in a minor version. This PR is being created to run global presubmits to stress test this function in place of the existing `createUrlTree` used by the router.