### PR TITLE
fix(compiler-cli): preserve `forwardRef` for component scopes

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -356,10 +356,14 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
  * @codeGenApi
  */
 export function ɵɵsetComponentScope(
-    type: ComponentType<any>, directives: Type<any>[], pipes: Type<any>[]): void {
+    type: ComponentType<any>, directives: Type<any>[]|(() => Type<any>[]),
+    pipes: Type<any>[]|(() => Type<any>[])): void {
   const def = (type.ɵcmp as ComponentDef<any>);
-  def.directiveDefs = () => directives.map(extractDirectiveDef) as DirectiveDefList;
-  def.pipeDefs = () => pipes.map(getPipeDef) as PipeDefList;
+  def.directiveDefs = () =>
+      (typeof directives === 'function' ? directives() : directives).map(extractDirectiveDef) as
+      DirectiveDefList;
+  def.pipeDefs = () =>
+      (typeof pipes === 'function' ? pipes() : pipes).map(getPipeDef) as PipeDefList;
 }
 
 export function extractDirectiveDef(type: Type<any>): DirectiveDef<any>|ComponentDef<any>|null {


### PR DESCRIPTION
Angular generally supports cycles between components in the same NgModule.
We have a mechanism of moving the component scope declaration into the
NgModule file in this case. This ensures that Angular never itself
introduces an import which creates a cycle.

What happens if the cycle already exists in the user's program, though, is a
bit different. In these cases, the "correct" emit for Angular is to generate
the component scope (whether direct or remote) inside of a closure, to
prevent evaluating the scope's references until module evaluation is
complete and all cyclic imports have been resolved. We don't want to do this
for *all* scopes because the code size cost of emitting a function wrapper
is non-zero.

In this fix, we take the presence of a `forwardRef` in a component's
`imports` or in an NgModule `declarations` or `imports` as a sign that
component scopes emitted into those files need to be protected against
cyclic references. In a future commit, we may introduce a warning or error
if cyclic imports are not protected behind `forwardRef` in these cases, but
this will take some time to implement.
