### PR TITLE
fix(router): Ensure that new `RouterOutlet` instances work after old …

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -183,7 +183,10 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
 
   /** @nodoc */
   ngOnDestroy(): void {
-    this.parentContexts.onChildOutletDestroyed(this.name);
+    // Ensure that the registered outlet is this one before removing it on the context.
+    if (this.parentContexts.getContext(this.name)?.outlet === this) {
+      this.parentContexts.onChildOutletDestroyed(this.name);
+    }
   }
 
   /** @nodoc */


### PR DESCRIPTION
…ones are destroyed

There can be timing issues with removing an old outlet and creating a
new one to replace it. Before calling `onChildOutletDestroyed`, the
`RouterOutlet` will first check to ensure that it is still the one
registered for that outlet name.

Fixes #36711
Fixes #32453
