### PR TITLE
docs: annotate more APIs with the `@developerPreview` tag

### DIFF
--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -27,6 +27,7 @@ import {INJECTOR_DEF_TYPES} from './internal_tokens';
 /**
  * A source of providers for the `importProvidersFrom` function.
  *
+ * @developerPreview
  * @publicApi
  */
 export type ImportProvidersSource =

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -24,6 +24,7 @@ const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 /**
  * Set of config options available during the bootstrap operation via `bootstrapApplication` call.
  *
+ * @developerPreview
  * @publicApi
  */
 export interface ApplicationConfig {
@@ -114,6 +115,7 @@ export function bootstrapApplication(
  * @returns An array of providers required to setup Testability for an application and make it
  *     available for testing using Protractor.
  *
+ * @developerPreview
  * @publicApi
  */
 export function provideProtractorTestingSupport(): Provider[] {


### PR DESCRIPTION
This commit updates a few more standalone-related APIs with the `@developerPreview` tag.


## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No