### PR TITLE
perf(core): allow `checkNoChanges` mode to be tree-shaken in production

### DIFF
--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -104,7 +104,7 @@ export abstract class ChangeDetectorRef {
    * Checks the change detector and its children, and throws if any changes are detected.
    *
    * Use in development mode to verify that running change detection doesn't introduce
-   * other changes.
+   * other changes. Calling it in production mode is a noop.
    */
   abstract checkNoChanges(): void;
 

--- a/packages/core/src/render3/instructions/advance.ts
+++ b/packages/core/src/render3/instructions/advance.ts
@@ -37,7 +37,8 @@ import {getLView, getSelectedIndex, getTView, isInCheckNoChangesMode, setSelecte
  */
 export function ɵɵadvance(delta: number): void {
   ngDevMode && assertGreaterThan(delta, 0, 'Can only advance forward');
-  selectIndexInternal(getTView(), getLView(), getSelectedIndex() + delta, isInCheckNoChangesMode());
+  selectIndexInternal(
+      getTView(), getLView(), getSelectedIndex() + delta, !!ngDevMode && isInCheckNoChangesMode());
 }
 
 export function selectIndexInternal(

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -384,7 +384,7 @@ export function refreshView<T>(
   enterView(lView);
   // Check no changes mode is a dev only mode used to verify that bindings have not changed
   // since they were assigned. We do not want to execute lifecycle hooks in that mode.
-  const isInCheckNoChangesPass = isInCheckNoChangesMode();
+  const isInCheckNoChangesPass = ngDevMode && isInCheckNoChangesMode();
   try {
     resetPreOrderHookFlags(lView);
 
@@ -505,7 +505,7 @@ export function refreshView<T>(
 export function renderComponentOrTemplate<T>(
     tView: TView, lView: LView, templateFn: ComponentTemplate<{}>|null, context: T) {
   const rendererFactory = lView[RENDERER_FACTORY];
-  const normalExecutionPath = !isInCheckNoChangesMode();
+  const normalExecutionPath = !ngDevMode || !isInCheckNoChangesMode();
   const creationModeIsActive = isCreationMode(lView);
   try {
     if (normalExecutionPath && !creationModeIsActive && rendererFactory.begin) {
@@ -531,7 +531,7 @@ function executeTemplate<T>(
     if (isUpdatePhase && lView.length > HEADER_OFFSET) {
       // When we're updating, inherently select 0 so we don't
       // have to generate that instruction for most update blocks.
-      selectIndexInternal(tView, lView, HEADER_OFFSET, isInCheckNoChangesMode());
+      selectIndexInternal(tView, lView, HEADER_OFFSET, !!ngDevMode && isInCheckNoChangesMode());
     }
 
     const preHookType =

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -505,10 +505,14 @@ export function refreshView<T>(
 export function renderComponentOrTemplate<T>(
     tView: TView, lView: LView, templateFn: ComponentTemplate<{}>|null, context: T) {
   const rendererFactory = lView[RENDERER_FACTORY];
-  const normalExecutionPath = !ngDevMode || !isInCheckNoChangesMode();
+
+  // Check no changes mode is a dev only mode used to verify that bindings have not changed
+  // since they were assigned. We do not want to invoke renderer factory functions in that mode
+  // to avoid any possible side-effects.
+  const checkNoChangesMode = !!ngDevMode && isInCheckNoChangesMode();
   const creationModeIsActive = isCreationMode(lView);
   try {
-    if (normalExecutionPath && !creationModeIsActive && rendererFactory.begin) {
+    if (!checkNoChangesMode && !creationModeIsActive && rendererFactory.begin) {
       rendererFactory.begin();
     }
     if (creationModeIsActive) {
@@ -516,7 +520,7 @@ export function renderComponentOrTemplate<T>(
     }
     refreshView(tView, lView, templateFn, context);
   } finally {
-    if (normalExecutionPath && !creationModeIsActive && rendererFactory.end) {
+    if (!checkNoChangesMode && !creationModeIsActive && rendererFactory.end) {
       rendererFactory.end();
     }
   }

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -184,8 +184,8 @@ const instructionState: InstructionState = {
  *
  * Necessary to support ChangeDetectorRef.checkNoChanges().
  *
- * checkNoChanges Runs only in devmode=true and verifies that no unintended changes exist in
- * the change detector or its children.
+ * The `checkNoChanges` function is invoked only in ngDevMode=true and verifies that no unintended
+ * changes exist in the change detector or its children.
  */
 let _isInCheckNoChangesMode = false;
 

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -7,7 +7,7 @@
  */
 
 import {InjectFlags} from '../di/interface/injector';
-import {assertDefined, assertEqual, assertGreaterThanOrEqual, assertLessThan, assertNotEqual} from '../util/assert';
+import {assertDefined, assertEqual, assertGreaterThanOrEqual, assertLessThan, assertNotEqual, throwError} from '../util/assert';
 
 import {assertLViewOrUndefined, assertTNodeForLView, assertTNodeForTView} from './assert';
 import {DirectiveDef} from './interfaces/definition';
@@ -172,23 +172,22 @@ interface InstructionState {
    * ```
    */
   bindingsEnabled: boolean;
-
-  /**
-   * In this mode, any changes in bindings will throw an ExpressionChangedAfterChecked error.
-   *
-   * Necessary to support ChangeDetectorRef.checkNoChanges().
-   *
-   * checkNoChanges Runs only in devmode=true and verifies that no unintended changes exist in
-   * the change detector or its children.
-   */
-  isInCheckNoChangesMode: boolean;
 }
 
 const instructionState: InstructionState = {
   lFrame: createLFrame(null),
   bindingsEnabled: true,
-  isInCheckNoChangesMode: false,
 };
+
+/**
+ * In this mode, any changes in bindings will throw an ExpressionChangedAfterChecked error.
+ *
+ * Necessary to support ChangeDetectorRef.checkNoChanges().
+ *
+ * checkNoChanges Runs only in devmode=true and verifies that no unintended changes exist in
+ * the change detector or its children.
+ */
+let _isInCheckNoChangesMode = false;
 
 /**
  * Returns true if the instruction state stack is empty.
@@ -353,12 +352,13 @@ export function getContextLView(): LView {
 }
 
 export function isInCheckNoChangesMode(): boolean {
-  // TODO(misko): remove this from the LView since it is ngDevMode=true mode only.
-  return instructionState.isInCheckNoChangesMode;
+  !ngDevMode && throwError('Must never be called in production mode');
+  return _isInCheckNoChangesMode;
 }
 
 export function setIsInCheckNoChangesMode(mode: boolean): void {
-  instructionState.isInCheckNoChangesMode = mode;
+  !ngDevMode && throwError('Must never be called in production mode');
+  _isInCheckNoChangesMode = mode;
 }
 
 // top level variables should not be exported for performance reasons (PERF_NOTES.md)

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -281,7 +281,9 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
    * introduce other changes.
    */
   checkNoChanges(): void {
-    checkNoChangesInternal(this._lView[TVIEW], this._lView, this.context as unknown as {});
+    if (ngDevMode) {
+      checkNoChangesInternal(this._lView[TVIEW], this._lView, this.context as unknown as {});
+    }
   }
 
   attachToViewContainerRef() {
@@ -318,7 +320,9 @@ export class RootViewRef<T> extends ViewRef<T> {
   }
 
   override checkNoChanges(): void {
-    checkNoChangesInRootView(this._view);
+    if (ngDevMode) {
+      checkNoChangesInRootView(this._view);
+    }
   }
 
   override get context(): T {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -726,12 +726,6 @@
     "name": "detachMovedView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "diPublicInInjector"
   },
   {
@@ -1023,9 +1017,6 @@
     "name": "isImportedNgModuleProviders"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {
@@ -1312,9 +1303,6 @@
   },
   {
     "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -237,9 +237,6 @@
     "name": "isCurrentTNodeParent"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -747,12 +747,6 @@
     "name": "detachView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "diPublicInInjector"
   },
   {
@@ -1128,9 +1122,6 @@
     "name": "isImportedNgModuleProviders"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {
@@ -1462,9 +1453,6 @@
   },
   {
     "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -720,12 +720,6 @@
     "name": "detachView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "diPublicInInjector"
   },
   {
@@ -1089,9 +1083,6 @@
     "name": "isImportedNgModuleProviders"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {
@@ -1441,9 +1432,6 @@
   },
   {
     "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -168,9 +168,6 @@
     "name": "invertObject"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isLView"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1023,12 +1023,6 @@
     "name": "detachView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "diPublicInInjector"
   },
   {
@@ -1467,9 +1461,6 @@
     "name": "isImportedNgModuleProviders"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {
@@ -1825,9 +1816,6 @@
   },
   {
     "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setRouterState"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -462,12 +462,6 @@
     "name": "detachMovedView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "domRendererFactory3"
   },
   {
@@ -669,9 +663,6 @@
     "name": "isImportedNgModuleProviders"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isLContainer"
   },
   {
@@ -847,9 +838,6 @@
   },
   {
     "name": "setInjectImplementation"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -300,12 +300,6 @@
     "name": "detachView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "diPublicInInjector"
   },
   {
@@ -552,9 +546,6 @@
     "name": "isDirectiveHost"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {
@@ -757,9 +748,6 @@
   },
   {
     "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setSelectedIndex"


### PR DESCRIPTION
This commit guards all logic that exists for the `checkNoChanges` mode
with `ngDevMode` checks such that the logic can be tree-shaken.