### PR TITLE
[13.3] perf(core): allow `checkNoChanges` mode to be tree-shaken in production

### DIFF
--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -104,7 +104,7 @@ export abstract class ChangeDetectorRef {
    * Checks the change detector and its children, and throws if any changes are detected.
    *
    * Use in development mode to verify that running change detection doesn't introduce
-   * other changes.
+   * other changes. Calling it in production mode is a noop.
    */
   abstract checkNoChanges(): void;
 

--- a/packages/core/src/render3/instructions/advance.ts
+++ b/packages/core/src/render3/instructions/advance.ts
@@ -37,7 +37,8 @@ import {getLView, getSelectedIndex, getTView, isInCheckNoChangesMode, setSelecte
  */
 export function ɵɵadvance(delta: number): void {
   ngDevMode && assertGreaterThan(delta, 0, 'Can only advance forward');
-  selectIndexInternal(getTView(), getLView(), getSelectedIndex() + delta, isInCheckNoChangesMode());
+  selectIndexInternal(
+      getTView(), getLView(), getSelectedIndex() + delta, !!ngDevMode && isInCheckNoChangesMode());
 }
 
 export function selectIndexInternal(

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -360,7 +360,7 @@ export function refreshView<T>(
   enterView(lView);
   // Check no changes mode is a dev only mode used to verify that bindings have not changed
   // since they were assigned. We do not want to execute lifecycle hooks in that mode.
-  const isInCheckNoChangesPass = isInCheckNoChangesMode();
+  const isInCheckNoChangesPass = ngDevMode && isInCheckNoChangesMode();
   try {
     resetPreOrderHookFlags(lView);
 
@@ -481,10 +481,14 @@ export function refreshView<T>(
 export function renderComponentOrTemplate<T>(
     tView: TView, lView: LView, templateFn: ComponentTemplate<{}>|null, context: T) {
   const rendererFactory = lView[RENDERER_FACTORY];
-  const normalExecutionPath = !isInCheckNoChangesMode();
+
+  // Check no changes mode is a dev only mode used to verify that bindings have not changed
+  // since they were assigned. We do not want to invoke renderer factory functions in that mode
+  // to avoid any possible side-effects.
+  const checkNoChangesMode = !!ngDevMode && isInCheckNoChangesMode();
   const creationModeIsActive = isCreationMode(lView);
   try {
-    if (normalExecutionPath && !creationModeIsActive && rendererFactory.begin) {
+    if (!checkNoChangesMode && !creationModeIsActive && rendererFactory.begin) {
       rendererFactory.begin();
     }
     if (creationModeIsActive) {
@@ -492,7 +496,7 @@ export function renderComponentOrTemplate<T>(
     }
     refreshView(tView, lView, templateFn, context);
   } finally {
-    if (normalExecutionPath && !creationModeIsActive && rendererFactory.end) {
+    if (!checkNoChangesMode && !creationModeIsActive && rendererFactory.end) {
       rendererFactory.end();
     }
   }
@@ -507,7 +511,7 @@ function executeTemplate<T>(
     if (isUpdatePhase && lView.length > HEADER_OFFSET) {
       // When we're updating, inherently select 0 so we don't
       // have to generate that instruction for most update blocks.
-      selectIndexInternal(tView, lView, HEADER_OFFSET, isInCheckNoChangesMode());
+      selectIndexInternal(tView, lView, HEADER_OFFSET, !!ngDevMode && isInCheckNoChangesMode());
     }
 
     const preHookType =

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -7,7 +7,7 @@
  */
 
 import {InjectFlags} from '../di/interface/injector';
-import {assertDefined, assertEqual, assertGreaterThanOrEqual, assertLessThan, assertNotEqual} from '../util/assert';
+import {assertDefined, assertEqual, assertGreaterThanOrEqual, assertLessThan, assertNotEqual, throwError} from '../util/assert';
 
 import {assertLViewOrUndefined, assertTNodeForLView, assertTNodeForTView} from './assert';
 import {DirectiveDef} from './interfaces/definition';
@@ -172,23 +172,22 @@ interface InstructionState {
    * ```
    */
   bindingsEnabled: boolean;
-
-  /**
-   * In this mode, any changes in bindings will throw an ExpressionChangedAfterChecked error.
-   *
-   * Necessary to support ChangeDetectorRef.checkNoChanges().
-   *
-   * checkNoChanges Runs only in devmode=true and verifies that no unintended changes exist in
-   * the change detector or its children.
-   */
-  isInCheckNoChangesMode: boolean;
 }
 
 const instructionState: InstructionState = {
   lFrame: createLFrame(null),
   bindingsEnabled: true,
-  isInCheckNoChangesMode: false,
 };
+
+/**
+ * In this mode, any changes in bindings will throw an ExpressionChangedAfterChecked error.
+ *
+ * Necessary to support ChangeDetectorRef.checkNoChanges().
+ *
+ * The `checkNoChanges` function is invoked only in ngDevMode=true and verifies that no unintended
+ * changes exist in the change detector or its children.
+ */
+let _isInCheckNoChangesMode = false;
 
 /**
  * Returns true if the instruction state stack is empty.
@@ -336,12 +335,13 @@ export function getContextLView(): LView {
 }
 
 export function isInCheckNoChangesMode(): boolean {
-  // TODO(misko): remove this from the LView since it is ngDevMode=true mode only.
-  return instructionState.isInCheckNoChangesMode;
+  !ngDevMode && throwError('Must never be called in production mode');
+  return _isInCheckNoChangesMode;
 }
 
 export function setIsInCheckNoChangesMode(mode: boolean): void {
-  instructionState.isInCheckNoChangesMode = mode;
+  !ngDevMode && throwError('Must never be called in production mode');
+  _isInCheckNoChangesMode = mode;
 }
 
 // top level variables should not be exported for performance reasons (PERF_NOTES.md)

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -281,7 +281,9 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
    * introduce other changes.
    */
   checkNoChanges(): void {
-    checkNoChangesInternal(this._lView[TVIEW], this._lView, this.context);
+    if (ngDevMode) {
+      checkNoChangesInternal(this._lView[TVIEW], this._lView, this.context);
+    }
   }
 
   attachToViewContainerRef() {
@@ -318,7 +320,9 @@ export class RootViewRef<T> extends ViewRef<T> {
   }
 
   override checkNoChanges(): void {
-    checkNoChangesInRootView(this._view);
+    if (ngDevMode) {
+      checkNoChangesInRootView(this._view);
+    }
   }
 
   override get context(): T {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -717,12 +717,6 @@
     "name": "detachMovedView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "diPublicInInjector"
   },
   {
@@ -997,9 +991,6 @@
   },
   {
     "name": "isFunction"
-  },
-  {
-    "name": "isInCheckNoChangesMode"
   },
   {
     "name": "isInlineTemplate"
@@ -1285,9 +1276,6 @@
   },
   {
     "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -243,9 +243,6 @@
     "name": "isCurrentTNodeParent"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -738,12 +738,6 @@
     "name": "detachView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "diPublicInInjector"
   },
   {
@@ -1110,9 +1104,6 @@
     "name": "isFunction"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {
@@ -1435,9 +1426,6 @@
   },
   {
     "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -717,12 +717,6 @@
     "name": "detachView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "diPublicInInjector"
   },
   {
@@ -1074,9 +1068,6 @@
     "name": "isFunction"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {
@@ -1417,9 +1408,6 @@
   },
   {
     "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -174,9 +174,6 @@
     "name": "invertObject"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isProceduralRenderer"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -993,12 +993,6 @@
     "name": "detachView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "diPublicInInjector"
   },
   {
@@ -1416,9 +1410,6 @@
     "name": "isImmediateMatch"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {
@@ -1759,9 +1750,6 @@
   },
   {
     "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setRouterState"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -306,12 +306,6 @@
     "name": "detachView"
   },
   {
-    "name": "detectChangesInRootView"
-  },
-  {
-    "name": "detectChangesInternal"
-  },
-  {
     "name": "diPublicInInjector"
   },
   {
@@ -549,9 +543,6 @@
     "name": "isDirectiveHost"
   },
   {
-    "name": "isInCheckNoChangesMode"
-  },
-  {
     "name": "isInlineTemplate"
   },
   {
@@ -745,9 +736,6 @@
   },
   {
     "name": "setInputsFromAttrs"
-  },
-  {
-    "name": "setIsInCheckNoChangesMode"
   },
   {
     "name": "setSelectedIndex"


### PR DESCRIPTION
Cherry-pick of #45913 for 13.3.x branch