### PR TITLE
build: set up post approval changes commit action

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -13,6 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-      - uses: angular/dev-infra/github-actions/commit-message-based-labels@6f5ad484efbab50c504a6ae0ea15fd9439888321
+      - uses: angular/dev-infra/github-actions/commit-message-based-labels@08aafccf8bf346aae1b3e1983e4a39f7eea1d44b
+        with:
+          angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
+  post_approval_changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+      - uses: angular/dev-infra/github-actions/post-approval-changes@08aafccf8bf346aae1b3e1983e4a39f7eea1d44b
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}


### PR DESCRIPTION
This action will enforce that all pull requests receive an approval from
at least one googler on the final commit for the pull request. Historically,
we have allowed all post approval changes regardless of authorship. Moving
forward, with this change, we will only allow known googlers to perform
post approval changes.

When a post approval change occurs by a non-googler, the action will
automatically rerequest a review from the latest googler who provided
an approval on the change.


Caretaker Note: Once this is merged, let me know and I can remove the current enforcement done by Github.