### PR TITLE
build: use vendored yarn script for installing Sass repositories

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -144,14 +144,16 @@ cldr_xml_data_repository(
 # sass rules
 http_archive(
     name = "io_bazel_rules_sass",
-    sha256 = "b83d695bc8deb5ab5fb3a8e6919999eebf738a4a5aa57a43a63ee70109f80224",
-    strip_prefix = "rules_sass-1.50.0",
+    sha256 = "856080c608e51993ab3088c08c70361d3f1fce383e14499cc2279060b350898c",
+    strip_prefix = "rules_sass-1.51.0",
     urls = [
-        "https://github.com/bazelbuild/rules_sass/archive/1.50.0.zip",
+        "https://github.com/bazelbuild/rules_sass/archive/1.51.0.zip",
     ],
 )
 
 # Setup the rules_sass toolchain
 load("@io_bazel_rules_sass//sass:sass_repositories.bzl", "sass_repositories")
 
-sass_repositories()
+sass_repositories(
+    yarn_script = "//:.yarn/releases/yarn-1.22.17.cjs",
+)


### PR DESCRIPTION
Fixes the Bazel analysis warning and the fact that Yarn is unnecessarily
downloaded by `rules_nodejs`.

```
DEBUG: /home/circleci/.cache/bazel/_bazel_circleci/9ce5c2144ecf75d11717c0aa41e45a8d/external/build_bazel_rules_nodejs/index.bzl:73:14: yarn_install#yarn attribute not set and no repository named 'yarn' exists; installing default yarn
```