### PR TITLE
refactor(core): clean up closure deoptimization

### DIFF
--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -276,8 +276,6 @@ export function getTView(): TView {
   return instructionState.lFrame.tView;
 }
 
-// TODO(crisbeto): revert the @noinline once Closure issue is resolved.
-
 /**
  * Restores `contextViewData` to the given OpaqueViewState instance.
  *
@@ -289,7 +287,6 @@ export function getTView(): TView {
  * @returns Context of the restored OpaqueViewState instance.
  *
  * @codeGenApi
- * @noinline Disable inlining due to issue with Closure in listeners inside embedded views.
  */
 export function ɵɵrestoreView<T = any>(viewToRestore: OpaqueViewState): T {
   instructionState.lFrame.contextLView = viewToRestore as any as LView;


### PR DESCRIPTION
In #45445 function inlining had to be disabled on one of our instructions, because Closure wasn't optimizing it correctly, causing an error at runtime. The error has been resolved so we can remove the deoptimization hint.