### PR TITLE
fix(core): update unknown tag error for jit standalone components

### DIFF
--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -7,17 +7,15 @@
  */
 
 import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../../errors';
-import {Type} from '../../interface/type';
 import {SchemaMetadata} from '../../metadata/schema';
 import {assertDefined, assertEqual, assertIndexInRange} from '../../util/assert';
 import {assertFirstCreatePass, assertHasParent} from '../assert';
 import {attachPatchData} from '../context_discovery';
-import {getComponentDef} from '../definition';
 import {registerPostOrderHooks} from '../hooks';
 import {hasClassInput, hasStyleInput, TAttributes, TElementNode, TNodeFlags, TNodeType} from '../interfaces/node';
 import {RElement} from '../interfaces/renderer_dom';
 import {isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
-import {CONTEXT, DECLARATION_COMPONENT_VIEW, HEADER_OFFSET, LView, RENDERER, TView} from '../interfaces/view';
+import {HEADER_OFFSET, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
 import {appendChild, createElementNode, writeDirectClass, writeDirectStyle} from '../node_manipulation';
 import {decreaseElementDepthCount, getBindingIndex, getCurrentTNode, getElementDepthCount, getLView, getNamespace, getTView, increaseElementDepthCount, isCurrentTNodeParent, setCurrentTNode, setCurrentTNodeAsNotParent} from '../state';
@@ -26,7 +24,7 @@ import {setUpAttributes} from '../util/attrs_utils';
 import {getConstant} from '../util/view_utils';
 
 import {setDirectiveInputsWhichShadowsStyling} from './property';
-import {createDirectivesInstances, executeContentQueries, getOrCreateTNode, matchingSchemas, resolveDirectives, saveResolvedLocalsInData} from './shared';
+import {createDirectivesInstances, executeContentQueries, getOrCreateTNode, isHostComponentStandalone, matchingSchemas, resolveDirectives, saveResolvedLocalsInData} from './shared';
 
 let shouldThrowErrorOnUnknownElement = false;
 
@@ -60,10 +58,7 @@ function elementStartFirstCreatePass(
     const hasDirectives =
         resolveDirectives(tView, lView, tNode, getConstant<string[]>(tViewConsts, localRefsIndex));
 
-    const declarationLView = lView[DECLARATION_COMPONENT_VIEW] as LView<Type<unknown>>;
-    const context = declarationLView[CONTEXT];
-    const def = getComponentDef(context.constructor);
-    const hostIsStandalone = !!(def?.standalone);
+    const hostIsStandalone = isHostComponentStandalone(lView);
 
     validateElementIsKnown(native, tNode.value, tView.schemas, hasDirectives, hostIsStandalone);
   }

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -57,9 +57,7 @@ function elementStartFirstCreatePass(
   if (ngDevMode) {
     const hasDirectives =
         resolveDirectives(tView, lView, tNode, getConstant<string[]>(tViewConsts, localRefsIndex));
-
     const hostIsStandalone = isHostComponentStandalone(lView);
-
     validateElementIsKnown(native, tNode.value, tView.schemas, hasDirectives, hostIsStandalone);
   }
 

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -54,9 +54,9 @@ function elementStartFirstCreatePass(
   const attrs = getConstant<TAttributes>(tViewConsts, attrsIndex);
   const tNode = getOrCreateTNode(tView, index, TNodeType.Element, name, attrs);
 
+  const hasDirectives =
+      resolveDirectives(tView, lView, tNode, getConstant<string[]>(tViewConsts, localRefsIndex));
   if (ngDevMode) {
-    const hasDirectives =
-        resolveDirectives(tView, lView, tNode, getConstant<string[]>(tViewConsts, localRefsIndex));
     const hostIsStandalone = isHostComponentStandalone(lView);
     validateElementIsKnown(native, tNode.value, tView.schemas, hasDirectives, hostIsStandalone);
   }

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -9,16 +9,18 @@ import {Injector} from '../../di';
 import {ErrorHandler} from '../../error_handler';
 import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../../errors';
 import {DoCheck, OnChanges, OnInit} from '../../interface/lifecycle_hooks';
+import {Type} from '../../interface/type';
 import {CUSTOM_ELEMENTS_SCHEMA, NO_ERRORS_SCHEMA, SchemaMetadata} from '../../metadata/schema';
 import {ViewEncapsulation} from '../../metadata/view';
 import {validateAgainstEventAttributes, validateAgainstEventProperties} from '../../sanitization/sanitization';
 import {Sanitizer} from '../../sanitization/sanitizer';
-import {assertDefined, assertDomNode, assertEqual, assertGreaterThanOrEqual, assertIndexInRange, assertNotEqual, assertNotSame, assertSame, assertString} from '../../util/assert';
+import {assertDefined, assertDomNode, assertEqual, assertGreaterThanOrEqual, assertIndexInRange, assertNotEqual, assertNotSame, assertSame, assertString, throwError} from '../../util/assert';
 import {escapeCommentText} from '../../util/dom';
 import {normalizeDebugBindingName, normalizeDebugBindingValue} from '../../util/ng_reflect';
 import {stringify} from '../../util/stringify';
 import {assertFirstCreatePass, assertFirstUpdatePass, assertLContainer, assertLView, assertTNodeForLView, assertTNodeForTView} from '../assert';
 import {attachPatchData, readPatchedLView} from '../context_discovery';
+import {getComponentDef} from '../definition';
 import {getFactoryDef} from '../definition_factory';
 import {diPublicInInjector, getNodeInjectable, getOrCreateNodeInjectorForNode} from '../di';
 import {throwMultipleComponentError} from '../errors';
@@ -266,6 +268,20 @@ export function createTNodeAtIndex(
   return tNode;
 }
 
+/**
+ * Checks if the component of a given view is a standalone one or not.
+ *
+ * @param lView The `LView` containing the view's data
+ * @returns `true` if the component owning this view is a standalone one, `false` otherwise
+ */
+export function isHostComponentStandalone(lView: LView): boolean {
+  !ngDevMode && throwError('Must never be called in production mode');
+
+  const declarationLView = lView[DECLARATION_COMPONENT_VIEW] as LView<Type<unknown>>;
+  const context = declarationLView[CONTEXT];
+  const def = getComponentDef(context.constructor);
+  return !!(def?.standalone);
+}
 
 /**
  * When elements are created dynamically after a view blueprint is created (e.g. through

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -269,18 +269,17 @@ export function createTNodeAtIndex(
 }
 
 /**
- * Checks if the component of a given view is a standalone one or not.
+ * Checks if the current component is declared inside of a standalone component template.
  *
- * @param lView The `LView` containing the view's data
- * @returns `true` if the component owning this view is a standalone one, `false` otherwise
+ * @param lView An `LView` that represents a current component that is being rendered.
  */
 export function isHostComponentStandalone(lView: LView): boolean {
   !ngDevMode && throwError('Must never be called in production mode');
 
   const declarationLView = lView[DECLARATION_COMPONENT_VIEW] as LView<Type<unknown>>;
   const context = declarationLView[CONTEXT];
-  const def = getComponentDef(context.constructor);
-  return !!(def?.standalone);
+  const componentDef = getComponentDef(context.constructor);
+  return !!(componentDef?.standalone);
 }
 
 /**

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -278,6 +278,10 @@ export function isHostComponentStandalone(lView: LView): boolean {
 
   const declarationLView = lView[DECLARATION_COMPONENT_VIEW] as LView<Type<unknown>>;
   const context = declarationLView[CONTEXT];
+
+  // Unable to obtain a context, fall back to the non-standalone scenario.
+  if (!context) return false;
+
   const componentDef = getComponentDef(context.constructor);
   return !!(componentDef?.standalone);
 }

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -631,15 +631,14 @@ describe('standalone components, directives and pipes', () => {
   });
 
   describe('unknown template elements', () => {
-    const unknownElErrorRegex =
-        (tag: string) => {
-          const prefix = `'${tag}' is not a known element:`;
-          const message1 = `1. If '${
-              tag}' is an Angular component, then verify that it is included in the '@Component.imports' of this component.`;
-          const message2 = `2. If '${
-              tag}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@Component.schemas' of this component to suppress this message.`;
-          return new RegExp(`${prefix}\s*\n\s*${message1}\s*\n\s*${message2}`);
-        }
+    const unknownElErrorRegex = (tag: string) => {
+      const prefix = `'${tag}' is not a known element:`;
+      const message1 = `1. If '${
+          tag}' is an Angular component, then verify that it is included in the '@Component.imports' of this component.`;
+      const message2 = `2. If '${
+          tag}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@Component.schemas' of this component to suppress this message.`;
+      return new RegExp(`${prefix}\s*\n\s*${message1}\s*\n\s*${message2}`);
+    };
 
     it('should warn the user when an unknown element is present', () => {
       const spy = spyOn(console, 'error');

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -630,6 +630,84 @@ describe('standalone components, directives and pipes', () => {
     });
   });
 
+  describe('unknown template elements', () => {
+    const unknownElErrorRegex =
+        (tag: string) => {
+          const prefix = `'${tag}' is not a known element:`;
+          const message1 = `1. If '${
+              tag}' is an Angular component, then verify that it is included in the '@Component.imports' of this component.`;
+          const message2 = `2. If '${
+              tag}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@Component.schemas' of this component to suppress this message.`;
+          return new RegExp(`${prefix}\s*\n\s*${message1}\s*\n\s*${message2}`);
+        }
+
+    it('should warn the user when an unknown element is present', () => {
+      const spy = spyOn(console, 'error');
+      @Component({
+        standalone: true,
+        template: '<unknown-tag></unknown-tag>',
+      })
+      class AppCmp {
+      }
+
+      TestBed.createComponent(AppCmp);
+
+      const errorRegex = unknownElErrorRegex('unknown-tag');
+      expect(spy).toHaveBeenCalledOnceWith(jasmine.stringMatching(errorRegex));
+    });
+
+    it('should warn the user when multiple unknown elements are present', () => {
+      const spy = spyOn(console, 'error');
+      @Component({
+        standalone: true,
+        template: '<unknown-tag-A></unknown-tag-A><unknown-tag-B></unknown-tag-B>',
+      })
+      class AppCmp {
+      }
+
+      TestBed.createComponent(AppCmp);
+
+      const errorRegexA = unknownElErrorRegex('unknown-tag-A');
+      const errorRegexB = unknownElErrorRegex('unknown-tag-B');
+
+      expect(spy).toHaveBeenCalledWith(jasmine.stringMatching(errorRegexA));
+      expect(spy).toHaveBeenCalledWith(jasmine.stringMatching(errorRegexB));
+    });
+
+    it('should not warn the user when an unknown element is present inside an ng-template', () => {
+      const spy = spyOn(console, 'error');
+      @Component({
+        standalone: true,
+        template: '<ng-template><unknown-tag></unknown-tag><ng-template>',
+      })
+      class AppCmp {
+      }
+
+      TestBed.createComponent(AppCmp);
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('should warn the user when an unknown element is present in an instantiated embedded view',
+       () => {
+         debugger;
+         const spy = spyOn(console, 'error');
+         @Component({
+           standalone: true,
+           template: '<ng-template [ngIf]="true"><unknown-tag></unknown-tag><ng-template>',
+           imports: [CommonModule],
+         })
+         class AppCmp {
+         }
+
+         const fixture = TestBed.createComponent(AppCmp);
+         fixture.detectChanges();
+
+         const errorRegex = unknownElErrorRegex('unknown-tag');
+         expect(spy).toHaveBeenCalledOnceWith(jasmine.stringMatching(errorRegex));
+       });
+  });
+
   /*
     The following test verify that we don't impose limits when it comes to extending components of
     various type (standalone vs. non-standalone).

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -690,7 +690,6 @@ describe('standalone components, directives and pipes', () => {
 
     it('should warn the user when an unknown element is present in an instantiated embedded view',
        () => {
-         debugger;
          const spy = spyOn(console, 'error');
          @Component({
            standalone: true,


### PR DESCRIPTION
update the error message presented during jit compilation when an unrecognized
tag/element is found in a standalone component so that it does not mention
the ngModule anymore

Note: the aot variant is present in PR #45919

resolves #45818

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature (may be a bugfix)
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: #45818


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

Result:
![JIT](https://user-images.githubusercontent.com/61631103/167289309-4dbf2835-6609-45bc-b712-8824dfc844c2.png)

