### PR TITLE
refactor(common): create an NgModule for the `NgOptimizedImage` directive

### DIFF
--- a/packages/common/src/directives/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Inject, Injectable, InjectionToken, Injector, Input, NgZone, OnChanges, OnDestroy, OnInit, Renderer2, SimpleChanges, ɵformatRuntimeError as formatRuntimeError, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {Directive, ElementRef, Inject, Injectable, InjectionToken, Injector, Input, NgModule, NgZone, OnChanges, OnDestroy, OnInit, Renderer2, SimpleChanges, ɵformatRuntimeError as formatRuntimeError, ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {DOCUMENT} from '../dom_tokens';
 import {RuntimeErrorCode} from '../errors';
@@ -144,7 +144,6 @@ class LCPImageObserver implements OnDestroy {
  * TODO: add Image directive usage notes.
  */
 @Directive({
-  standalone: true,
   selector: 'img[rawSrc]',
 })
 export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
@@ -266,6 +265,22 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
   private setHostAttribute(name: string, value: string): void {
     this.renderer.setAttribute(this.imgElement.nativeElement, name, value);
   }
+}
+
+
+/**
+ * NgModule that declares and exports the `NgOptimizedImage` directive.
+ * This NgModule is a compatibility layer for apps that use pre-v14
+ * versions of Angular (before the `standalone` flag became available).
+ *
+ * The `NgOptimizedImage` will become a standalone directive in v14 and
+ * this NgModule will be removed.
+ */
+@NgModule({
+  declarations: [NgOptimizedImage],
+  exports: [NgOptimizedImage],
+})
+export class NgOptimizedImageModule {
 }
 
 /***** Helpers *****/

--- a/packages/common/src/private_export.ts
+++ b/packages/common/src/private_export.ts
@@ -6,6 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {IMAGE_LOADER as ɵIMAGE_LOADER, ImageLoaderConfig as ɵImageLoaderConfig, NgOptimizedImage as ɵNgOptimizedImage} from './directives/ng_optimized_image';
+export {IMAGE_LOADER as ɵIMAGE_LOADER, ImageLoaderConfig as ɵImageLoaderConfig, NgOptimizedImage as ɵNgOptimizedImage, NgOptimizedImageModule as ɵNgOptimizedImageModule} from './directives/ng_optimized_image';
 export {DomAdapter as ɵDomAdapter, getDOM as ɵgetDOM, setRootDomAdapter as ɵsetRootDomAdapter} from './dom_adapter';
 export {BrowserPlatformLocation as ɵBrowserPlatformLocation} from './location/platform_location';

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, DOCUMENT} from '@angular/common';
-import {IMAGE_LOADER, ImageLoader, ImageLoaderConfig, NgOptimizedImage} from '@angular/common/src/directives/ng_optimized_image';
+import {IMAGE_LOADER, ImageLoader, ImageLoaderConfig, NgOptimizedImageModule} from '@angular/common/src/directives/ng_optimized_image';
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -363,7 +363,7 @@ function setupTestingModule(config?: {imageLoader: ImageLoader}) {
     declarations: [TestComponent],
     // Note: the `NgOptimizedImage` directive is experimental and is not a part of the
     // `CommonModule` yet, so it's imported separately.
-    imports: [CommonModule, NgOptimizedImage],
+    imports: [CommonModule, NgOptimizedImageModule],
     providers,
   });
 }

--- a/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
+++ b/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImage as NgOptimizedImage} from '@angular/common';
+import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImageModule as NgOptimizedImageModule} from '@angular/common';
 import {Component} from '@angular/core';
 
 @Component({
   selector: 'basic',
   standalone: true,
-  imports: [NgOptimizedImage],
+  imports: [NgOptimizedImageModule],
   template: `<img rawSrc="/e2e/a.png" width="150" height="150" priority>`,
   providers: [{provide: IMAGE_LOADER, useValue: () => '/e2e/b.png'}],
 })

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵNgOptimizedImage as NgOptimizedImage} from '@angular/common';
+import {ɵNgOptimizedImageModule as NgOptimizedImageModule} from '@angular/common';
 import {Component} from '@angular/core';
 
 @Component({
   selector: 'lcp-check',
   standalone: true,
-  imports: [NgOptimizedImage],
+  imports: [NgOptimizedImageModule],
   template: `
     <!--
       'b.png' should *not* be treated as an LCP element,

--- a/packages/core/test/bundling/image-directive/playground.ts
+++ b/packages/core/test/bundling/image-directive/playground.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵImageLoaderConfig as ImageLoaderConfig, ɵNgOptimizedImage as NgOptimizedImage} from '@angular/common';
+import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵImageLoaderConfig as ImageLoaderConfig, ɵNgOptimizedImageModule as NgOptimizedImageModule} from '@angular/common';
 import {Component} from '@angular/core';
 
 const CUSTOM_IMGIX_LOADER = (config: ImageLoaderConfig) => {
@@ -48,7 +48,7 @@ const CUSTOM_IMGIX_LOADER = (config: ImageLoaderConfig) => {
     </main>
   `,
   standalone: true,
-  imports: [NgOptimizedImage],
+  imports: [NgOptimizedImageModule],
   providers: [{provide: IMAGE_LOADER, useValue: CUSTOM_IMGIX_LOADER}],
 })
 export class PlaygroundComponent {


### PR DESCRIPTION
This commit updates the `NgOptimizedImage` directive to drop the `standalone` flag and create a new NgModule which declares and exports it, so that the directive can be used in apps that use pre-v14 version of Angular.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No