### PR TITLE
ci: enable renovate commit message body table to fix minimum commit message

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "semanticCommits": "enabled",
   "semanticCommitScope": "",
   "semanticCommitType": "build",
+  "commitBodyTable": true,
   "separateMajorMinor": false,
   "prHourlyLimit": 3,
   "timezone": "America/Tijuana",


### PR DESCRIPTION
We recently switched Renovate from upstream branches to operate in
forks. Given that change, the `ng-dev commit-message` lint now also
applies to the auto-created PRs. The default Renovate commits do not
have any body and fail our ng-dev commit message minimum lint.

Other repositories do not have this, but framework has, so we enable
a renovate option to append the update table to the commit message body.

This is actually also a good thing as it captures what is directly
merged. The PR description is not necessarily matching.

See; https://docs.renovatebot.com/configuration-options/#commitbodytable