### PR TITLE
fix(docs-infra): add member name to search index without ignore list

### DIFF
--- a/aio/tools/transforms/angular-base-package/processors/generateKeywords.js
+++ b/aio/tools/transforms/angular-base-package/processors/generateKeywords.js
@@ -27,6 +27,7 @@ module.exports = function generateKeywordsProcessor(log) {
 
       const dictionary = new Map();
 
+      const emptySet = new Set();
       // Keywords to ignore
       const ignoreWords = new Set(this.ignoreWords);
       log.debug('Words to ignore', ignoreWords);
@@ -53,7 +54,7 @@ module.exports = function generateKeywordsProcessor(log) {
           }
         }
 
-        const memberTokens = extractMemberTokens(doc, ignoreWords, dictionary);
+        const memberTokens = extractMemberTokens(doc, dictionary);
 
         // Extract all the keywords from the headings
         let headingTokens = [];
@@ -161,22 +162,22 @@ module.exports = function generateKeywordsProcessor(log) {
         tokens.push(dictionary.get(token));
       }
 
-      function extractMemberTokens(doc, ignoreWords, dictionary) {
+      function extractMemberTokens(doc, dictionary) {
         if (!doc) return [];
 
         let memberContent = [];
 
         if (doc.members) {
-          doc.members.forEach(member => memberContent.push(...tokenize(member.name, ignoreWords, dictionary)));
+          doc.members.forEach(member => memberContent.push(...tokenize(member.name, emptySet, dictionary)));
         }
         if (doc.statics) {
-          doc.statics.forEach(member => memberContent.push(...tokenize(member.name, ignoreWords, dictionary)));
+          doc.statics.forEach(member => memberContent.push(...tokenize(member.name, emptySet, dictionary)));
         }
         if (doc.extendsClauses) {
-          doc.extendsClauses.forEach(clause => memberContent.push(...extractMemberTokens(clause.doc, ignoreWords, dictionary)));
+          doc.extendsClauses.forEach(clause => memberContent.push(...extractMemberTokens(clause.doc, dictionary)));
         }
         if (doc.implementsClauses) {
-          doc.implementsClauses.forEach(clause => memberContent.push(...extractMemberTokens(clause.doc, ignoreWords, dictionary)));
+          doc.implementsClauses.forEach(clause => memberContent.push(...extractMemberTokens(clause.doc, dictionary)));
         }
 
         return memberContent;

--- a/aio/tools/transforms/angular-base-package/processors/generateKeywords.js
+++ b/aio/tools/transforms/angular-base-package/processors/generateKeywords.js
@@ -28,6 +28,7 @@ module.exports = function generateKeywordsProcessor(log) {
       const dictionary = new Map();
 
       const emptySet = new Set();
+
       // Keywords to ignore
       const ignoreWords = new Set(this.ignoreWords);
       log.debug('Words to ignore', ignoreWords);


### PR DESCRIPTION
Previously classs, interface and enum members where filtered with the default word ignore list. This lead to  poor search results if a search for a member on the ignore list was performed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently a search for an word that is on the ignored word list and is also a memeber of a class, enum or interface will not return the corresponding class, enum or interface in the search results. 

Issue Number: N/A


## What is the new behavior?
The ignored word list is not used to filter members of classes, interfaces and enums. Therefore when searching for a member that is also contained in the ignored word list the corresponding class, enum or interface will be found.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Here are also some example screen shots with the old and the new behavior:
| Old | New |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/1596276/169278063-a571970b-8007-4231-9dde-31e4c67b42e2.png" alt="none old" height="50%"/> | <img src="https://user-images.githubusercontent.com/1596276/169276695-a2614346-74f3-4e9e-9f77-664554e5013d.png" alt="none new" height="50%"/> |
| <img src="https://user-images.githubusercontent.com/1596276/169278341-fb7d5559-17db-49e6-be69-4c41ab232983.png" alt="last old" height="50%" />  | <img src="https://user-images.githubusercontent.com/1596276/169278214-bd2c8472-5262-47b7-8327-abb414d4602e.png" alt="last new" height="50%" />  |
|  <img src="https://user-images.githubusercontent.com/1596276/169278507-bf3c40a3-d6ba-4316-aadb-fc640d1a9fed.png" alt="state old" height="50%" /> | <img src="https://user-images.githubusercontent.com/1596276/169278489-9b304053-7cc5-419e-86a1-9ce8a3eba675.png" alt="state new" height="50%" /> | 
| <img src="https://user-images.githubusercontent.com/1596276/169278683-211eb51a-4615-4309-b483-c2fc7838280a.png" alt="put old" height="50%" /> | <img src="https://user-images.githubusercontent.com/1596276/169278692-41fbf9b2-ac45-4f11-b230-215e4967a15f.png" alt="put new" height="50%" /> |


<details><summary>I compiled a list that contains the members that where previously ignored and the document id whre the member contained</summary>

```
state: animations/AnimationMetadataType, common/PopStateEvent, common/LocationChangeEvent, common/testing/MockPlatformLocation, common/upgrade/$locationShim, forms/RadioControlValueAccessor, router/RouterLink, router/RouterLinkWithHref, router/GuardsCheckEnd, router/GuardsCheckStart, router/ResolveEnd, router/ResolveStart, router/RoutesRecognized, router/NavigationBehaviorOptions, router/NavigationBehaviorOptions
name: animations/AnimationStateMetadata, animations/AnimationTriggerMetadata, common/http/HttpErrorResponse, core/NgProbeToken, core/DebugElement, core/DebugEventListener, core/Pipe, core/SchemaMetadata, core/global/Listener, elements/NgElementStrategyEvent, forms/ControlContainer, forms/ControlContainer, forms/NgControl, forms/ControlContainer, forms/NgModel, forms/NgControl, forms/NgModelGroup, forms/ControlContainer, forms/RadioControlValueAccessor, forms/NgControl, forms/FormControlName, forms/NgControl, forms/ControlContainer, forms/FormArrayName, forms/ControlContainer, forms/FormGroupName, forms/ControlContainer
get: common/http/HttpClient, common/http/HttpContext, common/http/HttpHeaders, common/http/HttpParams, common/upgrade/$locationShimProvider, core/Injector, core/EnvironmentInjector, core/Injector, core/ReflectiveInjector, core/Injector, core/ReflectiveKey, core/QueryList, core/ViewContainerRef, core/testing/TestBed, core/testing/TestBedStatic, forms/AbstractControl, forms/AbstractControl, forms/AbstractControl, forms/AbstractControl, forms/AbstractControl, platform-browser/TransferState, router/ParamMap
put: common/http/HttpClient
has: common/http/HttpContext, common/http/HttpHeaders, common/http/HttpParams, router/ParamMap
keys: common/http/HttpContext, common/http/HttpHeaders, common/http/HttpParams, router/ParamMap
ok: common/http/HttpErrorResponse, common/http/HttpResponseBase, common/http/HttpResponseBase, common/http/HttpResponseBase, common/http/HttpResponseBase, common/http/HttpStatusCode
sent: common/http/HttpEventType
found: common/http/HttpStatusCode
gone: common/http/HttpStatusCode
zero: common/Plural
one: common/Plural
two: common/Plural
few: common/Plural
many: common/Plural
other: common/Plural
index: common/NgForOfContext, core/SimpleChanges
first: common/NgForOfContext, core/Query, core/QueryList
last: common/NgForOfContext, core/QueryList
even: common/NgForOfContext
value: common/NgPluralCase, common/KeyValue, elements/NgElementStrategyEvent, forms/AbstractControlDirective, forms/AbstractControlDirective, forms/AbstractControlDirective, forms/AbstractControlDirective, forms/AbstractControlDirective, forms/AbstractControlDirective, forms/AbstractControlDirective, forms/RadioControlValueAccessor, forms/AbstractControlDirective, forms/AbstractControlDirective, forms/AbstractControlDirective, forms/AbstractControlDirective, forms/AbstractControlDirective, forms/NgSelectOption, forms/SelectControlValueAccessor, forms/SelectMultipleControlValueAccessor, forms/AbstractControl, forms/AbstractControl, forms/AbstractControl, forms/FormControlState, forms/AbstractControl, forms/AbstractControl
back: common/HashLocationStrategy, common/LocationStrategy, common/Location, common/LocationStrategy, common/PathLocationStrategy, common/LocationStrategy, common/PlatformLocation, common/testing/SpyLocation, common/Location, common/testing/MockLocationStrategy, common/LocationStrategy, common/testing/MockPlatformLocation, common/PlatformLocation
go: common/Location, common/testing/SpyLocation, common/Location
done: core/ApplicationInitStatus
none: core/SecurityContext, core/ViewEncapsulation
id: core/NgModule, core/ReflectiveKey, core/RendererType2, forms/NgSelectOption, router/RouterEvent, router/RouterEvent, router/RouterEvent, router/RouterEvent, router/RouterEvent, router/RouterEvent, router/RouterEvent, router/RouterEvent, router/RouterEvent, router/RouterEvent, router/Navigation
self: core/InjectFlags
run: core/NgZone
begin: core/RendererFactory2
end: core/RendererFactory2
important: core/RendererStyleFlags2
some: core/QueryList
new: core/testing/TestBedStatic, elements/NgElementConstructor
at: forms/FormArray
contains: forms/FormGroup, forms/FormRecord, forms/FormGroup
all: platform-browser/By
available: service-worker/UpdateAvailableEvent, service-worker/SwUpdate
```

</details>
