### PR TITLE
test(core): remove enableRenderer3 and Renderer3 from tests

### DIFF
--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -9,10 +9,8 @@
 import {DOCUMENT} from '@angular/common';
 import {ApplicationRef, Component, ComponentFactoryResolver, ComponentRef, ElementRef, InjectionToken, Injector, Input, NgModule, OnDestroy, Renderer2, RendererFactory2, Type, ViewChild, ViewContainerRef, ViewEncapsulation, ɵsetDocument} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
-import {domRendererFactory3, enableRenderer3} from '../../src/render3/interfaces/renderer';
 import {global} from '../../src/util/global';
 
 
@@ -581,74 +579,64 @@ describe('component', () => {
     expect(cmpFactory.selector).toBe('[foo],div:not(.bar)');
   });
 
-  describe('should clear host element if provided in ComponentFactory.create', () => {
-    beforeAll(() => enableRenderer3());
-    function runTestWithRenderer(rendererProviders: any[]) {
-      @Component({
-        selector: 'dynamic-comp',
-        template: 'DynamicComponent Content',
-      })
-      class DynamicComponent {
-      }
-
-      @Component({
-        selector: 'app',
-        template: `
-          <div id="dynamic-comp-root-a">
-            Existing content in slot A, which <b><i>includes</i> some HTML elements</b>.
-          </div>
-          <div id="dynamic-comp-root-b">
-            <p>
-              Existing content in slot B, which includes some HTML elements.
-            </p>
-          </div>
-        `,
-      })
-      class App {
-        constructor(public injector: Injector, public cfr: ComponentFactoryResolver) {}
-
-        createDynamicComponent(target: any) {
-          const dynamicCompFactory = this.cfr.resolveComponentFactory(DynamicComponent);
-          dynamicCompFactory.create(this.injector, [], target);
-        }
-      }
-
-      function _document(): any {
-        // Tell Ivy about the global document
-        ɵsetDocument(document);
-        return document;
-      }
-
-      TestBed.configureTestingModule({
-        declarations: [App, DynamicComponent],
-        providers: [
-          {provide: DOCUMENT, useFactory: _document, deps: []},
-          rendererProviders,
-        ],
-      });
-
-      const fixture = TestBed.createComponent(App);
-      fixture.detectChanges();
-
-      // Create an instance of DynamicComponent and provide host element *reference*
-      let targetEl = document.getElementById('dynamic-comp-root-a')!;
-      fixture.componentInstance.createDynamicComponent(targetEl);
-      fixture.detectChanges();
-      expect(targetEl.innerHTML).not.toContain('Existing content in slot A');
-      expect(targetEl.innerHTML).toContain('DynamicComponent Content');
-
-      // Create an instance of DynamicComponent and provide host element *selector*
-      targetEl = document.getElementById('dynamic-comp-root-b')!;
-      fixture.componentInstance.createDynamicComponent('#dynamic-comp-root-b');
-      fixture.detectChanges();
-      expect(targetEl.innerHTML).not.toContain('Existing content in slot B');
-      expect(targetEl.innerHTML).toContain('DynamicComponent Content');
+  it('should clear host element if provided in ComponentFactory.create', () => {
+    @Component({
+      selector: 'dynamic-comp',
+      template: 'DynamicComponent Content',
+    })
+    class DynamicComponent {
     }
 
-    it('with Renderer2',
-       () => runTestWithRenderer([{provide: RendererFactory2, useClass: DomRendererFactory2}]));
+    @Component({
+      selector: 'app',
+      template: `
+        <div id="dynamic-comp-root-a">
+          Existing content in slot A, which <b><i>includes</i> some HTML elements</b>.
+        </div>
+        <div id="dynamic-comp-root-b">
+          <p>
+            Existing content in slot B, which includes some HTML elements.
+          </p>
+        </div>
+      `,
+    })
+    class App {
+      constructor(public injector: Injector, public cfr: ComponentFactoryResolver) {}
 
-    it('with Renderer3',
-       () => runTestWithRenderer([{provide: RendererFactory2, useValue: domRendererFactory3}]));
+      createDynamicComponent(target: any) {
+        const dynamicCompFactory = this.cfr.resolveComponentFactory(DynamicComponent);
+        dynamicCompFactory.create(this.injector, [], target);
+      }
+    }
+
+    function _document(): any {
+      // Tell Ivy about the global document
+      ɵsetDocument(document);
+      return document;
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [App, DynamicComponent],
+      providers: [
+        {provide: DOCUMENT, useFactory: _document, deps: []},
+      ],
+    });
+
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    // Create an instance of DynamicComponent and provide host element *reference*
+    let targetEl = document.getElementById('dynamic-comp-root-a')!;
+    fixture.componentInstance.createDynamicComponent(targetEl);
+    fixture.detectChanges();
+    expect(targetEl.innerHTML).not.toContain('Existing content in slot A');
+    expect(targetEl.innerHTML).toContain('DynamicComponent Content');
+
+    // Create an instance of DynamicComponent and provide host element *selector*
+    targetEl = document.getElementById('dynamic-comp-root-b')!;
+    fixture.componentInstance.createDynamicComponent('#dynamic-comp-root-b');
+    fixture.detectChanges();
+    expect(targetEl.innerHTML).not.toContain('Existing content in slot B');
+    expect(targetEl.innerHTML).toContain('DynamicComponent Content');
   });
 });

