### PR TITLE
ci: payload size update in intergration test app

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -33,7 +33,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2835,
-      "main": 237084,
+      "main": 236480,
       "polyfills": 33842,
       "src_app_lazy_lazy_module_ts": 780
     }


### PR DESCRIPTION
This commit updates a golden file to decrease the payload size for the `cli-hello-world-lazy` app. Previously merged Router-related commits improved tree-shaking, so this is likely a result of those changes.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No