### PR TITLE
ci: enable the `aio_preview` CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -785,17 +785,14 @@ workflows:
       - test_docs_examples:
           requires:
             - build-npm-packages
-      # NOTE: the following CI jobs are currently disabled due to CircleCI API changes
-      #       and the jobs will be enabled again once the code is fully compatible.
-      #       More info is available here: https://github.com/angular/angular/issues/45931
-      #- aio_preview:
-      #    # Only run on PR builds. (There can be no previews for non-PR builds.)
-      #    <<: *only_on_pull_requests
-      #    requires:
-      #      - setup
-      #- test_aio_preview:
-      #    requires:
-      #      - aio_preview
+      - aio_preview:
+          # Only run on PR builds. (There can be no previews for non-PR builds.)
+          <<: *only_on_pull_requests
+          requires:
+            - setup
+      - test_aio_preview:
+          requires:
+            - aio_preview
       - publish_packages_as_artifacts:
           requires:
             - build-npm-packages


### PR DESCRIPTION
This reverts commit dbc0dababae6a4a8aa9c5e628f93cd8745fd285f, since the fix has landed in https://github.com/angular/angular/commit/c4340970c7a6419eee28804c9b82254dbcf59315.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No