### PR TITLE
Add CanMatch guard to Route

### DIFF
--- a/aio/content/examples/router/src/app/admin/admin-routing.module.2.ts
+++ b/aio/content/examples/router/src/app/admin/admin-routing.module.2.ts
@@ -1,44 +1,40 @@
 // #docplaster
 // #docregion
-import { NgModule } from '@angular/core';
-import { RouterModule, Routes } from '@angular/router';
-
-import { AdminComponent } from './admin/admin.component';
-import { AdminDashboardComponent } from './admin-dashboard/admin-dashboard.component';
-import { ManageCrisesComponent } from './manage-crises/manage-crises.component';
-import { ManageHeroesComponent } from './manage-heroes/manage-heroes.component';
+import {NgModule} from '@angular/core';
+import {RouterModule, Routes} from '@angular/router';
 
 // #docregion admin-route
-import { AuthGuard } from '../auth/auth.guard';
+import {AuthGuard} from '../auth/auth.guard';
 
-const adminRoutes: Routes = [
-  {
-    path: 'admin',
-    component: AdminComponent,
-    canActivate: [AuthGuard],
+import {AdminDashboardComponent} from './admin-dashboard/admin-dashboard.component';
+import {AdminComponent} from './admin/admin.component';
+import {ManageCrisesComponent} from './manage-crises/manage-crises.component';
+import {ManageHeroesComponent} from './manage-heroes/manage-heroes.component';
+
+const adminRoutes: Routes = [{
+  path: 'admin',
+  component: AdminComponent,
+  canActivate: [AuthGuard],
+
+  // #enddocregion admin-route
+  // #docregion can-match
+  canMatch: [AuthGuard],
+  // #enddocregion can-match
+  // #docregion admin-route
+  children: [{
+    path: '',
     children: [
-      {
-        path: '',
-        children: [
-          { path: 'crises', component: ManageCrisesComponent },
-          { path: 'heroes', component: ManageHeroesComponent },
-          { path: '', component: AdminDashboardComponent }
-        ],
-        // #enddocregion admin-route
-        canActivateChild: [AuthGuard]
-        // #docregion admin-route
-      }
-    ]
-  }
-];
+      {path: 'crises', component: ManageCrisesComponent},
+      {path: 'heroes', component: ManageHeroesComponent},
+      {path: '', component: AdminDashboardComponent}
+    ],
+    // #enddocregion admin-route
+    canActivateChild: [AuthGuard]
+    // #docregion admin-route
+  }]
+}];
 
-@NgModule({
-  imports: [
-    RouterModule.forChild(adminRoutes)
-  ],
-  exports: [
-    RouterModule
-  ]
-})
-export class AdminRoutingModule {}
+@NgModule({imports: [RouterModule.forChild(adminRoutes)], exports: [RouterModule]})
+export class AdminRoutingModule {
+}
 // #enddocregion

--- a/aio/content/examples/router/src/app/auth/auth.guard.2.ts
+++ b/aio/content/examples/router/src/app/auth/auth.guard.2.ts
@@ -1,13 +1,16 @@
 // #docregion
-import { Injectable } from '@angular/core';
-import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, Router, UrlTree } from '@angular/router';
+import {Injectable} from '@angular/core';
+import {
+  ActivatedRouteSnapshot, CanActivate, CanMatch,
+  Route, Router, RouterStateSnapshot, UrlTree
+} from '@angular/router';
 
-import { AuthService } from './auth.service';
+import {AuthService} from './auth.service';
 
 @Injectable({
   providedIn: 'root',
 })
