### PR TITLE
test(core): set parent injector in `createEnvironmentInjector` calls in tests

### DIFF
--- a/packages/core/test/acceptance/environment_injector_spec.ts
+++ b/packages/core/test/acceptance/environment_injector_spec.ts
@@ -8,6 +8,7 @@
 
 import {Component, ComponentFactoryResolver, createEnvironmentInjector, ENVIRONMENT_INITIALIZER, EnvironmentInjector, InjectionToken, INJECTOR, Injector, NgModuleRef} from '@angular/core';
 import {R3Injector} from '@angular/core/src/di/r3_injector';
+import {TestBed} from '@angular/core/testing';
 
 describe('environment injector', () => {
   it('should create and destroy an environment injector', () => {
@@ -78,7 +79,8 @@ describe('environment injector', () => {
          constructor(readonly service: Service) {}
        }
 
-       const envInjector = createEnvironmentInjector([Service]);
+       const envInjector =
+           createEnvironmentInjector([Service], TestBed.inject(EnvironmentInjector));
        const cfr = envInjector.get(ComponentFactoryResolver);
        const cf = cfr.resolveComponentFactory(TestComponent);
        const cRef = cf.create(Injector.NULL);

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -303,8 +303,8 @@ describe('standalone components, directives and pipes', () => {
              parent: this.inj,
            });
 
-           const rhsInj =
-               createEnvironmentInjector([{provide: Service, useClass: EnvOverrideService}]);
+           const rhsInj = createEnvironmentInjector(
+               [{provide: Service, useClass: EnvOverrideService}], this.envInj);
 
            this.vcRef.createComponent(InnerCmp, {injector: lhsInj, environmentInjector: rhsInj});
          }
@@ -352,8 +352,8 @@ describe('standalone components, directives and pipes', () => {
          constructor(readonly envInj: EnvironmentInjector) {}
 
          ngOnInit(): void {
-           const rhsInj =
-               createEnvironmentInjector([{provide: Service, useClass: EnvOverrideService}]);
+           const rhsInj = createEnvironmentInjector(
+               [{provide: Service, useClass: EnvOverrideService}], this.envInj);
 
            this.vcRef.createComponent(InnerCmp, {environmentInjector: rhsInj});
          }


### PR DESCRIPTION
This commit updates the `createEnvironmentInjector` calls in standalone components tests, so that an injector is wired to the DI hierarchy and the code doesn't fall back to using a Renderer3.

Note: this should fix [CI issues](https://app.circleci.com/pipelines/github/angular/angular/48097/workflows/dbfd297c-7ee9-4372-890b-36a7891f5c14/jobs/1189366) in the patch branch.

This is not a problem in the main branch, since the `createEnvironmentInjector` calls were previously refactored to always pass parent as a part of hardening function types.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: tests-related changes.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No