### PR TITLE
ci: fix pullapprove `fnmatch` patterns due to recent changes

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -164,7 +164,7 @@ groups:
     <<: *defaults
     conditions:
       - >
-        contains_any_globs(files.exclude('packages/compiler-cli/ngcc/**/{*,.*}'), [
+        contains_any_globs(files.exclude('packages/compiler-cli/ngcc/*'), [
           'packages/compiler/**/{*,.*}',
           'packages/examples/compiler/**/{*,.*}',
           'aio/content/examples/angular-compiler-options/**/{*,.*}',
@@ -187,7 +187,7 @@ groups:
   fw-ngcc:
     <<: *defaults
     conditions:
-      - files.include('packages/compiler-cli/ngcc/**/{*,.*}')
+      - files.include('packages/compiler-cli/ngcc/*')
     reviewers:
       users:
         - alxhub
@@ -200,7 +200,7 @@ groups:
   fw-migrations:
     <<: *defaults
     conditions:
-      - files.include("packages/core/schematics/**/{*,.*}")
+      - files.include("packages/core/schematics/*")
     reviewers:
       users:
         - alxhub
@@ -215,7 +215,7 @@ groups:
     <<: *defaults
     conditions:
       - >
-        contains_any_globs(files.exclude("packages/core/schematics/**/{*,.*}"), [
+        contains_any_globs(files.exclude("packages/core/schematics/*"), [
           'packages/core/**/{*,.*}',
           'packages/examples/core/**/{*,.*}',
           'packages/platform-browser/**/{*,.*}',
@@ -369,7 +369,7 @@ groups:
     <<: *defaults
     conditions:
       - >
-        contains_any_globs(files.exclude("packages/core/schematics/**/{*,.*}").exclude("packages/common/http/**/{*,.*}"), [
+        contains_any_globs(files.exclude("packages/common/http/*"), [
           'packages/common/**/{*,.*}',
           'packages/examples/common/**/{*,.*}',
           ])
@@ -614,8 +614,8 @@ groups:
     <<: *defaults
     conditions:
       - >
-        contains_any_globs(files.exclude('packages/compiler-cli/**/{*,.*}').exclude('packages/language-service/**/{*,.*}').exclude('packages/service-worker/**/{*,.*}'), [
-          'packages/**/{*,.*}/testing/**/{*,.*}',
+        contains_any_globs(files.exclude('packages/compiler-cli/*').exclude('packages/language-service/*').exclude('packages/service-worker/*'), [
+          'packages/**/testing/**/{*,.*}',
           'aio/content/guide/testing.md',
           'aio/content/guide/test-debugging.md',
           'aio/content/guide/testing-attribute-directives.md',


### PR DESCRIPTION
We recently changed our pullapprove config to work with hidden
directories. As part of that, we accidentally invalidated some
other pattern parameters due to inconsistency in Pullapprove.

e.g. contains any globs uses wcmatch, while `files.exclude` and
`files.include` uses `fnmatch`. The current fnmatch patterns are
actual wcmatch glob patterns and need to be adjusted for `fnmatch`.

As part of this fix (which ensures groups are more correct again),
this commit also cleans up some unused `file.exclude` in the `fw-common`
group (likely due to a copy-paste mistake).

Also the previous fnmatch patterns were using double asterisk, which is not
a thing in `fnmatch` patterns. This commit just uses a single asterisk.

https://github.com/dropseed/pullapprove/blob/8a26c19346680cfcb8a635707257a74ee56b91ca/pullapprove/context/base.py#L95-L113