### PR TITLE
build(bazel): remove tsec patch to enable runfiles on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -210,7 +210,7 @@
     "semver": "^7.3.5",
     "send": "^0.18.0",
     "ts-node": "^10.8.1",
-    "tsec": "0.2.2",
+    "tsec": "0.2.5",
     "tslint-eslint-rules": "5.4.0",
     "tslint-no-toplevel-property-access": "0.0.2",
     "typed-graphqlify": "^3.1.1",

--- a/packages/compiler/BUILD.bazel
+++ b/packages/compiler/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_package", "ts_library")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "ng_package", "ts_library", "tsec_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
-load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_module", "ng_package")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "api_golden_test", "api_golden_test_npm_package", "ng_module", "ng_package", "tsec_test")
 load("//packages/common/locales:index.bzl", "generate_base_locale_file")
 
 package(default_visibility = ["//visibility:public"])

--- a/packages/core/src/compiler/BUILD.bazel
+++ b/packages/core/src/compiler/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "ts_library", "tsec_test")
 
 package(default_visibility = [
     "//packages/compiler/test:__pkg__",

--- a/packages/core/src/di/interface/BUILD.bazel
+++ b/packages/core/src/di/interface/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "ts_library", "tsec_test")
 
 package(default_visibility = [
     "//devtools:__subpackages__",

--- a/packages/core/src/interface/BUILD.bazel
+++ b/packages/core/src/interface/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "ts_library", "tsec_test")
 
 package(default_visibility = [
     "//packages/core:__subpackages__",

--- a/packages/core/src/reflection/BUILD.bazel
+++ b/packages/core/src/reflection/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "ts_library", "tsec_test")
 
 package(default_visibility = [
     "//packages/core:__subpackages__",

--- a/packages/core/src/util/BUILD.bazel
+++ b/packages/core/src/util/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ts_library")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "ts_library", "tsec_test")
 
 package(default_visibility = [
     "//devtools:__subpackages__",

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_module", "ng_package")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_module", "ng_package", "tsec_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/packages/platform-browser/animations/BUILD.bazel
+++ b/packages/platform-browser/animations/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_module")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "ng_module", "tsec_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_module", "ng_package")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_module", "ng_package", "tsec_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/packages/platform-server/init/BUILD.bazel
+++ b/packages/platform-server/init/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//tools:defaults.bzl", "ng_module")
-load("@npm//tsec:index.bzl", "tsec_test")
+load("//tools:defaults.bzl", "ng_module", "tsec_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -15,6 +15,7 @@ load("@npm//@angular/dev-infra-private/bazel/karma:index.bzl", _karma_web_test =
 load("@npm//@angular/dev-infra-private/bazel/api-golden:index.bzl", _api_golden_test = "api_golden_test", _api_golden_test_npm_package = "api_golden_test_npm_package")
 load("@npm//@angular/dev-infra-private/bazel:extract_js_module_output.bzl", "extract_js_module_output")
 load("@npm//@angular/dev-infra-private/bazel/esbuild:index.bzl", _esbuild = "esbuild", _esbuild_config = "esbuild_config")
+load("@npm//tsec:index.bzl", _tsec_test = "tsec_test")
 
 _DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test"
 _INTERNAL_NG_MODULE_COMPILER = "//packages/bazel/src/ngc-wrapped"
@@ -588,5 +589,12 @@ def api_golden_test(**kwargs):
 
 def api_golden_test_npm_package(**kwargs):
     _api_golden_test_npm_package(
+        **kwargs
+    )
+
+def tsec_test(**kwargs):
+    """Default values for tsec_test"""
+    _tsec_test(
+        use_runfiles_on_windows = True,  # We explicitly enable runfiles in .bazelrc
         **kwargs
     )

--- a/tools/postinstall-patches.js
+++ b/tools/postinstall-patches.js
@@ -61,12 +61,6 @@ ls('node_modules/@types').filter(f => f.startsWith('babel__')).forEach(pkg => {
   }
 });
 
-// patch tsec 0.2.2 to enable runfiles on windows
-// Note that we need to use tsec 0.2.2 as future versions don't publish this bzl file
-log('\n# patch: tsec to enable using runfiles on windows');
-sed('-i', '@platforms//os:windows": False', '@platforms//os:windows": True',
-    'node_modules/tsec/index.bzl');
-
 log('\n# patch: use local version of @angular/* and zone.js in Starlark files from @angular/dev-infra-private');
 
 const ngDevPatches = new Map();

--- a/yarn.lock
+++ b/yarn.lock
@@ -15364,10 +15364,10 @@ tsconfig-paths@^3.10.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tsec@0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/tsec/-/tsec-0.2.2.tgz#d86d771215fb09a5e226f2b252a1c038c7fa17ca"
-  integrity sha512-gKm+nnIKcE9xtrJw2cIJFjfuDGK0AvH3r4RayTEIkUvja/s9z9GPFgcSdEaapm6N10KrmWWcLjsHlKmH2tqzMw==
+tsec@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/tsec/-/tsec-0.2.5.tgz#5943f48c13b15442a858d8d405d6eb9ab8b11f4d"
+  integrity sha512-Tp5AJWwYwifFO/+Puprhe/ooZpLmZctQI1eprkxOqU/nUmPuCvosYh0ky9LLcrvJGOF9NqryID4sBBm/1PBSKg==
   dependencies:
     glob "^7.1.1"
     minimatch "^3.0.3"


### PR DESCRIPTION
@devversion @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We had to patch tsec to get it to use runfiles on Windows.

## What is the new behavior?

@uraj released a patch fix so we no longer need to patch it manually.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No