### PR TITLE
refactor(compiler-cli): fix "for to" typo in code comment

### DIFF
--- a/packages/compiler-cli/src/transformers/downlevel_decorators_transform/downlevel_decorators_transform.ts
+++ b/packages/compiler-cli/src/transformers/downlevel_decorators_transform/downlevel_decorators_transform.ts
@@ -531,7 +531,7 @@ export function getDownlevelDecoratorsTransform(
         const isNgDecorator = isAngularDecorator(decorator, isCore);
 
         // Keep track if we come across an Angular class decorator. This is used
-        // for to determine whether constructor parameters should be captured or not.
+        // to determine whether constructor parameters should be captured or not.
         if (isNgDecorator) {
           hasAngularDecorator = true;
         }


### PR DESCRIPTION
fix the typo/extra for in a code comment saying
"this is used for to determine" so that it only says
"this is used to determine"

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 Just a very small typo fix :stuck_out_tongue: 