### PR TITLE
refactor(compiler-cli): don't emit decls/imports in NgModule type

### DIFF
--- a/packages/compiler/src/render3/r3_module_compiler.ts
+++ b/packages/compiler/src/render3/r3_module_compiler.ts
@@ -247,12 +247,11 @@ export function compileNgModuleDeclarationExpression(meta: R3DeclareNgModuleFaca
   return o.importExpr(R3.defineNgModule).callFn([definitionMap.toLiteralMap()]);
 }
 
-export function createNgModuleType(
-    {type: moduleType, declarations, imports, exports}: R3NgModuleMetadata): o.ExpressionType {
-  return new o.ExpressionType(o.importExpr(R3.NgModuleDeclaration, [
-    new o.ExpressionType(moduleType.type), tupleTypeOf(declarations), tupleTypeOf(imports),
-    tupleTypeOf(exports)
-  ]));
+export function createNgModuleType({type: moduleType, exports}: R3NgModuleMetadata):
+    o.ExpressionType {
+  return new o.ExpressionType(o.importExpr(
+      R3.NgModuleDeclaration,
+      [new o.ExpressionType(moduleType.type), o.NONE_TYPE, o.NONE_TYPE, tupleTypeOf(exports)]));
 }
 
 /**


### PR DESCRIPTION
This is an experimental commit to test the effects of not emitting the full
NgModule type.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
