### PR TITLE
refactor(common): align tree shakable error messages to the new format

### DIFF
--- a/packages/animations/browser/src/error_helpers.ts
+++ b/packages/animations/browser/src/error_helpers.ts
@@ -10,69 +10,68 @@ import {ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {RuntimeErrorCode} from './errors';
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 const LINE_START = '\n - ';
 
 export function invalidTimingValue(exp: string|number): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_TIMING_VALUE,
-      NG_DEV_MODE && `The provided timing value "${exp}" is invalid.`);
+      ngDevMode && `The provided timing value "${exp}" is invalid.`);
 }
 
 export function negativeStepValue(): Error {
   return new RuntimeError(
       RuntimeErrorCode.NEGATIVE_STEP_VALUE,
-      NG_DEV_MODE && 'Duration values below 0 are not allowed for this animation step.');
+      ngDevMode && 'Duration values below 0 are not allowed for this animation step.');
 }
 
 export function negativeDelayValue(): Error {
   return new RuntimeError(
       RuntimeErrorCode.NEGATIVE_DELAY_VALUE,
-      NG_DEV_MODE && 'Delay values below 0 are not allowed for this animation step.');
+      ngDevMode && 'Delay values below 0 are not allowed for this animation step.');
 }
 
 export function invalidStyleParams(varName: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_STYLE_PARAMS,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `Unable to resolve the local animation param ${varName} in the given list of values`);
 }
 
 export function invalidParamValue(varName: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_PARAM_VALUE,
-      NG_DEV_MODE && `Please provide a value for the animation param ${varName}`);
+      ngDevMode && `Please provide a value for the animation param ${varName}`);
 }
 
 export function invalidNodeType(nodeType: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_NODE_TYPE,
-      NG_DEV_MODE && `Unable to resolve animation metadata node #${nodeType}`);
+      ngDevMode && `Unable to resolve animation metadata node #${nodeType}`);
 }
 
 export function invalidCssUnitValue(userProvidedProperty: string, value: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_CSS_UNIT_VALUE,
-      NG_DEV_MODE && `Please provide a CSS unit value for ${userProvidedProperty}:${value}`);
+      ngDevMode && `Please provide a CSS unit value for ${userProvidedProperty}:${value}`);
 }
 
 export function invalidTrigger(): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_TRIGGER,
-      NG_DEV_MODE &&
+      ngDevMode &&
           'animation triggers cannot be prefixed with an `@` sign (e.g. trigger(\'@foo\', [...]))');
 }
 
 export function invalidDefinition(): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_DEFINITION,
-      NG_DEV_MODE && 'only state() and transition() definitions can sit inside of a trigger()');
+      ngDevMode && 'only state() and transition() definitions can sit inside of a trigger()');
 }
 
 export function invalidState(metadataName: string, missingSubs: string[]): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_STATE,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `state("${
               metadataName}", ...) must define default values for all the following style substitutions: ${
               missingSubs.join(', ')}`);
@@ -81,13 +80,13 @@ export function invalidState(metadataName: string, missingSubs: string[]): Error
 export function invalidStyleValue(value: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_STYLE_VALUE,
-      NG_DEV_MODE && `The provided style string value ${value} is not allowed.`);
+      ngDevMode && `The provided style string value ${value} is not allowed.`);
 }
 
 export function invalidProperty(prop: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_PROPERTY,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `The provided animation property "${
               prop}" is not a supported CSS property for animations`);
 }
@@ -97,7 +96,7 @@ export function invalidParallelAnimation(
     secondEnd: number): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_PARALLEL_ANIMATION,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `The CSS property "${prop}" that exists between the times of "${firstStart}ms" and "${
               firstEnd}ms" is also being animated in a parallel animation between the times of "${
               secondStart}ms" and "${secondEnd}ms"`);
@@ -106,37 +105,37 @@ export function invalidParallelAnimation(
 export function invalidKeyframes(): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_KEYFRAMES,
-      NG_DEV_MODE && `keyframes() must be placed inside of a call to animate()`);
+      ngDevMode && `keyframes() must be placed inside of a call to animate()`);
 }
 
 export function invalidOffset(): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_OFFSET,
