### PR TITLE
refactor(platform-browser): Updates keyboard event library to support code field

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,8 +15,8 @@
       "main": 462546,
       "polyfills": 33922,
       "styles": 73640,
-      "light-theme": 78276,
-      "dark-theme": 78381
+      "light-theme": 78045,
+      "dark-theme": 78177
     }
   }
 }

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -507,9 +507,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_contains"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -363,9 +363,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -519,9 +519,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -513,9 +513,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -765,9 +765,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -315,9 +315,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -441,9 +441,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/platform-browser/test/dom/events/key_events_spec.ts
+++ b/packages/platform-browser/test/dom/events/key_events_spec.ts
@@ -10,12 +10,6 @@ import {KeyEventsPlugin} from '@angular/platform-browser/src/dom/events/key_even
 
 {
   describe('KeyEventsPlugin', () => {
-    if (isNode) {
-      // Jasmine will throw if there are no tests.
-      it('should pass', () => {});
-      return;
-    }
-
     it('should ignore unrecognized events', () => {
       expect(KeyEventsPlugin.parseEventName('keydown')).toEqual(null);
       expect(KeyEventsPlugin.parseEventName('keyup')).toEqual(null);
@@ -54,20 +48,373 @@ import {KeyEventsPlugin} from '@angular/platform-browser/src/dom/events/key_even
           .toEqual({'domEventName': 'keydown', 'fullKey': 'control.shift'});
       expect(KeyEventsPlugin.parseEventName('keyup.control.shift'))
           .toEqual({'domEventName': 'keyup', 'fullKey': 'control.shift'});
+
+      // key code ordering
+      expect(KeyEventsPlugin.parseEventName('keyup.code.control.shift'))
+          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift'});
+      expect(KeyEventsPlugin.parseEventName('keyup.control.code.shift'))
+          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift'});
+      // capitalization gets lowercased
+      expect(KeyEventsPlugin.parseEventName('keyup.control.code.shift.KeyS'))
+          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift.keys'});
+      // user provided order of `code.` does not matter
+      expect(KeyEventsPlugin.parseEventName('keyup.control.shift.code.KeyS'))
+          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift.keys'});
+      // except for putting `code` at the end
+      expect(KeyEventsPlugin.parseEventName('keyup.control.shift.KeyS.code')).toBeNull();
     });
 
     it('should alias esc to escape', () => {
       expect(KeyEventsPlugin.parseEventName('keyup.control.esc'))
           .toEqual(KeyEventsPlugin.parseEventName('keyup.control.escape'));
+      expect(KeyEventsPlugin.parseEventName('keyup.control.Esc'))
+          .toEqual(KeyEventsPlugin.parseEventName('keyup.control.escape'));
     });
 
-    it('should implement addGlobalEventListener', () => {
-      const plugin = new KeyEventsPlugin(document);
+    if (!isNode) {
+      it('should implement addGlobalEventListener', () => {
+        const plugin = new KeyEventsPlugin(document);
 
-      spyOn(plugin, 'addEventListener').and.callFake(() => () => {});
+        spyOn(plugin, 'addEventListener').and.callFake(() => () => {});
 
-      expect(() => plugin.addGlobalEventListener('window', 'keyup.control.esc', () => {}))
-          .not.toThrowError();
+        expect(() => plugin.addGlobalEventListener('window', 'keyup.control.esc', () => {}))
+            .not.toThrowError();
+      });
+    }
+
+    it('should match key field', () => {
+      const baseKeyboardEvent = {
+        isTrusted: true,
+        bubbles: true,
+        cancelBubble: false,
+        cancelable: true,
+        composed: true,
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        type: 'keydown'
+      };
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
+                 'alt.ß'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'S', code: 'KeyS', altKey: true}),
+                 'alt.s'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'F', code: 'KeyF', metaKey: true}),
+                 'meta.f'))
+          .toBeTruthy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'ArrowUp', code: 'ArrowUp'}),
+              'arrowup'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'ArrowDown', code: 'ArrowDown'}),
+                 'arrowdown'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}), 'a'))
+          .toBeTruthy();
+
+      // special characters
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Esc', code: 'Escape'}),
+                 'escape'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\x1B', code: 'Escape'}),
+                 'escape'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\b', code: 'Backspace'}),
+                 'backspace'))
+          .toBeTruthy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\t', code: 'Tab'}), 'tab'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Del', code: 'Delete'}),
+                 'delete'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\x7F', code: 'Delete'}),
+                 'delete'))
+          .toBeTruthy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Left', code: 'ArrowLeft'}),
+              'arrowleft'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'Right', code: 'ArrowRight'}),
+                 'arrowright'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Up', code: 'ArrowUp'}),
+                 'arrowup'))
+          .toBeTruthy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Down', code: 'ArrowDown'}),
+              'arrowdown'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'Menu', code: 'ContextMenu'}),
+                 'contextmenu'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'Scroll', code: 'ScrollLock'}),
+                 'scrolllock'))
+          .toBeTruthy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Win', code: 'OS'}), 'os'))
+          .toBeTruthy();
+    });
+
+    it('should match code field', () => {
+      const baseKeyboardEvent = {
+        isTrusted: true,
+        bubbles: true,
+        cancelBubble: false,
+        cancelable: true,
+        composed: true,
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        type: 'keydown'
+      };
+      // Windows
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 's', code: 'KeyS', altKey: true}),
+                 'code.alt.keys'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 's', code: 'KeyS', altKey: true}),
+                 'alt.s'))
+          .toBeTruthy();
+
+      // MacOS
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
+                 'code.alt.keys'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
+                 'alt.s'))
+          .toBeFalsy();
+
+      // Arrow Keys
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'ArrowUp', code: 'ArrowUp'}),
+              'code.arrowup'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'ArrowDown', code: 'ArrowDown'}),
+                 'arrowdown'))
+          .toBeTruthy();
+
+      // Basic key match
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}), 'a'))
+          .toBeTruthy();
+
+      // Basic code match
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}),
+                 'code.a'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}),
+                 'code.keya'))
+          .toBeTruthy();
+
+      // basic special key
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Shift', code: 'LeftShift'}),
+              'code.shift'))
+          .toBeFalsy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Shift', code: 'LeftShift'}),
+              'code.leftshift'))
+          .toBeTruthy();
+
+      // combination keys with code match
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'AltLeft',
+                   shiftKey: true,
+                   altKey: true
+                 }),
+                 'code.alt.shift.altleft'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'AltLeft',
+                   shiftKey: true,
+                   altKey: true
+                 }),
+                 'code.shift.altleft'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Meta',
+                   code: 'MetaLeft',
+                   shiftKey: true,
+                   metaKey: true
+                 }),
+                 'code.meta.shift.metaleft'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'MetaLeft',
+                   shiftKey: true,
+                   metaKey: true
+                 }),
+                 'code.shift.meta'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown',
+                     {...baseKeyboardEvent, key: 'S', code: 'KeyS', shiftKey: true, metaKey: true}),
+                 'code.meta.shift.keys'))
+          .toBeTruthy();
+
+      // combination keys without code match
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'AltLeft',
+                   shiftKey: true,
+                   altKey: true
+                 }),
+                 'shift.alt'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Meta',
+                   code: 'MetaLeft',
+                   shiftKey: true,
+                   metaKey: true
+                 }),
+                 'shift.meta'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown',
+                     {...baseKeyboardEvent, key: 'S', code: 'KeyS', shiftKey: true, metaKey: true}),
+                 'meta.shift.s'))
+          .toBeTruthy();
+
+      // OS mismatch
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Meta',
+                   code: 'MetaLeft',
+                   shiftKey: true,
+                   metaKey: true
+                 }),
+                 'shift.alt'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'AltLeft',
+                   shiftKey: true,
+                   altKey: true
+                 }),
+                 'shift.meta'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Meta',
+                   code: 'MetaLeft',
+                   shiftKey: true,
+                   metaKey: true
+                 }),
+                 'code.shift.altleft'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'AltLeft',
+                   shiftKey: true,
+                   altKey: true
+                 }),
+                 'code.shift.metaleft'))
+          .toBeFalsy();
+
+      // special key character cases
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent(
+                  'keydown',
+                  {...baseKeyboardEvent, key: ' ', code: 'Space', shiftKey: false, altKey: false}),
+              'space'))
+          .toBeTruthy();
+
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent(
+                  'keydown',
+                  {...baseKeyboardEvent, key: '.', code: 'Period', shiftKey: false, altKey: false}),
+              'dot'))
+          .toBeTruthy();
+    });
+
+    // unidentified key
+    it('should return false when key is unidentified', () => {
+      const baseKeyboardEvent = {
+        isTrusted: true,
+        bubbles: true,
+        cancelBubble: false,
+        cancelable: true,
+        composed: true,
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        type: 'keydown'
+      };
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, shiftKey: false, altKey: false}),
+              ''))
+          .toBeFalsy();
     });
   });
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Right now we only ever rely on the keyboardEvent `key` field, which is
limiting to users as far as matching keyboard events across OS and 
different keyboard layouts. The alt / option key behavior with MacOS
is a specific issue.

Issue Number: resolves #45992


## What is the new behavior?

On MacOS, pressing the alt key and another key turns into symbols, and
doesn't match the intended behavior. For example, `keydown.alt.s`
reports instead as `keydown.alt.ß`. We rely on the `key` field and not
the `code` field, which properly reports the code for S in this case.

This change adds support to allow users to specify they want to look at
the `code` field instead of the `key` field within their event string.
Example: `keydown.code.alt.leftshift` would only match the LeftShift and
not the right shift based on code values. It would also allow the user
to specify `keydown.code.alt.keys` to match S instead of ß when alt /
option is pressed on MacOS and would also work on Windows.

The proposed structure is `{event}.{type}.{optional modifier}.{key/code}`.
Alternatively we could do `{event}.{optional modifier}.{type}.{key/code}`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
