### PR TITLE
docs(forms): add usage notes

### DIFF
--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -684,13 +684,13 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * // Reference to the RequiredValidator
    * const ctrl = new FormControl<string | null>('', Validators.required);
    * ctrl.removeValidators(Validators.required);
-   * 
+   *
    * // Reference to anonymous function inside MinValidator
    * const minValidator = Validators.min(3);
    * const ctrl = new FormControl<string | null>('', minValidator);
    * expect(ctrl.hasValidator(minValidator)).toEqual(true)
    * expect(ctrl.hasValidator(Validators.min(3)).toEqual(false)
-   * 
+   *
    * ctrl.removeValidators(minValidator);
    * ```
    *
@@ -730,7 +730,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * // Reference to the RequiredValidator
    * const ctrl = new FormControl<number | null>(0, Validators.required);
    * expect(ctrl.hasValidator(Validators.required)).toEqual(true)
-   * 
+   *
    * // Reference to anonymous function inside MinValidator
    * const minValidator = Validators.min(3);
    * const ctrl = new FormControl<number | null>(0, minValidator);

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -737,6 +737,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * expect(ctrl.hasValidator(minValidator)).toEqual(true)
    * expect(ctrl.hasValidator(Validators.min(3)).toEqual(false)
    * ```
+   *
    * @param validator The validator to check for presence. Compared by function reference.
    * @returns Whether the provided validator was found on this control.
    */

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -676,6 +676,24 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * validator function as the one that was originally set. If a provided validator is not found,
    * it is ignored.
    *
+   * @usageNotes
+   *
+   * ### Reference to a ValidatorFn
+   *
+   * ```
+   * // Reference to the RequiredValidator
+   * const ctrl = new FormControl<string | null>('', Validators.required);
+   * ctrl.removeValidators(Validators.required);
+   * 
+   * // Reference to anonymous function inside MinValidator
+   * const minValidator = Validators.min(3);
+   * const ctrl = new FormControl<string | null>('', minValidator);
+   * expect(ctrl.hasValidator(minValidator)).toEqual(true)
+   * expect(ctrl.hasValidator(Validators.min(3)).toEqual(false)
+   * 
+   * ctrl.removeValidators(minValidator);
+   * ```
+   *
    * When you add or remove a validator at run time, you must call
    * `updateValueAndValidity()` for the new validation to take effect.
    *
@@ -704,6 +722,21 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * Check whether a synchronous validator function is present on this control. The provided
    * validator must be a reference to the exact same function that was provided.
    *
+   * @usageNotes
+   *
+   * ### Reference to a ValidatorFn
+   *
+   * ```
+   * // Reference to the RequiredValidator
+   * const ctrl = new FormControl<number | null>(0, Validators.required);
+   * expect(ctrl.hasValidator(Validators.required)).toEqual(true)
+   * 
+   * // Reference to anonymous function inside MinValidator
+   * const minValidator = Validators.min(3);
+   * const ctrl = new FormControl<number | null>(0, minValidator);
+   * expect(ctrl.hasValidator(minValidator)).toEqual(true)
+   * expect(ctrl.hasValidator(Validators.min(3)).toEqual(false)
+   * ```
    * @param validator The validator to check for presence. Compared by function reference.
    * @returns Whether the provided validator was found on this control.
    */


### PR DESCRIPTION
Add usage notes for removeValidators and hasValidators to better understand how to use these functions

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The description to use `removeValidators` and `hasValidators` wasn't clear enough for me. I always prefer to have a concrete usage note

## What is the new behavior?
Add usage note for the two methods mentionned above

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
