### PR TITLE
fix(compiler-cli): update unknown tag error for aot standalone components

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -542,7 +542,8 @@ export class ComponentDecoratorHandler implements
     const binder = new R3TargetBinder(scope.matcher);
     ctx.addTemplate(
         new Reference(node), binder, meta.template.diagNodes, scope.pipes, scope.schemas,
-        meta.template.sourceMapping, meta.template.file, meta.template.errors);
+        meta.template.sourceMapping, meta.template.file, meta.template.errors,
+        meta.meta.isStandalone);
   }
 
   extendedTemplateCheck(

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -8,8 +8,8 @@
 
 import {AbsoluteSourceSpan, BoundTarget, DirectiveMeta, ParseSourceSpan, SchemaMetadata} from '@angular/compiler';
 import ts from 'typescript';
-import {ErrorCode} from '../../diagnostics';
 
+import {ErrorCode} from '../../diagnostics';
 import {AbsoluteFsPath} from '../../file_system';
 import {Reference} from '../../imports';
 import {ClassPropertyMapping, DirectiveTypeCheckMeta} from '../../metadata';
@@ -76,6 +76,11 @@ export interface TypeCheckBlockMetadata {
    * Schemas that apply to this template.
    */
   schemas: SchemaMetadata[];
+
+  /*
+   * A boolean indicating whether the component is standalone.
+   */
+  isStandalone: boolean;
 }
 
 export interface TypeCtorMetadata {

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/context.ts
@@ -36,13 +36,14 @@ export interface TypeCheckContext {
    * template text described by the AST.
    * @param file the `ParseSourceFile` associated with the template.
    * @param parseErrors the `ParseError`'s associated with the template.
+   * @param isStandalone a boolean indicating whether the component is standalone.
    */
   addTemplate(
       ref: Reference<ClassDeclaration<ts.ClassDeclaration>>,
       binder: R3TargetBinder<TypeCheckableDirectiveMeta>, template: TmplAstNode[],
       pipes: Map<string, Reference<ClassDeclaration<ts.ClassDeclaration>>>,
       schemas: SchemaMetadata[], sourceMapping: TemplateSourceMapping, file: ParseSourceFile,
-      parseErrors: ParseError[]|null): void;
+      parseErrors: ParseError[]|null, isStandalone: boolean): void;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -210,7 +210,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
       binder: R3TargetBinder<TypeCheckableDirectiveMeta>, template: TmplAstNode[],
       pipes: Map<string, Reference<ClassDeclaration<ts.ClassDeclaration>>>,
       schemas: SchemaMetadata[], sourceMapping: TemplateSourceMapping, file: ParseSourceFile,
-      parseErrors: ParseError[]|null): void {
+      parseErrors: ParseError[]|null, isStandalone: boolean): void {
     if (!this.host.shouldCheckComponent(ref.node)) {
       return;
     }
@@ -286,6 +286,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
       boundTarget,
       pipes,
       schemas,
+      isStandalone
     };
     this.perf.eventCount(PerfEvent.GenerateTcb);
     if (inliningRequirement !== TcbInliningRequirement.None &&

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/dom.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/dom.ts
@@ -41,8 +41,12 @@ export interface DomSchemaChecker {
    * @param element the element node in question.
    * @param schemas any active schemas for the template, which might affect the validity of the
    * element.
+   * @param hostIsStandalone boolean indicating whether the element's host is a standalone
+   *     component.
    */
-  checkElement(id: string, element: TmplAstElement, schemas: SchemaMetadata[]): void;
+  checkElement(
+      id: string, element: TmplAstElement, schemas: SchemaMetadata[],
+      hostIsStandalone: boolean): void;
 
   /**
    * Check a property binding on an element and record any diagnostics about it.
@@ -73,7 +77,9 @@ export class RegistryDomSchemaChecker implements DomSchemaChecker {
 
   constructor(private resolver: TemplateSourceResolver) {}
 
-  checkElement(id: TemplateId, element: TmplAstElement, schemas: SchemaMetadata[]): void {
+  checkElement(
+      id: TemplateId, element: TmplAstElement, schemas: SchemaMetadata[],
+      hostIsStandalone: boolean): void {
     // HTML elements inside an SVG `foreignObject` are declared in the `xhtml` namespace.
     // We need to strip it before handing it over to the registry because all HTML tag names
     // in the registry are without a namespace.
@@ -82,15 +88,17 @@ export class RegistryDomSchemaChecker implements DomSchemaChecker {
     if (!REGISTRY.hasElement(name, schemas)) {
       const mapping = this.resolver.getSourceMapping(id);
 
+      const schemas = `'${hostIsStandalone ? '@Component' : '@NgModule'}.schemas'`;
       let errorMsg = `'${name}' is not a known element:\n`;
-      errorMsg +=
-          `1. If '${name}' is an Angular component, then verify that it is part of this module.\n`;
+      errorMsg += `1. If '${name}' is an Angular component, then verify that it is ${
+          hostIsStandalone ? 'included in the \'@Component.imports\' of this component' :
+                             'part of this module'}.\n`;
       if (name.indexOf('-') > -1) {
-        errorMsg += `2. If '${
-            name}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.`;
+        errorMsg += `2. If '${name}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the ${
+            schemas} of this component to suppress this message.`;
       } else {
         errorMsg +=
-            `2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`;
+            `2. To allow any element add 'NO_ERRORS_SCHEMA' to the ${schemas} of this component.`;
       }
 
       const diag = makeTemplateDiagnostic(

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -83,7 +83,8 @@ export function generateTypeCheckBlock(
     oobRecorder: OutOfBandDiagnosticRecorder,
     genericContextBehavior: TcbGenericContextBehavior): ts.FunctionDeclaration {
   const tcb = new Context(
-      env, domSchemaChecker, oobRecorder, meta.id, meta.boundTarget, meta.pipes, meta.schemas);
+      env, domSchemaChecker, oobRecorder, meta.id, meta.boundTarget, meta.pipes, meta.schemas,
+      meta.isStandalone);
   const scope = Scope.forNodes(tcb, null, tcb.boundTarget.target.template!, /* guard */ null);
   const ctxRawType = env.referenceType(ref);
   if (!ts.isTypeReferenceNode(ctxRawType)) {
@@ -849,7 +850,8 @@ class TcbDomSchemaCheckerOp extends TcbOp {
 
   override execute(): ts.Expression|null {
     if (this.checkElement) {
-      this.tcb.domSchemaChecker.checkElement(this.tcb.id, this.element, this.tcb.schemas);
+      this.tcb.domSchemaChecker.checkElement(
+          this.tcb.id, this.element, this.tcb.schemas, this.tcb.hostIsStandalone);
     }
 
     // TODO(alxhub): this could be more efficient.
@@ -1144,7 +1146,7 @@ export class Context {
       readonly oobRecorder: OutOfBandDiagnosticRecorder, readonly id: TemplateId,
       readonly boundTarget: BoundTarget<TypeCheckableDirectiveMeta>,
       private pipes: Map<string, Reference<ClassDeclaration<ts.ClassDeclaration>>>,
-      readonly schemas: SchemaMetadata[]) {}
+      readonly schemas: SchemaMetadata[], readonly hostIsStandalone: boolean) {}
 
   /**
    * Allocate a new variable name for use within the `Context`.

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -281,7 +281,7 @@ export function tcb(
   const boundTarget = binder.bind({template: nodes});
 
   const id = 'tcb' as TemplateId;
-  const meta: TypeCheckBlockMetadata = {id, boundTarget, pipes, schemas: []};
+  const meta: TypeCheckBlockMetadata = {id, boundTarget, pipes, schemas: [], isStandalone: false};
 
   const fullConfig: TypeCheckingConfig = {
     applyTemplateContextGuards: true,
@@ -483,7 +483,8 @@ export function setup(targets: TypeCheckingTarget[], overrides: {
           node: classRef.node.name,
         };
 
-        ctx.addTemplate(classRef, binder, nodes, pipes, [], sourceMapping, templateFile, errors);
+        ctx.addTemplate(
+            classRef, binder, nodes, pipes, [], sourceMapping, templateFile, errors, false);
       }
     }
   });
@@ -713,7 +714,9 @@ export class NoopSchemaChecker implements DomSchemaChecker {
     return [];
   }
 
-  checkElement(id: string, element: TmplAstElement, schemas: SchemaMetadata[]): void {}
+  checkElement(
+      id: string, element: TmplAstElement, schemas: SchemaMetadata[],
+      hostIsStandalone: boolean): void {}
   checkProperty(
       id: string, element: TmplAstElement, name: string, span: ParseSourceSpan,
       schemas: SchemaMetadata[]): void {}

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -2096,6 +2096,27 @@ export declare class AnimationEvent {
 2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`);
       });
 
+      it('should check for unknown elements in standalone components', () => {
+        env.write('test.ts', `
+        import {Component, NgModule} from '@angular/core';
+        @Component({
+          selector: 'blah',
+          template: '<foo>test</foo>',
+          standalone: true,
+        })
+        export class FooCmp {}
+        @NgModule({
+          imports: [FooCmp],
+        })
+        export class FooModule {}
+      `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText).toBe(`'foo' is not a known element:
+1. If 'foo' is an Angular component, then verify that it is included in the '@Component.imports' of this component.
+2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@Component.schemas' of this component.`);
+      });
+
       it('should have a descriptive error for unknown elements that contain a dash', () => {
         env.write('test.ts', `
         import {Component, NgModule} from '@angular/core';
@@ -2115,6 +2136,28 @@ export declare class AnimationEvent {
 1. If 'my-foo' is an Angular component, then verify that it is part of this module.
 2. If 'my-foo' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.`);
       });
+
+      it('should have a descriptive error for unknown elements that contain a dash in standalone components',
+         () => {
+           env.write('test.ts', `
+        import {Component, NgModule} from '@angular/core';
+        @Component({
+          selector: 'blah',
+          template: '<my-foo>test</my-foo>',
+          standalone: true,
+        })
+        export class FooCmp {}
+        @NgModule({
+          imports: [FooCmp],
+        })
+        export class FooModule {}
+      `);
+           const diags = env.driveDiagnostics();
+           expect(diags.length).toBe(1);
+           expect(diags[0].messageText).toBe(`'my-foo' is not a known element:
+1. If 'my-foo' is an Angular component, then verify that it is included in the '@Component.imports' of this component.
+2. If 'my-foo' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@Component.schemas' of this component to suppress this message.`);
+         });
 
       it('should check for unknown properties', () => {
         env.write('test.ts', `


### PR DESCRIPTION
update the error message presented during aot compilation when an unrecognized
tag/element is found in a standalone component so that it does not mention
the ngModule anymore

Note: the jit variant is present in PR #45920

resolves #45818

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (or bugfix maybe)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: #45818


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Result:
![AOT](https://user-images.githubusercontent.com/61631103/167289278-a4611d84-53d0-49d0-bc50-5a7fb9ee6e86.png)

