### PR TITLE
refactor(platform-browser): Changes key_events to rely on code field

### DIFF
--- a/packages/platform-browser/src/dom/events/key_events.ts
+++ b/packages/platform-browser/src/dom/events/key_events.ts
@@ -8,6 +8,7 @@
 
 import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
 import {Inject, Injectable, NgZone} from '@angular/core';
+
 import {EventManagerPlugin} from './event_manager';
 
 /**
@@ -194,7 +195,7 @@ export class KeyEventsPlugin extends EventManagerPlugin {
 }
 
 function getEventKey(event: any): string {
-  let key = event.key;
+  let key = event.code || event.key;
   if (key == null) {
     key = event.keyIdentifier;
     // keyIdentifier is defined in the old draft of DOM Level 3 Events implemented by Chrome and

--- a/packages/platform-browser/test/dom/events/key_events_spec.ts
+++ b/packages/platform-browser/test/dom/events/key_events_spec.ts
@@ -69,5 +69,44 @@ import {KeyEventsPlugin} from '@angular/platform-browser/src/dom/events/key_even
       expect(() => plugin.addGlobalEventListener('window', 'keyup.control.esc', () => {}))
           .not.toThrowError();
     });
+
+    it('should get key codes', () => {
+      const baseKeyboardEvent = {
+        isTrusted: true,
+        bubbles: true,
+        cancelBubble: false,
+        cancelable: true,
+        composed: true,
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        type: 'keydown'
+      };
+      expect(KeyEventsPlugin.getEventFullKey(new KeyboardEvent(
+                 'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true})))
+          .toEqual('alt.keys');
+      expect(KeyEventsPlugin.getEventFullKey(new KeyboardEvent(
+                 'keydown', {...baseKeyboardEvent, key: 'S', code: 'KeyS', altKey: true})))
+          .toEqual('alt.keys');
+      expect(KeyEventsPlugin.getEventFullKey(new KeyboardEvent(
+                 'keydown', {...baseKeyboardEvent, key: 'F', code: 'KeyF', metaKey: true})))
+          .toEqual('meta.keyf');
+      expect(KeyEventsPlugin.getEventFullKey(new KeyboardEvent(
+                 'keydown', {...baseKeyboardEvent, key: '∫', code: 'KeyB', altKey: true})))
+          .toEqual('alt.keyb');
+      expect(KeyEventsPlugin.getEventFullKey(new KeyboardEvent(
+                 'keydown', {...baseKeyboardEvent, key: 'å', code: 'KeyA', altKey: true})))
+          .toEqual('alt.keya');
+      expect(KeyEventsPlugin.getEventFullKey(new KeyboardEvent(
+                 'keydown', {...baseKeyboardEvent, key: 'ArrowUp', code: 'ArrowUp'})))
+          .toEqual('arrowup');
+      expect(KeyEventsPlugin.getEventFullKey(new KeyboardEvent(
+                 'keydown', {...baseKeyboardEvent, key: 'ArrowDown', code: 'ArrowDown'})))
+          .toEqual('arrowdown');
+      expect(KeyEventsPlugin.getEventFullKey(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'ArrowDown'})))
+          .toEqual('arrowdown');
+    });
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently we rely on `key` instead of `code` on keyboard events. This results in unexpected
behaviors on MacOS. On MacOS, pressing the alt key and another key turns into symbols, and
doesn't match the intended behavior. For example, `keydown.alt.s` reports instead as 
`keydown.alt.ß`. We rely on the `key` field and not the `code` field, which properly reports
the code for S in this case.


Issue Number: #45992


## What is the new behavior?
We match to `code` instead, and behaviors binding to keyboard events should be consistent
everywhere.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
