### PR TITLE
fix(animations): reset the start and done fns on player reset

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 456412,
+      "main": 456957,
       "polyfills": 33922,
       "styles": 72829,
       "light-theme": 78276,

--- a/packages/animations/browser/src/render/web_animations/web_animations_player.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_player.ts
@@ -24,6 +24,12 @@ export class WebAnimationsPlayer implements AnimationPlayer {
   private _destroyed = false;
   private _finalKeyframe?: ɵStyleDataMap;
 
+  // the following original fns are persistent copies of the _onStartFns and _onDoneFns
+  // and are used to reset the fns to their original values upon reset()
+  // (since the _onStartFns and _onDoneFns get deleted after they are called)
+  private _originalOnDoneFns: Function[] = [];
+  private _originalOnStartFns: Function[] = [];
+
   // TODO(issue/24571): remove '!'.
   public readonly domPlayer!: DOMAnimation;
   public time = 0;
@@ -89,10 +95,12 @@ export class WebAnimationsPlayer implements AnimationPlayer {
   }
 
   onStart(fn: () => void): void {
+    this._originalOnStartFns.push(fn);
     this._onStartFns.push(fn);
   }
 
   onDone(fn: () => void): void {
+    this._originalOnDoneFns.push(fn);
     this._onDoneFns.push(fn);
   }
 
@@ -132,6 +140,8 @@ export class WebAnimationsPlayer implements AnimationPlayer {
     this._destroyed = false;
     this._finished = false;
     this._started = false;
+    this._onStartFns = this._originalOnStartFns;
+    this._onDoneFns = this._originalOnDoneFns;
   }
 
   private _resetDomPlayerState() {

--- a/packages/animations/src/players/animation_player.ts
+++ b/packages/animations/src/players/animation_player.ts
@@ -123,6 +123,8 @@ export class NoopAnimationPlayer implements AnimationPlayer {
   private _onDoneFns: Function[] = [];
   private _onStartFns: Function[] = [];
   private _onDestroyFns: Function[] = [];
+  private _originalOnDoneFns: Function[] = [];
+  private _originalOnStartFns: Function[] = [];
   private _started = false;
   private _destroyed = false;
   private _finished = false;
@@ -140,9 +142,11 @@ export class NoopAnimationPlayer implements AnimationPlayer {
     }
   }
   onStart(fn: () => void): void {
+    this._originalOnStartFns.push(fn);
     this._onStartFns.push(fn);
   }
   onDone(fn: () => void): void {
+    this._originalOnDoneFns.push(fn);
     this._onDoneFns.push(fn);
   }
   onDestroy(fn: () => void): void {
@@ -188,6 +192,9 @@ export class NoopAnimationPlayer implements AnimationPlayer {
   }
   reset(): void {
     this._started = false;
+    this._finished = false;
+    this._onStartFns = this._originalOnStartFns;
+    this._onDoneFns = this._originalOnDoneFns;
   }
   setPosition(position: number): void {
     this._position = this.totalTime ? position * this.totalTime : 1;

--- a/packages/platform-browser/animations/test/browser_animation_builder_spec.ts
+++ b/packages/platform-browser/animations/test/browser_animation_builder_spec.ts
@@ -45,6 +45,75 @@ import {NoopAnimationsModule, ɵBrowserAnimationBuilder as BrowserAnimationBuild
       expect(cmp.builder instanceof BrowserAnimationBuilder).toBeTruthy();
     });
 
+    it('should listen on start and done on the animation builder\'s player after it has been reset',
+       fakeAsync(() => {
+         @Component({
+           selector: 'ani-cmp',
+           template: '...',
+         })
+         class Cmp {
+           @ViewChild('target') public target: any;
+
+           constructor(public builder: AnimationBuilder) {}
+
+           build() {
+             const definition =
+                 this.builder.build([style({opacity: 0}), animate(1000, style({opacity: 1}))]);
+
+             return definition.create(this.target);
+           }
+         }
+
+         TestBed.configureTestingModule({declarations: [Cmp]});
+
+         const fixture = TestBed.createComponent(Cmp);
+         const cmp = fixture.componentInstance;
+         fixture.detectChanges();
+
+         const player = cmp.build();
+
+         let startedCount = 0;
+         player.onStart(() => startedCount++);
+
+         let finishedCount = 0;
+         player.onDone(() => finishedCount++);
+
+         player.init();
+         flushMicrotasks();
+         expect(startedCount).toEqual(0);
+         expect(finishedCount).toEqual(0);
+
+         player.play();
+         flushMicrotasks();
+         expect(startedCount).toEqual(1);
+         expect(finishedCount).toEqual(0);
+
+         player.finish();
+         flushMicrotasks();
+         expect(startedCount).toEqual(1);
+         expect(finishedCount).toEqual(1);
+
+         player.play();
+         player.finish();
+         flushMicrotasks();
+         expect(startedCount).toEqual(1);
+         expect(finishedCount).toEqual(1);
+
+         [0, 1, 2, 3].forEach(i => {
+           player.reset();
+
+           player.play();
+           flushMicrotasks();
+           expect(startedCount).toEqual(i + 2);
+           expect(finishedCount).toEqual(i + 1);
+
+           player.finish();
+           flushMicrotasks();
+           expect(startedCount).toEqual(i + 2);
+           expect(finishedCount).toEqual(i + 2);
+         });
+       }));
+
     it('should listen on start and done on the animation builder\'s player', fakeAsync(() => {
          @Component({
            selector: 'ani-cmp',


### PR DESCRIPTION
in the animation players, make sure than upon reset the
_onStartFns and _onDoneFns are also re-applied so that
they can be called again after resetting the animation

also set the noop animation player's _finished to false
when the player resets (needed to make sure that the _onDoneFns
get called)

resolves #26630

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #26630

Animations created with the animationBuilder only trigger the start and done callbacks once

For example:
![before](https://user-images.githubusercontent.com/61631103/173671175-3113b75f-fd96-4ce3-9930-82251b6a19f2.gif)


## What is the new behavior?

The animation re-trigger the callbacks if the animation has been reset

For example:
![after](https://user-images.githubusercontent.com/61631103/173671199-d69a766b-8520-48e9-87f6-7327aa3617a6.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

