### PR TITLE
fix(core): make parent injector argument required in `createEnvironmentInjector`

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -289,7 +289,7 @@ export interface ContentChildrenDecorator {
 }
 
 // @public
-export function createEnvironmentInjector(providers: Array<Provider | ImportedNgModuleProviders>, parent?: EnvironmentInjector | null, debugName?: string | null): EnvironmentInjector;
+export function createEnvironmentInjector(providers: Array<Provider | ImportedNgModuleProviders>, parent: EnvironmentInjector, debugName?: string | null): EnvironmentInjector;
 
 // @public
 export function createNgModuleRef<T>(ngModule: Type<T>, parentInjector?: Injector): NgModuleRef<T>;

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -142,11 +142,19 @@ class EnvironmentNgModuleRefAdapter extends viewEngine_NgModuleRef<null> {
 /**
  * Create a new environment injector.
  *
+ * Learn more about environment injectors in
+ * [this guide](guide/standalone-components#environment-injectors).
+ *
+ * @param providers An array of providers.
+ * @param parent A parent environment injector.
+ * @param debugName An optional name for this injector instance, which will be used in error
+ *     messages.
+ *
  * @publicApi
  * @developerPreview
  */
 export function createEnvironmentInjector(
-    providers: Array<Provider|ImportedNgModuleProviders>, parent: EnvironmentInjector|null = null,
+    providers: Array<Provider|ImportedNgModuleProviders>, parent: EnvironmentInjector,
     debugName: string|null = null): EnvironmentInjector {
   const adapter = new EnvironmentNgModuleRefAdapter(providers, parent, debugName);
   return adapter.injector;

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Attribute, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, createEnvironmentInjector, Directive, ElementRef, ENVIRONMENT_INITIALIZER, EventEmitter, forwardRef, Host, HostBinding, ImportedNgModuleProviders, importProvidersFrom, ImportProvidersSource, inject, Inject, Injectable, InjectFlags, InjectionToken, INJECTOR, Injector, Input, LOCALE_ID, ModuleWithProviders, NgModule, NgZone, Optional, Output, Pipe, PipeTransform, Provider, Self, SkipSelf, TemplateRef, Type, ViewChild, ViewContainerRef, ViewRef, ɵcreateInjector as createInjector, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵINJECTOR_SCOPE} from '@angular/core';
+import {Attribute, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, createEnvironmentInjector, Directive, ElementRef, ENVIRONMENT_INITIALIZER, EnvironmentInjector, EventEmitter, forwardRef, Host, HostBinding, ImportedNgModuleProviders, importProvidersFrom, ImportProvidersSource, inject, Inject, Injectable, InjectFlags, InjectionToken, INJECTOR, Injector, Input, LOCALE_ID, ModuleWithProviders, NgModule, NgZone, Optional, Output, Pipe, PipeTransform, Provider, Self, SkipSelf, TemplateRef, Type, ViewChild, ViewContainerRef, ViewRef, ɵcreateInjector as createInjector, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵINJECTOR_SCOPE} from '@angular/core';
 import {ViewRef as ViewRefInternal} from '@angular/core/src/render3/view_ref';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -210,7 +210,8 @@ describe('importProvidersFrom', () => {
        expect(hasProviderWithToken(providers, C)).toBe(true);
        expect(hasProviderWithToken(providers, D)).toBe(true);
 
-       const injector = createEnvironmentInjector(providers);
+       const parentEnvInjector = TestBed.inject(EnvironmentInjector);
+       const injector = createEnvironmentInjector(providers, parentEnvInjector);
 
        // Verify that overridden token A has the right value.
        expect(injector.get(A)).toBe('Overridden A');

--- a/packages/core/test/acceptance/env_injector_standalone_spec.ts
+++ b/packages/core/test/acceptance/env_injector_standalone_spec.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, createEnvironmentInjector, importProvidersFrom, InjectionToken, NgModule} from '@angular/core';
+import {Component, createEnvironmentInjector, EnvironmentInjector, importProvidersFrom, InjectionToken, NgModule} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
 
 import {internalImportProvidersFrom} from '../../src/di/provider_collection';
 
@@ -22,8 +23,9 @@ describe('environment injector and standalone components', () => {
     class StandaloneComponent {
     }
 
-    const envInjector =
-        createEnvironmentInjector(internalImportProvidersFrom(false, StandaloneComponent));
+    const parentEnvInjector = TestBed.inject(EnvironmentInjector);
+    const envInjector = createEnvironmentInjector(
+        internalImportProvidersFrom(false, StandaloneComponent), parentEnvInjector);
     expect(envInjector.get(ModuleService)).toBeInstanceOf(ModuleService);
   });
 
@@ -42,7 +44,9 @@ describe('environment injector and standalone components', () => {
     class AppModule {
     }
 
-    const envInjector = createEnvironmentInjector([importProvidersFrom(AppModule)]);
+    const parentEnvInjector = TestBed.inject(EnvironmentInjector);
+    const envInjector =
+        createEnvironmentInjector([importProvidersFrom(AppModule)], parentEnvInjector);
     expect(envInjector.get(ModuleService)).toBeInstanceOf(ModuleService);
   });
 
@@ -68,7 +72,9 @@ describe('environment injector and standalone components', () => {
     class AppModule {
     }
 
-    const envInjector = createEnvironmentInjector([importProvidersFrom(AppModule)]);
+    const parentEnvInjector = TestBed.inject(EnvironmentInjector);
+    const envInjector =
+        createEnvironmentInjector([importProvidersFrom(AppModule)], parentEnvInjector);
     const services = envInjector.get(ModuleService) as ModuleService[];
 
     expect(services.length).toBe(1);
@@ -90,7 +96,8 @@ describe('environment injector and standalone components', () => {
         ]
       ]
     ];
-    const envInjector = createEnvironmentInjector(providers);
+    const parentEnvInjector = TestBed.inject(EnvironmentInjector);
+    const envInjector = createEnvironmentInjector(providers, parentEnvInjector);
     expect(envInjector.get(A)).toBe('A');
     expect(envInjector.get(B)).toBe('B');
     expect(envInjector.get(C)).toBe('C');

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -303,8 +303,8 @@ describe('standalone components, directives and pipes', () => {
              parent: this.inj,
            });
 
-           const rhsInj =
-               createEnvironmentInjector([{provide: Service, useClass: EnvOverrideService}]);
+           const rhsInj = createEnvironmentInjector(
+               [{provide: Service, useClass: EnvOverrideService}], this.envInj);
 
            this.vcRef.createComponent(InnerCmp, {injector: lhsInj, environmentInjector: rhsInj});
          }
@@ -352,8 +352,8 @@ describe('standalone components, directives and pipes', () => {
          constructor(readonly envInj: EnvironmentInjector) {}
 
          ngOnInit(): void {
-           const rhsInj =
-               createEnvironmentInjector([{provide: Service, useClass: EnvOverrideService}]);
+           const rhsInj = createEnvironmentInjector(
+               [{provide: Service, useClass: EnvOverrideService}], this.envInj);
 
            this.vcRef.createComponent(InnerCmp, {environmentInjector: rhsInj});
          }


### PR DESCRIPTION
Previously, the `createEnvironmentInjector` function allowed creating an instance of an EnvironmentInjector without providing a parent injector. This resulted in an injector instance, which was detached from the DI tree, thus having limited value. This commit updates the types of the `createEnvironmentInjector` function to make the parent injector a required argument.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No. The `createEnvironmentInjector` API is in the **Developer Preview phase** (and it's marked as such), so this change can be included into the patch branch.