### PR TITLE
feat(core): allow specifying `ngZone*` options when bootstrapping standalone component

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -998,9 +998,9 @@ export const platformCore: (extraProviders?: StaticProvider[] | undefined) => Pl
 
 // @public
 export class PlatformRef {
-    bootstrapModule<M>(moduleType: Type<M>, compilerOptions?: (CompilerOptions & BootstrapOptions) | Array<CompilerOptions & BootstrapOptions>): Promise<NgModuleRef<M>>;
+    bootstrapModule<M>(moduleType: Type<M>, compilerOptions?: (CompilerOptions & ɵBootstrapOptions) | Array<CompilerOptions & ɵBootstrapOptions>): Promise<NgModuleRef<M>>;
     // @deprecated
-    bootstrapModuleFactory<M>(moduleFactory: NgModuleFactory<M>, options?: BootstrapOptions): Promise<NgModuleRef<M>>;
+    bootstrapModuleFactory<M>(moduleFactory: NgModuleFactory<M>, options?: ɵBootstrapOptions): Promise<NgModuleRef<M>>;
     destroy(): void;
     get destroyed(): boolean;
     get injector(): Injector;

--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -22,9 +22,10 @@ import { SecurityContext } from '@angular/core';
 import { StaticProvider } from '@angular/core';
 import { Type } from '@angular/core';
 import { Version } from '@angular/core';
+import { ɵBootstrapOptions } from '@angular/core';
 
 // @public
-export interface ApplicationConfig {
+export interface ApplicationConfig extends ɵBootstrapOptions {
     providers: Array<Provider | ImportedNgModuleProviders>;
 }
 

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -189,13 +189,15 @@ export function internalBootstrapApplication(config: {
   rootComponent: Type<unknown>,
   appProviders?: Array<Provider|ImportedNgModuleProviders>,
   platformProviders?: Provider[],
+  bootstrapOptions?: BootstrapOptions
 }): Promise<ApplicationRef> {
   const {rootComponent, appProviders, platformProviders} = config;
   NG_DEV_MODE && assertStandaloneComponentType(rootComponent);
 
   const platformInjector = createOrReusePlatformInjector(platformProviders as StaticProvider[]);
 
-  const ngZone = new NgZone(getNgZoneOptions());
+  const ngZone =
+      getNgZone(config.bootstrapOptions?.ngZone, getNgZoneOptions(config.bootstrapOptions));
 
   return ngZone.run(() => {
     // Create root application injector based on a set of providers configured at the platform
@@ -550,8 +552,8 @@ interface NgZoneOptions {
 function getNgZoneOptions(options?: BootstrapOptions): NgZoneOptions {
   return {
     enableLongStackTrace: typeof ngDevMode === 'undefined' ? false : !!ngDevMode,
-    shouldCoalesceEventChangeDetection: !!(options && options.ngZoneEventCoalescing) || false,
-    shouldCoalesceRunChangeDetection: !!(options && options.ngZoneRunCoalescing) || false,
+    shouldCoalesceEventChangeDetection: options?.ngZoneEventCoalescing || false,
+    shouldCoalesceRunChangeDetection: options?.ngZoneRunCoalescing || false,
   };
 }
 

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS, internalBootstrapApplication as ɵinternalBootstrapApplication} from './application_ref';
+export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS, BootstrapOptions as ɵBootstrapOptions, internalBootstrapApplication as ɵinternalBootstrapApplication} from './application_ref';
 export {APP_ID_RANDOM_PROVIDER as ɵAPP_ID_RANDOM_PROVIDER} from './application_tokens';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {ChangeDetectorStatus as ɵChangeDetectorStatus, isDefaultChangeDetectionStrategy as ɵisDefaultChangeDetectionStrategy} from './change_detection/constants';

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, DOCUMENT, XhrFactory, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {APP_ID, ApplicationModule, ApplicationRef, createPlatformFactory, ErrorHandler, ImportedNgModuleProviders, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalBootstrapApplication as internalBootstrapApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
+import {APP_ID, ApplicationModule, ApplicationRef, createPlatformFactory, ErrorHandler, ImportedNgModuleProviders, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵBootstrapOptions as BootstrapOptions, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalBootstrapApplication as internalBootstrapApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
 import {SERVER_TRANSITION_PROVIDERS, TRANSITION_ID} from './browser/server-transition';
@@ -27,7 +27,7 @@ const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
  * @developerPreview
  * @publicApi
  */
-export interface ApplicationConfig {
+export interface ApplicationConfig extends BootstrapOptions {
   /**
    * List of providers that should be available to the root component and all its children.
    */
@@ -103,6 +103,7 @@ export function bootstrapApplication(
       ...(options?.providers ?? []),
     ],
     platformProviders: INTERNAL_BROWSER_PLATFORM_PROVIDERS,
+    bootstrapOptions: options
   });
 }
 

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -7,10 +7,11 @@
  */
 
 import {DOCUMENT, isPlatformBrowser, ɵgetDOM as getDOM} from '@angular/common';
-import {APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, Inject, InjectionToken, Injector, Input, LOCALE_ID, NgModule, NgModuleRef, OnDestroy, Pipe, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Testability, TestabilityRegistry, Type, VERSION} from '@angular/core';
+import {APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, Inject, InjectionToken, Injector, Input, LOCALE_ID, NgModule, NgModuleRef, NgZone, OnDestroy, Pipe, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Testability, TestabilityRegistry, Type, VERSION} from '@angular/core';
 import {ApplicationRef, destroyPlatform} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
+import {NoopNgZone} from '@angular/core/src/zone/ng_zone';
 import {inject, TestBed} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 import {BrowserModule} from '@angular/platform-browser';
@@ -314,6 +315,15 @@ function bootstrap(
             'make sure it has the `@Component` decorator.';
         expect(() => bootstrapApplication(NonAnnotatedClass)).toThrowError(msg);
       });
+
+      it('should be possible to provide ngZone* options when bootstrapping standalone component',
+         async () => {
+           const appRef = await bootstrapApplication(SimpleComp, {providers: [], ngZone: 'noop'});
+           // Not sure if it's the right way of getting `ApplicationRef` because it's marked as
+           // `@internal`.
+           const ngZone = appRef['_injector'].get(NgZone);
+           expect(ngZone).toBeInstanceOf(NoopNgZone);
+         });
     });
 
     it('should throw if bootstrapped Directive is not a Component', done => {


### PR DESCRIPTION
It's possible providing `BootstrapOptions` when bootstrapping the root
module (e.g. `ngZoneEventCoalescing`). It should be possible providing the
same options when bootstrapping standalone components.