### PR TITLE
docs(router): mark title strategy as injectable

### DIFF
--- a/aio/content/examples/router/src/app/app-routing.module.10.ts
+++ b/aio/content/examples/router/src/app/app-routing.module.10.ts
@@ -40,6 +40,7 @@ export class ResolvedChildATitle implements Resolve<string> {
 
 
 // #docregion custom-page-title
+@Injectable({providedIn: 'root'})
 export class TemplatePageTitleStrategy extends TitleStrategy {
   constructor(private readonly title: Title) {
     super();


### PR DESCRIPTION
Add the `@Injectable` decorator in the title strategy example so that it can be injected in the providers of the routing module.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
