### PR TITLE
docs(router): fix errors in CanMatch examples

### DIFF
--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -835,7 +835,7 @@ export type CanDeactivateFn<T> =
  * class CanMatchTeamSection implements CanMatch {
  *   constructor(private permissions: Permissions, private currentUser: UserToken) {}
  *
- *   canLoad(route: Route, segments: UrlSegment[]): Observable<boolean>|Promise<boolean>|boolean {
+ *   canMatch(route: Route, segments: UrlSegment[]): Observable<boolean>|Promise<boolean>|boolean {
  *     return this.permissions.canAccess(this.currentUser, route, segments);
  *   }
  * }
@@ -873,6 +873,8 @@ export type CanDeactivateFn<T> =
  * You can alternatively provide an in-line function with the `canMatch` signature:
  *
  * ```
+ * const CAN_MATCH_TEAM_SECTION = new InjectionToken('CanMatchTeamSection');
+ *
  * @NgModule({
  *   imports: [
  *     RouterModule.forRoot([
@@ -880,7 +882,7 @@ export type CanDeactivateFn<T> =
  *         path: 'team/:id',
  *         component: TeamComponent,
  *         loadChildren: () => import('./team').then(mod => mod.TeamModule),
- *         canMatch: ['canMatchTeamSection']
+ *         canMatch: [CAN_MATCH_TEAM_SECTION]
  *       },
  *       {
  *         path: '**',
@@ -890,7 +892,7 @@ export type CanDeactivateFn<T> =
  *   ],
  *   providers: [
  *     {
- *       provide: 'canMatchTeamSection',
+ *       provide: CAN_MATCH_TEAM_SECTION,
  *       useValue: (route: Route, segments: UrlSegment[]) => true
  *     }
  *   ]


### PR DESCRIPTION
This commit fixes compilation errors in CanMatch examples.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
