### PR TITLE
fix(router): Ensure APP_INITIALIZER of enabledBlocking option completes

### DIFF
--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -15,7 +15,7 @@ import {ActivationStart, ChildActivationStart, Event} from '../events';
 import {CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanLoadFn, CanMatch, CanMatchFn, Route} from '../models';
 import {NavigationTransition} from '../router';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from '../router_state';
-import {navigationCancelingError} from '../shared';
+import {navigationCancelingError, REDIRECTING_CANCELLATION_REASON} from '../shared';
 import {UrlSegment, UrlSerializer, UrlTree} from '../url_tree';
 import {wrapIntoObservable} from '../utils/collection';
 import {CanActivate, CanDeactivate, getCanActivateChild, getToken} from '../utils/preactivation';
@@ -219,8 +219,8 @@ function redirectIfUrlTree(urlSerializer: UrlSerializer):
       tap((result: UrlTree|boolean) => {
         if (!isUrlTree(result)) return;
 
-        const error: Error&{url?: UrlTree} =
-            navigationCancelingError(`Redirecting to "${urlSerializer.serialize(result)}"`);
+        const error: Error&{url?: UrlTree} = navigationCancelingError(
+            REDIRECTING_CANCELLATION_REASON + urlSerializer.serialize(result));
         error.url = result;
         throw error;
       }),

--- a/packages/router/src/shared.ts
+++ b/packages/router/src/shared.ts
@@ -111,6 +111,7 @@ export function convertToParamMap(params: Params): ParamMap {
   return new ParamsAsMap(params);
 }
 
+export const REDIRECTING_CANCELLATION_REASON = 'Redirecting to ';
 const NAVIGATION_CANCELING_ERROR = 'ngNavigationCancelingError';
 
 export function navigationCancelingError(message: string|null|false) {

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -77,40 +77,40 @@ describe('bootstrap', () => {
     }
   }));
 
-  // TODO(#44355): bootstrapping fails when the initial navigation fails
-  xit('should complete resolvers when initial navigation fails and initialNavigation = enabledBlocking',
-      async () => {
-        @NgModule({
-          imports: [
-            BrowserModule,
-            RouterModule.forRoot(
-                [{
-                  matcher: () => {
-                    throw new Error('error in matcher');
-                  },
-                  children: []
-                }],
-                {useHash: true, initialNavigation: 'enabledBlocking'})
-          ],
-          declarations: [RootCmp],
-          bootstrap: [RootCmp],
-          providers: [...testProviders],
-          schemas: [CUSTOM_ELEMENTS_SCHEMA]
-        })
-        class TestModule {
-          constructor() {
-            log.push('TestModule');
-          }
-        }
+  it('should complete resolvers when initial navigation fails and initialNavigation = enabledBlocking',
+     async () => {
+       @NgModule({
+         imports: [
+           BrowserModule,
+           RouterModule.forRoot(
+               [{
+                 matcher: () => {
+                   throw new Error('error in matcher');
+                 },
+                 children: []
+               }],
+               {useHash: true, initialNavigation: 'enabledBlocking'})
+         ],
+         declarations: [RootCmp],
+         bootstrap: [RootCmp],
+         providers: [...testProviders],
+         schemas: [CUSTOM_ELEMENTS_SCHEMA]
+       })
+       class TestModule {
+         constructor(router: Router) {
+           log.push('TestModule');
+           router.events.subscribe(e => log.push(e.constructor.name));
+         }
+       }
 
-        await platformBrowserDynamic([]).bootstrapModule(TestModule).then(res => {
-          const router = res.injector.get(Router);
-          expect(router.navigated).toEqual(false);
-          expect(router.getCurrentNavigation()).toBeNull();
-          expect(log).toContain('TestModule');
-          expect(log).toContain('NavigationError');
-        });
-      });
+       await platformBrowserDynamic([]).bootstrapModule(TestModule).then(res => {
+         const router = res.injector.get(Router);
+         expect(router.navigated).toEqual(false);
+         expect(router.getCurrentNavigation()).toBeNull();
+         expect(log).toContain('TestModule');
+         expect(log).toContain('NavigationError');
+       });
+     });
 
   it('should wait for redirect when initialNavigation = enabledBlocking', async () => {
     @Injectable({providedIn: 'root'})


### PR DESCRIPTION
Previously, if `initialNavigation` were set to `enabledBlocking`, the
Router's `APP_INITIALIZER` would never resolve if that initial
navigation failed. This results in the application load hanging and
never completing.

fixes https://github.com/angular/angular/issues/44355