### PR TITLE
ci: do not run firefox components repo tests

### DIFF
--- a/scripts/ci/run_angular_components_unit_tests.sh
+++ b/scripts/ci/run_angular_components_unit_tests.sh
@@ -15,7 +15,7 @@ cd ${COMPONENTS_REPO_TMP_DIR}
 
 # Now actually run the tests.
 bazel test \
-  --build_tag_filters=-docs-package,-e2e,-browser:firefox-local \
-  --test_tag_filters=-e2e,-browser:firefox-local \
+  --build_tag_filters=-docs-package,-e2e,-browser:firefox \
+  --test_tag_filters=-e2e,-browser:firefox \
   --build_tests_only \
   -- src/...


### PR DESCRIPTION
It seems like the tag for Firefox web tests has changed, and we need to adjust our filter.

