### PR TITLE
docs(core): improve `inject` function docs

### DIFF
--- a/aio/content/errors/NG0203.md
+++ b/aio/content/errors/NG0203.md
@@ -15,9 +15,7 @@ export class Car {
   // OK: field initializer
   spareTyre = inject(Tyre);
   
-  // OK: constructor parameter
-  constructor(readonly engine: Engine = inject(Engine)) {
-
+  constructor() {
     // OK: constructor body
     this.radio = inject(Radio);
   }
@@ -36,32 +34,13 @@ providers: [
 ]
 ```
 
-The `inject()` calls might be wrapped in an intermediate function and will work correctly as long as a wrapper function is used in one of the allowed contexts:
+Calls to the `inject()` function outside of the class creation context will result in error. Most notably, calls to `inject()` are disallowed after a class instance was created, in methods (including lifecycle hooks):
 
 ```typescript
-function getAndLog<T>(token: ProviderToken<T>): T {
-  const instance = inject(token);
-
-  console.log('Getting', token.toString());
-
-  return instance;
-}
-
-@Injectable({providedIn: 'root'})
-export class Car {
-  constructor(readonly engine: Engine = getAndLog(Engine)) {
-  }
-}
-```
-
-Calls to the `inject()` function outside of the class creation context will result in error. Most notably, calls to `inject()` are disallowed after a class instance was created, in methods:
-
-```typescript
-@Injectable({providedIn: 'root'})
-export class Car {
-
-  start() {
-    // ERROR: too late, the Car instance was already created and fully initialized
+@Component({ ... })
+export class CarComponent {
+  ngOnInit() {
+    // ERROR: too late, the component instance was already created
     const engine = inject(Engine);
     engine.start();
   }

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -597,8 +597,11 @@ export interface Inject {
 // @public
 export const Inject: InjectDecorator;
 
-// @public
-export const inject: typeof ɵɵinject;
+// @public (undocumented)
+export function inject<T>(token: ProviderToken<T>): T;
+
+// @public (undocumented)
+export function inject<T>(token: ProviderToken<T>, flags?: InjectFlags): T | null;
 
 // @public
 export interface Injectable {

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -125,8 +125,13 @@ export function inject<T>(token: ProviderToken<T>): T;
 export function inject<T>(token: ProviderToken<T>, flags?: InjectFlags): T|null;
 /**
  * Injects a token from the currently active injector.
- * The injection context for this function is available during the class creation and
- * initialization, as well as in a factory function, such as one defined for an `InjectionToken`.
+ * `inject` is only supported during instantiation of a dependency by the DI system. It can be used
+ * during:
+ * - Construction (via the `constructor`) of a class being instantiated by the DI system, such
+ * as an `@Injectable` or `@Component`.
+ * - In the initializer for fields of such classes.
+ * - In the factory function specified for `useFactory` of a `Provider` or an `@Injectable`.
+ * - In the `factory` function specified for an `InjectionToken`.
  *
  * @param token A token that represents a dependency that should be injected.
  * @param flags Optional flags that control how injection is executed.
@@ -146,8 +151,7 @@ export function inject<T>(token: ProviderToken<T>, flags?: InjectFlags): T|null;
  *   // OK: field initializer
  *   spareTyre = inject(Tyre);
  *
- *   // OK: constructor parameter
- *   constructor(readonly engine: Engine = inject(Engine)) {
+ *   constructor() {
  *     // OK: constructor body
  *     this.radio = inject(Radio);
  *   }
@@ -166,31 +170,15 @@ export function inject<T>(token: ProviderToken<T>, flags?: InjectFlags): T|null;
  * ]
  * ```
  *
- * The `inject()` calls might be wrapped in an intermediate function and will work correctly as long
- * as a wrapper function is used in one of the allowed contexts:
- *
- * ```typescript
- * function getAndLog<T>(token: ProviderToken<T>): T {
- *   const instance = inject(token);
- *   console.log('Getting', token.toString());
- *   return instance;
- * }
- *
- * @Injectable({providedIn: 'root'})
- * export class Car {
- *   constructor(readonly engine: Engine = getAndLog(Engine)) {
- *   }
- * }
- * ```
- *
  * Calls to the `inject()` function outside of the class creation context will result in error. Most
- * notably, calls to `inject()` are disallowed after a class instance was created, in methods:
+ * notably, calls to `inject()` are disallowed after a class instance was created, in methods
+ * (including lifecycle hooks):
  *
  * ```typescript
- * @Injectable({providedIn: 'root'})
- * export class Car {
- *   start() {
- *     // ERROR: too late, the Car instance was already created and fully initialized
+ * @Component({ ... })
+ * export class CarComponent {
+ *   ngOnInit() {
+ *     // ERROR: too late, the component instance was already created
  *     const engine = inject(Engine);
  *     engine.start();
  *   }

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -942,9 +942,6 @@
     "name": "initTNodeFlags"
   },
   {
-    "name": "inject"
-  },
-  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1038,9 +1038,6 @@
     "name": "initTNodeFlags"
   },
   {
-    "name": "inject"
-  },
-  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1002,9 +1002,6 @@
     "name": "initTNodeFlags"
   },
   {
-    "name": "inject"
-  },
-  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1377,9 +1377,6 @@
     "name": "initTNodeFlags"
   },
   {
-    "name": "inject"
-  },
-  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -600,9 +600,6 @@
     "name": "incrementInitPhaseFlags"
   },
   {
-    "name": "inject"
-  },
-  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -109,8 +109,8 @@ export const getTestBed: () => TestBed = _getTestBedRender3;
 /**
  * Allows injecting dependencies in `beforeEach()` and `it()`. Note: this function
  * (imported from the `@angular/core/testing` package) can **only** be used to inject dependencies
- * in tests. To inject dependencies in your application code, use [the `inject` function from the
- * `@angular/core` package](api/core/inject) instead.
+ * in tests. To inject dependencies in your application code, use the [`inject`](api/core/inject)
+ * function from the `@angular/core` package instead.
  *
  * Example:
  *

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -107,7 +107,10 @@ export const TestBed: TestBedStatic = TestBedRender3;
 export const getTestBed: () => TestBed = _getTestBedRender3;
 
 /**
- * Allows injecting dependencies in `beforeEach()` and `it()`.
+ * Allows injecting dependencies in `beforeEach()` and `it()`. Note: this function
+ * (imported from the `@angular/core/testing` package) can **only** be used to inject dependencies
+ * in tests. To inject dependencies in your application code, use [the `inject` function from the
+ * `@angular/core` package](api/core/inject) instead.
  *
  * Example:
  *


### PR DESCRIPTION
This commit updates the `inject` function docs by:
- rephrasing a description to include more usage cases
- adding usage examples
- making a function itself a public API (vs its alias const that was used previously)

Before/after comparison:
<img width="1574" alt="inject-docs" src="https://user-images.githubusercontent.com/43554145/170901846-7bc020ba-1486-478f-9c81-ea3ba59107d1.png">

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
