### PR TITLE
ci: override existing snapshot tag if publish snapshot job is restarted

### DIFF
--- a/scripts/ci/publish-build-artifacts.sh
+++ b/scripts/ci/publish-build-artifacts.sh
@@ -96,7 +96,7 @@ function publishRepo {
     git config user.email "${COMMITTER_USER_EMAIL}" && \
     git add --all && \
     git commit -m "${COMMIT_MSG}" --quiet && \
-    git tag "${BUILD_VER}" && \
+    git tag "${BUILD_VER}" --force && \
     git push origin "${BRANCH}" --tags --force
   )
 }


### PR DESCRIPTION
If the snapshot publish job is manually being restarted, the tag in the
snapshot repo might already exist and the job will fail. We can just
forcibly re-create the tag (even if it will be at the same revision).

We use force mode in a couple of other commands as well, such as `git
push` of the actual tag and snapshot revision/SHA.

Arguably, there is lots of room for improvement in this script as currently it does not guarantee a linear chronological history anyway. We can improve this when we share this script in the dev-infra ORB. At the same time though, snapshots are in no way important enough for us to worry 