### PR TITLE
fix(core): set correct context for inject() for component ctors

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -12,7 +12,7 @@
       "main": "TODO(i): temporarily increase the payload size limit from 17597 - this needs to be investigate further what caused the increase.",
       "main": "Likely there is a missing PURE annotation https://github.com/angular/angular/pull/43344",
       "main": "Tracking issue: https://github.com/angular/angular/issues/43568",
-      "main": 20826,
+      "main": 23891,
       "polyfills": 33848
     }
   },

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -46,6 +46,7 @@ import {getFirstLContainer, getLViewParent, getNextLContainer} from '../util/vie
 import {getComponentLViewByIndex, getNativeByIndex, getNativeByTNode, isCreationMode, resetPreOrderHookFlags, unwrapLView, updateTransplantedViewCount, viewAttachedToChangeDetector} from '../util/view_utils';
 
 import {selectIndexInternal} from './advance';
+import {ɵɵdirectiveInject} from './di';
 import {attachLContainerDebug, attachLViewDebug, cloneToLViewFromTViewBlueprint, cloneToTViewData, LCleanup, LViewBlueprint, MatchesArray, TCleanup, TNodeDebug, TNodeInitialInputs, TNodeLocalNames, TViewComponents, TViewConstructor} from './lview_debug';
 
 let shouldThrowErrorOnUnknownProperty = false;
