### PR TITLE
ci: fix formatting for `babel_ast_host.ts` file after recent changes

### DIFF
--- a/packages/compiler-cli/linker/babel/src/ast/babel_ast_host.ts
+++ b/packages/compiler-cli/linker/babel/src/ast/babel_ast_host.ts
@@ -163,7 +163,8 @@ function isNotSpreadElement(e: t.Expression|t.SpreadElement): e is t.Expression 
  * Notably in the Babel AST, object patterns (for destructuring) could be of type
  * `t.PrivateName` so we need a distinction between object expressions and patterns.
  */
-function isObjectExpressionPropertyName(n: t.Node): n is t.Identifier|t.StringLiteral|t.NumericLiteral {
+function isObjectExpressionPropertyName(n: t.Node): n is t.Identifier|t.StringLiteral|
+    t.NumericLiteral {
   return t.isIdentifier(n) || t.isStringLiteral(n) || t.isNumericLiteral(n);
 }
 


### PR DESCRIPTION
The formatting of the `babel_ast_host.ts` file is invalid due to a
recently-merged PR. The PR had a passing `lint` state but this seemed
to just appear like this because the Git comparison range on upstream
branches can become invalid (due to a known bug in CircleCI -- reported)

In the interim we have two options to fix this without having to wait on CircleCI:
Add custom logic to determine/fetch the comparison range of a PR/ or use the Renovate
fork app (to operate on forks instead).