### PR TITLE
refactor: clean-up pre-CLDR 39 safety check

### DIFF
--- a/packages/common/locales/generate-locales-tool/cldr-data.ts
+++ b/packages/common/locales/generate-locales-tool/cldr-data.ts
@@ -106,17 +106,11 @@ export class CldrData {
     for (const localeName of allLocales) {
       const localeData = this.getLocaleData(localeName);
 
-      // If `cldrjs` is unable to resolve a `bundle` for the current locale, then there is no data
-      // for this locale, and it should not be generated. This can happen as with older versions of
-      // CLDR where `availableLocales.json` specifies locales for which no data is available
-      // (even within the `full` tier packages). See:
-      // http://cldr.unicode.org/development/development-process/design-proposals/json-packaging.
-      // TODO(devversion): Remove if we update to CLDR v39 where this seems fixed. Note that this
-      //  worked before in the Gulp tooling without such a check because the `cldr-data-downloader`
-      //  overwrote the `availableLocales` to only capture locales with data.
-      if (localeData !== null) {
-        localesWithData.push(localeData);
+      if (localeData === null) {
+        throw new Error(`Missing locale data for the "${localeName}" locale.`);
       }
+
+      localesWithData.push(localeData);
     }
 
     return localesWithData;


### PR DESCRIPTION
This commit cleans-up/removes a check we added before we supported CLDR
39. This check was necessary due to a incomplete/invalid list of locales
provided as part of the JSON data.