### PR TITLE
build: exclude bazel commits from release notes

### DIFF
--- a/.ng-dev/release.ts
+++ b/.ng-dev/release.ts
@@ -30,7 +30,7 @@ export const release: ReleaseConfig = {
     return buildTargetPackages('dist/release-output', false, 'Release', /* isRelease */ true);
   },
   releaseNotes: {
-    hiddenScopes: ['aio', 'dev-infra', 'docs-infra', 'zone.js', 'devtools'],
+    hiddenScopes: ['aio', 'bazel', 'dev-infra', 'docs-infra', 'zone.js', 'devtools'],
   },
   releasePrLabels: ['comp: build & ci', 'action: merge', 'PullApprove: disable'],
 };


### PR DESCRIPTION
@angular/bazel has been deprecated since v10, and is no longer supported. We
don't need to mention fixes/features for Bazel in the release notes.