### PR TITLE
fix(docs-infra): add missing aria-labels to contributors page

### DIFF
--- a/aio/src/app/custom-elements/contributor/contributor.component.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.component.ts
@@ -15,15 +15,18 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
             <div class="contributor-image"
                  [style.background-image]="'url('+pictureBase+(person.picture || noPicture)+')'">
                  <div class="contributor-info">
-                     <button *ngIf="person.bio" mat-button class="info-item">
+                     <button *ngIf="person.bio" mat-button class="info-item"
+                        [attr.aria-label]="'View bio of ' + person.name">
                          View Bio
                      </button>
                      <a *ngIf="person.twitter" mat-icon-button class="info-item icon"
+                         [attr.aria-label]="'twitter of ' + person.name"
                          href="https://twitter.com/{{person.twitter}}"
                          target="_blank" (click)="$event.stopPropagation()">
                          <mat-icon svgIcon="logos:twitter"></mat-icon>
                      </a>
                      <a *ngIf="person.website" mat-icon-button class="info-item icon"
+                         [attr.aria-label]="'website of ' + person.name"
                          href="{{person.website}}" target="_blank" (click)="$event.stopPropagation()">
                          <mat-icon class="link-icon">link</mat-icon>
                      </a>

--- a/aio/src/app/custom-elements/contributor/contributor.component.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.component.ts
@@ -16,17 +16,17 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
                  [style.background-image]="'url('+pictureBase+(person.picture || noPicture)+')'">
                  <div class="contributor-info">
                      <button *ngIf="person.bio" mat-button class="info-item"
-                        [attr.aria-label]="'View bio of ' + person.name">
+                        attr.aria-label="view bio of {{person.name}}">
                          View Bio
                      </button>
                      <a *ngIf="person.twitter" mat-icon-button class="info-item icon"
-                         [attr.aria-label]="'twitter of ' + person.name"
+                         attr.aria-label="twitter of {{person.name}}"
                          href="https://twitter.com/{{person.twitter}}"
                          target="_blank" (click)="$event.stopPropagation()">
                          <mat-icon svgIcon="logos:twitter"></mat-icon>
                      </a>
                      <a *ngIf="person.website" mat-icon-button class="info-item icon"
-                         [attr.aria-label]="'website of ' + person.name"
+                         attr.aria-label="website of {{person.name}}"
                          href="{{person.website}}" target="_blank" (click)="$event.stopPropagation()">
                          <mat-icon class="link-icon">link</mat-icon>
                      </a>


### PR DESCRIPTION
add proper aria-labels for the twitter and website link of contributors
(which being icons they have no text) so that they can be correctly read
by screenreaders

also add aria-labels to the view-bio buttons for a better user
experience


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - just a minor a11y improvement/fix in the aio contributors page :slightly_smiling_face: 
 
Before and after:
https://user-images.githubusercontent.com/61631103/172951057-b60b1c06-fe07-4ae9-b01e-a4fa28eca2cd.mp4
(I actually think that the view bio button should also have a more descriptive label :thinking:)

 I've also added an aria-label to the view-bio button :slightly_smiling_face: 
https://user-images.githubusercontent.com/61631103/172951872-6c28f136-6555-40af-888b-9138b2847ccd.mp4

 