### PR TITLE
Fix start and pipe docs

### DIFF
--- a/aio/content/guide/pipes.md
+++ b/aio/content/guide/pipes.md
@@ -42,7 +42,7 @@ To use pipes you should have a basic understanding of the following:
 
 ## Using a pipe in a template
 
-To apply a pipe, use the pipe \(`|\`) character within a template expression as shown in the following code example, along with the *name* of the pipe, which is `date` for the built-in [`DatePipe`](api/common/DatePipe).
+To apply a pipe, use the pipe \(`|`) character within a template expression as shown in the following code example, along with the *name* of the pipe, which is `date` for the built-in [`DatePipe`](api/common/DatePipe).
 The tabs in the example show the following:
 
 | Files                         | Details |

--- a/aio/content/start/start-data.md
+++ b/aio/content/start/start-data.md
@@ -166,7 +166,7 @@ This section shows you how to use the cart service to display the products in th
 
 1.  Verify that your cart works as expected:
 
-    1.  Click **My Store*.
+    1.  Click **My Store**.
     1.  Click on a product name to display its details.
     1.  Click **Buy** to add the product to the cart.
     1.  Click **Checkout** to see the cart.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The start-data page has some text that is displayed in italics rather than bold because it is missing the second closing asterisk. The second opening asterisk is displayed since it doesn't have a matching closing asterisk. : https://angular.io/start/start-data#display-the-cart-items (item 5.a)

The pipes documentation page shows a backslash after the vertical pipe character. I think this backslash was meant to escape the closing parenthesis, but since the opening parenthesis was escaped, the closing parenthesis does not need to be escaped. Additionally, the backslash was in the wrong place anyway. : https://angular.io/guide/pipes#using-a-pipe-in-a-template

Issue Number: N/A


## What is the new behavior?

The italic text is now properly displayed as bold.

The unnecessary backslash is no longer present.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
