### PR TITLE
fix(language-service): Fix detection of Angular for v14+ projects

### DIFF
--- a/packages/language-service/override_rename_ts_plugin.ts
+++ b/packages/language-service/override_rename_ts_plugin.ts
@@ -13,7 +13,7 @@ function isAngularCore(path: string): boolean {
 }
 
 function isExternalAngularCore(path: string): boolean {
-  return path.endsWith('@angular/core/core.d.ts');
+  return path.endsWith('@angular/core/core.d.ts') || path.endsWith('@angular/core/index.d.ts');
 }
 
 function isInternalAngularCore(path: string): boolean {


### PR DESCRIPTION
In v14, the .d.ts file for angular core is now "index.d.ts" rather than "core.d.ts".

This change happened in https://github.com/ng-packagr/ng-packagr/commit/c6f6e4d701d31e3d9e8636703ede731c3790778b

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
