### PR TITLE
refactor(core): disable renderer3 unless explicitly enabled by tests

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -22,7 +22,7 @@ import {addToViewTree, CLEAN_PROMISE, createLView, createTView, getOrCreateTComp
 import {ComponentDef, ComponentType, RenderFlags} from './interfaces/definition';
 import {TElementNode, TNodeType} from './interfaces/node';
 import {PlayerHandler} from './interfaces/player';
-import {domRendererFactory3, Renderer3, RendererFactory3} from './interfaces/renderer';
+import {domRendererFactory3, enableRenderer3, Renderer3, RendererFactory3} from './interfaces/renderer';
 import {RElement} from './interfaces/renderer_dom';
 import {CONTEXT, HEADER_OFFSET, LView, LViewFlags, RootContext, RootContextFlags, TVIEW, TViewType} from './interfaces/view';
 import {writeDirectClass, writeDirectStyle} from './node_manipulation';
@@ -114,6 +114,8 @@ export function renderComponent<T>(
     opts: CreateComponentOptions = {}): T {
   ngDevMode && publishDefaultGlobalUtils();
   ngDevMode && assertComponentType(componentType);
+
+  enableRenderer3();
 
   const rendererFactory = opts.rendererFactory || domRendererFactory3;
   const sanitizer = opts.sanitizer || null;

--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -17,6 +17,7 @@
 
 import {RendererStyleFlags2, RendererType2} from '../../render/api_flags';
 import {TrustedHTML, TrustedScript, TrustedScriptURL} from '../../util/security/trusted_type_defs';
+
 import {getDocument} from './document';
 import {RComment, RElement, RNode, RText} from './renderer_dom';
 
@@ -105,8 +106,20 @@ export interface RendererFactory3 {
   end?(): void;
 }
 
+let renderer3Enabled = false;
+
+export function enableRenderer3() {
+  renderer3Enabled = true;
+}
+
 export const domRendererFactory3: RendererFactory3 = {
   createRenderer: (hostElement: RElement|null, rendererType: RendererType2|null): Renderer3 => {
+    if (!renderer3Enabled) {
+      throw new Error(
+          ngDevMode ?
+              `Renderer3 is not supported. This problem is likely caused by some component in the hierarchy was constructed without a correct parent injector.` :
+              'Renderer3 disabled');
+    }
     return getDocument();
   }
 };

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -12,7 +12,7 @@ import {TestBed} from '@angular/core/testing';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-import {domRendererFactory3} from '../../src/render3/interfaces/renderer';
+import {domRendererFactory3, enableRenderer3} from '../../src/render3/interfaces/renderer';
 import {global} from '../../src/util/global';
 
 
@@ -582,6 +582,7 @@ describe('component', () => {
   });
 
   describe('should clear host element if provided in ComponentFactory.create', () => {
+    beforeAll(() => enableRenderer3());
     function runTestWithRenderer(rendererProviders: any[]) {
       @Component({
         selector: 'dynamic-comp',

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -150,9 +150,6 @@
     "name": "DIMENSIONAL_PROP_SET"
   },
   {
-    "name": "DOCUMENT"
-  },
-  {
     "name": "DOCUMENT2"
   },
   {
@@ -549,9 +546,6 @@
     "name": "_randomChar"
   },
   {
-    "name": "componentDefCount"
-  },
-  {
     "name": "_testabilityGetter"
   },
   {
@@ -640,6 +634,9 @@
   },
   {
     "name": "collectNativeNodes"
+  },
+  {
+    "name": "componentDefCount"
   },
   {
     "name": "computeStaticStyling"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -66,9 +66,6 @@
     "name": "_injectImplementation"
   },
   {
-    "name": "componentDefCount"
-  },
-  {
     "name": "addComponentLogic"
   },
   {
@@ -97,6 +94,9 @@
   },
   {
     "name": "classIndexOf"
+  },
+  {
+    "name": "componentDefCount"
   },
   {
     "name": "computeStaticStyling"
@@ -364,6 +364,9 @@
   },
   {
     "name": "renderView"
+  },
+  {
+    "name": "renderer3Enabled"
   },
   {
     "name": "resetPreOrderHookFlags"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -108,9 +108,6 @@
     "name": "DEFAULT_VALUE_ACCESSOR"
   },
   {
-    "name": "DOCUMENT"
-  },
-  {
     "name": "DOCUMENT2"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -114,9 +114,6 @@
     "name": "DEFAULT_VALUE_ACCESSOR"
   },
   {
-    "name": "DOCUMENT"
-  },
-  {
     "name": "DOCUMENT2"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -63,9 +63,6 @@
     "name": "_injectImplementation"
   },
   {
-    "name": "componentDefCount"
-  },
-  {
     "name": "allocExpando"
   },
   {
@@ -85,6 +82,9 @@
   },
   {
     "name": "callHooks"
+  },
+  {
+    "name": "componentDefCount"
   },
   {
     "name": "concatStringsWithSpace"
@@ -280,6 +280,9 @@
   },
   {
     "name": "renderView"
+  },
+  {
+    "name": "renderer3Enabled"
   },
   {
     "name": "resetPreOrderHookFlags"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -141,9 +141,6 @@
     "name": "DEFAULT_SERIALIZER"
   },
   {
-    "name": "DOCUMENT"
-  },
-  {
     "name": "DOCUMENT2"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -60,9 +60,6 @@
     "name": "ConnectableSubscriber"
   },
   {
-    "name": "DOCUMENT"
-  },
-  {
     "name": "DOCUMENT2"
   },
   {
@@ -342,9 +339,6 @@
     "name": "_randomChar"
   },
   {
-    "name": "componentDefCount"
-  },
-  {
     "name": "_wrapInTimeout"
   },
   {
@@ -391,6 +385,9 @@
   },
   {
     "name": "collectNativeNodes"
+  },
+  {
+    "name": "componentDefCount"
   },
   {
     "name": "concatStringsWithSpace"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -165,9 +165,6 @@
     "name": "_injectImplementation"
   },
   {
-    "name": "componentDefCount"
-  },
-  {
     "name": "_symbolIterator"
   },
   {
@@ -238,6 +235,9 @@
   },
   {
     "name": "collectStylingFromTAttrs"
+  },
+  {
+    "name": "componentDefCount"
   },
   {
     "name": "computeStaticStyling"
@@ -697,6 +697,9 @@
   },
   {
     "name": "renderView"
+  },
+  {
+    "name": "renderer3Enabled"
   },
   {
     "name": "resetPreOrderHookFlags"

--- a/packages/core/test/render3/perf/setup.ts
+++ b/packages/core/test/render3/perf/setup.ts
@@ -8,13 +8,14 @@
 import {addToViewTree, createLContainer, createLView, createTNode, createTView, getOrCreateTNode, refreshView, renderView} from '../../../src/render3/instructions/shared';
 import {ComponentTemplate, DirectiveDefList} from '../../../src/render3/interfaces/definition';
 import {TAttributes, TElementNode, TNodeType} from '../../../src/render3/interfaces/node';
-import {domRendererFactory3, RendererFactory3} from '../../../src/render3/interfaces/renderer';
+import {domRendererFactory3, enableRenderer3, RendererFactory3} from '../../../src/render3/interfaces/renderer';
 import {LView, LViewFlags, TVIEW, TView, TViewType} from '../../../src/render3/interfaces/view';
 import {insertView} from '../../../src/render3/node_manipulation';
 
 import {MicroBenchmarkRendererFactory} from './noop_renderer';
 
 const isBrowser = typeof process === 'undefined';
+enableRenderer3();
 const rendererFactory: RendererFactory3 =
     isBrowser ? domRendererFactory3 : new MicroBenchmarkRendererFactory;
 const renderer = rendererFactory.createRenderer(null, null);

--- a/packages/core/test/render3/render_util.ts
+++ b/packages/core/test/render3/render_util.ts
@@ -36,7 +36,7 @@ import {NG_ELEMENT_ID} from '../../src/render3/fields';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveType, renderComponent as _renderComponent, RenderFlags, tick, ɵɵdefineComponent, ɵɵdefineDirective, ɵɵProvidersFeature} from '../../src/render3/index';
 import {DirectiveDefList, DirectiveDefListOrFactory, DirectiveTypesOrFactory, HostBindingsFunction, PipeDef, PipeDefList, PipeDefListOrFactory, PipeTypesOrFactory} from '../../src/render3/interfaces/definition';
 import {PlayerHandler} from '../../src/render3/interfaces/player';
-import {domRendererFactory3, ProceduralRenderer3, Renderer3, RendererFactory3, RendererStyleFlags3} from '../../src/render3/interfaces/renderer';
+import {domRendererFactory3, enableRenderer3, ProceduralRenderer3, Renderer3, RendererFactory3, RendererStyleFlags3} from '../../src/render3/interfaces/renderer';
 import {LView, LViewFlags, TVIEW, TViewType} from '../../src/render3/interfaces/view';
 import {destroyLView} from '../../src/render3/node_manipulation';
 import {getRootView} from '../../src/render3/util/view_traversal_utils';
@@ -44,6 +44,7 @@ import {Sanitizer} from '../../src/sanitization/sanitizer';
 
 import {getRendererFactory2} from './imported_renderer2';
 
+enableRenderer3();
 
 
 export abstract class BaseFixture {


### PR DESCRIPTION
The `Renderer3` abstraction in Angular was an experimental code path in Ivy
which uses direct DOM operations instead of the former `Renderer2` path. To
allow `Renderer2` to tree-shake away, `Renderer3` is the default _unless_
`Renderer2` is provided. It was only an experiment, and never meant to be a
production code path.

However, it's possible for `Renderer3` to leak into user code. This commit
prevents that possibility by causing the `Renderer3` path to throw, unless
an explicit function has been called to enable it.
