### PR TITLE
fix(core): Update ngfor error code to be negative

### DIFF
--- a/goldens/public-api/common/errors.md
+++ b/goldens/public-api/common/errors.md
@@ -9,7 +9,7 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     INVALID_PIPE_ARGUMENT = 2100,
     // (undocumented)
-    NG_FOR_MISSING_DIFFER = 2200,
+    NG_FOR_MISSING_DIFFER = -2200,
     // (undocumented)
     PARENT_NG_SWITCH_NOT_FOUND = 2000
 }

--- a/packages/common/src/errors.ts
+++ b/packages/common/src/errors.ts
@@ -16,5 +16,5 @@ export const enum RuntimeErrorCode {
   // Pipe errors
   INVALID_PIPE_ARGUMENT = 2100,
   // NgForOf errors
-  NG_FOR_MISSING_DIFFER = 2200,
+  NG_FOR_MISSING_DIFFER = -2200,
 }

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -120,7 +120,7 @@ let thisArg: any;
          getComponent().items = <any>'whaaa';
          expect(() => fixture.detectChanges())
              .toThrowError(
-                 /NG02200: Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables, such as Arrays./);
+                 `NG02200: Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables, such as Arrays. Find more at https://angular.io/errors/NG02200`);
        }));
 
     it('should throw on non-iterable ref and suggest using an array ', waitForAsync(() => {
@@ -129,7 +129,7 @@ let thisArg: any;
          getComponent().items = <any>{'stuff': 'whaaa'};
          expect(() => fixture.detectChanges())
              .toThrowError(
-                 /NG02200: Cannot find a differ supporting object '\[object Object\]' of type 'object'. NgFor only supports binding to Iterables, such as Arrays. Did you mean to use the keyvalue pipe?/);
+                 `NG02200: Cannot find a differ supporting object '\[object Object\]' of type 'object'. NgFor only supports binding to Iterables, such as Arrays. Did you mean to use the keyvalue pipe? Find more at https://angular.io/errors/NG02200`);
        }));
 
     it('should throw on ref changing to string', waitForAsync(() => {


### PR DESCRIPTION
This adds the fancy link to the error code documentation automatically

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Error code is non-negative, meaning it won't auto insert the docs link

Issue Number: N/A


## What is the new behavior?
The error code is now negative, and the docs link inserts itself.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
