### PR TITLE
fix(compiler-cli): use inline type-check blocks for components outside `rootDir`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/context.ts
@@ -264,7 +264,7 @@ export class TypeCheckContextImpl implements TypeCheckContext {
     });
 
     const inliningRequirement =
-        requiresInlineTypeCheckBlock(ref.node, shimData.file, pipes, this.reflector);
+        requiresInlineTypeCheckBlock(ref, shimData.file, pipes, this.reflector);
 
     // If inlining is not supported, but is required for either the TCB or one of its directive
     // dependencies, then exit here with an error.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/ts_util.ts
@@ -8,8 +8,6 @@
 
 import ts from 'typescript';
 
-import {ClassDeclaration} from '../../reflection';
-
 const PARSED_TS_VERSION = parseFloat(ts.versionMajorMinor);
 
 
@@ -149,49 +147,6 @@ export function tsUpdateTypeParameterDeclaration(
       ts.factory.updateTypeParameterDeclaration(node, name, constraint, defaultType) :
       (ts.factory.updateTypeParameterDeclaration as any)(
           node, /* modifiers */[], name, constraint, defaultType);
-}
-
-export function checkIfClassIsExported(node: ClassDeclaration): boolean {
-  // A class is exported if one of two conditions is met:
-  // 1) it has the 'export' modifier.
-  // 2) it's declared at the top level, and there is an export statement for the class.
-  if (node.modifiers !== undefined &&
-      node.modifiers.some(mod => mod.kind === ts.SyntaxKind.ExportKeyword)) {
-    // Condition 1 is true, the class has an 'export' keyword attached.
-    return true;
-  } else if (
-      node.parent !== undefined && ts.isSourceFile(node.parent) &&
-      checkIfFileHasExport(node.parent, node.name.text)) {
-    // Condition 2 is true, the class is exported via an 'export {}' statement.
-    return true;
-  }
-  return false;
-}
-
-function checkIfFileHasExport(sf: ts.SourceFile, name: string): boolean {
-  for (const stmt of sf.statements) {
-    if (ts.isExportDeclaration(stmt) && stmt.exportClause !== undefined &&
-        ts.isNamedExports(stmt.exportClause)) {
-      for (const element of stmt.exportClause.elements) {
-        if (element.propertyName === undefined && element.name.text === name) {
-          // The named declaration is directly exported.
-          return true;
-        } else if (element.propertyName !== undefined && element.propertyName.text == name) {
-          // The named declaration is exported via an alias.
-          return true;
-        }
-      }
-    }
-  }
-  return false;
-}
-
-export function checkIfGenericTypesAreUnbound(node: ClassDeclaration<ts.ClassDeclaration>):
-    boolean {
-  if (node.typeParameters === undefined) {
-    return true;
-  }
-  return node.typeParameters.every(param => param.constraint === undefined);
 }
 
 export function isAccessExpression(node: ts.Node): node is ts.ElementAccessExpression|

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/diagnostics_spec.ts
@@ -688,6 +688,18 @@ class TestComponent {
           [`TestComponent.html(1, 15): Type 'number' is not assignable to type 'string'.`]);
     });
   });
+
+  // https://github.com/angular/angular/issues/44999
+  it('should not fail for components outside of rootDir', () => {
+    // This test configures a component that is located outside the configured `rootDir`. Such
+    // configuration requires that an inline type-check block is used as the reference emitter does
+    // not allow generating imports outside `rootDir`.
+    const messages =
+        diagnose(`{{invalid}}`, `export class TestComponent {}`, [], [], {}, {rootDir: '/root'});
+
+    expect(messages).toEqual(
+        [`TestComponent.html(1, 3): Property 'invalid' does not exist on type 'TestComponent'.`]);
+  });
 });
 
 function diagnose(


### PR DESCRIPTION
An inline type-check block is required when a reference to a component class
cannot be emitted from an ngtypecheck shim file, but the logic to detect this
situation did not consider the configured `rootDir`. When a `rootDir` is
configured the reference emitter does not allow generating an import outside
this directory, which meant that a shim file wouldn't be able to reference
the component class. Consequently, type-check block generation would fail
with a fatal error that is unaccounted for, as gathering diagnostics should
be non-fallible.

This commit fixes the problem by leveraging the existing `canReferenceType`
logic of the type-checking `Environment`, instead of the rudimentary check
whether the class is exported as top-level symbol (`checkIfClassIsExported`).
Instead, `canReferenceType` pre-flights the generation of an import using the
`ReferenceEmitter` to tell exactly whether it will succeed or not; thus taking
into account the `rootDirs` constraint as well.

Fixes #44999