### PR TITLE
fix(docs-infra): correctly show CLI version in install command

### DIFF
--- a/aio/content/cli/index.md
+++ b/aio/content/cli/index.md
@@ -10,7 +10,7 @@ Install the CLI using the `npm` package manager:
 
 <code-example format="shell" language="shell">
 
-npm install -g &commat;angular/cli
+npm install -g &commat;angular/cli<aio-angular-dist-tag class="pln"></aio-angular-dist-tag>
 
 </code-example>
 

--- a/aio/content/guide/setup-local.md
+++ b/aio/content/guide/setup-local.md
@@ -43,7 +43,7 @@ To install the Angular CLI, open a terminal window and run the following command
 
 <code-example format="shell" language="shell">
 
-npm install -g &commat;angular/cli<aio-angular-dist-tag></aio-angular-dist-tag>
+npm install -g &commat;angular/cli<aio-angular-dist-tag class="pln"></aio-angular-dist-tag>
 
 </code-example>
 


### PR DESCRIPTION
This PR addresses two issues related to the CLI install command.
See individual commits for details.