### PR TITLE
CanMatch fixes

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -142,6 +142,9 @@ export interface CanMatch {
 }
 
 // @public
+export type CanMatchFn = (route: Route, segments: UrlSegment[]) => Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean;
+
+// @public
 export class ChildActivationEnd {
     constructor(
     snapshot: ActivatedRouteSnapshot);

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -15,7 +15,7 @@ import {runCanLoadGuards} from './operators/check_guards';
 import {RouterConfigLoader} from './router_config_loader';
 import {navigationCancelingError, Params, PRIMARY_OUTLET} from './shared';
 import {createRoot, squashSegmentGroup, UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
-import {forEach, wrapIntoObservable} from './utils/collection';
+import {forEach} from './utils/collection';
 import {getOrCreateRouteInjectorIfNeeded, getOutlet, sortByMatchingOutlets} from './utils/config';
 import {isImmediateMatch, match, matchWithChecks, noLeftoversInUrl, split} from './utils/config_matching';
 
@@ -289,9 +289,8 @@ class ApplyRedirects {
             switchMap(({matched, consumedSegments, remainingSegments}) => {
               if (!matched) return noMatch(rawSegmentGroup);
 
-              // Only create the Route's `EnvironmentInjector` if it matches the attempted
-              // navigation
-              injector = getOrCreateRouteInjectorIfNeeded(route, injector);
+              // If the route has an injector created from providers, we should start using that.
+              injector = route._injector ?? injector;
               const childConfig$ = this.getChildConfig(injector, route, segments);
 
               return childConfig$.pipe(mergeMap((routerConfig: LoadedRouterConfig) => {

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -12,7 +12,7 @@ export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet, RouterOutletContract} from './directives/router_outlet';
 export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, EventType, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
-export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, CanMatch, Data, LoadChildren, LoadChildrenCallback, QueryParamsHandling, Resolve, ResolveData, Route, Routes, RunGuardsAndResolvers, UrlMatcher, UrlMatchResult} from './models';
+export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, CanMatch, CanMatchFn, Data, LoadChildren, LoadChildrenCallback, QueryParamsHandling, Resolve, ResolveData, Route, Routes, RunGuardsAndResolvers, UrlMatcher, UrlMatchResult} from './models';
 export {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
 export {BaseRouteReuseStrategy, DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Navigation, NavigationBehaviorOptions, NavigationExtras, Router, UrlCreationOptions} from './router';

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -905,6 +905,13 @@ export interface CanMatch {
       Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean|UrlTree;
 }
 
+/**
+ * The signature of a function used as a `CanMatch` guard on a `Route`.
+ *
+ * @publicApi
+ * @see `CanMatch`
+ * @see `Route`
+ */
 export type CanMatchFn = (route: Route, segments: UrlSegment[]) =>
     Observable<boolean|UrlTree>|Promise<boolean|UrlTree>|boolean;
 

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -173,7 +173,7 @@ export class Recognizer {
     let matchResult: Observable<{
       snapshot: ActivatedRouteSnapshot,
       consumedSegments: UrlSegment[],
-      remainingSegments: UrlSegment[]
+      remainingSegments: UrlSegment[],
     }|null>;
 
     if (route.path === '**') {
@@ -219,9 +219,8 @@ export class Recognizer {
         return of(null);
       }
       const {snapshot, consumedSegments, remainingSegments} = result;
-      // Only create the Route's `EnvironmentInjector` if it matches the attempted
-      // navigation
-      injector = getOrCreateRouteInjectorIfNeeded(route, injector);
+      // If the route has an injector created from providers, we should start using that.
+      injector = route._injector ?? injector;
       const childInjector = route._loadedInjector ?? injector;
       const childConfig: Route[] = getChildConfig(route);
 

--- a/packages/router/test/apply_redirects.spec.ts
+++ b/packages/router/test/apply_redirects.spec.ts
@@ -262,7 +262,7 @@ describe('applyRedirects', () => {
         throw 'Should not be reached';
       }
     });
-  })
+  });
 
   describe('lazy loading', () => {
     it('should load config on demand', () => {


### PR DESCRIPTION
## Commit 1
fix(router): Ensure Route injector is created before running CanMatch guards

Once a `Route` matches via the `match` or `path` property, we need to
immediately create the injector for the route (if it has providers)
before running the `CanMatch` guards. This is necessary because the
`CanMatch` guards might be provided in the `Route` providers.

Fixes https://github.com/angular/angular/issues/46386


## Commit 2
fix(router): Expose CanMatchFn as public API

The `CanMatchFn` is already exposed in the type signature for `canMatch` on the
`Route`. This function type should already be exposed as public API but was
missed in the initial implementation because the older guards use the `any` type
instead.
