### PR TITLE
perf(platform-browser): avoid including Testability by default in `bootstrapApplication`

### DIFF
--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -178,6 +178,9 @@ export type MetaDefinition = {
 export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef;
 
 // @public
+export function provideProtractorTestingSupport(): Provider[];
+
+// @public
 export interface SafeHtml extends SafeValue {
 }
 

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -55,7 +55,7 @@
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 1090,
-      "main": 87940,
+      "main": 84237,
       "polyfills": 33945
     }
   },

--- a/integration/standalone-bootstrap/e2e/src/app.e2e-spec.ts
+++ b/integration/standalone-bootstrap/e2e/src/app.e2e-spec.ts
@@ -1,24 +1,11 @@
-import {browser, logging} from 'protractor';
-
-import {AppPage} from './app.po';
-
+/**
+ * Note: this file contains no e2e tests, since they rely on Protractor,
+ * which requires Testability. Testability is not included by default when
+ * the `bootstrapApplication` function is used (which is the case in this app).
+ * We use this app primarily to measure payload size, so we want to keep
+ * Testability excluded.
+ */
 describe('Standalone Bootstrap app', () => {
-  let page: AppPage;
-
-  beforeEach(() => {
-    page = new AppPage();
-  });
-
-  it('should display title', () => {
-    page.navigateTo();
-    expect(page.getTitleText()).toEqual('Standalone Bootstrap app');
-  });
-
-  afterEach(async () => {
-    // Assert that there are no errors emitted from the browser
-    const logs = await browser.manage().logs().get(logging.Type.BROWSER);
-    expect(logs).not.toContain(jasmine.objectContaining({
-      level: logging.Level.SEVERE,
-    } as logging.Entry));
-  });
+  // Jasmine will throw if there are no tests.
+  it('should pass', () => {});
 });

--- a/packages/core/src/testability/testability.ts
+++ b/packages/core/src/testability/testability.ts
@@ -66,8 +66,22 @@ export const TESTABILITY_GETTER = new InjectionToken<GetTestability>('');
 
 /**
  * The Testability service provides testing hooks that can be accessed from
- * the browser. Each bootstrapped Angular application on the page will have
- * an instance of Testability.
+ * the browser.
+ *
+ * Angular applications bootstrapped using an NgModule (via `@NgModule.bootstrap` field) will also
+ * instantiate Testability by default (in both development and production modes).
+ *
+ * For applications bootstrapped using the `bootstrapApplication` function, Testability is not
+ * included by default. You can include it into your applications by getting the list of necessary
+ * providers using the `provideProtractorTestingSupport()` function and adding them into the
+ * `options.providers` array. Example:
+ *
+ * ```typescript
+ * import {provideProtractorTestingSupport} from '@angular/platform-browser';
+ *
+ * await bootstrapApplication(RootComponent, providers: [provideProtractorTestingSupport()]);
+ * ```
+ *
  * @publicApi
  */
 @Injectable()

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -69,9 +69,6 @@
     "name": "DefaultDomRenderer2"
   },
   {
-    "name": "DomEventsPlugin"
-  },
-  {
     "name": "DomRendererFactory2"
   },
   {
@@ -136,9 +133,6 @@
   },
   {
     "name": "Injector"
-  },
-  {
-    "name": "KeyEventsPlugin"
   },
   {
     "name": "LOCALE_ID2"
@@ -297,22 +291,10 @@
     "name": "TESTABILITY"
   },
   {
-    "name": "TESTABILITY_GETTER"
-  },
-  {
-    "name": "TESTABILITY_PROVIDERS"
-  },
-  {
     "name": "THROW_IF_NOT_FOUND"
   },
   {
     "name": "TRACKED_LVIEWS"
-  },
-  {
-    "name": "Testability"
-  },
-  {
-    "name": "TestabilityRegistry"
   },
   {
     "name": "USE_VALUE"
@@ -361,9 +343,6 @@
   },
   {
     "name": "_renderCompCount"
-  },
-  {
-    "name": "_testabilityGetter"
   },
   {
     "name": "_wrapInTimeout"
@@ -814,9 +793,6 @@
   },
   {
     "name": "scheduleArray"
-  },
-  {
-    "name": "scheduleMicroTask"
   },
   {
     "name": "searchTokensOnInjector"

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {ApplicationConfig, bootstrapApplication, BrowserModule, platformBrowser} from './browser';
+export {ApplicationConfig, bootstrapApplication, BrowserModule, platformBrowser, provideProtractorTestingSupport} from './browser';
 export {Meta, MetaDefinition} from './browser/meta';
 export {Title} from './browser/title';
 export {disableDebugTools, enableDebugTools} from './browser/tools/tools';


### PR DESCRIPTION
The Testability-related logic was refactored in https://github.com/angular/angular/pull/45657 to become tree-shaking-friendly: it was decoupled from the core providers of the `BrowserModule`. This commit updates the newly-introduced `bootstrapApplication` function to exclude Testability-providers by default (note: the Testability is still included in the NgModule-based bootstrap).

In order to add the Testability to the app bootstrapped via `bootstrapApplication`, the `withProtractorTestingSupport` function is introduced.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: performance improvement


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No, since the `bootstrapApplication` function is not released yet (will be released in v14).
