### PR TITLE
fix(core): handle AOT-compiled standalone components in TestBed correctly

### DIFF
--- a/packages/core/testing/src/r3_test_bed_compiler.ts
+++ b/packages/core/testing/src/r3_test_bed_compiler.ts
@@ -440,7 +440,14 @@ export class R3TestBedCompiler {
       const def = getComponentDef(moduleType);
       const dependencies = maybeUnwrapFn(def.dependencies ?? []);
       for (const dependency of dependencies) {
-        this.applyProviderOverridesToModule(dependency);
+        // Proceed with examining dependencies recursively
+        // when a dependency is a standalone component or an NgModule.
+        // In AOT, the `dependencies` might also contain regular (NgModule-based)
+        // Component, Directive and Pipes. Skip them here, they are handled in a
+        // different location (in the `configureTestingModule` function).
+        if (isStandaloneComponent(dependency) || hasNgModuleDef(dependency)) {
+          this.applyProviderOverridesToModule(dependency);
+        }
       }
     } else {
       const providers = [
@@ -576,7 +583,18 @@ export class R3TestBedCompiler {
         } else if (isStandaloneComponent(value)) {
           this.queueType(value, null);
           const def = getComponentDef(value);
-          queueTypesFromModulesArrayRecur(maybeUnwrapFn(def.dependencies ?? []));
+          const dependencies = maybeUnwrapFn(def.dependencies ?? []);
+          dependencies.forEach((dependency) => {
+            // Note: in AOT, the `dependencies` might also contain regular
+            // (NgModule-based) Component, Directive and Pipes, so we handle
+            // them separately and proceed with recursive process for standalone
+            // Components and NgModules only.
+            if (isStandaloneComponent(dependency) || hasNgModuleDef(dependency)) {
+              queueTypesFromModulesArrayRecur([dependency]);
+            } else {
+              this.queueType(dependency, null);
+            }
+          });
         }
       }
     };


### PR DESCRIPTION
Previously, the code in TestBed didn't take into account the fact that the `cmp.dependencies` array after the AOT compilation might contain regular (NgModule-based) Components/Directive/Pipes. As a result, some NgModule-specific code paths were invoked for non-NgModule types, thus leading to errors.

This commit updates the code to handle AOT-compiled structure of standalone components correctly.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No