### PR TITLE
refactor(bazel): add support for starlark's unused_inputs_list

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -22,7 +22,9 @@ type CompilerCliModule =
 
 // Add devmode for blaze internal
 interface BazelOptions extends ExternalBazelOptions {
+  allowedInputs?: string[];
   devmode?: boolean;
+  unusedInputsListPath?: string;
 }
 
 /**
@@ -443,7 +445,53 @@ export function compile({
     originalWriteFile(fileName, '', false);
   }
 
+  if (!compilerOpts.noEmit) {
+    maybeWriteUnusedInputsList(program.getTsProgram(), compilerOpts, bazelOpts);
+  }
+
   return {program, diagnostics};
+}
+
+/**
+ * Writes a collection of unused input files and directories which can be
+ * consumed by bazel to avoid triggering rebuilds if only unused inputs are
+ * changed.
+ *
+ * See https://bazel.build/contribute/codebase#input-discovery
+ */
+export function maybeWriteUnusedInputsList(
+    program: ts.Program, options: ts.CompilerOptions, bazelOpts: BazelOptions) {
+  if (!bazelOpts?.unusedInputsListPath) {
+    return;
+  }
+
+  // ts.Program's getSourceFiles() gets populated by the sources actually
+  // loaded while the program is being built.
+  const usedFiles = new Set();
+  for (const sourceFile of program.getSourceFiles()) {
+    // Only concern ourselves with typescript files.
+    usedFiles.add(sourceFile.fileName);
+  }
+
+  // allowedInputs are absolute paths to files which may also end with /* which
+  // implies any files in that directory can be used.
+  const unusedInputs: string[] = [];
+  for (const f of bazelOpts.allowedInputs) {
+    // A ts/x file is unused if it was not found directly in the used sources.
+    if ((f.endsWith('.ts') || f.endsWith('.tsx')) && !usedFiles.has(f)) {
+      unusedInputs.push(f);
+      continue;
+    }
+
+    // TODO: Iterate over contents of allowed directories checking for used files.
+  }
+
+  // Bazel expects the unused input list to contain paths relative to the
+  // execroot directory.
+  // See https://docs.bazel.build/versions/main/output_directories.html
+  fs.writeFileSync(
+      bazelOpts.unusedInputsListPath,
+      unusedInputs.map(f => path.relative(options.rootDir!, f)).join('\n'));
 }
 
 function isCompilationTarget(bazelOpts: BazelOptions, sf: ts.SourceFile): boolean {


### PR DESCRIPTION
This change adds the capability of ngc_wrapped to emit an
unused_inputs_list file that could be used by starlark.

We are making this change because in situations where angular modules
depend on angular modules, it becomes very easy for a single change to
trigger a long cascading set of angular builds since each angular rule
depends on the transitive closure of input files.

With this change in place, and once it is properly configured, bazel
will update the set of inputs to a build rule after it is built once
removing any of the inputs specified in this list, making incremental
builds quicker by skipping any rebuilds that only had changes to unused
inputs.

This logic should be, and is likely duplicated in tsc_wrapped to solve
the same problem in pure TypeScript situations, ideally we could use the
same implementation one day.

In addition, its possible that tree artifacts are not as supported as
we'd like, and where this change should mark entire directories as
unused, we may get better performance gains by enumerating the directory
and being more explicit about specific inputs which are unused.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
ngc-wrapped build actions are dependent on the full transitive closure of input files, making long cascading template compilations common when changing the public api somewhere in a dependency chain, even if those changed files are not used during compilation.

Issue Number: N/A


## What is the new behavior?
Implements support for starlark's unused_inputs_list for ngc-wrapped build operations. This let's bazel skip targets where the only changed inputs are known to be unused, improving build times and minimizing cascading angular builds.

See:
https://docs.bazel.build/versions/main/skylark/lib/actions.html#:~:text=of%20the%20action.-,unused_inputs_list,-File%3B%20or%20None

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
