### PR TITLE
docs: remove broken code from TOH tutorial

### DIFF
--- a/aio/content/tutorial/toh-pt2.md
+++ b/aio/content/tutorial/toh-pt2.md
@@ -203,10 +203,4 @@ Here are the code files discussed on this page, including the `HeroesComponent` 
 *   You used `*ngIf` to conditionally include or exclude a block of HTML
 *   You can toggle a CSS style class with a `class` binding.
 
-    <code-example format="typescript" language="typescript">
-
-    header="src/app/heroes/heroes.component.html (HeroesComponent's template)"
-
-    </code-example>
-
-@reviewed 2022-02-28
+@reviewed 2022-05-23


### PR DESCRIPTION
At the end of Part 2 of the Tour or Heroes tutorial, there is a code sample that is broken. It looks like it was added by mistake because it is not related to the summary.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
