### PR TITLE
refactor(router): Only create the `Route` injector when the path matches

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1248,6 +1248,9 @@
     "name": "getOrCreateNodeInjectorForNode"
   },
   {
+    "name": "getOrCreateRouteInjectorIfNeeded"
+  },
+  {
     "name": "getOrCreateTComponentView"
   },
   {

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -6,12 +6,29 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, Type, ɵisStandalone as isStandalone} from '@angular/core';
+import {createEnvironmentInjector, EnvironmentInjector, Type, ɵisStandalone as isStandalone} from '@angular/core';
 
 import {EmptyOutletComponent} from '../components/empty_outlet';
 import {Route, Routes} from '../models';
 import {ActivatedRouteSnapshot} from '../router_state';
 import {PRIMARY_OUTLET} from '../shared';
+
+/**
+ * Creates an `EnvironmentInjector` if the `Route` has providers and one does not already exist
+ * and returns the injector. Otherwise, if the `Route` does not have `providers`, returns the
+ * `currentInjector`.
+ *
+ * @param route The route that might have providers
+ * @param currentInjector The parent injector of the `Route`
+ */
+export function getOrCreateRouteInjectorIfNeeded(
+    route: Route, currentInjector: EnvironmentInjector) {
+  if (route.providers && !route._injector) {
+    route._injector =
+        createEnvironmentInjector(route.providers, currentInjector, `Route: ${route.path}`);
+  }
+  return route._injector ?? currentInjector;
+}
 
 export function getLoadedRoutes(route: Route): Route[]|undefined {
   return route._loadedRoutes;


### PR DESCRIPTION
Currently, the `Router` will create the `EnvironmentInjector` for a
`Route` with `providers` as soon as it _attempts_ to match segments to
the `Route`. Instead, this change updates the logic to only create the
injector once we have confirmed that the `Route` matches. Note that this
will include partial matches where the final navigation still fails with
a "cannot match any routes to segment" error. We need to maintain the
injector hierarchy so we still need to create parent injectors before
descending into the child routes and determining if there is a full
match or just a partial one.

resolves #45988
