### PR TITLE
refactor(core): remove unnecessary periods in runtime errors formatting

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -103,10 +103,13 @@ export function formatRuntimeError<T extends number = RuntimeErrorCode>(
   // generate a link to the error details page on angular.io.
   const fullCode = `NG0${Math.abs(code)}`;
 
-  let errorMessage = `${fullCode}${message ? ': ' + message : ''}`;
+  let errorMessage = `${fullCode}${message ? ': ' + message.trim() : ''}`;
 
   if (ngDevMode && code < 0) {
-    errorMessage = `${errorMessage}. Find more at ${ERROR_DETAILS_PAGE_BASE_URL}/${fullCode}`;
+    const addPeriodSeparator = !errorMessage.match(/[.,;!?]$/);
+    const separator = addPeriodSeparator ? '.' : '';
+    errorMessage =
+        `${errorMessage}${separator} Find more at ${ERROR_DETAILS_PAGE_BASE_URL}/${fullCode}`;
   }
   return errorMessage;
 }

--- a/packages/core/test/runtime_error_spec.ts
+++ b/packages/core/test/runtime_error_spec.ts
@@ -9,24 +9,24 @@
 import {RuntimeError, RuntimeErrorCode} from '../src/errors';
 
 describe('RuntimeError utils', () => {
-  it('should format the error message correctly', () => {
-    // Error with a guide, but without an error message.
-    let errorInstance = new RuntimeError<RuntimeErrorCode>(RuntimeErrorCode.EXPORT_NOT_FOUND, '');
-    expect(errorInstance.toString())
-        .toBe('Error: NG0301. Find more at https://angular.io/errors/NG0301');
+  it('should correctly format an error without an error message', () => {
+    const error = new RuntimeError<RuntimeErrorCode>(RuntimeErrorCode.EXPORT_NOT_FOUND, '');
+    expect(error.toString()).toBe('Error: NG0301. Find more at https://angular.io/errors/NG0301');
+  });
 
-    // Error without a guide and an error message.
-    errorInstance = new RuntimeError(RuntimeErrorCode.TEMPLATE_STRUCTURE_ERROR, '');
-    expect(errorInstance.toString()).toBe('Error: NG0305');
+  it('should correctly format an error without an error message not aio guide', () => {
+    const error = new RuntimeError(RuntimeErrorCode.TEMPLATE_STRUCTURE_ERROR, '');
+    expect(error.toString()).toBe('Error: NG0305');
+  });
 
-    // Error without a guide, but with an error message.
-    errorInstance =
-        new RuntimeError(RuntimeErrorCode.TEMPLATE_STRUCTURE_ERROR, 'Some error message');
-    expect(errorInstance.toString()).toBe('Error: NG0305: Some error message');
+  it('should correctly format an error with an error message but without an aio guide', () => {
+    const error = new RuntimeError(RuntimeErrorCode.TEMPLATE_STRUCTURE_ERROR, 'Some error message');
+    expect(error.toString()).toBe('Error: NG0305: Some error message');
+  });
 
-    // Error with both a guide and an error message.
-    errorInstance = new RuntimeError(RuntimeErrorCode.EXPORT_NOT_FOUND, 'Some error message');
-    expect(errorInstance.toString())
+  it('should correctly format an error with both an error message and an aio guide', () => {
+    const error = new RuntimeError(RuntimeErrorCode.EXPORT_NOT_FOUND, 'Some error message');
+    expect(error.toString())
         .toBe('Error: NG0301: Some error message. Find more at https://angular.io/errors/NG0301');
   });
 

--- a/packages/core/test/runtime_error_spec.ts
+++ b/packages/core/test/runtime_error_spec.ts
@@ -29,4 +29,30 @@ describe('RuntimeError utils', () => {
     expect(errorInstance.toString())
         .toBe('Error: NG0301: Some error message. Find more at https://angular.io/errors/NG0301');
   });
+
+  it('should trim the provided error message', () => {
+    const error = new RuntimeError(RuntimeErrorCode.EXPORT_NOT_FOUND, '   Some error message ');
+    expect(error.toString())
+        .toBe('Error: NG0301: Some error message. Find more at https://angular.io/errors/NG0301');
+  });
+
+  ['.', ',', ';', '!', '?'].forEach(
+      character => it(
+          `should not add a period between the error message and the aio guide suffix if the message ends with '${
+              character}'`,
+          () => {
+            const errorMessage = `Pipe not found${character}`;
+            const error =
+                new RuntimeError<RuntimeErrorCode>(RuntimeErrorCode.PIPE_NOT_FOUND, errorMessage);
+            expect(error.toString())
+                .toBe(`Error: NG0302: Pipe not found${
+                    character} Find more at https://angular.io/errors/NG0302`);
+          }));
+
+  it('should trim the error message before applying the period check', () => {
+    const errorMessage = `Pipe not found?  `;
+    const error = new RuntimeError<RuntimeErrorCode>(RuntimeErrorCode.PIPE_NOT_FOUND, errorMessage);
+    expect(error.toString())
+        .toBe(`Error: NG0302: Pipe not found? Find more at https://angular.io/errors/NG0302`);
+  });
 });


### PR DESCRIPTION
the formatted error messages always include a period separator between the
provided error message and the find-more suffix, this is not always
desirable as it may add periods when they shoud not be, so improve the
formatting by checking and applying the period only if the provided message
doesn't end with a character which already represents a separator

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue
Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
@AndrewKushnir :slightly_smiling_face::+1: 