### PR TITLE
perf(bazel): use allowedInputs to avoid fs.stat

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -255,37 +255,8 @@ export function compile({
         }
       };
 
-  // Patch fileExists when resolving modules, so that CompilerHost can ask TypeScript to
-  // resolve non-existing generated files that don't exist on disk, but are
-  // synthetic and added to the `programWithStubs` based on real inputs.
-  const generatedFileModuleResolverHost = Object.create(tsHost);
-  generatedFileModuleResolverHost.fileExists = (fileName: string) => {
-    const match = NGC_GEN_FILES.exec(fileName);
-    if (match) {
-      const [, file, suffix, ext] = match;
-      // Performance: skip looking for files other than .d.ts or .ts
-      if (ext !== '.ts' && ext !== '.d.ts') return false;
-      if (suffix.indexOf('ngstyle') >= 0) {
-        // Look for foo.css on disk
-        fileName = file;
-      } else {
-        // Look for foo.d.ts or foo.ts on disk
-        fileName = file + (ext || '');
-      }
-    }
-    return tsHost.fileExists(fileName);
-  };
-
-  function generatedFileModuleResolver(
-      moduleName: string, containingFile: string,
-      compilerOptions: ts.CompilerOptions): ts.ResolvedModuleWithFailedLookupLocations {
-    return ts.resolveModuleName(
-        moduleName, containingFile, compilerOptions, generatedFileModuleResolverHost);
-  }
-
   if (!bazelHost) {
-    bazelHost = new CompilerHost(
-        files, compilerOpts, bazelOpts, tsHost, fileLoader, generatedFileModuleResolver);
+    bazelHost = new CompilerHost(files, compilerOpts, bazelOpts, tsHost, fileLoader);
   }
 
   if (isInIvyMode) {
@@ -330,8 +301,24 @@ export function compile({
     bazelHost.transformTypesToClosure = true;
   }
 
+  // Patch fileExists when resolving modules, so that CompilerHost can ask TypeScript to
+  // resolve non-existing generated files that don't exist on disk, but are
+  // synthetic and added to the `programWithStubs` based on real inputs.
   const origBazelHostFileExist = bazelHost.fileExists;
   bazelHost.fileExists = (fileName: string) => {
+    const match = NGC_GEN_FILES.exec(fileName);
+    if (match) {
+      const [, file, suffix, ext] = match;
+      // Performance: skip looking for files other than .d.ts or .ts
+      if (ext !== '.ts' && ext !== '.d.ts') return false;
+      if (suffix.indexOf('ngstyle') >= 0) {
+        // Look for foo.css on disk
+        fileName = file;
+      } else {
+        // Look for foo.d.ts or foo.ts on disk
+        fileName = file + (ext || '');
+      }
+    }
     if (NGC_ASSETS.test(fileName)) {
       return tsHost.fileExists(fileName);
     }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Regarding tests: Do you have a way to test for file system calls during compilation?

## PR Type

- [x] Build related changes

## What is the current behavior?

ngc-wrapped calls TypeScript's fileExists function during module resolution, which calls fs.statSync.

File system calls can be quite slow depending on the file system. In google3 I saw a 38 seconds compilation, which spent 6 seconds just doing fs.stat calls during module resolution.

## What is the new behavior?

Call tsc_wrapped's fileExists function instead of TypeScript's.

tsc_wrapped (used internally by ngc-wrapped) has an optimization under bazel to avoid file system calls where possible. It takes advantage bazelOpts.allowedInputs, which contains a list of all files available for compilation.

The fs.stat calls mentioned for the slow google3 target are entirely gone after with this change.

## Does this PR introduce a breaking change?

- [x] No