### PR TITLE
ci: update NgBot to sync internal and external configs

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -53,6 +53,14 @@ merge:
       - 'packages/compiler-cli/linker/**'
       - 'packages/compiler-cli/ngcc/**'
       - 'packages/compiler-cli/src/ngtsc/sourcemaps/**'
+      # 'private' mostly contains entrypoints for 3P Angular.
+      # Note that 'private/migrations' _is_ used.
+      - 'packages/compiler-cli/private/bazel.ts'
+      - 'packages/compiler-cli/private/localize.ts'
+      - 'packages/compiler-cli/private/tooling.ts'
+      - 'packages/compiler-cli/private/babel.d.ts'
+      # google3 defines its own binary entrypoints.
+      - 'packages/compiler-cli/src/bin/**'
       - 'packages/docs/**'
       - 'packages/elements/schematics/**'
       - 'packages/examples/**'


### PR DESCRIPTION
There was a difference in the set of paths between check/sync scripts internally and externally.
This commit aligns both configurations.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No