### PR TITLE
test(docs-infra): ensure examples are split correctly across shards

### DIFF
--- a/aio/tools/examples/run-example-e2e.mjs
+++ b/aio/tools/examples/run-example-e2e.mjs
@@ -417,6 +417,7 @@ function getE2eSpecsFor(basePath, specFile, filter) {
   return globby(e2eSpecGlob, {cwd: basePath, nodir: true})
       .then(
           paths => paths.filter(file => !IGNORED_EXAMPLES.some(ignored => file.startsWith(ignored)))
+                       .sort()
                        .map(file => path.join(basePath, file)));
 }
 


### PR DESCRIPTION
Previously, the examples were split across shards based on the order in which `globby()` returned them. This was based on the assumption that `globby()`/the OS would list files in a deterministic order. However, it turns out that examples can be listed in different orders between executions, leading in them not being split correctly across shards on CI (which further means that some examples may be tested multiple times and others may not be tested at all).
You can see an example [here][1], where the `getting-started` example is tested in both the 4th and 5th shards.

This commit fixes this by explicitly sorting the examples based on their path.

[1]: https://circleci.com/gh/angular/angular/1165448
