### PR TITLE
build: account for rename of `angular/code-of-conduct` default branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -394,7 +394,7 @@ The following documents can help you sort out issues with GitHub accounts and mu
 
 
 [angular-group]: https://groups.google.com/forum/#!forum/angular
-[coc]: https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md
+[coc]: https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md
 [commit-message-format]: https://docs.google.com/document/d/1QrDFcIiPjSLDn3EL15IJygNPiHORgU1_OOAqWjiDU5Y/edit#
 [corporate-cla]: https://cla.developers.google.com/about/google-corporate
 [dev-doc]: https://github.com/angular/angular/blob/main/docs/DEVELOPER.md

--- a/aio/content/marketing/docs.md
+++ b/aio/content/marketing/docs.md
@@ -53,4 +53,4 @@ See [Contributing to Angular](https://github.com/angular/angular/blob/main/CONTR
 for information about submission guidelines.
 
 Our community values respectful, supportive communication.
-Please consult and adhere to the [Code of Conduct](https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md "Contributor code of conduct").
+Please consult and adhere to the [Code of Conduct](https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md "Contributor code of conduct").

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -1266,7 +1266,7 @@
           "tooltip": "Post issues and suggestions on github."
         },
         {
-          "url": "https://github.com/angular/code-of-conduct/blob/master/CODE_OF_CONDUCT.md",
+          "url": "https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md",
           "title": "Code of Conduct",
           "tooltip": "Treating each other with respect."
         }


### PR DESCRIPTION
We just renamed the Angular code of conduct repository default branch
to `main`. This repository was not part of the large migration and is
now handled separately as a little clean-up.