--- a/packages/core/test/render3/instructions/mock_renderer_factory.ts
+++ b/packages/core/test/render3/instructions/mock_renderer_factory.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2} from '@angular/core';
+import {RElement} from '@angular/core/src/render3/interfaces/renderer_dom';
+
+export class MockRendererFactory implements RendererFactory2 {
+  createRenderer(hostElement: RElement|null, rendererType: RendererType2|null): Renderer2 {
+    return new MockRenderer();
+  }
+}
+
+class MockRenderer implements Renderer2 {
+  data = {};
+
+  destroyNode: ((node: any) => void)|null = null;
+
+  destroy(): void {}
+  createComment(value: string): Comment {
+    return document.createComment(value);
+  }
+  createElement(name: string, namespace?: string|null): Element {
+    return namespace ? document.createElementNS(namespace, name) : document.createElement(name);
+  }
+  createText(value: string): Text {
+    return document.createTextNode(value);
+  }
+  appendChild(parent: RElement, newChild: Node): void {
+    parent.appendChild(newChild);
+  }
+  insertBefore(parent: Node, newChild: Node, refChild: Node|null): void {
+    parent.insertBefore(newChild, refChild);
+  }
+  removeChild(parent: RElement, oldChild: Node): void {
+    parent.removeChild(oldChild);
+  }
+  selectRootElement(selectorOrNode: string|any): RElement {
+    return typeof selectorOrNode === 'string' ? document.querySelector(selectorOrNode) :
+                                                selectorOrNode;
+  }
+  parentNode(node: Node): Element|null {
+    return node.parentNode as Element;
+  }
+  nextSibling(node: Node): Node|null {
+    return node.nextSibling;
+  }
+  setAttribute(el: RElement, name: string, value: string, namespace?: string|null): void {
+    // set all synthetic attributes as properties
+    if (name[0] === '@') {
+      this.setProperty(el, name, value);
+    } else {
+      el.setAttribute(name, value);
+    }
+  }
+  removeAttribute(el: RElement, name: string, namespace?: string|null): void {}
+  addClass(el: RElement, name: string): void {
+    el.classList.add(name);
+  }
+  removeClass(el: RElement, name: string): void {
+    el.classList.remove(name);
+  }
+  setStyle(el: RElement, style: string, value: any, flags: RendererStyleFlags2 = 0): void {
+    if (flags & (RendererStyleFlags2.DashCase | RendererStyleFlags2.Important)) {
+      el.style.setProperty(style, value, flags & RendererStyleFlags2.Important ? 'important' : '');
+    } else {
+      el.style.setProperty(style, value);
+    }
+  }
+  removeStyle(el: RElement, style: string, flags?: RendererStyleFlags2): void {
+    el.style.removeProperty(style);
+  }
+  setProperty(el: RElement, name: string, value: any): void {
+    (el as any)[name] = value;
+  }
+  setValue(node: Text, value: string): void {
+    node.textContent = value;
+  }
+
+  // TODO: Deprecate in favor of addEventListener/removeEventListener
+  listen(target: Node, eventName: string, callback: (event: any) => boolean | void): () => void {
+    return () => {};
+  }
+}

