### PR TITLE
refactor(common): mark experimental `NgOptimizedImage` directive as standalone

### DIFF
--- a/packages/common/src/directives/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image.ts
@@ -59,7 +59,10 @@ export const IMAGE_LOADER = new InjectionToken<ImageLoader>('ImageLoader', {
  * @usageNotes
  * TODO: add Image directive usage notes.
  */
-@Directive({selector: 'img[rawSrc]'})
+@Directive({
+  standalone: true,
+  selector: 'img[rawSrc]',
+})
 export class NgOptimizedImage implements OnInit {
   constructor(
       @Inject(IMAGE_LOADER) private imageLoader: ImageLoader, private renderer: Renderer2,
@@ -151,17 +154,6 @@ export class NgOptimizedImage implements OnInit {
   private setHostAttribute(name: string, value: string): void {
     this.renderer.setAttribute(this.imgElement.nativeElement, name, value);
   }
-}
-
-/**
- * Temporary NgModule that exports the NgOptimizedImage directive.
- * The module should not be needed once the `standalone` flag is supported as a public API.
- */
-@NgModule({
-  declarations: [NgOptimizedImage],
-  exports: [NgOptimizedImage],
-})
-export class NgOptimizedImageModule {
 }
 
 /***** Helpers *****/

--- a/packages/common/src/private_export.ts
+++ b/packages/common/src/private_export.ts
@@ -6,6 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {IMAGE_LOADER as ɵIMAGE_LOADER, NgOptimizedImage as ɵNgOptimizedImage, NgOptimizedImageModule as ɵNgOptimizedImageModule} from './directives/ng_optimized_image';
+export {IMAGE_LOADER as ɵIMAGE_LOADER, NgOptimizedImage as ɵNgOptimizedImage} from './directives/ng_optimized_image';
 export {DomAdapter as ɵDomAdapter, getDOM as ɵgetDOM, setRootDomAdapter as ɵsetRootDomAdapter} from './dom_adapter';
 export {BrowserPlatformLocation as ɵBrowserPlatformLocation} from './location/platform_location';

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -217,10 +217,10 @@ function setupTestingModule(config?: {imageLoader: ImageLoader}) {
   const providers =
       config?.imageLoader ? [{provide: IMAGE_LOADER, useValue: config?.imageLoader}] : [];
   TestBed.configureTestingModule({
-    // Note: the `NgOptimizedImage` is a part of declarations for now,
-    // since it's experimental and not yet added to the `CommonModule`.
-    declarations: [TestComponent, NgOptimizedImage],
-    imports: [CommonModule],
+    declarations: [TestComponent],
+    // Note: the `NgOptimizedImage` directive is experimental and is not a part of the
+    // `CommonModule` yet, so it's imported separately.
+    imports: [CommonModule, NgOptimizedImage],
     providers,
   });
 }

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImageModule as NgOptimizedImageModule} from '@angular/common';
+import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImage as NgOptimizedImage} from '@angular/common';
 import {Component, NgModule} from '@angular/core';
 import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 
@@ -21,7 +21,7 @@ class RootComponent {
 
 @NgModule({
   declarations: [RootComponent],
-  imports: [BrowserModule, NgOptimizedImageModule],
+  imports: [BrowserModule, NgOptimizedImage],
   bootstrap: [RootComponent],
   providers: [{provide: IMAGE_LOADER, useValue: () => 'b.png'}],
 })


### PR DESCRIPTION
This commit updates the `NgOptimizedImage` directive as standalone, so it's easier to import it in
 an app (without importing any NgModules).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No