### PR TITLE
Introduce the Developer Preview concept in AIO

### DIFF
--- a/aio/content/guide/releases.md
+++ b/aio/content/guide/releases.md
@@ -160,15 +160,15 @@ For details, see [Supported Public API Surface of Angular](https://github.com/an
 
 Any changes to the public API surface are done using the versioning, support, and depreciation policies previously described.
 
-<a id="labs"></a>
+<a id="developer-preview"></a>
 
-## Angular Labs
+## Developer Preview
 
-Angular Labs is an initiative to cultivate new features and iterate on them quickly.
-Angular Labs provides a safe place for exploration and experimentation by the Angular team.
+Occasionally we introduce new APIs under the label of "Developer Preview". These are APIs that are fully functional and polished, but that we are not ready to stabilize under our normal deprecation policy.
 
-Angular Labs projects are not ready for production use, and no commitment is made to bring them to production.
-The policies and practices that are described in this document do not apply to Angular Labs projects.
+This may be because we want to gather feedback from real applications before stabilization, or because the associated documentation or migration tooling is not fully complete.
+
+The policies and practices that are described in this document do not apply to APIs marked as Developer Preview. Such APIs can change at any time, even in new patch versions of the framework. Teams should decide for themselves whether the benefits of using Developer Preview APIs are worth the risk of breaking changes outside of our normal use of semantic versioning.
 
 <!-- links -->
 

--- a/aio/src/styles/2-modules/label/_label-theme.scss
+++ b/aio/src/styles/2-modules/label/_label-theme.scss
@@ -4,13 +4,17 @@
 @mixin theme($theme) {
   .api-header label {
     color: constants.$white;
+  }
 
+  label {
     &.api-status-label {
+      color: constants.$white;
       background-color: constants.$mediumgray;
 
       &.deprecated,
       &.security,
-      &.impure-pipe {
+      &.impure-pipe,
+      &.dev-preview {
         background-color: constants.$brightred;
       }
 
@@ -22,6 +26,7 @@
     }
 
     &.api-type-label {
+      color: constants.$white;
       background-color: constants.$accentblue;
 
       @each $name, $symbol in constants.$api-symbols {
@@ -32,11 +37,13 @@
     }
 
     &.page-label {
+      color: constants.$white;
       background-color: constants.$mist;
       color: constants.$mediumgray;
     }
 
     &.property-type-label {
+      color: constants.$white;
       background-color: constants.$darkgray;
       color: constants.$white;
     }

--- a/aio/src/styles/2-modules/label/_label.scss
+++ b/aio/src/styles/2-modules/label/_label.scss
@@ -1,6 +1,7 @@
 @use '../../mixins';
 
-.api-header label {
+.api-header label,
+label.api-status-label {
   border-radius: 4px;
   padding: 2px 10px;
   display: inline;

--- a/aio/tools/transforms/angular-api-package/tag-defs/developerPreview.js
+++ b/aio/tools/transforms/angular-api-package/tag-defs/developerPreview.js
@@ -1,0 +1,9 @@
+/**
+ * Use this tag to indicate that an API is in Developer Preview. 
+ */
+ module.exports = function() {
+  return {
+    name: 'developerPreview',
+    transforms: function() { return true; }
+  };
+};

--- a/aio/tools/transforms/templates/api/base.template.html
+++ b/aio/tools/transforms/templates/api/base.template.html
@@ -34,6 +34,11 @@
     <label class="github-links api-status-label final" title="This class should not be extended.">
       <a href="{$ github.githubVersionedUrl(versionInfo) $}/docs/PUBLIC_API.md#final-classes">final</a>
     </label>{% endif %}
+    {%- if doc.developerPreview %}
+    <label class="api-status-label dev-preview" title="This API is in Developer Preview">
+      <a href="{$ github.githubVersionedUrl(versionInfo) $}/guide/releases#developer-preview">developer preview</a>
+    </label>
+    {% endif %}
   </header>
   {%- endblock %}
   <aio-toc class="embedded"></aio-toc>

--- a/aio/tools/transforms/templates/api/decorator.template.html
+++ b/aio/tools/transforms/templates/api/decorator.template.html
@@ -17,6 +17,12 @@
         <th>
           <div class="with-github-links">
             <h3>{$ option.name $}</h3>
+            {%- if option.developerPreview %}
+            <label class="api-status-label dev-preview" title="This API is in Developer Preview">
+              <a href="{$ github.githubVersionedUrl(versionInfo) $}/guide/releases#developer-preview">developer
+                preview</a>
+            </label>
+            {% endif %}
             {$ github.githubLinks(option, versionInfo) $}
           </div>
         </th>

--- a/aio/tools/transforms/templates/api/includes/decorator-overview.html
+++ b/aio/tools/transforms/templates/api/includes/decorator-overview.html
@@ -13,7 +13,15 @@
           <code>{$ option.name $}{%- if option.isOptional  %}?{% endif -%}</code>
         </a>
       </td>
-      <td>{$ option.shortDescription | marked $}</td>
+      <td>
+        {%- if option.developerPreview %}
+        <label class="api-status-label dev-preview" title="This API is in Developer Preview">
+          <a href="{$ github.githubVersionedUrl(versionInfo) $}/guide/releases#developer-preview">developer preview</a>
+        </label>
+        {% endif %}
+
+        {$ option.shortDescription | marked $}
+      </td>
     </tr>
     {%- endfor %}
   </tbody>

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -364,6 +364,7 @@ export interface ModuleWithProviders<T> {
  * @see `importProvidersFrom`
  *
  * @publicApi
+ * @developerPreview
  */
 export interface ImportedNgModuleProviders {
   ɵproviders: Provider[];

--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -42,6 +42,7 @@ export type ImportProvidersSource =
  *
  * @returns The collected providers from the specified list of types.
  * @publicApi
+ * @developerPreview
  */
 export function importProvidersFrom(...sources: ImportProvidersSource[]):
     ImportedNgModuleProviders {

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -73,6 +73,8 @@ interface Record<T> {
 /**
  * An `Injector` that's part of the environment injector hierarchy, which exists outside of the
  * component tree.
+ *
+ * @developerPreview
  */
 export abstract class EnvironmentInjector implements Injector {
   /**

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -328,6 +328,8 @@ export interface Directive {
    *
    * More information about standalone components, directives and pipes can be found in [this
    * guide](guide/standalone-components).
+   *
+   * @developerPreview
    */
   standalone?: boolean;
 }
@@ -604,6 +606,8 @@ export interface Component extends Directive {
    *
    * More information about standalone components, directives and pipes can be found in [this
    * guide](guide/standalone-components).
+   *
+   * @developerPreview
    */
   standalone?: boolean;
 
@@ -617,6 +621,8 @@ export interface Component extends Directive {
    *
    * More information about standalone components, directives and pipes can be found in [this
    * guide](guide/standalone-components).
+   *
+   * @developerPreview
    */
   imports?: (Type<any>|any[])[];
 

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -143,6 +143,7 @@ class EnvironmentNgModuleRefAdapter extends viewEngine_NgModuleRef<null> {
  * Create a new environment injector.
  *
  * @publicApi
+ * @developerPreview
  */
 export function createEnvironmentInjector(
     providers: Array<Provider|ImportedNgModuleProviders>, parent: EnvironmentInjector|null = null,

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -66,6 +66,7 @@ export interface ApplicationConfig {
  * @returns A promise that returns an `ApplicationRef` instance once resolved.
  *
  * @publicApi
+ * @developerPreview
  */
 export function bootstrapApplication(
     rootComponent: Type<unknown>, options?: ApplicationConfig): Promise<ApplicationRef> {

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -136,6 +136,7 @@ export function renderModule<T>(
  * @returns A Promise, that returns serialized (to a string) rendered page, once resolved.
  *
  * @publicApi
+ * @developerPreview
  */
 export function renderApplication<T>(rootComponent: Type<T>, options: {
   appId: string,


### PR DESCRIPTION
* Documentation on "Developer Preview"
* New `@preview` tag which adds an API status chip linking to the Developer Preview docs
* Adds `@preview` to all standalone APIs