### PR TITLE
docs: release notes for the v13.3.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="13.3.6"></a>
+# 13.3.6 (2022-05-04)
+## Special Thanks
+Andrew Kushnir, Andrew Scott, George Kalpakas, Paul Gschwendtner, Pawel Kozlowski, Ryan Day and dario-piotrowicz
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="14.0.0-next.15"></a>
 # 14.0.0-next.15 (2022-04-27)
 ## Breaking Changes


### PR DESCRIPTION
Cherry-picks the changelog from the "13.3.x" branch to the next branch (main).