### PR TITLE
build(docs-infra): upgrade cli command docs sources to 78db454ce

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js b71844f36",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 78db454ce",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint && yarn security-lint",
     "test": "yarn check-env && ng test",
     "test:bazel": "bazelisk test //aio:test",


### PR DESCRIPTION
Updating [angular#14.0.x](https://github.com/angular/angular/tree/14.0.x) from [cli-builds#14.0.x](https://github.com/angular/cli-builds/tree/14.0.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/b71844f36...78db454ce):

**Modified**
- help/completion.json