### PR TITLE
docs: fix multicast observable example output

### DIFF
--- a/aio/content/examples/observables/src/multicasting.ts
+++ b/aio/content/examples/observables/src/multicasting.ts
@@ -161,8 +161,8 @@ export function docRegionMulticastSequence(console: Console, runSequence: boolea
   // (at 2 seconds): 2nd subscribe: 2
   // (at 3 seconds): Emitting 3
   // (at 3 seconds): 1st subscribe: 3
-  // (at 3 seconds): 1st sequence finished
   // (at 3 seconds): 2nd subscribe: 3
+  // (at 3 seconds): 1st sequence finished
   // (at 3 seconds): 2nd sequence finished
 
   // #enddocregion multicast_sequence


### PR DESCRIPTION
Fix the order of logs that represent the output of the multicasting example, as the correct behavior is that all observers are notified of the final value before any of them is notified about completion.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
