### PR TITLE
refactor(common): reference DOCUMENT token via @angular/common import

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -4,6 +4,13 @@
     "packages/animations/browser/src/render/shared.ts"
   ],
   [
+    "packages/common/index.ts",
+    "packages/common/public_api.ts",
+    "packages/common/src/common.ts",
+    "packages/common/src/private_export.ts",
+    "packages/common/src/directives/ng_optimized_image.ts"
+  ],
+  [
     "packages/compiler-cli/ngcc/src/packages/configuration.ts",
     "packages/compiler-cli/ngcc/src/packages/entry_point.ts"
   ],

--- a/packages/common/src/directives/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {DOCUMENT} from '@angular/common';
 import {Directive, ElementRef, Inject, Injectable, InjectionToken, Injector, Input, NgModule, NgZone, OnChanges, OnDestroy, OnInit, Renderer2, SimpleChanges, ɵformatRuntimeError as formatRuntimeError, ɵRuntimeError as RuntimeError} from '@angular/core';
 
-import {DOCUMENT} from '../dom_tokens';
 import {RuntimeErrorCode} from '../errors';
 
 /**
@@ -84,7 +84,10 @@ class LCPImageObserver implements OnDestroy {
   private window: Window|null = null;
   private observer: PerformanceObserver|null = null;
 
-  constructor(@Inject(DOCUMENT) doc: Document) {
+  constructor(injector: Injector) {
+    // Retrieve the `DOCUMENT` token inside a constructor (vs injecting it
+    // as an argument) to avoid accessing it before its initialization.
+    const doc = injector.get(DOCUMENT);
     const win = doc.defaultView;
     if (typeof win !== 'undefined' && typeof PerformanceObserver !== 'undefined') {
       this.window = win;


### PR DESCRIPTION
This commit changes the `DOCUMENT` token import from the relative path to an import via a public API (`@angular/common`). This is needed to make sure that the token is always referenced from the same location. This might become an issue in case a directive is packaged as a separate module (for testing purposes).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No