### PR TITLE
build: fix unbound variable error in build artifact script

### DIFF
--- a/scripts/ci/publish-build-artifacts.sh
+++ b/scripts/ci/publish-build-artifacts.sh
@@ -48,7 +48,7 @@ function publishRepo {
   mkdir -p ${REPO_DIR}
 
   echo "Starting cloning process of ${REPO_URL} into ${REPO_DIR}.."
-  
+
   (
     if [[ $(git ls-remote --heads ${REPO_URL} ${BRANCH}) ]]; then
       echo "Branch ${BRANCH} already exists. Cloning that branch."
@@ -57,7 +57,7 @@ function publishRepo {
       cd ${REPO_DIR}
       echo "Cloned repository and switched into the repository directory (${REPO_DIR})."
     else
-      echo "Branch ${BRANCH} does not exist on ${packageRepo} yet."
+      echo "Branch ${BRANCH} does not exist on ${BUILD_REPO} yet."
       echo "Cloning default branch and creating branch '${BRANCH}' on top of it."
 
       git clone ${REPO_URL} ${REPO_DIR} --depth 1


### PR DESCRIPTION
We recently had a couple of issues with the shallowing of snapshot
git repositories. In an attempt to fix this, parts of the publish
script of the COMP repo have been used, but variables have not been
updated properly.

This commit fixes an unbound variable, avoiding errors when snapshots
are published for a new branch (e.g. when we branch-off).