### PR TITLE
docs: fix angularfire2 hyperlink

### DIFF
--- a/aio/content/guide/ngmodules.md
+++ b/aio/content/guide/ngmodules.md
@@ -15,7 +15,7 @@ For explanations on the individual techniques, visit the relevant NgModule pages
 Modules are a great way to organize an application and extend it with capabilities from external libraries.
 
 Angular libraries are NgModules, such as `FormsModule`, `HttpClientModule`, and `RouterModule`.
-Many third-party libraries are available as NgModules such as [Material Design](https://material.angular.io), [Ionic](https://ionicframework.com), and [AngularFire2](https://github.com/angular/angularfire2.
+Many third-party libraries are available as NgModules such as [Material Design](https://material.angular.io), [Ionic](https://ionicframework.com), and [AngularFire2](https://github.com/angular/angularfire2).
 
 NgModules consolidate components, directives, and pipes into cohesive blocks of functionality, each focused on a feature area, application business domain, workflow, or common collection of utilities.
 


### PR DESCRIPTION
Hyperlink to **angularFire2** was incorrect, it was missing a _')'_ at the end to close the link per Markdown syntax.