### PR TITLE
docs: update build section to include autoprefixer link.

### DIFF
--- a/aio/content/guide/build.md
+++ b/aio/content/guide/build.md
@@ -306,7 +306,7 @@ To disable these warnings, add the CommonJS module name to `allowedCommonJsDepen
 The CLI uses [Autoprefixer](https://github.com/postcss/autoprefixer) to ensure compatibility with different browser and browser versions.
 You might find it necessary to target specific browsers or exclude certain browser versions from your build.
 
-Internally, Autoprefixer relies on a library called [Browserslist](https://github.com/browserslist/browserslist) to figure out which browsers to support with prefixing.
+Internally, [Autoprefixer](https://goonlinetools.com/autoprefixer/) relies on a library called [Browserslist](https://github.com/browserslist/browserslist) to figure out which browsers to support with prefixing.
 Browserlist looks for configuration options in a `browserslist` property of the package configuration file, or in a configuration file named `.browserslistrc`.
 Autoprefixer looks for the `browserslist` configuration when it prefixes your CSS.
 


### PR DESCRIPTION
Added online version of Autoprefixer. So users can instantly use it without installing it.

