### PR TITLE
refactor(core): remove obsolete `data:` url validation

### DIFF
--- a/packages/core/src/sanitization/url_sanitizer.ts
+++ b/packages/core/src/sanitization/url_sanitizer.ts
@@ -33,18 +33,11 @@
  *
  * This regular expression was taken from the Closure sanitization library.
  */
-const SAFE_URL_PATTERN = /^(?:(?:https?|mailto|ftp|tel|file|sms):|[^&:/?#]*(?:[/?#]|$))/gi;
-
-/* A pattern that matches safe srcset values */
-const SAFE_SRCSET_PATTERN = /^(?:(?:https?|file):|[^&:/?#]*(?:[/?#]|$))/gi;
-
-/** A pattern that matches safe data URLs. Only matches image, video and audio types. */
-const DATA_URL_PATTERN =
-    /^data:(?:image\/(?:bmp|gif|jpeg|jpg|png|tiff|webp)|video\/(?:mpeg|mp4|ogg|webm)|audio\/(?:mp3|oga|ogg|opus));base64,[a-z0-9+\/]+=*$/i;
+const SAFE_URL_PATTERN = /^(?:(?:https?|mailto|data|ftp|tel|file|sms):|[^&:/?#]*(?:[/?#]|$))/gi;
 
 export function _sanitizeUrl(url: string): string {
   url = String(url);
-  if (url.match(SAFE_URL_PATTERN) || url.match(DATA_URL_PATTERN)) return url;
+  if (url.match(SAFE_URL_PATTERN)) return url;
 
   if (typeof ngDevMode === 'undefined' || ngDevMode) {
     console.warn(`WARNING: sanitizing unsafe URL value ${url} (see https://g.co/ng/security#xss)`);

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -132,9 +132,6 @@
     "name": "Console"
   },
   {
-    "name": "DATA_URL_PATTERN"
-  },
-  {
     "name": "DEFAULT_SERIALIZER"
   },
   {

--- a/packages/core/test/sanitization/url_sanitizer_spec.ts
+++ b/packages/core/test/sanitization/url_sanitizer_spec.ts
@@ -66,11 +66,6 @@ import {_sanitizeUrl, sanitizeSrcset} from '../../src/sanitization/url_sanitizer
         '&#x6A&#x61&#x76&#x61&#x73&#x63&#x72&#x69&#x70&#x74&#x3A;',
         'jav&#x09;ascript:alert();',
         'jav\u0000ascript:alert();',
-        'data:;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
-        'data:,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
-        'data:iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
-        'data:text/javascript;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
-        'data:application/x-msdownload;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/',
       ];
       for (const url of invalidUrls) {
         it(`valid ${url}`, () => expect(_sanitizeUrl(url)).toMatch(/^unsafe:/));


### PR DESCRIPTION
Validation for `data:` urls is obsolete now that modern browsers ([Firefox as of v57+](https://blog.mozilla.org/security/2017/10/04/treating-data-urls-unique-origins-firefox-57)) don't treat `data:` urls as same-origin resources.

Googlers can see internal change cl/363609175 for additional context.