### PR TITLE
feat(router): Add ability to create `UrlTree` from any `ActivatedRouteSnapshot`

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -315,7 +315,7 @@
   ],
   [
     "packages/router/src/models.ts",
-    "packages/router/src/router_state.ts",
+    "packages/router/src/url_tree.ts",
     "packages/router/src/shared.ts"
   ],
   [
@@ -341,10 +341,5 @@
   [
     "packages/router/src/shared.ts",
     "packages/router/src/url_tree.ts"
-  ],
-  [
-    "packages/router/src/shared.ts",
-    "packages/router/src/url_tree.ts",
-    "packages/router/src/utils/collection.ts"
   ]
 ]

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -176,7 +176,7 @@ export class ChildrenOutletContexts {
 export function convertToParamMap(params: Params): ParamMap;
 
 // @public
-export function createUrlTreeFromSnapshot(relativeTo: ActivatedRouteSnapshot, commands: any[], queryParams: Params | null, fragment: string | null): UrlTree;
+export function createUrlTreeFromSnapshot(relativeTo: ActivatedRouteSnapshot, commands: any[], queryParams?: Params | null, fragment?: string | null): UrlTree;
 
 // @public
 export type Data = {

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -176,6 +176,9 @@ export class ChildrenOutletContexts {
 export function convertToParamMap(params: Params): ParamMap;
 
 // @public
+export function createUrlTreeFromSnapshot(relativeTo: ActivatedRouteSnapshot, commands: any[], queryParams: Params | null, fragment: string | null): UrlTree;
+
+// @public
 export type Data = {
     [key: string | symbol]: any;
 };

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -963,6 +963,9 @@
     "name": "createResultForNode"
   },
   {
+    "name": "createRoot"
+  },
+  {
     "name": "createRouterScroller"
   },
   {

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -6,10 +6,76 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ActivatedRoute} from './router_state';
+import {ActivatedRoute, ActivatedRouteSnapshot} from './router_state';
 import {Params, PRIMARY_OUTLET} from './shared';
-import {UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
+import {createRoot, squashSegmentGroup, UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
 import {forEach, last, shallowEqual} from './utils/collection';
+
+/**
+ * Creates a `UrlTree` relative to an `ActivatedRouteSnapshot`.
+ *
+ * @publicApi
+ * @param relativeTo The `ActivatedRouteSnapshot` to apply the commands to
+ * @param commands An array of URL fragments with which to construct the new URL tree.
+ * If the path is static, can be the literal URL string. For a dynamic path, pass an array of path
+ * segments, followed by the parameters for each segment.
+ * The fragments are applied to the one provided in the `relativeTo` parameter.
+ * @param queryParams The query parameters for the `UrlTree`. `null` if the `UrlTree` does not have
+ *     any query parameters.
+ * @param fragment The fragment for the `UrlTree`. `null` if the `UrlTree` does not have a fragment.
+ */
+export function createUrlTreeFromSnapshot(
+    relativeTo: ActivatedRouteSnapshot, commands: any[], queryParams: Params|null,
+    fragment: string|null): UrlTree {
+  const relativeToUrlSegmentGroup = createSegmentGroupFromRoute(relativeTo);
+  return createUrlTreeFromSegmentGroup(relativeToUrlSegmentGroup, commands, queryParams, fragment);
+}
+
+function createSegmentGroupFromRoute(route: ActivatedRouteSnapshot): UrlSegmentGroup {
+  let targetGroup: UrlSegmentGroup|undefined;
+
+  function createSegmentGroupFromRouteRecursive(currentRoute: ActivatedRouteSnapshot) {
+    const childOutlets: {[outlet: string]: UrlSegmentGroup} = {};
+    for (const childSnapshot of currentRoute.children) {
+      const root = createSegmentGroupFromRouteRecursive(childSnapshot);
+      childOutlets[childSnapshot.outlet] = root;
+    }
+    const segmentGroup = new UrlSegmentGroup(currentRoute.url, childOutlets);
+    if (currentRoute === route) {
+      targetGroup = segmentGroup;
+    }
+    return segmentGroup;
+  }
+  const rootCandidate = createSegmentGroupFromRouteRecursive(route.root);
+  const rootSegmentGroup = createRoot(rootCandidate);
+
+  return targetGroup ?? rootSegmentGroup;
+}
+
+export function createUrlTreeFromSegmentGroup(
+    relativeTo: UrlSegmentGroup, commands: any[], queryParams: Params|null,
+    fragment: string|null): UrlTree {
+  let root = relativeTo;
+  while (root.parent) {
+    root = root.parent;
+  }
+  const targetGroup = relativeTo;
+  if (commands.length === 0) {
+    return tree(root, root, root, queryParams, fragment);
+  }
+
+  const nav = computeNavigation(commands);
+
+  if (nav.toRoot()) {
+    return tree(root, root, new UrlSegmentGroup([], {}), queryParams, fragment);
+  }
+
+  const position = findStartingPositionForTargetGroup(nav, root, targetGroup);
+  const newSegmentGroup = position.processChildren ?
+      updateSegmentGroupChildren(position.segmentGroup, position.index, nav.commands) :
+      updateSegmentGroup(position.segmentGroup, position.index, nav.commands);
+  return tree(root, position.segmentGroup, newSegmentGroup, queryParams, fragment);
+}
 
 export function createUrlTree(
     route: ActivatedRoute, urlTree: UrlTree, commands: any[], queryParams: Params|null,
@@ -76,14 +142,24 @@ function tree(
     });
   }
 
+  let rootCandidate: UrlSegmentGroup;
   if (oldRoot === oldSegmentGroup) {
-    return new UrlTree(newSegmentGroup, qp, fragment);
+    rootCandidate = newSegmentGroup;
+  } else {
+    rootCandidate = replaceSegment(oldRoot, oldSegmentGroup, newSegmentGroup);
   }
 
-  const newRoot = replaceSegment(oldRoot, oldSegmentGroup, newSegmentGroup);
+  const newRoot = createRoot(squashSegmentGroup(rootCandidate));
   return new UrlTree(newRoot, qp, fragment);
 }
 
+/**
+ * Replaces the `oldSegment` which is located in some child of the `current` with the `newSegment`.
+ * This also has the effect of creating new `UrlSegmentGroup` copies to update references. This
+ * shouldn't be necessary but the fallback logic for an invalid ActivatedRoute in the creation uses
+ * the Router's current url tree. If we don't create new segment groups, we end up modifying that
+ * value.
+ */
 function replaceSegment(
     current: UrlSegmentGroup, oldSegment: UrlSegmentGroup,
     newSegment: UrlSegmentGroup): UrlSegmentGroup {
@@ -170,6 +246,24 @@ class Position {
   constructor(
       public segmentGroup: UrlSegmentGroup, public processChildren: boolean, public index: number) {
   }
+}
+
+function findStartingPositionForTargetGroup(
+    nav: Navigation, root: UrlSegmentGroup, target: UrlSegmentGroup): Position {
+  if (nav.isAbsolute) {
+    return new Position(root, true, 0);
+  }
+
+  if (!target) {
+    return new Position(root, false, NaN);
+  }
+  if (target.parent === null) {
+    return new Position(target, true, 0);
+  }
+
+  const modifier = isMatrixParams(nav.commands[0]) ? 0 : 1;
+  const index = target.segments.length - 1 + modifier;
+  return createPositionApplyingDoubleDots(target, index, nav.numberOfDoubleDots);
 }
 
 function findStartingPosition(

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -49,8 +49,8 @@ import {forEach, last, shallowEqual} from './utils/collection';
  * // remove the right secondary node
  * createUrlTreeFromSnapshot(snapshot, ['/team', 33, {outlets: {primary: 'user/11', right: null}}]);
  *
- * // assuming the current URL is for the `/team/33/user/11` and the `ActivatedRouteSnapshot` points
- * to `user/11`
+ * // For the examples below, assume the current URL is for the `/team/33/user/11` and the
+ * `ActivatedRouteSnapshot` points to `user/11`:
  *
  * // navigate to /team/33/user/11/details
  * createUrlTreeFromSnapshot(snapshot, ['details']);

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -30,41 +30,41 @@ import {forEach, last, shallowEqual} from './utils/collection';
  *
  * ```
  * // create /team/33/user/11
- * createUrlTree(snapshot, ['/team', 33, 'user', 11], null, null);
+ * createUrlTreeFromSnapshot(snapshot, ['/team', 33, 'user', 11]);
  *
  * // create /team/33;expand=true/user/11
- * createUrlTree(snapshot, ['/team', 33, {expand: true}, 'user', 11], null, null);
+ * createUrlTreeFromSnapshot(snapshot, ['/team', 33, {expand: true}, 'user', 11]);
  *
  * // you can collapse static segments like this (this works only with the first passed-in value):
- * createUrlTree(snapshot, ['/team/33/user', userId], null, null);
+ * createUrlTreeFromSnapshot(snapshot, ['/team/33/user', userId]);
  *
  * // If the first segment can contain slashes, and you do not want the router to split it,
  * // you can do the following:
- * createUrlTree(snapshot, [{segmentPath: '/one/two'}], null, null);
+ * createUrlTreeFromSnapshot(snapshot, [{segmentPath: '/one/two'}]);
  *
  * // create /team/33/(user/11//right:chat)
- * createUrlTree(snapshot, ['/team', 33, {outlets: {primary: 'user/11', right: 'chat'}}], null,
- * null);
+ * createUrlTreeFromSnapshot(snapshot, ['/team', 33, {outlets: {primary: 'user/11', right:
+ * 'chat'}}], null, null);
  *
  * // remove the right secondary node
- * createUrlTree(snapshot, ['/team', 33, {outlets: {primary: 'user/11', right: null}}], null, null);
+ * createUrlTreeFromSnapshot(snapshot, ['/team', 33, {outlets: {primary: 'user/11', right: null}}]);
  *
  * // assuming the current URL is for the `/team/33/user/11` and the `ActivatedRouteSnapshot` points
  * to `user/11`
  *
  * // navigate to /team/33/user/11/details
- * createUrlTree(snapshot, ['details'], null, null);
+ * createUrlTreeFromSnapshot(snapshot, ['details']);
  *
  * // navigate to /team/33/user/22
- * createUrlTree(snapshot, ['../22'], null, null);
+ * createUrlTreeFromSnapshot(snapshot, ['../22']);
  *
  * // navigate to /team/44/user/22
- * createUrlTree(snapshot, ['../../team/44/user/22'], null, null);
+ * createUrlTreeFromSnapshot(snapshot, ['../../team/44/user/22']);
  * ```
  */
 export function createUrlTreeFromSnapshot(
-    relativeTo: ActivatedRouteSnapshot, commands: any[], queryParams: Params|null,
-    fragment: string|null): UrlTree {
+    relativeTo: ActivatedRouteSnapshot, commands: any[], queryParams: Params|null = null,
+    fragment: string|null = null): UrlTree {
   const relativeToUrlSegmentGroup = createSegmentGroupFromRoute(relativeTo);
   return createUrlTreeFromSegmentGroup(relativeToUrlSegmentGroup, commands, queryParams, fragment);
 }

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 
+export {createUrlTreeFromSnapshot} from './create_url_tree';
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet, RouterOutletContract} from './directives/router_outlet';


### PR DESCRIPTION
This exposes a new function from the router public API that allows
developers to create a `UrlTree` from _any_ `ActivatedRouteSnapshot`.
The current Router APIs only support creating a `UrlTree` from an
`ActivatedRoute` which is both active _and_ materially appears in the
`UrlTree` (it cannot be an empty path named outlet). This is because the
implementation of the current way of creating a `UrlTree` attempts to
look up the `UrlSegment` of the `ActivatedRoute` in the currently active
`UrlTree` of the router. When this doesn't work, the `UrlTree` creation
fails.

Note that this API does not replace the current one. That would actually be a
breaking change but should be done at some point in the future (v15). That is,
`router.navigate` should call this new function. At that point, we can
remove `_lastPathIndex`, `_urlSegment`, and `_correctedPathIndex` from
the `ActivatedRoute`, along with all of the logic associated with
determining what those should be. In addition, this would unblock a fix
for https://github.com/angular/angular/issues/26081 because the `applyRedirects` and `recognize` operations
could be combined into one.  Overall, this would simplify logic in the router
and reduce code size. It also exposes core routing capabilities as a helper function
which were previously private API, which is a necessary step towards https://github.com/angular/angular/issues/42953.

As a stress test for this new function, it _was_ swapped in as the
default for `UrlTree` creation in https://github.com/angular/angular/pull/45859 and tested internally. The
results indicate that this function behaves correctly.

resolves https://github.com/angular/angular/issues/42191 (Tested directly)
resolves https://github.com/angular/angular/issues/38276 (The test with a guard covers this case)
resolves https://github.com/angular/angular/issues/22763 (Tested directly)