### PR TITLE
docs: replace broken  `<br/>` from service worker

### DIFF
--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -97,7 +97,7 @@ As a result, that new tab can be running a different version of the application 
 
 <div class="alert is-important">
 
-**IMPORTANT**: </br />
+**IMPORTANT**: <br />
 This guarantee is **stronger** than that provided by the normal web deployment model.
 Without a service worker, there is no guarantee that code lazily loaded later in a running application is from the same version as the initial code for the application.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Wrong rendering of html on https://angular.io/guide/service-worker-devops
![Angular-Service-worker-in-production](https://user-images.githubusercontent.com/18737653/171109679-35b0e531-bfc7-475f-848a-8fd0fd9ff161.png)

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
