### PR TITLE
test: drop no longer needed postinstall step from integration test apps

### DIFF
--- a/integration/animations/package.json
+++ b/integration/animations/package.json
@@ -8,8 +8,7 @@
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",
-    "e2e": "ng e2e --port 0",
-    "postinstall": "ngcc --properties es2015 --create-ivy-entry-points"
+    "e2e": "ng e2e --port 0"
   },
   "private": true,
   "dependencies": {

--- a/integration/forms/package.json
+++ b/integration/forms/package.json
@@ -8,8 +8,7 @@
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",
-    "e2e": "ng e2e --port 0",
-    "postinstall": "ngcc --properties es2015 --create-ivy-entry-points"
+    "e2e": "ng e2e --port 0"
   },
   "private": true,
   "dependencies": {

--- a/integration/standalone-bootstrap/package.json
+++ b/integration/standalone-bootstrap/package.json
@@ -8,8 +8,7 @@
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",
-    "e2e": "ng e2e --port 0",
-    "postinstall": "ngcc --properties es2015 --create-ivy-entry-points"
+    "e2e": "ng e2e --port 0"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
This commit removed no longer needed postinstall step (to run ngcc) from integration test apps, to avoid extra processing.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: test-related improvements.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No