### PR TITLE
fix(docs-infra): slightly improve aio-top-menu css

### DIFF
--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -106,22 +106,14 @@ mat-toolbar.app-toolbar {
 
   // TOP MENU
   aio-top-menu {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    width: 80%;
-
     ul {
       display: flex;
-      flex-direction: row;
-      align-items: center;
-      list-style-position: inside;
       padding: 0px;
       margin: 0px;
 
       li {
+        display: flex;
         padding-bottom: 2px;
-        list-style-type: none;
         cursor: pointer;
 
         &:focus {
@@ -132,6 +124,7 @@ mat-toolbar.app-toolbar {
           margin: 0 4px;
           padding: 0px;
           cursor: pointer;
+          display: flex;
 
           .nav-link-inner {
             border-radius: 4px;
@@ -146,7 +139,6 @@ mat-toolbar.app-toolbar {
             .nav-link-inner {
               display: inline-flex;
               align-items: center;
-              line-height: normal;
               &::after {
                 content: "\e89e"; // codepoint for "open_in_new"
                 margin-left: 0.3rem;


### PR DESCRIPTION
slightly improve the aio-top-menu css by making it more robust
regarding differnt font-sizes and also remove unnecessary css rules

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue

Issue Number: N/A


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - @gkalpak as we mentioned [here](https://github.com/angular/angular/pull/45876#pullrequestreview-971286636)
 
 - this is the before and after: 
![Peek 2022-06-19 12-29](https://user-images.githubusercontent.com/61631103/174478917-e9b48095-a674-4c4b-9174-f684731d808e.gif)
 notice the blog link loosing alignment on huge font sizes in the current implementation (well other stuff break before that even happens, but still, making it more robust seems better to me :P)
 
- This is a very very minor improvement, but makes the thing slightly more robust and the removal or unnecessary css rules should lighten a bit the aio payload :slightly_smiling_face: 

