### PR TITLE
refactor(devtools): remove support for v11 and older versions of Angular

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -27,7 +27,7 @@ Angular DevTools is a Chrome extension that provides debugging and profiling cap
 
 ## Supported version
 
-Angular DevTools supports Angular v9 and above, with Ivy enabled.
+Angular DevTools supports Angular v12 and above, with Ivy enabled.
 
 ## Working on Angular DevTools
 

--- a/devtools/docs/overview.md
+++ b/devtools/docs/overview.md
@@ -17,7 +17,7 @@
 
 # DevTools Overview
 
-Angular DevTools is a Chrome extension that provides debugging and profiling capabilities for Angular applications. Angular DevTools supports Angular v9 and above, with Ivy enabled.
+Angular DevTools is a Chrome extension that provides debugging and profiling capabilities for Angular applications. Angular DevTools supports Angular v12 and above.
 
 You can find Angular DevTools in the [Chrome Web Store](https://chrome.google.com/webstore/detail/angular-developer-tools/ienfalfjdbdpebioblfackkekamfmbnh).
 

--- a/devtools/projects/ng-devtools-backend/src/lib/angular-check.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/angular-check.spec.ts
@@ -29,12 +29,12 @@ describe('angular-check', () => {
     });
 
     it('should work with new versions', () => {
-      setNgVersion('9.0.0');
+      setNgVersion('12.0.0');
       expect(appIsSupportedAngularVersion()).toBeTrue();
     });
 
     it('should return false for older version', () => {
-      setNgVersion('8.0.0');
+      setNgVersion('9.0.0');
       expect(appIsSupportedAngularVersion()).toBeFalse();
     });
 

--- a/devtools/projects/ng-devtools-backend/src/lib/angular-check.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/angular-check.ts
@@ -26,7 +26,7 @@ export const appIsSupportedAngularVersion = (): boolean => {
     return false;
   }
   const major = parseInt(version.toString().split('.')[0], 10);
-  return appIsAngular() && (major >= 9 || major === 0);
+  return appIsAngular() && (major >= 12 || major === 0);
 };
 
 /**

--- a/devtools/projects/ng-devtools/src/lib/devtools.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools.component.html
@@ -6,8 +6,7 @@
       </div>
       <ng-template #notSupported>
         <p class="text-message">
-          Angular Devtools only supports Angular versions 9 and above with
-          <a href="https://angular.io/guide/ivy" target="_blank">ivy</a> enabled.
+          Angular Devtools only supports Angular versions 12 and above
         </p>
       </ng-template>
     </ng-container>

--- a/devtools/projects/shell-browser/src/popups/unsupported.html
+++ b/devtools/projects/shell-browser/src/popups/unsupported.html
@@ -60,7 +60,7 @@
       </section>
       <section>
         <span class="material-icons md-48">settings</span>
-        <p>You can use DevTools with Angular v9+ <a href="https://angular.io/guide/ivy">Ivy.</a></p>
+        <p>You can use DevTools with Angular v12+</p>
       </section>
     </div>
   </div>


### PR DESCRIPTION
In Angular v12 we introduced debugging APIs sufficient for DevTools.
Prior to that Angular DevTools accesses the logical data structures of
Ivy directly, which sometimes produces suboptimal results and skips
dynamically inserted content.

With the end of v11's LTS, we'll support only Angular v12 and up.

closes #45881 