### PR TITLE
feat(common): support URL object in HttpClient

### DIFF
--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -22,7 +22,7 @@ export abstract class HttpBackend implements HttpHandler {
 // @public
 export class HttpClient {
     constructor(handler: HttpHandler);
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -36,7 +36,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<ArrayBuffer>;
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -50,7 +50,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<Blob>;
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -64,7 +64,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<string>;
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -78,7 +78,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -92,7 +92,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<HttpEvent<Blob>>;
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -106,7 +106,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<HttpEvent<string>>;
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -120,7 +120,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<HttpEvent<Object>>;
-    delete<T>(url: string, options: {
+    delete<T>(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -134,7 +134,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<HttpEvent<T>>;
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -148,7 +148,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -162,7 +162,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<HttpResponse<Blob>>;
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -176,7 +176,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<HttpResponse<string>>;
-    delete(url: string, options: {
+    delete(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -190,7 +190,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<HttpResponse<Object>>;
-    delete<T>(url: string, options: {
+    delete<T>(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -204,7 +204,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<HttpResponse<T>>;
-    delete(url: string, options?: {
+    delete(url: string | URL, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -218,7 +218,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<Object>;
-    delete<T>(url: string, options?: {
+    delete<T>(url: string | URL, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -232,7 +232,7 @@ export class HttpClient {
         withCredentials?: boolean;
         body?: any | null;
     }): Observable<T>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -245,7 +245,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -258,7 +258,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -271,7 +271,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -284,7 +284,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -297,7 +297,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -310,7 +310,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -323,7 +323,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
-    get<T>(url: string, options: {
+    get<T>(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -336,7 +336,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -349,7 +349,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -362,7 +362,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -375,7 +375,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
-    get(url: string, options: {
+    get(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -388,7 +388,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
-    get<T>(url: string, options: {
+    get<T>(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -401,7 +401,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
-    get(url: string, options?: {
+    get(url: string | URL, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -414,7 +414,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
-    get<T>(url: string, options?: {
+    get<T>(url: string | URL, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -427,7 +427,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -440,7 +440,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -453,7 +453,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -466,7 +466,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -479,7 +479,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -492,7 +492,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -505,7 +505,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -518,7 +518,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
-    head<T>(url: string, options: {
+    head<T>(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -531,7 +531,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -544,7 +544,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -557,7 +557,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -570,7 +570,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
-    head(url: string, options: {
+    head(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -583,7 +583,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
-    head<T>(url: string, options: {
+    head<T>(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -596,7 +596,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
-    head(url: string, options?: {
+    head(url: string | URL, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -609,7 +609,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
-    head<T>(url: string, options?: {
+    head<T>(url: string | URL, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -622,9 +622,9 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
-    jsonp(url: string, callbackParam: string): Observable<Object>;
-    jsonp<T>(url: string, callbackParam: string): Observable<T>;
-    options(url: string, options: {
+    jsonp(url: string | URL, callbackParam: string): Observable<Object>;
+    jsonp<T>(url: string | URL, callbackParam: string): Observable<T>;
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -637,7 +637,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
-    options(url: string, options: {
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -650,7 +650,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
-    options(url: string, options: {
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -663,7 +663,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
-    options(url: string, options: {
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -676,7 +676,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    options(url: string, options: {
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -689,7 +689,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
-    options(url: string, options: {
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -702,7 +702,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
-    options(url: string, options: {
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -715,7 +715,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
-    options<T>(url: string, options: {
+    options<T>(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -728,7 +728,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
-    options(url: string, options: {
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -741,7 +741,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    options(url: string, options: {
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -754,7 +754,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
-    options(url: string, options: {
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -767,7 +767,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
-    options(url: string, options: {
+    options(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -780,7 +780,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
-    options<T>(url: string, options: {
+    options<T>(url: string | URL, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -793,7 +793,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
-    options(url: string, options?: {
+    options(url: string | URL, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -806,7 +806,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
-    options<T>(url: string, options?: {
+    options<T>(url: string | URL, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -819,7 +819,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -832,7 +832,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -845,7 +845,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -858,7 +858,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -871,7 +871,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -884,7 +884,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -897,7 +897,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -910,7 +910,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
-    patch<T>(url: string, body: any | null, options: {
+    patch<T>(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -923,7 +923,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -936,7 +936,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -949,7 +949,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -962,7 +962,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
-    patch(url: string, body: any | null, options: {
+    patch(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -975,7 +975,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
-    patch<T>(url: string, body: any | null, options: {
+    patch<T>(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -988,7 +988,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
-    patch(url: string, body: any | null, options?: {
+    patch(url: string | URL, body: any | null, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1001,7 +1001,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
-    patch<T>(url: string, body: any | null, options?: {
+    patch<T>(url: string | URL, body: any | null, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1014,7 +1014,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1027,7 +1027,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1040,7 +1040,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1053,7 +1053,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1066,7 +1066,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1079,7 +1079,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1092,7 +1092,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1105,7 +1105,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
-    post<T>(url: string, body: any | null, options: {
+    post<T>(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1118,7 +1118,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1131,7 +1131,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1144,7 +1144,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1157,7 +1157,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
-    post(url: string, body: any | null, options: {
+    post(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1170,7 +1170,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
-    post<T>(url: string, body: any | null, options: {
+    post<T>(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1183,7 +1183,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
-    post(url: string, body: any | null, options?: {
+    post(url: string | URL, body: any | null, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1196,7 +1196,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
-    post<T>(url: string, body: any | null, options?: {
+    post<T>(url: string | URL, body: any | null, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1209,7 +1209,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<T>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1222,7 +1222,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1235,7 +1235,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1248,7 +1248,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1261,7 +1261,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1274,7 +1274,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1287,7 +1287,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1300,7 +1300,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Object>>;
-    put<T>(url: string, body: any | null, options: {
+    put<T>(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1313,7 +1313,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<T>>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1326,7 +1326,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1339,7 +1339,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1352,7 +1352,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
-    put(url: string, body: any | null, options: {
+    put(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1365,7 +1365,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
-    put<T>(url: string, body: any | null, options: {
+    put<T>(url: string | URL, body: any | null, options: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1378,7 +1378,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<T>>;
-    put(url: string, body: any | null, options?: {
+    put(url: string | URL, body: any | null, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1391,7 +1391,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<Object>;
-    put<T>(url: string, body: any | null, options?: {
+    put<T>(url: string | URL, body: any | null, options?: {
         headers?: HttpHeaders | {
             [header: string]: string | string[];
         };
@@ -1405,7 +1405,7 @@ export class HttpClient {
         withCredentials?: boolean;
     }): Observable<T>;
     request<R>(req: HttpRequest<any>): Observable<HttpEvent<R>>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1419,7 +1419,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<ArrayBuffer>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1433,7 +1433,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<Blob>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1447,7 +1447,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<string>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1461,7 +1461,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpEvent<ArrayBuffer>>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1475,7 +1475,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpEvent<Blob>>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1489,7 +1489,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpEvent<string>>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1503,7 +1503,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<any>>;
-    request<R>(method: string, url: string, options: {
+    request<R>(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1517,7 +1517,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpEvent<R>>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1531,7 +1531,7 @@ export class HttpClient {
         responseType: 'arraybuffer';
         withCredentials?: boolean;
     }): Observable<HttpResponse<ArrayBuffer>>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1545,7 +1545,7 @@ export class HttpClient {
         responseType: 'blob';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Blob>>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1559,7 +1559,7 @@ export class HttpClient {
         responseType: 'text';
         withCredentials?: boolean;
     }): Observable<HttpResponse<string>>;
-    request(method: string, url: string, options: {
+    request(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1573,7 +1573,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<Object>>;
-    request<R>(method: string, url: string, options: {
+    request<R>(method: string, url: string | URL, options: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1587,7 +1587,7 @@ export class HttpClient {
         responseType?: 'json';
         withCredentials?: boolean;
     }): Observable<HttpResponse<R>>;
-    request(method: string, url: string, options?: {
+    request(method: string, url: string | URL, options?: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1601,7 +1601,7 @@ export class HttpClient {
         reportProgress?: boolean;
         withCredentials?: boolean;
     }): Observable<Object>;
-    request<R>(method: string, url: string, options?: {
+    request<R>(method: string, url: string | URL, options?: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1615,7 +1615,7 @@ export class HttpClient {
         reportProgress?: boolean;
         withCredentials?: boolean;
     }): Observable<R>;
-    request(method: string, url: string, options?: {
+    request(method: string, url: string | URL, options?: {
         body?: any;
         headers?: HttpHeaders | {
             [header: string]: string | string[];
@@ -1814,7 +1814,7 @@ export interface HttpProgressEvent {
 
 // @public
 export class HttpRequest<T> {
-    constructor(method: 'DELETE' | 'GET' | 'HEAD' | 'JSONP' | 'OPTIONS', url: string, init?: {
+    constructor(method: 'DELETE' | 'GET' | 'HEAD' | 'JSONP' | 'OPTIONS', url: string | URL, init?: {
         headers?: HttpHeaders;
         context?: HttpContext;
         reportProgress?: boolean;
@@ -1822,7 +1822,7 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
     });
-    constructor(method: 'POST' | 'PUT' | 'PATCH', url: string, body: T | null, init?: {
+    constructor(method: 'POST' | 'PUT' | 'PATCH', url: string | URL, body: T | null, init?: {
         headers?: HttpHeaders;
         context?: HttpContext;
         reportProgress?: boolean;
@@ -1830,7 +1830,7 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer' | 'blob' | 'json' | 'text';
         withCredentials?: boolean;
     });
-    constructor(method: string, url: string, body: T | null, init?: {
+    constructor(method: string, url: string | URL, body: T | null, init?: {
         headers?: HttpHeaders;
         context?: HttpContext;
         reportProgress?: boolean;
@@ -1885,7 +1885,6 @@ export class HttpRequest<T> {
     readonly reportProgress: boolean;
     readonly responseType: 'arraybuffer' | 'blob' | 'json' | 'text';
     serializeBody(): ArrayBuffer | Blob | FormData | string | null;
-    // (undocumented)
     readonly url: string;
     readonly urlWithParams: string;
     readonly withCredentials: boolean;

--- a/goldens/public-api/common/http/testing/index.md
+++ b/goldens/public-api/common/http/testing/index.md
@@ -23,15 +23,15 @@ export class HttpClientTestingModule {
 
 // @public
 export abstract class HttpTestingController {
-    abstract expectNone(url: string, description?: string): void;
+    abstract expectNone(url: string | URL, description?: string): void;
     abstract expectNone(params: RequestMatch, description?: string): void;
     abstract expectNone(matchFn: ((req: HttpRequest<any>) => boolean), description?: string): void;
-    abstract expectNone(match: string | RequestMatch | ((req: HttpRequest<any>) => boolean), description?: string): void;
-    abstract expectOne(url: string, description?: string): TestRequest;
+    abstract expectNone(match: string | URL | RequestMatch | ((req: HttpRequest<any>) => boolean), description?: string): void;
+    abstract expectOne(url: string | URL, description?: string): TestRequest;
     abstract expectOne(params: RequestMatch, description?: string): TestRequest;
     abstract expectOne(matchFn: ((req: HttpRequest<any>) => boolean), description?: string): TestRequest;
-    abstract expectOne(match: string | RequestMatch | ((req: HttpRequest<any>) => boolean), description?: string): TestRequest;
-    abstract match(match: string | RequestMatch | ((req: HttpRequest<any>) => boolean)): TestRequest[];
+    abstract expectOne(match: string | URL | RequestMatch | ((req: HttpRequest<any>) => boolean), description?: string): TestRequest;
+    abstract match(match: string | URL | RequestMatch | ((req: HttpRequest<any>) => boolean)): TestRequest[];
     abstract verify(opts?: {
         ignoreCancelled?: boolean;
     }): void;
@@ -42,7 +42,7 @@ export interface RequestMatch {
     // (undocumented)
     method?: string;
     // (undocumented)
-    url?: string;
+    url?: string | URL;
 }
 
 // @public

--- a/packages/common/http/src/client.ts
+++ b/packages/common/http/src/client.ts
@@ -129,7 +129,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as an `ArrayBuffer`.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -150,7 +150,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type `Blob`.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -171,7 +171,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type string.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -193,7 +193,7 @@ export class HttpClient {
    * @return An `Observable` of the response, with the response body as an array of `HttpEvent`s for
    * the request.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -215,7 +215,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type `Blob`.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
@@ -236,7 +236,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type string.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
@@ -257,7 +257,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type `Object`.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -279,7 +279,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body of type `R`.
    */
-  request<R>(method: string, url: string, options: {
+  request<R>(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -300,7 +300,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body as an `ArrayBuffer`.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
@@ -319,7 +319,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of type `Blob`.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
@@ -339,7 +339,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the HTTP response, with the response body of type string.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
@@ -360,7 +360,7 @@ export class HttpClient {
    * @return An `Observable` of the full `HttpResponse`,
    * with the response body of type `Object`.
    */
-  request(method: string, url: string, options: {
+  request(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -381,7 +381,7 @@ export class HttpClient {
    *
    * @return  An `Observable` of the full `HttpResponse`, with the response body of type `R`.
    */
-  request<R>(method: string, url: string, options: {
+  request<R>(method: string, url: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -402,7 +402,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of type `Object`.
    */
-  request(method: string, url: string, options?: {
+  request(method: string, url: string|URL, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -424,7 +424,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of type `R`.
    */
-  request<R>(method: string, url: string, options?: {
+  request<R>(method: string, url: string|URL, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -445,7 +445,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the requested response, with body of type `any`.
    */
-  request(method: string, url: string, options?: {
+  request(method: string, url: string|URL, options?: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -483,7 +483,7 @@ export class HttpClient {
    *   * An `observe` value of body returns an observable of `<T>` with the same `T` body type.
    *
    */
-  request(first: string|HttpRequest<any>, url?: string, options: {
+  request(first: string|HttpRequest<any>, url?: string|URL, options: {
     body?: any,
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
@@ -611,7 +611,7 @@ export class HttpClient {
    *
    * @return  An `Observable` of the response body as an `ArrayBuffer`.
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -632,7 +632,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response body as a `Blob`.
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -652,7 +652,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type string.
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -673,7 +673,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with response body as an `ArrayBuffer`.
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -693,7 +693,7 @@ export class HttpClient {
    * @return An `Observable` of all the `HttpEvent`s for the request, with the response body as a
    * `Blob`.
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -713,7 +713,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request, with the response
    * body of type string.
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -733,7 +733,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request, with response body of
    * type `Object`.
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -754,7 +754,7 @@ export class HttpClient {
    * @return An `Observable` of all the `HttpEvent`s for the request, with a response
    * body in the requested type.
    */
-  delete<T>(url: string, options: {
+  delete<T>(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -774,7 +774,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the full `HttpResponse`, with the response body as an `ArrayBuffer`.
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -793,7 +793,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of type `Blob`.
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -812,7 +812,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the full `HttpResponse`, with the response body of type string.
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -832,7 +832,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse`, with the response body of type `Object`.
    *
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -852,7 +852,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with the response body of the requested type.
    */
-  delete<T>(url: string, options: {
+  delete<T>(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -872,7 +872,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type `Object`.
    */
-  delete(url: string, options?: {
+  delete(url: string|URL, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -893,7 +893,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with response body in the requested type.
    */
-  delete<T>(url: string, options?: {
+  delete<T>(url: string|URL, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -914,7 +914,7 @@ export class HttpClient {
    * @param options The HTTP options to send with the request.
    *
    */
-  delete(url: string, options: {
+  delete(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body'|'events'|'response',
@@ -938,7 +938,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as an `ArrayBuffer`.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -957,7 +957,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as a `Blob`.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -976,7 +976,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type string.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -996,7 +996,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request, with the response
    * body as an `ArrayBuffer`.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1014,7 +1014,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as a `Blob`.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1032,7 +1032,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type string.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1050,7 +1050,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type `Object`.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1069,7 +1069,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with a response body in the requested type.
    */
-  get<T>(url: string, options: {
+  get<T>(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1089,7 +1089,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body as an `ArrayBuffer`.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1108,7 +1108,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body as a `Blob`.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1127,7 +1127,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body of type string.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1146,7 +1146,7 @@ export class HttpClient {
    * @return An `Observable` of the full `HttpResponse`,
    * with the response body of type `Object`.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1166,7 +1166,7 @@ export class HttpClient {
    * @return An `Observable` of the full `HttpResponse` for the request,
    * with a response body in the requested type.
    */
-  get<T>(url: string, options: {
+  get<T>(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1186,7 +1186,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response body as a JSON object.
    */
-  get(url: string, options?: {
+  get(url: string|URL, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1206,7 +1206,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with a response body in the requested type.
    */
-  get<T>(url: string, options?: {
+  get<T>(url: string|URL, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1222,7 +1222,7 @@ export class HttpClient {
    * `GET` request to execute on the server. See the individual overloads for
    * details on the return type.
    */
-  get(url: string, options: {
+  get(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body'|'events'|'response',
@@ -1245,7 +1245,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as an `ArrayBuffer`.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1265,7 +1265,7 @@ export class HttpClient {
    * @return  An `Observable` of the response, with the response body as a `Blob`.
    */
 
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1284,7 +1284,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type string.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1304,7 +1304,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body as an `ArrayBuffer`.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1323,7 +1323,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body as a `Blob`.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1342,7 +1342,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request, with the response body of type
    * string.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1361,7 +1361,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request, with a response body of
    * type `Object`.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1381,7 +1381,7 @@ export class HttpClient {
    * @param url     The endpoint URL.
    * @param options The HTTP options to send with the request.
    */
-  head<T>(url: string, options: {
+  head<T>(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1401,7 +1401,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body as an `ArrayBuffer`.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1420,7 +1420,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body as a blob.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1439,7 +1439,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body of type string.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1458,7 +1458,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body of type `Object`.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1478,7 +1478,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with a response body of the requested type.
    */
-  head<T>(url: string, options: {
+  head<T>(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1497,7 +1497,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as a JSON object.
    */
-  head(url: string, options?: {
+  head(url: string|URL, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1518,7 +1518,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with a response body of the given type.
    */
-  head<T>(url: string, options?: {
+  head<T>(url: string|URL, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1536,7 +1536,7 @@ export class HttpClient {
    * resource itself. See the individual overloads for
    * details on the return type.
    */
-  head(url: string, options: {
+  head(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body'|'events'|'response',
@@ -1557,7 +1557,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response object, with response body as an object.
    */
-  jsonp(url: string, callbackParam: string): Observable<Object>;
+  jsonp(url: string|URL, callbackParam: string): Observable<Object>;
 
   /**
    * Constructs a `JSONP` request for the given URL and name of the callback parameter.
@@ -1571,7 +1571,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response object, with response body in the requested type.
    */
-  jsonp<T>(url: string, callbackParam: string): Observable<T>;
+  jsonp<T>(url: string|URL, callbackParam: string): Observable<T>;
 
   /**
    * Constructs an `Observable` that, when subscribed, causes a request with the special method
@@ -1591,7 +1591,7 @@ export class HttpClient {
    * @param callbackParam The callback function name.
    *
    */
-  jsonp<T>(url: string, callbackParam: string): Observable<T> {
+  jsonp<T>(url: string|URL, callbackParam: string): Observable<T> {
     return this.request<any>('JSONP', url, {
       params: new HttpParams().append(callbackParam, 'JSONP_CALLBACK'),
       observe: 'body',
@@ -1608,7 +1608,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as an `ArrayBuffer`.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1627,7 +1627,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as a `Blob`.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1646,7 +1646,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body of type string.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1666,7 +1666,7 @@ export class HttpClient {
    * @return  An `Observable` of all `HttpEvent`s for the request,
    * with the response body as an `ArrayBuffer`.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1685,7 +1685,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body as a `Blob`.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1704,7 +1704,7 @@ export class HttpClient {
    * @return An `Observable` of all the `HttpEvent`s for the request,
    * with the response body of type string.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1723,7 +1723,7 @@ export class HttpClient {
    * @return An `Observable` of all the `HttpEvent`s for the request with the response
    * body of type `Object`.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1743,7 +1743,7 @@ export class HttpClient {
    * @return An `Observable` of all the `HttpEvent`s for the request,
    * with a response body in the requested type.
    */
-  options<T>(url: string, options: {
+  options<T>(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -1763,7 +1763,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body as an `ArrayBuffer`.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1782,7 +1782,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body as a `Blob`.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1801,7 +1801,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body of type string.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1820,7 +1820,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body of type `Object`.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1840,7 +1840,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with a response body in the requested type.
    */
-  options<T>(url: string, options: {
+  options<T>(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -1859,7 +1859,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as a JSON object.
    */
-  options(url: string, options?: {
+  options(url: string|URL, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1879,7 +1879,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the `HttpResponse`, with a response body of the given type.
    */
-  options<T>(url: string, options?: {
+  options<T>(url: string|URL, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1897,7 +1897,7 @@ export class HttpClient {
    * without implying a resource action. See the individual overloads for
    * details on the return type.
    */
-  options(url: string, options: {
+  options(url: string|URL, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body'|'events'|'response',
@@ -1920,7 +1920,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as an `ArrayBuffer`.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1940,7 +1940,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as a `Blob`.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1960,7 +1960,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with a response body of type string.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -1982,7 +1982,7 @@ export class HttpClient {
    * with the response body as an `ArrayBuffer`.
    */
 
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2002,7 +2002,7 @@ export class HttpClient {
    * @return An `Observable` of all the `HttpEvent`s for the request, with the
    * response body as `Blob`.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2022,7 +2022,7 @@ export class HttpClient {
    * @return An `Observable` of all the `HttpEvent`s for the request, with a
    * response body of type string.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2042,7 +2042,7 @@ export class HttpClient {
    * @return An `Observable` of all the `HttpEvent`s for the request,
    * with a response body of type `Object`.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2063,7 +2063,7 @@ export class HttpClient {
    * @return An `Observable` of all the `HttpEvent`s for the request,
    * with a response body in the requested type.
    */
-  patch<T>(url: string, body: any|null, options: {
+  patch<T>(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2084,7 +2084,7 @@ export class HttpClient {
    * @return  An `Observable` of the `HttpResponse` for the request,
    * with the response body as an `ArrayBuffer`.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2104,7 +2104,7 @@ export class HttpClient {
    * @return  An `Observable` of the `HttpResponse` for the request,
    * with the response body as a `Blob`.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2124,7 +2124,7 @@ export class HttpClient {
    * @return  An `Observable` of the `HttpResponse` for the request,
    * with a response body of type string.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2144,7 +2144,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with a response body in the requested type.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2165,7 +2165,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with a response body in the given type.
    */
-  patch<T>(url: string, body: any|null, options: {
+  patch<T>(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2185,7 +2185,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as a JSON object.
    */
-  patch(url: string, body: any|null, options?: {
+  patch(url: string|URL, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2207,7 +2207,7 @@ export class HttpClient {
    * @return  An `Observable` of the `HttpResponse` for the request,
    * with a response body in the given type.
    */
-  patch<T>(url: string, body: any|null, options?: {
+  patch<T>(url: string|URL, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2223,7 +2223,7 @@ export class HttpClient {
    * `PATCH` request to execute on the server. See the individual overloads for
    * details on the return type.
    */
-  patch(url: string, body: any|null, options: {
+  patch(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body'|'events'|'response',
@@ -2246,7 +2246,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as an `ArrayBuffer`.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2266,7 +2266,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as a `Blob`.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2286,7 +2286,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with a response body of type string.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2307,7 +2307,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body as an `ArrayBuffer`.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2326,7 +2326,7 @@ export class HttpClient {
    *
    * @return An `Observable` of all `HttpEvent`s for the request, with the response body as `Blob`.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2346,7 +2346,7 @@ export class HttpClient {
    * @return  An `Observable` of all `HttpEvent`s for the request,
    * with a response body of type string.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2366,7 +2366,7 @@ export class HttpClient {
    * @return  An `Observable` of all `HttpEvent`s for the request,
    * with a response body of type `Object`.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2387,7 +2387,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with a response body in the requested type.
    */
-  post<T>(url: string, body: any|null, options: {
+  post<T>(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2408,7 +2408,7 @@ export class HttpClient {
    * @return  An `Observable` of the `HttpResponse` for the request, with the response body as an
    * `ArrayBuffer`.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2428,7 +2428,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body as a `Blob`.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2448,7 +2448,7 @@ export class HttpClient {
    * @return  An `Observable` of the `HttpResponse` for the request,
    * with a response body of type string.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2468,7 +2468,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request, with a response body of type
    * `Object`.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2490,7 +2490,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request, with a response body in the
    * requested type.
    */
-  post<T>(url: string, body: any|null, options: {
+  post<T>(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2510,7 +2510,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as a JSON object.
    */
-  post(url: string, body: any|null, options?: {
+  post(url: string|URL, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2532,7 +2532,7 @@ export class HttpClient {
    * @return  An `Observable` of the `HttpResponse` for the request, with a response body in the
    * requested type.
    */
-  post<T>(url: string, body: any|null, options?: {
+  post<T>(url: string|URL, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2549,7 +2549,7 @@ export class HttpClient {
    * the replaced resource. See the individual overloads for
    * details on the return type.
    */
-  post(url: string, body: any|null, options: {
+  post(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body'|'events'|'response',
@@ -2572,7 +2572,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as an `ArrayBuffer`.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2592,7 +2592,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with the response body as a `Blob`.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2612,7 +2612,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response, with a response body of type string.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2633,7 +2633,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body as an `ArrayBuffer`.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2653,7 +2653,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with the response body as a `Blob`.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2673,7 +2673,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request, with a response body
    * of type string.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2693,7 +2693,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request, with a response body of
    * type `Object`.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2714,7 +2714,7 @@ export class HttpClient {
    * @return An `Observable` of all `HttpEvent`s for the request,
    * with a response body in the requested type.
    */
-  put<T>(url: string, body: any|null, options: {
+  put<T>(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'events',
     context?: HttpContext,
     params?: HttpParams|
@@ -2735,7 +2735,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request, with the response body as an
    * `ArrayBuffer`.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2755,7 +2755,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with the response body as a `Blob`.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2775,7 +2775,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request, with a response body of type
    * string.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2795,7 +2795,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request, with a response body
    * of type 'Object`.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2816,7 +2816,7 @@ export class HttpClient {
    * @return An `Observable` of the `HttpResponse` for the request,
    * with a response body in the requested type.
    */
-  put<T>(url: string, body: any|null, options: {
+  put<T>(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]}, observe: 'response',
     context?: HttpContext,
     params?: HttpParams|
@@ -2836,7 +2836,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the response as a JSON object.
    */
-  put(url: string, body: any|null, options?: {
+  put(url: string|URL, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2857,7 +2857,7 @@ export class HttpClient {
    *
    * @return An `Observable` of the requested type.
    */
-  put<T>(url: string, body: any|null, options?: {
+  put<T>(url: string|URL, body: any|null, options?: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body',
@@ -2874,7 +2874,7 @@ export class HttpClient {
    * with a new set of values.
    * See the individual overloads for details on the return type.
    */
-  put(url: string, body: any|null, options: {
+  put(url: string|URL, body: any|null, options: {
     headers?: HttpHeaders|{[header: string]: string | string[]},
     context?: HttpContext,
     observe?: 'body'|'events'|'response',

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -152,7 +152,10 @@ export class HttpRequest<T> {
    */
   readonly urlWithParams: string;
 
-  constructor(method: 'DELETE'|'GET'|'HEAD'|'JSONP'|'OPTIONS', url: string, init?: {
+  /** URL used when constructing the request. */
+  readonly url: string;
+
+  constructor(method: 'DELETE'|'GET'|'HEAD'|'JSONP'|'OPTIONS', url: string|URL, init?: {
     headers?: HttpHeaders,
     context?: HttpContext,
     reportProgress?: boolean,
@@ -160,7 +163,7 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
   });
-  constructor(method: 'POST'|'PUT'|'PATCH', url: string, body: T|null, init?: {
+  constructor(method: 'POST'|'PUT'|'PATCH', url: string|URL, body: T|null, init?: {
     headers?: HttpHeaders,
     context?: HttpContext,
     reportProgress?: boolean,
@@ -168,7 +171,7 @@ export class HttpRequest<T> {
     responseType?: 'arraybuffer'|'blob'|'json'|'text',
     withCredentials?: boolean,
   });
-  constructor(method: string, url: string, body: T|null, init?: {
+  constructor(method: string, url: string|URL, body: T|null, init?: {
     headers?: HttpHeaders,
     context?: HttpContext,
     reportProgress?: boolean,
@@ -177,7 +180,7 @@ export class HttpRequest<T> {
     withCredentials?: boolean,
   });
   constructor(
-      method: string, readonly url: string, third?: T|{
+      method: string, url: string|URL, third?: T|{
         headers?: HttpHeaders,
         context?: HttpContext,
         reportProgress?: boolean,
@@ -193,6 +196,7 @@ export class HttpRequest<T> {
         responseType?: 'arraybuffer'|'blob'|'json'|'text',
         withCredentials?: boolean,
       }) {
+    this.url = url = url.toString();
     this.method = method.toUpperCase();
     // Next, need to figure out which argument holds the HttpRequestInit
     // options, if any.

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -122,6 +122,13 @@ import {toArray} from 'rxjs/operators';
         expect(req.request.reportProgress).toEqual(true);
         req.flush({});
       });
+      it('using a URL object', done => {
+        client.get(new URL('http://example.com/test?foo=1&bar=2')).subscribe(res => {
+          expect((res as any)['data']).toEqual('hello world');
+          done();
+        });
+        backend.expectOne('http://example.com/test?foo=1&bar=2').flush({'data': 'hello world'});
+      });
     });
     describe('makes a POST request', () => {
       it('with text data', done => {

--- a/packages/common/http/testing/src/api.ts
+++ b/packages/common/http/testing/src/api.ts
@@ -17,7 +17,7 @@ import {TestRequest} from './request';
  */
 export interface RequestMatch {
   method?: string;
-  url?: string;
+  url?: string|URL;
 }
 
 /**
@@ -30,7 +30,8 @@ export abstract class HttpTestingController {
   /**
    * Search for requests that match the given parameter, without any expectations.
    */
-  abstract match(match: string|RequestMatch|((req: HttpRequest<any>) => boolean)): TestRequest[];
+  abstract match(match: string|URL|RequestMatch|
+                 ((req: HttpRequest<any>) => boolean)): TestRequest[];
 
   /**
    * Expect that a single request has been made which matches the given URL, and return its
@@ -39,7 +40,7 @@ export abstract class HttpTestingController {
    * If no such request has been made, or more than one such request has been made, fail with an
    * error message including the given request description, if any.
    */
-  abstract expectOne(url: string, description?: string): TestRequest;
+  abstract expectOne(url: string|URL, description?: string): TestRequest;
 
   /**
    * Expect that a single request has been made which matches the given parameters, and return
@@ -68,7 +69,7 @@ export abstract class HttpTestingController {
    * error message including the given request description, if any.
    */
   abstract expectOne(
-      match: string|RequestMatch|((req: HttpRequest<any>) => boolean),
+      match: string|URL|RequestMatch|((req: HttpRequest<any>) => boolean),
       description?: string): TestRequest;
 
   /**
@@ -77,7 +78,7 @@ export abstract class HttpTestingController {
    * If a matching request has been made, fail with an error message including the given request
    * description, if any.
    */
-  abstract expectNone(url: string, description?: string): void;
+  abstract expectNone(url: string|URL, description?: string): void;
 
   /**
    * Expect that no requests have been made which match the given parameters.
@@ -102,7 +103,8 @@ export abstract class HttpTestingController {
    * description, if any.
    */
   abstract expectNone(
-      match: string|RequestMatch|((req: HttpRequest<any>) => boolean), description?: string): void;
+      match: string|URL|RequestMatch|((req: HttpRequest<any>) => boolean),
+      description?: string): void;
 
   /**
    * Verify that no unmatched requests are outstanding.

--- a/packages/common/http/testing/src/backend.ts
+++ b/packages/common/http/testing/src/backend.ts
@@ -49,9 +49,10 @@ export class HttpClientTestingBackend implements HttpBackend, HttpTestingControl
   /**
    * Helper function to search for requests in the list of open requests.
    */
-  private _match(match: string|RequestMatch|((req: HttpRequest<any>) => boolean)): TestRequest[] {
-    if (typeof match === 'string') {
-      return this.open.filter(testReq => testReq.request.urlWithParams === match);
+  private _match(match: string|URL|RequestMatch|
+                 ((req: HttpRequest<any>) => boolean)): TestRequest[] {
+    if (typeof match === 'string' || match instanceof URL) {
+      return this.open.filter(testReq => testReq.request.urlWithParams === match.toString());
     } else if (typeof match === 'function') {
       return this.open.filter(testReq => match(testReq.request));
     } else {
@@ -65,7 +66,7 @@ export class HttpClientTestingBackend implements HttpBackend, HttpTestingControl
    * Search for requests in the list of open requests, and return all that match
    * without asserting anything about the number of matches.
    */
-  match(match: string|RequestMatch|((req: HttpRequest<any>) => boolean)): TestRequest[] {
+  match(match: string|URL|RequestMatch|((req: HttpRequest<any>) => boolean)): TestRequest[] {
     const results = this._match(match);
     results.forEach(result => {
       const index = this.open.indexOf(result);
@@ -83,8 +84,9 @@ export class HttpClientTestingBackend implements HttpBackend, HttpTestingControl
    * Requests returned through this API will no longer be in the list of open requests,
    * and thus will not match twice.
    */
-  expectOne(match: string|RequestMatch|((req: HttpRequest<any>) => boolean), description?: string):
-      TestRequest {
+  expectOne(
+      match: string|URL|RequestMatch|((req: HttpRequest<any>) => boolean),
+      description?: string): TestRequest {
     description = description || this.descriptionFromMatcher(match);
     const matches = this.match(match);
     if (matches.length > 1) {
@@ -107,8 +109,9 @@ export class HttpClientTestingBackend implements HttpBackend, HttpTestingControl
    * Expect that no outstanding requests match the given matcher, and throw an error
    * if any do.
    */
-  expectNone(match: string|RequestMatch|((req: HttpRequest<any>) => boolean), description?: string):
-      void {
+  expectNone(
+      match: string|URL|RequestMatch|((req: HttpRequest<any>) => boolean),
+      description?: string): void {
     description = description || this.descriptionFromMatcher(match);
     const matches = this.match(match);
     if (matches.length > 0) {
@@ -134,10 +137,10 @@ export class HttpClientTestingBackend implements HttpBackend, HttpTestingControl
     }
   }
 
-  private descriptionFromMatcher(matcher: string|RequestMatch|
+  private descriptionFromMatcher(matcher: string|URL|RequestMatch|
                                  ((req: HttpRequest<any>) => boolean)): string {
-    if (typeof matcher === 'string') {
-      return `Match URL: ${matcher}`;
+    if (typeof matcher === 'string' || matcher instanceof URL) {
+      return `Match URL: ${matcher.toString()}`;
     } else if (typeof matcher === 'object') {
       const method = matcher.method || '(any)';
       const url = matcher.url || '(any)';

--- a/packages/common/http/testing/test/request_spec.ts
+++ b/packages/common/http/testing/test/request_spec.ts
@@ -109,4 +109,17 @@ describe('HttpClient TestRequest', () => {
               ' GET /some-other-url?query=world, POST /and-another-url');
     }
   });
+
+  it('accepts a URL object', () => {
+    const mock = new HttpClientTestingBackend();
+    const client = new HttpClient(mock);
+
+    let resp: any;
+    client.post(new URL('http://example.com/test?foo=1&bar=2'), {}).subscribe(body => resp = body);
+
+    const req = mock.expectOne(new URL('http://example.com/test?foo=1&bar=2'));
+    req.flush({test: true});
+
+    expect(resp).toEqual({test: true});
+  });
 });


### PR DESCRIPTION
Adds support for the `URL` object in `HttpClient` and `HttpClientTestingBackend`.

BREAKING CHANGE:
Implementations of `HttpTestingController` have to support the `URL` object as well.

Fixes #45497.