### PR TITLE
docs: mark version 13 as LTS in releases guide

### DIFF
--- a/aio/content/guide/releases.md
+++ b/aio/content/guide/releases.md
@@ -120,7 +120,7 @@ The following table provides the status for Angular versions under support.
 | Version | Status | Released   | Active ends | LTS ends   |
 |:---     |:---    |:---        |:---         |:---        |
 | ^14.0.0 | Active | 2022-06-02 | 2022-12-02  | 2023-12-02 |
-| ^13.0.0 | Active | 2021-11-04 | 2022-06-02  | 2023-05-04 |
+| ^13.0.0 | LTS    | 2021-11-04 | 2022-06-02  | 2023-05-04 |
 | ^12.0.0 | LTS    | 2021-05-12 | 2021-11-12  | 2022-11-12 |
 
 Angular versions v2 to v11 are no longer under support.


### PR DESCRIPTION
Verson 13 is now in LTS.
