### PR TITLE
Revert "fix(common): sanitize `rawSrc` and `rawSrcset` values in NgOptimizedImage directive"

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, Inject, Injector, Input, NgModule, NgZone, OnChanges, OnDestroy, OnInit, Renderer2, SimpleChanges, ɵ_sanitizeUrl as sanitizeUrl, ɵformatRuntimeError as formatRuntimeError, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {Directive, ElementRef, Inject, Injector, Input, NgModule, NgZone, OnChanges, OnDestroy, OnInit, Renderer2, SimpleChanges, ɵformatRuntimeError as formatRuntimeError, ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {RuntimeErrorCode} from '../../errors';
 
@@ -167,15 +167,9 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     }
     this.setHostAttribute('loading', this.getLoadingBehavior());
     this.setHostAttribute('fetchpriority', this.getFetchPriority());
-
-    // Use the `sanitizeUrl` function directly (vs using `DomSanitizer`),
-    // to make the code more tree-shakable (avoid referencing the entire class).
-    // The same function is used when regular `src` is used on an `<img>` element.
-    const src = sanitizeUrl(this.getRewrittenSrc());
-
     // The `src` and `srcset` attributes should be set last since other attributes
     // could affect the image's loading behavior.
-    this.setHostAttribute('src', src);
+    this.setHostAttribute('src', this.getRewrittenSrc());
     if (this.rawSrcset) {
       this.setHostAttribute('srcset', this.getRewrittenSrcset());
     }
@@ -216,8 +210,7 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     const finalSrcs = this.rawSrcset.split(',').filter(src => src !== '').map(srcStr => {
       srcStr = srcStr.trim();
       const width = widthSrcSet ? parseFloat(srcStr) : parseFloat(srcStr) * this.width!;
-      const imgSrc = sanitizeUrl(this.imageLoader({src: this.rawSrc, width}));
-      return `${imgSrc} ${srcStr}`;
+      return `${this.imageLoader({src: this.rawSrc, width})} ${srcStr}`;
     });
     return finalSrcs.join(', ');
   }

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -504,56 +504,6 @@ describe('Image directive', () => {
     });
   });
 
-  describe('sanitization', () => {
-    // Loader function that just returns provided `src`.
-    const noopLoader = (config: ImageLoaderConfig) => config.src;
-
-    it('should apply sanitization to the `rawSrc` with a static value', () => {
-      setupTestingModule({imageLoader: noopLoader});
-
-      const template =
-          '<img rawSrc="javascript:alert(`Unsafe code execution`)" width="50" height="50">';
-      const fixture = createTestComponent(template);
-      fixture.detectChanges();
-
-      const img = fixture.nativeElement.querySelector('img')!;
-      // The `src` looks like this: 'unsafe:javascript:alert(`Unsafe code execution`)'
-      expect(img.src.startsWith('unsafe:')).toBe(true);
-    });
-
-    it('should apply sanitization to the `rawSrc` when used as a binding', () => {
-      setupTestingModule({imageLoader: noopLoader});
-
-      const template =
-          '<img [rawSrc]="\'javascript:alert(`Unsafe code execution`)\'" width="50" height="50">';
-      const fixture = createTestComponent(template);
-      fixture.detectChanges();
-
-      const img = fixture.nativeElement.querySelector('img')!;
-      // The `src` looks like this: 'unsafe:javascript:alert(`Unsafe code execution`)'
-      expect(img.src.startsWith('unsafe:')).toBe(true);
-    });
-
-    it('should apply sanitization to the `rawSrcset` value', () => {
-      setupTestingModule({imageLoader: noopLoader});
-
-      const template =
-          `<img rawSrc="javascript:alert(\`Unsafe code execution\`)" rawSrcset="100w, 200w" width="100" height="50">`;
-      const fixture = createTestComponent(template);
-      fixture.detectChanges();
-
-      const nativeElement = fixture.nativeElement as HTMLElement;
-      const img = nativeElement.querySelector('img')!;
-
-      // The `src` looks like this: 'unsafe:javascript:alert(`Unsafe code execution`)'
-      expect(img.src.startsWith('unsafe:')).toBe(true);
-      expect(img.srcset)
-          .toBe(
-              'unsafe:javascript:alert(`Unsafe code execution`) 100w, ' +
-              'unsafe:javascript:alert(`Unsafe code execution`) 200w');
-    });
-  });
-
   describe('fetch priority', () => {
     it('should be "high" for priority images', () => {
       setupTestingModule();


### PR DESCRIPTION
This reverts commit a0fdb8c7e9ec08bd2088614bc354e1155cd2ed85.

The `src` and `srcset` attributes don't pose security threats in modern browser, so sanitization is not really necessary.

## PR Type
What kind of change does this PR introduce?

- [ ] Other... Please describe: reverting an unnecessary change

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No