### PR TITLE
feat(compiler-cli): add option for template debug sources

### DIFF
--- a/goldens/public-api/compiler-cli/compiler_options.md
+++ b/goldens/public-api/compiler-cli/compiler_options.md
@@ -8,6 +8,7 @@
 export interface BazelAndG3Options {
     annotateForClosureCompiler?: boolean;
     generateDeepReexports?: boolean;
+    generateTemplateDebugSource?: boolean;
 }
 
 // @public

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -165,6 +165,7 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
       template: {
         nodes: template.nodes,
         ngContentSelectors: template.ngContentSelectors,
+        debugSource: null,
       },
       declarationListEmitMode,
       styles: metaObj.has('styles') ? metaObj.getArray('styles').map(entry => entry.getString()) :

--- a/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/decoration_analyzer.ts
@@ -110,7 +110,8 @@ export class DecorationAnalyzer {
         /* i18nNormalizeLineEndingsInICUs */ false, this.moduleResolver, this.cycleAnalyzer,
         CycleHandlingStrategy.UseRemoteScoping, this.refEmitter, NOOP_DEPENDENCY_TRACKER,
         this.injectableRegistry,
-        /* semanticDepGraphUpdater */ null, !!this.compilerOptions.annotateForClosureCompiler,
+        /* semanticDepGraphUpdater */ null, /* unifiedModulesHost */ null,
+        !!this.compilerOptions.annotateForClosureCompiler, /* generateTemplateDebugSource */ false,
         NOOP_PERF_RECORDER),
 
     // See the note in ngtsc about why this cast is needed.

--- a/packages/compiler-cli/src/ngtsc/annotations/component/BUILD.bazel
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/BUILD.bazel
@@ -12,6 +12,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/annotations/common",
         "//packages/compiler-cli/src/ngtsc/annotations/directive",
         "//packages/compiler-cli/src/ngtsc/annotations/ng_module",
+        "//packages/compiler-cli/src/ngtsc/core:api",
         "//packages/compiler-cli/src/ngtsc/cycles",
         "//packages/compiler-cli/src/ngtsc/diagnostics",
         "//packages/compiler-cli/src/ngtsc/file_system",

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
@@ -9,6 +9,7 @@
 import {DEFAULT_INTERPOLATION_CONFIG, InterpolationConfig, LexerRange, ParsedTemplate, ParseSourceFile, parseTemplate, TmplAstNode} from '@angular/compiler';
 import ts from 'typescript';
 
+import {UnifiedModulesHost} from '../../../core/api';
 import {ErrorCode, FatalDiagnosticError} from '../../../diagnostics';
 import {absoluteFrom} from '../../../file_system';
 import {DependencyTracker} from '../../../incremental/api';
@@ -561,4 +562,15 @@ export function _extractTemplateStyleUrls(template: ParsedTemplateWithSource): S
   const nodeForError = getTemplateDeclarationNodeForError(template.declaration);
   return template.styleUrls.map(
       url => ({url, source: ResourceTypeForDiagnostics.StylesheetFromTemplate, nodeForError}));
