### PR TITLE
docs: change wrong alerts to callouts

### DIFF
--- a/aio/content/guide/hierarchical-dependency-injection.md
+++ b/aio/content/guide/hierarchical-dependency-injection.md
@@ -41,7 +41,7 @@ The `ModuleInjector` can be configured in one of two ways:
 
 <div class="callout is-helpful">
 
-<header>Tree-shaking and <code>&commat;Injectable()</code></header>
+<header>Tree-shaking and &commat;Injectable()</header>
 
 Using the `@Injectable()` `providedIn` property is preferable to the `@NgModule()` `providers` array because with `@Injectable()` `providedIn`, optimization tools can perform tree-shaking, which removes services that your application isn't using and results in smaller bundle sizes.
 
@@ -112,7 +112,7 @@ All requests forward up to the root injector, whether you configured it with the
 
 <div class="callout is-helpful">
 
-<header><code>&commat;Injectable()</code> vs. <code>&commat;NgModule()</code></header>
+<header>&commat;Injectable() vs. &commat;NgModule()</header>
 
 If you configure an app-wide provider in the `@NgModule()` of `AppModule`, it overrides one configured for `root` in the `@Injectable()` metadata.
 You can do this to configure a non-default provider of a service that is shared with multiple applications.

--- a/aio/content/guide/hierarchical-dependency-injection.md
+++ b/aio/content/guide/hierarchical-dependency-injection.md
@@ -39,7 +39,7 @@ The `ModuleInjector` can be configured in one of two ways:
 *   Using the `@Injectable()` `providedIn` property to refer to `@NgModule()`, or `root`
 *   Using the `@NgModule()` `providers` array
 
-<div class="is-helpful alert">
+<div class="callout is-helpful">
 
 <header>Tree-shaking and <code>&commat;Injectable()</code></header>
 
@@ -110,7 +110,7 @@ You have the option to create `ModuleInjector`s whenever a dynamically loaded co
 
 All requests forward up to the root injector, whether you configured it with the `bootstrapModule()` method, or registered all providers with `root` in their own services.
 
-<div class="alert is-helpful">
+<div class="callout is-helpful">
 
 <header><code>&commat;Injectable()</code> vs. <code>&commat;NgModule()</code></header>
 

--- a/aio/content/guide/upgrade-performance.md
+++ b/aio/content/guide/upgrade-performance.md
@@ -77,7 +77,7 @@ For the most part, you specify the modules in the same way you would for a regul
 Then, you use the `upgrade/static` helpers to let the two frameworks know about assets they can use from each other.
 This is known as "upgrading" and "downgrading".
 
-<div class="alert is-helpful">
+<div class="callout is-helpful">
 
 <header>Definitions:</header>
 

--- a/aio/content/guide/upgrade.md
+++ b/aio/content/guide/upgrade.md
@@ -1171,7 +1171,7 @@ That is pretty exciting!
 You're not running any actual Angular components yet.
 That is next.
 
-<div class="alert is-helpful">
+<div class="callout is-helpful">
 
 <header>Why declare *angular* as *angular.IAngularStatic*?</header>
 
@@ -1183,7 +1183,7 @@ If you used `import * as angular from 'angular'` instead, you'd also have to loa
 This is a considerable effort and it often isn't worth it, especially since you are in the process of moving your code to Angular.
 Instead, declare `angular` as `angular.IAngularStatic` to indicate it is a global variable and still have full typing support.
 
-<div class="alert is-important">
+<div class="callout is-important">
 
 <header>Manually create a UMD bundle for your Angular application</header>
 

--- a/aio/content/guide/user-input.md
+++ b/aio/content/guide/user-input.md
@@ -142,7 +142,7 @@ Type something in the input box, and watch the display update with each keystrok
 
 </div>
 
-<div class="alert is-helpful">
+<div class="callout is-helpful">
 
 <header>This won't work at all unless you bind to an event.</header>
 

--- a/aio/content/guide/zone.md
+++ b/aio/content/guide/zone.md
@@ -440,7 +440,7 @@ By default, `Zone` is loaded and works without additional configuration.
 However, you don't necessarily have to use `Zone` to make Angular work.
 Instead, you can opt to trigger change detection on your own.
 
-<div class="alert is-helpful">
+<div class="callout is-helpful">
 
 <header>Disabling <code>Zone</code></header>
 

--- a/aio/content/guide/zone.md
+++ b/aio/content/guide/zone.md
@@ -442,7 +442,7 @@ Instead, you can opt to trigger change detection on your own.
 
 <div class="callout is-helpful">
 
-<header>Disabling <code>Zone</code></header>
+<header>Disabling Zone</header>
 
 **If you disable `Zone`, you will need to trigger all change detection at the correct timing yourself, which requires comprehensive knowledge of change detection**.
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

In the aio docs there are some alerts with headers but alerts don't support headers (see the [docs style guide - alerts and callouts](https://angular.io/guide/docs-style-guide#alerts-and-callouts) section) and this just causes such headers to be wrongly rendered, as for example the [ModuleInjector one](https://angular.io/guide/hierarchical-dependency-injection#moduleinjector):

![Screenshot at 2022-06-05 17-49-22](https://user-images.githubusercontent.com/61631103/172064263-3798b520-e2ff-44ed-9c18-3fb5b3fcfc13.png)


## What is the new behavior?

Such alerts have been converted to callouts so that the headers are not correctly rendered:

![Screenshot at 2022-06-05 19-02-30](https://user-images.githubusercontent.com/61631103/172064343-c861b33c-e096-4464-b14a-eb1bb3c2dedb.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - this is exactly the same as #46145 , then I thought that was a one thing so I did not check for other occurrences, this time around I've run a regex search so hopefully I got all them all :slightly_smiling_face: 
 - I needed to remove the code tags from the headers since they were rendered quite awkwardly (with a very low color contrast):
![Screenshot at 2022-06-05 18-59-10](https://user-images.githubusercontent.com/61631103/172064459-330123c2-5e27-4f78-96e5-60fcc586fbc8.png)
(I did that in a separate fixup commit, so if you disagree I can easily drop that one)
