### PR TITLE
fix(forms): Tighten up the typing of `.get`.

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -41,8 +41,8 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     }): void;
     get enabled(): boolean;
     readonly errors: ValidationErrors | null;
-    get<P extends string | (readonly (string | number)[])>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null;
-    get<P extends string | Array<string | number>>(path: P): AbstractControl<ɵGetProperty<TRawValue, P>> | null;
+    get<P extends string | (readonly (string | number)[])>(path: P): ɵGetProperty<TRawValue, P>;
+    get<P extends string | Array<string | number>>(path: P): ɵGetProperty<TRawValue, P>;
     getError(errorCode: string, path?: Array<string | number> | string): any;
     getRawValue(): any;
     hasAsyncValidator(validator: AsyncValidatorFn): boolean;

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -556,7 +556,6 @@ describe('Typed Class', () => {
           'returnIfFound', new FormControl('200 Ellis, San Francisco', {nonNullable: true}));
       c.setControl(
           'returnIfFound', new FormControl('200 Ellis, San Francisco', {nonNullable: true}));
-      // c.removeControl('returnIfFound'); // Not allowed
       c.contains('returnIfFound');
       c.setValue({returnIfFound: '200 Ellis, San Francisco', alex: '1 Main', andrew: '2 Main'});
       c.patchValue({});
@@ -576,6 +575,8 @@ describe('Typed Class', () => {
       c.reset({returnIfFound: '200 Ellis, San Francisco', igor: '300 Page, San Francisco'});
       // @ts-expect-error
       c.removeControl('igor');
+      // @ts-expect-error
+      c.removeControl('returnIfFound');  // Not allowed
     });
 
     it('should have strongly-typed get', () => {
@@ -591,29 +592,39 @@ describe('Typed Class', () => {
       const rv = c.getRawValue();
       {
         type ValueType = {day: number, month: string};
-        let t: ValueType = c.get('venue.date')!.value;
+        let t: ValueType = c.get('venue.date').value;
         let t1 = c.get('venue.date')!.value;
         t1 = null as unknown as ValueType;
       }
       {
         type ValueType = string;
-        let t: ValueType = c.get('venue.date.month')!.value;
-        let t1 = c.get('venue.date.month')!.value;
+        let t: ValueType = c.get('venue.date.month').value;
+        let t1 = c.get('venue.date.month').value;
         t1 = null as unknown as ValueType;
       }
       {
         type ValueType = string;
-        let t: ValueType = c.get(['venue', 'date', 'month'] as const)!.value;
-        let t1 = c.get(['venue', 'date', 'month'] as const)!.value;
+        let t: ValueType = c.get(['venue', 'date', 'month'] as const).value;
+        let t1 = c.get(['venue', 'date', 'month'] as const).value;
         t1 = null as unknown as ValueType;
       }
       {
-        // .get(...) should be `never`, but we use `?` to coerce to undefined so the test passes at
-        // runtime.
-        type ValueType = never|undefined;
-        let t: ValueType = c.get('foobar')?.value;
-        let t1 = c.get('foobar')?.value;
-        t1 = null as unknown as ValueType;
+        type ControlType = AbstractControl<any>|null;
+        let t: ControlType = c.get(['venue', 'date', 'month']);
+        let t1 = c.get(['venue', 'date', 'month']);
+        t1 = null as unknown as ControlType;
+      }
+      {
+        type ControlType = null;
+        let t: ControlType = c.get('foobar');
+        let t1 = c.get('foobar');
+        t1 = null as unknown as ControlType;
+      }
+      {
+        type ControlType = null;
+        let t: ControlType = c.get('foobar.0');
+        let t1 = c.get('foobar.0');
+        t1 = null as unknown as ControlType;
       }
     });
 


### PR DESCRIPTION
Previously, `.get()` always included `null` in its type, regardless of whether we can prove the control exists (i.e. is non-null). By pushing the `AbstractControl` container type into the helpers, we can explicitly include `null` in the failure cases (but *not* in the success cases), allowing us to have more correct types:

* If the control is known to be present, `null` can be excluded.
* If the control is known to be absent, we can fail to just `null` instead of `AbstractControl<never>`, which is more correct
* For indeterminate cases (e.g. non-const arrays), we fail to `AbstractControl<any>|null`, which is exactly the same as before

This comes at the cost of a slightly messier `ɵNavigate`, which is OK since it's an internal type anyway.

Here's an example of the improvement:

```
const fg = new FormGroup({
  foo: new FormControl('bar'),
});

// Before: an exclamation point is required
const val = fg.get('foo')!.value;

// After: the compiler knows the control exists and is non-null
const val = fg.get('foo').value;

// Before: `AbstractControl<never>`
const val = fg.get('oops');

// After: `null`
const val = fg.get('oops');
```

Inspired by [this YAQS question](https://yaqs.corp.google.com/eng/q/1033305634621095936), as well as feedback from @cexbrayat.