### PR TITLE
build: manually unshallow the repo for builds publishing, use absolute paths

### DIFF
--- a/scripts/ci/publish-build-artifacts.sh
+++ b/scripts/ci/publish-build-artifacts.sh
@@ -49,23 +49,31 @@ function publishRepo {
 
   echo "Starting cloning process of ${REPO_URL} into ${REPO_DIR}.."
   
-  if [[ $(git ls-remote --heads ${REPO_URL} ${BRANCH}) ]]; then
-    echo "Branch ${BRANCH} already exists. Cloning that branch."
-    git clone ${REPO_URL} ${REPO_DIR} --depth 1 --branch ${BRANCH}
+  (
+    if [[ $(git ls-remote --heads ${REPO_URL} ${BRANCH}) ]]; then
+      echo "Branch ${BRANCH} already exists. Cloning that branch."
+      git clone ${REPO_URL} ${REPO_DIR} --depth 1 --branch ${BRANCH}
 
-    cd ${REPO_DIR}
-    echo "Cloned repository and switched into the repository directory (${REPO_DIR})."
-  else
-    echo "Branch ${BRANCH} does not exist on ${packageRepo} yet."
-    echo "Cloning default branch and creating branch '${BRANCH}' on top of it."
+      cd ${REPO_DIR}
+      echo "Cloned repository and switched into the repository directory (${REPO_DIR})."
+    else
+      echo "Branch ${BRANCH} does not exist on ${packageRepo} yet."
+      echo "Cloning default branch and creating branch '${BRANCH}' on top of it."
 
-    git clone ${REPO_URL} ${REPO_DIR} --depth 1
-    cd ${REPO_DIR}
+      git clone ${REPO_URL} ${REPO_DIR} --depth 1
+      cd ${REPO_DIR}
 
-    echo "Cloned repository and switched into directory. Creating new branch now.."
+      echo "Cloned repository and switched into directory. Creating new branch now.."
 
-    git checkout -b ${BRANCH}
-  fi
+      git checkout -b ${BRANCH}
+    fi
+  )
+
+  # Unshallow the repo manually so that it doesn't trigger a push failure.
+  # This is generally unsafe, however we immediately remove all of the files from within
+  # the repo on the next line, so we should be able to safely treat the entire repo
+  # contents as an atomic piece to be pushed.
+  rm $REPO_DIR/.git/shallow
 
   # copy over build artifacts into the repo directory
   rm -rf $REPO_DIR/*
@@ -135,11 +143,12 @@ function publishAllBuilds() {
   COMMIT_MSG=`git log --oneline -1`
   COMMITTER_USER_NAME=`git --no-pager show -s --format='%cN' HEAD`
   COMMITTER_USER_EMAIL=`git --no-pager show -s --format='%cE' HEAD`
+  PACKAGES_DIST="$(pwd)/dist/packages-dist"
 
   local shortSha=`git rev-parse --short HEAD`
   local latestTag=`getLatestTag`
 
-  publishPackages $GIT_SCHEME dist/packages-dist $CUR_BRANCH "${latestTag}+${shortSha}"
+  publishPackages $GIT_SCHEME $PACKAGES_DIST $CUR_BRANCH "${latestTag}+${shortSha}"
 }
 
 # See docs/DEVELOPER.md for help


### PR DESCRIPTION
Use the absolute path for the artifacts directory, as well as encapsulate the clone
vs init logic to prevent it from changing directories.

Manually remove the shallow marker so that git does not recognize this as a shallow repo.
