### PR TITLE
fix(forms): Update a Forms validator error to use RuntimeError

### DIFF
--- a/aio/content/errors/NG1003.md
+++ b/aio/content/errors/NG1003.md
@@ -1,0 +1,30 @@
+@name Wrong Async Validator Return Type
+@category forms
+@shortDescription Async validator must return a Promise or Observable
+
+@description
+Async validators must return a promise or an observable, and emit/resolve them whether the validation fails or succeeds. In particular, they must implement the [AsyncValidatorFn API](api/forms/AsyncValidator)
+
+```typescript
+export function isTenAsync(control: AbstractControl): 
+  Observable<ValidationErrors> | null {
+    const v: number = control.value;
+    if (v !== 10) {
+    // Emit an object with a validation error.
+      return of({ 'notTen': true, 'requiredValue': 10 });
+    }
+    // Emit null, to indicate no error occurred.
+    return of(null);
+  }
+```
+
+@debugging
+Did you mistakenly use a synchronous validator instead of an async validator?
+
+<!-- links -->
+
+<!-- external links -->
+
+<!-- end links -->
+
+@reviewed 2022-06-28

--- a/goldens/public-api/forms/errors.md
+++ b/goldens/public-api/forms/errors.md
@@ -11,7 +11,9 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     MISSING_CONTROL_VALUE = 1002,
     // (undocumented)
-    NO_CONTROLS = 1000
+    NO_CONTROLS = 1000,
+    // (undocumented)
+    WRONG_VALIDATOR_RETURN_TYPE = -1101
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1137,9 +1137,6 @@
     "name": "isObject"
   },
   {
-    "name": "isObservable"
-  },
-  {
     "name": "isOptionsObj"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1098,9 +1098,6 @@
     "name": "isObject"
   },
   {
-    "name": "isObservable"
-  },
-  {
     "name": "isOptionsObj"
   },
   {

--- a/packages/forms/src/errors.ts
+++ b/packages/forms/src/errors.ts
@@ -18,5 +18,8 @@ export const enum RuntimeErrorCode {
   MISSING_CONTROL = 1001,
   MISSING_CONTROL_VALUE = 1002,
 
+  // Validators errors
+  WRONG_VALIDATOR_RETURN_TYPE = -1101,
+
   // Template-driven Forms errors (11xx)
 }

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -1467,7 +1467,10 @@ describe('FormControl', () => {
         // test for the specific error since without the error check it would still throw an error
         // but
         // not a meaningful one
-        expect(fn).toThrowError(`Expected validator to return Promise or Observable.`);
+        expect(fn).toThrowError(
+            'NG01101: Expected async validator to return Promise or Observable. ' +
+            'Are you using a synchronous validator where an async validator is expected? ' +
+            'Find more at https://angular.io/errors/NG01101');
       });
 
       it('should not emit value change events when emitEvent = false', () => {


### PR DESCRIPTION
Replace `new Error()` in a forms Validators function with `RuntimeError`, for better tree-shakability. Also, improve the error messages, and add documentation.