### PR TITLE
docs: update CLI command-language syntax

### DIFF
--- a/aio/content/cli/index.md
+++ b/aio/content/cli/index.md
@@ -112,6 +112,10 @@ Command syntax is shown as follows:
 Boolean options have two forms: `--this-option` sets the flag to `true`, `--no-this-option` sets it to `false`.
 If neither option is supplied, the flag remains in its default state, as listed in the reference documentation.
 
+### Array options
+
+Array options can be provided in two forms: `--option value1 value2` or `--option value1 --option value2`.
+
 ### Relative paths
 
 Options that specify files can be given as absolute paths, or as paths relative to the current working directory, which is generally either the workspace or project root.

--- a/aio/content/cli/index.md
+++ b/aio/content/cli/index.md
@@ -87,7 +87,7 @@ Option names in the configuration file must use [camelCase](guide/glossary#case-
 
 Command syntax is shown as follows:
 
-`ng` *commandNameOrAlias* *requiredArg* [*optionalArg*] `[options]`
+`ng` *<command-name>* *<required-arg>* [*optional-arg*] `[options]`
 
 *   Most commands, and some options, have aliases.
     Aliases are shown in the syntax statement for each command.
@@ -105,8 +105,7 @@ Command syntax is shown as follows:
 
 *   Typically, the name of a generated artifact can be given as an argument to the command or specified with the `--name` option.
 
-*   Argument and option names can be given in either [camelCase or dash-case](guide/glossary#case-types).
-    `--myOptionName` is equivalent to `--my-option-name`.
+*   Arguments and option names must be given in [dash-case](guide/glossary#case-types) `--my-option-name`.
 
 ### Boolean options
 

--- a/aio/content/cli/index.md
+++ b/aio/content/cli/index.md
@@ -105,7 +105,8 @@ Command syntax is shown as follows:
 
 *   Typically, the name of a generated artifact can be given as an argument to the command or specified with the `--name` option.
 
-*   Arguments and option names must be given in [dash-case](guide/glossary#case-types) `--my-option-name`.
+*   Arguments and option names must be given in [dash-case](guide/glossary#case-types).
+    For example: `--my-option-name`
 
 ### Boolean options
 


### PR DESCRIPTION


**docs: add how to pass array options to the CLI**
With this change we add an example on how to use array options in the CLI.

Closes #33851


**docs: update CLI command-language syntax**
Remove reference to camel case options and arguments as this is no longer valid in version 14.

Also, wrap required arguments with `<>` as this is correct syntax to differentiate between optional and required args.