### PR TITLE
fix(common): allow null in ngComponentOutlet

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -416,7 +416,7 @@ export class NgClass implements DoCheck {
 export class NgComponentOutlet implements OnChanges, OnDestroy {
     constructor(_viewContainerRef: ViewContainerRef);
     // (undocumented)
-    ngComponentOutlet: Type<any>;
+    ngComponentOutlet: Type<any> | null;
     // (undocumented)
     ngComponentOutletContent?: any[][];
     // (undocumented)

--- a/packages/common/src/directives/ng_component_outlet.ts
+++ b/packages/common/src/directives/ng_component_outlet.ts
@@ -70,7 +70,7 @@ import {ComponentRef, createNgModuleRef, Directive, Injector, Input, NgModuleFac
  */
 @Directive({selector: '[ngComponentOutlet]'})
 export class NgComponentOutlet implements OnChanges, OnDestroy {
-  @Input() ngComponentOutlet!: Type<any>;
+  @Input() ngComponentOutlet: Type<any>|null = null;
 
   @Input() ngComponentOutletInjector?: Injector;
   @Input() ngComponentOutletContent?: any[][];


### PR DESCRIPTION
`ngComponentOutlet` already handles null/undefined values, but the types don't reflect that. These changes update the types.

Fixes #45716.