### PR TITLE
fix(compiler-cli): don't emit empty providers array

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/GOLDEN_PARTIAL.js
@@ -584,3 +584,58 @@ export declare class ForwardModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<ForwardModule>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: empty_fields.js
+ ****************************************************************************************************/
+import { NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class FooModule {
+}
+FooModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: FooModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+FooModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: FooModule });
+FooModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: FooModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: FooModule, decorators: [{
+            type: NgModule,
+            args: [{
+                    providers: [],
+                    declarations: [],
+                    imports: [],
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: empty_fields.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class FooModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<FooModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<FooModule, never, never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<FooModule>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: variable_providers.js
+ ****************************************************************************************************/
+import { InjectionToken, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+const PROVIDERS = [{ provide: new InjectionToken('token'), useValue: 1 }];
+export class FooModule {
+}
+FooModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: FooModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+FooModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: FooModule });
+FooModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: FooModule, providers: PROVIDERS });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: FooModule, decorators: [{
+            type: NgModule,
+            args: [{ providers: PROVIDERS }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: variable_providers.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class FooModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<FooModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<FooModule, never, never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<FooModule>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/TEST_CASES.json
@@ -164,6 +164,34 @@
       "angularCompilerOptions": {
         "linkerJitMode": true
       }
+    },
+    {
+      "description": "should not pass along empty array fields to the declaration",
+      "inputFiles": [
+        "empty_fields.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Invalid injector definition",
+          "files": [
+            "empty_fields.js"
+          ]
+        }
+      ]
+    },
+    {
+      "description": "should handle providers passed in as a variable",
+      "inputFiles": [
+        "variable_providers.ts"
+      ],
+      "expectations": [
+        {
+          "failureMessage": "Invalid injector definition",
+          "files": [
+            "variable_providers.js"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/empty_fields.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/empty_fields.js
@@ -1,0 +1,4 @@
+export class FooModule {}
+FooModule.ɵfac = …;
+FooModule.ɵmod = …;
+FooModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/empty_fields.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/empty_fields.ts
@@ -1,0 +1,9 @@
+import {NgModule} from '@angular/core';
+
+@NgModule({
+  providers: [],
+  declarations: [],
+  imports: [],
+})
+export class FooModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/variable_providers.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/variable_providers.js
@@ -1,0 +1,5 @@
+const PROVIDERS = [{provide: new InjectionToken('token'), useValue: 1}];
+export class FooModule {}
+FooModule.ɵfac = …;
+FooModule.ɵmod = …;
+FooModule.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({providers: PROVIDERS});

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/variable_providers.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/ng_modules/variable_providers.ts
@@ -1,0 +1,7 @@
+import {InjectionToken, NgModule} from '@angular/core';
+
+const PROVIDERS = [{provide: new InjectionToken('token'), useValue: 1}];
+
+@NgModule({providers: PROVIDERS})
+export class FooModule {
+}

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -107,7 +107,9 @@ export class CompilerFacadeImpl implements CompilerFacade {
       name: facade.name,
       type: wrapReference(facade.type),
       internalType: new WrappedNodeExpr(facade.type),
-      providers: new WrappedNodeExpr(facade.providers),
+      providers: facade.providers && facade.providers.length > 0 ?
+          new WrappedNodeExpr(facade.providers) :
+          null,
       imports: facade.imports.map(i => new WrappedNodeExpr(i)),
     };
     const res = compileInjector(meta);
@@ -661,8 +663,9 @@ function convertDeclareInjectorFacadeToMetadata(declaration: R3DeclareInjectorFa
     name: declaration.type.name,
     type: wrapReference(declaration.type),
     internalType: new WrappedNodeExpr(declaration.type),
-    providers: declaration.providers !== undefined ? new WrappedNodeExpr(declaration.providers) :
-                                                     null,
+    providers: declaration.providers !== undefined && declaration.providers.length > 0 ?
+        new WrappedNodeExpr(declaration.providers) :
+        null,
     imports: declaration.imports !== undefined ?
         declaration.imports.map(i => new WrappedNodeExpr(i)) :
         [],


### PR DESCRIPTION
Saves us some bytes by not emitting `providers` in `defineInjector`. While the amount of bytes isn't huge, I think that this change is worthwhile, because `ng generate` currently generates `providers: []` with every `NgModule` which users can forget to remove.

