### PR TITLE
fix(forms): Make some fixes to typed forms API and docs.

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -494,7 +494,7 @@ export class FormGroupName extends AbstractFormGroupDirective implements OnInit,
 }
 
 // @public
-export class FormRecord<TControl extends AbstractControl<Value<TControl>, RawValue<TControl>> = AbstractControl> extends FormGroup<{
+export class FormRecord<TControl extends AbstractControl<ɵValue<TControl>, ɵRawValue<TControl>> = AbstractControl> extends FormGroup<{
     [key: string]: TControl;
 }> {
 }
@@ -506,10 +506,10 @@ export interface FormRecord<TControl> {
     }): void;
     contains(controlName: string): boolean;
     getRawValue(): {
-        [key: string]: RawValue<TControl>;
+        [key: string]: ɵRawValue<TControl>;
     };
     patchValue(value: {
-        [key: string]: Value<TControl>;
+        [key: string]: ɵValue<TControl>;
     }, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
@@ -519,7 +519,7 @@ export interface FormRecord<TControl> {
         emitEvent?: boolean;
     }): void;
     reset(value?: {
-        [key: string]: Value<TControl>;
+        [key: string]: ɵValue<TControl>;
     }, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
@@ -528,7 +528,7 @@ export interface FormRecord<TControl> {
         emitEvent?: boolean;
     }): void;
     setValue(value: {
-        [key: string]: Value<TControl>;
+        [key: string]: ɵValue<TControl>;
     }, options?: {
         onlySelf?: boolean;
         emitEvent?: boolean;
@@ -768,9 +768,6 @@ export class RangeValueAccessor extends BuiltInControlValueAccessor implements C
 }
 
 // @public
-export type RawValue<T extends AbstractControl | undefined> = T extends AbstractControl<any, any> ? (T['setValue'] extends ((v: infer R) => void) ? R : never) : never;
-
-// @public
 export class ReactiveFormsModule {
     static withConfig(opts: {
         warnOnNgModelWithFormControl: 'never' | 'once' | 'always';
@@ -889,9 +886,6 @@ export class Validators {
     static required(control: AbstractControl): ValidationErrors | null;
     static requiredTrue(control: AbstractControl): ValidationErrors | null;
 }
-
-// @public
-export type Value<T extends AbstractControl | undefined> = T extends AbstractControl<any, any> ? T['value'] : never;
 
 // @public (undocumented)
 export const VERSION: Version;

--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -493,13 +493,13 @@ export class FormGroupName extends AbstractFormGroupDirective implements OnInit,
     static ɵfac: i0.ɵɵFactoryDeclaration<FormGroupName, [{ optional: true; host: true; skipSelf: true; }, { optional: true; self: true; }, { optional: true; self: true; }]>;
 }
 
-// @public (undocumented)
+// @public
 export class FormRecord<TControl extends AbstractControl<Value<TControl>, RawValue<TControl>> = AbstractControl> extends FormGroup<{
     [key: string]: TControl;
 }> {
 }
 
-// @public
+// @public (undocumented)
 export interface FormRecord<TControl> {
     addControl(name: string, control: TControl, options?: {
         emitEvent?: boolean;

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -324,7 +324,7 @@ export class FormBuilder {
 })
 export abstract class NonNullableFormBuilder {
   /**
-   * Similar to {@see FormBuilder#group}, except any implicitly constructed `FormControl`
+   * Similar to `FormBuilder#group`, except any implicitly constructed `FormControl`
    * will be non-nullable (i.e. it will have `initialValueIsDefault` set to true). Note
    * that already-constructed controls will not be altered.
    */
@@ -334,7 +334,7 @@ export abstract class NonNullableFormBuilder {
       ): FormGroup<{[K in keyof T]: ɵElement<T[K], never>}>;
 
   /**
-   * Similar to {@see FormBuilder#array}, except any implicitly constructed `FormControl`
+   * Similar to `FormBuilder#array`, except any implicitly constructed `FormControl`
    * will be non-nullable (i.e. it will have `initialValueIsDefault` set to true). Note
    * that already-constructed controls will not be altered.
    */
@@ -343,7 +343,7 @@ export abstract class NonNullableFormBuilder {
       asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null): FormArray<ɵElement<T, never>>;
 
   /**
-   * Similar to {@see FormBuilder#control}, except this overridden version of `control` forces
+   * Similar to `FormBuilder#control`, except this overridden version of `control` forces
    * `initialValueIsDefault` to be `true`, resulting in the control always being non-nullable.
    */
   abstract control<T>(
@@ -358,7 +358,7 @@ export abstract class NonNullableFormBuilder {
 @Injectable({providedIn: ReactiveFormsModule})
 export class UntypedFormBuilder extends FormBuilder {
   /**
-   * Like {@see FormBuilder#group}, except the resulting group is untyped.
+   * Like `FormBuilder#group`, except the resulting group is untyped.
    */
   override group(
       controlsConfig: {[key: string]: any},
@@ -381,7 +381,7 @@ export class UntypedFormBuilder extends FormBuilder {
   }
 
   /**
-   * Like {@see FormBuilder#control}, except the resulting control is untyped.
+   * Like `FormBuilder#control`, except the resulting control is untyped.
    */
   override control(
       formState: any, validatorOrOpts?: ValidatorFn|ValidatorFn[]|FormControlOptions|null,
@@ -390,7 +390,7 @@ export class UntypedFormBuilder extends FormBuilder {
   }
 
   /**
-   * Like {@see FormBuilder#array}, except the resulting array is untyped.
+   * Like `FormBuilder#array`, except the resulting array is untyped.
    */
   override array(
       controlsConfig: any[],

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -42,7 +42,7 @@ export {NgSelectOption, SelectControlValueAccessor} from './directives/select_co
 export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './directives/select_multiple_control_value_accessor';
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {FormBuilder, NonNullableFormBuilder, UntypedFormBuilder, ɵElement} from './form_builder';
-export {AbstractControl, AbstractControlOptions, FormControlStatus, RawValue, Value, ɵCoerceStrArrToNumArr, ɵGetProperty, ɵNavigate, ɵTokenize, ɵTypedOrUntyped, ɵWriteable} from './model/abstract_model';
+export {AbstractControl, AbstractControlOptions, FormControlStatus, ɵCoerceStrArrToNumArr, ɵGetProperty, ɵNavigate, ɵRawValue, ɵTokenize, ɵTypedOrUntyped, ɵValue, ɵWriteable} from './model/abstract_model';
 export {FormArray, UntypedFormArray, ɵFormArrayRawValue, ɵFormArrayValue} from './model/form_array';
 export {FormControl, FormControlOptions, FormControlState, UntypedFormControl, ɵFormControlCtor} from './model/form_control';
 export {FormGroup, FormRecord, UntypedFormGroup, ɵFormGroupRawValue, ɵFormGroupValue, ɵOptionalKeys} from './model/form_group';

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -214,8 +214,10 @@ export type ɵTypedOrUntyped<T, Typed, Untyped> = ɵIsAny<T, Untyped, Typed>;
  * ```
  *
  * The resulting type is `string[]`.
+ *
+ * **Internal: not for public use.**
  */
-export type Value<T extends AbstractControl|undefined> =
+export type ɵValue<T extends AbstractControl|undefined> =
     T extends AbstractControl<any, any>? T['value'] : never;
 
 /**
@@ -244,8 +246,10 @@ export type Value<T extends AbstractControl|undefined> =
  * ```
  *
  * The resulting type is `{address: string}`. (Note the absence of `undefined`.)
+ *
+ *  **Internal: not for public use.**
  */
-export type RawValue<T extends AbstractControl|undefined> = T extends AbstractControl<any, any>?
+export type ɵRawValue<T extends AbstractControl|undefined> = T extends AbstractControl<any, any>?
     (T['setValue'] extends((v: infer R) => void) ? R : never) :
     never;
 

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -8,7 +8,7 @@
 
 import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
 
-import {AbstractControl, AbstractControlOptions, assertAllValuesPresent, assertControlPresent, pickAsyncValidators, pickValidators, RawValue, Value, ɵTypedOrUntyped} from './abstract_model';
+import {AbstractControl, AbstractControlOptions, assertAllValuesPresent, assertControlPresent, pickAsyncValidators, pickValidators, ɵRawValue, ɵTypedOrUntyped, ɵValue} from './abstract_model';
 
 /**
  * FormArrayValue extracts the type of `.value` from a FormArray's element type, and wraps it in an
@@ -18,7 +18,7 @@ import {AbstractControl, AbstractControlOptions, assertAllValuesPresent, assertC
  * case falls back to any[].
  */
 export type ɵFormArrayValue<T extends AbstractControl<any>> =
-    ɵTypedOrUntyped<T, Array<Value<T>>, any[]>;
+    ɵTypedOrUntyped<T, Array<ɵValue<T>>, any[]>;
 
 /**
  * FormArrayRawValue extracts the type of `.getRawValue()` from a FormArray's element type, and
@@ -27,7 +27,7 @@ export type ɵFormArrayValue<T extends AbstractControl<any>> =
  * Angular uses this type internally to support Typed Forms; do not use it directly.
  */
 export type ɵFormArrayRawValue<T extends AbstractControl<any>> =
-    ɵTypedOrUntyped<T, Array<RawValue<T>>, any[]>;
+    ɵTypedOrUntyped<T, Array<ɵRawValue<T>>, any[]>;
 
 /**
  * Tracks the value and validity state of an array of `FormControl`,

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -606,10 +606,6 @@ export const UntypedFormGroup: UntypedFormGroupCtor = FormGroup;
 
 export const isFormGroup = (control: unknown): control is FormGroup => control instanceof FormGroup;
 
-export class FormRecord<TControl extends AbstractControl<Value<TControl>, RawValue<TControl>> =
-                                             AbstractControl> extends
-    FormGroup<{[key: string]: TControl}> {}
-
 /**
  * Tracks the value and validity state of a collection of `FormControl` instances, each of which has
  * the same value type.
@@ -629,39 +625,43 @@ export class FormRecord<TControl extends AbstractControl<Value<TControl>, RawVal
  *
  * @publicApi
  */
+export class FormRecord<TControl extends AbstractControl<Value<TControl>, RawValue<TControl>> =
+                                             AbstractControl> extends
+    FormGroup<{[key: string]: TControl}> {}
+
 export interface FormRecord<TControl> {
   /**
    * Registers a control with the records's list of controls.
    *
-   * {@see FormGroup#registerControl}
+   * See `FormGroup#registerControl` for additional information.
    */
   registerControl(name: string, control: TControl): TControl;
 
   /**
    * Add a control to this group.
    *
-   * {@see FormGroup#addControl}
+   * See `FormGroup#addControl` for additional information.
    */
   addControl(name: string, control: TControl, options?: {emitEvent?: boolean}): void;
 
   /**
    * Remove a control from this group.
    *
-   * {@see FormGroup#removeControl}
+   * See `FormGroup#removeControl` for additional information.
    */
   removeControl(name: string, options?: {emitEvent?: boolean}): void;
 
   /**
    * Replace an existing control.
    *
-   * {@see FormGroup#setControl}
+   * See `FormGroup#setControl` for additional information.
    */
   setControl(name: string, control: TControl, options?: {emitEvent?: boolean}): void;
 
   /**
    * Check whether there is an enabled control with the given name in the group.
    *
-   * {@see FormGroup#contains}
+   * See `FormGroup#contains` for additional information.
    */
   contains(controlName: string): boolean;
 
@@ -669,7 +669,7 @@ export interface FormRecord<TControl> {
    * Sets the value of the `FormRecord`. It accepts an object that matches
    * the structure of the group, with control names as keys.
    *
-   * {@see FormGroup#setValue}
+   * See `FormGroup#setValue` for additional information.
    */
   setValue(value: {[key: string]: Value<TControl>}, options?: {
     onlySelf?: boolean,
@@ -681,7 +681,7 @@ export interface FormRecord<TControl> {
    * names as keys, and does its best to match the values to the correct controls
    * in the group.
    *
-   * {@see FormGroup#patchValue}
+   * See `FormGroup#patchValue` for additional information.
    */
   patchValue(value: {[key: string]: Value<TControl>}, options?: {
     onlySelf?: boolean,
@@ -692,7 +692,7 @@ export interface FormRecord<TControl> {
    * Resets the `FormRecord`, marks all descendants `pristine` and `untouched` and sets
    * the value of all descendants to null.
    *
-   * {@see FormGroup#reset}
+   * See `FormGroup#reset` for additional information.
    */
   reset(value?: {[key: string]: Value<TControl>}, options?: {
     onlySelf?: boolean,
@@ -702,7 +702,7 @@ export interface FormRecord<TControl> {
   /**
    * The aggregate value of the `FormRecord`, including any disabled controls.
    *
-   * {@see FormGroup#getRawValue}
+   * See `FormGroup#getRawValue` for additional information.
    */
   getRawValue(): {[key: string]: RawValue<TControl>};
 }

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -8,7 +8,7 @@
 
 import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
 
-import {AbstractControl, AbstractControlOptions, assertAllValuesPresent, assertControlPresent, pickAsyncValidators, pickValidators, RawValue, Value, ɵTypedOrUntyped} from './abstract_model';
+import {AbstractControl, AbstractControlOptions, assertAllValuesPresent, assertControlPresent, pickAsyncValidators, pickValidators, ɵRawValue, ɵTypedOrUntyped, ɵValue} from './abstract_model';
 
 /**
  * FormGroupValue extracts the type of `.value` from a FormGroup's inner object type. The untyped
@@ -19,7 +19,7 @@ import {AbstractControl, AbstractControlOptions, assertAllValuesPresent, assertC
  * For internal use only.
  */
 export type ɵFormGroupValue<T extends {[K in keyof T]?: AbstractControl<any>}> =
-    ɵTypedOrUntyped<T, Partial<{[K in keyof T]: Value<T[K]>}>, {[key: string]: any}>;
+    ɵTypedOrUntyped<T, Partial<{[K in keyof T]: ɵValue<T[K]>}>, {[key: string]: any}>;
 
 /**
  * FormGroupRawValue extracts the type of `.getRawValue()` from a FormGroup's inner object type. The
@@ -30,7 +30,7 @@ export type ɵFormGroupValue<T extends {[K in keyof T]?: AbstractControl<any>}> 
  * For internal use only.
  */
 export type ɵFormGroupRawValue<T extends {[K in keyof T]?: AbstractControl<any>}> =
-    ɵTypedOrUntyped<T, {[K in keyof T]: RawValue<T[K]>}, {[key: string]: any}>;
+    ɵTypedOrUntyped<T, {[K in keyof T]: ɵRawValue<T[K]>}, {[key: string]: any}>;
 
 /**
  * OptionalKeys returns the union of all optional keys in the object.
@@ -625,7 +625,7 @@ export const isFormGroup = (control: unknown): control is FormGroup => control i
  *
  * @publicApi
  */
-export class FormRecord<TControl extends AbstractControl<Value<TControl>, RawValue<TControl>> =
+export class FormRecord<TControl extends AbstractControl<ɵValue<TControl>, ɵRawValue<TControl>> =
                                              AbstractControl> extends
     FormGroup<{[key: string]: TControl}> {}
 
@@ -671,7 +671,7 @@ export interface FormRecord<TControl> {
    *
    * See `FormGroup#setValue` for additional information.
    */
-  setValue(value: {[key: string]: Value<TControl>}, options?: {
+  setValue(value: {[key: string]: ɵValue<TControl>}, options?: {
     onlySelf?: boolean,
     emitEvent?: boolean
   }): void;
@@ -683,7 +683,7 @@ export interface FormRecord<TControl> {
    *
    * See `FormGroup#patchValue` for additional information.
    */
-  patchValue(value: {[key: string]: Value<TControl>}, options?: {
+  patchValue(value: {[key: string]: ɵValue<TControl>}, options?: {
     onlySelf?: boolean,
     emitEvent?: boolean
   }): void;
@@ -694,7 +694,7 @@ export interface FormRecord<TControl> {
    *
    * See `FormGroup#reset` for additional information.
    */
-  reset(value?: {[key: string]: Value<TControl>}, options?: {
+  reset(value?: {[key: string]: ɵValue<TControl>}, options?: {
     onlySelf?: boolean,
     emitEvent?: boolean
   }): void;
@@ -704,7 +704,7 @@ export interface FormRecord<TControl> {
    *
    * See `FormGroup#getRawValue` for additional information.
    */
-  getRawValue(): {[key: string]: RawValue<TControl>};
+  getRawValue(): {[key: string]: ɵRawValue<TControl>};
 }
 
 export const isFormRecord = (control: unknown): control is FormRecord =>


### PR DESCRIPTION
* `FormRecord` JSDoc should now appear on a.io
* The `{@see foo#bar}` syntax previously did not work, and has been replace with backticks
* Value and RawValue have been removed from the public API (rolling back #45978); this needs more discussion (see #fw-forms)
