### PR TITLE
Revert "fix(zone.js): do not silence uncaught promise rejections when the `finally` is called (#45449)"

### DIFF
--- a/packages/zone.js/lib/common/promise.ts
+++ b/packages/zone.js/lib/common/promise.ts
@@ -249,17 +249,8 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
   function scheduleResolveOrReject<R, U1, U2>(
       promise: ZoneAwarePromise<any>, zone: Zone, chainPromise: ZoneAwarePromise<any>,
       onFulfilled?: ((value: R) => U1)|null|undefined,
-      onRejected?: ((error: any) => U2)|null|undefined, scheduledByFinally = false): void {
-    // Note: the native promise implementation logs unhandled promise rejections after `onFinally`
-    // has been called. We may rely on the `scheduledByFinally` argument, which is `false` by
-    // default, to avoid creating a breaking change; this will also allow us to reduce the number of
-    // changes. The `finally` function should not silence unhandled promise rejections, because
-    // they're not silenced in any implementation. If the `scheduleResolveOrReject` is called within
-    // the `finally` we won't clear unhandled rejections. We'll keep the same behaviour if the
-    // `scheduleResolveOrReject` is called within the `then`.
-    if (!scheduledByFinally) {
-      clearRejectedNoCatch(promise);
-    }
+      onRejected?: ((error: any) => U2)|null|undefined): void {
+    clearRejectedNoCatch(promise);
     const promiseState = (promise as any)[symbolState];
     const delegate = promiseState ?
         (typeof onFulfilled === 'function') ? onFulfilled : forwardResolution :
@@ -515,8 +506,7 @@ Zone.__load_patch('ZoneAwarePromise', (global: any, Zone: ZoneType, api: _ZonePr
       if ((this as any)[symbolState] == UNRESOLVED) {
         (<any[]>(this as any)[symbolValue]).push(zone, chainPromise, onFinally, onFinally);
       } else {
-        scheduleResolveOrReject(
-            this, zone, chainPromise as any, onFinally, onFinally, /* scheduledByFinally */ true);
+        scheduleResolveOrReject(this, zone, chainPromise as any, onFinally, onFinally);
       }
       return chainPromise;
     }

--- a/packages/zone.js/test/common/Promise.spec.ts
+++ b/packages/zone.js/test/common/Promise.spec.ts
@@ -376,28 +376,6 @@ describe(
                });
              });
 
-          it('should not silence rejected promise errors after .finally has been called', done => {
-            Zone.current.fork({name: 'promise-error'}).run(() => {
-              (Zone as any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] = false;
-              const originalConsoleError = console.error;
-              const spy = console.error = jasmine.createSpy('console.error');
-              new Promise((resolve, reject) => {
-                throw new Error('promise error');
-              }).finally(() => {
-                // Ensure that uncaught promise `console.error` is called after the `finally` is
-                // called.
-                expect(spy).not.toHaveBeenCalled();
-                setTimeout(() => {
-                  const {args} = spy.calls.mostRecent();
-                  expect(args).toContain('Unhandled Promise rejection:');
-                  expect(args).toContain('promise error');
-                  console.error = originalConsoleError;
-                  done();
-                }, 10);
-              });
-            });
-          });
-
           it('should not output error to console if ignoreConsoleErrorUncaughtError is true',
              (done) => {
                Zone.current.fork({name: 'promise-error'}).run(() => {


### PR DESCRIPTION
This reverts commit cb57cdbbd4c09be2333876711f128d1c8c51fba7.

The reason for the revert: this change was causing failures in g3.
