### PR TITLE
fix(core): handle NgModules with standalone pipes in TestBed correctly 

### DIFF
--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -367,6 +367,48 @@ describe('TestBed with Standalone types', () => {
     expect(rootElement.innerHTML).toBe('Overridden MyStandaloneComponent');
   });
 
+  it('should make overridden providers available in pipes', () => {
+    const TOKEN_A = new InjectionToken('TOKEN_A');
+    @Pipe({
+      name: 'testPipe',
+      standalone: true,
+    })
+    class TestPipe {
+      constructor(@Inject(TOKEN_A) private token: string) {}
+
+      transform(value: string): string {
+        return `transformed ${value} using ${this.token} token`;
+      }
+    }
+    @NgModule({
+      imports: [TestPipe],
+      exports: [TestPipe],
+      providers: [{provide: TOKEN_A, useValue: 'A'}],
+    })
+    class TestNgModule {
+    }
+
+    @Component({
+      selector: 'test-component',
+      standalone: true,
+      imports: [TestNgModule],
+      template: `{{ 'original value' | testPipe }}`
+    })
+    class TestComponent {
+    }
+
+    TestBed.configureTestingModule({
+      imports: [TestComponent],
+    });
+    TestBed.overrideProvider(TOKEN_A, {useValue: 'Overridden A'});
+
+    const fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+
+    const hostElement = fixture.nativeElement.firstChild;
+    expect(hostElement.textContent).toBe('transformed original value using Overridden A token');
+  });
+
   describe('NgModules as dependencies', () => {
     @Component({
       selector: 'test-cmp',


### PR DESCRIPTION
Prior to this commit, the TestBed logic erroneously tried to apply provider overrides to standalone pipes that were imported in an NgModule. This commit updates the logic to recognize types that may have a scope (an NgModule or a standalone component) and skip other types while applying provider overrides recursively.

**Note to the reviewers**: this PR has 2 commits (one is a refactoring and the second is an actual fix), it might be easier to review commits individually.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No