### PR TITLE
fix(common): remove trailing whitespaces from URL in HttpRequest (#45418)

### DIFF
--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -177,7 +177,7 @@ export class HttpRequest<T> {
     withCredentials?: boolean,
   });
   constructor(
-      method: string, readonly url: string, third?: T|{
+      method: string, public url: string, third?: T|{
         headers?: HttpHeaders,
         context?: HttpContext,
         reportProgress?: boolean,
@@ -244,6 +244,9 @@ export class HttpRequest<T> {
       this.context = new HttpContext();
     }
 
+    // trim the request URL so that the outcome of sending an HTTP request behaves consistently,
+    // regardless of whether or not query parameters are utilized (#45418)
+    this.url = url.trim();
     // If no parameters have been passed in, construct a new HttpUrlEncodedParams instance.
     if (!this.params) {
       this.params = new HttpParams();

--- a/packages/common/http/test/request_spec.ts
+++ b/packages/common/http/test/request_spec.ts
@@ -187,6 +187,10 @@ const TEST_STRING = `I'm a body!`;
         const req = baseReq.clone({setParams: {'test': 'false'}});
         expect(req.urlWithParams).toEqual('/test?test=false');
       });
+      it('removes trailing whitespaces from the base URL', () => {
+        const httpRequest = new HttpRequest('GET', '/test   ', null, {params});
+        expect(httpRequest.urlWithParams).toEqual('/test?test=true');
+      });
     });
   });
 }


### PR DESCRIPTION
When using HttpClient to send an HTTP request, if trailing whitespaces are present in the URL, then:
 - if there are no query parameters, the trailing whitespaces are trimmed
 - if there are one or more query parameters, the trailing whitespaces are encoded

This commit aims to trim the request URL so that the outcome of sending an HTTP request stays consistent, regardless of whether or not query parameters are utilized

Fixes #45418

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
