### PR TITLE
feat(docs-infra): add open_in_new icon to external nav-item links

### DIFF
--- a/aio/src/app/layout/nav-item/nav-item.component.html
+++ b/aio/src/app/layout/nav-item/nav-item.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="!node.children">
   <a href="{{node.url}}" [ngClass]="classes" title="{{node.tooltip}}"
     class="vertical-menu-item">
-    <span>{{node.title}}</span>
+    <span class="vertical-menu-item-text">{{node.title}}</span>
   </a>
 </div>
 

--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -91,6 +91,22 @@ aio-nav-menu {
       }
     }
 
+    a.vertical-menu-item {
+      &[href^="http:"],
+      &[href^="https:"] {
+        .vertical-menu-item-text {
+          display: inline-flex;
+          align-items: center;
+          &::after {
+            content: "\e89e"; // codepoint for "open_in_new"
+            margin-left: 0.3rem;
+            line-height: normal;
+            font-family: "Material Icons";
+          }
+        }
+      }
+    }
+
     button.vertical-menu-item {
       border: none;
       background-color: transparent;


### PR DESCRIPTION
add a mat open_in_new icon to the blog external link present in the
left sidenav on smaller screens so that it can be distinguished from
the other (/internal) links

this is a continuation of #45876

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A


## What is the new behavior?

New open_in_new icon added to the left sidenav menu:
![Screenshot at 2022-06-16 08-20-54](https://user-images.githubusercontent.com/61631103/174015124-9c01dd0f-8b79-48b1-b403-1966452d9d9c.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - @gkalpak as you proposed [here](https://github.com/angular/angular/pull/45876#pullrequestreview-1003010071) :slightly_smiling_face: 
 
 - since I think we have this sort of behavior in 2/3 places already I think it would be worth attempting to create a mixing/function to try to reuse the scss code, I'd imagine I can attempt that in a followup PR to keep things simple and clear