-export class AuthGuard implements CanActivate {
+export class AuthGuard implements CanActivate, CanMatch {
   constructor(private authService: AuthService, private router: Router) {}
 
   canActivate(
@@ -18,8 +21,19 @@ export class AuthGuard implements CanActivate {
     return this.checkLogin(url);
   }
 
+  // #enddocregion
+  // #docregion can-match
+  canMatch(route: Route) {
+    const url = `/${route.path}`;
+    return this.checkLogin(url) === true;
+  }
+  // #enddocregion can-match
+  // #docregion
+
   checkLogin(url: string): true|UrlTree {
-    if (this.authService.isLoggedIn) { return true; }
+    if (this.authService.isLoggedIn) {
+      return true;
+    }
 
     // Store the attempted URL for redirecting
     this.authService.redirectUrl = url;

--- a/aio/content/guide/router-tutorial-toh.md
+++ b/aio/content/guide/router-tutorial-toh.md
@@ -1646,9 +1646,8 @@ A guard's return value controls the router's behavior:
 
 <div class="alert is-helpful">
 
-**NOTE**: <br />
-The guard can also tell the router to navigate elsewhere, effectively canceling the current navigation.
-When doing so inside a guard, the guard should return `false`.
+**Note:** The guard can also tell the router to navigate elsewhere, effectively canceling the current navigation.
+When doing so inside a guard, the guard should return `UrlTree`;
 
 </div>
 
@@ -1675,12 +1674,16 @@ The router supports multiple guard interfaces:
 | [`CanDeactivate`](api/router/CanDeactivate)       | To mediate navigation *away* from the current route                 |
 | [`Resolve`](api/router/Resolve)                   | To perform route data retrieval *before* route activation           |
 | [`CanLoad`](api/router/CanLoad)                   | To mediate navigation *to* a feature module loaded *asynchronously* |
+| [`CanMatch`](api/router/CanMatch)                 | To control whether a `Route` should be used at all, even if the `path` matches the URL segment. |
 
 You can have multiple guards at every level of a routing hierarchy.
 The router checks the `CanDeactivate` guards first, from the deepest child route to the top.
 Then it checks the `CanActivate` and `CanActivateChild` guards from the top down to the deepest child route.
 If the feature module is loaded asynchronously, the `CanLoad` guard is checked before the module is loaded.
-If *any* guard returns false, pending guards that have not completed are canceled, and the entire navigation is canceled.
+
+With the exception of `CanMatch`, if *any* guard returns false, pending guards that have not completed are canceled, and the entire navigation is canceled. If a `CanMatch` guard returns `false`, the `Router` continues
+processing the rest of the `Routes` to see if a different `Route` config matches the URL. You can think of this 
+as though the `Router` is pretending the `Route` with the `CanMatch` guard did not exist.
 
 There are several examples over the next few sections.
 
@@ -1940,6 +1943,19 @@ In `app.module.ts`, import and add the `AuthModule` to the `AppModule` imports.
     <code-pane header="src/app/auth/login/login.component.ts" path="router/src/app/auth/login/login.component.1.ts"></code-pane>
     <code-pane header="src/app/auth/auth.module.ts" path="router/src/app/auth/auth.module.ts"></code-pane>
 </code-tabs>
+
+<a id="can-match-guard"></a>
+
+### `CanMatch`: Controlling `Route` matching based on application conditions
+
+As an alternative to using a `CanActivate` guard which redirects the user to a new page if they do not have access, you can instead
+use a `CanMatch` guard to control whether the `Router` even attempts to activate a `Route`. This allows you to have
+multiple `Route` configurations which share the same `path` but are match based on different conditions. In addition, this approach
+can allow the `Router` to match the wildcard `Route` instead.
+
+<code-example path="router/src/app/auth/auth.guard.2.ts" header="src/app/auth/auth.guard.ts (excerpt)" region="can-match"></code-example>
+
+<code-example path="router/src/app/admin/admin-routing.module.2.ts" header="src/app/admin/admin-routing.module.ts (guarded admin route)" region="can-match"></code-example>
 
 <a id="can-activate-child-guard"></a>
 

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -306,6 +306,12 @@
     "packages/forms/src/model/abstract_model.ts"
   ],
   [
+    "packages/router/src/apply_redirects.ts",
+    "packages/router/src/operators/check_guards.ts",
+    "packages/router/src/router.ts",
+    "packages/router/src/operators/apply_redirects.ts"
+  ],
+  [
     "packages/router/src/directives/router_outlet.ts",
     "packages/router/src/router_outlet_context.ts"
   ],
@@ -324,10 +330,6 @@
   ],
   [
     "packages/router/src/operators/apply_redirects.ts",
-    "packages/router/src/router.ts"
-  ],
-  [
-    "packages/router/src/operators/check_guards.ts",
     "packages/router/src/router.ts"
   ],
   [

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -136,6 +136,12 @@ export interface CanLoad {
 }
 
 // @public
+export interface CanMatch {
+    // (undocumented)
+    canMatch(route: Route, segments: UrlSegment[]): Observable<boolean> | Promise<boolean> | boolean;
+}
+
+// @public
 export class ChildActivationEnd {
     constructor(
     snapshot: ActivatedRouteSnapshot);
@@ -511,6 +517,7 @@ export interface Route {
     canActivateChild?: any[];
     canDeactivate?: any[];
     canLoad?: any[];
+    canMatch?: Array<Type<CanMatch> | InjectionToken<CanMatchFn>>;
     children?: Routes;
     component?: Type<any>;
     data?: Data;

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -138,7 +138,7 @@ export interface CanLoad {
 // @public
 export interface CanMatch {
     // (undocumented)
-    canMatch(route: Route, segments: UrlSegment[]): Observable<boolean> | Promise<boolean> | boolean;
+    canMatch(route: Route, segments: UrlSegment[]): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree;
 }
 
 // @public

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -33,7 +33,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2835,
-      "main": 237084,
+      "main": 238471,
       "polyfills": 33842,
       "src_app_lazy_lazy_module_ts": 780
     }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -495,6 +495,9 @@
     "name": "ROUTES2"
   },
   {
+    "name": "Recognizer"
+  },
+  {
     "name": "RefCountOperator"
   },
   {
@@ -673,6 +676,9 @@
   },
   {
     "name": "TakeSubscriber"
+  },
+  {
+    "name": "TakeWhileSubscriber"
   },
   {
     "name": "TapSubscriber"
@@ -1521,6 +1527,9 @@
     "name": "joinWithSlash"
   },
   {
+    "name": "last"
+  },
+  {
     "name": "last2"
   },
   {
@@ -1563,6 +1572,9 @@
     "name": "matchSegments"
   },
   {
+    "name": "matchWithChecks"
+  },
+  {
     "name": "materializeViewResults"
   },
   {
@@ -1603,9 +1615,6 @@
   },
   {
     "name": "navigationCancelingError"
-  },
-  {
-    "name": "newObservableError"
   },
   {
     "name": "nextBindingIndex"
@@ -1668,6 +1677,9 @@
     "name": "pathCompareMap"
   },
   {
+    "name": "pipeFromArray"
+  },
+  {
     "name": "platformBrowser"
   },
   {
@@ -1695,7 +1707,7 @@
     "name": "readPatchedLView"
   },
   {
-    "name": "recognize2"
+    "name": "redirectIfUrlTree"
   },
   {
     "name": "refCount"

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -284,7 +284,7 @@ class ApplyRedirects {
       return of(new UrlSegmentGroup(segments, {}));
     }
 
-    return matchWithChecks(rawSegmentGroup, route, segments, injector)
+    return matchWithChecks(rawSegmentGroup, route, segments, injector, this.urlSerializer)
         .pipe(
             switchMap(({matched, consumedSegments, remainingSegments}) => {
               if (!matched) return noMatch(rawSegmentGroup);

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -8,18 +8,16 @@
 
 import {EnvironmentInjector} from '@angular/core';
 import {EmptyError, from, Observable, of, throwError} from 'rxjs';
-import {catchError, concatMap, first, last, map, mergeMap, scan, tap} from 'rxjs/operators';
+import {catchError, concatMap, first, last, map, mergeMap, scan, switchMap, tap} from 'rxjs/operators';
 
-import {CanLoadFn, LoadedRouterConfig, Route, Routes} from './models';
+import {LoadedRouterConfig, Route, Routes} from './models';
 import {runCanLoadGuards} from './operators/check_guards';
-import {prioritizedGuardValue} from './operators/prioritized_guard_value';
 import {RouterConfigLoader} from './router_config_loader';
 import {navigationCancelingError, Params, PRIMARY_OUTLET} from './shared';
 import {createRoot, squashSegmentGroup, UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
 import {forEach, wrapIntoObservable} from './utils/collection';
 import {getOrCreateRouteInjectorIfNeeded, getOutlet, sortByMatchingOutlets} from './utils/config';
-import {isImmediateMatch, match, noLeftoversInUrl, split} from './utils/config_matching';
-import {isCanLoad, isFunction, isUrlTree} from './utils/type_guards';
+import {isImmediateMatch, match, matchWithChecks, noLeftoversInUrl, split} from './utils/config_matching';
 
 class NoMatch {
   public segmentGroup: UrlSegmentGroup|null;
@@ -286,41 +284,46 @@ class ApplyRedirects {
       return of(new UrlSegmentGroup(segments, {}));
     }
 
-    const {matched, consumedSegments, remainingSegments} = match(rawSegmentGroup, route, segments);
-    if (!matched) return noMatch(rawSegmentGroup);
+    return matchWithChecks(rawSegmentGroup, route, segments, injector)
+        .pipe(
+            switchMap(({matched, consumedSegments, remainingSegments}) => {
+              if (!matched) return noMatch(rawSegmentGroup);
 
-    // Only create the Route's `EnvironmentInjector` if it matches the attempted navigation
-    injector = getOrCreateRouteInjectorIfNeeded(route, injector);
-    const childConfig$ = this.getChildConfig(injector, route, segments);
+              // Only create the Route's `EnvironmentInjector` if it matches the attempted
+              // navigation
+              injector = getOrCreateRouteInjectorIfNeeded(route, injector);
+              const childConfig$ = this.getChildConfig(injector, route, segments);
 
-    return childConfig$.pipe(mergeMap((routerConfig: LoadedRouterConfig) => {
-      const childInjector = routerConfig.injector ?? injector;
-      const childConfig = routerConfig.routes;
+              return childConfig$.pipe(mergeMap((routerConfig: LoadedRouterConfig) => {
+                const childInjector = routerConfig.injector ?? injector;
+                const childConfig = routerConfig.routes;
 
-      const {segmentGroup: splitSegmentGroup, slicedSegments} =
-          split(rawSegmentGroup, consumedSegments, remainingSegments, childConfig);
-      // See comment on the other call to `split` about why this is necessary.
-      const segmentGroup =
-          new UrlSegmentGroup(splitSegmentGroup.segments, splitSegmentGroup.children);
+                const {segmentGroup: splitSegmentGroup, slicedSegments} =
+                    split(rawSegmentGroup, consumedSegments, remainingSegments, childConfig);
+                // See comment on the other call to `split` about why this is necessary.
+                const segmentGroup =
+                    new UrlSegmentGroup(splitSegmentGroup.segments, splitSegmentGroup.children);
 
-      if (slicedSegments.length === 0 && segmentGroup.hasChildren()) {
-        const expanded$ = this.expandChildren(childInjector, childConfig, segmentGroup);
-        return expanded$.pipe(
-            map((children: any) => new UrlSegmentGroup(consumedSegments, children)));
-      }
+                if (slicedSegments.length === 0 && segmentGroup.hasChildren()) {
+                  const expanded$ = this.expandChildren(childInjector, childConfig, segmentGroup);
+                  return expanded$.pipe(
+                      map((children: any) => new UrlSegmentGroup(consumedSegments, children)));
+                }
 
-      if (childConfig.length === 0 && slicedSegments.length === 0) {
-        return of(new UrlSegmentGroup(consumedSegments, {}));
-      }
+                if (childConfig.length === 0 && slicedSegments.length === 0) {
+                  return of(new UrlSegmentGroup(consumedSegments, {}));
+                }
 
-      const matchedOnOutlet = getOutlet(route) === outlet;
-      const expanded$ = this.expandSegment(
-          childInjector, segmentGroup, childConfig, slicedSegments,
-          matchedOnOutlet ? PRIMARY_OUTLET : outlet, true);
-      return expanded$.pipe(
-          map((cs: UrlSegmentGroup) =>
-                  new UrlSegmentGroup(consumedSegments.concat(cs.segments), cs.children)));
-    }));
+                const matchedOnOutlet = getOutlet(route) === outlet;
+                const expanded$ = this.expandSegment(
+                    childInjector, segmentGroup, childConfig, slicedSegments,
+                    matchedOnOutlet ? PRIMARY_OUTLET : outlet, true);
+                return expanded$.pipe(
+                    map((cs: UrlSegmentGroup) => new UrlSegmentGroup(
+                            consumedSegments.concat(cs.segments), cs.children)));
+              }));
+            }),
+        );
   }
 
   private getChildConfig(injector: EnvironmentInjector, route: Route, segments: UrlSegment[]):

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -12,7 +12,7 @@ export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet, RouterOutletContract} from './directives/router_outlet';
 export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, EventType, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
-export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, Data, LoadChildren, LoadChildrenCallback, QueryParamsHandling, Resolve, ResolveData, Route, Routes, RunGuardsAndResolvers, UrlMatcher, UrlMatchResult} from './models';
+export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, CanMatch, Data, LoadChildren, LoadChildrenCallback, QueryParamsHandling, Resolve, ResolveData, Route, Routes, RunGuardsAndResolvers, UrlMatcher, UrlMatchResult} from './models';
 export {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
 export {BaseRouteReuseStrategy, DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Navigation, NavigationBehaviorOptions, NavigationExtras, Router, UrlCreationOptions} from './router';

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, ImportedNgModuleProviders, NgModuleFactory, Provider, Type} from '@angular/core';
+import {EnvironmentInjector, ImportedNgModuleProviders, InjectionToken, NgModuleFactory, Provider, Type} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
@@ -455,6 +455,12 @@ export interface Route {
    */
   canActivate?: any[];
   /**
+   * An array of DI tokens used to look up `CanMatch()`
+   * handlers, in order to determine if the current user is allowed to
+   * match the `Route`. By default, any route can match.
+   */
+  canMatch?: Array<Type<CanMatch>|InjectionToken<CanMatchFn>>;
+  /**
    * An array of DI tokens used to look up `CanActivateChild()` handlers,
    * in order to determine if the current user is allowed to activate
    * a child of the component. By default, any user can activate a child.
@@ -804,6 +810,102 @@ export type CanDeactivateFn<T> =
     (component: T, currentRoute: ActivatedRouteSnapshot, currentState: RouterStateSnapshot,
      nextState?: RouterStateSnapshot) =>
         Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
+
+/**
+ * @description
+ *
+ * Interface that a class can implement to be a guard deciding if a `Route` can be matched.
+ * If all guards return `true`, navigation continues and the `Router` will use the `Route` during
+ * activation. If any guard returns `false`, the `Route` is skipped for matching and other `Route`
+ * configurations are processed instead.
+ *
+ * The following example implements a `CanMatch` function that decides whether the
+ * current user has permission to access the users page.
+ *
+ *
+ * ```
+ * class UserToken {}
+ * class Permissions {
+ *   canAccess(user: UserToken, id: string, segments: UrlSegment[]): boolean {
+ *     return true;
+ *   }
+ * }
+ *
+ * @Injectable()
+ * class CanMatchTeamSection implements CanMatch {
+ *   constructor(private permissions: Permissions, private currentUser: UserToken) {}
+ *
+ *   canLoad(route: Route, segments: UrlSegment[]): Observable<boolean>|Promise<boolean>|boolean {
+ *     return this.permissions.canAccess(this.currentUser, route, segments);
+ *   }
+ * }
+ * ```
+ *
+ * Here, the defined guard function is provided as part of the `Route` object
+ * in the router configuration:
+ *
+ * ```
+ *
+ * @NgModule({
+ *   imports: [
+ *     RouterModule.forRoot([
+ *       {
+ *         path: 'team/:id',
+ *         component: TeamComponent,
+ *         loadChildren: () => import('./team').then(mod => mod.TeamModule),
+ *         canMatch: [CanMatchTeamSection]
+ *       },
+ *       {
+ *         path: '**',
+ *         component: NotFoundComponent
+ *       }
+ *     ])
+ *   ],
+ *   providers: [CanMatchTeamSection, UserToken, Permissions]
+ * })
+ * class AppModule {}
+ * ```
+ *
+ * If the `CanMatchTeamSection` were to return `false`, the router would continue navigating to the
+ * `team/:id` URL, but would load the `NotFoundComponent` because the `Route` for `'team/:id'`
+ * could not be used for a URL match but the catch-all `**` `Route` did instead.
+ *
+ * You can alternatively provide an in-line function with the `canMatch` signature:
+ *
+ * ```
+ * @NgModule({
+ *   imports: [
+ *     RouterModule.forRoot([
+ *       {
+ *         path: 'team/:id',
+ *         component: TeamComponent,
+ *         loadChildren: () => import('./team').then(mod => mod.TeamModule),
+ *         canMatch: ['canMatchTeamSection']
+ *       },
+ *       {
+ *         path: '**',
+ *         component: NotFoundComponent
+ *       }
+ *     ])
+ *   ],
+ *   providers: [
+ *     {
+ *       provide: 'canMatchTeamSection',
+ *       useValue: (route: Route, segments: UrlSegment[]) => true
+ *     }
+ *   ]
+ * })
+ * class AppModule {}
+ * ```
+ *
+ * @publicApi
+ */
+export interface CanMatch {
+  canMatch(route: Route, segments: UrlSegment[]): Observable<boolean>|Promise<boolean>|boolean;
+}
+
+export type CanMatchFn = (route: Route, segments: UrlSegment[]) =>
+    Observable<boolean>|Promise<boolean>|boolean;
 
 /**
  * @description

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -901,11 +901,12 @@ export type CanDeactivateFn<T> =
  * @publicApi
  */
 export interface CanMatch {
-  canMatch(route: Route, segments: UrlSegment[]): Observable<boolean>|Promise<boolean>|boolean;
+  canMatch(route: Route, segments: UrlSegment[]):
+      Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
 }
 
 export type CanMatchFn = (route: Route, segments: UrlSegment[]) =>
-    Observable<boolean>|Promise<boolean>|boolean;
+    Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean;
 
 /**
  * @description

--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -8,17 +8,17 @@
 
 import {EnvironmentInjector, Injector} from '@angular/core';
 import {concat, defer, from, MonoTypeOperatorFunction, Observable, of, OperatorFunction, pipe} from 'rxjs';
-import {concatMap, first, map, mergeMap, tap} from 'rxjs/operators';
+import {concatMap, filter, first, map, mergeMap, tap} from 'rxjs/operators';
 
 import {ActivationStart, ChildActivationStart, Event} from '../events';
-import {CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanLoadFn, Route} from '../models';
+import {CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanLoadFn, CanMatch, CanMatchFn, Route} from '../models';
 import {NavigationTransition} from '../router';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from '../router_state';
 import {navigationCancelingError} from '../shared';
 import {UrlSegment, UrlSerializer, UrlTree} from '../url_tree';
 import {wrapIntoObservable} from '../utils/collection';
 import {CanActivate, CanDeactivate, getCanActivateChild, getToken} from '../utils/preactivation';
-import {isBoolean, isCanActivate, isCanActivateChild, isCanDeactivate, isCanLoad, isFunction, isUrlTree} from '../utils/type_guards';
+import {isBoolean, isCanActivate, isCanActivateChild, isCanDeactivate, isCanLoad, isCanMatch, isFunction, isUrlTree} from '../utils/type_guards';
 
 import {prioritizedGuardValue} from './prioritized_guard_value';
 
@@ -178,7 +178,6 @@ function runCanDeactivate(
   return of(canDeactivateObservables).pipe(prioritizedGuardValue());
 }
 
-
 export function runCanLoadGuards(
     injector: EnvironmentInjector, route: Route, segments: UrlSegment[],
     urlSerializer: UrlSerializer): Observable<boolean> {
@@ -220,4 +219,22 @@ function redirectIfUrlTree(urlSerializer: UrlSerializer):
       }),
       map(result => result === true),
   );
+}
+
+export function runCanMatchGuards(
+    injector: Injector, route: Route, segments: UrlSegment[]): Observable<boolean> {
+  const canMatch = route.canMatch;
+  if (!canMatch || canMatch.length === 0) return of(true);
+
+  const canMatchObservables = canMatch.map(injectionToken => {
+    const guard = injector.get<CanMatch|CanMatchFn>(injectionToken);
+    const guardVal = isCanMatch(guard) ? guard.canMatch(route, segments) : guard(route, segments);
+    return wrapIntoObservable(guardVal);
+  });
+
+  return of(canMatchObservables)
+      .pipe(
+          prioritizedGuardValue(),
+          filter((v): v is boolean => !(v instanceof UrlTree)),
+      );
 }

--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -222,7 +222,8 @@ function redirectIfUrlTree(urlSerializer: UrlSerializer):
 }
 
 export function runCanMatchGuards(
-    injector: Injector, route: Route, segments: UrlSegment[]): Observable<boolean> {
+    injector: Injector, route: Route, segments: UrlSegment[],
+    urlSerializer: UrlSerializer): Observable<boolean> {
   const canMatch = route.canMatch;
   if (!canMatch || canMatch.length === 0) return of(true);
 
@@ -235,6 +236,6 @@ export function runCanMatchGuards(
   return of(canMatchObservables)
       .pipe(
           prioritizedGuardValue(),
-          filter((v): v is boolean => !(v instanceof UrlTree)),
+          redirectIfUrlTree(urlSerializer),
       );
 }

--- a/packages/router/src/operators/recognize.ts
+++ b/packages/router/src/operators/recognize.ts
@@ -13,15 +13,16 @@ import {map, mergeMap} from 'rxjs/operators';
 import {Route} from '../models';
 import {recognize as recognizeFn} from '../recognize';
 import {NavigationTransition} from '../router';
-import {UrlTree} from '../url_tree';
+import {UrlSerializer, UrlTree} from '../url_tree';
 
 export function recognize(
     injector: EnvironmentInjector, rootComponentType: Type<any>|null, config: Route[],
-    serializer: (url: UrlTree) => string, paramsInheritanceStrategy: 'emptyOnly'|'always',
+    serializer: UrlSerializer, paramsInheritanceStrategy: 'emptyOnly'|'always',
     relativeLinkResolution: 'legacy'|'corrected'): MonoTypeOperatorFunction<NavigationTransition> {
   return mergeMap(
       t => recognizeFn(
                injector, rootComponentType, config, t.urlAfterRedirects!,
-               serializer(t.urlAfterRedirects!), paramsInheritanceStrategy, relativeLinkResolution)
+               serializer.serialize(t.urlAfterRedirects!), serializer, paramsInheritanceStrategy,
+               relativeLinkResolution)
                .pipe(map(targetSnapshot => ({...t, targetSnapshot}))));
 }

--- a/packages/router/src/operators/recognize.ts
+++ b/packages/router/src/operators/recognize.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type} from '@angular/core';
+import {EnvironmentInjector, Injector, Type} from '@angular/core';
 import {MonoTypeOperatorFunction} from 'rxjs';
 import {map, mergeMap} from 'rxjs/operators';
 
@@ -16,12 +16,12 @@ import {NavigationTransition} from '../router';
 import {UrlTree} from '../url_tree';
 
 export function recognize(
-    rootComponentType: Type<any>|null, config: Route[], serializer: (url: UrlTree) => string,
-    paramsInheritanceStrategy: 'emptyOnly'|'always',
+    injector: EnvironmentInjector, rootComponentType: Type<any>|null, config: Route[],
+    serializer: (url: UrlTree) => string, paramsInheritanceStrategy: 'emptyOnly'|'always',
     relativeLinkResolution: 'legacy'|'corrected'): MonoTypeOperatorFunction<NavigationTransition> {
   return mergeMap(
       t => recognizeFn(
-               rootComponentType, config, t.urlAfterRedirects!, serializer(t.urlAfterRedirects!),
-               paramsInheritanceStrategy, relativeLinkResolution)
+               injector, rootComponentType, config, t.urlAfterRedirects!,
+               serializer(t.urlAfterRedirects!), paramsInheritanceStrategy, relativeLinkResolution)
                .pipe(map(targetSnapshot => ({...t, targetSnapshot}))));
 }

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createEnvironmentInjector, EnvironmentInjector, Injector, NgModuleRef, Type} from '@angular/core';
-import {from, Observable, Observer, of} from 'rxjs';
-import {switchMap} from 'rxjs/operators';
+import {createEnvironmentInjector, EnvironmentInjector, Type} from '@angular/core';
+import {EmptyError, from, Observable, Observer, of} from 'rxjs';
+import {catchError, concatMap, defaultIfEmpty, first, last as rxjsLast, map, scan, startWith, switchMap, takeLast, takeWhile} from 'rxjs/operators';
 
 import {Data, ResolveData, Route, Routes} from './models';
 import {ActivatedRouteSnapshot, inheritedParamsDataResolve, ParamsInheritanceStrategy, RouterStateSnapshot} from './router_state';
@@ -33,23 +33,17 @@ export function recognize(
     urlTree: UrlTree, url: string, urlSerializer: UrlSerializer,
     paramsInheritanceStrategy: ParamsInheritanceStrategy = 'emptyOnly',
     relativeLinkResolution: 'legacy'|'corrected' = 'legacy'): Observable<RouterStateSnapshot> {
-  try {
-    const result = new Recognizer(
-                       injector, rootComponentType, config, urlTree, url, paramsInheritanceStrategy,
-                       relativeLinkResolution, urlSerializer)
-                       .recognize();
-    return from(result).pipe(switchMap(result => {
-      if (result === null) {
-        return newObservableError(new NoMatch());
-      } else {
-        return of(result);
-      }
-    }));
-  } catch (e) {
-    // Catch the potential error from recognize due to duplicate outlet matches and return as an
-    // `Observable` error instead.
-    return newObservableError(e);
-  }
+  return new Recognizer(
+             injector, rootComponentType, config, urlTree, url, paramsInheritanceStrategy,
+             relativeLinkResolution, urlSerializer)
+      .recognize()
+      .pipe(switchMap(result => {
+        if (result === null) {
+          return newObservableError(new NoMatch());
+        } else {
+          return of(result);
+        }
+      }));
 }
 
 export class Recognizer {
@@ -60,29 +54,31 @@ export class Recognizer {
       private relativeLinkResolution: 'legacy'|'corrected',
       private readonly urlSerializer: UrlSerializer) {}
 
-  async recognize(): Promise<RouterStateSnapshot|null> {
+  recognize(): Observable<RouterStateSnapshot|null> {
     const rootSegmentGroup =
         split(
             this.urlTree.root, [], [], this.config.filter(c => c.redirectTo === undefined),
             this.relativeLinkResolution)
             .segmentGroup;
 
-    const children = await this.processSegmentGroup(
-        this.injector, this.config, rootSegmentGroup, PRIMARY_OUTLET);
-    if (children === null) {
-      return null;
-    }
+    return this.processSegmentGroup(this.injector, this.config, rootSegmentGroup, PRIMARY_OUTLET)
+        .pipe(map(children => {
+          if (children === null) {
+            return null;
+          }
 
-    // Use Object.freeze to prevent readers of the Router state from modifying it outside of a
-    // navigation, resulting in the router being out of sync with the browser.
-    const root = new ActivatedRouteSnapshot(
-        [], Object.freeze({}), Object.freeze({...this.urlTree.queryParams}), this.urlTree.fragment,
-        {}, PRIMARY_OUTLET, this.rootComponentType, null, this.urlTree.root, -1, {});
+          // Use Object.freeze to prevent readers of the Router state from modifying it outside of a
+          // navigation, resulting in the router being out of sync with the browser.
+          const root = new ActivatedRouteSnapshot(
+              [], Object.freeze({}), Object.freeze({...this.urlTree.queryParams}),
+              this.urlTree.fragment, {}, PRIMARY_OUTLET, this.rootComponentType, null,
+              this.urlTree.root, -1, {});
 
-    const rootNode = new TreeNode<ActivatedRouteSnapshot>(root, children);
-    const routeState = new RouterStateSnapshot(this.url, rootNode);
-    this.inheritParamsAndData(routeState._root);
-    return routeState;
+          const rootNode = new TreeNode<ActivatedRouteSnapshot>(root, children);
+          const routeState = new RouterStateSnapshot(this.url, rootNode);
+          this.inheritParamsAndData(routeState._root);
+          return routeState;
+        }));
   }
 
   inheritParamsAndData(routeNode: TreeNode<ActivatedRouteSnapshot>): void {
@@ -95,9 +91,9 @@ export class Recognizer {
     routeNode.children.forEach(n => this.inheritParamsAndData(n));
   }
 
-  async processSegmentGroup(
+  processSegmentGroup(
       injector: EnvironmentInjector, config: Route[], segmentGroup: UrlSegmentGroup,
-      outlet: string): Promise<TreeNode<ActivatedRouteSnapshot>[]|null> {
+      outlet: string): Observable<TreeNode<ActivatedRouteSnapshot>[]|null> {
     if (segmentGroup.segments.length === 0 && segmentGroup.hasChildren()) {
       return this.processChildren(injector, config, segmentGroup);
     }
@@ -113,68 +109,77 @@ export class Recognizer {
    * @param segmentGroup - The `UrlSegmentGroup` whose children need to be matched against the
    *     config.
    */
-  async processChildren(
-      injector: EnvironmentInjector, config: Route[],
-      segmentGroup: UrlSegmentGroup): Promise<TreeNode<ActivatedRouteSnapshot>[]|null> {
-    const children: Array<TreeNode<ActivatedRouteSnapshot>> = [];
-    for (const childOutlet of Object.keys(segmentGroup.children)) {
-      const child = segmentGroup.children[childOutlet];
-      // Sort the config so that routes with outlets that match the one being activated appear
-      // first, followed by routes for other outlets, which might match if they have an empty path.
-      const sortedConfig = sortByMatchingOutlets(config, childOutlet);
-      const outletChildren =
-          await this.processSegmentGroup(injector, sortedConfig, child, childOutlet);
-      if (outletChildren === null) {
-        // Configs must match all segment children so because we did not find a match for this
-        // outlet, return `null`.
-        return null;
-      }
-      children.push(...outletChildren);
-    }
-    // Because we may have matched two outlets to the same empty path segment, we can have multiple
-    // activated results for the same outlet. We should merge the children of these results so the
-    // final return value is only one `TreeNode` per outlet.
-    const mergedChildren = mergeEmptyPathMatches(children);
-    if (typeof ngDevMode === 'undefined' || ngDevMode) {
-      // This should really never happen - we are only taking the first match for each outlet and
-      // merge the empty path matches.
-      checkOutletNameUniqueness(mergedChildren);
-    }
-    sortActivatedRouteSnapshots(mergedChildren);
-    return mergedChildren;
+  processChildren(injector: EnvironmentInjector, config: Route[], segmentGroup: UrlSegmentGroup):
+      Observable<TreeNode<ActivatedRouteSnapshot>[]|null> {
+    return from(Object.keys(segmentGroup.children))
+        .pipe(
+            concatMap(childOutlet => {
+              const child = segmentGroup.children[childOutlet];
+              // Sort the config so that routes with outlets that match the one being activated
+              // appear first, followed by routes for other outlets, which might match if they have
+              // an empty path.
+              const sortedConfig = sortByMatchingOutlets(config, childOutlet);
+              return this.processSegmentGroup(injector, sortedConfig, child, childOutlet);
+            }),
+            scan((children, outletChildren) => {
+              if (!children || !outletChildren) return null;
+              children.push(...outletChildren);
+              return children;
+            }),
+            takeWhile(children => children !== null),
+            defaultIfEmpty(null as TreeNode<ActivatedRouteSnapshot>[] | null),
+            rxjsLast(),
+            map(children => {
+              if (children === null) return null;
+              // Because we may have matched two outlets to the same empty path segment, we can have
+              // multiple activated results for the same outlet. We should merge the children of
+              // these results so the final return value is only one `TreeNode` per outlet.
+              const mergedChildren = mergeEmptyPathMatches(children);
+              if (typeof ngDevMode === 'undefined' || ngDevMode) {
+                // This should really never happen - we are only taking the first match for each
+                // outlet and merge the empty path matches.
+                checkOutletNameUniqueness(mergedChildren);
+              }
+              sortActivatedRouteSnapshots(mergedChildren);
+              return mergedChildren;
+            }),
+        );
   }
 
-  async processSegment(
-      injector: EnvironmentInjector, config: Route[], segmentGroup: UrlSegmentGroup,
-      segments: UrlSegment[], outlet: string): Promise<TreeNode<ActivatedRouteSnapshot>[]|null> {
-    for (const r of config) {
-      const children = await this.processSegmentAgainstRoute(
-          r._injector ?? injector, r, segmentGroup, segments, outlet);
-      if (children !== null) {
-        return children;
-      }
-    }
-    if (noLeftoversInUrl(segmentGroup, segments, outlet)) {
-      return [];
-    }
-
-    return null;
+  processSegment(
+      injector: EnvironmentInjector, routes: Route[], segmentGroup: UrlSegmentGroup,
+      segments: UrlSegment[], outlet: string): Observable<TreeNode<ActivatedRouteSnapshot>[]|null> {
+    return from(routes).pipe(
+        concatMap(r => {
+          return this.processSegmentAgainstRoute(
+              r._injector ?? injector, r, segmentGroup, segments, outlet);
+        }),
+        first((x): x is TreeNode<ActivatedRouteSnapshot>[] => !!x), catchError(e => {
+          if (e instanceof EmptyError) {
+            if (noLeftoversInUrl(segmentGroup, segments, outlet)) {
+              return of([]);
+            }
+            return of(null);
+          }
+          throw e;
+        }));
   }
 
-  async processSegmentAgainstRoute(
+  processSegmentAgainstRoute(
       injector: EnvironmentInjector, route: Route, rawSegment: UrlSegmentGroup,
-      segments: UrlSegment[], outlet: string): Promise<TreeNode<ActivatedRouteSnapshot>[]|null> {
-    if (route.redirectTo || !isImmediateMatch(route, rawSegment, segments, outlet)) return null;
+      segments: UrlSegment[], outlet: string): Observable<TreeNode<ActivatedRouteSnapshot>[]|null> {
+    if (route.redirectTo || !isImmediateMatch(route, rawSegment, segments, outlet)) return of(null);
 
-    let snapshot: ActivatedRouteSnapshot;
-    let consumedSegments: UrlSegment[] = [];
-    let remainingSegments: UrlSegment[] = [];
+    let matchResult: Observable<{
+      snapshot: ActivatedRouteSnapshot,
+      consumedSegments: UrlSegment[],
+      remainingSegments: UrlSegment[]
+    }|null>;
 
     if (route.path === '**') {
-      injector = getOrCreateRouteInjectorIfNeeded(route, injector);
       const params = segments.length > 0 ? last(segments)!.parameters : {};
       const pathIndexShift = getPathIndexShift(rawSegment) + segments.length;
-      snapshot = new ActivatedRouteSnapshot(
+      const snapshot = new ActivatedRouteSnapshot(
           segments, params, Object.freeze({...this.urlTree.queryParams}), this.urlTree.fragment,
           getData(route), getOutlet(route), route.component ?? route._loadedComponent ?? null,
           route, getSourceSegmentGroup(rawSegment), pathIndexShift, getResolve(route),
@@ -183,65 +188,83 @@ export class Recognizer {
           // depending on `relativeLinkResolution: 'legacy'` in dev mode.
           (NG_DEV_MODE ? getCorrectedPathIndexShift(rawSegment) + segments.length :
                          pathIndexShift));
+      matchResult = of({
+        snapshot,
+        consumedSegments: [],
+        remainingSegments: [],
+      });
     } else {
-      const result =
-          await matchWithChecks(rawSegment, route, segments, injector, this.urlSerializer)
-              .toPromise();
-      if (!result.matched) {
-        return null;
-      }
-      consumedSegments = result.consumedSegments;
-      remainingSegments = result.remainingSegments;
-      const pathIndexShift = getPathIndexShift(rawSegment) + consumedSegments.length;
+      matchResult =
+          matchWithChecks(rawSegment, route, segments, injector, this.urlSerializer)
+              .pipe(map(({matched, consumedSegments, remainingSegments, parameters}) => {
+                if (!matched) {
+                  return null;
+                }
+                const pathIndexShift = getPathIndexShift(rawSegment) + consumedSegments.length;
 
-      snapshot = new ActivatedRouteSnapshot(
-          consumedSegments, result.parameters, Object.freeze({...this.urlTree.queryParams}),
-          this.urlTree.fragment, getData(route), getOutlet(route),
-          route.component ?? route._loadedComponent ?? null, route,
-          getSourceSegmentGroup(rawSegment), pathIndexShift, getResolve(route),
-          (NG_DEV_MODE ? getCorrectedPathIndexShift(rawSegment) + consumedSegments.length :
+                const snapshot = new ActivatedRouteSnapshot(
+                    consumedSegments, parameters, Object.freeze({...this.urlTree.queryParams}),
+                    this.urlTree.fragment, getData(route), getOutlet(route),
+                    route.component ?? route._loadedComponent ?? null, route,
+                    getSourceSegmentGroup(rawSegment), pathIndexShift, getResolve(route),
+                    (NG_DEV_MODE ?
+                         getCorrectedPathIndexShift(rawSegment) + consumedSegments.length :
                          pathIndexShift));
+                return {snapshot, consumedSegments, remainingSegments};
+              }));
     }
 
-    injector = getOrCreateRouteInjectorIfNeeded(route, injector);
-    const childInjector = route._loadedInjector ?? injector;
-    const childConfig: Route[] = getChildConfig(route);
-
-    const {segmentGroup, slicedSegments} = split(
-        rawSegment, consumedSegments, remainingSegments,
-        // Filter out routes with redirectTo because we are trying to create activated route
-        // snapshots and don't handle redirects here. That should have been done in
-        // `applyRedirects`.
-        childConfig.filter(c => c.redirectTo === undefined), this.relativeLinkResolution);
-
-    if (slicedSegments.length === 0 && segmentGroup.hasChildren()) {
-      const children = await this.processChildren(childInjector, childConfig, segmentGroup);
-      if (children === null) {
-        return null;
+    return matchResult.pipe(switchMap((result) => {
+      if (result === null) {
+        return of(null);
       }
-      return [new TreeNode<ActivatedRouteSnapshot>(snapshot, children)];
-    }
+      const {snapshot, consumedSegments, remainingSegments} = result;
+      // Only create the Route's `EnvironmentInjector` if it matches the attempted
+      // navigation
+      injector = getOrCreateRouteInjectorIfNeeded(route, injector);
+      const childInjector = route._loadedInjector ?? injector;
+      const childConfig: Route[] = getChildConfig(route);
 
-    if (childConfig.length === 0 && slicedSegments.length === 0) {
-      return [new TreeNode<ActivatedRouteSnapshot>(snapshot, [])];
-    }
+      const {segmentGroup, slicedSegments} = split(
+          rawSegment, consumedSegments, remainingSegments,
+          // Filter out routes with redirectTo because we are trying to create activated route
+          // snapshots and don't handle redirects here. That should have been done in
+          // `applyRedirects`.
+          childConfig.filter(c => c.redirectTo === undefined), this.relativeLinkResolution);
 
-    const matchedOnOutlet = getOutlet(route) === outlet;
-    // If we matched a config due to empty path match on a different outlet, we need to continue
-    // passing the current outlet for the segment rather than switch to PRIMARY.
-    // Note that we switch to primary when we have a match because outlet configs look like this:
-    // {path: 'a', outlet: 'a', children: [
-    //  {path: 'b', component: B},
-    //  {path: 'c', component: C},
-    // ]}
-    // Notice that the children of the named outlet are configured with the primary outlet
-    const children = await this.processSegment(
-        childInjector, childConfig, segmentGroup, slicedSegments,
-        matchedOnOutlet ? PRIMARY_OUTLET : outlet);
-    if (children === null) {
-      return null;
-    }
-    return [new TreeNode<ActivatedRouteSnapshot>(snapshot, children)];
+      if (slicedSegments.length === 0 && segmentGroup.hasChildren()) {
+        return this.processChildren(childInjector, childConfig, segmentGroup).pipe(map(children => {
+          if (children === null) {
+            return null;
+          }
+          return [new TreeNode<ActivatedRouteSnapshot>(snapshot, children)];
+        }));
+      }
+
+      if (childConfig.length === 0 && slicedSegments.length === 0) {
+        return of([new TreeNode<ActivatedRouteSnapshot>(snapshot, [])]);
+      }
+
+      const matchedOnOutlet = getOutlet(route) === outlet;
+      // If we matched a config due to empty path match on a different outlet, we need to
+      // continue passing the current outlet for the segment rather than switch to PRIMARY.
+      // Note that we switch to primary when we have a match because outlet configs look like
+      // this: {path: 'a', outlet: 'a', children: [
+      //  {path: 'b', component: B},
+      //  {path: 'c', component: C},
+      // ]}
+      // Notice that the children of the named outlet are configured with the primary outlet
+      return this
+          .processSegment(
+              childInjector, childConfig, segmentGroup, slicedSegments,
+              matchedOnOutlet ? PRIMARY_OUTLET : outlet)
+          .pipe(map(children => {
+            if (children === null) {
+              return null;
+            }
+            return [new TreeNode<ActivatedRouteSnapshot>(snapshot, children)];
+          }));
+    }));
   }
 }
 
@@ -271,9 +294,9 @@ function hasEmptyPathConfig(node: TreeNode<ActivatedRouteSnapshot>) {
 }
 
 /**
- * Finds `TreeNode`s with matching empty path route configs and merges them into `TreeNode` with the
- * children from each duplicate. This is necessary because different outlets can match a single
- * empty path route config and the results need to then be merged.
+ * Finds `TreeNode`s with matching empty path route configs and merges them into `TreeNode` with
+ * the children from each duplicate. This is necessary because different outlets can match a
+ * single empty path route config and the results need to then be merged.
  */
 function mergeEmptyPathMatches(nodes: Array<TreeNode<ActivatedRouteSnapshot>>):
     Array<TreeNode<ActivatedRouteSnapshot>> {
@@ -297,9 +320,9 @@ function mergeEmptyPathMatches(nodes: Array<TreeNode<ActivatedRouteSnapshot>>):
     }
   }
   // For each node which has children from multiple sources, we need to recompute a new `TreeNode`
-  // by also merging those children. This is necessary when there are multiple empty path configs in
-  // a row. Put another way: whenever we combine children of two nodes, we need to also check if any
-  // of those children can be combined into a single node as well.
+  // by also merging those children. This is necessary when there are multiple empty path configs
+  // in a row. Put another way: whenever we combine children of two nodes, we need to also check
+  // if any of those children can be combined into a single node as well.
   for (const mergedNode of mergedNodes) {
     const mergedChildren = mergeEmptyPathMatches(mergedNode.children);
     result.push(new TreeNode(mergedNode.value, mergedChildren));

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -6,16 +6,17 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type} from '@angular/core';
-import {Observable, Observer, of} from 'rxjs';
+import {createEnvironmentInjector, EnvironmentInjector, Injector, NgModuleRef, Type} from '@angular/core';
+import {from, Observable, Observer, of} from 'rxjs';
+import {switchMap} from 'rxjs/operators';
 
 import {Data, ResolveData, Route, Routes} from './models';
 import {ActivatedRouteSnapshot, inheritedParamsDataResolve, ParamsInheritanceStrategy, RouterStateSnapshot} from './router_state';
 import {PRIMARY_OUTLET} from './shared';
 import {UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
 import {last} from './utils/collection';
-import {getOutlet, sortByMatchingOutlets} from './utils/config';
-import {isImmediateMatch, match, noLeftoversInUrl, split} from './utils/config_matching';
+import {getOrCreateRouteInjectorIfNeeded, getOutlet, sortByMatchingOutlets} from './utils/config';
+import {isImmediateMatch, matchWithChecks, noLeftoversInUrl, split} from './utils/config_matching';
 import {TreeNode} from './utils/tree';
 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
@@ -28,19 +29,22 @@ function newObservableError(e: unknown): Observable<RouterStateSnapshot> {
 }
 
 export function recognize(
-    rootComponentType: Type<any>|null, config: Routes, urlTree: UrlTree, url: string,
+    injector: EnvironmentInjector, rootComponentType: Type<any>|null, config: Routes,
+    urlTree: UrlTree, url: string,
     paramsInheritanceStrategy: ParamsInheritanceStrategy = 'emptyOnly',
     relativeLinkResolution: 'legacy'|'corrected' = 'legacy'): Observable<RouterStateSnapshot> {
   try {
     const result = new Recognizer(
-                       rootComponentType, config, urlTree, url, paramsInheritanceStrategy,
+                       injector, rootComponentType, config, urlTree, url, paramsInheritanceStrategy,
                        relativeLinkResolution)
                        .recognize();
-    if (result === null) {
-      return newObservableError(new NoMatch());
-    } else {
-      return of(result);
-    }
+    return from(result).pipe(switchMap(result => {
+      if (result === null) {
+        return newObservableError(new NoMatch());
+      } else {
+        return of(result);
+      }
+    }));
   } catch (e) {
     // Catch the potential error from recognize due to duplicate outlet matches and return as an
     // `Observable` error instead.
@@ -50,18 +54,20 @@ export function recognize(
 
 export class Recognizer {
   constructor(
-      private rootComponentType: Type<any>|null, private config: Routes, private urlTree: UrlTree,
-      private url: string, private paramsInheritanceStrategy: ParamsInheritanceStrategy,
+      private injector: EnvironmentInjector, private rootComponentType: Type<any>|null,
+      private config: Routes, private urlTree: UrlTree, private url: string,
+      private paramsInheritanceStrategy: ParamsInheritanceStrategy,
       private relativeLinkResolution: 'legacy'|'corrected') {}
 
-  recognize(): RouterStateSnapshot|null {
+  async recognize(): Promise<RouterStateSnapshot|null> {
     const rootSegmentGroup =
         split(
             this.urlTree.root, [], [], this.config.filter(c => c.redirectTo === undefined),
             this.relativeLinkResolution)
             .segmentGroup;
 
-    const children = this.processSegmentGroup(this.config, rootSegmentGroup, PRIMARY_OUTLET);
+    const children = await this.processSegmentGroup(
+        this.injector, this.config, rootSegmentGroup, PRIMARY_OUTLET);
     if (children === null) {
       return null;
     }
@@ -88,13 +94,14 @@ export class Recognizer {
     routeNode.children.forEach(n => this.inheritParamsAndData(n));
   }
 
-  processSegmentGroup(config: Route[], segmentGroup: UrlSegmentGroup, outlet: string):
-      TreeNode<ActivatedRouteSnapshot>[]|null {
+  async processSegmentGroup(
+      injector: EnvironmentInjector, config: Route[], segmentGroup: UrlSegmentGroup,
+      outlet: string): Promise<TreeNode<ActivatedRouteSnapshot>[]|null> {
     if (segmentGroup.segments.length === 0 && segmentGroup.hasChildren()) {
-      return this.processChildren(config, segmentGroup);
+      return this.processChildren(injector, config, segmentGroup);
     }
 
-    return this.processSegment(config, segmentGroup, segmentGroup.segments, outlet);
+    return this.processSegment(injector, config, segmentGroup, segmentGroup.segments, outlet);
   }
 
   /**
@@ -105,15 +112,17 @@ export class Recognizer {
    * @param segmentGroup - The `UrlSegmentGroup` whose children need to be matched against the
    *     config.
    */
-  processChildren(config: Route[], segmentGroup: UrlSegmentGroup):
-      TreeNode<ActivatedRouteSnapshot>[]|null {
+  async processChildren(
+      injector: EnvironmentInjector, config: Route[],
+      segmentGroup: UrlSegmentGroup): Promise<TreeNode<ActivatedRouteSnapshot>[]|null> {
     const children: Array<TreeNode<ActivatedRouteSnapshot>> = [];
     for (const childOutlet of Object.keys(segmentGroup.children)) {
       const child = segmentGroup.children[childOutlet];
       // Sort the config so that routes with outlets that match the one being activated appear
       // first, followed by routes for other outlets, which might match if they have an empty path.
       const sortedConfig = sortByMatchingOutlets(config, childOutlet);
-      const outletChildren = this.processSegmentGroup(sortedConfig, child, childOutlet);
+      const outletChildren =
+          await this.processSegmentGroup(injector, sortedConfig, child, childOutlet);
       if (outletChildren === null) {
         // Configs must match all segment children so because we did not find a match for this
         // outlet, return `null`.
@@ -134,11 +143,12 @@ export class Recognizer {
     return mergedChildren;
   }
 
-  processSegment(
-      config: Route[], segmentGroup: UrlSegmentGroup, segments: UrlSegment[],
-      outlet: string): TreeNode<ActivatedRouteSnapshot>[]|null {
+  async processSegment(
+      injector: EnvironmentInjector, config: Route[], segmentGroup: UrlSegmentGroup,
+      segments: UrlSegment[], outlet: string): Promise<TreeNode<ActivatedRouteSnapshot>[]|null> {
     for (const r of config) {
-      const children = this.processSegmentAgainstRoute(r, segmentGroup, segments, outlet);
+      const children = await this.processSegmentAgainstRoute(
+          r._injector ?? injector, r, segmentGroup, segments, outlet);
       if (children !== null) {
         return children;
       }
@@ -150,9 +160,9 @@ export class Recognizer {
     return null;
   }
 
-  processSegmentAgainstRoute(
-      route: Route, rawSegment: UrlSegmentGroup, segments: UrlSegment[],
-      outlet: string): TreeNode<ActivatedRouteSnapshot>[]|null {
+  async processSegmentAgainstRoute(
+      injector: EnvironmentInjector, route: Route, rawSegment: UrlSegmentGroup,
+      segments: UrlSegment[], outlet: string): Promise<TreeNode<ActivatedRouteSnapshot>[]|null> {
     if (route.redirectTo || !isImmediateMatch(route, rawSegment, segments, outlet)) return null;
 
     let snapshot: ActivatedRouteSnapshot;
@@ -160,6 +170,7 @@ export class Recognizer {
     let remainingSegments: UrlSegment[] = [];
 
     if (route.path === '**') {
+      injector = getOrCreateRouteInjectorIfNeeded(route, injector);
       const params = segments.length > 0 ? last(segments)!.parameters : {};
       const pathIndexShift = getPathIndexShift(rawSegment) + segments.length;
       snapshot = new ActivatedRouteSnapshot(
@@ -172,7 +183,7 @@ export class Recognizer {
           (NG_DEV_MODE ? getCorrectedPathIndexShift(rawSegment) + segments.length :
                          pathIndexShift));
     } else {
-      const result = match(rawSegment, route, segments);
+      const result = await matchWithChecks(rawSegment, route, segments, injector).toPromise();
       if (!result.matched) {
         return null;
       }
@@ -189,6 +200,8 @@ export class Recognizer {
                          pathIndexShift));
     }
 
+    injector = getOrCreateRouteInjectorIfNeeded(route, injector);
+    const childInjector = route._loadedInjector ?? injector;
     const childConfig: Route[] = getChildConfig(route);
 
     const {segmentGroup, slicedSegments} = split(
@@ -199,7 +212,7 @@ export class Recognizer {
         childConfig.filter(c => c.redirectTo === undefined), this.relativeLinkResolution);
 
     if (slicedSegments.length === 0 && segmentGroup.hasChildren()) {
-      const children = this.processChildren(childConfig, segmentGroup);
+      const children = await this.processChildren(childInjector, childConfig, segmentGroup);
       if (children === null) {
         return null;
       }
@@ -219,8 +232,9 @@ export class Recognizer {
     //  {path: 'c', component: C},
     // ]}
     // Notice that the children of the named outlet are configured with the primary outlet
-    const children = this.processSegment(
-        childConfig, segmentGroup, slicedSegments, matchedOnOutlet ? PRIMARY_OUTLET : outlet);
+    const children = await this.processSegment(
+        childInjector, childConfig, segmentGroup, slicedSegments,
+        matchedOnOutlet ? PRIMARY_OUTLET : outlet);
     if (children === null) {
       return null;
     }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -690,7 +690,7 @@ export class Router {
                              // Recognize
                              recognize(
                                  this.ngModule.injector, this.rootComponentType, this.config,
-                                 (url) => this.serializeUrl(url), this.paramsInheritanceStrategy,
+                                 this.urlSerializer, this.paramsInheritanceStrategy,
                                  this.relativeLinkResolution),
 
                              // Update URL if in `eager` update mode

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -689,7 +689,7 @@ export class Router {
 
                              // Recognize
                              recognize(
-                                 this.rootComponentType, this.config,
+                                 this.ngModule.injector, this.rootComponentType, this.config,
                                  (url) => this.serializeUrl(url), this.paramsInheritanceStrategy,
                                  this.relativeLinkResolution),
 

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -13,7 +13,7 @@ import {map} from 'rxjs/operators';
 import {Route} from '../models';
 import {runCanMatchGuards} from '../operators/check_guards';
 import {defaultUrlMatcher, PRIMARY_OUTLET} from '../shared';
-import {UrlSegment, UrlSegmentGroup} from '../url_tree';
+import {UrlSegment, UrlSegmentGroup, UrlSerializer} from '../url_tree';
 
 import {forEach} from './collection';
 import {getOutlet} from './config';
@@ -35,13 +35,13 @@ const noMatch: MatchResult = {
 };
 
 export function matchWithChecks(
-    segmentGroup: UrlSegmentGroup, route: Route, segments: UrlSegment[],
-    injector: Injector): Observable<MatchResult> {
+    segmentGroup: UrlSegmentGroup, route: Route, segments: UrlSegment[], injector: Injector,
+    urlSerializer: UrlSerializer): Observable<MatchResult> {
   const result = match(segmentGroup, route, segments);
   if (!result.matched) {
     return of(result);
   }
-  return runCanMatchGuards(injector, route, segments)
+  return runCanMatchGuards(injector, route, segments, urlSerializer)
       .pipe(
           map((v) => v === true ? result : {...noMatch}),
       );

--- a/packages/router/src/utils/type_guards.ts
+++ b/packages/router/src/utils/type_guards.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CanActivate, CanActivateChild, CanDeactivate, CanLoad} from '../models';
+import {CanActivate, CanActivateChild, CanDeactivate, CanLoad, CanMatch} from '../models';
 import {UrlTree} from '../url_tree';
 
 /**
@@ -48,4 +48,7 @@ export function isCanActivateChild(guard: any): guard is CanActivateChild {
 
 export function isCanDeactivate<T>(guard: any): guard is CanDeactivate<T> {
   return guard && isFunction<CanDeactivate<T>>(guard.canDeactivate);
+}
+export function isCanMatch(guard: any): guard is CanMatch {
+  return guard && isFunction<CanMatch>(guard.canMatch);
 }

--- a/packages/router/test/create_router_state.spec.ts
+++ b/packages/router/test/create_router_state.spec.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {EnvironmentInjector} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
 import {createRouterState} from '../src/create_router_state';
 import {Routes} from '../src/models';
 import {recognize} from '../src/recognize';
@@ -15,7 +18,7 @@ import {PRIMARY_OUTLET} from '../src/shared';
 import {DefaultUrlSerializer, UrlSegmentGroup, UrlTree} from '../src/url_tree';
 import {TreeNode} from '../src/utils/tree';
 
-describe('create router state', () => {
+describe('create router state', async () => {
   let reuseStrategy: DefaultRouteReuseStrategy;
   beforeEach(() => {
     reuseStrategy = new DefaultRouteReuseStrategy();
@@ -24,10 +27,10 @@ describe('create router state', () => {
   const emptyState = () =>
       createEmptyState(new (UrlTree as any)(new UrlSegmentGroup([], {}), {}, null!), RootComponent);
 
-  it('should create new state', () => {
+  it('should create new state', async () => {
     const state = createRouterState(
         reuseStrategy,
-        createState(
+        await createState(
             [
               {path: 'a', component: ComponentA},
               {path: 'b', component: ComponentB, outlet: 'left'},
@@ -44,16 +47,17 @@ describe('create router state', () => {
     checkActivatedRoute(c[2], ComponentC, 'right');
   });
 
-  it('should reuse existing nodes when it can', () => {
+  it('should reuse existing nodes when it can', async () => {
     const config = [
       {path: 'a', component: ComponentA}, {path: 'b', component: ComponentB, outlet: 'left'},
       {path: 'c', component: ComponentC, outlet: 'left'}
     ];
 
     const prevState =
-        createRouterState(reuseStrategy, createState(config, 'a(left:b)'), emptyState());
+        createRouterState(reuseStrategy, await createState(config, 'a(left:b)'), emptyState());
     advanceState(prevState);
-    const state = createRouterState(reuseStrategy, createState(config, 'a(left:c)'), prevState);
+    const state =
+        createRouterState(reuseStrategy, await createState(config, 'a(left:c)'), prevState);
 
     expect(prevState.root).toBe(state.root);
     const prevC = (prevState as any).children(prevState.root);
@@ -64,7 +68,7 @@ describe('create router state', () => {
     checkActivatedRoute(currC[1], ComponentC, 'left');
   });
 
-  it('should handle componentless routes', () => {
+  it('should handle componentless routes', async () => {
     const config = [{
       path: 'a/:id',
       children:
@@ -73,10 +77,10 @@ describe('create router state', () => {
 
 
     const prevState = createRouterState(
-        reuseStrategy, createState(config, 'a/1;p=11/(b//right:c)'), emptyState());
+        reuseStrategy, await createState(config, 'a/1;p=11/(b//right:c)'), emptyState());
     advanceState(prevState);
-    const state =
-        createRouterState(reuseStrategy, createState(config, 'a/2;p=22/(b//right:c)'), prevState);
+    const state = createRouterState(
+        reuseStrategy, await createState(config, 'a/2;p=22/(b//right:c)'), prevState);
 
     expect(prevState.root).toBe(state.root);
     const prevP = (prevState as any).firstChild(prevState.root)!;
@@ -92,7 +96,7 @@ describe('create router state', () => {
     checkActivatedRoute(currC[1], ComponentB, 'right');
   });
 
-  it('should not retrieve routes when `shouldAttach` is always false', () => {
+  it('should not retrieve routes when `shouldAttach` is always false', async () => {
     const config: Routes = [
       {path: 'a', component: ComponentA}, {path: 'b', component: ComponentB, outlet: 'left'},
       {path: 'c', component: ComponentC, outlet: 'left'}
@@ -100,23 +104,24 @@ describe('create router state', () => {
     spyOn(reuseStrategy, 'retrieve');
 
     const prevState =
-        createRouterState(reuseStrategy, createState(config, 'a(left:b)'), emptyState());
+        createRouterState(reuseStrategy, await createState(config, 'a(left:b)'), emptyState());
     advanceState(prevState);
-    createRouterState(reuseStrategy, createState(config, 'a(left:c)'), prevState);
+    createRouterState(reuseStrategy, await createState(config, 'a(left:c)'), prevState);
     expect(reuseStrategy.retrieve).not.toHaveBeenCalled();
   });
 
-  it('should consistently represent future and current state', () => {
+  it('should consistently represent future and current state', async () => {
     const config: Routes = [
       {path: '', pathMatch: 'full', component: ComponentA},
       {path: 'product/:id', component: ComponentB}
     ];
     spyOn(reuseStrategy, 'shouldReuseRoute').and.callThrough();
-    const previousState = createRouterState(reuseStrategy, createState(config, ''), emptyState());
+    const previousState =
+        createRouterState(reuseStrategy, await createState(config, ''), emptyState());
     advanceState(previousState);
     (reuseStrategy.shouldReuseRoute as jasmine.Spy).calls.reset();
 
-    createRouterState(reuseStrategy, createState(config, 'product/30'), previousState);
+    createRouterState(reuseStrategy, await createState(config, 'product/30'), previousState);
 
     // One call for the root and one call for each of the children
     expect(reuseStrategy.shouldReuseRoute).toHaveBeenCalledTimes(2);
@@ -143,10 +148,9 @@ function advanceNode(node: TreeNode<ActivatedRoute>): void {
   node.children.forEach(advanceNode);
 }
 
-function createState(config: Routes, url: string): RouterStateSnapshot {
-  let res: RouterStateSnapshot = undefined!;
-  recognize(RootComponent, config, tree(url), url).forEach(s => res = s);
-  return res;
+async function createState(config: Routes, url: string): Promise<RouterStateSnapshot> {
+  return recognize(TestBed.inject(EnvironmentInjector), RootComponent, config, tree(url), url)
+      .toPromise();
 }
 
 function checkActivatedRoute(

--- a/packages/router/test/create_router_state.spec.ts
+++ b/packages/router/test/create_router_state.spec.ts
@@ -149,7 +149,9 @@ function advanceNode(node: TreeNode<ActivatedRoute>): void {
 }
 
 async function createState(config: Routes, url: string): Promise<RouterStateSnapshot> {
-  return recognize(TestBed.inject(EnvironmentInjector), RootComponent, config, tree(url), url)
+  return recognize(
+             TestBed.inject(EnvironmentInjector), RootComponent, config, tree(url), url,
+             new DefaultUrlSerializer())
       .toPromise();
 }
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -6,19 +6,19 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_BASE_HREF, CommonModule, HashLocationStrategy, Location, LOCATION_INITIALIZED, LocationStrategy, PlatformLocation} from '@angular/common';
+import {CommonModule, HashLocationStrategy, Location, LocationStrategy} from '@angular/common';
 import {SpyLocation} from '@angular/common/testing';
 import {ChangeDetectionStrategy, Component, EventEmitter, Inject, Injectable, InjectionToken, NgModule, NgModuleRef, NgZone, OnDestroy, ViewChild, ɵConsole as Console, ɵNoopNgZone as NoopNgZone} from '@angular/core';
 import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DefaultUrlSerializer, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, Navigation, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ParamMap, Params, PreloadAllModules, PreloadingStrategy, PRIMARY_OUTLET, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouteReuseStrategy, RouterEvent, RouterLink, RouterLinkWithHref, RouterModule, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
-import {EMPTY, Observable, Observer, of, Subscription, SubscriptionLike} from 'rxjs';
+import {EMPTY, Observable, Observer, of, Subscription} from 'rxjs';
 import {delay, filter, first, map, mapTo, tap} from 'rxjs/operators';
 
+import {CanMatch} from '../src/models';
 import {forEach} from '../src/utils/collection';
 import {getLoadedRoutes} from '../src/utils/config';
-import {isUrlTree} from '../src/utils/type_guards';
 import {RouterTestingModule} from '../testing';
 
 describe('Integration', () => {
@@ -4738,6 +4738,94 @@ describe('Integration', () => {
 
                expect(logger.logs).toEqual(['canDeactivate_simple', 'canDeactivate_team']);
              })));
+    });
+
+    describe('canMatch', () => {
+      @Injectable({providedIn: 'root'})
+      class ConfigurableGuard implements CanMatch {
+        result: Promise<boolean>|Observable<boolean>|boolean = false;
+        canMatch() {
+          return this.result;
+        }
+      }
+
+      it('falls back to second route when canMatch returns false', fakeAsync(() => {
+           const router = TestBed.inject(Router);
+           router.resetConfig([
+             {path: 'a', canMatch: [ConfigurableGuard], component: BlankCmp},
+             {path: 'a', component: SimpleCmp},
+           ]);
+           const fixture = createRoot(router, RootCmp);
+
+           router.navigateByUrl('/a');
+           advance(fixture);
+           expect(fixture.nativeElement.innerHTML).toContain('simple');
+         }));
+
+      it('uses route when canMatch returns true', fakeAsync(() => {
+           const router = TestBed.inject(Router);
+           TestBed.inject(ConfigurableGuard).result = Promise.resolve(true);
+           router.resetConfig([
+             {path: 'a', canMatch: [ConfigurableGuard], component: SimpleCmp},
+             {path: 'a', component: BlankCmp},
+           ]);
+           const fixture = createRoot(router, RootCmp);
+
+
+           router.navigateByUrl('/a');
+           advance(fixture);
+           expect(fixture.nativeElement.innerHTML).toContain('simple');
+         }));
+
+      it('runs canMatch guards provided in lazy module', fakeAsync(() => {
+           const router = TestBed.inject(Router);
+           @Component(
+               {selector: 'lazy', template: 'lazy-loaded-parent [<router-outlet></router-outlet>]'})
+           class ParentLazyLoadedComponent {
+           }
+
+           @Component({selector: 'lazy', template: 'lazy-loaded-child'})
+           class ChildLazyLoadedComponent {
+           }
+           @Injectable()
+           class LazyCanMatchFalse implements CanMatch {
+             canMatch() {
+               return false;
+             }
+           }
+           @Component({template: 'restricted'})
+           class Restricted {
+           }
+           @NgModule({
+             declarations: [ParentLazyLoadedComponent, ChildLazyLoadedComponent, Restricted],
+             providers: [LazyCanMatchFalse],
+             imports: [RouterModule.forChild([
+               {
+                 path: 'loaded',
+                 canMatch: [LazyCanMatchFalse],
+                 component: Restricted,
+                 children: [{path: 'child', component: Restricted}],
+               },
+               {
+                 path: 'loaded',
+                 component: ParentLazyLoadedComponent,
+                 children: [{path: 'child', component: ChildLazyLoadedComponent}]
+               }
+             ])]
+           })
+           class LoadedModule {
+           }
+
+
+           const fixture = createRoot(router, RootCmp);
+
+           router.resetConfig([{path: 'lazy', loadChildren: () => LoadedModule}]);
+           router.navigateByUrl('/lazy/loaded/child');
+           advance(fixture);
+
+           expect(TestBed.inject(Location).path()).toEqual('/lazy/loaded/child');
+           expect(fixture.nativeElement).toHaveText('lazy-loaded-parent [lazy-loaded-child]');
+         }));
     });
   });
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -4743,7 +4743,7 @@ describe('Integration', () => {
     describe('canMatch', () => {
       @Injectable({providedIn: 'root'})
       class ConfigurableGuard implements CanMatch {
-        result: Promise<boolean>|Observable<boolean>|boolean = false;
+        result: Promise<boolean|UrlTree>|Observable<boolean|UrlTree>|boolean|UrlTree = false;
         canMatch() {
           return this.result;
         }
@@ -4775,6 +4775,22 @@ describe('Integration', () => {
            router.navigateByUrl('/a');
            advance(fixture);
            expect(fixture.nativeElement.innerHTML).toContain('simple');
+         }));
+
+      it('can return UrlTree from canMatch guard', fakeAsync(() => {
+           const router = TestBed.inject(Router);
+           TestBed.inject(ConfigurableGuard).result =
+               Promise.resolve(router.createUrlTree(['/team/1']));
+           router.resetConfig([
+             {path: 'a', canMatch: [ConfigurableGuard], component: SimpleCmp},
+             {path: 'team/:id', component: TeamCmp},
+           ]);
+           const fixture = createRoot(router, RootCmp);
+
+
+           router.navigateByUrl('/a');
+           advance(fixture);
+           expect(fixture.nativeElement.innerHTML).toContain('team');
          }));
 
       it('runs canMatch guards provided in lazy module', fakeAsync(() => {

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -659,7 +659,8 @@ describe('recognize', async () => {
                            },
                          ],
                          tree('/b'), '/b', 'emptyOnly', 'corrected', new DefaultUrlSerializer())
-                         .recognize();
+                         .recognize()
+                         .toPromise();
            expect(s).toBeNull();
          });
     });
@@ -835,7 +836,8 @@ async function recognize(
   const result = await new Recognizer(
                      TestBed.inject(EnvironmentInjector), RootComponent, config, tree(url), url,
                      paramsInheritanceStrategy, relativeLinkResolution, serializer)
-                     .recognize();
+                     .recognize()
+                     .toPromise();
   expect(result).not.toBeNull();
   return result!;
 }

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -658,7 +658,7 @@ describe('recognize', async () => {
                              children: [{path: 'b', component: ComponentB}],
                            },
                          ],
-                         tree('/b'), '/b', 'emptyOnly', 'corrected')
+                         tree('/b'), '/b', 'emptyOnly', 'corrected', new DefaultUrlSerializer())
                          .recognize();
            expect(s).toBeNull();
          });
@@ -831,9 +831,10 @@ describe('recognize', async () => {
 async function recognize(
     config: Routes, url: string, paramsInheritanceStrategy: 'emptyOnly'|'always' = 'emptyOnly',
     relativeLinkResolution: 'legacy'|'corrected' = 'legacy'): Promise<RouterStateSnapshot> {
+  const serializer = new DefaultUrlSerializer();
   const result = await new Recognizer(
                      TestBed.inject(EnvironmentInjector), RootComponent, config, tree(url), url,
-                     paramsInheritanceStrategy, relativeLinkResolution)
+                     paramsInheritanceStrategy, relativeLinkResolution, serializer)
                      .recognize();
   expect(result).not.toBeNull();
   return result!;

--- a/packages/router/test/recognize.spec.ts
+++ b/packages/router/test/recognize.spec.ts
@@ -6,28 +6,32 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {EnvironmentInjector, NgModuleRef} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
 import {Routes} from '../src/models';
 import {Recognizer} from '../src/recognize';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from '../src/router_state';
 import {Params, PRIMARY_OUTLET} from '../src/shared';
 import {DefaultUrlSerializer, UrlTree} from '../src/url_tree';
 
-describe('recognize', () => {
-  it('should work', () => {
-    const s = recognize([{path: 'a', component: ComponentA}], 'a');
+describe('recognize', async () => {
+  it('should work', async () => {
+    const s = await recognize([{path: 'a', component: ComponentA}], 'a');
     checkActivatedRoute(s.root, '', {}, RootComponent);
     checkActivatedRoute(s.root.firstChild!, 'a', {}, ComponentA);
   });
 
-  it('should freeze params object', () => {
-    const s: RouterStateSnapshot = recognize([{path: 'a/:id', component: ComponentA}], 'a/10');
+  it('should freeze params object', async () => {
+    const s: RouterStateSnapshot =
+        await recognize([{path: 'a/:id', component: ComponentA}], 'a/10');
     checkActivatedRoute(s.root, '', {}, RootComponent);
     const child = s.root.firstChild!;
     expect(Object.isFrozen(child.params)).toBeTruthy();
   });
 
-  it('should support secondary routes', () => {
-    const s: RouterStateSnapshot = recognize(
+  it('should support secondary routes', async () => {
+    const s: RouterStateSnapshot = await recognize(
         [
           {path: 'a', component: ComponentA}, {path: 'b', component: ComponentB, outlet: 'left'},
           {path: 'c', component: ComponentC, outlet: 'right'}
@@ -39,9 +43,9 @@ describe('recognize', () => {
     checkActivatedRoute(c[2], 'c', {}, ComponentC, 'right');
   });
 
-  it('should set url segment and index properly', () => {
+  it('should set url segment and index properly', async () => {
     const url = tree('a(left:b//right:c)');
-    const s = recognize(
+    const s = await recognize(
         [
           {path: 'a', component: ComponentA}, {path: 'b', component: ComponentB, outlet: 'left'},
           {path: 'c', component: ComponentC, outlet: 'right'}
@@ -61,9 +65,9 @@ describe('recognize', () => {
     expect((c[2] as any)._lastPathIndex).toBe(0);
   });
 
-  it('should set url segment and index properly (nested case)', () => {
+  it('should set url segment and index properly (nested case)', async () => {
     const url = tree('a/b/c');
-    const s = recognize(
+    const s = await recognize(
         [
           {path: 'a/b', component: ComponentA, children: [{path: 'c', component: ComponentC}]},
         ],
@@ -82,9 +86,9 @@ describe('recognize', () => {
     expect((compC as any)._lastPathIndex).toBe(2);
   });
 
-  it('should set url segment and index properly (wildcard)', () => {
+  it('should set url segment and index properly (wildcard)', async () => {
     const url = tree('a/b/c');
-    const s = recognize(
+    const s = await recognize(
         [
           {path: 'a', component: ComponentA, children: [{path: '**', component: ComponentB}]},
         ],
@@ -103,8 +107,8 @@ describe('recognize', () => {
     expect((compC as any)._lastPathIndex).toBe(2);
   });
 
-  it('should match routes in the depth first order', () => {
-    const s = recognize(
+  it('should match routes in the depth first order', async () => {
+    const s = await recognize(
         [
           {path: 'a', component: ComponentA, children: [{path: ':id', component: ComponentB}]},
           {path: 'a/:id', component: ComponentC}
@@ -114,14 +118,14 @@ describe('recognize', () => {
     checkActivatedRoute(s.root.firstChild!, 'a', {}, ComponentA);
     checkActivatedRoute(s.root.firstChild!.firstChild!, 'paramA', {id: 'paramA'}, ComponentB);
 
-    const s2 = recognize(
+    const s2 = await recognize(
         [{path: 'a', component: ComponentA}, {path: 'a/:id', component: ComponentC}], 'a/paramA');
     checkActivatedRoute(s2.root, '', {}, RootComponent);
     checkActivatedRoute(s2.root.firstChild!, 'a/paramA', {id: 'paramA'}, ComponentC);
   });
 
-  it('should use outlet name when matching secondary routes', () => {
-    const s = recognize(
+  it('should use outlet name when matching secondary routes', async () => {
+    const s = await recognize(
         [
           {path: 'a', component: ComponentA}, {path: 'b', component: ComponentB, outlet: 'left'},
           {path: 'b', component: ComponentC, outlet: 'right'}
@@ -132,8 +136,8 @@ describe('recognize', () => {
     checkActivatedRoute(c[1], 'b', {}, ComponentC, 'right');
   });
 
-  it('should handle non top-level secondary routes', () => {
-    const s = recognize(
+  it('should handle non top-level secondary routes', async () => {
+    const s = await recognize(
         [
           {
             path: 'a',
@@ -149,8 +153,8 @@ describe('recognize', () => {
     checkActivatedRoute(c[1], 'c', {}, ComponentC, 'left');
   });
 
-  it('should sort routes by outlet name', () => {
-    const s = recognize(
+  it('should sort routes by outlet name', async () => {
+    const s = await recognize(
         [
           {path: 'a', component: ComponentA}, {path: 'c', component: ComponentC, outlet: 'c'},
           {path: 'b', component: ComponentB, outlet: 'b'}
@@ -162,8 +166,8 @@ describe('recognize', () => {
     checkActivatedRoute(c[2], 'c', {}, ComponentC, 'c');
   });
 
-  it('should support matrix parameters', () => {
-    const s = recognize(
+  it('should support matrix parameters', async () => {
+    const s = await recognize(
         [
           {path: 'a', component: ComponentA, children: [{path: 'b', component: ComponentB}]},
           {path: 'c', component: ComponentC, outlet: 'left'}
@@ -175,15 +179,15 @@ describe('recognize', () => {
     checkActivatedRoute(c[1], 'c', {c1: '1111', c2: '2222'}, ComponentC, 'left');
   });
 
-  describe('data', () => {
-    it('should set static data', () => {
-      const s = recognize([{path: 'a', data: {one: 1}, component: ComponentA}], 'a');
+  describe('data', async () => {
+    it('should set static data', async () => {
+      const s = await recognize([{path: 'a', data: {one: 1}, component: ComponentA}], 'a');
       const r: ActivatedRouteSnapshot = s.root.firstChild!;
       expect(r.data).toEqual({one: 1});
     });
 
-    it('should inherit componentless route\'s data', () => {
-      const s = recognize(
+    it('should inherit componentless route\'s data', async () => {
+      const s = await recognize(
           [{
             path: 'a',
             data: {one: 1},
@@ -194,8 +198,8 @@ describe('recognize', () => {
       expect(r.data).toEqual({one: 1, two: 2});
     });
 
-    it('should not inherit route\'s data if it has component', () => {
-      const s = recognize(
+    it('should not inherit route\'s data if it has component', async () => {
+      const s = await recognize(
           [{
             path: 'a',
             component: ComponentA,
@@ -207,8 +211,8 @@ describe('recognize', () => {
       expect(r.data).toEqual({two: 2});
     });
 
-    it('should inherit route\'s data if paramsInheritanceStrategy is \'always\'', () => {
-      const s = recognize(
+    it('should inherit route\'s data if paramsInheritanceStrategy is \'always\'', async () => {
+      const s = await recognize(
           [{
             path: 'a',
             component: ComponentA,
@@ -220,35 +224,36 @@ describe('recognize', () => {
       expect(r.data).toEqual({one: 1, two: 2});
     });
 
-    it('should set resolved data', () => {
-      const s = recognize([{path: 'a', resolve: {one: 'some-token'}, component: ComponentA}], 'a');
+    it('should set resolved data', async () => {
+      const s =
+          await recognize([{path: 'a', resolve: {one: 'some-token'}, component: ComponentA}], 'a');
       const r: any = s.root.firstChild!;
       expect(r._resolve).toEqual({one: 'some-token'});
     });
   });
 
-  describe('empty path', () => {
-    describe('root', () => {
-      it('should work', () => {
-        const s = recognize([{path: '', component: ComponentA}], '');
+  describe('empty path', async () => {
+    describe('root', async () => {
+      it('should work', async () => {
+        const s = await recognize([{path: '', component: ComponentA}], '');
         checkActivatedRoute(s.root.firstChild!, '', {}, ComponentA);
       });
 
-      it('should match when terminal', () => {
-        const s = recognize([{path: '', pathMatch: 'full', component: ComponentA}], '');
+      it('should match when terminal', async () => {
+        const s = await recognize([{path: '', pathMatch: 'full', component: ComponentA}], '');
         checkActivatedRoute(s.root.firstChild!, '', {}, ComponentA);
       });
 
-      it('should work (nested case)', () => {
-        const s = recognize(
+      it('should work (nested case)', async () => {
+        const s = await recognize(
             [{path: '', component: ComponentA, children: [{path: '', component: ComponentB}]}], '');
         checkActivatedRoute(s.root.firstChild!, '', {}, ComponentA);
         checkActivatedRoute(s.root.firstChild!.firstChild!, '', {}, ComponentB);
       });
 
-      it('should set url segment and index properly', () => {
+      it('should set url segment and index properly', async () => {
         const url = tree('') as any;
-        const s = recognize(
+        const s = await recognize(
             [{path: '', component: ComponentA, children: [{path: '', component: ComponentB}]}], '');
         expect((s.root as any)._urlSegment.toString()).toEqual(url.root.toString());
         expect((s.root as any)._lastPathIndex).toBe(-1);
@@ -262,8 +267,8 @@ describe('recognize', () => {
         expect((c2 as any)._lastPathIndex).toBe(-1);
       });
 
-      it('should inherit params', () => {
-        const s = recognize(
+      it('should inherit params', async () => {
+        const s = await recognize(
             [{
               path: 'a',
               component: ComponentA,
@@ -277,9 +282,9 @@ describe('recognize', () => {
       });
     });
 
-    describe('aux split is in the middle', () => {
-      it('should match (non-terminal)', () => {
-        const s = recognize(
+    describe('aux split is in the middle', async () => {
+      it('should match (non-terminal)', async () => {
+        const s = await recognize(
             [{
               path: 'a',
               component: ComponentA,
@@ -296,7 +301,7 @@ describe('recognize', () => {
       });
 
       it('should match (non-terminal) when both primary and secondary and primary has a child',
-         () => {
+         async () => {
            const config = [{
              path: 'parent',
              children: [
@@ -316,7 +321,7 @@ describe('recognize', () => {
              ]
            }];
 
-           const s = recognize(config, 'parent/b');
+           const s = await recognize(config, 'parent/b');
            checkActivatedRoute(s.root, '', {}, RootComponent);
            checkActivatedRoute(s.root.firstChild!, 'parent', {}, null);
 
@@ -327,8 +332,8 @@ describe('recognize', () => {
            checkActivatedRoute(cc[0].firstChild!, 'b', {}, ComponentB);
          });
 
-      it('should match (terminal)', () => {
-        const s = recognize(
+      it('should match (terminal)', async () => {
+        const s = await recognize(
             [{
               path: 'a',
               component: ComponentA,
@@ -345,9 +350,9 @@ describe('recognize', () => {
         checkActivatedRoute(c[0], 'b', {}, ComponentB);
       });
 
-      it('should set url segment and index properly', () => {
+      it('should set url segment and index properly', async () => {
         const url = tree('a/b') as any;
-        const s = recognize(
+        const s = await recognize(
             [{
               path: 'a',
               component: ComponentA,
@@ -375,9 +380,9 @@ describe('recognize', () => {
         expect((c as any)._lastPathIndex).toBe(0);
       });
 
-      it('should set url segment and index properly when nested empty-path segments', () => {
+      it('should set url segment and index properly when nested empty-path segments', async () => {
         const url = tree('a') as any;
-        const s = recognize(
+        const s = await recognize(
             [{
               path: 'a',
               children:
@@ -404,9 +409,9 @@ describe('recognize', () => {
       });
 
       it('should set url segment and index properly with the "corrected" option for nested empty-path segments',
-         () => {
+         async () => {
            const url = tree('a/b');
-           const s = recognize(
+           const s = await recognize(
                [{
                  path: 'a',
                  children: [{
@@ -444,35 +449,37 @@ describe('recognize', () => {
            expect((d as any)._lastPathIndex).toBe(1);
          });
 
-      it('should set url segment and index properly when nested empty-path segments (2)', () => {
-        const url = tree('');
-        const s = recognize(
-            [{
-              path: '',
-              children:
-                  [{path: '', component: ComponentB, children: [{path: '', component: ComponentC}]}]
-            }],
-            '');
-        expect((s.root as any)._urlSegment.toString()).toEqual(url.root.toString());
-        expect((s.root as any)._lastPathIndex).toBe(-1);
+      it('should set url segment and index properly when nested empty-path segments (2)',
+         async () => {
+           const url = tree('');
+           const s = await recognize(
+               [{
+                 path: '',
+                 children: [
+                   {path: '', component: ComponentB, children: [{path: '', component: ComponentC}]}
+                 ]
+               }],
+               '');
+           expect((s.root as any)._urlSegment.toString()).toEqual(url.root.toString());
+           expect((s.root as any)._lastPathIndex).toBe(-1);
 
-        const a = s.root.firstChild!;
-        expect((a as any)._urlSegment.toString()).toEqual(url.root.toString());
-        expect((a as any)._lastPathIndex).toBe(-1);
+           const a = s.root.firstChild!;
+           expect((a as any)._urlSegment.toString()).toEqual(url.root.toString());
+           expect((a as any)._lastPathIndex).toBe(-1);
 
-        const b = a.firstChild!;
-        expect((b as any)._urlSegment.toString()).toEqual(url.root.toString());
-        expect((b as any)._lastPathIndex).toBe(-1);
+           const b = a.firstChild!;
+           expect((b as any)._urlSegment.toString()).toEqual(url.root.toString());
+           expect((b as any)._lastPathIndex).toBe(-1);
 
-        const c = b.firstChild!;
-        expect((c as any)._urlSegment.toString()).toEqual(url.root.toString());
-        expect((c as any)._lastPathIndex).toBe(-1);
-      });
+           const c = b.firstChild!;
+           expect((c as any)._urlSegment.toString()).toEqual(url.root.toString());
+           expect((c as any)._lastPathIndex).toBe(-1);
+         });
     });
 
-    describe('aux split at the end (no right child)', () => {
-      it('should match (non-terminal)', () => {
-        const s = recognize(
+    describe('aux split at the end (no right child)', async () => {
+      it('should match (non-terminal)', async () => {
+        const s = await recognize(
             [{
               path: 'a',
               component: ComponentA,
@@ -489,8 +496,8 @@ describe('recognize', () => {
         checkActivatedRoute(c[1], '', {}, ComponentC, 'aux');
       });
 
-      it('should match (terminal)', () => {
-        const s = recognize(
+      it('should match (terminal)', async () => {
+        const s = await recognize(
             [{
               path: 'a',
               component: ComponentA,
@@ -507,8 +514,8 @@ describe('recognize', () => {
         checkActivatedRoute(c[1], '', {}, ComponentC, 'aux');
       });
 
-      it('should work only only primary outlet', () => {
-        const s = recognize(
+      it('should work only only primary outlet', async () => {
+        const s = await recognize(
             [{
               path: 'a',
               component: ComponentA,
@@ -525,8 +532,8 @@ describe('recognize', () => {
         checkActivatedRoute(c[1], 'c', {}, ComponentC, 'aux');
       });
 
-      it('should work when split is at the root level', () => {
-        const s = recognize(
+      it('should work when split is at the root level', async () => {
+        const s = await recognize(
             [
               {path: '', component: ComponentA}, {path: 'b', component: ComponentB},
               {path: 'c', component: ComponentC, outlet: 'aux'}
@@ -541,9 +548,9 @@ describe('recognize', () => {
       });
     });
 
-    describe('split at the end (right child)', () => {
-      it('should match (non-terminal)', () => {
-        const s = recognize(
+    describe('split at the end (right child)', async () => {
+      it('should match (non-terminal)', async () => {
+        const s = await recognize(
             [{
               path: 'a',
               component: ComponentA,
@@ -568,9 +575,9 @@ describe('recognize', () => {
       });
     });
 
-    describe('with outlets', () => {
-      it('should work when outlet is a child of empty path parent', () => {
-        const s = recognize(
+    describe('with outlets', async () => {
+      it('should work when outlet is a child of empty path parent', async () => {
+        const s = await recognize(
             [{
               path: '',
               component: ComponentA,
@@ -581,8 +588,8 @@ describe('recognize', () => {
         checkActivatedRoute(s.root.children[0].children[0], 'b', {}, ComponentB, 'b');
       });
 
-      it('should work for outlets adjacent to empty path', () => {
-        const s = recognize(
+      it('should work for outlets adjacent to empty path', async () => {
+        const s = await recognize(
             [
               {
                 path: '',
@@ -598,24 +605,25 @@ describe('recognize', () => {
         checkActivatedRoute(primaryChild.children[0], '', {}, ComponentC);
       });
 
-      it('should work with named outlets both adjecent to and as a child of empty path', () => {
-        const s = recognize(
-            [
-              {
-                path: '',
-                component: ComponentA,
-                children: [{path: 'b', outlet: 'b', component: ComponentB}]
-              },
-              {path: 'c', outlet: 'c', component: ComponentC}
-            ],
-            '(b:b//c:c)');
-        checkActivatedRoute(s.root.children[0], '', {}, ComponentA);
-        checkActivatedRoute(s.root.children[1], 'c', {}, ComponentC, 'c');
-        checkActivatedRoute(s.root.children[0].children[0], 'b', {}, ComponentB, 'b');
-      });
+      it('should work with named outlets both adjecent to and as a child of empty path',
+         async () => {
+           const s = await recognize(
+               [
+                 {
+                   path: '',
+                   component: ComponentA,
+                   children: [{path: 'b', outlet: 'b', component: ComponentB}]
+                 },
+                 {path: 'c', outlet: 'c', component: ComponentC}
+               ],
+               '(b:b//c:c)');
+           checkActivatedRoute(s.root.children[0], '', {}, ComponentA);
+           checkActivatedRoute(s.root.children[1], 'c', {}, ComponentC, 'c');
+           checkActivatedRoute(s.root.children[0].children[0], 'b', {}, ComponentB, 'b');
+         });
 
-      it('should work with children outlets within two levels of empty parents', () => {
-        const s = recognize(
+      it('should work with children outlets within two levels of empty parents', async () => {
+        const s = await recognize(
             [{
               path: '',
               component: ComponentA,
@@ -638,34 +646,35 @@ describe('recognize', () => {
         checkActivatedRoute(compCConfig, 'c', {}, ComponentC, 'c');
       });
 
-      it('should not persist a primary segment beyond the boundary of a named outlet match', () => {
-        const s = new Recognizer(
-                      RootComponent,
-                      [
-                        {
-                          path: '',
-                          component: ComponentA,
-                          outlet: 'a',
-                          children: [{path: 'b', component: ComponentB}],
-                        },
-                      ],
-                      tree('/b'), '/b', 'emptyOnly', 'corrected')
-                      .recognize();
-        expect(s).toBeNull();
-      });
+      it('should not persist a primary segment beyond the boundary of a named outlet match',
+         async () => {
+           const s = await new Recognizer(
+                         TestBed.inject(EnvironmentInjector), RootComponent,
+                         [
+                           {
+                             path: '',
+                             component: ComponentA,
+                             outlet: 'a',
+                             children: [{path: 'b', component: ComponentB}],
+                           },
+                         ],
+                         tree('/b'), '/b', 'emptyOnly', 'corrected')
+                         .recognize();
+           expect(s).toBeNull();
+         });
     });
   });
 
-  describe('wildcards', () => {
-    it('should support simple wildcards', () => {
-      const s = recognize([{path: '**', component: ComponentA}], 'a/b/c/d;a1=11');
+  describe('wildcards', async () => {
+    it('should support simple wildcards', async () => {
+      const s = await recognize([{path: '**', component: ComponentA}], 'a/b/c/d;a1=11');
       checkActivatedRoute(s.root.firstChild!, 'a/b/c/d', {a1: '11'}, ComponentA);
     });
   });
 
-  describe('componentless routes', () => {
-    it('should work', () => {
-      const s = recognize(
+  describe('componentless routes', async () => {
+    it('should work', async () => {
+      const s = await recognize(
           [{
             path: 'p/:id',
             children: [
@@ -681,8 +690,8 @@ describe('recognize', () => {
       checkActivatedRoute(c[1], 'b', {id: '11', pp: '22', pb: '44'}, ComponentB, 'aux');
     });
 
-    it('should inherit params until encounters a normal route', () => {
-      const s = recognize(
+    it('should inherit params until encounters a normal route', async () => {
+      const s = await recognize(
           [{
             path: 'p/:id',
             children: [{
@@ -706,8 +715,8 @@ describe('recognize', () => {
       checkActivatedRoute(c, 'c', {}, ComponentC);
     });
 
-    it('should inherit all params if paramsInheritanceStrategy is \'always\'', () => {
-      const s = recognize(
+    it('should inherit all params if paramsInheritanceStrategy is \'always\'', async () => {
+      const s = await recognize(
           [{
             path: 'p/:id',
             children: [{
@@ -723,17 +732,17 @@ describe('recognize', () => {
     });
   });
 
-  describe('empty URL leftovers', () => {
-    it('should not throw when no children matching', () => {
-      const s = recognize(
+  describe('empty URL leftovers', async () => {
+    it('should not throw when no children matching', async () => {
+      const s = await recognize(
           [{path: 'a', component: ComponentA, children: [{path: 'b', component: ComponentB}]}],
           '/a');
       const a = s.root.firstChild;
       checkActivatedRoute(a!, 'a', {}, ComponentA);
     });
 
-    it('should not throw when no children matching (aux routes)', () => {
-      const s = recognize(
+    it('should not throw when no children matching (aux routes)', async () => {
+      const s = await recognize(
           [{
             path: 'a',
             component: ComponentA,
@@ -749,8 +758,8 @@ describe('recognize', () => {
     });
   });
 
-  describe('custom path matchers', () => {
-    it('should use custom path matcher', () => {
+  describe('custom path matchers', async () => {
+    it('should use custom path matcher', async () => {
       const matcher = (s: any, g: any, r: any) => {
         if (s[0].path === 'a') {
           return {consumed: s.slice(0, 2), posParams: {id: s[1]}};
@@ -759,7 +768,7 @@ describe('recognize', () => {
         }
       };
 
-      const s = recognize(
+      const s = await recognize(
           [{
             matcher: matcher,
             component: ComponentA,
@@ -771,18 +780,18 @@ describe('recognize', () => {
       checkActivatedRoute(a.firstChild!, 'b', {}, ComponentB);
     });
 
-    it('should work with terminal route', () => {
+    it('should work with terminal route', async () => {
       const matcher = (s: any, g: any, r: any) => s.length === 0 ? ({consumed: s}) : null;
 
-      const s = recognize([{matcher, component: ComponentA}] as any, '');
+      const s = await recognize([{matcher, component: ComponentA}] as any, '');
       const a = s.root.firstChild!;
       checkActivatedRoute(a, '', {}, ComponentA);
     });
 
-    it('should work with child terminal route', () => {
+    it('should work with child terminal route', async () => {
       const matcher = (s: any, g: any, r: any) => s.length === 0 ? ({consumed: s}) : null;
 
-      const s = recognize(
+      const s = await recognize(
           [{path: 'a', component: ComponentA, children: [{matcher, component: ComponentB}]}] as any,
           'a');
       const a = s.root.firstChild!;
@@ -790,42 +799,42 @@ describe('recognize', () => {
     });
   });
 
-  describe('query parameters', () => {
-    it('should support query params', () => {
+  describe('query parameters', async () => {
+    it('should support query params', async () => {
       const config = [{path: 'a', component: ComponentA}];
-      const s = recognize(config, 'a?q=11');
+      const s = await recognize(config, 'a?q=11');
       expect(s.root.queryParams).toEqual({q: '11'});
       expect(s.root.queryParamMap.get('q')).toEqual('11');
     });
 
-    it('should freeze query params object', () => {
-      const s = recognize([{path: 'a', component: ComponentA}], 'a?q=11');
+    it('should freeze query params object', async () => {
+      const s = await recognize([{path: 'a', component: ComponentA}], 'a?q=11');
       expect(Object.isFrozen(s.root.queryParams)).toBeTruthy();
     });
 
-    it('should not freeze UrlTree query params', () => {
+    it('should not freeze UrlTree query params', async () => {
       const url = tree('a?q=11');
-      const s = recognize([{path: 'a', component: ComponentA}], 'a?q=11');
+      const s = await recognize([{path: 'a', component: ComponentA}], 'a?q=11');
       expect(Object.isFrozen(url.queryParams)).toBe(false);
     });
   });
 
-  describe('fragment', () => {
-    it('should support fragment', () => {
+  describe('fragment', async () => {
+    it('should support fragment', async () => {
       const config = [{path: 'a', component: ComponentA}];
-      const s = recognize(config, 'a#f1');
+      const s = await recognize(config, 'a#f1');
       expect(s.root.fragment).toEqual('f1');
     });
   });
 });
 
-function recognize(
+async function recognize(
     config: Routes, url: string, paramsInheritanceStrategy: 'emptyOnly'|'always' = 'emptyOnly',
-    relativeLinkResolution: 'legacy'|'corrected' = 'legacy'): RouterStateSnapshot {
-  const result =
-      new Recognizer(
-          RootComponent, config, tree(url), url, paramsInheritanceStrategy, relativeLinkResolution)
-          .recognize();
+    relativeLinkResolution: 'legacy'|'corrected' = 'legacy'): Promise<RouterStateSnapshot> {
+  const result = await new Recognizer(
+                     TestBed.inject(EnvironmentInjector), RootComponent, config, tree(url), url,
+                     paramsInheritanceStrategy, relativeLinkResolution)
+                     .recognize();
   expect(result).not.toBeNull();
   return result!;
 }


### PR DESCRIPTION
Currently we have two main types of guards:
`CanLoad`: decides if we can load a module (used with lazy loading)
`CanActivate` and friends. It decides if we can activate/deactivate a route.
So we always decide where we want to navigate first ("recognize") and create a new router state snapshot. And only then we run guards to check if the navigation should be allowed.
This doesn't handle one very important use case where we want to decide where to navigate based on some data (e.g., who the user is).
I suggest to add a new guard that allows us to do that.

```
[
  {path: 'home', component: AdminHomePage, canUse: [IsAdmin]},
  {path: 'home', component: SimpleHomePage}
]
```

Here, navigating to '/home' will render `AdminHomePage` if the user is an admin and will render 'SimpleHomePage' otherwise. Note that the url will remain '/home'.

With the introduction of standalone components and new features in the Router such as `loadComponent`,
there's a case for deprecating `CanLoad` and replacing it with the `CanMatch` guard. There are a few reasons for this:

* One of the intentions of having separate providers on a Route is that lazy
loading should not be an architectural feature of an application. It's an
optimization you do for code size. That is, there should not be an architectural
feature in the router to specifically control whether to lazy load something or
not based on conditions such as authentication. This is a slight nuanced
difference between the proposed canUse guard: this guard would control whether
you can use the route at all and as a side-effect, whether we download the code.
`CanLoad` only specified whether the code should be downloaded so canUse is more powerful and more appropriate.
* The naming of `CanLoad` will be potentially misunderstood for the `loadComponent` feature.
Because it applies to `loadChildren`, it feels reasonable to think that it will
also apply to `loadComponent`. This isn’t the case: since we don't need
to load the component until right before activation, we defer the
loading until all guards/resolvers have run.

When considering the removal of `CanLoad` and replacing it with `CanMatch`, this
does inform another decision that needed to be made: whether it makes sense for
`CanMatch` guards to return a UrlTree or if they should be restricted to just boolean.
The original thought was that no, these new guards should not allow returning UrlTree
because that significantly expands the intent of the feature from simply
“can I use the route” to “can I use this route, and if not, should I redirect?”
I now believe it should allowed to return `UrlTree` for several reasons:

* For feature parity with `CanLoad`
* Because whether we allow it as a return value or not, developers will still be
able to trigger a redirect from the guards using the `Router.navigate` function.
* Inevitably, there will be developers who disagree with the philosophical decision
to disallow `UrlTree` and we don’t necessarily have a compelling reason to refuse this as a feature.

Relates to https://github.com/angular/angular/issues/16211 - `CanMatch` instead of `CanActivate` would prevent
blank screen. Additional work is required to close this issue. This can
be accomplished by making the initial navigation result trackable (including
the redirects).
Resolves https://github.com/angular/angular/issues/14515
Replaces https://github.com/angular/angular/pull/16416
Resolves https://github.com/angular/angular/issues/34231
Resolves https://github.com/angular/angular/issues/17145
Resolves https://github.com/angular/angular/issues/12088