### PR TITLE
build: load ng-dev release package builder using CJS interop

### DIFF
--- a/.ng-dev/release.mts
+++ b/.ng-dev/release.mts
@@ -26,8 +26,10 @@ export const release: ReleaseConfig = {
   buildPackages: async () => {
     // The buildTargetPackages function is loaded at runtime as the loading the script causes an
     // invocation of bazel.
-    const {buildTargetPackages} = require(join(__dirname, '../scripts/build/package-builder'));
-    return buildTargetPackages('dist/release-output', false, 'Release', /* isRelease */ true);
+    const packageBuilder = await import('../scripts/build/package-builder.js');
+
+    return packageBuilder.default.buildTargetPackages(
+      'dist/release-output', 'Release', /* isRelease */ true);
   },
   releaseNotes: {
     hiddenScopes: ['aio', 'bazel', 'dev-infra', 'docs-infra', 'zone.js', 'devtools'],

--- a/scripts/build/package-builder.d.ts
+++ b/scripts/build/package-builder.d.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Build the Angular packages.
+ *
+ * @param {string} destDir Path to the output directory into which we copy the npm packages.
+ * This path should either be absolute or relative to the project root.
+ * @param {string} description Human-readable description of the build.
+ * @param {boolean?} isRelease True, if the build should be stamped for a release.
+ * @returns {Array<{name: string, outputPath: string}} A list of packages built.
+ */
+export declare function buildTargetPackages(destDir, description, isRelease: boolean): {name: string, outputPath: string}[];


### PR DESCRIPTION
We need to switch the package builder to ESM or TS, like we did
in the components repo, but for now until we can, the release script
should work by loading the package builder CJS through the dynamic
import expression.