### PR TITLE
refactor(docs-infra): reimplement aio-select using mat-select

### DIFF
--- a/aio/src/app/custom-elements/api/api-list.component.spec.ts
+++ b/aio/src/app/custom-elements/api/api-list.component.spec.ts
@@ -7,6 +7,7 @@ import { LocationService } from 'app/shared/location.service';
 import { Logger } from 'app/shared/logger.service';
 import { MockLogger } from 'testing/logger.service';
 import { ApiListModule } from './api-list.module';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('ApiListComponent', () => {
   let component: ApiListComponent;
@@ -15,7 +16,7 @@ describe('ApiListComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [ ApiListModule ],
+      imports: [ ApiListModule, NoopAnimationsModule ],
       providers: [
         { provide: ApiService, useClass: TestApiService },
         { provide: Logger, useClass: MockLogger },

--- a/aio/src/app/shared/select/select.component.html
+++ b/aio/src/app/shared/select/select.component.html
@@ -1,16 +1,11 @@
-<div class="form-select-menu">
-  <button class="form-select-button" (click)="toggleOptions()" [disabled]="disabled">
-    <span><strong>{{label}}</strong></span><span *ngIf="showSymbol" class="symbol {{selected?.value}}"></span><span>{{selected?.title}}</span>
-  </button>
-  <ul class="form-select-dropdown" *ngIf="showOptions">
-    <li *ngFor="let option of options; index as i"
-        [class.selected]="option === selected"
-        role="button"
-        tabindex="0"
-        (click)="select(option, i)"
-        (keydown.enter)="select(option, i)"
-        (keydown.space)="select(option, i); $event.preventDefault()">
+<mat-form-field>
+  <mat-label>{{label}}</mat-label>
+  <mat-select [disabled]="disabled" [(value)]="selectedIdx" (valueChange)="select($event)">
+    <mat-select-trigger>
+      <span *ngIf="showSymbol" class="symbol {{selected?.value}}"></span><span>{{selected?.title}}</span>
+    </mat-select-trigger>
+    <mat-option *ngFor="let option of options; index as i" [value]="i">
       <span *ngIf="showSymbol" class="symbol {{option.value}}"></span><span>{{option.title}}</span>
-    </li>
-  </ul>
-</div>
+    </mat-option>
+  </mat-select>
+</mat-form-field>

--- a/aio/src/app/shared/select/select.component.spec.ts
+++ b/aio/src/app/shared/select/select.component.spec.ts
@@ -1,189 +1,63 @@
-import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { By } from '@angular/platform-browser';
-import { SelectComponent, Option } from './select.component';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+import { SelectComponent } from './select.component';
+import {TestbedHarnessEnvironment} from '@angular/cdk/testing/testbed';
+import { HarnessLoader } from '@angular/cdk/testing';
+
+import { MatSelectHarness } from '@angular/material/select/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MatFormFieldHarness } from "@angular/material/form-field/testing";
 
 const options = [
   { title: 'Option A', value: 'option-a' },
   { title: 'Option B', value: 'option-b' }
 ];
 
-let host: HostComponent;
-let fixture: ComponentFixture<HostComponent>;
-let element: DebugElement;
+let component: SelectComponent;
+let fixture: ComponentFixture<SelectComponent>;
 
 describe('SelectComponent', () => {
+  let loader: HarnessLoader;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ SelectComponent, HostComponent ],
+      declarations: [SelectComponent],
+      imports: [MatSelectModule, MatFormFieldModule, NoopAnimationsModule],
     });
   });
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(HostComponent);
-    host = fixture.componentInstance;
-    element = fixture.debugElement.query(By.directive(SelectComponent));
+    fixture = TestBed.createComponent(SelectComponent);
+    loader = TestbedHarnessEnvironment.loader(fixture);
+    component = fixture.componentInstance;
   });
 
