### PR TITLE
fix(docs-infra): correct developer preview link

### DIFF
--- a/aio/tools/transforms/templates/api/base.template.html
+++ b/aio/tools/transforms/templates/api/base.template.html
@@ -36,7 +36,7 @@
     </label>{% endif %}
     {%- if doc.developerPreview %}
     <label class="api-status-label dev-preview" title="This API is in Developer Preview">
-      <a href="{$ github.githubVersionedUrl(versionInfo) $}/guide/releases#developer-preview">developer preview</a>
+      <a href="guide/releases#developer-preview">developer preview</a>
     </label>
     {% endif %}
   </header>

--- a/aio/tools/transforms/templates/api/decorator.template.html
+++ b/aio/tools/transforms/templates/api/decorator.template.html
@@ -19,7 +19,7 @@
             <h3>{$ option.name $}</h3>
             {%- if option.developerPreview %}
             <label class="api-status-label dev-preview" title="This API is in Developer Preview">
-              <a href="{$ github.githubVersionedUrl(versionInfo) $}/guide/releases#developer-preview">developer
+              <a href="guide/releases#developer-preview">developer
                 preview</a>
             </label>
             {% endif %}

--- a/aio/tools/transforms/templates/api/includes/decorator-overview.html
+++ b/aio/tools/transforms/templates/api/includes/decorator-overview.html
@@ -16,7 +16,7 @@
       <td>
         {%- if option.developerPreview %}
         <label class="api-status-label dev-preview" title="This API is in Developer Preview">
-          <a href="{$ github.githubVersionedUrl(versionInfo) $}/guide/releases#developer-preview">developer preview</a>
+          <a href="guide/releases#developer-preview">developer preview</a>
         </label>
         {% endif %}
 


### PR DESCRIPTION
The developer preview link was previously prefixed with the Github URL for
Angular's repo. However, it's meant to go to a guide page on AIO itself.
This commit removes the link prefix.
