### PR TITLE
refactor(common): align tree shakable error messages to new format

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -138,10 +138,10 @@ export class NgProbeToken {
  */
 export function createPlatform(injector: Injector): PlatformRef {
   if (_platformInjector && !_platformInjector.get(ALLOW_MULTIPLE_PLATFORMS, false)) {
-    const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-        'There can be only one platform. Destroy the previous one to create a new one.' :
-        '';
-    throw new RuntimeError(RuntimeErrorCode.MULTIPLE_PLATFORMS, errorMessage);
+    throw new RuntimeError(
+        RuntimeErrorCode.MULTIPLE_PLATFORMS,
+        ngDevMode &&
+            'There can be only one platform. Destroy the previous one to create a new one.');
   }
   publishDefaultGlobalUtils();
   _platformInjector = injector;
@@ -281,9 +281,7 @@ export function assertPlatform(requiredToken: any): PlatformRef {
   const platform = getPlatform();
 
   if (!platform) {
-    const errorMessage =
-        (typeof ngDevMode === 'undefined' || ngDevMode) ? 'No platform exists!' : '';
-    throw new RuntimeError(RuntimeErrorCode.PLATFORM_NOT_FOUND, errorMessage);
+    throw new RuntimeError(RuntimeErrorCode.PLATFORM_NOT_FOUND, ngDevMode && 'No platform exists!');
   }
 
   if ((typeof ngDevMode === 'undefined' || ngDevMode) &&
@@ -426,10 +424,9 @@ export class PlatformRef {
       const moduleRef = <InternalNgModuleRef<M>>moduleFactory.create(ngZoneInjector);
       const exceptionHandler: ErrorHandler|null = moduleRef.injector.get(ErrorHandler, null);
       if (!exceptionHandler) {
-        const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-            'No ErrorHandler. Is platform module (BrowserModule) included?' :
-            '';
-        throw new RuntimeError(RuntimeErrorCode.ERROR_HANDLER_NOT_FOUND, errorMessage);
+        throw new RuntimeError(
+            RuntimeErrorCode.ERROR_HANDLER_NOT_FOUND,
+            ngDevMode && 'No ErrorHandler. Is platform module (BrowserModule) included?');
       }
       ngZone!.runOutsideAngular(() => {
         const subscription = ngZone!.onError.subscribe({
@@ -488,12 +485,12 @@ export class PlatformRef {
     } else if (moduleRef.instance.ngDoBootstrap) {
       moduleRef.instance.ngDoBootstrap(appRef);
     } else {
-      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-          `The module ${stringify(moduleRef.instance.constructor)} was bootstrapped, ` +
-              `but it does not declare "@NgModule.bootstrap" components nor a "ngDoBootstrap" method. ` +
-              `Please define one of these.` :
-          '';
-      throw new RuntimeError(RuntimeErrorCode.BOOTSTRAP_COMPONENTS_NOT_FOUND, errorMessage);
+      throw new RuntimeError(
+          RuntimeErrorCode.BOOTSTRAP_COMPONENTS_NOT_FOUND,
+          ngDevMode &&
+              `The module ${stringify(moduleRef.instance.constructor)} was bootstrapped, ` +
+                  `but it does not declare "@NgModule.bootstrap" components nor a "ngDoBootstrap" method. ` +
+                  `Please define one of these.`);
     }
     this._modules.push(moduleRef);
   }
@@ -519,10 +516,9 @@ export class PlatformRef {
    */
   destroy() {
     if (this._destroyed) {
-      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-          'The platform has already been destroyed!' :
-          '';
-      throw new RuntimeError(RuntimeErrorCode.PLATFORM_ALREADY_DESTROYED, errorMessage);
+      throw new RuntimeError(
+          RuntimeErrorCode.PLATFORM_ALREADY_DESTROYED,
+          ngDevMode && 'The platform has already been destroyed!');
     }
     this._modules.slice().forEach(module => module.destroy());
     this._destroyListeners.forEach(listener => listener());
@@ -975,10 +971,9 @@ export class ApplicationRef {
   tick(): void {
     NG_DEV_MODE && this.warnIfDestroyed();
     if (this._runningTick) {
-      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-          'ApplicationRef.tick is called recursively' :
-          '';
-      throw new RuntimeError(RuntimeErrorCode.RECURSIVE_APPLICATION_REF_TICK, errorMessage);
+      throw new RuntimeError(
+          RuntimeErrorCode.RECURSIVE_APPLICATION_REF_TICK,
+          ngDevMode && 'ApplicationRef.tick is called recursively');
     }
 
     try {
@@ -1076,7 +1071,7 @@ export class ApplicationRef {
     if (this._destroyed) {
       throw new RuntimeError(
           RuntimeErrorCode.APPLICATION_REF_ALREADY_DESTROYED,
-          NG_DEV_MODE && 'This instance of the `ApplicationRef` has already been destroyed.');
+          ngDevMode && 'This instance of the `ApplicationRef` has already been destroyed.');
     }
 
     // This is a temporary type to represent an instance of an R3Injector, which can be destroyed.

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -153,10 +153,11 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
   diff(collection: NgIterable<V>|null|undefined): DefaultIterableDiffer<V>|null {
     if (collection == null) collection = [];
     if (!isListLikeIterable(collection)) {
-      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-          `Error trying to diff '${stringify(collection)}'. Only arrays and iterables are allowed` :
-          '';
-      throw new RuntimeError(RuntimeErrorCode.INVALID_DIFFER_INPUT, errorMessage);
+      throw new RuntimeError(
+          RuntimeErrorCode.INVALID_DIFFER_INPUT,
+          ngDevMode &&
+              `Error trying to diff '${
+                  stringify(collection)}'. Only arrays and iterables are allowed`);
     }
 
     if (this.check(collection)) {

--- a/packages/core/src/change_detection/differs/default_keyvalue_differ.ts
+++ b/packages/core/src/change_detection/differs/default_keyvalue_differ.ts
@@ -81,10 +81,10 @@ export class DefaultKeyValueDiffer<K, V> implements KeyValueDiffer<K, V>, KeyVal
     if (!map) {
       map = new Map();
     } else if (!(map instanceof Map || isJsObject(map))) {
-      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-          `Error trying to diff '${stringify(map)}'. Only maps and objects are allowed` :
-          '';
-      throw new RuntimeError(RuntimeErrorCode.INVALID_DIFFER_INPUT, errorMessage);
+      throw new RuntimeError(
+          RuntimeErrorCode.INVALID_DIFFER_INPUT,
+          ngDevMode &&
+              `Error trying to diff '${stringify(map)}'. Only maps and objects are allowed`);
     }
 
     return this.check(map) ? this : null;

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -251,11 +251,11 @@ export class IterableDiffers {
     if (factory != null) {
       return factory;
     } else {
-      const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-          `Cannot find a differ supporting object '${iterable}' of type '${
-              getTypeNameForDebugging(iterable)}'` :
-          '';
-      throw new RuntimeError(RuntimeErrorCode.NO_SUPPORTING_DIFFER_FACTORY, errorMessage);
+      throw new RuntimeError(
+          RuntimeErrorCode.NO_SUPPORTING_DIFFER_FACTORY,
+          ngDevMode &&
+              `Cannot find a differ supporting object '${iterable}' of type '${
+                  getTypeNameForDebugging(iterable)}'`);
     }
   }
 }

--- a/packages/core/src/change_detection/differs/keyvalue_differs.ts
+++ b/packages/core/src/change_detection/differs/keyvalue_differs.ts
@@ -183,9 +183,8 @@ export class KeyValueDiffers {
     if (factory) {
       return factory;
     }
-    const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-        `Cannot find a differ supporting object '${kv}'` :
-        '';
-    throw new RuntimeError(RuntimeErrorCode.NO_SUPPORTING_DIFFER_FACTORY, errorMessage);
+    throw new RuntimeError(
+        RuntimeErrorCode.NO_SUPPORTING_DIFFER_FACTORY,
+        ngDevMode && `Cannot find a differ supporting object '${kv}'`);
   }
 }

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -54,10 +54,10 @@ export function injectInjectorOnly<T>(token: ProviderToken<T>, flags?: InjectFla
 export function injectInjectorOnly<T>(token: ProviderToken<T>, flags = InjectFlags.Default): T|
     null {
   if (_currentInjector === undefined) {
-    const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-        `inject() must be called from an injection context (a constructor, a factory function or a field initializer)` :
-        '';
-    throw new RuntimeError(RuntimeErrorCode.MISSING_INJECTION_CONTEXT, errorMessage);
+    throw new RuntimeError(
+        RuntimeErrorCode.MISSING_INJECTION_CONTEXT,
+        ngDevMode &&
+            `inject() must be called from an injection context (a constructor, a factory function or a field initializer)`);
   } else if (_currentInjector === null) {
     return injectRootLimpMode(token, undefined, flags);
   } else {
@@ -197,10 +197,9 @@ export function injectArgs(types: (ProviderToken<any>|any[])[]): any[] {
     const arg = resolveForwardRef(types[i]);
     if (Array.isArray(arg)) {
       if (arg.length === 0) {
-        const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-            'Arguments array must have arguments.' :
-            '';
-        throw new RuntimeError(RuntimeErrorCode.INVALID_DIFFER_INPUT, errorMessage);
+        throw new RuntimeError(
+            RuntimeErrorCode.INVALID_DIFFER_INPUT,
+            ngDevMode && 'Arguments array must have arguments.');
       }
       let type: Type<any>|undefined = undefined;
       let flags: InjectFlags = InjectFlags.Default;

--- a/packages/core/src/render3/features/inherit_definition_feature.ts
+++ b/packages/core/src/render3/features/inherit_definition_feature.ts
@@ -41,12 +41,12 @@ export function ɵɵInheritDefinitionFeature(definition: DirectiveDef<any>|Compo
       superDef = superType.ɵcmp || superType.ɵdir;
     } else {
       if (superType.ɵcmp) {
-        const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-            `Directives cannot inherit Components. Directive ${
-                stringifyForError(definition.type)} is attempting to extend component ${
-                stringifyForError(superType)}` :
-            '';
-        throw new RuntimeError(RuntimeErrorCode.INVALID_INHERITANCE, errorMessage);
+        throw new RuntimeError(
+            RuntimeErrorCode.INVALID_INHERITANCE,
+            ngDevMode &&
+                `Directives cannot inherit Components. Directive ${
+                    stringifyForError(definition.type)} is attempting to extend component ${
+                    stringifyForError(superType)}`);
       }
       // Don't use getComponentDef/getDirectiveDef. This logic relies on inheritance.
       superDef = superType.ɵdir;

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -288,9 +288,9 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
 
   attachToViewContainerRef() {
     if (this._appRef) {
-      const errorMessage =
-          ngDevMode ? 'This view is already attached directly to the ApplicationRef!' : '';
-      throw new RuntimeError(RuntimeErrorCode.VIEW_ALREADY_ATTACHED, errorMessage);
+      throw new RuntimeError(
+          RuntimeErrorCode.VIEW_ALREADY_ATTACHED,
+          ngDevMode && 'This view is already attached directly to the ApplicationRef!');
     }
     this._attachedToViewContainer = true;
   }
@@ -302,8 +302,9 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
 
   attachToAppRef(appRef: ViewRefTracker) {
     if (this._attachedToViewContainer) {
-      const errorMessage = ngDevMode ? 'This view is already attached to a ViewContainer!' : '';
-      throw new RuntimeError(RuntimeErrorCode.VIEW_ALREADY_ATTACHED, errorMessage);
+      throw new RuntimeError(
+          RuntimeErrorCode.VIEW_ALREADY_ATTACHED,
+          ngDevMode && 'This view is already attached to a ViewContainer!');
     }
     this._appRef = appRef;
   }

--- a/packages/core/src/sanitization/sanitization.ts
+++ b/packages/core/src/sanitization/sanitization.ts
@@ -118,10 +118,10 @@ export function ɵɵsanitizeResourceUrl(unsafeResourceUrl: any): TrustedScriptUR
   if (allowSanitizationBypassAndThrow(unsafeResourceUrl, BypassType.ResourceUrl)) {
     return trustedScriptURLFromStringBypass(unwrapSafeValue(unsafeResourceUrl));
   }
-  const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-      'unsafe value used in a resource URL context (see https://g.co/ng/security#xss)' :
-      '';
-  throw new RuntimeError(RuntimeErrorCode.UNSAFE_VALUE_IN_RESOURCE_URL, errorMessage);
+  throw new RuntimeError(
+      RuntimeErrorCode.UNSAFE_VALUE_IN_RESOURCE_URL,
+      ngDevMode &&
+          'unsafe value used in a resource URL context (see https://g.co/ng/security#xss)');
 }
 
 /**
@@ -145,10 +145,9 @@ export function ɵɵsanitizeScript(unsafeScript: any): TrustedScript|string {
   if (allowSanitizationBypassAndThrow(unsafeScript, BypassType.Script)) {
     return trustedScriptFromStringBypass(unwrapSafeValue(unsafeScript));
   }
-  const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-      'unsafe value used in a script context' :
-      '';
-  throw new RuntimeError(RuntimeErrorCode.UNSAFE_VALUE_IN_SCRIPT, errorMessage);
+  throw new RuntimeError(
+      RuntimeErrorCode.UNSAFE_VALUE_IN_SCRIPT,
+      ngDevMode && 'unsafe value used in a script context');
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Tree shakable error message has a long format with `errorMessage` variables.

Issue Number: N/A


## What is the new behavior?

Align tree shakable error messages are simplified with the new format introduced by @AndrewKushnir and remove `errorMessage` variables.

```ts
throw new RuntimeError(
  RuntimeErrorCode.INJECTOR_ALREADY_DESTROYED,
  ngDevMode && 'Injector has already been destroyed.');
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
