### PR TITLE
Revert "fix(language-service): Add resource files as roots to their a…

### DIFF
--- a/packages/compiler-cli/ngcc/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/BUILD.bazel
@@ -28,7 +28,6 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/perf",
         "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/scope",
-        "//packages/compiler-cli/src/ngtsc/shims",
         "//packages/compiler-cli/src/ngtsc/sourcemaps",
         "//packages/compiler-cli/src/ngtsc/transform",
         "//packages/compiler-cli/src/ngtsc/translator",

--- a/packages/compiler-cli/ngcc/src/analysis/ngcc_trait_compiler.ts
+++ b/packages/compiler-cli/ngcc/src/analysis/ngcc_trait_compiler.ts
@@ -11,7 +11,6 @@ import {IncrementalBuild} from '../../../src/ngtsc/incremental/api';
 import {SemanticSymbol} from '../../../src/ngtsc/incremental/semantic_graph';
 import {NOOP_PERF_RECORDER} from '../../../src/ngtsc/perf';
 import {ClassDeclaration, Decorator} from '../../../src/ngtsc/reflection';
-import {isShim} from '../../../src/ngtsc/shims';
 import {CompilationMode, DecoratorHandler, DtsTransformRegistry, HandlerFlags, Trait, TraitCompiler} from '../../../src/ngtsc/transform';
 import {NgccReflectionHost} from '../host/ngcc_host';
 import {isDefined} from '../utils';