-  describe('(initially)', () => {
-    it('should show the button and no options', () => {
-      expect(getButton()).toBeDefined();
-      expect(getOptionContainer()).toEqual(null);
-    });
+  it('should display the label if provided', async () => {
+    const field = await loader.getHarness(MatFormFieldHarness);
+    expect((await field.getLabel())).toEqual('');
+    component.label = 'Label:';
+    fixture.detectChanges();
+    expect((await field.getLabel())).toEqual('Label:');
   });
 
-  describe('button', () => {
-    it('should display the label if provided', () => {
-      expect(getButton().textContent?.trim()).toEqual('');
-      host.label = 'Label:';
-      fixture.detectChanges();
-      expect(getButton().textContent?.trim()).toEqual('Label:');
-    });
+  it('should be disabled if the component is disabled', async () => {
+    component.options = options;
+    fixture.detectChanges();
+    const select = await loader.getHarness(MatSelectHarness);
+    expect(await select.isDisabled()).toBe(false);
 
-    it('should contain a symbol if hasSymbol is true', () => {
-      expect(getButtonSymbol()).toEqual(null);
-      host.showSymbol = true;
-      fixture.detectChanges();
-      expect(getButtonSymbol()).not.toEqual(null);
-    });
-
-    it('should display the selected option, if there is one', () => {
-      host.showSymbol = true;
-      host.selected = options[0];
-      fixture.detectChanges();
-      expect(getButton().textContent).toContain(options[0].title);
-      expect(getButtonSymbol()?.className).toContain(options[0].value);
-    });
-
-    it('should toggle the visibility of the options list when clicked', () => {
-      host.options = options;
-      getButton().click();
-      fixture.detectChanges();
-      expect(getOptionContainer()).not.toEqual(null);
-      getButton().click();
-      fixture.detectChanges();
-      expect(getOptionContainer()).toEqual(null);
-    });
-
-    it('should be disabled if the component is disabled', () => {
-      host.options = options;
-      fixture.detectChanges();
-      expect(getButton().disabled).toBe(false);
-      expect(getButton().getAttribute('disabled')).toBe(null);
-
-      host.disabled = true;
-      fixture.detectChanges();
-      expect(getButton().disabled).toBe(true);
-      expect(getButton().getAttribute('disabled')).toBeDefined();
-    });
-
-    it('should not toggle the visibility of the options list if disabled', () => {
-      host.options = options;
-      host.disabled = true;
-
-      fixture.detectChanges();
-      getButton().click();
-      fixture.detectChanges();
-      expect(getOptionContainer()).toEqual(null);
-    });
+    component.disabled = true;
+    fixture.detectChanges();
+    expect(await select.isDisabled()).toBe(true);
   });
 
-  describe('options list', () => {
-    beforeEach(() => {
-      host.options = options;
-      host.showSymbol = true;
-      getButton().click(); // ensure the options are visible
-      fixture.detectChanges();
-    });
-
-    it('should show the corresponding title of each option', () => {
-      getOptions().forEach((li, index) => {
-        expect(li.textContent).toContain(options[index].title);
-      });
-    });
-
-    it('should select the option that is clicked', () => {
-      getOptions()[0].click();
-      fixture.detectChanges();
-      expect(host.onChange).toHaveBeenCalledWith({ option: options[0], index: 0 });
-      expect(getButton().textContent).toContain(options[0].title);
-      expect(getButtonSymbol()?.className).toContain(options[0].value);
-    });
-
-    it('should select the current option when enter is pressed', () => {
-      const e = new KeyboardEvent('keydown', {bubbles: true, cancelable: true, key: 'Enter'});
-      getOptions()[0].dispatchEvent(e);
-      fixture.detectChanges();
-      expect(host.onChange).toHaveBeenCalledWith({ option: options[0], index: 0 });
-      expect(getButton().textContent).toContain(options[0].title);
-      expect(getButtonSymbol()?.className).toContain(options[0].value);
-    });
-
-    it('should select the current option when space is pressed', () => {
-      const e = new KeyboardEvent('keydown', {bubbles: true, cancelable: true, key: ' '});
-      getOptions()[0].dispatchEvent(e);
-      fixture.detectChanges();
-      expect(host.onChange).toHaveBeenCalledWith({ option: options[0], index: 0 });
-      expect(getButton().textContent).toContain(options[0].title);
-      expect(getButtonSymbol()?.className).toContain(options[0].value);
-    });
-
-    it('should hide when an option is clicked', () => {
-      getOptions()[0].click();
-      fixture.detectChanges();
-      expect(getOptionContainer()).toEqual(null);
-    });
-
-    it('should hide when there is a click that is not on the option list', () => {
-      fixture.nativeElement.click();
-      fixture.detectChanges();
-      expect(getOptionContainer()).toEqual(null);
-    });
-
-    it('should hide if the escape button is pressed', () => {
-      const e = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, key: 'Escape' });
-      document.dispatchEvent(e);
-      fixture.detectChanges();
-      expect(getOptionContainer()).toEqual(null);
-    });
+  it('should display the selected option, if there is one', async () => {
+    component.showSymbol = true;
+    component.options = options;
+    component.selected = options[0];
+    fixture.detectChanges();
+    const select = await loader.getHarness(MatSelectHarness);
+    expect(await select.getValueText()).toContain(options[0].title);
   });
 });
-
-
-
-@Component({
-  template: `
-    <aio-select (change)="onChange($event)"
-              [options]="options"
-              [selected]="selected"
-              [label]="label"
-              [showSymbol]="showSymbol"
-              [disabled]="disabled">
-    </aio-select>`
-})
-class HostComponent {
-  onChange = jasmine.createSpy('onChange');
-  options: Option[];
-  selected: Option;
-  label: string;
-  showSymbol: boolean;
-  disabled: boolean;
-}
-
-function getButton(): HTMLButtonElement {
-  return element.query(By.css('button')).nativeElement;
-}
-
-function getButtonSymbol(): HTMLElement | null {
-  return getButton().querySelector('.symbol');
-}
-
-function getOptionContainer(): HTMLUListElement|null {
-  const de = element.query(By.css('ul'));
-  return de && de.nativeElement;
-}
-
-function getOptions(): HTMLLIElement[] {
-  return element.queryAll(By.css('li')).map(de => de.nativeElement);
-}

--- a/aio/src/app/shared/select/select.component.spec.ts
+++ b/aio/src/app/shared/select/select.component.spec.ts
@@ -7,7 +7,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatFormFieldHarness } from "@angular/material/form-field/testing";
+import { MatFormFieldHarness } from '@angular/material/form-field/testing';
 
 const options = [
   { title: 'Option A', value: 'option-a' },

--- a/aio/src/app/shared/select/select.component.ts
+++ b/aio/src/app/shared/select/select.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostListener, Input, Output, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnInit } from '@angular/core';
 
 export interface Option {
   title: string;
@@ -10,7 +10,15 @@ export interface Option {
   templateUrl: 'select.component.html'
 })
 export class SelectComponent implements OnInit {
-  @Input() selected: Option;
+  selectedIdx = -1;
+
+  @Input() set selected(selected: Option) {
+    this.selectedIdx = (this.options ?? []).indexOf(selected);
+  };
+
+  get selected(): Option {
+    return this.options?.[this.selectedIdx];
+  }
 
   @Input() options: Option[];
 
@@ -23,38 +31,12 @@ export class SelectComponent implements OnInit {
 
   @Input() disabled: boolean;
 
-  showOptions = false;
-
-  constructor(private hostElement: ElementRef) {}
-
   ngOnInit() {
     this.label = this.label || '';
   }
 
-  toggleOptions() {
-    this.showOptions = !this.showOptions;
-  }
-
-  hideOptions() {
-    this.showOptions = false;
-  }
-
-  select(option: Option, index: number) {
-    this.selected = option;
-    this.change.emit({option, index});
-    this.hideOptions();
-  }
-
-  @HostListener('document:click', ['$event.target'])
-  onClick(eventTarget: HTMLElement) {
-    // Hide the options if we clicked outside the component
-    if (!this.hostElement.nativeElement.contains(eventTarget)) {
-      this.hideOptions();
-    }
-  }
-
-  @HostListener('document:keydown.escape')
-  onKeyDown() {
-    this.hideOptions();
+  select(index: number) {
+    this.selected = this.options[index];
+    this.change.emit({option: this.selected, index});
   }
 }

--- a/aio/src/app/shared/shared.module.ts
+++ b/aio/src/app/shared/shared.module.ts
@@ -3,11 +3,15 @@ import { CommonModule } from '@angular/common';
 import { SearchResultsComponent } from './search-results/search-results.component';
 import { SelectComponent } from './select/select.component';
 import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
 
 @NgModule({
   imports: [
     CommonModule,
     MatIconModule,
+    MatSelectModule,
+    MatFormFieldModule,
   ],
   exports: [
     SearchResultsComponent,

--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -6,6 +6,8 @@
   transition: none;
 }
 
+$level1ItemPaddingLeft: 20px;
+
 mat-sidenav-container.sidenav-container {
   min-height: 100%;
   height: auto !important;
@@ -40,6 +42,7 @@ mat-sidenav-container.sidenav-container {
     // Angular Version Selector
     .doc-version {
       padding: 8px;
+      padding-left: $level1ItemPaddingLeft;
     }
   }
 }
@@ -129,7 +132,7 @@ aio-nav-menu {
       @include mixins.font-size(16);
       @include mixins.line-height(28);
       font-weight: 400;
-      padding-left: 20px;
+      padding-left: $level1ItemPaddingLeft;
       margin: 0;
       transition: background-color 0.2s;
     }

--- a/aio/tests/e2e/src/app.po.ts
+++ b/aio/tests/e2e/src/app.po.ts
@@ -99,8 +99,8 @@ export class SitePage {
   }
 
   async clickDropdownItem(dropdown: ElementFinder, itemName: string){
-    await dropdown.element(by.css('.form-select-button')).click();
-    const menuItem = dropdown.element(by.cssContainingText('.form-select-dropdown li', itemName));
+    await dropdown.element(by.css('mat-select')).click();
+    const menuItem = element(by.cssContainingText('mat-option', itemName));
     await menuItem.click();
   }
 }


### PR DESCRIPTION
the current aio-select component is implemented using buttons instead of
a native select element, this causes the component not to be very
accessible (screen readers for example do not tell the user that there
is a selection available, and not all keyboard navigation
functionalities work as per the wai-aria guidelines)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

As mentioned in the commit description this is an attempt to make `aio-select` more accessible as I believe it currently is not

This is how it currently looks:

![Screenshot at 2022-05-09 21-19-26](https://user-images.githubusercontent.com/61631103/167490991-3d4b0717-4bc1-48fc-ab13-1ac5a17c3acc.png)


## What is the new behavior?

This is how it looks with mat-select:

![Screenshot at 2022-05-09 21-19-01](https://user-images.githubusercontent.com/61631103/167491030-486898e1-cedf-478e-95dc-793246aa2c68.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - I've checked the code and the only places using the component are the api-list page and the version select on the left sidenav
 - This is just an idea, since we've got material I figured we could try reusing mat-select, if the change in style is undesirable I can scratch the change and just manually re-implement the component using the native select element
 - This relates but does not completely addresses https://github.com/angular/angular/issues/44339
 - Most of the aio-select unit tests have been removed since they test basic functionalities which should be guaranteed by the mat-select out of the box (like the fact that the options show up when you click on the element, etc...)
 - I think the mat-select has a slight issue with the a11y of the label, I've opened an issue for that in the components repo (https://github.com/angular/components/issues/24899)
