### PR TITLE
docs: fix division by zero in progress events example

### DIFF
--- a/aio/content/examples/http/src/app/uploader/uploader.service.ts
+++ b/aio/content/examples/http/src/app/uploader/uploader.service.ts
@@ -62,7 +62,7 @@ export class UploaderService {
 
       case HttpEventType.UploadProgress:
         // Compute and show the % done:
-        const percentDone = Math.round(100 * event.loaded / (event.total ?? 0));
+        const percentDone = event.total ? Math.round(100 * event.loaded / event.total) : 0;
         return `File "${file.name}" is ${percentDone}% uploaded.`;
 
       case HttpEventType.Response:


### PR DESCRIPTION
If the `event.total` is undefined, this line would have generated a `NaN` due to division by zero. I suppose, that a `0` would be more suitable for this case.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Division by zero leads to NaN

Issue Number: N/A


## What is the new behavior?
Progress returns `0` instead of `NaN` if `event.total` is `undefined`. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
