### PR TITLE
test: avoid test fixture affecting zone in all web tests

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -25,7 +25,6 @@ filegroup(
         "//packages/zone.js/bundles:zone.umd.js",
         "//packages/zone.js/bundles:zone-testing.umd.js",
         "//packages/zone.js/bundles:task-tracking.umd.js",
-        "//:test-events.js",
         # Including systemjs because it defines `__eval`, which produces correct stack traces.
         "@npm//:node_modules/systemjs/dist/system.src.js",
         "@npm//:node_modules/reflect-metadata/Reflect.js",

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -36,6 +36,10 @@ module.exports = function(config) {
       'node_modules/core-js-bundle/index.js',
       'node_modules/jasmine-ajax/lib/mock-ajax.js',
 
+      // ZoneJS configuration needed for some event manager tests. This config could
+      // affect all legacy tests but in reality is scoped to certain special tests.
+      'packages/platform-browser/test/dom/events/zone_event_unpatched_init.js',
+
       // Dependencies built by Bazel. See `config.yml` for steps running before
       // the legacy Saucelabs tests run.
       'dist/bin/packages/zone.js/npm_package/bundles/zone.umd.js',

--- a/packages/platform-browser/test/BUILD.bazel
+++ b/packages/platform-browser/test/BUILD.bazel
@@ -50,6 +50,10 @@ jasmine_node_test(
 
 karma_web_test_suite(
     name = "test_web",
+    bootstrap = [
+        "dom/events/zone_event_unpatched_init.js",
+        "//:web_test_bootstrap_scripts",
+    ],
     static_files = [
         ":static_assets/test.html",
     ],

--- a/packages/platform-browser/test/dom/events/zone_event_unpatched_init.js
+++ b/packages/platform-browser/test/dom/events/zone_event_unpatched_init.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// NOTE: This file affects most of tests in `platform-browser/test`. Make sure to
+// not change semantics of Angular that would result in false-positives. If you need
+// to change semantics of Angular, please create a separate test BUILD target.
+
+// This file marks the `unpatchedEventManagerTest` event as unpatched. This is not
+// strictly needed, but done for a specific test verifying that unpatched events are
+// running outside the zone. See `event_manager_spec.ts` and the
+// `unpatchedEvents handler outside of ngZone` spec.
+window.__zone_symbol__UNPATCHED_EVENTS = ['unpatchedEventManagerTest'];

--- a/packages/zone.js/lib/common/events.ts
+++ b/packages/zone.js/lib/common/events.ts
@@ -396,7 +396,7 @@ export function patchEventTarget(
         const options = buildEventListenerOptions(arguments[2], passive);
 
         if (unpatchedEvents) {
-          // check upatched list
+          // check unpatched list
           for (let i = 0; i < unpatchedEvents.length; i++) {
             if (eventName === unpatchedEvents[i]) {
               if (passive) {

--- a/test-events.js
+++ b/test-events.js
@@ -1,9 +1,0 @@
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
-
-Zone[Zone.__symbol__('UNPATCHED_EVENTS')] = ['scroll'];


### PR DESCRIPTION
We have a file called `test-events.js` (named in an ambiguous way
anyway) that runs for all Karma web tests and configures ZoneJS to
not patch the `scroll` event. There are two issues:

1. The patch applies to all web tests. This could cause unexpected
   issues.
2. The file is named ambiguously and also is placed at the project root,
   in a wrong spot.

Additionally, the test doesn't even fail when the file is removed. This
commit applies the Zone config locally to the closest build target and
also reworks the test to actually ensure it's testing what it describes.