### PR TITLE
fix(core): trigger `ApplicationRef.destroy` when Platform is destroyed

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -60,7 +60,8 @@ export const ALLOW_MULTIPLE_PLATFORMS = new InjectionToken<boolean>('AllowMultip
  * `PlatformRef` class (i.e. register the callback via `PlatformRef.onDestroy`), thus making the
  * entire class tree-shakeable.
  */
-const PLATFORM_ON_DESTROY = new InjectionToken<() => void>('PlatformOnDestroy');
+const PLATFORM_DESTROY_LISTENERS =
+    new InjectionToken<Set<VoidFunction>>('PlatformDestroyListeners');
 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
 
@@ -230,7 +231,18 @@ export function internalBootstrapApplication(config: {
         setLocaleId(localeId || DEFAULT_LOCALE_ID);
 
         const appRef = appInjector.get(ApplicationRef);
-        appRef.onDestroy(() => onErrorSubscription.unsubscribe());
+
+        // If the whole platform is destroyed, invoke the `destroy` method
+        // for all bootstrapped applications as well.
+        const destroyListener = () => appRef.destroy();
+        const onPlatformDestroyListeners = platformInjector.get(PLATFORM_DESTROY_LISTENERS, null);
+        onPlatformDestroyListeners?.add(destroyListener);
+
+        appRef.onDestroy(() => {
+          onPlatformDestroyListeners?.delete(destroyListener);
+          onErrorSubscription.unsubscribe();
+        });
+
         appRef.bootstrap(rootComponent);
         return appRef;
       });
@@ -303,7 +315,7 @@ export function createPlatformInjector(providers: StaticProvider[] = [], name?: 
     name,
     providers: [
       {provide: INJECTOR_SCOPE, useValue: 'platform'},
-      {provide: PLATFORM_ON_DESTROY, useValue: () => _platformInjector = null},  //
+      {provide: PLATFORM_DESTROY_LISTENERS, useValue: new Set([() => _platformInjector = null])},
       ...providers
     ],
   });
@@ -523,8 +535,11 @@ export class PlatformRef {
     this._modules.slice().forEach(module => module.destroy());
     this._destroyListeners.forEach(listener => listener());
 
-    const destroyListener = this._injector.get(PLATFORM_ON_DESTROY, null);
-    destroyListener?.();
+    const destroyListeners = this._injector.get(PLATFORM_DESTROY_LISTENERS, null);
+    if (destroyListeners) {
+      destroyListeners.forEach(listener => listener());
+      destroyListeners.clear();
+    }
 
     this._destroyed = true;
   }

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -357,13 +357,13 @@
     "name": "PARAM_REGEX"
   },
   {
+    "name": "PLATFORM_DESTROY_LISTENERS"
+  },
+  {
     "name": "PLATFORM_ID"
   },
   {
     "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PLATFORM_ON_DESTROY"
   },
   {
     "name": "PlatformRef"
@@ -549,9 +549,6 @@
     "name": "_randomChar"
   },
   {
-    "name": "componentDefCount"
-  },
-  {
     "name": "_testabilityGetter"
   },
   {
@@ -640,6 +637,9 @@
   },
   {
     "name": "collectNativeNodes"
+  },
+  {
+    "name": "componentDefCount"
   },
   {
     "name": "computeStaticStyling"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -66,9 +66,6 @@
     "name": "_injectImplementation"
   },
   {
-    "name": "componentDefCount"
-  },
-  {
     "name": "addComponentLogic"
   },
   {
@@ -97,6 +94,9 @@
   },
   {
     "name": "classIndexOf"
+  },
+  {
+    "name": "componentDefCount"
   },
   {
     "name": "computeStaticStyling"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -360,13 +360,13 @@
     "name": "Optional"
   },
   {
+    "name": "PLATFORM_DESTROY_LISTENERS"
+  },
+  {
     "name": "PLATFORM_ID"
   },
   {
     "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PLATFORM_ON_DESTROY"
   },
   {
     "name": "PlatformRef"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -354,13 +354,13 @@
     "name": "Optional"
   },
   {
+    "name": "PLATFORM_DESTROY_LISTENERS"
+  },
+  {
     "name": "PLATFORM_ID"
   },
   {
     "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PLATFORM_ON_DESTROY"
   },
   {
     "name": "PlatformRef"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -63,9 +63,6 @@
     "name": "_injectImplementation"
   },
   {
-    "name": "componentDefCount"
-  },
-  {
     "name": "allocExpando"
   },
   {
@@ -85,6 +82,9 @@
   },
   {
     "name": "callHooks"
+  },
+  {
+    "name": "componentDefCount"
   },
   {
     "name": "concatStringsWithSpace"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -435,13 +435,13 @@
     "name": "OutletInjector"
   },
   {
+    "name": "PLATFORM_DESTROY_LISTENERS"
+  },
+  {
     "name": "PLATFORM_ID"
   },
   {
     "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PLATFORM_ON_DESTROY"
   },
   {
     "name": "PathLocationStrategy"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -225,13 +225,13 @@
     "name": "Observable"
   },
   {
+    "name": "PLATFORM_DESTROY_LISTENERS"
+  },
+  {
     "name": "PLATFORM_ID"
   },
   {
     "name": "PLATFORM_INITIALIZER"
-  },
-  {
-    "name": "PLATFORM_ON_DESTROY"
   },
   {
     "name": "R3Injector"
@@ -342,9 +342,6 @@
     "name": "_randomChar"
   },
   {
-    "name": "componentDefCount"
-  },
-  {
     "name": "_wrapInTimeout"
   },
   {
@@ -391,6 +388,9 @@
   },
   {
     "name": "collectNativeNodes"
+  },
+  {
+    "name": "componentDefCount"
   },
   {
     "name": "concatStringsWithSpace"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -165,9 +165,6 @@
     "name": "_injectImplementation"
   },
   {
-    "name": "componentDefCount"
-  },
-  {
     "name": "_symbolIterator"
   },
   {
@@ -238,6 +235,9 @@
   },
   {
     "name": "collectStylingFromTAttrs"
+  },
+  {
+    "name": "componentDefCount"
   },
   {
     "name": "computeStaticStyling"


### PR DESCRIPTION
This commit updates the `ApplicationRef` logic to trigger the destroy operation when an underlying platform is destroyed. This is needed to make sure all teardown processing is completed correctly to avoid memory leaks.

Closes #46473.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No