--- a/packages/core/test/render3/instructions/shared_spec.ts
+++ b/packages/core/test/render3/instructions/shared_spec.ts
@@ -8,10 +8,10 @@
 
 import {createLView, createTNode, createTView} from '@angular/core/src/render3/instructions/shared';
 import {TNodeType} from '@angular/core/src/render3/interfaces/node';
-import {domRendererFactory3} from '@angular/core/src/render3/interfaces/renderer';
 import {HEADER_OFFSET, LViewFlags, TVIEW, TViewType} from '@angular/core/src/render3/interfaces/view';
 import {enterView, getBindingRoot, getLView, setBindingIndex, setSelectedIndex} from '@angular/core/src/render3/state';
 
+import {MockRendererFactory} from './mock_renderer_factory';
 
 
 /**
@@ -30,7 +30,8 @@ import {enterView, getBindingRoot, getLView, setBindingIndex, setSelectedIndex} 
  * ```
  */
 export function enterViewWithOneDiv() {
-  const renderer = domRendererFactory3.createRenderer(null, null);
+  const rendererFactory = new MockRendererFactory();
+  const renderer = rendererFactory.createRenderer(null, null);
   const div = renderer.createElement('div');
   const consts = 1;
   const vars = 60;  // Space for directive expando,  template, component + 3 directives if we assume
@@ -41,8 +42,8 @@ export function enterViewWithOneDiv() {
   tView.expandoStartIndex = HEADER_OFFSET + 10;
   const tNode = tView.firstChild = createTNode(tView, null!, TNodeType.Element, 0, 'div', null);
   const lView = createLView(
-      null, tView, null, LViewFlags.CheckAlways, null, null, domRendererFactory3, renderer, null,
-      null, null);
+      null, tView, null, LViewFlags.CheckAlways, null, null, rendererFactory, renderer, null, null,
+      null);
   lView[HEADER_OFFSET] = div;
   tView.data[HEADER_OFFSET] = tNode;
   enterView(lView);

--- a/packages/core/test/render3/instructions/styling_spec.ts
+++ b/packages/core/test/render3/instructions/styling_spec.ts
@@ -10,7 +10,6 @@ import {DirectiveDef} from '@angular/core/src/render3';
 import {ɵɵdefineDirective} from '@angular/core/src/render3/definition';
 import {classStringParser, styleStringParser, toStylingKeyValueArray, ɵɵclassProp, ɵɵstyleMap, ɵɵstyleProp} from '@angular/core/src/render3/instructions/styling';
 import {AttributeMarker, TAttributes} from '@angular/core/src/render3/interfaces/node';
-import {enableRenderer3} from '@angular/core/src/render3/interfaces/renderer';
 import {getTStylingRangeNext, getTStylingRangeNextDuplicate, getTStylingRangePrev, getTStylingRangePrevDuplicate, setTStylingRangeNext, setTStylingRangePrev, StylingRange, toTStylingRange, TStylingKey, TStylingRange} from '@angular/core/src/render3/interfaces/styling';
 import {HEADER_OFFSET, TVIEW} from '@angular/core/src/render3/interfaces/view';
 import {getLView, leaveView, setBindingRootForHostBindings} from '@angular/core/src/render3/state';
@@ -22,7 +21,6 @@ import {getElementClasses, getElementStyles} from '@angular/core/testing/src/sty
 import {clearFirstUpdatePass, enterViewWithOneDiv, rewindBindingIndex} from './shared_spec';
 
 describe('styling', () => {
-  beforeAll(enableRenderer3);
   beforeEach(enterViewWithOneDiv);
   afterEach(leaveView);
 

--- a/packages/core/test/render3/integration_spec.ts
+++ b/packages/core/test/render3/integration_spec.ts
@@ -8,12 +8,9 @@
 
 import {CommonModule} from '@angular/common';
 import {Component, Directive, HostBinding} from '@angular/core';
-import {RElement} from '@angular/core/src/render3/interfaces/renderer_dom';
 import {TestBed} from '@angular/core/testing';
 
-import {RendererType2} from '../../src/render/api_flags';
 import {getLContext, readPatchedData} from '../../src/render3/context_discovery';
-import {domRendererFactory3, Renderer3, RendererFactory3} from '../../src/render3/interfaces/renderer';
 import {CONTEXT, HEADER_OFFSET} from '../../src/render3/interfaces/view';
 import {Sanitizer} from '../../src/sanitization/sanitizer';
 import {SecurityContext} from '../../src/sanitization/security';

--- a/packages/core/test/render3/perf/noop_renderer.ts
+++ b/packages/core/test/render3/perf/noop_renderer.ts
@@ -5,9 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {RendererStyleFlags2} from '@angular/core/src/render';
 import {RComment, RElement, RNode, RText} from '@angular/core/src/render3/interfaces/renderer_dom';
 
-import {ProceduralRenderer3, Renderer3, RendererFactory3, RendererStyleFlags3} from '../../../src/render3/interfaces/renderer';
+import {ProceduralRenderer3, RendererFactory3, RendererStyleFlags3} from '../../../src/render3/interfaces/renderer';
 
 export class MicroBenchmarkRenderNode implements RNode, RComment, RText {
   tagName?: string;
@@ -39,7 +40,6 @@ export class MicroBenchmarkRenderer implements ProceduralRenderer3 {
   createText(value: string): RText {
     return new MicroBenchmarkRenderNode();
   }
-  destroyNode?: ((node: RNode) => void)|null|undefined;
   appendChild(parent: RElement, newChild: RNode): void {}
   insertBefore(parent: RNode, newChild: RNode, refChild: RNode|null): void {}
   removeChild(parent: RElement, oldChild: RNode, isHostElement?: boolean|undefined): void {}
@@ -82,11 +82,115 @@ export class MicroBenchmarkRenderer implements ProceduralRenderer3 {
 }
 
 export class MicroBenchmarkRendererFactory implements RendererFactory3 {
-  createRenderer(hostElement: RElement|null, rendererType: null): Renderer3 {
+  createRenderer(hostElement: RElement|null, rendererType: null): ProceduralRenderer3 {
     if (typeof global !== 'undefined') {
       (global as any).Node = MicroBenchmarkRenderNode;
     }
     return new MicroBenchmarkRenderer();
+  }
+}
+
+class MicroBenchmarkDomRenderer implements ProceduralRenderer3 {
+  destroy(): void {
+    throw new Error('Method not implemented.');
+  }
+  createElement(name: string, namespace?: string): any {
+    return document.createElement(name);
+  }
+
+  createComment(value: string): any {
+    return document.createComment(value);
+  }
+
+  createText(value: string): any {
+    return document.createTextNode(value);
+  }
+
+  appendChild(parent: any, newChild: any): void {
+    parent.appendChild(newChild);
+  }
+
+  insertBefore(parent: any, newChild: any, refChild: any): void {
+    parent.insertBefore(newChild, refChild);
+  }
+
+  removeChild(parent: any, oldChild: any): void {
+    if (parent) {
+      parent.removeChild(oldChild);
+    }
+  }
+
+  selectRootElement(selectorOrNode: string|any, preserveContent?: boolean): any {
+    let el: any = typeof selectorOrNode === 'string' ? document.querySelector(selectorOrNode) :
+                                                       selectorOrNode;
+    if (!el) {
+      throw new Error(`The selector "${selectorOrNode}" did not match any elements`);
+    }
+    if (!preserveContent) {
+      el.textContent = '';
+    }
+    return el;
+  }
+
+  parentNode(node: any): any {
+    return node.parentNode;
+  }
+
+  nextSibling(node: any): any {
+    return node.nextSibling;
+  }
+
+  setAttribute(el: any, name: string, value: string, namespace?: string): void {
+    el.setAttribute(name, value);
+  }
+
+  removeAttribute(el: any, name: string, namespace?: string): void {
+    el.removeAttribute(name);
+  }
+
+  addClass(el: any, name: string): void {
+    el.classList.add(name);
+  }
+
+  removeClass(el: any, name: string): void {
+    el.classList.remove(name);
+  }
+
+  setStyle(el: any, style: string, value: any, flags: RendererStyleFlags2): void {
+    if (flags & (RendererStyleFlags2.DashCase | RendererStyleFlags2.Important)) {
+      el.style.setProperty(style, value, flags & RendererStyleFlags2.Important ? 'important' : '');
+    } else {
+      el.style[style] = value;
+    }
+  }
+
+  removeStyle(el: any, style: string, flags: RendererStyleFlags2): void {
+    if (flags & RendererStyleFlags2.DashCase) {
+      el.style.removeProperty(style);
+    } else {
+      // IE requires '' instead of null
+      // see https://github.com/angular/angular/issues/7916
+      el.style[style] = '';
+    }
+  }
+
+  setProperty(el: any, name: string, value: any): void {
+    el[name] = value;
+  }
+
+  setValue(node: any, value: string): void {
+    node.nodeValue = value;
+  }
+
+  listen(target: 'window'|'document'|'body'|any, event: string, callback: (event: any) => boolean):
+      () => void {
+    return () => {};
+  }
+}
+
+export class MicroBenchmarkDomRendererFactory implements RendererFactory3 {
+  createRenderer(hostElement: RElement|null, rendererType: null): ProceduralRenderer3 {
+    return new MicroBenchmarkDomRenderer();
   }
 }
 

--- a/packages/core/test/render3/perf/setup.ts
+++ b/packages/core/test/render3/perf/setup.ts
@@ -8,16 +8,14 @@
 import {addToViewTree, createLContainer, createLView, createTNode, createTView, getOrCreateTNode, refreshView, renderView} from '../../../src/render3/instructions/shared';
 import {ComponentTemplate, DirectiveDefList} from '../../../src/render3/interfaces/definition';
 import {TAttributes, TElementNode, TNodeType} from '../../../src/render3/interfaces/node';
-import {domRendererFactory3, enableRenderer3, RendererFactory3} from '../../../src/render3/interfaces/renderer';
 import {LView, LViewFlags, TVIEW, TView, TViewType} from '../../../src/render3/interfaces/view';
 import {insertView} from '../../../src/render3/node_manipulation';
 
-import {MicroBenchmarkRendererFactory} from './noop_renderer';
+import {MicroBenchmarkDomRendererFactory, MicroBenchmarkRendererFactory} from './noop_renderer';
 
 const isBrowser = typeof process === 'undefined';
-enableRenderer3();
-const rendererFactory: RendererFactory3 =
-    isBrowser ? domRendererFactory3 : new MicroBenchmarkRendererFactory;
+const rendererFactory =
+    isBrowser ? new MicroBenchmarkDomRendererFactory() : new MicroBenchmarkRendererFactory();
 const renderer = rendererFactory.createRenderer(null, null);
 
 export function createAndRenderLView(


### PR DESCRIPTION
Remove calls to enableRenderer3 in the functional unit tests.
This effectively cuts code paths going through the Renderer3
in the functional tests.
