### PR TITLE
docs: close lightbox div to fix page display

### DIFF
--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -161,6 +161,8 @@ To verify that the directive works, click the button to change the value of `con
 
 <img alt="UnlessDirective in action" src="generated/images/guide/structural-directives/unless-anim.gif">
 
+</div>
+
 ## Structural directive syntax reference
 
 When you write your own structural directives, use the following syntax:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] ~~Tests for the changes have been added (for bug fixes / features)~~
- [ ] ~~Docs have been added / updated (for bug fixes / features)~~


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

This doc page is unreadable after a certain point: https://angular.io/guide/structural-directives#structural-directive-syntax-reference

![Screen Shot 2022-05-26 at 11 52 08 AM](https://user-images.githubusercontent.com/16456186/170525309-3a56f96f-328e-4488-9800-ca1bd4f70a47.png)


## What is the new behavior?

Closed the lightbox `<div>` so the page is readable again:

![Screen Shot 2022-05-26 at 11 53 04 AM](https://user-images.githubusercontent.com/16456186/170525545-ff5e9a06-2e4b-4829-95be-7156575f2125.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

N/A
