### PR TITLE
refactor(core): declare TestModuleMetadata as an interface

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -221,15 +221,20 @@ export interface TestEnvironmentOptions {
 }
 
 // @public (undocumented)
-export type TestModuleMetadata = {
-    providers?: any[];
+export interface TestModuleMetadata {
+    // (undocumented)
     declarations?: any[];
-    imports?: any[];
-    schemas?: Array<SchemaMetadata | any[]>;
-    teardown?: ModuleTeardownOptions;
     errorOnUnknownElements?: boolean;
     errorOnUnknownProperties?: boolean;
-};
+    // (undocumented)
+    imports?: any[];
+    // (undocumented)
+    providers?: any[];
+    // (undocumented)
+    schemas?: Array<SchemaMetadata | any[]>;
+    // (undocumented)
+    teardown?: ModuleTeardownOptions;
+}
 
 // @public
 export function tick(millis?: number, tickOptions?: {

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -45,11 +45,11 @@ export const ComponentFixtureNoNgZone = new InjectionToken<boolean[]>('Component
 /**
  * @publicApi
  */
-export type TestModuleMetadata = {
-  providers?: any[],
-  declarations?: any[],
-  imports?: any[],
-  schemas?: Array<SchemaMetadata|any[]>,
+export interface TestModuleMetadata {
+  providers?: any[];
+  declarations?: any[];
+  imports?: any[];
+  schemas?: Array<SchemaMetadata|any[]>;
   teardown?: ModuleTeardownOptions;
   /**
    * Whether NG0304 runtime errors should be thrown when unknown elements are present in component's
@@ -65,7 +65,7 @@ export type TestModuleMetadata = {
    * @see https://angular.io/errors/NG8002 for the description of the error and how to fix it
    */
   errorOnUnknownProperties?: boolean;
-};
+}
 
 /**
  * @publicApi


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)


## What is the current behavior?
The documentation of the options of TestModuleMetadata don't show on the docs, as it is a type https://next.angular.io/api/core/testing/TestModuleMetadata

## What is the new behavior?
This allows the documentation for the options `errorOnUnknownElements` and `errorOnUnknownProperties` to be displayed in the docs.
They aren't currently displayed, as `TestModuleMetadata` is a type and not an interface.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
