### PR TITLE
fix(animations): make sure query works with shadow dom elements

### DIFF
--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -177,11 +177,33 @@ if (_isNode || typeof Element !== 'undefined') {
   }
 
   _query = (element: any, selector: string, multi: boolean): any[] => {
-    if (multi) {
-      return Array.from(element.querySelectorAll(selector));
+    return queryFn(element, selector, multi, [], true);
+    function queryFn(
+        element: any, selector: string, multi: boolean, matched: any[] = [],
+        skipElement = false): any[] {
+      const matches = skipElement ? false : element.matches(selector);
+
+      if (!multi && matches) {
+        return [element];
+      }
+
+      if (multi && matches) {
+        matched.push(element);
+      }
+
+      const childEls = Array.from(element.children);
+      const shadowChildEls = element.shadowRoot ? Array.from(element.shadowRoot.children) : [];
+      const allChildEls = [...childEls, ...shadowChildEls];
+
+      for (let i = 0; i < allChildEls.length; i++) {
+        const result = queryFn(allChildEls[i], selector, multi);
+        if (!multi && result.length) {
+          return result;
+        }
+        matched = matched.concat(result);
+      }
+      return matched;
     }
-    const elem = element.querySelector(selector);
-    return elem ? [elem] : [];
   };
 }
 

--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -179,28 +179,26 @@ if (_isNode || typeof Element !== 'undefined') {
   _query = (element: any, selector: string, multi: boolean): any[] => {
     return queryFn(element, selector, multi, [], true);
     function queryFn(
-        element: any, selector: string, multi: boolean, matched: any[] = [],
-        skipElement = false): any[] {
-      const matches = skipElement ? false : element.matches(selector);
+        element: any, selector: string, multi: boolean, matched: any[],
+        isStartElement: boolean): any[] {
+      const matches = isStartElement ? false : element.matches(selector);
 
-      if (!multi && matches) {
-        return [element];
-      }
-
-      if (multi && matches) {
+      if (matches) {
         matched.push(element);
+        if (!multi) {
+          return matched;
+        }
       }
 
       const childEls = Array.from(element.children);
       const shadowChildEls = element.shadowRoot ? Array.from(element.shadowRoot.children) : [];
-      const allChildEls = [...childEls, ...shadowChildEls];
 
-      for (let i = 0; i < allChildEls.length; i++) {
-        const result = queryFn(allChildEls[i], selector, multi);
-        if (!multi && result.length) {
-          return result;
+      for (let i = 0; i < childEls.length + shadowChildEls.length; i++) {
+        const el = i < childEls.length ? childEls[i] : shadowChildEls[i - childEls.length];
+        matched = queryFn(el, selector, multi, matched, false);
+        if (!multi && matched.length) {
+          return matched;
         }
-        matched = matched.concat(result);
       }
       return matched;
     }

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -314,13 +314,10 @@ export class AnimationTransitionNamespace {
 
   private _signalRemovalForInnerTriggers(rootElement: any, context: any) {
     const elements = this._engine.driver.query(rootElement, NG_TRIGGER_SELECTOR, true);
-    const shadowElements = rootElement.shadowRoot ?
-        this._engine.driver.query(rootElement.shadowRoot, NG_TRIGGER_SELECTOR, true) :
-        [];
     // emulate a leave animation for all inner nodes within this node.
     // If there are no animations found for any of the nodes then clear the cache
     // for the element.
-    [...elements, ...shadowElements].forEach(elm => {
+    elements.forEach(elm => {
       // this means that an inner remove() operation has already kicked off
       // the animation on this element...
       if (elm[REMOVAL_FLAG]) return;


### PR DESCRIPTION
fix the query function not taking into consideration element inside
components using the shadowDom view encapsulation

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The `query` function does not check elements inside shadow roots (which are created with the SahdowDom view encapsulation)

For example:
![shadow-before](https://user-images.githubusercontent.com/61631103/175536395-ce1f1b35-0de5-4e35-b2a1-5a3ca1c7f157.gif)


## What is the new behavior?

Elements inside shadow roots are also being considered

For example:
![shadow-after](https://user-images.githubusercontent.com/61631103/175536463-f041f790-cbe3-4174-b831-9010b34bb900.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - There is no equivalent of querySelector that also takes shadowRoot elements into account so I needed to implement it myself, this is of course bound to be much less performant than the native querySelector functions, but I think that it should be ok for the use case, still something to keep in mind
 - I made sure to keep the ordering of query the same as the querySelector one (which according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) is DFS) so the behavior should be the exact same as before
- In my implementation I used recursion which I believe is the most natural and clean way to accomplish this, I don't expect it being able to blow the stack at all, but if there are some concerns please let me know and I can do an iterative version (which would likely be more complex and less clear and maintainable)