### PR TITLE
test(common): configure e2e testing infrastructure for `NgOptimizedImage` test app

### DIFF
--- a/packages/core/test/bundling/image-directive/BUILD.bazel
+++ b/packages/core/test/bundling/image-directive/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//tools:defaults.bzl", "app_bundle", "ng_module", "ts_devserver")
+load("//tools:defaults.bzl", "app_bundle", "ng_module", "protractor_web_test_suite", "ts_devserver", "ts_library")
 load("@npm//http-server:index.bzl", "http_server")
 
 package(default_visibility = ["//visibility:public"])
@@ -6,12 +6,14 @@ package(default_visibility = ["//visibility:public"])
 ng_module(
     name = "image-directive",
     srcs = [
+        "basic/basic.ts",
         "index.ts",
     ],
     deps = [
         "//packages/common",
         "//packages/core",
         "//packages/platform-browser",
+        "//packages/router",
     ],
 )
 
@@ -23,6 +25,7 @@ app_bundle(
         "//packages/common",
         "//packages/core",
         "//packages/platform-browser",
+        "//packages/router",
         "@npm//rxjs",
     ],
 )
@@ -40,7 +43,9 @@ genrule(
 
 ts_devserver(
     name = "devserver",
+    bootstrap = ["//packages/zone.js/bundles:zone.umd.js"],
     entry_module = "@angular/core/test/bundling/image-directive",
+    port = 4200,
     scripts = [
         "//tools/rxjs:rxjs_umd_modules",
     ],
@@ -60,5 +65,27 @@ http_server(
         "index.html",
         ":bundle.debug.min.js",
         ":bundle.min.js",
+    ],
+)
+
+ts_library(
+    name = "img_dir_e2e_tests_lib",
+    testonly = True,
+    srcs = glob(["**/*.e2e-spec.ts"]),
+    tsconfig = ":tsconfig-e2e.json",
+    deps = [
+        "//packages/examples/test-utils",
+        "//packages/private/testing",
+        "@npm//protractor",
+    ],
+)
+
+protractor_web_test_suite(
+    name = "protractor_tests",
+    on_prepare = ":start-server.js",
+    server = ":devserver",
+    deps = [
+        ":img_dir_e2e_tests_lib",
+        "@npm//selenium-webdriver",
     ],
 )

--- a/packages/core/test/bundling/image-directive/basic/basic.e2e-spec.ts
+++ b/packages/core/test/bundling/image-directive/basic/basic.e2e-spec.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {browser, by, element} from 'protractor';
+
+import {verifyNoBrowserErrors} from '../../../../../examples/test-utils';
+
+describe('NgOptimizedImage directive', () => {
+  afterEach(verifyNoBrowserErrors);
+
+  it('should render an image with an updated `src`', async () => {
+    await browser.get('/');
+    const imgs = element.all(by.css('img'));
+    const src = await imgs.get(0).getAttribute('src');
+    expect(src.endsWith('b.png')).toBe(true);
+  });
+});

--- a/packages/core/test/bundling/image-directive/basic/basic.ts
+++ b/packages/core/test/bundling/image-directive/basic/basic.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImage as NgOptimizedImage} from '@angular/common';
+import {Component} from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [NgOptimizedImage],
+  template: `<img rawSrc="./a.png" width="150" height="150">`,
+  providers: [{provide: IMAGE_LOADER, useValue: () => 'b.png'}],
+})
+export class BasicComponent {
+}

--- a/packages/core/test/bundling/image-directive/index.html
+++ b/packages/core/test/bundling/image-directive/index.html
@@ -3,6 +3,7 @@
 <html>
   <head>
     <title>Image Directive Example</title>
+    <base href="/">
   </head>
   <body>
     <!-- The Angular application will be bootstrapped into this element. -->

--- a/packages/core/test/bundling/image-directive/index.ts
+++ b/packages/core/test/bundling/image-directive/index.ts
@@ -5,28 +5,26 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImage as NgOptimizedImage} from '@angular/common';
-import {Component, NgModule} from '@angular/core';
-import {BrowserModule, platformBrowser} from '@angular/platform-browser';
+
+import {Component, importProvidersFrom} from '@angular/core';
+import {bootstrapApplication} from '@angular/platform-browser';
+import {RouterModule} from '@angular/router';
+
+import {BasicComponent} from './basic/basic';
 
 @Component({
   selector: 'app-root',
-  template: `
-    <img rawSrc="./a.png" width="150" height="150">
-  `,
+  standalone: true,
+  imports: [RouterModule],
+  template: '<router-outlet></router-outlet>',
 })
-class RootComponent {
-  constructor() {}
+export class RootComponent {
 }
 
-@NgModule({
-  declarations: [RootComponent],
-  imports: [BrowserModule, NgOptimizedImage],
-  bootstrap: [RootComponent],
-  providers: [{provide: IMAGE_LOADER, useValue: () => 'b.png'}],
-})
-class ImageDirectiveExampleModule {
-}
+const ROUTES = [
+  {path: '', component: BasicComponent}  //
+];
 
-(window as any).waitForApp =
-    platformBrowser().bootstrapModule(ImageDirectiveExampleModule, {ngZone: 'noop'});
+bootstrapApplication(RootComponent, {
+  providers: [importProvidersFrom(RouterModule.forRoot(ROUTES))],
+});

--- a/packages/core/test/bundling/image-directive/start-server.js
+++ b/packages/core/test/bundling/image-directive/start-server.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+const protractorUtils = require('@bazel/protractor/protractor-utils');
+const protractor = require('protractor');
+
+module.exports = async function(config) {
+  const {port} = await protractorUtils.runServer(config.workspace, config.server, '-port', []);
+  const serverUrl = `http://localhost:${port}`;
+
+  protractor.browser.baseUrl = serverUrl;
+};

--- a/packages/core/test/bundling/image-directive/tsconfig-e2e.json
+++ b/packages/core/test/bundling/image-directive/tsconfig-e2e.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "lib": ["es2015"],
+    "types": ["node", "jasminewd2"]
+  }
+}


### PR DESCRIPTION
This commit adds the necessary e2e testing infrastructure to the `NgOptimizedImage` test app, so that the test coverage can be extended and extra scenarios can be tested in a browser.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: e2e testing setup


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
