### PR TITLE
feat(docs-infra): add open_in_new icon to external aio-top-menu links

### DIFF
--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -146,10 +146,10 @@ mat-toolbar.app-toolbar {
             .nav-link-inner {
               display: inline-flex;
               align-items: center;
+              line-height: normal;
               &::after {
                 content: "\e89e"; // codepoint for "open_in_new"
                 margin-left: 0.3rem;
-                margin-bottom: 0.3rem;
                 font-family: "Material Icons";
               }
             }

--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -141,6 +141,20 @@ mat-toolbar.app-toolbar {
             padding: 8px clamp(5px, 0.7vw, 16px);
           }
 
+          &[href^="http:"],
+          &[href^="https:"] {
+            .nav-link-inner {
+              display: inline-flex;
+              align-items: center;
+              &::after {
+                content: "\e89e"; // codepoint for "open_in_new"
+                margin-left: 0.3rem;
+                margin-bottom: 0.3rem;
+                font-family: "Material Icons";
+              }
+            }
+          }
+
           &:focus {
             outline: none;
 

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -4,7 +4,7 @@
       "runtime": 4325,
       "main": 453332,
       "polyfills": 33814,
-      "styles": 72183,
+      "styles": 72829,
       "light-theme": 78276,
       "dark-theme": 78381
     }
@@ -14,7 +14,7 @@
       "runtime": 4325,
       "main": 453359,
       "polyfills": 33922,
-      "styles": 72183,
+      "styles": 72829,
       "light-theme": 78276,
       "dark-theme": 78381
     }


### PR DESCRIPTION
add a mat open_in_new icon to the blog external link present in the
aio-top-menu so that it can be distinguished from the other (/internal)
links

resolves #38412

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: #38412


## What is the new behavior?

A new icon has been added to the aio-top-menu blog link:
![Screenshot at 2022-05-04 21-55-39](https://user-images.githubusercontent.com/61631103/166824550-31ea540f-9da9-4136-9340-0b4f8d09f0bc.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
