### PR TITLE
ci: update AIO payload size

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -4,7 +4,7 @@
       "runtime": 4325,
       "main": 456483,
       "polyfills": 33814,
-      "styles": 72047,
+      "styles": 72616,
       "light-theme": 78276,
       "dark-theme": 78381
     }
@@ -14,7 +14,7 @@
       "runtime": 4325,
       "main": 456957,
       "polyfills": 33922,
-      "styles": 72047,
+      "styles": 72616,
       "light-theme": 78276,
       "dark-theme": 78381
     }


### PR DESCRIPTION
This commit increases the AIO payload size (related to styles). The increase is likely organic and the most recent commit (https://github.com/angular/angular/commit/f659dc8e532f17c9ac36420db7b75b4986b7b59a) just added a few extra bytes that pushed the size over the threshold, so there are no extra action items other than updating the golden file.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No