@@ -1532,7 +1533,11 @@ function configureViewWithDirective<T>(
   tView.data[directiveIndex] = def;
   const directiveFactory =
       def.factory || ((def as {factory: Function}).factory = getFactoryDef(def.type, true));
-  const nodeInjectorFactory = new NodeInjectorFactory(directiveFactory, isComponentDef(def), null);
+  // Even though `directiveFactory` will already be using `ɵɵdirectiveInject` in its generated code,
+  // we also want to support `inject()` directly from the directive constructor context so we set
+  // `ɵɵdirectiveInject` as the inject implementation here too.
+  const nodeInjectorFactory =
+      new NodeInjectorFactory(directiveFactory, isComponentDef(def), ɵɵdirectiveInject);
   tView.blueprint[directiveIndex] = nodeInjectorFactory;
   lView[directiveIndex] = nodeInjectorFactory;
 

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -855,6 +855,9 @@
     "name": "getNullInjector"
   },
   {
+    "name": "getOrCreateInjectable"
+  },
+  {
     "name": "getOrCreateNodeInjectorForNode"
   },
   {
@@ -1390,6 +1393,9 @@
   },
   {
     "name": "ɵɵdefineNgModule"
+  },
+  {
+    "name": "ɵɵdirectiveInject"
   },
   {
     "name": "ɵɵelement"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -27,7 +27,16 @@
     "name": "NG_FACTORY_DEF"
   },
   {
+    "name": "NG_INJECTABLE_DEF"
+  },
+  {
     "name": "NG_PIPE_DEF"
+  },
+  {
+    "name": "NG_PROV_DEF"
+  },
+  {
+    "name": "NOT_FOUND"
   },
   {
     "name": "NO_CHANGE"
@@ -46,6 +55,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "__forward_ref__"
   },
   {
     "name": "_global"
@@ -75,6 +87,9 @@
     "name": "attachPatchData"
   },
   {
+    "name": "bloomHasToken"
+  },
+  {
     "name": "callHook"
   },
   {
@@ -99,6 +114,9 @@
     "name": "createLView"
   },
   {
+    "name": "createNodeInjector"
+  },
+  {
     "name": "createTView"
   },
   {
@@ -109,6 +127,9 @@
   },
   {
     "name": "domRendererFactory3"
+  },
+  {
+    "name": "enterDI"
   },
   {
     "name": "enterView"
@@ -130,6 +151,9 @@
   },
   {
     "name": "findAttrIndexInNode"
+  },
+  {
+    "name": "forwardRef"
   },
   {
     "name": "generateInitialInputs"
@@ -165,6 +189,9 @@
     "name": "getFirstLContainer"
   },
   {
+    "name": "getInjectorIndex"
+  },
+  {
     "name": "getLView"
   },
   {
@@ -180,6 +207,9 @@
     "name": "getNodeInjectable"
   },
   {
+    "name": "getOrCreateInjectable"
+  },
+  {
     "name": "getOrCreateNodeInjectorForNode"
   },
   {
@@ -187,6 +217,18 @@
   },
   {
     "name": "getOrCreateTNode"
+  },
+  {
+    "name": "getOwnDefinition"
+  },
+  {
+    "name": "getParentInjectorIndex"
+  },
+  {
+    "name": "getParentInjectorLocation"
+  },
+  {
+    "name": "getParentInjectorView"
   },
   {
     "name": "getPipeDef"
@@ -211,6 +253,9 @@
   },
   {
     "name": "initTNodeFlags"
+  },
+  {
+    "name": "injectInjectorOnly"
   },
   {
     "name": "insertBloom"
@@ -267,6 +312,12 @@
     "name": "leaveViewLight"
   },
   {
+    "name": "lookupTokenUsingModuleInjector"
+  },
+  {
+    "name": "lookupTokenUsingNodeInjector"
+  },
+  {
     "name": "markAsComponentHost"
   },
   {
@@ -286,6 +337,9 @@
   },
   {
     "name": "nonNull"
+  },
+  {
+    "name": "notFoundValueOrThrow"
   },
   {
     "name": "refreshComponent"
@@ -315,7 +369,13 @@
     "name": "resetPreOrderHookFlags"
   },
   {
+    "name": "resolveForwardRef"
+  },
+  {
     "name": "saveNameToExportMap"
+  },
+  {
+    "name": "searchTokensOnInjector"
   },
   {
     "name": "setBindingRootForHostBindings"
@@ -348,6 +408,18 @@
     "name": "setUpAttributes"
   },
   {
+    "name": "shouldSearchParent"
+  },
+  {
+    "name": "stringify"
+  },
+  {
+    "name": "stringifyForError"
+  },
+  {
+    "name": "throwProviderNotFoundError"
+  },
+  {
     "name": "uniqueIdCounter"
   },
   {
@@ -366,6 +438,9 @@
     "name": "ɵɵdefineComponent"
   },
   {
+    "name": "ɵɵdirectiveInject"
+  },
+  {
     "name": "ɵɵelement"
   },
   {
@@ -373,5 +448,8 @@
   },
   {
     "name": "ɵɵelementStart"
+  },
+  {
+    "name": "ɵɵinject"
   }
 ]

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -27,7 +27,16 @@
     "name": "NG_FACTORY_DEF"
   },
   {
+    "name": "NG_INJECTABLE_DEF"
+  },
+  {
     "name": "NG_PIPE_DEF"
+  },
+  {
+    "name": "NG_PROV_DEF"
+  },
+  {
+    "name": "NOT_FOUND"
   },
   {
     "name": "NO_CHANGE"
@@ -43,6 +52,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "__forward_ref__"
   },
   {
     "name": "_global"
@@ -66,6 +78,9 @@
     "name": "attachPatchData"
   },
   {
+    "name": "bloomHasToken"
+  },
+  {
     "name": "callHook"
   },
   {
@@ -81,6 +96,9 @@
     "name": "createLView"
   },
   {
+    "name": "createNodeInjector"
+  },
+  {
     "name": "createTView"
   },
   {
@@ -88,6 +106,9 @@
   },
   {
     "name": "domRendererFactory3"
+  },
+  {
+    "name": "enterDI"
   },
   {
     "name": "enterView"
@@ -106,6 +127,9 @@
   },
   {
     "name": "extractDirectiveDef"
+  },
+  {
+    "name": "forwardRef"
   },
   {
     "name": "getClosureSafeProperty"
@@ -129,6 +153,12 @@
     "name": "getFirstLContainer"
   },
   {
+    "name": "getInjectorIndex"
+  },
+  {
+    "name": "getLView"
+  },
+  {
     "name": "getNativeByTNode"
   },
   {
@@ -141,7 +171,22 @@
     "name": "getNodeInjectable"
   },
   {
+    "name": "getOrCreateInjectable"
+  },
+  {
     "name": "getOrCreateTNode"
+  },
+  {
+    "name": "getOwnDefinition"
+  },
+  {
+    "name": "getParentInjectorIndex"
+  },
+  {
+    "name": "getParentInjectorLocation"
+  },
+  {
+    "name": "getParentInjectorView"
   },
   {
     "name": "getPipeDef"
@@ -159,6 +204,9 @@
     "name": "incrementInitPhaseFlags"
   },
   {
+    "name": "injectInjectorOnly"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -166,6 +214,9 @@
   },
   {
     "name": "invertObject"
+  },
+  {
+    "name": "isComponentDef"
   },
   {
     "name": "isLView"
@@ -186,6 +237,12 @@
     "name": "leaveViewLight"
   },
   {
+    "name": "lookupTokenUsingModuleInjector"
+  },
+  {
+    "name": "lookupTokenUsingNodeInjector"
+  },
+  {
     "name": "nativeAppendOrInsertBefore"
   },
   {
@@ -196,6 +253,9 @@
   },
   {
     "name": "nonNull"
+  },
+  {
+    "name": "notFoundValueOrThrow"
   },
   {
     "name": "refreshComponent"
@@ -225,6 +285,12 @@
     "name": "resetPreOrderHookFlags"
   },
   {
+    "name": "resolveForwardRef"
+  },
+  {
+    "name": "searchTokensOnInjector"
+  },
+  {
     "name": "setBindingRootForHostBindings"
   },
   {
@@ -243,6 +309,18 @@
     "name": "setSelectedIndex"
   },
   {
+    "name": "shouldSearchParent"
+  },
+  {
+    "name": "stringify"
+  },
+  {
+    "name": "stringifyForError"
+  },
+  {
+    "name": "throwProviderNotFoundError"
+  },
+  {
     "name": "uniqueIdCounter"
   },
   {
@@ -253,5 +331,11 @@
   },
   {
     "name": "ɵɵdefineComponent"
+  },
+  {
+    "name": "ɵɵdirectiveInject"
+  },
+  {
+    "name": "ɵɵinject"
   }
 ]

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -543,6 +543,9 @@
     "name": "getNullInjector"
   },
   {
+    "name": "getOrCreateInjectable"
+  },
+  {
     "name": "getOrCreateTNode"
   },
   {
@@ -880,6 +883,9 @@
   },
   {
     "name": "ɵɵdefineInjectable"
+  },
+  {
+    "name": "ɵɵdirectiveInject"
   },
   {
     "name": "ɵɵinject"


### PR DESCRIPTION
The `inject()` function was introduced with Ivy to support imperative
injection in factory/constructor contexts, such as directive or service
constructors as well as factory functions defined in `@Injectable` or
`InjectionToken`. However, `inject()` in a component/directive constructor
did not work due to a flaw in the logic for creating the internal factory
for components/directives.

The original intention of this logic was to keep `ɵɵdirectiveInject` tree-
shakable for applications which don't use any component-level DI. However,
this breaks the `inject()` functionality for component/directive
constructors.

This commit fixes that issue and adds tests for all the various cases in
which `inject()` should function. As a result `ɵɵdirectiveInject` is no
longer tree-shakable, but that's totally acceptable as any application that
uses `*ngIf` or `*ngFor` already contains this function. It's possible to
change how `inject()` works to restore this tree-shakability if needed.