### PR TITLE
test: replace `--prod` with `--configuration production`

### DIFF
--- a/integration/animations/package.json
+++ b/integration/animations/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --configuration production",
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",

--- a/integration/cli-elements-universal/package.json
+++ b/integration/cli-elements-universal/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "build": "ng build",
     "pretest": "ng version",
-    "test": "ng test && yarn e2e --prod && yarn test-ssr",
+    "test": "ng test && yarn e2e --configuration production && yarn test-ssr",
     "lint": "ng lint",
     "e2e": "ng e2e --port 0",
     "pretest-ssr": "yarn ng run cli-elements-universal:app-shell:production",

--- a/integration/cli-hello-world-ivy-compat/package.json
+++ b/integration/cli-hello-world-ivy-compat/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "ng build --prod",
+    "build": "ng build --configuration production",
     "e2e": "ng e2e --port 0",
     "lint": "ng lint",
     "ng": "ng",

--- a/integration/cli-hello-world-ivy-i18n/package.json
+++ b/integration/cli-hello-world-ivy-i18n/package.json
@@ -3,13 +3,13 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "ng build --prod",
+    "build": "ng build --configuration production",
     "e2e": "ng e2e --port 0",
     "lint": "ng lint",
     "ng": "ng",
     "start": "ng serve",
     "pretest": "ng version",
-    "test": "ng e2e --port 0 --prod && ng xi18n && yarn translate && ng e2e --port 0 --configuration fr && ng e2e --port 0 --configuration de",
+    "test": "ng e2e --port 0 --configuration production && ng xi18n && yarn translate && ng e2e --port 0 --configuration fr && ng e2e --port 0 --configuration de",
     "translate": "cp src/locale/messages.xlf src/locale/messages.fr.xlf && cp src/locale/messages.xlf src/locale/messages.de.xlf && sed -i.bak -e 's/source>/target>/g' -e 's/Hello/Bonjour/' src/locale/messages.fr.xlf && sed -i.bak -e 's/source>/target>/g' -e 's/Hello/Hallo/' src/locale/messages.de.xlf",
     "serve": "serve --no-clipboard --listen 4200"
   },

--- a/integration/cli-hello-world-ivy-minimal/package.json
+++ b/integration/cli-hello-world-ivy-minimal/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "ng build --prod",
+    "build": "ng build --configuration production",
     "e2e": "ng e2e --port 0",
     "lint": "ng lint",
     "ng": "ng",

--- a/integration/cli-hello-world-lazy/package.json
+++ b/integration/cli-hello-world-lazy/package.json
@@ -2,8 +2,8 @@
   "name": "cli-hello-world-lazy",
   "version": "0.0.0",
   "scripts": {
-    "build": "ng build --prod",
-    "e2e": "ng e2e --port 0 --prod",
+    "build": "ng build --configuration production",
+    "e2e": "ng e2e --port 0 --configuration production",
     "test": "yarn e2e && yarn build && node check-output-for-ngdevmode.js"
   },
   "private": true,

--- a/integration/cli-hello-world-mocha/package.json
+++ b/integration/cli-hello-world-mocha/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --configuration production",
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",

--- a/integration/cli-hello-world/package.json
+++ b/integration/cli-hello-world/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --configuration production",
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",

--- a/integration/forms/package.json
+++ b/integration/forms/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --configuration production",
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",

--- a/integration/ivy-i18n/package.json
+++ b/integration/ivy-i18n/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "ng build --prod",
+    "build": "ng build --configuration production",
     "e2e": "ng e2e --port 0",
     "lint": "ng lint",
     "ng": "ng",

--- a/integration/standalone-bootstrap/package.json
+++ b/integration/standalone-bootstrap/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --configuration production",
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",

--- a/integration/trusted-types/package.json
+++ b/integration/trusted-types/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build --configuration production",
     "pretest": "ng version",
     "test": "ng test && yarn e2e --configuration=ci && yarn e2e --configuration=ci-production",
     "lint": "ng lint",


### PR DESCRIPTION
In Angular CLI version 14, the deprecated `--prod` option has been removed.

This is needed to land https://github.com/angular/angular/pull/46545
