### PR TITLE
refactor(compiler-cli): improve error for non-exported non-standalone

### DIFF
--- a/packages/compiler-cli/src/ngtsc/scope/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/util.ts
@@ -36,16 +36,11 @@ export function makeNotStandaloneDiagnostic(
   if (scope !== null && scope.kind === ComponentScopeKind.NgModule) {
     // The directive/pipe in question is declared in an NgModule. Check if it's also exported.
     const isExported = scope.exported.dependencies.some(dep => dep.ref.node === ref.node);
-    if (isExported) {
-      relatedInformation = [makeRelatedInformation(
-          scope.ngModule.name,
-          `It can be imported using its NgModule '${scope.ngModule.name.text}' instead.`)];
-    } else {
-      relatedInformation = [makeRelatedInformation(
-          scope.ngModule.name,
-          `It's declared in the NgModule '${
-              scope.ngModule.name.text}', but is not exported. Consider exporting it.`)];
-    }
+    const relatedInfoMessageText = isExported ?
+        `It can be imported using its '${scope.ngModule.name.text}' NgModule instead.` :
+        `It's declared in the '${scope.ngModule.name.text}' NgModule, but is not exported. ` +
+            'Consider exporting it and importing the NgModule instead.';
+    relatedInformation = [makeRelatedInformation(scope.ngModule.name, relatedInfoMessageText)];
   } else {
     // TODO(alxhub): the above case handles directives/pipes in NgModules that are declared in the
     // current compilation, but not those imported from .d.ts dependencies. We could likely scan the

--- a/packages/compiler-cli/test/ngtsc/standalone_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/standalone_spec.ts
@@ -381,7 +381,7 @@ runInEachFileSystem(() => {
         expect(diags[0].relatedInformation).not.toBeUndefined();
         expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0])).toEqual('TestModule');
         expect(diags[0].relatedInformation![0].messageText)
-            .toContain('It can be imported using its NgModule');
+            .toMatch(/It can be imported using its '.*' NgModule instead./);
       });
 
       it('should error when a standalone component imports a ModuleWithProviders using a foreign function',
@@ -480,14 +480,12 @@ runInEachFileSystem(() => {
            expect(diags[0].code).toBe(ngErrorCode(ErrorCode.COMPONENT_IMPORT_NOT_STANDALONE));
            expect(getSourceCodeForDiagnostic(diags[0])).toEqual('TestDir');
 
-           // The diagnostic produced here should suggest that the directive be imported via its
-           // NgModule instead.
            expect(diags[0].relatedInformation).not.toBeUndefined();
            expect(getSourceCodeForDiagnostic(diags[0].relatedInformation![0]))
                .toEqual('TestModule');
            expect(diags[0].relatedInformation![0].messageText)
                .toEqual(
-                   `It's declared in the NgModule 'TestModule', but is not exported. Consider exporting it.`);
+                   `It's declared in the 'TestModule' NgModule, but is not exported. Consider exporting it and importing the NgModule instead.`);
          });
 
       it('should type-check standalone component templates', () => {


### PR DESCRIPTION
improve the error message for non-standalone components which are not
exported from their module, and that are also imported directly as if
they were standalone

this change simply adds the suggestion to the developer to import the
ngModule instead

resolves #46004

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: #46004



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - I think/hope this resolves #46004, unless I understood the issue wrongly :sweat: 
 
This is the result:
![Screenshot at 2022-05-23 23-06-47](https://user-images.githubusercontent.com/61631103/169913262-5f790668-dc68-48c1-9360-d8a99fb33e7c.png)
 