### PR TITLE
refactor(common): rename `NgOptimizedImage` directive selector

### DIFF
--- a/packages/common/src/directives/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image.ts
@@ -51,7 +51,7 @@ export const IMAGE_LOADER = new InjectionToken<ImageLoader>('ImageLoader', {
  * TODO: add Image directive usage notes.
  */
 @Directive({
-  selector: 'img[raw-src]',
+  selector: 'img[rawSrc]',
   host: {
     '[src]': 'getRewrittenSrc()',
   },
@@ -68,7 +68,7 @@ export class NgOptimizedImage implements OnInit {
    * Image name will be processed by the image loader and the final URL will be applied as the `src`
    * property of the image.
    */
-  @Input('raw-src') rawSrc!: string;
+  @Input() rawSrc!: string;
 
   /**
    * The intrinsic width of the image in px.
@@ -96,7 +96,7 @@ export class NgOptimizedImage implements OnInit {
 
   /**
    * Get a value of the `src` if it's set on a host <img> element.
-   * This input is needed to verify that there are no `src` and `raw-src` provided
+   * This input is needed to verify that there are no `src` and `rawSrc` provided
    * at the same time (thus causing an ambiguity on which src to use).
    */
   @Input() src?: string;
@@ -139,7 +139,7 @@ function inputToInteger(value: string|number|undefined): number|undefined {
 
 function imgDirectiveDetails(dir: NgOptimizedImage) {
   return `The NgOptimizedImage directive (activated on an <img> element ` +
-      `with the \`raw-src="${dir.rawSrc}"\`)`;
+      `with the \`rawSrc="${dir.rawSrc}"\`)`;
 }
 
 /***** Assert functions *****/
@@ -151,6 +151,6 @@ function assertExistingSrc(dir: NgOptimizedImage) {
         RuntimeErrorCode.UNEXPECTED_SRC_ATTR,
         `${imgDirectiveDetails(dir)} detected that the \`src\` is also set (to \`${dir.src}\`). ` +
             `Please remove the \`src\` attribute from this image. The NgOptimizedImage directive will use ` +
-            `the \`raw-src\` to compute the final image URL and set the \`src\` itself.`);
+            `the \`rawSrc\` to compute the final image URL and set the \`src\` itself.`);
   }
 }

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -13,10 +13,10 @@ import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 describe('Image directive', () => {
-  it('should set `src` to `raw-src` value if image loader is not provided', () => {
+  it('should set `src` to `rawSrc` value if image loader is not provided', () => {
     setupTestingModule();
 
-    const template = '<img raw-src="path/img.png" width="100" height="50">';
+    const template = '<img rawSrc="path/img.png" width="100" height="50">';
     const fixture = createTestComponent(template);
     fixture.detectChanges();
 
@@ -29,7 +29,7 @@ describe('Image directive', () => {
     const imageLoader = (config: ImageLoaderConfig) => `${config.src}?w=${config.width}`;
     setupTestingModule({imageLoader});
 
-    const template = '<img raw-src="path/img.png" width="150" height="50">';
+    const template = '<img rawSrc="path/img.png" width="150" height="50">';
     const fixture = createTestComponent(template);
     fixture.detectChanges();
 
@@ -39,19 +39,19 @@ describe('Image directive', () => {
   });
 
   describe('setup error handling', () => {
-    it('should throw if both `src` and `raw-src` are present', () => {
+    it('should throw if both `src` and `rawSrc` are present', () => {
       setupTestingModule();
 
-      const template = '<img raw-src="path/img.png" src="path/img2.png" width="100" height="50">';
+      const template = '<img rawSrc="path/img.png" src="path/img2.png" width="100" height="50">';
       expect(() => {
         const fixture = createTestComponent(template);
         fixture.detectChanges();
       })
           .toThrowError(
               'NG02950: The NgOptimizedImage directive (activated on an <img> element with the ' +
-              '`raw-src="path/img.png"`) detected that the `src` is also set (to `path/img2.png`). ' +
+              '`rawSrc="path/img.png"`) detected that the `src` is also set (to `path/img2.png`). ' +
               'Please remove the `src` attribute from this image. The NgOptimizedImage directive will use ' +
-              'the `raw-src` to compute the final image URL and set the `src` itself.');
+              'the `rawSrc` to compute the final image URL and set the `src` itself.');
     });
   });
 });

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -12,7 +12,7 @@ import {BrowserModule, platformBrowser} from '@angular/platform-browser';
 @Component({
   selector: 'app-root',
   template: `
-    <img raw-src="./a.png" width="150" height="150">
+    <img rawSrc="./a.png" width="150" height="150">
   `,
 })
 class RootComponent {


### PR DESCRIPTION
This commit changes the `NgOptimizedImage` directive selector from `raw-src` to `rawSrc` to better align with the style guide.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No