### PR TITLE
fix(docs-infra): improve accessibility of aio-select component

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -64,7 +64,7 @@
     <aio-nav-menu [nodes]="sideNavNodes" [currentNode]="currentNodes?.SideNav" [isWide]="dockSideNav" navLabel="guides and docs"></aio-nav-menu>
 
     <div class="doc-version">
-      <aio-select (change)="onDocVersionChange($event.index)" [options]="docVersions" [selected]="currentDocVersion"></aio-select>
+      <aio-select (optionsToggled)="scrollSelectIntoView()" (change)="onDocVersionChange($event.index)" [options]="docVersions" [selected]="currentDocVersion"></aio-select>
     </div>
   </mat-sidenav>
 

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -22,6 +22,7 @@ import { TocService } from 'app/shared/toc.service';
 import { SwUpdatesService } from 'app/sw-updates/sw-updates.service';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { first, map } from 'rxjs/operators';
+import { SelectComponent } from './shared/select/select.component';
 
 const sideNavView = 'SideNav';
 export const showTopMenuWidth = 1150;
@@ -115,6 +116,9 @@ export class AppComponent implements OnInit {
   @ViewChild('appToolbar', { read: ElementRef }) toolbar: ElementRef;
 
   @ViewChildren('themeToggle, externalIcons', { read: ElementRef }) toolbarIcons: QueryList<ElementRef>;
+
+  @ViewChild(SelectComponent, { read: ElementRef })
+  docVersionSelectElement: ElementRef;
 
   constructor(
     public deployment: Deployment,
@@ -476,5 +480,13 @@ export class AppComponent implements OnInit {
         this.focusSearchBox();
       }
     }
+  }
+
+  scrollSelectIntoView() {
+    // this method is used to scroll the select component into view when it is clicked/opened
+    // the setTimeout is needed so that the scroll happens after the component has expanded
+    setTimeout(() =>
+      this.docVersionSelectElement.nativeElement?.scrollIntoView({behavior: 'smooth'})
+    );
   }
 }

--- a/aio/src/app/shared/select/select.component.html
+++ b/aio/src/app/shared/select/select.component.html
@@ -1,16 +1,33 @@
 <div class="form-select-menu">
-  <button class="form-select-button" (click)="toggleOptions()" [disabled]="disabled">
-    <span><strong>{{label}}</strong></span><span *ngIf="showSymbol" class="symbol {{selected?.value}}"></span><span>{{selected?.title}}</span>
-  </button>
-  <ul class="form-select-dropdown" *ngIf="showOptions">
+  <div class="form-select-button"
+    role="combobox"
+    [attr.aria-controls]="listBoxId"
+    aria-haspopup="listbox"
+    (click)="toggleOptions()"
+    (keydown)="handleKeydown($event)"
+    [attr.aria-expanded]="showOptions"
+    [attr.aria-activedescendant]="currentOptionIdx > -1 && showOptions ? listBoxId + '-option-' + currentOptionIdx : null"
+    [attr.aria-label]="label +  (selected?.title ?? '')"
+    [class.disabled]="disabled"
+    tabindex="0"
+  >
+    <div aria-hidden="true">
+      <ng-container *ngTemplateOutlet="optionTemplate; context: { showLabel: true, value: selected?.value, title: selected?.title }"></ng-container>
+    </div>
+  </div>
+  <ul class="form-select-dropdown" *ngIf="showOptions" [id]="listBoxId" role="listbox" tabIndex="-1" #listBox>
+    <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -- the key events are handled in the ts class -->
     <li *ngFor="let option of options; index as i"
+        role="option"
         [class.selected]="option === selected"
-        role="button"
-        tabindex="0"
-        (click)="select(option, i)"
-        (keydown.enter)="select(option, i)"
-        (keydown.space)="select(option, i); $event.preventDefault()">
-      <span *ngIf="showSymbol" class="symbol {{option.value}}"></span><span>{{option.title}}</span>
+        [attr.aria-selected]="option === selected"
+        [class.current]="currentOptionIdx === i"
+        [id]="listBoxId + '-option-' + i"
+        (click)="select(i)">
+        <ng-container *ngTemplateOutlet="optionTemplate; context: { showLabel: false, value: option.value, title: option.title }"></ng-container>
     </li>
   </ul>
 </div>
+<ng-template #optionTemplate let-showLabel="showLabel" let-value="value" let-title="title">
+  <span *ngIf="showLabel"><strong>{{label}}</strong></span><span *ngIf="showSymbol" class="symbol {{value}}"></span><span>{{title}}</span>
+</ng-template>

