### PR TITLE
refactor(compiler-cli): add `forceEmit` flag to `performCompilation`

### DIFF
--- a/packages/compiler-cli/src/ngtsc/program.ts
+++ b/packages/compiler-cli/src/ngtsc/program.ts
@@ -233,6 +233,7 @@ export class NgtscProgram implements api.Program {
 
   emit(opts?: {
     emitFlags?: api.EmitFlags|undefined;
+    forceEmit?: boolean;
     cancellationToken?: ts.CancellationToken | undefined;
     customTransformers?: api.CustomTransformers | undefined;
     emitCallback?: api.TsEmitCallback | undefined;
@@ -254,6 +255,8 @@ export class NgtscProgram implements api.Program {
         };
       }
     }
+
+    const forceEmit = opts?.forceEmit ?? false;
 
     this.compiler.perfRecorder.memory(PerfCheckpoint.PreEmit);
 
@@ -295,7 +298,7 @@ export class NgtscProgram implements api.Program {
           continue;
         }
 
-        if (this.compiler.incrementalCompilation.safeToSkipEmit(targetSourceFile)) {
+        if (!forceEmit && this.compiler.incrementalCompilation.safeToSkipEmit(targetSourceFile)) {
           this.compiler.perfRecorder.eventCount(PerfEvent.EmitSkipSourceFile);
           continue;
         }

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -221,6 +221,7 @@ export function performCompilation({
   gatherDiagnostics = defaultGatherDiagnostics,
   customTransformers,
   emitFlags = api.EmitFlags.Default,
+  forceEmit = false,
   modifiedResourceFiles = null
 }: {
   rootNames: string[],
@@ -232,6 +233,7 @@ export function performCompilation({
   gatherDiagnostics?: (program: api.Program) => ReadonlyArray<ts.Diagnostic>,
   customTransformers?: api.CustomTransformers,
   emitFlags?: api.EmitFlags,
+  forceEmit?: boolean,
   modifiedResourceFiles?: Set<string>| null,
 }): PerformCompilationResult {
   let program: api.Program|undefined;
@@ -256,8 +258,8 @@ export function performCompilation({
     }
 
     if (!hasErrors(allDiagnostics)) {
-      emitResult =
-          program!.emit({emitCallback, mergeEmitResultsCallback, customTransformers, emitFlags});
+      emitResult = program!.emit(
+          {emitCallback, mergeEmitResultsCallback, customTransformers, emitFlags, forceEmit});
       allDiagnostics.push(...emitResult.diagnostics);
       return {diagnostics: allDiagnostics, program, emitResult};
     }

--- a/packages/compiler-cli/src/transformers/api.ts
+++ b/packages/compiler-cli/src/transformers/api.ts
@@ -250,14 +250,21 @@ export interface Program {
    *
    * Angular structural information is required to emit files.
    */
-  emit({emitFlags, cancellationToken, customTransformers, emitCallback, mergeEmitResultsCallback}?:
-           {
-             emitFlags?: EmitFlags,
-             cancellationToken?: ts.CancellationToken,
-             customTransformers?: CustomTransformers,
-             emitCallback?: TsEmitCallback,
-             mergeEmitResultsCallback?: TsMergeEmitResultsCallback
-           }): ts.EmitResult;
+  emit({
+    emitFlags,
+    forceEmit,
+    cancellationToken,
+    customTransformers,
+    emitCallback,
+    mergeEmitResultsCallback,
+  }?: {
+    emitFlags?: EmitFlags,
+    forceEmit?: boolean,
+    cancellationToken?: ts.CancellationToken,
+    customTransformers?: CustomTransformers,
+    emitCallback?: TsEmitCallback,
+    mergeEmitResultsCallback?: TsMergeEmitResultsCallback
+  }): ts.EmitResult;
 
   /**
    * @internal


### PR DESCRIPTION
In Bazel worker-land, workers which use incremental compilation must still
emit all declared outputs and cannot rely on these outputs persisting from
previous builds.

This commit adds a flag to `performCompilation` which can be used by the
worker infrastructure to instruct the compiler to always emit all possible
output files, regardless of any incremental build optimizations.