### PR TITLE
refactor(common): move `NgOptimizedImage` logic that sets `src` to a different hook

### DIFF
--- a/packages/common/src/directives/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image.ts
@@ -132,12 +132,6 @@ export class NgOptimizedImage implements OnInit, OnChanges {
       assertRequiredNumberInput(this, this.width, 'width');
       assertRequiredNumberInput(this, this.height, 'height');
     }
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (ngDevMode) {
-      assertNoPostInitInputChange(this, changes, ['rawSrc', 'width', 'height', 'priority']);
-    }
     this.setHostAttribute('loading', this.getLoadingBehavior());
     this.setHostAttribute('fetchpriority', this.getFetchPriority());
     // The `src` attribute should be set last since other attributes
@@ -145,15 +139,21 @@ export class NgOptimizedImage implements OnInit, OnChanges {
     this.setHostAttribute('src', this.getRewrittenSrc());
   }
 
-  getLoadingBehavior(): string {
+  ngOnChanges(changes: SimpleChanges) {
+    if (ngDevMode) {
+      assertNoPostInitInputChange(this, changes, ['rawSrc', 'width', 'height', 'priority']);
+    }
+  }
+
+  private getLoadingBehavior(): string {
     return this.priority ? 'eager' : 'lazy';
   }
 
-  getFetchPriority(): string {
+  private getFetchPriority(): string {
     return this.priority ? 'high' : 'auto';
   }
 
-  getRewrittenSrc(): string {
+  private getRewrittenSrc(): string {
     const imgConfig = {
       src: this.rawSrc,
       // TODO: if we're going to support responsive serving, we don't want to request the width


### PR DESCRIPTION
Currently, the logic that sets the `src` on the host `<img>` element is located in the `ngOnChanges` lifecycle hook and guarded by the dev-mode checks that the inputs do not change. However, those checks would be tree-shaken in prod mode and the `src` would be set each time the `ngOnChanges` hook is invoked. This is undesirable and may potentially lead to performance issues.

This commit moves the `src`-related logic to the `ngOnInit` hook instead, which would have the same effect (executed only once, after all inputs are set) and would behave consistently in dev and prod modes.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No