### PR TITLE
fix(zone.js): cancel tasks only when they are scheduled or running

### DIFF
--- a/packages/zone.js/lib/zone.ts
+++ b/packages/zone.js/lib/zone.ts
@@ -956,6 +956,11 @@ const Zone: ZoneType = (function(global: any) {
         throw new Error(
             'A task can only be cancelled in the zone of creation! (Creation: ' +
             (task.zone || NO_ZONE).name + '; Execution: ' + this.name + ')');
+
+      if (task.state !== scheduled && task.state !== running) {
+        return;
+      }
+
       (task as ZoneTask<any>)._transitionTo(canceling, scheduled, running);
       try {
         this._zoneDelegate.cancelTask(this, task);


### PR DESCRIPTION
Currently, there's no check if the task (that is being canceled) has the right state.
Only `scheduled` and `running` tasks can be canceled. If the task has a non-appropriate
state, then an error will be thrown. Cancelation should not throw an error on an already
canceled task, e.g. `clearTimeout` does not throw errors when it's called multiple times
on the same timer.

- [x] Bugfix

Issue Number: #45711


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No