### PR TITLE
docs: replace double dashes with m-dashes, fix typos

### DIFF
--- a/aio/content/guide/complex-animation-sequences.md
+++ b/aio/content/guide/complex-animation-sequences.md
@@ -37,7 +37,7 @@ The first argument of `query()` is a [css selector](https://developer.mozilla.or
 |:---                        |:---     |
 | `:enter` <br /> `:leave`   | For entering/leaving elements.               |
 | `:animating`               | For elements currently animating.            |
-| `@*` <br /> `@triggerName` | For elements with any —or a specific—trigger. |
+| `@*` <br /> `@triggerName` | For elements with any—or a specific—trigger. |
 | `:self`                    | The animating element itself.                |
 
 <div class="callout is-helpful">

--- a/aio/content/guide/what-is-angular.md
+++ b/aio/content/guide/what-is-angular.md
@@ -82,13 +82,13 @@ When the application loads the component and its template, the user sees the fol
 
 </code-example>
 
-Notice the use of double curly braces--they instruct Angular to interpolate the contents within them.
+Notice the use of double curly braces—they instruct Angular to interpolate the contents within them.
 
 Angular also supports property bindings, to help you set values for properties and attributes of HTML elements and pass values to your application's presentation logic.
 
 <code-example format="html" language="html" path="what-is-angular/src/app/hello-world-bindings/hello-world-bindings.component.html" region="bindings"></code-example>
 
-Notice the use of the square brackets--that syntax indicates that you're binding the property or attribute to a value in the component class.
+Notice the use of the square brackets—that syntax indicates that you're binding the property or attribute to a value in the component class.
 
 Declare event listeners to listen for and respond to user actions such as keystrokes, mouse movements, clicks, and touches.
 You declare an event listener by specifying the event name in parentheses:


### PR DESCRIPTION
Fixes #46173

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #46173 


## What is the new behavior?

m-dashes are used instead of double dashes and typos aren’t present


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


