### PR TITLE
docs: change wrong alert to callout

### DIFF
--- a/aio/content/guide/lifecycle-hooks.md
+++ b/aio/content/guide/lifecycle-hooks.md
@@ -320,7 +320,7 @@ The following *AfterContent* hooks take action based on changing values in a *co
 
 <a id="no-unidirectional-flow-worries"></a>
 
-<div class="alert is-helpful">
+<div class="callout is-helpful">
 
 <header>No need to wait for content updates</header>
 


### PR DESCRIPTION
change the alert present in the lifecycicle-hook docs to a callout so
that its header can be properly rendered (since alters don't support have headers)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The alert present in the [lifecycle-hooks guide](https://angular.io/guide/lifecycle-hooks) has a header which is not rendered correctly:

![Screenshot at 2022-05-25 21-51-41](https://user-images.githubusercontent.com/61631103/170366212-9f86ffb4-9ca0-4dcb-9189-e5aecf05185f.png)

I believe the issue is that only callouts support headers (see the [docs style guide - alerts and callouts](https://angular.io/guide/docs-style-guide#alerts-and-callouts) section)

## What is the new behavior?

I am changing the alert in a callout so that its header is correctly displayed:

![Screenshot at 2022-05-25 21-54-39](https://user-images.githubusercontent.com/61631103/170366402-39e07b4c-55df-4a9f-b224-64989e97903d.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

