### PR TITLE
fix(core): include component name into unknown element/property error message

### DIFF
--- a/packages/core/test/acceptance/ng_module_spec.ts
+++ b/packages/core/test/acceptance/ng_module_spec.ts
@@ -271,64 +271,65 @@ describe('NgModule', () => {
       const fixture = TestBed.createComponent(MyComp);
       fixture.detectChanges();
       expect(spy.calls.mostRecent().args[0])
-          .toMatch(/Can't bind to 'unknown-prop' since it isn't a known property of 'div'/);
+          .toMatch(
+              /Can't bind to 'unknown-prop' since it isn't a known property of 'div' \(used in the 'MyComp' component template\)/);
     });
 
-    it('should log an error on unknown props of `ng-template` if NO_ERRORS_SCHEMA is absent',
-       () => {
-         @Component({
-           selector: 'my-comp',
-           template: `
+    it('should log an error on unknown props of `ng-template` if NO_ERRORS_SCHEMA is absent', () => {
+      @Component({
+        selector: 'my-comp',
+        template: `
               <ng-template *ngIf="condition"></ng-template>
             `,
-         })
-         class MyComp {
-           condition = true;
-         }
+      })
+      class MyComp {
+        condition = true;
+      }
 
-         @NgModule({
-           declarations: [MyComp],
-         })
-         class MyModule {
-         }
+      @NgModule({
+        declarations: [MyComp],
+      })
+      class MyModule {
+      }
 
-         TestBed.configureTestingModule({imports: [MyModule]});
+      TestBed.configureTestingModule({imports: [MyModule]});
 
-         const spy = spyOn(console, 'error');
-         const fixture = TestBed.createComponent(MyComp);
-         fixture.detectChanges();
+      const spy = spyOn(console, 'error');
+      const fixture = TestBed.createComponent(MyComp);
+      fixture.detectChanges();
 
-         expect(spy.calls.mostRecent().args[0])
-             .toMatch(/Can't bind to 'ngIf' since it isn't a known property of 'ng-template'/);
-       });
+      expect(spy.calls.mostRecent().args[0])
+          .toMatch(
+              /Can't bind to 'ngIf' since it isn't a known property of 'ng-template' \(used in the 'MyComp' component template\)/);
+    });
 
-    it('should log an error on unknown props of `ng-container` if NO_ERRORS_SCHEMA is absent',
-       () => {
-         @Component({
-           selector: 'my-comp',
-           template: `
+    it('should log an error on unknown props of `ng-container` if NO_ERRORS_SCHEMA is absent', () => {
+      @Component({
+        selector: 'my-comp',
+        template: `
               <ng-container *ngIf="condition"></ng-container>
             `,
-         })
-         class MyComp {
-           condition = true;
-         }
+      })
+      class MyComp {
+        condition = true;
+      }
 
-         @NgModule({
-           declarations: [MyComp],
-         })
-         class MyModule {
-         }
+      @NgModule({
+        declarations: [MyComp],
+      })
+      class MyModule {
+      }
 
-         TestBed.configureTestingModule({imports: [MyModule]});
+      TestBed.configureTestingModule({imports: [MyModule]});
 
-         const spy = spyOn(console, 'error');
-         const fixture = TestBed.createComponent(MyComp);
-         fixture.detectChanges();
+      const spy = spyOn(console, 'error');
+      const fixture = TestBed.createComponent(MyComp);
+      fixture.detectChanges();
 
-         expect(spy.calls.mostRecent().args[0])
-             .toMatch(/Can't bind to 'ngIf' since it isn't a known property of 'ng-container'/);
-       });
+      expect(spy.calls.mostRecent().args[0])
+          .toMatch(
+              /Can't bind to 'ngIf' since it isn't a known property of 'ng-container' \(used in the 'MyComp' component template\)/);
+    });
 
     it('should log an error on unknown props of `ng-content` if NO_ERRORS_SCHEMA is absent', () => {
       @Component({
@@ -354,7 +355,8 @@ describe('NgModule', () => {
       fixture.detectChanges();
 
       expect(spy.calls.mostRecent().args[0])
-          .toMatch(/Can't bind to 'ngIf' since it isn't a known property of 'ng-content'/);
+          .toMatch(
+              /Can't bind to 'ngIf' since it isn't a known property of 'ng-content' \(used in the 'MyComp' component template\)/);
     });
 
     it('should throw an error with errorOnUnknownProperties on unknown props if NO_ERRORS_SCHEMA is absent',
@@ -385,7 +387,7 @@ describe('NgModule', () => {
            fixture.detectChanges();
          })
              .toThrowError(
-                 /NG0303: Can't bind to 'unknown-prop' since it isn't a known property of 'div'/g);
+                 /NG0303: Can't bind to 'unknown-prop' since it isn't a known property of 'div' \(used in the 'MyComp' component template\)/g);
        });
 
     it('should not throw on unknown props if NO_ERRORS_SCHEMA is present', () => {
@@ -543,7 +545,8 @@ describe('NgModule', () => {
       fixture.detectChanges();
 
       expect(spy.calls.mostRecent()?.args[0])
-          .toMatch(/Can't bind to 'unknownProp' since it isn't a known property of 'ng-content'/);
+          .toMatch(
+              /Can't bind to 'unknownProp' since it isn't a known property of 'ng-content' \(used in the 'App' component template\)/);
     });
 
     it('should throw an error on unknown property bindings on ng-content when errorOnUnknownProperties is enabled',
@@ -558,7 +561,7 @@ describe('NgModule', () => {
            fixture.detectChanges();
          })
              .toThrowError(
-                 /NG0303: Can't bind to 'unknownProp' since it isn't a known property of 'ng-content'/g);
+                 /NG0303: Can't bind to 'unknownProp' since it isn't a known property of 'ng-content' \(used in the 'App' component template\)/g);
        });
 
     it('should report unknown property bindings on ng-container', () => {
@@ -573,7 +576,7 @@ describe('NgModule', () => {
 
       expect(spy.calls.mostRecent()?.args[0])
           .toMatch(
-              /Can't bind to 'unknown-prop' since it isn't a known property of 'ng-container'/);
+              /Can't bind to 'unknown-prop' since it isn't a known property of 'ng-container' \(used in the 'App' component template\)/);
     });
 
     it('should throw error on unknown property bindings on ng-container when errorOnUnknownProperties is enabled',
@@ -588,7 +591,7 @@ describe('NgModule', () => {
            fixture.detectChanges();
          })
              .toThrowError(
-                 /NG0303: Can't bind to 'unknown-prop' since it isn't a known property of 'ng-container'/g);
+                 /NG0303: Can't bind to 'unknown-prop' since it isn't a known property of 'ng-container' \(used in the 'App' component template\)/g);
        });
 
     it('should log an error on unknown props and include a note on Web Components', () => {
@@ -623,7 +626,7 @@ describe('NgModule', () => {
 
       // Split the error message into chunks, so it's easier to debug if needed.
       const lines = [
-        `NG0303: Can't bind to 'unknownProp' since it isn't a known property of 'may-be-web-component'.`,
+        `NG0303: Can't bind to 'unknownProp' since it isn't a known property of 'may-be-web-component' \\(used in the 'MyComp' component template\\).`,
         `1. If 'may-be-web-component' is an Angular component and it has the 'unknownProp' input, then verify that it is a part of an @NgModule where this component is declared.`,
         `2. If 'may-be-web-component' is a Web Component then add 'CUSTOM_ELEMENTS_SCHEMA' to the '@NgModule.schemas' of this component to suppress this message.`,
         `3. To allow any property add 'NO_ERRORS_SCHEMA' to the '@NgModule.schemas' of this component.`
@@ -657,7 +660,8 @@ describe('NgModule', () => {
 
            // Split the error message into chunks, so it's easier to debug if needed.
            const lines = [
-             `NG0303: Can't bind to '${directive}' since it isn't a known property of 'div'.`,
+             `NG0303: Can't bind to '${
+                 directive}' since it isn't a known property of 'div' \\(used in the 'App' component template\\).`,
              `If the '${directive}' is an Angular control flow directive, please make sure ` +
                  `that the 'CommonModule' is a part of an @NgModule where this component is declared.`
            ];
@@ -683,7 +687,8 @@ describe('NgModule', () => {
 
            // Split the error message into chunks, so it's easier to debug if needed.
            const lines = [
-             `NG0303: Can't bind to '${directive}' since it isn't a known property of 'div'.`,
+             `NG0303: Can't bind to '${
+                 directive}' since it isn't a known property of 'div' \\(used in the 'App' component template\\).`,
              `If the '${directive}' is an Angular control flow directive, please make sure ` +
                  `that the 'CommonModule' is included in the '@Component.imports' of this component.`
            ];

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -632,7 +632,8 @@ describe('standalone components, directives and pipes', () => {
 
   describe('unknown template elements', () => {
     const unknownElErrorRegex = (tag: string) => {
-      const prefix = `'${tag}' is not a known element:`;
+      const prefix =
+          `'${tag}' is not a known element \\(used in the 'AppCmp' component template\\):`;
       const message1 = `1. If '${
           tag}' is an Angular component, then verify that it is included in the '@Component.imports' of this component.`;
       const message2 = `2. If '${


### PR DESCRIPTION
This commit adds the component name into unknown element/property error message, so that it's easier to find a location of a template where the problem happened.

Closes #46080.

// cc @dario-piotrowicz 

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No