--- a/aio/src/app/shared/select/select.component.ts
+++ b/aio/src/app/shared/select/select.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, EventEmitter, HostListener, Input, Output, OnInit } from '@angular/core';
+import { Component, ElementRef, EventEmitter, HostListener, Input, Output, OnInit, ViewChild } from '@angular/core';
 
 export interface Option {
   title: string;
@@ -10,6 +10,8 @@ export interface Option {
   templateUrl: 'select.component.html'
 })
 export class SelectComponent implements OnInit {
+  static instancesCounter = 0;
+
   @Input() selected: Option;
 
   @Input() options: Option[];
@@ -17,13 +19,34 @@ export class SelectComponent implements OnInit {
   // eslint-disable-next-line @angular-eslint/no-output-native
   @Output() change = new EventEmitter<{option: Option, index: number}>();
 
+  @Output() optionsToggled = new EventEmitter<boolean>();
+
   @Input() showSymbol = false;
 
-  @Input() label: string;
+  @Input() label!: string;
 
   @Input() disabled: boolean;
 
-  showOptions = false;
+  @ViewChild('listBox', { read: ElementRef }) listBox: ElementRef;
+
+  private _showOptions = false;
+
+  get showOptions() {
+    return this._showOptions;
+  }
+
+  set showOptions(showOptions: boolean) {
+    if(!this.disabled) {
+      if(this.showOptions !== showOptions) {
+        this.optionsToggled.emit(showOptions);
+      }
+      this._showOptions = showOptions;
+    }
+  }
+
+  listBoxId = `aio-select-list-box-${SelectComponent.instancesCounter++}`;
+
+  currentOptionIdx = 0;
 
   constructor(private hostElement: ElementRef) {}
 
@@ -39,7 +62,8 @@ export class SelectComponent implements OnInit {
     this.showOptions = false;
   }
 
-  select(option: Option, index: number) {
+  select(index: number) {
+    const option = this.options[index];
     this.selected = option;
     this.change.emit({option, index});
     this.hideOptions();
@@ -53,8 +77,41 @@ export class SelectComponent implements OnInit {
     }
   }
 
-  @HostListener('document:keydown.escape')
-  onKeyDown() {
-    this.hideOptions();
+  handleKeydown(event: KeyboardEvent) {
+    const runOrOpenOptions = (fn: () => void): void => {
+      if(!this.showOptions) {
+        this.showOptions = true;
+        const indexOfSelected =  (this.options ?? []).indexOf(this.selected);
+        this.currentOptionIdx = indexOfSelected > 0 ? indexOfSelected : 0;
+      } else {
+        fn();
+      }
+    };
+    switch(event.key) {
+      case 'ArrowDown':
+        runOrOpenOptions(() =>
+          this.currentOptionIdx = Math.min(this.currentOptionIdx + 1, (this.options?.length ?? 0) - 1)
+        );
+        break;
+      case 'ArrowUp':
+        runOrOpenOptions(() => this.currentOptionIdx = Math.max(this.currentOptionIdx - 1, 0));
+        break;
+      case 'Escape':
+        this.hideOptions();
+        break;
+      case 'Tab':
+        if(this.showOptions) {
+          this.select(this.currentOptionIdx);
+        }
+        break;
+      case 'Enter':
+      case 'Space':
+      case ' ':
+        runOrOpenOptions(() => this.select(this.currentOptionIdx));
+        break;
+    }
+    if(event.key !== 'Tab') {
+      event.preventDefault();
+    }
   }
 }

--- a/aio/src/styles/2-modules/select-menu/_select-menu-theme.scss
+++ b/aio/src/styles/2-modules/select-menu/_select-menu-theme.scss
@@ -18,7 +18,7 @@
         box-shadow: 0 2px 2px rgba(constants.$blue-400, 0.24), 0 0 2px rgba(constants.$blue-400, 0.12);
       }
 
-      &[disabled] {
+      &.disabled {
         color: lightgrey;
       }
     }
@@ -28,7 +28,7 @@
       box-shadow: 0 16px 16px rgba(constants.$black, 0.24), 0 0 16px rgba(constants.$black, 0.12);
 
       li {
-        &:hover {
+        &:hover, &.current {
           background-color: if($is-dark-theme, constants.$darkgray, constants.$blue-grey-50);
           color: f($is-dark-theme, constants.$blue-grey-400, constants.$blue-grey-500);
         }

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,7 +2,7 @@
   "aio": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 454714,
+      "main": 456483,
       "polyfills": 33814,
       "styles": 72183,
       "light-theme": 78276,
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 457623,
+      "main": 456412,
       "polyfills": 33922,
       "styles": 72183,
       "light-theme": 78276,

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,7 +2,7 @@
   "aio": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 453332,
+      "main": 454714,
       "polyfills": 33814,
       "styles": 72183,
       "light-theme": 78276,
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 453359,
+      "main": 457623,
       "polyfills": 33922,
       "styles": 72183,
       "light-theme": 78276,


### PR DESCRIPTION
improve the accessibility of the aio-select component so that it is
clear for screen reader users its functionality (currently it is
presented as a simple button), following the WAI-ARIA authoring
practices (see: https://www.w3.org/TR/wai-aria-practices/#combobox)

A first attempt in improving the accessibility of the component has been
tried in PR #45937 by replacing it with the material select component,
such implementation has however been scrapped since the increase of
payload sizes has proven prohibitively large

(also note that given native select elements haven't been used given the lack
of syling options for such elements)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Screen readers read the aio-select elements as if they were normal buttons without clearly indicating to users how to interact with them:

https://user-images.githubusercontent.com/61631103/168682930-57d923bf-ac60-40f5-b315-c3ddfbf42072.mp4

(note in the video how the elements are referred as normal buttons , note that the keyboard interaction is pretty ad-hoc and does not follow the wai-aria authoring practices)

## What is the new behavior?

both aspects have been improved making the element more accessible:

https://user-images.githubusercontent.com/61631103/168683162-afa33cf4-b4b5-4cbf-bf5b-a21570f9ff5c.mp4

(note in the video how the elements are referred as combo boxes now, note that the keyboard interaction now follows the wai-aria authoring practices)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - @gkalpak :slightly_smiling_face: 
 - I wanted to re-implement this using the native select elements. but I was unaware/forgot that such type of element can't really be styled :see_no_evil: (I guess I now know why this component was created in the first place) so I just kept it as is but improved its a11y
 - I did add unit tests for keyboard navigation, I thought of adding unit tests for aria attributes as well, but that felt a bit overkill, but I do can add them if we deem it beneficial :slightly_smiling_face: 