### PR TITLE
fix(core): better error message when unknown property is present

### DIFF
--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -255,7 +255,7 @@ function validateElementIsKnown(
       let message = `'${tagName}' is not a known element:\n`;
       message += `1. If '${tagName}' is an Angular component, then verify that it is ${
           hostIsStandalone ? 'included in the \'@Component.imports\' of this component' :
-                             'a part of this module'}.\n`;
+                             'a part of an @NgModule where this component is declared'}.\n`;
       if (tagName && tagName.indexOf('-') > -1) {
         message +=
             `2. If '${tagName}' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the ${


### PR DESCRIPTION
Prior to this commit, the error message that was produced for the unknown property situation, din't contain extra info on how the problem can be fixed. This commit adds more info to the error message and makes it similar to the one we use during the AOT compilation.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No