### PR TITLE
build: update dev-infra shared code to latest revision

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-      - uses: angular/dev-infra/github-actions/commit-message-based-labels@d9ebdd25b15708c18acc99ac1bfb8101d765f703
+      - uses: angular/dev-infra/github-actions/commit-message-based-labels@91ba217766e28a53c469d5ca43a76e37af64e3f1
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
   post_approval_changes:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-      - uses: angular/dev-infra/github-actions/post-approval-changes@d9ebdd25b15708c18acc99ac1bfb8101d765f703
+      - uses: angular/dev-infra/github-actions/post-approval-changes@91ba217766e28a53c469d5ca43a76e37af64e3f1
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/feature-requests.yml
+++ b/.github/workflows/feature-requests.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.repository == 'angular/angular'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/feature-request@d9ebdd25b15708c18acc99ac1bfb8101d765f703
+      - uses: angular/dev-infra/github-actions/feature-request@91ba217766e28a53c469d5ca43a76e37af64e3f1
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.repository == 'angular/angular'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@d9ebdd25b15708c18acc99ac1bfb8101d765f703
+      - uses: angular/dev-infra/github-actions/lock-closed@91ba217766e28a53c469d5ca43a76e37af64e3f1
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
   },
   "// 2": "devDependencies are not used under Bazel. Many can be removed after test.sh is deleted.",
   "devDependencies": {
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#896abf3bcff5a8513def1b86e019818c997cd90a",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#e45a962f80dbcd36bcdfe82497d8b6ce3990506c",
     "@bazel/bazelisk": "^1.7.5",
     "@bazel/buildifier": "^5.0.0",
     "@bazel/ibazel": "^0.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,12 +18,12 @@
     "@angular-devkit/core" "13.3.6"
     rxjs "6.6.7"
 
-"@angular-devkit/architect@0.1400.0-rc.1":
-  version "0.1400.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1400.0-rc.1.tgz#625eb39870027edca3b83262fe9f9d84bfc0aeee"
-  integrity sha512-mr+K42ohs8fHTkinvf3/11XtpCbBwoK0AFT7tISnBlni1h/TkAoWPWjcLhnnUAAqAB3vA5t3oqgjxojdnJij9g==
+"@angular-devkit/architect@0.1400.0-rc.3":
+  version "0.1400.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1400.0-rc.3.tgz#54e328a203f98f243298b014bf4ce2abfde32a06"
+  integrity sha512-lv0HB50hyrKZDpImI3lk8BVzmD0zUIPARZ/2/wpS3ZCY5lpNSHZSGiN7SnMB9Y2h+RpbjTYeF7/5WLs0cXA6UA==
   dependencies:
-    "@angular-devkit/core" "14.0.0-rc.1"
+    "@angular-devkit/core" "14.0.0-rc.3"
     rxjs "6.6.7"
 
 "@angular-devkit/build-angular@13.3.6":
@@ -98,15 +98,15 @@
   optionalDependencies:
     esbuild "0.14.22"
 
-"@angular-devkit/build-angular@14.0.0-rc.1":
-  version "14.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-angular/-/build-angular-14.0.0-rc.1.tgz#1df00720712797c931687b64668dd634d11758ec"
-  integrity sha512-NjN/0IKRPRoUkUFQQlHhjk8aJ2Fcfv5C/whCKWqaN/kE7IDlCVEIT7ohrHgXPhkiDmVlJXX1QdaYfzgkXKErTA==
+"@angular-devkit/build-angular@14.0.0-rc.3":
+  version "14.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-angular/-/build-angular-14.0.0-rc.3.tgz#c168049a4e78b9ef6bed58521979aa5344983547"
+  integrity sha512-Blta5TUS548p8yxdR4pBYdEuzp7XkVxX38EhrFiPEAqgXyqDM8LwxCk8o9XwqLM9LtgqGd86x5RCx6YgTntUdw==
   dependencies:
     "@ampproject/remapping" "2.2.0"
-    "@angular-devkit/architect" "0.1400.0-rc.1"
-    "@angular-devkit/build-webpack" "0.1400.0-rc.1"
-    "@angular-devkit/core" "14.0.0-rc.1"
+    "@angular-devkit/architect" "0.1400.0-rc.3"
+    "@angular-devkit/build-webpack" "0.1400.0-rc.3"
+    "@angular-devkit/core" "14.0.0-rc.3"
     "@babel/core" "7.17.10"
     "@babel/generator" "7.17.10"
     "@babel/helper-annotate-as-pure" "7.16.7"
@@ -117,7 +117,7 @@
     "@babel/runtime" "7.17.9"
     "@babel/template" "7.16.7"
     "@discoveryjs/json-ext" "0.5.7"
-    "@ngtools/webpack" "14.0.0-rc.1"
+    "@ngtools/webpack" "14.0.0-rc.3"
     ansi-colors "4.1.1"
     babel-loader "8.2.5"
     babel-plugin-istanbul "6.1.1"
@@ -195,12 +195,12 @@
     "@angular-devkit/architect" "0.1303.6"
     rxjs "6.6.7"
 
-"@angular-devkit/build-webpack@0.1400.0-rc.1":
-  version "0.1400.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.1400.0-rc.1.tgz#69107ea2297fc97d406af8586f0d9076e5453e58"
-  integrity sha512-4QZTYzF6a7953NI6FnhwxRq5TOyvjd5lB7yCX4NJ+3AD7wOcEaM1of832hUGAUkH0yPT/HrygT4Nclw4/98ySA==
+"@angular-devkit/build-webpack@0.1400.0-rc.3":
+  version "0.1400.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.1400.0-rc.3.tgz#b862775a13b12eb0334afaa837f63d22aceaf909"
+  integrity sha512-AF+7lg4evuFGMYaU5S26zQm3bqRIjF2cA1HIwNFjwSLVBT/NC7+vZKY8HeyIXkeWid2LTiwgb+qZ/Qm1ei+1lg==
   dependencies:
-    "@angular-devkit/architect" "0.1400.0-rc.1"
+    "@angular-devkit/architect" "0.1400.0-rc.3"
     rxjs "6.6.7"
 
 "@angular-devkit/core@13.3.6":
@@ -215,10 +215,10 @@
     rxjs "6.6.7"
     source-map "0.7.3"
 
-"@angular-devkit/core@14.0.0-rc.1":
-  version "14.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-14.0.0-rc.1.tgz#f85d213c8e2617f948bb3e8e0767aa2865cbd598"
-  integrity sha512-Zb+Qnrq44xYgF3W0E8IsyzyPlS26JpD/Mpa28kPMELlI3id9qKJsmpvBjtklcjJG9MKQpRpigwhH21u++6I3+g==
+"@angular-devkit/core@14.0.0-rc.3":
+  version "14.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-14.0.0-rc.3.tgz#65e3083451f859032942c4e037daf67095319bf0"
+  integrity sha512-J+oWWvhJM1bOzsvyyIPxg56L0VEas/OwB9Sa8VdpZL873H03qnAgRdREOCPWhb/G6NBAG+UOFWPl62iMPIF+xw==
   dependencies:
     ajv "8.11.0"
     ajv-formats "2.1.1"
@@ -307,11 +307,11 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#896abf3bcff5a8513def1b86e019818c997cd90a":
-  version "0.0.0-d9ebdd25b15708c18acc99ac1bfb8101d765f703"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#896abf3bcff5a8513def1b86e019818c997cd90a"
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#e45a962f80dbcd36bcdfe82497d8b6ce3990506c":
+  version "0.0.0-91ba217766e28a53c469d5ca43a76e37af64e3f1"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#e45a962f80dbcd36bcdfe82497d8b6ce3990506c"
   dependencies:
-    "@angular-devkit/build-angular" "14.0.0-rc.1"
+    "@angular-devkit/build-angular" "14.0.0-rc.3"
     "@angular/benchpress" "0.3.0"
     "@babel/core" "^7.16.0"
     "@bazel/buildifier" "5.1.0"
@@ -321,7 +321,7 @@
     "@bazel/runfiles" "5.5.0"
     "@bazel/terser" "5.5.0"
     "@bazel/typescript" "5.5.0"
-    "@microsoft/api-extractor" "7.24.1"
+    "@microsoft/api-extractor" "7.24.2"
     "@types/browser-sync" "^2.26.3"
     "@types/node" "16.10.9"
     "@types/node-fetch" "^2.5.10"
@@ -336,12 +336,12 @@
     node-fetch "^2.6.1"
     prettier "2.6.2"
     protractor "^7.0.0"
-    selenium-webdriver "4.1.2"
+    selenium-webdriver "4.2.0"
     send "^0.18.0"
     tmp "^0.2.1"
     "true-case-path" "^2.2.1"
     tslib "^2.3.0"
-    typescript "~4.6.2"
+    typescript "~4.7.0"
     uuid "^8.3.2"
     yargs "^17.0.0"
 
@@ -2046,25 +2046,7 @@
     "@microsoft/tsdoc-config" "~0.16.1"
     "@rushstack/node-core-library" "3.45.5"
 
-"@microsoft/api-extractor@7.24.1":
-  version "7.24.1"
-  resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.24.1.tgz#cbbe32a5f4f32717b60f593cdc172b99e5c76fae"
-  integrity sha512-RjcKRvKRAtTK4z8UdC2qYsvgTYHEYvdsqF4QGoX4mNAVo7s6Jj4zcHtSrMEQMTUHujZbSd5+ihI5ktISp338mQ==
-  dependencies:
-    "@microsoft/api-extractor-model" "7.17.3"
-    "@microsoft/tsdoc" "0.14.1"
-    "@microsoft/tsdoc-config" "~0.16.1"
-    "@rushstack/node-core-library" "3.45.5"
-    "@rushstack/rig-package" "0.3.11"
-    "@rushstack/ts-command-line" "4.11.0"
-    colors "~1.2.1"
-    lodash "~4.17.15"
-    resolve "~1.17.0"
-    semver "~7.3.0"
-    source-map "~0.6.1"
-    typescript "~4.6.3"
-
-"@microsoft/api-extractor@^7.24.2":
+"@microsoft/api-extractor@7.24.2", "@microsoft/api-extractor@^7.24.2":
   version "7.24.2"
   resolved "https://registry.yarnpkg.com/@microsoft/api-extractor/-/api-extractor-7.24.2.tgz#4abb24319fa77884dab6d807388056e9cd85488e"
   integrity sha512-QWZh9aQZvBAdRVK+Go8NiW8YNMN//OGiNqgA3iZ2sEy8imUqkRBCybXgmw2HkEYyPnn55CFoMKvnAHvV9+4B/A==
@@ -2102,10 +2084,10 @@
   resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-13.3.6.tgz#98c9c830d1a4367a51593b1f12ca28b096b740ad"
   integrity sha512-QSdFtQIUgnDvM0EXFOpVRp5HTN0U4B9z60fHHfKKzxpNuU3z9EFzJoDUMZ8WabLXtWboUZWCSx0x3tdBt/sVQw==
 
-"@ngtools/webpack@14.0.0-rc.1":
-  version "14.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-14.0.0-rc.1.tgz#1188257876a7c6e40cde7f017729a5f1cb89274a"
-  integrity sha512-9CqEafLlZD09eqcu1a/rZjiglyBD0ufve8U87kBwOFc7ezWfWi+GLmAIdm3qdTQDcrthqZTKBOugCnxItiJLtA==
+"@ngtools/webpack@14.0.0-rc.3":
+  version "14.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-14.0.0-rc.3.tgz#2ba0e2b3b5b75ef91e87fd3024840c3745ad44a0"
+  integrity sha512-1FnYsG44kjSTJmJNDD7UECUlTKnWox6eKDhescMDW3x0nz0Ijsqnj+VpVdtVwrzbSQZ41l1xFpQbbgU4nVCq9w==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"
@@ -13991,7 +13973,6 @@ sass@1.51.0:
 
 "sauce-connect@https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz":
   version "0.0.0"
-  uid e5d7f82ad98251a653d1b0537f1103e49eda5e11
   resolved "https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz#e5d7f82ad98251a653d1b0537f1103e49eda5e11"
 
 saucelabs@7.1.3, saucelabs@^1.5.0, saucelabs@^4.6.3:
@@ -14077,10 +14058,10 @@ selenium-webdriver@3.6.0, selenium-webdriver@^3.0.1:
     tmp "0.0.30"
     xml2js "^0.4.17"
 
-selenium-webdriver@4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.1.2.tgz#d463b4335632d2ea41a9e988e435a55dc41f5314"
-  integrity sha512-e4Ap8vQvhipgBB8Ry9zBiKGkU6kHKyNnWiavGGLKkrdW81Zv7NVMtFOL/j3yX0G8QScM7XIXijKssNd4EUxSOw==
+selenium-webdriver@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.2.0.tgz#d3c9704735c6228e09580eb4613932b30bdb4d27"
+  integrity sha512-gPPXYSz4jJBM2kANRQ9cZW6KFBzR/ptxqGLtyC75eXtdgOsWWRRRyZz5F2pqdnwNmAjrCSFMMXfisJaZeWVejg==
   dependencies:
     jszip "^3.6.0"
     tmp "^0.2.1"
@@ -15750,10 +15731,15 @@ typescript@^4.6.2, typescript@~4.7.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
   integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
 
-typescript@~4.6.2, typescript@~4.6.3:
+typescript@~4.6.3:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
+
+typescript@~4.7.0:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
+  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
 
 ua-parser-js@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Updates dev-infra to the latest revision. This revision supports
for custom release prechecks and performs the release build
before the staging, verifying integrity later. This has various
benefits for stability and making the less less relucant to build
issues that mess up a previously-merged staging PR.