-      NG_DEV_MODE && `Please ensure that all keyframe offsets are between 0 and 1`);
+      ngDevMode && `Please ensure that all keyframe offsets are between 0 and 1`);
 }
 
 export function keyframeOffsetsOutOfOrder(): Error {
   return new RuntimeError(
       RuntimeErrorCode.KEYFRAME_OFFSETS_OUT_OF_ORDER,
-      NG_DEV_MODE && `Please ensure that all keyframe offsets are in order`);
+      ngDevMode && `Please ensure that all keyframe offsets are in order`);
 }
 
 export function keyframesMissingOffsets(): Error {
   return new RuntimeError(
       RuntimeErrorCode.KEYFRAMES_MISSING_OFFSETS,
-      NG_DEV_MODE && `Not all style() steps within the declared keyframes() contain offsets`);
+      ngDevMode && `Not all style() steps within the declared keyframes() contain offsets`);
 }
 
 export function invalidStagger(): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_STAGGER,
-      NG_DEV_MODE && `stagger() can only be used inside of query()`);
+      ngDevMode && `stagger() can only be used inside of query()`);
 }
 
 export function invalidQuery(selector: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_QUERY,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `\`query("${selector}")\` returned zero elements. (Use \`query("${
               selector}", { optional: true })\` if you wish to allow this.)`);
 }
@@ -144,31 +143,31 @@ export function invalidQuery(selector: string): Error {
 export function invalidExpression(expr: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_EXPRESSION,
-      NG_DEV_MODE && `The provided transition expression "${expr}" is not supported`);
+      ngDevMode && `The provided transition expression "${expr}" is not supported`);
 }
 
 export function invalidTransitionAlias(alias: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.INVALID_TRANSITION_ALIAS,
-      NG_DEV_MODE && `The transition alias value "${alias}" is not supported`);
+      ngDevMode && `The transition alias value "${alias}" is not supported`);
 }
 
 export function validationFailed(errors: Error[]): Error {
   return new RuntimeError(
       RuntimeErrorCode.VALIDATION_FAILED,
-      NG_DEV_MODE && `animation validation failed:\n${errors.map(err => err.message).join('\n')}`);
+      ngDevMode && `animation validation failed:\n${errors.map(err => err.message).join('\n')}`);
 }
 
 export function buildingFailed(errors: Error[]): Error {
   return new RuntimeError(
       RuntimeErrorCode.BUILDING_FAILED,
-      NG_DEV_MODE && `animation building failed:\n${errors.map(err => err.message).join('\n')}`);
+      ngDevMode && `animation building failed:\n${errors.map(err => err.message).join('\n')}`);
 }
 
 export function triggerBuildFailed(name: string, errors: Error[]): Error {
   return new RuntimeError(
       RuntimeErrorCode.TRIGGER_BUILD_FAILED,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `The animation trigger "${name}" has failed to build due to the following errors:\n - ${
               errors.map(err => err.message).join('\n - ')}`);
 }
@@ -176,7 +175,7 @@ export function triggerBuildFailed(name: string, errors: Error[]): Error {
 export function animationFailed(errors: Error[]): Error {
   return new RuntimeError(
       RuntimeErrorCode.ANIMATION_FAILED,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `Unable to animate due to the following errors:${LINE_START}${
               errors.map(err => err.message).join(LINE_START)}`);
 }
@@ -184,7 +183,7 @@ export function animationFailed(errors: Error[]): Error {
 export function registerFailed(errors: Error[]): Error {
   return new RuntimeError(
       RuntimeErrorCode.REGISTRATION_FAILED,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `Unable to build the animation due to the following errors: ${
               errors.map(err => err.message).join('\n')}`);
 }
@@ -192,13 +191,13 @@ export function registerFailed(errors: Error[]): Error {
 export function missingOrDestroyedAnimation(): Error {
   return new RuntimeError(
       RuntimeErrorCode.MISSING_OR_DESTROYED_ANIMATION,
-      NG_DEV_MODE && 'The requested animation doesn\'t exist or has already been destroyed');
+      ngDevMode && 'The requested animation doesn\'t exist or has already been destroyed');
 }
 
 export function createAnimationFailed(errors: Error[]): Error {
   return new RuntimeError(
       RuntimeErrorCode.CREATE_ANIMATION_FAILED,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `Unable to create the animation due to the following errors:${
               errors.map(err => err.message).join('\n')}`);
 }
@@ -206,13 +205,13 @@ export function createAnimationFailed(errors: Error[]): Error {
 export function missingPlayer(id: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.MISSING_PLAYER,
-      NG_DEV_MODE && `Unable to find the timeline player referenced by ${id}`);
+      ngDevMode && `Unable to find the timeline player referenced by ${id}`);
 }
 
 export function missingTrigger(phase: string, name: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.MISSING_TRIGGER,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `Unable to listen on the animation trigger event "${
               phase}" because the animation trigger "${name}" doesn\'t exist!`);
 }
