### PR TITLE
feat(core): support the descendants option for ContentChild queries

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -257,11 +257,13 @@ export const ContentChild: ContentChildDecorator;
 // @public
 export interface ContentChildDecorator {
     (selector: ProviderToken<unknown> | Function | string, opts?: {
+        descendants?: boolean;
         read?: any;
         static?: boolean;
     }): any;
     // (undocumented)
     new (selector: ProviderToken<unknown> | Function | string, opts?: {
+        descendants?: boolean;
         read?: any;
         static?: boolean;
     }): ContentChild;

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -249,6 +249,8 @@ export interface ContentChildDecorator {
    * **Metadata Properties**:
    *
    * * **selector** - The directive type or the name used for querying.
+   * * **descendants** - If `true` (default) include all descendants of the element. If `false` then
+   * only query direct children of the element.
    * * **read** - Used to read a different token from the queried element.
    * * **static** - True to resolve query results before change detection runs,
    * false to resolve after change detection. Defaults to false.
@@ -281,9 +283,10 @@ export interface ContentChildDecorator {
    *
    * @Annotation
    */
-  (selector: ProviderToken<unknown>|Function|string, opts?: {read?: any, static?: boolean}): any;
+  (selector: ProviderToken<unknown>|Function|string,
+   opts?: {descendants?: boolean, read?: any, static?: boolean}): any;
   new(selector: ProviderToken<unknown>|Function|string,
-      opts?: {read?: any, static?: boolean}): ContentChild;
+      opts?: {descendants?: boolean, read?: any, static?: boolean}): ContentChild;
 }
 
 /**

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -946,6 +946,36 @@ describe('query logic', () => {
          expect(outQList.length).toBe(2);
        });
 
+    it('should support shallow ContentChild queries', () => {
+      @Directive({selector: '[query-dir]', standalone: true})
+      class ContentQueryDirective {
+        @ContentChild('foo', {descendants: false}) shallow: ElementRef|undefined;
+        // ContentChild queries have {descendants: true} option by default
+        @ContentChild('foo') deep: ElementRef|undefined;
+      }
+
+      @Component({
+        standalone: true,
+        imports: [ContentQueryDirective],
+        template: `
+          <div query-dir>
+            <div>
+              <span #foo></span>
+            </div>
+          </div>
+        `
+      })
+      class TestCmp {
+        @ViewChild(ContentQueryDirective, {static: true}) queryDir!: ContentQueryDirective;
+      }
+
+      const fixture = TestBed.createComponent(TestCmp);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.queryDir.shallow).toBeUndefined();
+      expect(fixture.componentInstance.queryDir.deep).toBeInstanceOf(ElementRef);
+    });
+
     it('should support view and content queries matching the same element', () => {
       @Directive({
         selector: '[content-query]',


### PR DESCRIPTION
This change adds the support for the descendants option for ContentChild queries.

Closes #31921
