### PR TITLE
build: re-enable components-repo-unit-tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ var_4_win: &cache_key_win_fallback v8-angular-win-node-14-{{ checksum "month.txt
 
 # Cache key for the `components-repo-unit-tests` job. **Note** when updating the SHA in the
 # cache keys also update the SHA for the "COMPONENTS_REPO_COMMIT" environment variable.
-var_5: &components_repo_unit_tests_cache_key v1-angular-components-{{ checksum "month.txt" }}-e65f5f5bafcd00dbb64387878fb866283909a2dd
+var_5: &components_repo_unit_tests_cache_key v1-angular-components-{{ checksum "month.txt" }}-7a24e95bafbdeb697f74a48e275c2442bcbefc74
 var_6: &components_repo_unit_tests_cache_key_fallback v1-angular-components-{{ checksum "month.txt" }}
 
 # Workspace initially persisted by the `setup` job, and then enhanced by `build-npm-packages`.
@@ -808,10 +808,9 @@ workflows:
             # since the publishing script expects the legacy outputs layout.
             - build-npm-packages
             - legacy-unit-tests-saucelabs
-      # TODO(devversion): re-enable once `angular/components` is using `rules_nodejs` v5.
-      #- components-repo-unit-tests:
-      #    requires:
-      #      - build-npm-packages
+      - components-repo-unit-tests:
+          requires:
+            - build-npm-packages
       - test_zonejs:
           requires:
             - setup

--- a/.circleci/env.sh
+++ b/.circleci/env.sh
@@ -74,7 +74,7 @@ setPublicVar COMPONENTS_REPO_URL "https://github.com/angular/components.git"
 # TODO(BRANCH_RENAME_CLEANUP): fixup branch name to point to main branch
 setPublicVar COMPONENTS_REPO_BRANCH "main-branch-rename-do-not-delete"
 # **NOTE**: When updating the commit SHA, also update the cache key in the CircleCI `config.yml`.
-setPublicVar COMPONENTS_REPO_COMMIT "e65f5f5bafcd00dbb64387878fb866283909a2dd"
+setPublicVar COMPONENTS_REPO_COMMIT "7a24e95bafbdeb697f74a48e275c2442bcbefc74"
 
 ####################################################################################################
 # Create shell script in /tmp for Bazel actions to access CI envs without


### PR DESCRIPTION
Re-enables the components-repo-unit-tests job. It has previously
been disabled but never got re-enabled.