@@ -220,7 +219,7 @@ export function missingTrigger(phase: string, name: string): Error {
 export function missingEvent(name: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.MISSING_EVENT,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `Unable to listen on the animation trigger "${
               name}" because the provided event is undefined!`);
 }
@@ -228,7 +227,7 @@ export function missingEvent(name: string): Error {
 export function unsupportedTriggerEvent(phase: string, name: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.UNSUPPORTED_TRIGGER_EVENT,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `The provided animation trigger event "${phase}" for the animation trigger "${
               name}" is not supported!`);
 }
@@ -236,13 +235,13 @@ export function unsupportedTriggerEvent(phase: string, name: string): Error {
 export function unregisteredTrigger(name: string): Error {
   return new RuntimeError(
       RuntimeErrorCode.UNREGISTERED_TRIGGER,
-      NG_DEV_MODE && `The provided animation trigger "${name}" has not been registered!`);
+      ngDevMode && `The provided animation trigger "${name}" has not been registered!`);
 }
 
 export function triggerTransitionsFailed(errors: Error[]): Error {
   return new RuntimeError(
       RuntimeErrorCode.TRIGGER_TRANSITIONS_FAILED,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `Unable to process animations due to the following failed trigger transitions\n ${
               errors.map(err => err.message).join('\n')}`);
 }
@@ -250,7 +249,7 @@ export function triggerTransitionsFailed(errors: Error[]): Error {
 export function triggerParsingFailed(name: string, errors: Error[]): Error {
   return new RuntimeError(
       RuntimeErrorCode.TRIGGER_PARSING_FAILED,
-      NG_DEV_MODE &&
+      ngDevMode &&
           `Animation parsing for the ${name} trigger have failed:${LINE_START}${
               errors.map(err => err.message).join(LINE_START)}`);
 }
@@ -258,6 +257,5 @@ export function triggerParsingFailed(name: string, errors: Error[]): Error {
 export function transitionFailed(name: string, errors: Error[]): Error {
   return new RuntimeError(
       RuntimeErrorCode.TRANSITION_FAILED,
-      NG_DEV_MODE &&
-          `@${name} has failed due to:\n ${errors.map(err => err.message).join('\n- ')}`);
+      ngDevMode && `@${name} has failed due to:\n ${errors.map(err => err.message).join('\n- ')}`);
 }

--- a/packages/common/src/pipes/invalid_pipe_argument_error.ts
+++ b/packages/common/src/pipes/invalid_pipe_argument_error.ts
@@ -11,8 +11,7 @@ import {Type, ɵRuntimeError as RuntimeError, ɵstringify as stringify} from '@a
 import {RuntimeErrorCode} from '../errors';
 
 export function invalidPipeArgumentError(type: Type<any>, value: Object) {
-  const errorMessage = (typeof ngDevMode === 'undefined' || ngDevMode) ?
-      `InvalidPipeArgument: '${value}' for pipe '${stringify(type)}'` :
-      '';
-  return new RuntimeError(RuntimeErrorCode.INVALID_PIPE_ARGUMENT, errorMessage);
+  return new RuntimeError(
+      RuntimeErrorCode.INVALID_PIPE_ARGUMENT,
+      ngDevMode && `InvalidPipeArgument: '${value}' for pipe '${stringify(type)}'`);
 }


### PR DESCRIPTION
Simplifying the tree shakable error messages with the new format and removing the `errorMessage` variables

```ts
throw new RuntimeError(
RuntimeErrorCode.INJECTOR_ALREADY_DESTROYED,
ngDevMode && 'Injector has already been destroyed.');
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Tree shakable error message has a long format with errorMessage variables.

Issue Number: N/A


## What is the new behavior?
Simplifying the tree shakable error messages with the new format introduced by @AndrewKushnir and removing the `errorMessage` variables.
```ts
throw new RuntimeError(
  RuntimeErrorCode.INJECTOR_ALREADY_DESTROYED,
  ngDevMode && 'Injector has already been destroyed.');
```
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
