### PR TITLE
fix(core): Reimplement DefaultIterableDiffer to fix multiple bugs

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -364,27 +364,25 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
     // (undocumented)
     check(collection: NgIterable<V>): boolean;
     // (undocumented)
-    readonly collection: V[] | Iterable<V> | null;
+    get collection(): V[] | Iterable<V> | null;
     // (undocumented)
     diff(collection: NgIterable<V> | null | undefined): DefaultIterableDiffer<V> | null;
     // (undocumented)
-    forEachAddedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachAddedItem(fn: (record: _IterableChangeRecord<V>) => void): void;
     // (undocumented)
-    forEachIdentityChange(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachIdentityChange(fn: (record: _IterableChangeRecord<V>) => void): void;
     // (undocumented)
-    forEachItem(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachItem(fn: (record: _IterableChangeRecord<V>) => void): void;
     // (undocumented)
-    forEachMovedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachMovedItem(fn: (record: _IterableChangeRecord<V>) => void): void;
     // (undocumented)
-    forEachOperation(fn: (item: IterableChangeRecord<V>, previousIndex: number | null, currentIndex: number | null) => void): void;
+    forEachOperation(fn: (record: IterableChangeRecord<V>, previousIndex: number | null, currentIndex: number | null) => void): void;
     // (undocumented)
-    forEachPreviousItem(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachPreviousItem(fn: (record: _IterableChangeRecord<V>) => void): void;
     // (undocumented)
-    forEachRemovedItem(fn: (record: IterableChangeRecord_<V>) => void): void;
+    forEachRemovedItem(fn: (record: _IterableChangeRecord<V>) => void): void;
     // (undocumented)
-    get isDirty(): boolean;
-    // (undocumented)
-    readonly length: number;
+    get length(): number;
     // (undocumented)
     onDestroy(): void;
 }

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4343,
-      "main": 454794,
+      "main": 453107,
       "polyfills": 33980,
       "styles": 71714,
       "light-theme": 78213,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -33,7 +33,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2835,
-      "main": 237828,
+      "main": 236272,
       "polyfills": 33842,
       "src_app_lazy_lazy_module_ts": 780
     }
@@ -41,7 +41,7 @@
   "forms": {
     "uncompressed": {
       "runtime": 1063,
-      "main": 159280,
+      "main": 157487,
       "polyfills": 33804
     }
   },

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -31,122 +31,161 @@ const trackByIdentity = (index: number, item: any) => item;
  * @publicApi
  */
 export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChanges<V> {
-  public readonly length: number = 0;
-  // TODO(issue/24571): remove '!'.
-  public readonly collection!: V[]|Iterable<V>|null;
-  // Keeps track of the used records at any point in time (during & across `_check()` calls)
-  private _linkedRecords: _DuplicateMap<V>|null = null;
-  // Keeps track of the removed records at any point in time during `_check()` calls.
-  private _unlinkedRecords: _DuplicateMap<V>|null = null;
-  private _previousItHead: IterableChangeRecord_<V>|null = null;
-  private _itHead: IterableChangeRecord_<V>|null = null;
-  private _itTail: IterableChangeRecord_<V>|null = null;
-  private _additionsHead: IterableChangeRecord_<V>|null = null;
-  private _additionsTail: IterableChangeRecord_<V>|null = null;
-  private _movesHead: IterableChangeRecord_<V>|null = null;
-  private _movesTail: IterableChangeRecord_<V>|null = null;
-  private _removalsHead: IterableChangeRecord_<V>|null = null;
-  private _removalsTail: IterableChangeRecord_<V>|null = null;
-  // Keeps track of records where custom track by is the same, but item identity has changed
-  private _identityChangesHead: IterableChangeRecord_<V>|null = null;
-  private _identityChangesTail: IterableChangeRecord_<V>|null = null;
+  private _length = 0;
+  get length() {
+    return this._length;
+  }
+  private _collection: V[]|Iterable<V>|null = null;
+  get collection() {
+    return this._collection;
+  }
+  /** The previous list of change records */
+  private _previousItems = new _LinkedList<_IterableChangeRecord<V>>();
+  /** The current list of change records */
+  private _currentItems = new _LinkedList<_IterableChangeRecord<V>>();
+  /** The list of records added to the collection, sorted by current index, ascending */
+  private _addedItems = new _LinkedList<_IterableChangeRecord<V>>();
+  /** The list of records removed from the collection, sorted by previous index, ascending */
+  private _removedItems = new _LinkedList<_IterableChangeRecord<V>>();
+  /** The list of records moved within the collection, sorted by current index, ascending */
+  private _movedItems = new _LinkedList<_IterableChangeRecord<V>>();
+  /**
+   * The list of records with identity changes.
+   * Unmoved items appear first, then moved items, both are sorted by current index, ascending
+   */
+  private _identityChanges = new _LinkedList<_IterableChangeRecord<V>>();
+  /** Operations performed at each index, if any */
+  private _operations: {[key: number]: _Operations|undefined} = {};
+  /** Generates an identity for each item */
   private _trackByFn: TrackByFunction<V>;
 
   constructor(trackByFn?: TrackByFunction<V>) {
     this._trackByFn = trackByFn || trackByIdentity;
   }
 
-  forEachItem(fn: (record: IterableChangeRecord_<V>) => void) {
-    let record: IterableChangeRecord_<V>|null;
-    for (record = this._itHead; record !== null; record = record._next) {
-      fn(record);
+  forEachItem(fn: (record: _IterableChangeRecord<V>) => void) {
+    let node: _Node<_IterableChangeRecord<V>>|null;
+    for (node = this._currentItems.head; node !== null; node = node.next) {
+      fn(node.value);
     }
   }
 
   forEachOperation(
-      fn: (item: IterableChangeRecord<V>, previousIndex: number|null, currentIndex: number|null) =>
-          void) {
-    let nextIt = this._itHead;
-    let nextRemove = this._removalsHead;
-    let addRemoveOffset = 0;
-    let moveOffsets: number[]|null = null;
-    while (nextIt || nextRemove) {
-      // Figure out which is the next record to process
-      // Order: remove, add, move
-      const record: IterableChangeRecord<V> = !nextRemove ||
-              nextIt &&
-                  nextIt.currentIndex! <
-                      getPreviousIndex(nextRemove, addRemoveOffset, moveOffsets) ?
-          nextIt! :
-          nextRemove;
-      const adjPreviousIndex = getPreviousIndex(record, addRemoveOffset, moveOffsets);
-      const currentIndex = record.currentIndex;
+      fn:
+          (record: IterableChangeRecord<V>, previousIndex: number|null,
+           currentIndex: number|null) => void) {
+    /**
+     * Used to track how far items have shifted within the original iterable as
+     * a result of previous operations. The offset applies to indices >= the current index.
+     */
+    let totalOffset: number = 0;
+    let currItemNode: _Node<_IterableChangeRecord<V>>|null = this._currentItems.head;
+    let prevItemNode: _Node<_IterableChangeRecord<V>>|null = this._previousItems.head;
+    let index: number = 0;
 
-      // consume the item, and adjust the addRemoveOffset and update moveDistance if necessary
-      if (record === nextRemove) {
-        addRemoveOffset--;
-        nextRemove = nextRemove._nextRemoved;
-      } else {
-        nextIt = nextIt!._next;
-        if (record.previousIndex == null) {
-          addRemoveOffset++;
-        } else {
-          // INVARIANT:  currentIndex < previousIndex
-          if (!moveOffsets) moveOffsets = [];
-          const localMovePreviousIndex = adjPreviousIndex - addRemoveOffset;
-          const localCurrentIndex = currentIndex! - addRemoveOffset;
-          if (localMovePreviousIndex != localCurrentIndex) {
-            for (let i = 0; i < localMovePreviousIndex; i++) {
-              const offset = i < moveOffsets.length ? moveOffsets[i] : (moveOffsets[i] = 0);
-              const index = offset + i;
-              if (localCurrentIndex <= index && index < localMovePreviousIndex) {
-                moveOffsets[i] = offset + 1;
-              }
-            }
-            const previousIndex = record.previousIndex;
-            moveOffsets[previousIndex] = localCurrentIndex - localMovePreviousIndex;
+    while (currItemNode !== null || prevItemNode !== null) {
+      const currOps = this._operations[index];
+      if (currOps !== undefined) {
+        // Adjust for previous moves to / from this index
+        if (currOps.moveTo !== null && currOps.moveTo < index) totalOffset--;
+        if (currOps.moveFrom !== null && currOps.moveFrom < index) totalOffset++;
+
+        // Check if a new item needs to be added to this index
+        if (currOps.add) {
+          // Guaranteed to be a current item here since there is an add
+          fn(currItemNode!.value, null, index);
+          totalOffset++;
+        }
+        // Check if a previous item needs to be removed from this index
+        if (currOps.remove) {
+          // Guaranteed to be a previous item here since there is a removal
+          fn(prevItemNode!.value, index + totalOffset, null);
+          totalOffset--;
+        }
+
+        // Only perform moves such that items come from / go to indices greater than current
+        // This ensures items to the left of the current index have no offset
+
+        // Check if a previous item needs to be moved to this index
+        if (currOps.moveFrom !== null && currOps.moveFrom > index) {
+          // Adjust moveFrom to where the item actually is
+          // Only need to adjust for operations that have already happened, up to that index
+          let adjustedMoveFrom: number = currOps.moveFrom + totalOffset;
+          for (let i = index + 1; i <= currOps.moveFrom; i++) {
+            const nextOps = this._operations[i];
+            if (nextOps === undefined) continue;
+            if (nextOps.moveTo !== null && nextOps.moveTo < index) adjustedMoveFrom--;
+            if (nextOps.moveFrom !== null && nextOps.moveFrom < index) adjustedMoveFrom++;
           }
+          // No-op if the item is already at the correct index
+          if (adjustedMoveFrom !== index) {
+            // Guaranteed to be a current item here since there is a move to here
+            fn(currItemNode!.value, adjustedMoveFrom, index);
+          }
+          totalOffset++;
+        }
+
+        // Check if a previous item needs to be moved from this index
+        if (currOps.moveTo !== null && currOps.moveTo > index) {
+          const adjustedMoveFromIndex: number = index + totalOffset;
+          // Adjust the moveToIndex such that the item will end up at the correct index
+          // Only need to adjust for operations that haven't happened yet, between here and there
+          let adjustedMoveToIndex: number = currOps.moveTo;
+          for (let i = index + 1; i < currOps.moveTo; i++) {
+            const nextOps = this._operations[i];
+            if (nextOps === undefined) continue;
+            if (nextOps.add) adjustedMoveToIndex--;
+            if (nextOps.remove) adjustedMoveToIndex++;
+            if (nextOps.moveTo !== null && nextOps.moveTo > index) adjustedMoveToIndex++;
+            if (nextOps.moveFrom !== null && nextOps.moveFrom > index) adjustedMoveToIndex--;
+          }
+          // No-op if the item is already at the correct index
+          if (adjustedMoveFromIndex !== adjustedMoveToIndex) {
+            // Guaranteed to be a previous item here since there is a move from here
+            fn(prevItemNode!.value, adjustedMoveFromIndex, adjustedMoveToIndex);
+          }
+          totalOffset--;
         }
       }
 
-      if (adjPreviousIndex !== currentIndex) {
-        fn(record, adjPreviousIndex, currentIndex);
-      }
+      index++;
+      if (currItemNode !== null) currItemNode = currItemNode.next;
+      if (prevItemNode !== null) prevItemNode = prevItemNode.next;
     }
   }
 
-  forEachPreviousItem(fn: (record: IterableChangeRecord_<V>) => void) {
-    let record: IterableChangeRecord_<V>|null;
-    for (record = this._previousItHead; record !== null; record = record._nextPrevious) {
-      fn(record);
+  forEachPreviousItem(fn: (record: _IterableChangeRecord<V>) => void) {
+    let node: _Node<_IterableChangeRecord<V>>|null;
+    for (node = this._previousItems.head; node !== null; node = node.next) {
+      fn(node.value);
     }
   }
 
-  forEachAddedItem(fn: (record: IterableChangeRecord_<V>) => void) {
-    let record: IterableChangeRecord_<V>|null;
-    for (record = this._additionsHead; record !== null; record = record._nextAdded) {
-      fn(record);
+  forEachAddedItem(fn: (record: _IterableChangeRecord<V>) => void) {
+    let node: _Node<_IterableChangeRecord<V>>|null;
+    for (node = this._addedItems.head; node !== null; node = node.next) {
+      fn(node.value);
     }
   }
 
-  forEachMovedItem(fn: (record: IterableChangeRecord_<V>) => void) {
-    let record: IterableChangeRecord_<V>|null;
-    for (record = this._movesHead; record !== null; record = record._nextMoved) {
-      fn(record);
+  forEachMovedItem(fn: (record: _IterableChangeRecord<V>) => void) {
+    let node: _Node<_IterableChangeRecord<V>>|null;
+    for (node = this._movedItems.head; node !== null; node = node.next) {
+      fn(node.value);
     }
   }
 
-  forEachRemovedItem(fn: (record: IterableChangeRecord_<V>) => void) {
-    let record: IterableChangeRecord_<V>|null;
-    for (record = this._removalsHead; record !== null; record = record._nextRemoved) {
-      fn(record);
+  forEachRemovedItem(fn: (record: _IterableChangeRecord<V>) => void) {
+    let node: _Node<_IterableChangeRecord<V>>|null;
+    for (node = this._removedItems.head; node !== null; node = node.next) {
+      fn(node.value);
     }
   }
 
-  forEachIdentityChange(fn: (record: IterableChangeRecord_<V>) => void) {
-    let record: IterableChangeRecord_<V>|null;
-    for (record = this._identityChangesHead; record !== null; record = record._nextIdentityChange) {
-      fn(record);
+  forEachIdentityChange(fn: (record: _IterableChangeRecord<V>) => void) {
+    let node: _Node<_IterableChangeRecord<V>>|null;
+    for (node = this._identityChanges.head; node !== null; node = node.next) {
+      fn(node.value);
     }
   }
 
@@ -171,559 +210,268 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
   check(collection: NgIterable<V>): boolean {
     this._reset();
 
-    let record: IterableChangeRecord_<V>|null = this._itHead;
-    let mayBeDirty: boolean = false;
-    let index: number;
-    let item: V;
-    let itemTrackBy: any;
-    if (Array.isArray(collection)) {
-      (this as {length: number}).length = collection.length;
+    /** Stores changed nodes, could contain additions or moves */
+    const changedNodes = new _Queue<_Node<_IterableChangeRecord<V>>>();
+    /** Stores old records from changed nodes, mapped by trackById, could be deleted or moved */
+    const oldRecords = new _QueueMap<any, _IterableChangeRecord<V>>();
+    /**
+     * Keys that were enqueued to oldRecords, mapped by previous index
+     * This allows both iterating by index and deleting keys by index, which is needed later
+     */
+    const oldRecordKeys = new Map<number, any>();
 
-      for (let index = 0; index < this.length; index++) {
-        item = collection[index];
-        itemTrackBy = this._trackByFn(index, item);
-        if (record === null || !Object.is(record.trackById, itemTrackBy)) {
-          record = this._mismatch(record, item, itemTrackBy, index);
-          mayBeDirty = true;
-        } else {
-          if (mayBeDirty) {
-            // TODO(misko): can we limit this to duplicates only?
-            record = this._verifyReinsertion(record, item, itemTrackBy, index);
-          }
-          if (!Object.is(record.item, item)) this._addIdentityChange(record, item);
+    let node: _Node<_IterableChangeRecord<V>>|null = this._currentItems.head;
+    let index = 0;
+
+    iterateListLike(collection, (item: V) => {
+      if (node !== null && index !== 0) node = node.next;
+      const itemTrackBy: any = this._trackByFn(index, item);
+      // Add items to the tail if we've reached the end of current items
+      if (node === null) {
+        const newRecord = new _IterableChangeRecord(item, itemTrackBy, index);
+        node = this._currentItems.addLast(newRecord);
+        changedNodes.enqueue(node);
+      }
+      // Mismatch between new collection and current items
+      else if (!Object.is(node.value.trackById, itemTrackBy)) {
+        // Mark that this record is no longer here, not sure if it's a move or remove yet
+        node.value.previousIndex = node.value.currentIndex;
+        oldRecords.enqueue(node.value.trackById, node.value);
+        oldRecordKeys.set(index, node.value.trackById);
+        // Insert a new record for now, not sure if it's an add or move yet
+        const newRecord = new _IterableChangeRecord<V>(item, itemTrackBy, index);
+        node.value = newRecord;
+        changedNodes.enqueue(node);
+      }
+      // trackById matches, but object identity has changed
+      else if (!Object.is(node.value.item, item)) {
+        node.value.item = item;
+        this._identityChanges.addLast(node.value);
+      }
+      index++;
+    });
+
+    // Process any remaining nodes if the current list is longer than the new collection
+    if (node !== null && index < this._length) {
+      let oldNode: _Node<_IterableChangeRecord<V>>|null;
+      // If new collection is empty, remove everything including the head
+      if (index === 0) {
+        this._currentItems.clear();
+        oldNode = node;
+      }
+      // Otherwise everything after current node is removed
+      else {
+        this._currentItems.tail = node;
+        oldNode = node.next;
+        node.next = null;
+      }
+      while (oldNode !== null) {
+        // Mark that this record is no longer here, not sure if it's a move or remove yet
+        oldNode.value.previousIndex = oldNode.value.currentIndex;
+        oldRecords.enqueue(oldNode.value.trackById, oldNode.value);
+        oldRecordKeys.set(index++, oldNode.value.trackById);
+        oldNode = oldNode.next;
+      }
+    }
+
+    this._length = index;
+    this._collection = collection;
+    this._findOperations(changedNodes, oldRecords, oldRecordKeys);
+    return this._isDirty();
+  }
+
+  /**
+   * Finds add, remove, and move operations, populating the appropriate instance properties.
+   * If an item has been both added and removed, it is considered to be moved.
+   *
+   * @param changedNodes Nodes that contain records they did not previously,
+   *     these could be additions or moves. Node records must have non-null current index.
+   * @param oldRecords Items that no longer exist at their previous node, mapped to their
+   *     trackByIds, these could be removals or moves. Records must have non-null previous index.
+   * @param oldRecordKeys The trackByIds that were added to removalsMap, mapped by index that the
+   *     item was removed from. Keys must have been added in order of previous index, ascending.
+   */
+  private _findOperations(
+      changedNodes: _Queue<_Node<_IterableChangeRecord<V>>>,
+      oldRecords: _QueueMap<any, _IterableChangeRecord<V>>, oldRecordKeys: Map<number, any>): void {
+    // Dequeue changedNodes and look for matching old records
+    let changedNode: _Node<_IterableChangeRecord<V>>|null = changedNodes.dequeue();
+    while (changedNode !== null) {
+      const trackById = changedNode.value.trackById;
+      const currentIndex = changedNode.value.currentIndex!;
+      const oldRecord: _IterableChangeRecord<V>|null = oldRecords.dequeue(trackById);
+      // Found a matching old record - consider it to have been moved here
+      if (oldRecord !== null) {
+        const previousIndex: number = oldRecord.previousIndex!;
+        oldRecordKeys.delete(previousIndex);
+        // Check for identity change
+        if (!Object.is(changedNode.value.item, oldRecord.item)) {
+          oldRecord.item = changedNode.value.item;
+          this._identityChanges.addLast(oldRecord);
         }
-
-        record = record._next;
+        oldRecord.currentIndex = currentIndex;
+        changedNode.value = oldRecord;
+        this._movedItems.addLast(oldRecord);
+        this._updateOperations(currentIndex, {moveFrom: previousIndex});
+        this._updateOperations(previousIndex, {moveTo: currentIndex});
       }
-    } else {
-      index = 0;
-      iterateListLike(collection, (item: V) => {
-        itemTrackBy = this._trackByFn(index, item);
-        if (record === null || !Object.is(record.trackById, itemTrackBy)) {
-          record = this._mismatch(record, item, itemTrackBy, index);
-          mayBeDirty = true;
-        } else {
-          if (mayBeDirty) {
-            // TODO(misko): can we limit this to duplicates only?
-            record = this._verifyReinsertion(record, item, itemTrackBy, index);
-          }
-          if (!Object.is(record.item, item)) this._addIdentityChange(record, item);
-        }
-        record = record._next;
-        index++;
-      });
-      (this as {length: number}).length = index;
+      // No match, consider this a new item
+      else {
+        this._addedItems.addLast(changedNode.value);
+        this._updateOperations(currentIndex, {add: true});
+      }
+      changedNode = changedNodes.dequeue();
     }
 
-    this._truncate(record);
-    (this as {collection: V[] | Iterable<V>}).collection = collection;
-    return this.isDirty;
+    // Dequeue leftovers in oldRecords - these are all removed items
+    // oldRecordKeys are in order of index, so iterating through them yields a sorted list
+    const remIndexIterator: IterableIterator<number> = oldRecordKeys.keys();
+    let nextRemIndex: IteratorResult<number, any> = remIndexIterator.next();
+    while (nextRemIndex.done !== true) {
+      const remKey: any = oldRecordKeys.get(nextRemIndex.value);
+      const removed: _IterableChangeRecord<V> = oldRecords.dequeue(remKey)!;
+      removed.currentIndex = null;
+      this._removedItems.addLast(removed);
+      this._updateOperations(removed.previousIndex!, {remove: true});
+      nextRemIndex = remIndexIterator.next();
+    }
   }
 
-  /* CollectionChanges is considered dirty if it has any additions, moves, removals, or identity
-   * changes.
-   */
-  get isDirty(): boolean {
-    return this._additionsHead !== null || this._movesHead !== null ||
-        this._removalsHead !== null || this._identityChangesHead !== null;
+  /** Initializes operations if necessary and updates the object's properties */
+  private _updateOperations(index: number, newOps: {
+    add?: boolean,
+    remove?: boolean,
+    moveTo?: number,
+    moveFrom?: number,
+  }) {
+    if (this._operations[index] === undefined) this._operations[index] = new _Operations();
+    const ops = this._operations[index]!;
+    if (newOps.add !== undefined) ops.add = newOps.add;
+    if (newOps.remove !== undefined) ops.remove = newOps.remove;
+    if (newOps.moveFrom !== undefined) ops.moveFrom = newOps.moveFrom;
+    if (newOps.moveTo !== undefined) ops.moveTo = newOps.moveTo;
+  }
+
+  /** If there are any additions, moves, removals, or identity changes. */
+  private _isDirty(): boolean {
+    return (
+        !this._addedItems.isEmpty() || !this._movedItems.isEmpty() ||
+        !this._removedItems.isEmpty() || !this._identityChanges.isEmpty());
   }
 
   /**
-   * Reset the state of the change objects to show no changes. This means set previousKey to
-   * currentKey, and clear all of the queues (additions, moves, removals).
-   * Set the previousIndexes of moved and added items to their currentIndexes
-   * Reset the list of additions, moves and removals
-   *
-   * @internal
+   * Clear all change tracking instance properties, set previous indices to current indices,
+   * populate previous items list
    */
-  _reset() {
-    if (this.isDirty) {
-      let record: IterableChangeRecord_<V>|null;
+  private _reset(): void {
+    if (this._isDirty()) {
+      this._addedItems.clear();
+      this._removedItems.clear();
+      this._movedItems.clear();
+      this._identityChanges.clear();
+      this._previousItems.clear();
+      this._operations = {};
 
-      for (record = this._previousItHead = this._itHead; record !== null; record = record._next) {
-        record._nextPrevious = record._next;
-      }
-
-      for (record = this._additionsHead; record !== null; record = record._nextAdded) {
-        record.previousIndex = record.currentIndex;
-      }
-      this._additionsHead = this._additionsTail = null;
-
-      for (record = this._movesHead; record !== null; record = record._nextMoved) {
-        record.previousIndex = record.currentIndex;
-      }
-      this._movesHead = this._movesTail = null;
-      this._removalsHead = this._removalsTail = null;
-      this._identityChangesHead = this._identityChangesTail = null;
-
-      // TODO(vicb): when assert gets supported
-      // assert(!this.isDirty);
-    }
-  }
-
-  /**
-   * This is the core function which handles differences between collections.
-   *
-   * - `record` is the record which we saw at this position last time. If null then it is a new
-   *   item.
-   * - `item` is the current item in the collection
-   * - `index` is the position of the item in the collection
-   *
-   * @internal
-   */
-  _mismatch(record: IterableChangeRecord_<V>|null, item: V, itemTrackBy: any, index: number):
-      IterableChangeRecord_<V> {
-    // The previous record after which we will append the current one.
-    let previousRecord: IterableChangeRecord_<V>|null;
-
-    if (record === null) {
-      previousRecord = this._itTail;
-    } else {
-      previousRecord = record._prev;
-      // Remove the record from the collection since we know it does not match the item.
-      this._remove(record);
-    }
-
-    // See if we have evicted the item, which used to be at some anterior position of _itHead list.
-    record = this._unlinkedRecords === null ? null : this._unlinkedRecords.get(itemTrackBy, null);
-    if (record !== null) {
-      // It is an item which we have evicted earlier: reinsert it back into the list.
-      // But first we need to check if identity changed, so we can update in view if necessary.
-      if (!Object.is(record.item, item)) this._addIdentityChange(record, item);
-
-      this._reinsertAfter(record, previousRecord, index);
-    } else {
-      // Attempt to see if the item is at some posterior position of _itHead list.
-      record = this._linkedRecords === null ? null : this._linkedRecords.get(itemTrackBy, index);
-      if (record !== null) {
-        // We have the item in _itHead at/after `index` position. We need to move it forward in the
-        // collection.
-        // But first we need to check if identity changed, so we can update in view if necessary.
-        if (!Object.is(record.item, item)) this._addIdentityChange(record, item);
-
-        this._moveAfter(record, previousRecord, index);
-      } else {
-        // It is a new item: add it.
-        record =
-            this._addAfter(new IterableChangeRecord_<V>(item, itemTrackBy), previousRecord, index);
+      for (let node = this._currentItems.head; node != null; node = node.next) {
+        node.value.previousIndex = node.value.currentIndex;
+        this._previousItems.addLast(node.value);
       }
     }
-    return record;
-  }
-
-  /**
-   * This check is only needed if an array contains duplicates. (Short circuit of nothing dirty)
-   *
-   * Use case: `[a, a]` => `[b, a, a]`
-   *
-   * If we did not have this check then the insertion of `b` would:
-   *   1) evict first `a`
-   *   2) insert `b` at `0` index.
-   *   3) leave `a` at index `1` as is. <-- this is wrong!
-   *   3) reinsert `a` at index 2. <-- this is wrong!
-   *
-   * The correct behavior is:
-   *   1) evict first `a`
-   *   2) insert `b` at `0` index.
-   *   3) reinsert `a` at index 1.
-   *   3) move `a` at from `1` to `2`.
-   *
-   *
-   * Double check that we have not evicted a duplicate item. We need to check if the item type may
-   * have already been removed:
-   * The insertion of b will evict the first 'a'. If we don't reinsert it now it will be reinserted
-   * at the end. Which will show up as the two 'a's switching position. This is incorrect, since a
-   * better way to think of it is as insert of 'b' rather then switch 'a' with 'b' and then add 'a'
-   * at the end.
-   *
-   * @internal
-   */
-  _verifyReinsertion(record: IterableChangeRecord_<V>, item: V, itemTrackBy: any, index: number):
-      IterableChangeRecord_<V> {
-    let reinsertRecord: IterableChangeRecord_<V>|null =
-        this._unlinkedRecords === null ? null : this._unlinkedRecords.get(itemTrackBy, null);
-    if (reinsertRecord !== null) {
-      record = this._reinsertAfter(reinsertRecord, record._prev!, index);
-    } else if (record.currentIndex != index) {
-      record.currentIndex = index;
-      this._addToMoves(record, index);
-    }
-    return record;
-  }
-
-  /**
-   * Get rid of any excess {@link IterableChangeRecord_}s from the previous collection
-   *
-   * - `record` The first excess {@link IterableChangeRecord_}.
-   *
-   * @internal
-   */
-  _truncate(record: IterableChangeRecord_<V>|null) {
-    // Anything after that needs to be removed;
-    while (record !== null) {
-      const nextRecord: IterableChangeRecord_<V>|null = record._next;
-      this._addToRemovals(this._unlink(record));
-      record = nextRecord;
-    }
-    if (this._unlinkedRecords !== null) {
-      this._unlinkedRecords.clear();
-    }
-
-    if (this._additionsTail !== null) {
-      this._additionsTail._nextAdded = null;
-    }
-    if (this._movesTail !== null) {
-      this._movesTail._nextMoved = null;
-    }
-    if (this._itTail !== null) {
-      this._itTail._next = null;
-    }
-    if (this._removalsTail !== null) {
-      this._removalsTail._nextRemoved = null;
-    }
-    if (this._identityChangesTail !== null) {
-      this._identityChangesTail._nextIdentityChange = null;
-    }
-  }
-
-  /** @internal */
-  _reinsertAfter(
-      record: IterableChangeRecord_<V>, prevRecord: IterableChangeRecord_<V>|null,
-      index: number): IterableChangeRecord_<V> {
-    if (this._unlinkedRecords !== null) {
-      this._unlinkedRecords.remove(record);
-    }
-    const prev = record._prevRemoved;
-    const next = record._nextRemoved;
-
-    if (prev === null) {
-      this._removalsHead = next;
-    } else {
-      prev._nextRemoved = next;
-    }
-    if (next === null) {
-      this._removalsTail = prev;
-    } else {
-      next._prevRemoved = prev;
-    }
-
-    this._insertAfter(record, prevRecord, index);
-    this._addToMoves(record, index);
-    return record;
-  }
-
-  /** @internal */
-  _moveAfter(
-      record: IterableChangeRecord_<V>, prevRecord: IterableChangeRecord_<V>|null,
-      index: number): IterableChangeRecord_<V> {
-    this._unlink(record);
-    this._insertAfter(record, prevRecord, index);
-    this._addToMoves(record, index);
-    return record;
-  }
-
-  /** @internal */
-  _addAfter(
-      record: IterableChangeRecord_<V>, prevRecord: IterableChangeRecord_<V>|null,
-      index: number): IterableChangeRecord_<V> {
-    this._insertAfter(record, prevRecord, index);
-
-    if (this._additionsTail === null) {
-      // TODO(vicb):
-      // assert(this._additionsHead === null);
-      this._additionsTail = this._additionsHead = record;
-    } else {
-      // TODO(vicb):
-      // assert(_additionsTail._nextAdded === null);
-      // assert(record._nextAdded === null);
-      this._additionsTail = this._additionsTail._nextAdded = record;
-    }
-    return record;
-  }
-
-  /** @internal */
-  _insertAfter(
-      record: IterableChangeRecord_<V>, prevRecord: IterableChangeRecord_<V>|null,
-      index: number): IterableChangeRecord_<V> {
-    // TODO(vicb):
-    // assert(record != prevRecord);
-    // assert(record._next === null);
-    // assert(record._prev === null);
-
-    const next: IterableChangeRecord_<V>|null =
-        prevRecord === null ? this._itHead : prevRecord._next;
-    // TODO(vicb):
-    // assert(next != record);
-    // assert(prevRecord != record);
-    record._next = next;
-    record._prev = prevRecord;
-    if (next === null) {
-      this._itTail = record;
-    } else {
-      next._prev = record;
-    }
-    if (prevRecord === null) {
-      this._itHead = record;
-    } else {
-      prevRecord._next = record;
-    }
-
-    if (this._linkedRecords === null) {
-      this._linkedRecords = new _DuplicateMap<V>();
-    }
-    this._linkedRecords.put(record);
-
-    record.currentIndex = index;
-    return record;
-  }
-
-  /** @internal */
-  _remove(record: IterableChangeRecord_<V>): IterableChangeRecord_<V> {
-    return this._addToRemovals(this._unlink(record));
-  }
-
-  /** @internal */
-  _unlink(record: IterableChangeRecord_<V>): IterableChangeRecord_<V> {
-    if (this._linkedRecords !== null) {
-      this._linkedRecords.remove(record);
-    }
-
-    const prev = record._prev;
-    const next = record._next;
-
-    // TODO(vicb):
-    // assert((record._prev = null) === null);
-    // assert((record._next = null) === null);
-
-    if (prev === null) {
-      this._itHead = next;
-    } else {
-      prev._next = next;
-    }
-    if (next === null) {
-      this._itTail = prev;
-    } else {
-      next._prev = prev;
-    }
-
-    return record;
-  }
-
-  /** @internal */
-  _addToMoves(record: IterableChangeRecord_<V>, toIndex: number): IterableChangeRecord_<V> {
-    // TODO(vicb):
-    // assert(record._nextMoved === null);
-
-    if (record.previousIndex === toIndex) {
-      return record;
-    }
-
-    if (this._movesTail === null) {
-      // TODO(vicb):
-      // assert(_movesHead === null);
-      this._movesTail = this._movesHead = record;
-    } else {
-      // TODO(vicb):
-      // assert(_movesTail._nextMoved === null);
-      this._movesTail = this._movesTail._nextMoved = record;
-    }
-
-    return record;
-  }
-
-  private _addToRemovals(record: IterableChangeRecord_<V>): IterableChangeRecord_<V> {
-    if (this._unlinkedRecords === null) {
-      this._unlinkedRecords = new _DuplicateMap<V>();
-    }
-    this._unlinkedRecords.put(record);
-    record.currentIndex = null;
-    record._nextRemoved = null;
-
-    if (this._removalsTail === null) {
-      // TODO(vicb):
-      // assert(_removalsHead === null);
-      this._removalsTail = this._removalsHead = record;
-      record._prevRemoved = null;
-    } else {
-      // TODO(vicb):
-      // assert(_removalsTail._nextRemoved === null);
-      // assert(record._nextRemoved === null);
-      record._prevRemoved = this._removalsTail;
-      this._removalsTail = this._removalsTail._nextRemoved = record;
-    }
-    return record;
-  }
-
-  /** @internal */
-  _addIdentityChange(record: IterableChangeRecord_<V>, item: V) {
-    record.item = item;
-    if (this._identityChangesTail === null) {
-      this._identityChangesTail = this._identityChangesHead = record;
-    } else {
-      this._identityChangesTail = this._identityChangesTail._nextIdentityChange = record;
-    }
-    return record;
   }
 }
 
-export class IterableChangeRecord_<V> implements IterableChangeRecord<V> {
-  currentIndex: number|null = null;
+/** Record of of an item's identity and indices */
+class _IterableChangeRecord<V> implements IterableChangeRecord<V> {
   previousIndex: number|null = null;
-
-  /** @internal */
-  _nextPrevious: IterableChangeRecord_<V>|null = null;
-  /** @internal */
-  _prev: IterableChangeRecord_<V>|null = null;
-  /** @internal */
-  _next: IterableChangeRecord_<V>|null = null;
-  /** @internal */
-  _prevDup: IterableChangeRecord_<V>|null = null;
-  /** @internal */
-  _nextDup: IterableChangeRecord_<V>|null = null;
-  /** @internal */
-  _prevRemoved: IterableChangeRecord_<V>|null = null;
-  /** @internal */
-  _nextRemoved: IterableChangeRecord_<V>|null = null;
-  /** @internal */
-  _nextAdded: IterableChangeRecord_<V>|null = null;
-  /** @internal */
-  _nextMoved: IterableChangeRecord_<V>|null = null;
-  /** @internal */
-  _nextIdentityChange: IterableChangeRecord_<V>|null = null;
-
-
-  constructor(public item: V, public trackById: any) {}
+  constructor(public item: V, public trackById: any, public currentIndex: number|null) {}
 }
 
-// A linked list of IterableChangeRecords with the same IterableChangeRecord_.item
-class _DuplicateItemRecordList<V> {
-  /** @internal */
-  _head: IterableChangeRecord_<V>|null = null;
-  /** @internal */
-  _tail: IterableChangeRecord_<V>|null = null;
+/** Represents operations that occur at an index */
+class _Operations {
+  add: boolean = false;
+  remove: boolean = false;
+  moveTo: number|null = null;
+  moveFrom: number|null = null;
+}
 
-  /**
-   * Append the record to the list of duplicates.
-   *
-   * Note: by design all records in the list of duplicates hold the same value in record.item.
-   */
-  add(record: IterableChangeRecord_<V>): void {
-    if (this._head === null) {
-      this._head = this._tail = record;
-      record._nextDup = null;
-      record._prevDup = null;
+
+/** Singly linked node */
+class _Node<T> {
+  next: _Node<T>|null = null;
+  constructor(public value: T) {}
+}
+
+/** Singly linked list */
+class _LinkedList<T> {
+  head: _Node<T>|null = null;
+  tail: _Node<T>|null = null;
+
+  addLast(value: T): _Node<T> {
+    const node = new _Node(value);
+    if (this.tail === null) {
+      this.head = this.tail = node;
     } else {
-      // TODO(vicb):
-      // assert(record.item ==  _head.item ||
-      //       record.item is num && record.item.isNaN && _head.item is num && _head.item.isNaN);
-      this._tail!._nextDup = record;
-      record._prevDup = this._tail;
-      record._nextDup = null;
-      this._tail = record;
+      this.tail.next = node;
+      this.tail = node;
+    }
+    return node;
+  }
+
+  clear(): void {
+    this.head = this.tail = null;
+  }
+
+  isEmpty(): boolean {
+    return this.head === null;
+  }
+}
+
+/** First-in first-out queue */
+class _Queue<T> {
+  private _head: _Node<T>|null = null;
+  private _tail: _Node<T>|null = null;
+
+  enqueue(item: T): void {
+    if (this._tail === null) {
+      this._head = this._tail = new _Node<T>(item);
+    } else {
+      const node = new _Node<T>(item);
+      this._tail.next = node;
+      this._tail = node;
     }
   }
 
-  // Returns a IterableChangeRecord_ having IterableChangeRecord_.trackById == trackById and
-  // IterableChangeRecord_.currentIndex >= atOrAfterIndex
-  get(trackById: any, atOrAfterIndex: number|null): IterableChangeRecord_<V>|null {
-    let record: IterableChangeRecord_<V>|null;
-    for (record = this._head; record !== null; record = record._nextDup) {
-      if ((atOrAfterIndex === null || atOrAfterIndex <= record.currentIndex!) &&
-          Object.is(record.trackById, trackById)) {
-        return record;
-      }
-    }
-    return null;
+  dequeue(): T|null {
+    if (this._head === null) return null;
+    const item: T = this._head.value;
+    this._head = this._head.next;
+    if (this._head === null) this._tail = null;
+    return item;
   }
 
-  /**
-   * Remove one {@link IterableChangeRecord_} from the list of duplicates.
-   *
-   * Returns whether the list of duplicates is empty.
-   */
-  remove(record: IterableChangeRecord_<V>): boolean {
-    // TODO(vicb):
-    // assert(() {
-    //  // verify that the record being removed is in the list.
-    //  for (IterableChangeRecord_ cursor = _head; cursor != null; cursor = cursor._nextDup) {
-    //    if (identical(cursor, record)) return true;
-    //  }
-    //  return false;
-    //});
-
-    const prev: IterableChangeRecord_<V>|null = record._prevDup;
-    const next: IterableChangeRecord_<V>|null = record._nextDup;
-    if (prev === null) {
-      this._head = next;
-    } else {
-      prev._nextDup = next;
-    }
-    if (next === null) {
-      this._tail = prev;
-    } else {
-      next._prevDup = prev;
-    }
+  isEmpty(): boolean {
     return this._head === null;
   }
 }
 
-class _DuplicateMap<V> {
-  map = new Map<any, _DuplicateItemRecordList<V>>();
+/** Stores duplicate values in a Map by adding them to a queue */
+class _QueueMap<K, T> {
+  private _map = new Map<K, _Queue<T>>();
 
-  put(record: IterableChangeRecord_<V>) {
-    const key = record.trackById;
-
-    let duplicates = this.map.get(key);
-    if (!duplicates) {
-      duplicates = new _DuplicateItemRecordList<V>();
-      this.map.set(key, duplicates);
+  enqueue(key: K, item: T): void {
+    let queue: _Queue<T>|undefined = this._map.get(key);
+    if (queue === undefined) {
+      queue = new _Queue<T>();
+      this._map.set(key, queue);
     }
-    duplicates.add(record);
+    queue.enqueue(item);
   }
 
-  /**
-   * Retrieve the `value` using key. Because the IterableChangeRecord_ value may be one which we
-   * have already iterated over, we use the `atOrAfterIndex` to pretend it is not there.
-   *
-   * Use case: `[a, b, c, a, a]` if we are at index `3` which is the second `a` then asking if we
-   * have any more `a`s needs to return the second `a`.
-   */
-  get(trackById: any, atOrAfterIndex: number|null): IterableChangeRecord_<V>|null {
-    const key = trackById;
-    const recordList = this.map.get(key);
-    return recordList ? recordList.get(trackById, atOrAfterIndex) : null;
+  dequeue(key: K): T|null {
+    const queue: _Queue<T>|undefined = this._map.get(key);
+    if (queue === undefined) return null;
+    const item: T|null = queue.dequeue();
+    if (queue.isEmpty()) this._map.delete(key);
+    return item;
   }
-
-  /**
-   * Removes a {@link IterableChangeRecord_} from the list of duplicates.
-   *
-   * The list of duplicates also is removed from the map if it gets empty.
-   */
-  remove(record: IterableChangeRecord_<V>): IterableChangeRecord_<V> {
-    const key = record.trackById;
-    const recordList: _DuplicateItemRecordList<V> = this.map.get(key)!;
-    // Remove the list of duplicates when it gets empty
-    if (recordList.remove(record)) {
-      this.map.delete(key);
-    }
-    return record;
-  }
-
-  get isEmpty(): boolean {
-    return this.map.size === 0;
-  }
-
-  clear() {
-    this.map.clear();
-  }
-}
-
-function getPreviousIndex(item: any, addRemoveOffset: number, moveOffsets: number[]|null): number {
-  const previousIndex = item.previousIndex;
-  if (previousIndex === null) return previousIndex;
-  let moveOffset = 0;
-  if (moveOffsets && previousIndex < moveOffsets.length) {
-    moveOffset = moveOffsets[previousIndex];
-  }
-  return previousIndex + addRemoveOffset + moveOffset;
 }

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -234,12 +234,10 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
       // Mismatch between new collection and current items
       else if (!Object.is(node.value.trackById, itemTrackBy)) {
         // Mark that this record is no longer here, not sure if it's a move or remove yet
-        node.value.previousIndex = node.value.currentIndex;
         oldRecords.enqueue(node.value.trackById, node.value);
         oldRecordKeys.set(index, node.value.trackById);
         // Insert a new record for now, not sure if it's an add or move yet
-        const newRecord = new _IterableChangeRecord<V>(item, itemTrackBy, index);
-        node.value = newRecord;
+        node.value = new _IterableChangeRecord<V>(item, itemTrackBy, index);
         changedNodes.enqueue(node);
       }
       // trackById matches, but object identity has changed
@@ -253,10 +251,10 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
     const newLength = index;
 
     // Process any remaining nodes if the current list is longer than the new collection
-    if (node !== null && index < this._length) {
+    if (node !== null && newLength < this._length) {
       let oldNode: _Node<_IterableChangeRecord<V>>|null;
       // If new collection is empty, remove everything including the head
-      if (index === 0) {
+      if (newLength === 0) {
         this._currentItems.clear();
         oldNode = node;
       }
@@ -268,7 +266,6 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
       }
       while (oldNode !== null) {
         // Mark that this record is no longer here, not sure if it's a move or remove yet
-        oldNode.value.previousIndex = oldNode.value.currentIndex;
         oldRecords.enqueue(oldNode.value.trackById, oldNode.value);
         oldRecordKeys.set(index++, oldNode.value.trackById);
         oldNode = oldNode.next;
@@ -396,7 +393,7 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
   }
 }
 
-/** Record of of an item's identity and indices */
+/** Record of an item's identity and indices */
 class _IterableChangeRecord<V> implements IterableChangeRecord<V> {
   previousIndex: number|null = null;
   constructor(public item: V, public trackById: any, public currentIndex: number|null) {}

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -250,6 +250,8 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
       index++;
     });
 
+    const newLength = index;
+
     // Process any remaining nodes if the current list is longer than the new collection
     if (node !== null && index < this._length) {
       let oldNode: _Node<_IterableChangeRecord<V>>|null;
@@ -273,7 +275,7 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
       }
     }
 
-    this._length = index;
+    this._length = newLength;
     this._collection = collection;
     this._findOperations(changedNodes, oldRecords, oldRecordKeys, identityChanges);
     return this._isDirty();

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -219,9 +219,6 @@
     "name": "Injector"
   },
   {
-    "name": "IterableChangeRecord_"
-  },
-  {
     "name": "IterableDiffers"
   },
   {
@@ -513,10 +510,25 @@
     "name": "_DOM"
   },
   {
-    "name": "_DuplicateMap"
+    "name": "_IterableChangeRecord"
+  },
+  {
+    "name": "_LinkedList"
+  },
+  {
+    "name": "_Node"
   },
   {
     "name": "_NullComponentFactoryResolver"
+  },
+  {
+    "name": "_Operations"
+  },
+  {
+    "name": "_Queue"
+  },
+  {
+    "name": "_QueueMap"
   },
   {
     "name": "__forward_ref__"
@@ -949,9 +961,6 @@
   },
   {
     "name": "getPlatform"
-  },
-  {
-    "name": "getPreviousIndex"
   },
   {
     "name": "getProjectionNodes"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -207,9 +207,6 @@
     "name": "Injector"
   },
   {
-    "name": "IterableChangeRecord_"
-  },
-  {
     "name": "IterableDiffers"
   },
   {
@@ -507,10 +504,25 @@
     "name": "_DOM"
   },
   {
-    "name": "_DuplicateMap"
+    "name": "_IterableChangeRecord"
+  },
+  {
+    "name": "_LinkedList"
+  },
+  {
+    "name": "_Node"
   },
   {
     "name": "_NullComponentFactoryResolver"
+  },
+  {
+    "name": "_Operations"
+  },
+  {
+    "name": "_Queue"
+  },
+  {
+    "name": "_QueueMap"
   },
   {
     "name": "__forward_ref__"
@@ -913,9 +925,6 @@
   },
   {
     "name": "getPlatform"
-  },
-  {
-    "name": "getPreviousIndex"
   },
   {
     "name": "getProjectionNodes"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -27,9 +27,6 @@
     "name": "InjectFlags"
   },
   {
-    "name": "IterableChangeRecord_"
-  },
-  {
     "name": "IterableDiffers"
   },
   {
@@ -153,7 +150,22 @@
     "name": "_CLEAN_PROMISE"
   },
   {
-    "name": "_DuplicateMap"
+    "name": "_IterableChangeRecord"
+  },
+  {
+    "name": "_LinkedList"
+  },
+  {
+    "name": "_Node"
+  },
+  {
+    "name": "_Operations"
+  },
+  {
+    "name": "_Queue"
+  },
+  {
+    "name": "_QueueMap"
   },
   {
     "name": "__forward_ref__"
@@ -445,9 +457,6 @@
   },
   {
     "name": "getPipeDef"
-  },
-  {
-    "name": "getPreviousIndex"
   },
   {
     "name": "getProjectionNodes"

--- a/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
+++ b/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
@@ -261,6 +261,28 @@ type IterableChangeRecord<V> = {
         }));
       });
 
+      it('should update length and collection', () => {
+        const l1 = ['a', 'b', 'c'];
+        differ.check(l1);
+        expect(differ.length).toEqual(3);
+        expect(differ.collection).toEqual(l1);
+
+        const l2 = ['a', 'b', 'c', 'd', 'e', 'f'];
+        differ.check(l2);
+        expect(differ.length).toEqual(6);
+        expect(differ.collection).toEqual(l2);
+
+        const l3 = ['a', 'b'];
+        differ.check(l3);
+        expect(differ.length).toEqual(2);
+        expect(differ.collection).toEqual(l3);
+
+        const l4: any[] = [];
+        differ.check(l4);
+        expect(differ.length).toEqual(0);
+        expect(differ.collection).toEqual(l4);
+      });
+
       describe('with duplicates', () => {
         it('should support replacements', () => {
           const l = ['a', '*', '*', 'd', '-', '-', '-', 'e'];

--- a/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
+++ b/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
@@ -547,7 +547,7 @@ type IterableChangeRecord<V> = {
         differ.check(l);
         expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
           collection: ['{id: b}[1->0]', '{id: a}[0->1]', '{id: c}'],
-          identityChanges: ['{id: c}', '{id: b}[1->0]', '{id: a}[0->1]'],
+          identityChanges: ['{id: b}[1->0]', '{id: a}[0->1]', '{id: c}'],
           previous: ['{id: a}[0->1]', '{id: b}[1->0]', '{id: c}'],
           moves: ['{id: b}[1->0]', '{id: a}[0->1]']
         }));
@@ -591,8 +591,8 @@ type IterableChangeRecord<V> = {
             '{id: a, color: red}'
           ],
           identityChanges: [
-            '{id: c, color: orange}', '{id: a, color: red}', '{id: b, color: yellow}[1->0]',
-            '{id: a, color: blue}[0->1]'
+            '{id: b, color: yellow}[1->0]', '{id: a, color: blue}[0->1]', '{id: c, color: orange}',
+            '{id: a, color: red}'
           ],
           previous: [
             '{id: a, color: blue}[0->1]', '{id: b, color: yellow}[1->0]', '{id: c, color: orange}',

--- a/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
+++ b/packages/core/test/change_detection/differs/default_iterable_differ_spec.ts
@@ -31,7 +31,7 @@ type IterableChangeRecord<V> = {
   item: V,
   currentIndex: number|null,
   previousIndex: number|null,
-}
+};
 
 // TODO(vicb): UnmodifiableListView / frozen object when implemented
 {
@@ -305,7 +305,7 @@ type IterableChangeRecord<V> = {
         it('should support a mix of all operations', () => {
           let l = ['a', 'b', 'c', 'c', 'a', 'a', 'b', 'e', 'd'];
           differ.check(l);
-          l = ['d', 'd', 'f', 'b', 'b', 'a', 'a', 'c']
+          l = ['d', 'd', 'f', 'b', 'b', 'a', 'a', 'c'];
           differ.check(l);
           expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
             collection: [
@@ -324,7 +324,7 @@ type IterableChangeRecord<V> = {
         it('should find removal at correct index when replacing an item', () => {
           let l = ['a', 'a', 'a', 'a', 'a'];
           differ.check(l);
-          l = ['a', 'a', 'b', 'a', 'a']
+          l = ['a', 'a', 'b', 'a', 'a'];
           differ.check(l);
           expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
             collection: ['a', 'a', 'b[null->2]', 'a', 'a'],
@@ -337,7 +337,7 @@ type IterableChangeRecord<V> = {
         it('should not find moves when no items have moved', () => {
           let l = ['a', 'a', 'a', 'b', 'b'];
           differ.check(l);
-          l = ['b', 'a', 'a', 'b', 'b']
+          l = ['b', 'a', 'a', 'b', 'b'];
           differ.check(l);
           expect(iterableDifferToString(differ)).toEqual(iterableChangesAsString({
             collection: ['b[null->0]', 'a', 'a', 'b', 'b'],
@@ -346,7 +346,7 @@ type IterableChangeRecord<V> = {
             removals: ['a[0->null]']
           }));
         });
-      })
+      });
 
       describe('forEachOperation', () => {
         function stringifyItemChange(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
NgForOf on an iterable with duplicate values produces strange behaviour (see issue #45647).

This is due to the current implementation of `DefaultIterableDiffer`, particularly the functions `check()`, and `forEachOperation()`. In the case of replacing an item in an array of duplicate values (such as an array of empty strings, an array of zeroes, or an array of the same object at multiple indices), `forEachOperation()` will not recognize that an item has been replaced. Instead it will insert an item there, then remove an item from the end of the array, rather than the replaced index. In the linked issue example, this causes two duplicate HTML input elements to appear. This also causes an issue with NgClass: #17852.

`check()` does not always produce a minimal set of changes when duplicate items are involved. For example, take an iterable that starts as [0,0,0,1,1] and changes to [1,0,0,1,1]. `check()` should see that a minimal set of changes is one addition and one removal.  The current implementation instead finds one addition, one removal, and four moves. This reveals another issue, that `check()` is finding moves when there are no moves necessary.

`forEachOperation()` is capable of producing more operations than a minimal set of changes, even without duplicates. For example, switching the first and last elements of an array should trigger only two moves. The current implementation triggers n moves, where n is the length of the array. This reveals another issue, that `forEachOperation()` is performing moves when they are not necessary.

Issue Number: #45647


## What is the new behavior?
When an item is replaced in an iterable of duplicates, `DefaultIterableDiffer` adds a new item, then removes the correct index. This causes the initial example in #45647 to replace the input element that is being typed into. That causes the element to lose focus, but that is expected behaviour since the `trackById` has changed.

`check()` always produces a minimal set of changes. This is done in O(n) time.

`forEachOperation()` produces no more operations than the minimal set of changes. It is possible to produce less operations if items coincidentally land in the correct index while transforming the iterable. This is done in O(n*m) time where n is the length of the iterable, and m is the distance of moves, ie. worst case is a move at every index and the moves travel the maximum distance. This is because each move requires calculating index offsets that have happened or will happen in between the previous and current index. 

Through basic performance tests of randomly shuffling items around an array and measuring how long it takes NgForOf to finish updating the DOM, I've clocked the new implementation at about 20% faster on both firefox and chrome, regardless of if duplicate values exist or not. That's taking the average of 20 tests that ran at around 300 - 500 ms each. This was repeated 5 times with approximately the same result. By no means a professional measure, but a good indication.

Fixing the initial problem required a complete rewrite, so the other issues were fixed as a side effect.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

### Testing
New tests were added to validate that the issues mentioned no longer exist, and that it stays that way.

All relevant tests pass, but I get 12 failures in my environment even on the main branch, so it's clear it is not from these changes. If these 12 tests need to pass for the PR to be accepted I will provide the error info and try to debug. If it's a common issue for these tests to fail, any info would be appreciated.
![testsPass](https://user-images.githubusercontent.com/60244464/168896759-1734d481-a415-4b06-86b0-4eec2e485376.jpg)


### New algorithms summary
To produce a minimal set of changes:
Do one pass through both old and new iterables simultaneously and find changed nodes, storing the new and old records. It then iterates through the changed nodes and looks for an old value that matches the node's new `trackById`. If a match is found, then that old record is considered to be moved to that node. If no old records are found, then that node is considered to have an added item. Afterwards, all leftover old records are considered to be removed.

Note: this is a minimal set of changes, not an optimal set of changes. Moves are matched by simply popping nodes and records off queues in order of index, the distance of moves is not minimized. For example [1, 0, 0, 0, 1] -> [0, 0, 0, 1, 0] will move 1 from index 0, rather than the more optimal index 4. This is so changes can be found in O(n) time.

To produce a set of operations <= the minimal set of changes:
While producing the set of changes, record the changes at each index: add, remove, moved to another index and / or moved from another index. Keep track of an index offset that represents how far items shift while transforming the iterable. Iterate through the old and new iterables simultaneously and check the set of operations at each index. If there is an add, add the current item and increase offset, if there is a remove, remove the previous item and decrease offset.

Moves must be consumed such that records moved to / are moved from indices greater than the current index. This is so nothing to the left of the current index gets offset. Moving an item to a further index requires calculating what offsets will happen in the future between the current index and the final index. For example, if an item will be added in between, we reduce index by one. After the addition, the index will be correct. Moving an item from a further index to this one requires calculating the offsets that have already happened between current index and the item's previous index, plus the accumulated offset so far. The result is where the item actually is in the transforming iterable.

See some changed / added tests for concrete examples.

### Performance Testing
Simple random test to gauge the new performance. I would tweak the tests to be around 500 ms and take the average of 20 runs. Was consistently getting around 80% execution time of the current implementation, 20% faster.
The tests involved just clicking a button and waiting for completion before starting the next one.
The `MutationObserver` was just for visual confirmation that the div was actually finished updating before the test ended.

```typescript
import {ChangeDetectorRef, Component, ElementRef, ViewChild} from '@angular/core';

const p = performance;
const arraySize = 5e3;
const numChanges = 5e3;
const numDigits = 2;

@Component({
  selector: 'app-perf-test',
  templateUrl: './perf-test.component.html',
  styleUrls: ['./perf-test.component.css']
})
export class PerfTestComponent {
  @ViewChild('arrayDiv') arrayDiv?: ElementRef<HTMLDivElement>;
  array: number[] = new Array(arraySize).fill(0);
  results: number[] = [];
  testNumber = 0;

  constructor(private cd: ChangeDetectorRef) {};

  divObserver = new MutationObserver(() => console.log('Div Updated!'));
  ngAfterViewInit() {
    this.divObserver.observe(
        this.arrayDiv!.nativeElement, {subtree: true, childList: true});
  }

  test() {
    for (let i = 0; i < numChanges; i++) {
      const index = Math.floor(Math.random() * (arraySize - 1));
      const value = Math.floor(Math.random() * Math.pow(10, numDigits));
      this.array[index] = value;
    }
    const start = p.now();
    this.cd.detectChanges();
    setTimeout(() => {
      const time = p.now() - start;
      this.results.push(time);
      console.log('Time', this.testNumber, ':', time, 'ms')
    });
    this.testNumber++;
  }

  average() {
    console.log(
        'Average:',
        this.results.reduce((acc, next) => acc += next) / this.testNumber,
        'ms');
  }
}
```

```html
<button (click)="test()">TEST</button>
<button (click)="average()">AVERAGE</button>

<div #arrayDiv>
  <div *ngFor="let value of array">
    <div>{{ value }}</div>
  </div>
</div>
```