### PR TITLE
docs: move all bazel testing info to a single location

### DIFF
--- a/docs/BAZEL.md
+++ b/docs/BAZEL.md
@@ -48,9 +48,18 @@ new as of May 2017 and not very stable yet.
 
 ## Testing Angular
 
-- Test package in node: `yarn bazel test packages/core/test:test`
-- Test package in karma: `yarn bazel test packages/core/test:test_web`
-- Test all packages: `yarn bazel test packages/...`
+- Test package in node: `yarn test packages/core/test:test`
+- Test package in karma: `yarn test packages/core/test:test_web`
+- Test all packages: `yarn test packages/...`
+
+**Note**: The ellipsis in the last command above are not meant to be substituted by a package name, but
+are used by Bazel as a wildcard to execute all tests in the specified path. To execute all the tests for a
+single package, the commands are (exemplary):
+- `yarn test //packages/core/...` for all tests, or
+- `yarn test //packages/core/test:test` for a particular test suite.
+
+**Note**: The first test run will be much slower than future runs. This is because future runs will
+benefit from Bazel's capability to do incremental builds.
 
 You can use [ibazel] to get a "watch mode" that continuously
 keeps the outputs up-to-date as you save sources.

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -74,24 +74,15 @@ node ./scripts/build/build-packages-dist.js
 
 ## Running Tests Locally
 
-Bazel is used as the primary tool for building and testing Angular. Building and testing are
-incremental with Bazel, and it's possible to only run tests for an individual package instead
-of for all packages. Read more about this in the [BAZEL.md](./BAZEL.md) document.
+Bazel is used as the primary tool for building and testing Angular.
 
-You should execute all test suites before submitting a PR to GitHub.
-- `yarn test //packages/...`
+To see how to run and debug Angular tests locally please refer to the Bazel [Testing Angular](./BAZEL.md#testing-angular) section.
 
-**Note**: The ellipsis in the commands above is not meant to be substituted by a package name, but
-is used by Bazel as a wildcard to execute all tests in the specified path. To execute tests for a
-single package, the commands are (exemplary):
-- `yarn test //packages/core/...` for all tests, or
-- `yarn test //packages/core/test:test_web_firefox` for a particular test suite.
+Note that you should execute all test suites before submitting a PR to GitHub (`yarn test //packages/...`).
 
-**Note**: The first test run will be much slower than future runs. This is because future runs will
-benefit from Bazel's capability to do incremental builds.
+However, affected tests will be executed on our CI infrastructure. So if you forgot to run some affected tests which would fail, GitHub will indicate the error state and present you the failures.
 
-All the tests are executed on our Continuous Integration infrastructure. PRs can only be
-merged if the code is formatted properly and all tests are passing.
+PRs can only be merged if the code is formatted properly and all tests are passing.
 
 <a name="formatting-your-source-code">
 <a name="clang-format"></a>


### PR DESCRIPTION
instead of presenting the same (or similar information) in both the
DEVELOPER.md and the BAZEL.md files, more all the information in the
BAZEL file and refer to that section in the DEVELOPER file

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
 - basically I've been referring to the BAZEL file, but stumbled across the explanation of the `...` in the DEVELOPER one, which seemed quite valuable for the BAZEL file as well, instead of copy that section I just figured that the DEVELOPER's md should just point to the BAZEL one and that one should be the only point of reference (as it also contains various information for debugging)