### PR TITLE
refactor(docs-infra): create external-link-with-icon mixin

### DIFF
--- a/aio/src/styles/0-base/_typography.scss
+++ b/aio/src/styles/0-base/_typography.scss
@@ -208,16 +208,7 @@ code {
       > a {
         &[href^="http:"],
         &[href^="https:"] {
-          display: inline-flex;
-          padding-right: calc(1em + 0.25rem);
-          position: relative;
-
-          &::after {
-            content: "\e89e"; // codepoint for "open_in_new"
-            font-family: "Material Icons";
-            position: absolute;
-            right: 0;
-          }
+          @include mixins.external-link-with-icon();
         }
       }
     }

--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -95,14 +95,7 @@ aio-nav-menu {
       &[href^="http:"],
       &[href^="https:"] {
         .vertical-menu-item-text {
-          display: inline-flex;
-          align-items: center;
-          &::after {
-            content: "\e89e"; // codepoint for "open_in_new"
-            margin-left: 0.3rem;
-            line-height: normal;
-            font-family: "Material Icons";
-          }
+          @include mixins.external-link-with-icon();
         }
       }
     }

--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -137,13 +137,7 @@ mat-toolbar.app-toolbar {
           &[href^="http:"],
           &[href^="https:"] {
             .nav-link-inner {
-              display: inline-flex;
-              align-items: center;
-              &::after {
-                content: "\e89e"; // codepoint for "open_in_new"
-                margin-left: 0.3rem;
-                font-family: "Material Icons";
-              }
+              @include mixins.external-link-with-icon();
             }
           }
 

--- a/aio/src/styles/_mixins.scss
+++ b/aio/src/styles/_mixins.scss
@@ -194,3 +194,18 @@
     }
   }
 }
+
+@mixin external-link-with-icon() {
+  display: inline-flex;
+  align-items: center;
+
+  &::after {
+    content: "\e89e"; // codepoint for "open_in_new"
+    font-family: "Material Icons";
+    margin-left: 0.3rem;
+    // Note: float: right is used so that the icon doesn't inherit text underlines
+    float: right;
+    display: flex;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
create external-link-with-icon mixin in order to reduce scss code
duplication

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Issue
Issue Number: N/A


## What is the new behavior?

No difference in behaviour, just less scss duplicated code

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - @gkalpak as we agreed [here](https://github.com/angular/angular/pull/46384#issuecomment-1159489912) :slightly_smiling_face:
 - I was tempted to use content blocks but then ended up aligning all the styles into one, I think that this solution may be slightly less flexible then one with content blocks but it's cleaner and more concise :slightly_smiling_face: 
 