### PR TITLE
fix(devtools): stop relying on `getAllAngularRootElements` in Angular DevTools' backend code

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/angular-check.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/angular-check.spec.ts
@@ -68,13 +68,12 @@ describe('angular-check', () => {
     });
 
     it('should recognize Ivy apps', () => {
-      (window as any).getAllAngularRootElements = (): Element[] => {
-        const el = document.createElement('div');
-        (el as any).__ngContext__ = 0;
-        return [el];
-      };
+      const el = document.createElement('div');
+      el.setAttribute('ng-version', '0.0.0-PLACEHOLDER');
+      (el as any).__ngContext__ = 0;
+      document.body.append(el);
       expect(appIsAngularIvy()).toBeTrue();
-      delete (window as any).getAllAngularRootElements;
+      el.remove();
     });
   });
 

--- a/devtools/projects/ng-devtools-backend/src/lib/angular-check.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/angular-check.ts
@@ -13,7 +13,8 @@ export const appIsAngularInDevMode = (): boolean => {
 };
 
 export const appIsAngularIvy = (): boolean => {
-  return typeof (window as any).getAllAngularRootElements?.()?.[0]?.__ngContext__ !== 'undefined';
+  const rootElement = (window as any).document.querySelector('[ng-version]');
+  return typeof rootElement?.__ngContext__ !== 'undefined';
 };
 
 export const appIsAngular = (): boolean => {

--- a/devtools/projects/shell-browser/src/app/ng-validate.ts
+++ b/devtools/projects/shell-browser/src/app/ng-validate.ts
@@ -46,8 +46,7 @@ function detectAngular(win: Window): void {
       {
         // Needs to be inline because we're stringifying
         // this function and executing it with eval.
-        isIvy: typeof (window as any).getAllAngularRootElements?.()?.[0]?.__ngContext__ !==
-            'undefined',
+        isIvy: typeof (ngVersionElement as any)?.__ngContext__ !== 'undefined',
         isAngular,
         isDebugMode,
         isSupportedAngularVersion,


### PR DESCRIPTION
With the introduction of standalone components, it is no longer guaranteed that getAllAngularRootElements will be available on the global object. This PR removes the dependency on this function so that DevTools can continue to work for Angular applications that use `bootstrapApplication`.