### PR TITLE
docs: Add a guide for typed forms.

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -433,6 +433,7 @@ groups:
           'aio/content/examples/forms-overview/**',
           'aio/content/images/guide/forms-overview/**',
           'aio/content/guide/form-validation.md',
+          'aio/content/guide/typed-forms.md',
           'aio/content/examples/form-validation/**',
           'aio/content/images/guide/form-validation/**',
           'aio/content/guide/dynamic-form.md',

--- a/aio/content/guide/typed-forms.md
+++ b/aio/content/guide/typed-forms.md
@@ -1,0 +1,200 @@
+# Typed Forms
+
+As of Angular 14, reactive forms are strictly typed by default.
+
+<a id="prerequisites"></a>
+
+## Prerequisites
+
+As background for this guide, you should already be familiar with [Angular Reactive Forms](guide/reactive-forms "Reactive Forms").
+
+<a id="intro"></a>
+
+## Overview of Typed Forms
+
+With Angular reactive forms, you explicitly specify a *form model*. As a simple example, consider this basic user login form:
+
+```ts
+const login = new FormGroup({
+    email: new FormControl(''),
+    password: new FormControl(''),
+});
+```
+
+Angular provides many APIs for interacting with this `FormGroup`. For example, you may call `login.value`, `login.controls`, `login.patchValue`, etc. (For a full API reference, see the [API documentation](api/forms/FormGroup).)
+
+In previous Angular versions, most of these APIs included `any` somewhere in their types, and interacting with the structure of the controls, or the values themselves, was not type-safe. For example: you could write the following invalid code:
+
+```ts
+const emailDomain = login.value.email.domain;
+```
+
+With strictly typed reactive forms, the above code does not compile, because there is no `domain` property on `email`.
+
+In addition to the added safety, the types enable a variety of other improvements, such as better autocomplete in IDEs, and an explicit way to specify form structure.
+
+These improvements currently apply only to *reactive* forms (not [*template-driven* forms](guide/forms "Forms Guide")).
+
+<a id="automated-migration"></a>
+
+## Automated Untyped Forms Migration
+
+When upgrading to Angular 14, an included migration will automatically replace all the forms classes in your code with corresponding untyped versions. For example, the snippet from above would become:
+
+```ts
+const login = new UntypedFormGroup({
+    email: new UntypedFormControl(''),
+    password: new UntypedFormControl(''),
+});
+```
+
+Each `Untyped` symbol has exactly the same semantics as in previous Angular versions, so your application should continue to compile as before. By removing the `Untyped` prefixes, you can incrementally enable the types.
+
+<a id="form-control-inference"></a>
+
+## `FormControl`: Getting Started
+
+The simplest possible form consists of a single control:
+
+```ts
+const email = new FormControl('angularrox@gmail.com');
+```
+
+This control will be automatically inferred to have the type `FormControl<string|null>`. TypeScript will automatically enforce this type throughout the [`FormControl` API](api/forms/FormControl), such as `email.value`, `email.valueChanges`, `email.setValue(...)`, etc.
+
+### Nullability 
+
+You might wonder: why does the type of this control include `null`?  This is because the control can become `null` at any time, by calling reset:
+
+```ts
+const email = new FormControl('angularrox@gmail.com');
+email.reset();
+console.log(email.value); // null
+```
+
+TypeScript will enforce that you always handle the possibility that the control has become `null`. If you want to make this control non-nullable, you may use the `initialValueIsDefault` option. This will cause the control to reset to its intial value, instead of `null`:
+
+```ts
+const email = new FormControl('angularrox@gmail.com', {initialValueIsDefault: true});
+email.reset();
+console.log(email.value); // angularrox@gmail.com
+```
+
+To reiterate, this option affects the runtime behavior of your form when `.reset()` is called, and should be flipped with care.
+
+### Specifying an Explicit Type
+
+It is possible to specify the type, instead of relying on inference. Consider a control that is initialized to `null`. Because the initial value is `null`, TypeScript will infer `FormControl<null>`, which is narrower than we want.
+
+```ts
+const email = new FormControl(null);
+email.setValue('angularrox@gmail.com'); // Error!
+```
+
+To prevent this, we explicitly specify the type as `string|null`:
+
+```ts
+const email = new FormControl<string|null>(null);
+email.setValue('angularrox@gmail.com');
+```
+
+<a id="form-array"></a>
+
+## `FormArray`: Dynamic, Homogenous Collections
+
+A `FormArray` contains an open-ended list of controls. The type parameter corresponds to the type of each inner control:
+
+```ts
+const names = new FormArray([new FormControl('Alex')]);
+names.push(new FormControl('Jess'));
+```
+
+This `FormArray` will have the inner controls type `FormControl<string|null>`.
+
+If you want to have multiple different element types inside the array, you must use `UntypedFormArray`, because TypeScript cannot infer which element type will occur at which position.
+
+<a id="form-group-record"></a>
+
+## `FormGroup` and `FormRecord`
+
+Angular provides the `FormGroup` type for forms with an enumerated set of keys, and a type called `FormRecord`, for open-ended or dynamic groups.
+
+### Partial Values
+
+Consider again a login form:
+
+```ts
+const login = new FormGroup({
+    email: new FormControl('', {initialValueIsDefault: true}),
+    password: new FormControl('', {initialValueIsDefault: true}),
+});
+```
+
+On any `FormGroup`, it is [possible to disable controls](api/forms/FormGroup). Any disabled control will not appear in the group's value.
+
+As a consequence, the type of `login.value` is `Partial<{email: string, password: string}>`. The `Partial` in this type means that each member might be undefined.
+
+More specifically, the type of `login.value.email` is `string|undefined`, and TypeScript will enforce that you handle the possibly `undefined` value (if you have `strictNullChecks` enabled).
+
+If you want to access the value *including* disabled controls, and thus bypass possible `undefined` fields, you can use `login.getRawValue()`.
+
+### Optional Controls and Dynamic Groups
+
+Some forms have controls that may or may not be present, which can be added and removed at runtime. You can represent these controls using *optional fields*:
+
+```ts
+interface LoginForm {
+    email: FormControl<string>;
+    password?: FormControl<string>;
+}
+
+const login = new FormGroup<LoginForm>({
+    email: new FormControl('', {initialValueIsDefault: true}),
+    password: new FormControl('', {initialValueIsDefault: true}),
+});
+
+login.removeControl('password');
+```
+
+In this form, we explicitly specify the type, which allows us to make the `password` control optional. TypeScript will enforce that only optional controls can be added or removed.
+
+### `FormRecord`
+
+Some `FormGroup` usages do not fit the above pattern because the keys are not known ahead of time. The `FormRecord` class is designed for that case:
+
+```ts
+const addresses = new FormRecord<FormControl<string|null>>({});
+names.addControl('Andrew', new FormControl('2340 Folsom St'));
+```
+
+Any control of type `string|null` can be added to this `FormRecord`.
+
+If you need a `FormGroup` that is both dynamic (open-ended) and heterogenous (the controls are different types), no improved type safety is possible, and you should use `UntypedFormGroup`.
+
+## `FormBuilder` and `NonNullableFormBuilder`
+
+The `FormBuilder` class has been upgraded to support the new types as well, in the same manner as the above examples.
+
+Additionally, an additional builder is available: `NonNullableFormBuilder`. This type is shorthand for specifying `{initialValueIsDefault: true}` on every control, and can eliminate significant boilerplate from large non-nullable forms. You can access it using the `nonNullable` property on a `FormBuilder`:
+
+```ts
+const fb = new FormBuilder();
+const login = fb.nonNullable.group({
+    email: '',
+    password: '',
+});
+```
+
+On the above example, both inner controls will be non-nullable (i.e. `initialValueIsDefault` will be set).
+
+You can also inject it using the name `NonNullableFormBuilder`.
+
+<!-- links -->
+
+<!-- external links -->
+
+[NinjaSquadTypedFormsBlog]: https://blog.ninja-squad.com/2022/04/21/strictly-typed-forms-angular/ "NinjaSquad | Strictly typed forms in Angular"
+
+<!-- end links -->
+
+@reviewed 2022-05-10

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -313,6 +313,11 @@
               "tooltip": "Create a reactive form using FormBuilder, groups, and arrays."
             },
             {
+              "url": "guide/typed-forms",
+              "title": "Strictly Typed Reactive Forms In Depth",
+              "tooltip": "A deep-dive into the reactive forms types."
+            },
+            {
               "url": "guide/form-validation",
               "title": "Validate form input",
               "tooltip": "Validate user's form entries."


### PR DESCRIPTION
Create a new page describing strictly typed reactive forms, as well as how to migrate.