### PR TITLE
ci: temporarily publish snapshots for `image-directive` branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ var_11: &only_release_branches
     branches:
       only:
         - main
+        - image-directive
         - /\d+\.\d+\.x/
 
 # CircleCI orbs


### PR DESCRIPTION
This commit enables publishing of snapshots for the `image-directive`
feature branch. The artifacts can be accessed with the following steps:

1. Go to the corresponding snapshot repo (e.g. `angular/common-builds`)
2. Go to the `image-directive` branch
3. Copy the SHA of the latest commit in that branch
4. Use that SHA to install via NPM. e.g.
   `https://github.com/angular/common-builds.git#SHA`.