### PR TITLE
fix(language-service): Prevent TSServer from removing templates from …

### DIFF
--- a/packages/language-service/src/ts_plugin.ts
+++ b/packages/language-service/src/ts_plugin.ts
@@ -189,6 +189,7 @@ export function getExternalFiles(project: ts.server.Project): string[] {
     return [];  // project has not been initialized
   }
   const typecheckFiles: string[] = [];
+  const resourceFiles: string[] = [];
   for (const scriptInfo of project.getScriptInfos()) {
     if (scriptInfo.scriptKind === ts.ScriptKind.External) {
       // script info for typecheck file is marked as external, see
@@ -196,6 +197,14 @@ export function getExternalFiles(project: ts.server.Project): string[] {
       // packages/language-service/src/language_service.ts
       typecheckFiles.push(scriptInfo.fileName);
     }
+    if (scriptInfo.scriptKind === ts.ScriptKind.Unknown) {
+      // script info for resource file is marked as unknown.
+      // Including these as external files is necessary because otherwise they will get removed from
+      // the project when `updateNonInferredProjectFiles` is called as part of the
+      // `updateProjectIfDirty` cycle.
+      // https://sourcegraph.com/github.com/microsoft/TypeScript@c300fea3250abd7f75920d95a58d9e742ac730ee/-/blob/src/server/editorServices.ts?L2363
+      resourceFiles.push(scriptInfo.fileName);
+    }
   }
-  return typecheckFiles;
+  return [...typecheckFiles, ...resourceFiles];
 }

--- a/packages/language-service/test/legacy/ts_plugin_spec.ts
+++ b/packages/language-service/test/legacy/ts_plugin_spec.ts
@@ -23,7 +23,8 @@ describe('getExternalFiles()', () => {
     ngLS.getSemanticDiagnostics(APP_COMPONENT);
     // Now that global analysis is run, we should have all the typecheck files
     externalFiles = getExternalFiles(project);
-    expect(externalFiles.length).toBe(1);
+    // Includes 1 typecheck file, 1 template, and 1 css files
+    expect(externalFiles.length).toBe(3);
     expect(externalFiles[0].endsWith('app.component.ngtypecheck.ts')).toBeTrue();
   });
 });


### PR DESCRIPTION
…project

As part of the `updateProjectIfDirty` process and inside `updateNonInferredProjectFiles`
TS Server will remove the template files that we added as roots in
`readResource`.
https://sourcegraph.com/github.com/microsoft/TypeScript@c300fea3250abd7f75920d95a58d9e742ac730ee/-/blob/src/server/editorServices.ts?L2363

The external files are added to the list here so ensuring that the
templates are included in the `getExternalFiles` will prevent this from
happening
https://sourcegraph.com/github.com/microsoft/TypeScript@c300fea3250abd7f75920d95a58d9e742ac730ee/-/blob/src/server/editorServices.ts?L2395:18

Reviewer note: there are no tests here because we don't simulate the whole situation in the language service tests well enough. The currently [failing test](https://app.circleci.com/pipelines/github/angular/vscode-ng-language-service/3530/workflows/8ff8accd-6814-44c9-b810-db504d175a91/jobs/3458) in the vscode extension repo does pass with this change. Unfortunately, it's not included in this mono-repo, which is why it's hard to show and how this issue was introduced in the first place.