### PR TITLE
fix(bazel): speed up `d.ts` bundling by configuring worker

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@bazel/rollup": "5.4.1",
     "@bazel/runfiles": "5.4.1",
     "@bazel/terser": "5.4.1",
+    "@bazel/worker": "5.4.1",
     "@microsoft/api-extractor": "7.22.2",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.0",

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -30,6 +30,7 @@
   "peerDependencies": {
     "@angular/compiler-cli": "0.0.0-PLACEHOLDER",
     "@bazel/concatjs": "^5.3.0",
+    "@bazel/worker": "^5.3.0",
     "@rollup/plugin-commonjs": "^21.0.0",
     "@rollup/plugin-node-resolve": "^13.0.4",
     "rollup": "^2.56.3",

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -221,7 +221,7 @@ def _run_rollup(ctx, bundle_name, rollup_config, entry_point, inputs, js_output,
     if stamp and ctx.version_file:
         other_inputs.append(ctx.version_file)
     ctx.actions.run(
-        progress_message = "ng_package: Rollup %s %s" % (bundle_name, ctx.label),
+        progress_message = "ng_package: Rollup %s (%s)" % (bundle_name, entry_point.short_path),
         mnemonic = "AngularPackageRollup",
         inputs = inputs.to_list() + other_inputs,
         outputs = [js_output, map_output],

--- a/packages/bazel/src/types_bundle/BUILD.bazel
+++ b/packages/bazel/src/types_bundle/BUILD.bazel
@@ -10,6 +10,7 @@ ts_library(
         "index.ts",
     ],
     deps = [
+        "@npm//@bazel/worker",
         "@npm//@microsoft/api-extractor",
         "@npm//@types/node",
     ],
@@ -17,11 +18,7 @@ ts_library(
 
 nodejs_binary(
     name = "types_bundler",
-    data = [
-        ":lib",
-        "@npm//@bazel/concatjs",
-        "@npm//@microsoft/api-extractor",
-    ],
+    data = [":lib"],
     entry_point = ":index.ts",
     # Disable the linker and rely on patched resolution which works better on Windows
     # and is less prone to race conditions when targets build concurrently.

--- a/packages/bazel/src/types_bundle/index.bzl
+++ b/packages/bazel/src/types_bundle/index.bzl
@@ -28,12 +28,19 @@ def bundle_type_declaration(
         args.add(license_banner_file.path)
         inputs.append(license_banner_file)
 
+    # Pass arguments using a flag-file prefixed with `@`. This is
+    # a requirement for build action arguments in persistent workers.
+    # https://docs.bazel.build/versions/main/creating-workers.html#work-action-requirements.
+    args.use_param_file("@%s", use_always = True)
+    args.set_param_file_format("multiline")
+
     ctx.actions.run(
         mnemonic = "BundlingTypes",
         inputs = depset(inputs, transitive = [types]),
         outputs = [output_file],
         executable = ctx.executable._types_bundler_bin,
         arguments = [args],
+        execution_requirements = {"supports-workers": "1"},
         progress_message = "Bundling types (%s)" % entry_point.short_path,
     )
 


### PR DESCRIPTION
Speeds up the `d.ts` bundling by configuring it as a Bazel
persistent worker. Also improve logging for the ng packager
rule to make it easier to spot which actions/bundles take
up significant time.

Type bundling will occur for every entry-point so for machines
with rather limited cores/threads, this will be useful to save
NodeJS boot and resolution time.