### PR TITLE
build: update angular version of in-memory-web-api

### DIFF
--- a/packages/misc/angular-in-memory-web-api/package.json
+++ b/packages/misc/angular-in-memory-web-api/package.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-in-memory-web-api",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "An in-memory web api for Angular demos and tests",
   "author": "angular",
   "license": "MIT",
   "peerDependencies": {
-    "@angular/core": "^13.0.0",
-    "@angular/common": "^13.0.0",
+    "@angular/core": "^14.0.0",
+    "@angular/common": "^14.0.0",
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
Changes the required version of Angular in `angular-in-memory-web-api` to version 14.0.0. 

Fixes #46332.