### PR TITLE
feat(compiler): support non-ASCII indentifier in Angular expressions

### DIFF
--- a/packages/compiler/src/chars.ts
+++ b/packages/compiler/src/chars.ts
@@ -75,6 +75,8 @@ export const $AT = 64;
 
 export const $BT = 96;
 
+export const $NON_ASCII_START = 0x80;
+
 export function isWhitespace(code: number): boolean {
   return (code >= $TAB && code <= $SPACE) || (code == $NBSP);
 }
@@ -85,6 +87,10 @@ export function isDigit(code: number): boolean {
 
 export function isAsciiLetter(code: number): boolean {
   return code >= $a && code <= $z || code >= $A && code <= $Z;
+}
+
+export function isNonAscii(code: number): boolean {
+  return code >= $NON_ASCII_START;
 }
 
 export function isAsciiHexDigit(code: number): boolean {

--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -408,7 +408,7 @@ class _Scanner {
 
 function isIdentifierStart(code: number): boolean {
   return (chars.$a <= code && code <= chars.$z) || (chars.$A <= code && code <= chars.$Z) ||
-      (code == chars.$_) || (code == chars.$$);
+      (code == chars.$_) || (code == chars.$$) || chars.isNonAscii(code);
 }
 
 export function isIdentifier(input: string): boolean {
@@ -425,7 +425,7 @@ export function isIdentifier(input: string): boolean {
 
 function isIdentifierPart(code: number): boolean {
   return chars.isAsciiLetter(code) || chars.isDigit(code) || (code == chars.$_) ||
-      (code == chars.$$);
+      (code == chars.$$) || chars.isNonAscii(code);
 }
 
 function isExponentStart(code: number): boolean {

--- a/packages/compiler/test/expression_parser/lexer_spec.ts
+++ b/packages/compiler/test/expression_parser/lexer_spec.ts
@@ -75,6 +75,12 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
         expectIdentifierToken(tokens[0], 0, 1, 'j');
       });
 
+      it('should tokenize a non-ascii identifier', () => {
+        const tokens: number[] = lex('我的');
+        expect(tokens.length).toEqual(1);
+        expectIdentifierToken(tokens[0], 0, 2, '我的');
+      });
+
       it('should tokenize "this"', () => {
         const tokens: number[] = lex('this');
         expect(tokens.length).toEqual(1);
@@ -89,10 +95,25 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
         expectIdentifierToken(tokens[2], 2, 3, 'k');
       });
 
+
+      it('should tokenize a dotted non-ascii identifier', () => {
+        const tokens: number[] = lex('我的.属性');
+        expect(tokens.length).toEqual(3);
+        expectIdentifierToken(tokens[0], 0, 2, '我的');
+        expectCharacterToken(tokens[1], 2, 3, '.');
+        expectIdentifierToken(tokens[2], 3, 5, '属性');
+      });
+
       it('should tokenize a private identifier', () => {
         const tokens: number[] = lex('#a');
         expect(tokens.length).toEqual(1);
         expectPrivateIdentifierToken(tokens[0], 0, 2, '#a');
+      });
+
+      it('should tokenize a private non-ascii identifier', () => {
+        const tokens: number[] = lex('#我的');
+        expect(tokens.length).toEqual(1);
+        expectPrivateIdentifierToken(tokens[0], 0, 3, '#我的');
       });
 
       it('should tokenize a property access with private identifier', () => {
@@ -101,6 +122,14 @@ function expectErrorToken(token: Token, index: any, end: number, message: string
         expectIdentifierToken(tokens[0], 0, 1, 'j');
         expectCharacterToken(tokens[1], 1, 2, '.');
         expectPrivateIdentifierToken(tokens[2], 2, 4, '#k');
+      });
+
+      it('should tokenize a property access with private non-ascii identifier', () => {
+        const tokens: number[] = lex('我的.#属性');
+        expect(tokens.length).toEqual(3);
+        expectIdentifierToken(tokens[0], 0, 2, '我的');
+        expectCharacterToken(tokens[1], 2, 3, '.');
+        expectPrivateIdentifierToken(tokens[2], 3, 6, '#属性');
       });
 
       it('should throw an invalid character error when a hash character is discovered but ' +

--- a/packages/language-service/test/completions_spec.ts
+++ b/packages/language-service/test/completions_spec.ts
@@ -873,7 +873,7 @@ describe('completions', () => {
 
   describe('pipe scope', () => {
     it('should complete a pipe binding', () => {
-      const {templateFile} = setup(`{{ foo | some¦ }}`, '', SOME_PIPE);
+      const {templateFile} = setup(`{{ foo | some }}`, '', SOME_PIPE);
       templateFile.moveCursorToText('some¦');
       const completions = templateFile.getCompletionsAtPosition();
       expectContain(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
throws error when using non-ASCII indentifier in Angular expressions.

```typescript
@Component({
  selector: 'my-app',
  // error NG5002: Parser Error: Lexer Error: Unexpected character [我] at column 2 in expression [ 我的 ] at column 3 in [{{ 我的 }} ] ...
  //   template: '<div>{{ 我的 }} </div>',
  //                   ~~~~~~~~~
  template: '<div>{{ 我的 }} </div>',
})
export class AppComponent  {
  // Chinese character
  我的 = 'Angular';
}
```
Issue Number: #517


## What is the new behavior?
support non-ASCII indentifier in Angular expressions

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
