### PR TITLE
refactor(core): make i18n error messages tree shakable

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -51,6 +51,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     MISSING_INJECTION_CONTEXT = -203,
     // (undocumented)
+    MISSING_LOCALE_DATA = 701,
+    // (undocumented)
     MULTIPLE_COMPONENTS_MATCH = -300,
     // (undocumented)
     MULTIPLE_PLATFORMS = 400,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -56,6 +56,7 @@ export const enum RuntimeErrorCode {
 
   // i18n Errors
   INVALID_I18N_STRUCTURE = 700,
+  MISSING_LOCALE_DATA = 701,
 
   // standalone errors
   IMPORT_PROVIDERS_FROM_STANDALONE = 800,

--- a/packages/core/src/i18n/locale_data_api.ts
+++ b/packages/core/src/i18n/locale_data_api.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {global} from '../util/global';
 
 import localeEn from './locale_en';
@@ -62,7 +63,9 @@ export function findLocaleData(locale: string): any {
     return localeEn;
   }
 
-  throw new Error(`Missing locale data for the locale "${locale}".`);
+  throw new RuntimeError(
+      RuntimeErrorCode.MISSING_LOCALE_DATA,
+      ngDevMode && `Missing locale data for the locale "${locale}".`);
 }
 
 /**


### PR DESCRIPTION
Make the error messages tree shakable from the production build to reduce the bundle size.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Error messages under the i18n are made tree shakable from the production build.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
