### PR TITLE
ci: update github robot config to reflect update in syncing

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -45,6 +45,7 @@ merge:
       - 'packages/bazel/src/*'
       - 'packages/bazel/src/api-extractor/**'
       - 'packages/bazel/src/builders/**'
+      - 'packages/bazel/src/ng_module/**'
       - 'packages/bazel/src/ng_package/**'
       - 'packages/bazel/src/protractor/**'
       - 'packages/bazel/src/schematics/**'


### PR DESCRIPTION
The `ng_module` Starlark code is not used internally, just `ngc-wrapped`.