### PR TITLE
refactor(core): remove unused error handler logic

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -41,7 +41,7 @@
   "forms": {
     "uncompressed": {
       "runtime": 1063,
-      "main": 159280,
+      "main": 158766,
       "polyfills": 33804
     }
   },

--- a/packages/core/src/error_handler.ts
+++ b/packages/core/src/error_handler.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {getErrorLogger, getOriginalError} from './util/errors';
+import {getOriginalError} from './util/errors';
 
 /**
  * Provides a hook for centralized exception handling.
@@ -41,13 +41,10 @@ export class ErrorHandler {
 
   handleError(error: any): void {
     const originalError = this._findOriginalError(error);
-    // Note: Browser consoles show the place from where console.error was called.
-    // We can use this to give users additional information about the error.
-    const errorLogger = getErrorLogger(error);
 
-    errorLogger(this._console, `ERROR`, error);
+    this._console.error('ERROR', error);
     if (originalError) {
-      errorLogger(this._console, `ORIGINAL ERROR`, originalError);
+      this._console.error('ORIGINAL ERROR', originalError);
     }
   }
 

--- a/packages/core/src/util/errors.ts
+++ b/packages/core/src/util/errors.ts
@@ -7,8 +7,6 @@
  */
 
 export const ERROR_ORIGINAL_ERROR = 'ngOriginalError';
-export const ERROR_LOGGER = 'ngErrorLogger';
-
 
 export function wrappedError(message: string, originalError: any): Error {
   const msg = `${message} caused by: ${
@@ -20,12 +18,4 @@ export function wrappedError(message: string, originalError: any): Error {
 
 export function getOriginalError(error: Error): Error {
   return (error as any)[ERROR_ORIGINAL_ERROR];
-}
-
-export function getErrorLogger(error: unknown): (console: Console, ...values: any[]) => void {
-  return error && (error as any)[ERROR_LOGGER] || defaultErrorLogger;
-}
-
-function defaultErrorLogger(console: Console, ...values: any[]) {
-  (<any>console.error)(...values);
 }

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -717,9 +717,6 @@
     "name": "deepForEach"
   },
   {
-    "name": "defaultErrorLogger"
-  },
-  {
     "name": "defaultScheduler"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -729,9 +729,6 @@
     "name": "deepForEach"
   },
   {
-    "name": "defaultErrorLogger"
-  },
-  {
     "name": "defaultIterableDiffersFactory"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -702,9 +702,6 @@
     "name": "deepForEach"
   },
   {
-    "name": "defaultErrorLogger"
-  },
-  {
     "name": "defaultIterableDiffersFactory"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -996,9 +996,6 @@
     "name": "defaultErrorHandler"
   },
   {
-    "name": "defaultErrorLogger"
-  },
-  {
     "name": "defaultIfEmpty"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -432,9 +432,6 @@
     "name": "deepForEach"
   },
   {
-    "name": "defaultErrorLogger"
-  },
-  {
     "name": "defaultScheduler"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -282,9 +282,6 @@
     "name": "createTView"
   },
   {
-    "name": "defaultErrorLogger"
-  },
-  {
     "name": "defaultIterableDiffersFactory"
   },
   {

--- a/packages/core/test/error_handler_spec.ts
+++ b/packages/core/test/error_handler_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ErrorHandler} from '../src/error_handler';
-import {ERROR_LOGGER, wrappedError} from '../src/util/errors';
+import {wrappedError} from '../src/util/errors';
 
 class MockConsole {
   res: any[][] = [];
@@ -16,7 +16,6 @@ class MockConsole {
   }
 }
 
-(function() {
 function errorToString(error: any) {
   const logger = new MockConsole();
   const errorHandler = new ErrorHandler();
@@ -56,19 +55,4 @@ describe('ErrorHandler', () => {
       expect(e).toContain('custom');
     });
   });
-
-  it('should use the error logger on the error', () => {
-    const err = new Error('test');
-    const console = new MockConsole();
-    const errorHandler = new ErrorHandler();
-    (errorHandler as any)._console = console as any;
-    const logger = jasmine.createSpy('logger');
-    (err as any)[ERROR_LOGGER] = logger;
-
-    errorHandler.handleError(err);
-
-    expect(console.res).toEqual([]);
-    expect(logger).toHaveBeenCalledWith(console, 'ERROR', err);
-  });
 });
-})();


### PR DESCRIPTION
There's some old logic in the error handler that tries to read an `ngErrorHandler` property off of the errors that are being logged. As far as I can tell, this is a ViewEngine leftover and it isn't actually being used anywhere.