### PR TITLE
docs: fix missing closing div in http page

### DIFF
--- a/aio/content/guide/http.md
+++ b/aio/content/guide/http.md
@@ -762,6 +762,8 @@ The original response continues untouched back up through the chain of intercept
 
 Data services, such as `PackageSearchService`, are unaware that some of their `HttpClient` requests actually return cached responses.
 
+</div>
+  
 <a id="cache-refresh"></a>
 
 ### Using interceptors to request multiple values


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Alert div is not closing in [http](https://angular.io/guide/http) doc page:

![image](https://user-images.githubusercontent.com/741938/172026956-a8183f35-d3d8-4632-b430-780ada28497f.png)

Issue Number: N/A


## What is the new behavior?

Closing div in [http](https://angular.io/guide/http) doc page.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