+}
+
+export function getTemplateDebugSource(
+    declaration: TemplateDeclaration, unifiedModulesHost: UnifiedModulesHost): string {
+  if (declaration.isInline) {
+    const sourceFile = declaration.expression.getSourceFile().fileName;
+    return unifiedModulesHost.fileNameToModuleName(sourceFile, sourceFile);
+  } else {
+    const contextFile = declaration.templateUrlExpression.getSourceFile().fileName;
+    return unifiedModulesHost.fileNameToModuleName(declaration.resolvedTemplateUrl, contextFile);
+  }
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -85,7 +85,9 @@ function setup(program: ts.Program, options: ts.CompilerOptions, host: ts.Compil
       /* depTracker */ null,
       injectableRegistry,
       /* semanticDepGraphUpdater */ null,
+      /* unifiedModulesHost */ null,
       /* annotateForClosureCompiler */ false,
+      /* generateTemplateDebugSource */ false,
       NOOP_PERF_RECORDER,
   );
   return {reflectionHost, handler, resourceLoader, metaRegistry};

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -342,6 +342,16 @@ export interface BazelAndG3Options {
    * Insert JSDoc type annotations needed by Closure Compiler
    */
   annotateForClosureCompiler?: boolean;
+
+  /**
+   * Enables the generation of `TemplateDebugSourceFeature`, which causes components to be annotated
+   * with a `data-debug-source` attribute with a workspace-relative path to the template for that
+   * component.
+   *
+   * Only functional when the `CompilerHost` in use is a `UnifiedModulesHost` (that is, when the
+   * host environment supports generating a workspace-relative path from a file name).
+   */
+  generateTemplateDebugSource?: boolean;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1021,7 +1021,8 @@ export class NgCompiler {
           this.options.i18nNormalizeLineEndingsInICUs === true, this.moduleResolver,
           this.cycleAnalyzer, cycleHandlingStrategy, refEmitter,
           this.incrementalCompilation.depGraph, injectableRegistry, semanticDepGraphUpdater,
-          this.closureCompilerEnabled, this.delegatingPerfRecorder),
+          this.adapter.unifiedModulesHost, this.closureCompilerEnabled,
+          this.options.generateTemplateDebugSource ?? false, this.delegatingPerfRecorder),
 
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null`
       // not being assignable to `unknown` when wrapped in `Readonly`).

--- a/packages/compiler-cli/test/ngtsc/monorepo_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/monorepo_spec.ts
@@ -111,5 +111,48 @@ runInEachFileSystem(() => {
       // Check that the relative import has the leading './'.
       expect(jsContents).toContain(`import * as i1 from "./target";`);
     });
+
+    describe('template debug source', () => {
+      beforeEach(() => {
+        env.tsconfig({
+          '_useHostForImportGeneration': true,
+          generateTemplateDebugSource: true,
+        });
+      });
+      it('should be set for external templates', () => {
+        env.write('/app/test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            standalone: true,
+            selector: 'test-cmp',
+            templateUrl: './test.html',
+          })
+          export class TestCmp {}
+        `);
+        env.write('/app/test.html', '<span>Template!</span>');
+
+        env.driveMain();
+        const jsContents = env.getContents('app/test.js');
+        expect(jsContents).toContain('i0.ɵɵTemplateDebugSourceFeature("root/test.html")');
+      });
+
+      it('should be set for external templates', () => {
+        env.write('/app/test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            standalone: true,
+            selector: 'test-cmp',
+            template: '<span>Template!</span>',
+          })
+          export class TestCmp {}
+        `);
+
+        env.driveMain();
+        const jsContents = env.getContents('app/test.js');
+        expect(jsContents).toContain('i0.ɵɵTemplateDebugSourceFeature("root/test")');
+      });
+    });
   });
 });

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -187,7 +187,10 @@ export class CompilerFacadeImpl implements CompilerFacade {
       ...facade as R3ComponentMetadataFacadeNoPropAndWhitespace,
       ...convertDirectiveFacadeToMetadata(facade),
       selector: facade.selector || this.elementSchemaRegistry.getDefaultComponentElementName(),
-      template,
+      template: {
+        ...template,
+        debugSource: null,
+      },
       declarations: facade.declarations.map(convertDeclarationFacadeToMetadata),
       declarationListEmitMode: DeclarationListEmitMode.Direct,
       styles: [...facade.styles, ...template.styles],
@@ -437,7 +440,10 @@ function convertDeclareComponentFacadeToMetadata(
 
   return {
     ...convertDeclareDirectiveFacadeToMetadata(decl, typeSourceSpan),
-    template,
+    template: {
+      ...template,
+      debugSource: null,
+    },
     styles: decl.styles ?? [],
     declarations,
     viewProviders: decl.viewProviders !== undefined ? new WrappedNodeExpr(decl.viewProviders) :
@@ -509,7 +515,10 @@ function parseJitTemplate(
     const errors = parsed.errors.map(err => err.toString()).join(', ');
     throw new Error(`Errors during JIT compilation of template for ${typeName}: ${errors}`);
   }
-  return {template: parsed, interpolation: interpolationConfig};
+  return {
+    template: parsed,
+    interpolation: interpolationConfig,
+  };
 }
 
 // This seems to be needed to placate TS v3.0 only

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -324,6 +324,9 @@ export class Identifiers {
 
   static ProvidersFeature: o.ExternalReference = {name: 'ɵɵProvidersFeature', moduleName: CORE};
 
+  static TemplateDebugSourceFeature:
+      o.ExternalReference = {name: 'ɵɵTemplateDebugSourceFeature', moduleName: CORE};
+
   static listener: o.ExternalReference = {name: 'ɵɵlistener', moduleName: CORE};
 
   static getInheritedFactory: o.ExternalReference = {

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -187,6 +187,11 @@ export interface R3ComponentMetadata<DeclarationT extends R3TemplateDependency> 
      * element without selector is present.
      */
     ngContentSelectors: string[];
+
+    /**
+     * A string representing the origin of the template that's useful for debugging.
+     */
+    debugSource: string | null;
   };
 
   declarations: DeclarationT[];

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -112,13 +112,22 @@ function addFeatures(
   if (meta.lifecycle.usesOnChanges) {
     features.push(o.importExpr(R3.NgOnChangesFeature));
   }
-  // TODO: better way of differentiating component vs directive metadata.
-  if (meta.hasOwnProperty('template') && meta.isStandalone) {
+  if (isComponentMetadata(meta) && meta.isStandalone) {
     features.push(o.importExpr(R3.StandaloneFeature));
+  }
+  if (isComponentMetadata(meta) && meta.template.debugSource !== null) {
+    features.push(
+        o.importExpr(R3.TemplateDebugSourceFeature).callFn([o.literal(meta.template.debugSource)]));
   }
   if (features.length) {
     definitionMap.set('features', o.literalArr(features));
   }
+}
+
+function isComponentMetadata(metadata: R3DirectiveMetadata|
+                             R3ComponentMetadata<R3TemplateDependency>):
+    metadata is R3ComponentMetadata<R3TemplateDependency> {
+  return metadata.hasOwnProperty('template');
 }
 
 /**

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -196,6 +196,7 @@ export {
   ɵɵsyntheticHostListener,
   ɵɵsyntheticHostProperty,
   ɵɵtemplate,
+  ɵɵTemplateDebugSourceFeature,
   ɵɵtemplateRefExtractor,
   ɵɵtext,
   ɵɵtextInterpolate,

--- a/packages/core/src/render3/features/template_debug_source_feature.ts
+++ b/packages/core/src/render3/features/template_debug_source_feature.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {noop} from '../../util/noop';
+import {ɵɵattribute} from '../instructions/attribute';
+import {ComponentDef, HostBindingsFunction, RenderFlags} from '../interfaces/definition';
+
+/**
+ * A feature that augments components with an attribute `data-debug-source` which points to the
+ * origin file for that component's template.
+ *
+ * @codeGenApi
+ */
+export function ɵɵTemplateDebugSourceFeature(debugSource: string) {
+  return (def: ComponentDef<unknown>) => {
+    const prevHostBindings: HostBindingsFunction<unknown> = def.hostBindings || noop;
+    (def as any).hostBindings = (rf: RenderFlags, ctx: unknown) => {
+      if (rf & 2) {
+        ɵɵattribute('data-debug-source', debugSource);
+      }
+      prevHostBindings(rf, ctx);
+    };
+    (def as any).hostVars++;
+  };
+}

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -12,6 +12,7 @@ import {ɵɵInheritDefinitionFeature} from './features/inherit_definition_featur
 import {ɵɵNgOnChangesFeature} from './features/ng_onchanges_feature';
 import {ɵɵProvidersFeature} from './features/providers_feature';
 import {ɵɵStandaloneFeature} from './features/standalone_feature';
+import {ɵɵTemplateDebugSourceFeature} from './features/template_debug_source_feature';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveType, PipeDef} from './interfaces/definition';
 import {ɵɵComponentDeclaration, ɵɵDirectiveDeclaration, ɵɵFactoryDeclaration, ɵɵInjectorDeclaration, ɵɵNgModuleDeclaration, ɵɵPipeDeclaration} from './interfaces/public_definitions';
 import {ComponentDebugMetadata, DirectiveDebugMetadata, getComponent, getDirectiveMetadata, getDirectives, getHostElement, getRenderedText} from './util/discovery_utils';
@@ -215,4 +216,5 @@ export {
   ɵɵsetComponentScope,
   ɵɵsetNgModuleScope,
   ɵɵStandaloneFeature,
+  ɵɵTemplateDebugSourceFeature,
 };

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -50,6 +50,7 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵCopyDefinitionFeature': r3.ɵɵCopyDefinitionFeature,
        'ɵɵInheritDefinitionFeature': r3.ɵɵInheritDefinitionFeature,
        'ɵɵStandaloneFeature': r3.ɵɵStandaloneFeature,
+       'ɵɵTemplateDebugSourceFeature': r3.ɵɵTemplateDebugSourceFeature,
        'ɵɵnextContext': r3.ɵɵnextContext,
        'ɵɵnamespaceHTML': r3.ɵɵnamespaceHTML,
        'ɵɵnamespaceMathML': r3.ɵɵnamespaceMathML,

--- a/packages/core/test/acceptance/template_debug_source_feature_spec.ts
+++ b/packages/core/test/acceptance/template_debug_source_feature_spec.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, ɵComponentDef as ComponentDef, ɵComponentType as ComponentType, ɵɵTemplateDebugSourceFeature as TemplateDebugSourceFeature} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+describe('TemplateDebugSourceFeature', () => {
+  it('should record the template source when applied', () => {
+    @Component({
+      standalone: true,
+      selector: 'test-cmp',
+      template: '<span>Template</span>',
+    })
+    class TestCmp {
+    }
+
+    TemplateDebugSourceFeature('debug/template/url.html')(
+        (TestCmp as ComponentType<TestCmp>).ɵcmp as ComponentDef<TestCmp>);
+
+    @Component({
+      standalone: true,
+      selector: 'host-cmp',
+      imports: [TestCmp],
+      template: '<test-cmp></test-cmp>',
+    })
+    class HostCmp {
+    }
+
+    const fixture = TestBed.createComponent(HostCmp);
+    fixture.detectChanges();
+    expect(fixture.debugElement.children[0].attributes).toEqual({
+      'data-debug-source': 'debug/template/url.html'
+    });
+  });
+});


### PR DESCRIPTION
This commit adds a `generateTemplateDebugSource` option to the compiler options
available for bazel/g3 use cases. This option requires a compatible
`CompilerHost` which supports the `fileNameToModuleName` operation.

When this option is set, the compiler will generate a
`TemplateDebugSourceFeature` on components which adds a host binding to the
`data-debug-source` attribute. The value of this attribute is the workspace-
relative path to the component's template origin, whether that's the component
file itself or an external template path.