### PR TITLE
fix(docs-infra): correctly populate "Description" column in CLI command overview

### DIFF
--- a/aio/tools/transforms/templates/cli/cli-container.template.html
+++ b/aio/tools/transforms/templates/cli/cli-container.template.html
@@ -19,7 +19,7 @@
   <tr>
     <td><a class="code-anchor" href="{$ command.path $}"><code class="no-auto-link">{$ command.name $}</code></a></td>
     <td>{% for alias in command.commandAliases %}<code class="no-auto-link">{$ alias $} </code>{% endfor %}</td>
-    <td>{$ command.description | marked $}</td>
+    <td>{$ command.shortDescription | marked $}</td>
   </tr>
 {% endfor %}
 </tbody>


### PR DESCRIPTION
Previously, the "Description" column of the CLI command overview section was populated based on the CLI command docs' `description` property. Since #45225, the short description of CLI commands is stored in the `shortDescription` property.

This commit restores the content of the "Description" column by using the correct property to populate it.

Fixes #46489.

##
You can see the fix in action here:
- Before: https://angular.io/cli#command-overview
- After: https://pr46502-3cec2df.ngbuilds.io/cli#command-overview