### PR TITLE
fix(core): update unknown property error to account for standalone components in AOT

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -866,7 +866,8 @@ class TcbDomSchemaCheckerOp extends TcbOp {
           // A direct binding to a property.
           const propertyName = ATTR_TO_PROP[binding.name] || binding.name;
           this.tcb.domSchemaChecker.checkProperty(
-              this.tcb.id, this.element, propertyName, binding.sourceSpan, this.tcb.schemas);
+              this.tcb.id, this.element, propertyName, binding.sourceSpan, this.tcb.schemas,
+              this.tcb.hostIsStandalone);
         }
       }
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -719,7 +719,7 @@ export class NoopSchemaChecker implements DomSchemaChecker {
       hostIsStandalone: boolean): void {}
   checkProperty(
       id: string, element: TmplAstElement, name: string, span: ParseSourceSpan,
-      schemas: SchemaMetadata[]): void {}
+      schemas: SchemaMetadata[], hostIsStandalone: boolean): void {}
 }
 
 export class NoopOobRecorder implements OutOfBandDiagnosticRecorder {

--- a/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/template_typecheck_spec.ts
@@ -2117,6 +2117,33 @@ export declare class AnimationEvent {
 2. To allow any element add 'NO_ERRORS_SCHEMA' to the '@Component.schemas' of this component.`);
       });
 
+      it('should check for unknown properties in standalone components', () => {
+        env.write('test.ts', `
+          import {Component, NgModule} from '@angular/core';
+          @Component({
+            selector: 'my-comp',
+            template: '...',
+            standalone: true,
+          })
+          export class MyComp {}
+
+          @Component({
+            selector: 'blah',
+            imports: [MyComp],
+            template: '<my-comp [foo]="true"></my-comp>',
+            standalone: true,
+          })
+          export class FooCmp {}
+        `);
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(1);
+        expect(diags[0].messageText)
+            .toMatch(`Can't bind to 'foo' since it isn't a known property of 'my-comp'.
+1. If 'my-comp' is an Angular component and it has 'foo' input, then verify that it is included in the '@Component.imports' of this component.
+2. If 'my-comp' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@Component.schemas' of this component to suppress this message.
+3. To allow any property add 'NO_ERRORS_SCHEMA' to the '@Component.schemas' of this component.`);
+      });
+
       it('should have a descriptive error for unknown elements that contain a dash', () => {
         env.write('test.ts', `
         import {Component, NgModule} from '@angular/core';


### PR DESCRIPTION
This commit updates the error message to use correct info depending on whether a component is standalone or not. Previously we were always referring to @NgModules as a place to fix the issue, but not we also mention @Component when needed (for standalone components).

This is a followup PR after #45919.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No