### PR TITLE
fix(docs-infra): change color of code copy button

### DIFF
--- a/aio/src/styles/2-modules/code/_code-theme.scss
+++ b/aio/src/styles/2-modules/code/_code-theme.scss
@@ -66,14 +66,6 @@
         }
       }
 
-      .copy-button {
-        color: constants.$blue-grey-200;
-
-        &:hover {
-          color: constants.$mediumgray;
-        }
-      }
-
       &.lang-sh,
       &.lang-bash {
         .copy-button {
@@ -84,6 +76,10 @@
           }
         }
       }
+    }
+
+    .copy-button {
+      color: if($is-dark-theme, constants.$blue-grey-200, constants.$darkblue);
     }
   }
 
@@ -221,6 +217,10 @@
       .dec {
         color: constants.$codegreen;
       }
+      .copy-button {
+        color: constants.$blue-grey-200;
+      }
     }
+
   }
 }

--- a/aio/src/styles/2-modules/code/_code.scss
+++ b/aio/src/styles/2-modules/code/_code.scss
@@ -104,6 +104,13 @@ aio-code {
       background-color: transparent;
       border: none;
       cursor: pointer;
+
+      &:hover, &:focus {
+        transform: scale(1.1);
+      }
+      &:active {
+        transform: translateY(2px) scale(1.05);
+      }
     }
   }
 }


### PR DESCRIPTION
change the color of the code copy button so that it has a better color
contrast with its background

resolves #37817

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The aio copy code button for normal code example is too light in the light theme and doesn't meet the  wgac color contrast guidelines:
![Screenshot at 2022-06-22 21-58-23](https://user-images.githubusercontent.com/61631103/175142277-9fe58efa-c31d-46d4-a42b-19082adc0fd3.png)


Issue Number: #37817


## What is the new behavior?

The button's color is changed to dark blue so that it meets the AAA criteria:
![Screenshot at 2022-06-22 22-26-20](https://user-images.githubusercontent.com/61631103/175142367-3a124f9b-e1e2-41a0-addc-a584250befa5.png)

(
I left other instances as they are since their color contrast seems quite ok
![Screenshot at 2022-06-22 22-17-57](https://user-images.githubusercontent.com/61631103/175142667-436d7f87-fa78-4294-9193-d901e738a13c.png)
![Screenshot at 2022-06-22 22-34-00](https://user-images.githubusercontent.com/61631103/175142580-0af934c9-7630-4fd6-b611-0f78e8847f46.png)
)

I've also tweaked the hover and active styles to make sure interaction clear without changing the button's color, this is how it looks:
![Peek 2022-06-22 22-43](https://user-images.githubusercontent.com/61631103/175144195-2b52413c-a0a7-45d9-bb61-20cc8755a10e.gif)



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - I thought of using the same icon as the material website but it does seem quite more elaborated what what we have here and I bet that using that would increase the aio bundle size considerably so I imagined that the current changes would be more suited for aio
 - I changed the button's color to darkblue instead of accentblue, accentblue may look slightly nicer but doesn't meet the AAA criteria:
![Screenshot at 2022-06-22 22-39-08](https://user-images.githubusercontent.com/61631103/175143593-d03d3b17-e828-49e6-bfc4-a30bab4a2479.png)
  so I figured I could try to apply the darker blue to meet the AAA, but that is not that essential so if you prefer I can use the accentblue instead :slightly_smiling_face: 