@@ -29,7 +28,7 @@ export class NgccTraitCompiler extends TraitCompiler {
     super(
         handlers, ngccReflector, NOOP_PERF_RECORDER, new NoIncrementalBuild(),
         /* compileNonExportedClasses */ true, CompilationMode.FULL, new DtsTransformRegistry(),
-        /* semanticDepGraphUpdater */ null, {isShim, isResource: () => false});
+        /* semanticDepGraphUpdater */ null);
   }
 
   get analyzedFiles(): ts.SourceFile[] {

--- a/packages/compiler-cli/src/ngtsc/core/api/src/adapter.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/adapter.ts
@@ -43,8 +43,7 @@ export interface NgCompilerAdapter extends
     // incompatible with the `ts.CompilerHost` version which isn't. The combination of these two
     // still satisfies `ts.ModuleResolutionHost`.
         Omit<ts.ModuleResolutionHost, 'getCurrentDirectory'>,
-    Pick<ExtendedTsCompilerHost, 'getCurrentDirectory'|ExtendedCompilerHostMethods>,
-    SourceFileTypeIdentifier {
+    Pick<ExtendedTsCompilerHost, 'getCurrentDirectory'|ExtendedCompilerHostMethods> {
   /**
    * A path to a single file which represents the entrypoint of an Angular Package Format library,
    * if the current program is one.
@@ -87,9 +86,7 @@ export interface NgCompilerAdapter extends
    * Resolved list of root directories explicitly set in, or inferred from, the tsconfig.
    */
   readonly rootDirs: ReadonlyArray<AbsoluteFsPath>;
-}
 
-export interface SourceFileTypeIdentifier {
   /**
    * Distinguishes between shim files added by Angular to the compilation process (both those
    * intended for output, like ngfactory files, as well as internal shims like ngtypecheck files)
@@ -99,14 +96,4 @@ export interface SourceFileTypeIdentifier {
    * `true` if a file was written by the user, and `false` if a file was added by the compiler.
    */
   isShim(sf: ts.SourceFile): boolean;
-
-  /**
-   * Distinguishes between resource files added by Angular to the project and original files in the
-   * user's program.
-   *
-   * This is necessary only for the language service because it adds resource files as root files
-   * when they are read. This is done to indicate to TS Server that these resources are part of the
-   * project and ensures that projects are retained properly when navigating around the workspace.
-   */
-  isResource(sf: ts.SourceFile): boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1050,7 +1050,7 @@ export class NgCompiler {
     const traitCompiler = new TraitCompiler(
         handlers, reflector, this.delegatingPerfRecorder, this.incrementalCompilation,
         this.options.compileNonExportedClasses !== false, compilationMode, dtsTransforms,
-        semanticDepGraphUpdater, this.adapter);
+        semanticDepGraphUpdater);
 
     // Template type-checking may use the `ProgramDriver` to produce new `ts.Program`(s). If this
     // happens, they need to be tracked by the `NgCompiler`.

--- a/packages/compiler-cli/src/ngtsc/core/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/host.ts
@@ -234,16 +234,6 @@ export class NgCompilerHost extends DelegatingCompilerHost implements
     return isShim(sf);
   }
 
-  /**
-   * Check whether the given `ts.SourceFile` is a resource file.
-   *
-   * This simply returns `false` for the compiler-cli since resource files are not added as root
-   * files to the project.
-   */
-  isResource(sf: ts.SourceFile): boolean {
-    return false;
-  }
-
   getSourceFile(
       fileName: string, languageVersion: ts.ScriptTarget,
       onError?: ((message: string) => void)|undefined,

--- a/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
@@ -17,11 +17,6 @@ import {getDeclaration, makeProgram} from '../../testing';
 import {CompilationMode, DetectResult, DtsTransformRegistry, TraitCompiler} from '../../transform';
 import {AnalysisOutput, CompileResult, DecoratorHandler, HandlerPrecedence} from '../src/api';
 
-const fakeSfTypeIdentifier = {
-  isShim: () => false,
-  isResource: () => false
-};
-
 runInEachFileSystem(() => {
   describe('TraitCompiler', () => {
     let _: typeof absoluteFrom;
@@ -54,7 +49,7 @@ runInEachFileSystem(() => {
       const reflectionHost = new TypeScriptReflectionHost(checker);
       const compiler = new TraitCompiler(
           [new FakeDecoratorHandler()], reflectionHost, NOOP_PERF_RECORDER, NOOP_INCREMENTAL_BUILD,
-          true, CompilationMode.FULL, new DtsTransformRegistry(), null, fakeSfTypeIdentifier);
+          true, CompilationMode.FULL, new DtsTransformRegistry(), null);
       const sourceFile = program.getSourceFile('lib.d.ts')!;
       const analysis = compiler.analyzeSync(sourceFile);
 
@@ -143,7 +138,7 @@ runInEachFileSystem(() => {
         const compiler = new TraitCompiler(
             [new PartialDecoratorHandler(), new FullDecoratorHandler()], reflectionHost,
             NOOP_PERF_RECORDER, NOOP_INCREMENTAL_BUILD, true, CompilationMode.PARTIAL,
-            new DtsTransformRegistry(), null, fakeSfTypeIdentifier);
+            new DtsTransformRegistry(), null);
         const sourceFile = program.getSourceFile('test.ts')!;
         compiler.analyzeSync(sourceFile);
         compiler.resolve();
@@ -173,7 +168,7 @@ runInEachFileSystem(() => {
         const compiler = new TraitCompiler(
             [new PartialDecoratorHandler(), new FullDecoratorHandler()], reflectionHost,
             NOOP_PERF_RECORDER, NOOP_INCREMENTAL_BUILD, true, CompilationMode.FULL,
-            new DtsTransformRegistry(), null, fakeSfTypeIdentifier);
+            new DtsTransformRegistry(), null);
         const sourceFile = program.getSourceFile('test.ts')!;
         compiler.analyzeSync(sourceFile);
         compiler.resolve();

--- a/packages/language-service/src/adapters.ts
+++ b/packages/language-service/src/adapters.ts
@@ -61,11 +61,6 @@ export class LanguageServiceAdapter implements NgCompilerAdapter {
     return isShim(sf);
   }
 
-  isResource(sf: ts.SourceFile): boolean {
-    const scriptInfo = this.project.getScriptInfo(sf.fileName);
-    return scriptInfo?.scriptKind === ts.ScriptKind.Unknown;
-  }
-
   fileExists(fileName: string): boolean {
     return this.project.fileExists(fileName);
   }
@@ -105,21 +100,14 @@ export class LanguageServiceAdapter implements NgCompilerAdapter {
     // getScriptInfo() will not create one if it does not exist.
     // In this case, we *want* a script info to be created so that we could
     // keep track of its version.
+    const snapshot = this.project.getScriptSnapshot(fileName);
+    if (!snapshot) {
+      // This would fail if the file does not exist, or readFile() fails for
+      // whatever reasons.
+      throw new Error(`Failed to get script snapshot while trying to read ${fileName}`);
+    }
     const version = this.project.getScriptVersion(fileName);
     this.lastReadResourceVersion.set(fileName, version);
-    const scriptInfo = this.project.getScriptInfo(fileName);
-    if (!scriptInfo) {
-      // // This should not happen because it would have failed already at `getScriptVersion`.
-      throw new Error(`Failed to get script info when trying to read ${fileName}`);
-    }
-    // Add external resources as root files to the project since we project language service
-    // features for them (this is currently only the case for HTML files, but we could investigate
-    // css file features in the future). This prevents the project from being closed when navigating
-    // away from a resource file.
-    if (!this.project.isRoot(scriptInfo)) {
-      this.project.addRoot(scriptInfo);
-    }
-    const snapshot = scriptInfo.getSnapshot();
     return snapshot.getText(0, snapshot.getLength());
   }
 

--- a/packages/language-service/testing/src/project.ts
+++ b/packages/language-service/testing/src/project.ts
@@ -153,8 +153,7 @@ export class Project {
     const ngCompiler = this.ngLS.compilerFactory.getOrCreate();
 
     for (const sf of program.getSourceFiles()) {
-      if (sf.isDeclarationFile || sf.fileName.endsWith('.ngtypecheck.ts') ||
-          !sf.fileName.endsWith('.ts')) {
+      if (sf.isDeclarationFile || sf.fileName.endsWith('.ngtypecheck.ts')) {
         continue;
       }
 


### PR DESCRIPTION
…ssociated projects (#45601)"

This reverts commit d48cfbca75140511b03c4c4c083c7ffa0d75d66f.

This breaks the language service for templates on linux
https://app.circleci.com/pipelines/github/angular/vscode-ng-language-service/3530/workflows/8ff8accd-6814-44c9-b810-db504d175a91/jobs/3458
Verified that this is a real failure locally
