### PR TITLE
build: remove `inquirer` from repo dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,6 @@
     "gulp": "^4.0.2",
     "gulp-conventional-changelog": "^2.0.35",
     "husky": "7.0.4",
-    "inquirer": "^8.0.0",
     "karma-sauce-launcher": "^4.3.6",
     "madge": "^5.0.0",
     "minimist": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9051,7 +9051,7 @@ inquirer@8.2.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-inquirer@8.2.4, inquirer@^8.0.0:
+inquirer@8.2.4:
   version "8.2.4"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.4.tgz#ddbfe86ca2f67649a67daa6f1051c128f684f0b4"
   integrity sha512-nn4F01dxU8VeKfq192IjLsxu0/OmMZ4Lg3xKAns148rCaXP6ntAoEkVYZThWjwON8AlzdZZi6oqnhNbxUG9hVg==


### PR DESCRIPTION
`inquirer` is not directly used in this repo.
