### PR TITLE
ci: disable `aio_preview` CircleCI job temporarily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,14 +785,17 @@ workflows:
       - test_docs_examples:
           requires:
             - build-npm-packages
-      - aio_preview:
-          # Only run on PR builds. (There can be no previews for non-PR builds.)
-          <<: *only_on_pull_requests
-          requires:
-            - setup
-      - test_aio_preview:
-          requires:
-            - aio_preview
+      # NOTE: the following CI jobs are currently disabled due to CircleCI API changes
+      #       and the jobs will be enabled again once the code is fully compatible.
+      #       More info is available here: https://github.com/angular/angular/issues/45931
+      #- aio_preview:
+      #    # Only run on PR builds. (There can be no previews for non-PR builds.)
+      #    <<: *only_on_pull_requests
+      #    requires:
+      #      - setup
+      #- test_aio_preview:
+      #    requires:
+      #      - aio_preview
       - publish_packages_as_artifacts:
           requires:
             - build-npm-packages


### PR DESCRIPTION
This commit disables the `aio_preview` CircleCI job temporarily, since it's failing after switching to CircleCI API v2. It will be enabled back once the code is updated. More info can be found here: https://github.com/angular/angular/issues/45931

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No