### PR TITLE
docs: update the Angular DevTools supported version in docs and README

### DIFF
--- a/aio/content/guide/devtools.md
+++ b/aio/content/guide/devtools.md
@@ -1,7 +1,7 @@
 # DevTools Overview
 
-Angular DevTools is a Chrome extension that provides debugging and profiling capabilities for Angular applications.
-Angular DevTools supports Angular v9 and later, with Ivy enabled.
+Angular DevTools is a browser extension that provides debugging and profiling capabilities for Angular applications.
+Angular DevTools supports Angular v12 and later.
 
 <div class="video-container">
 

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -27,7 +27,7 @@ Angular DevTools is a Chrome extension that provides debugging and profiling cap
 
 ## Supported version
 
-Angular DevTools supports Angular v12 and above, with Ivy enabled.
+Angular DevTools supports Angular v12 and above.
 
 ## Working on Angular DevTools
 


### PR DESCRIPTION
Ensure we document we support Angular v12 or older. Also remove Ivy as
a requirement because that's implicit.
