### PR TITLE
fix(router): update title before NavigationEnd event

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1365,11 +1365,11 @@ export class Router {
           this.navigated = true;
           this.lastSuccessfulId = t.id;
           this.currentPageId = t.targetPageId;
+          this.titleStrategy?.updateTitle(this.routerState.snapshot);
           (this.events as Subject<Event>)
               .next(new NavigationEnd(
                   t.id, this.serializeUrl(t.extractedUrl), this.serializeUrl(this.currentUrlTree)));
           this.lastSuccessfulNavigation = this.currentNavigation;
-          this.titleStrategy?.updateTitle(this.routerState.snapshot);
           t.resolve(true);
         },
         e => {


### PR DESCRIPTION
fixes angular/angular#46179

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, router updates page title (using `TitleStrategy`) after `NavigationEnd` event is triggered. This prevents listeners of router events to rely on page title because it has not been updated yet.

Issue Number: #46179 


## What is the new behavior?
Router updates page title (`TitleStrategy.updateTitle()`) before triggering `NavigationEnd` event.


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


