### PR TITLE
build(docs-infra): be able to resolve root-relative image URLs in `getImageDimensions()`

### DIFF
--- a/aio/tools/transforms/angular-base-package/services/getImageDimensions.js
+++ b/aio/tools/transforms/angular-base-package/services/getImageDimensions.js
@@ -1,6 +1,6 @@
-const { resolve } = require('canonical-path');
+const { join } = require('canonical-path');
 const sizeOf = require('image-size');
 
 module.exports = function getImageDimensions() {
-  return (basePath, path) => sizeOf(resolve(basePath, path));
+  return (basePath, path) => sizeOf(join(basePath, path));
 };


### PR DESCRIPTION
Previously, `getImageDimensions()` would try to resolve image URLs relative to the base path using `path.resolve()`. This resulted in root-relative URLs (i.e. URLs starting with `/`) being treated as absolute filesystem paths and thus resolving incorrectly ([example failure][1]).

This commit fixes it by using `.join()` instead, which is more appropriate in this case. (Originally discussed [here][2].)

[1]: https://circleci.com/gh/angular/angular/1173150
[2]: https://github.com/angular/angular/pull/46134#issuecomment-1137191996
