### PR TITLE
build: cleanup `.gitattributes` file and remove outdated CRLF attribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,3 @@
 # JS and TS files must always use LF for tools to work
 *.js eol=lf
 *.ts eol=lf
-
-# Must keep Windows line ending to be parsed correctly
-scripts/windows/packages.txt eol=crlf


### PR DESCRIPTION
Cleans up the `.gitattributes` file and removes an outdated setting for
a now non-existent Windows CRLF file.