### PR TITLE
docs: update references to HeroListComponent

### DIFF
--- a/aio/content/guide/architecture-components.md
+++ b/aio/content/guide/architecture-components.md
@@ -1,19 +1,23 @@
 # Introduction to components and templates
 
-A *component* controls a patch of screen called a [*view*](guide/glossary#view "Definition of view").
-For example, individual components define and control each of these aspects of an application:
+A *component* controls a patch of screen called a [*view*](guide/glossary#view "Definition of view"). It consists
+of a TypeScript class, an HTML template, and a CSS style sheet. The TypeScript class defines the interaction 
+of the HTML template and the rendered DOM structure, while the style sheet describes its appearance.
+
+An Angular application uses individual components to define and control different aspects of the application.
+For example, an application could include components to describe:
 
 *   The application root with the navigation links
 *   The list of heroes
 *   The hero editor
 
-You define a component's application logic that supports the view inside a class.
-The class interacts with the view through an API of properties and methods.
+In the following example, the `HeroListComponent` class includes:
 
-In this example, `HeroListComponent` has a `heroes` property that holds an array of heroes.
-Its `selectHero()` method sets a `selectedHero` property when the user clicks to choose a hero from that list.
-The component acquires the heroes from a service, which is a TypeScript [parameter property](https://www.typescriptlang.org/docs/handbook/classes.html#parameter-properties) on the constructor.
-The service is provided to the component through the dependency injection system.
+* A `heroes` property that holds an array of heroes.
+* A `selectedHero` property that holds the last hero selected by the user.
+* A `selectHero()` method sets a `selectedHero` property when the user clicks to choose a hero from that list.
+
+The component initializes the `heroes` property by using the `HeroService` service, which is a TypeScript [parameter property](https://www.typescriptlang.org/docs/handbook/classes.html#parameter-properties) on the constructor. Angular's dependency injection system provides the `HeroService` service to the component.
 
 <code-example header="src/app/hero-list.component.ts (class)" path="architecture/src/app/hero-list.component.ts" region="class"></code-example>
 
@@ -61,7 +65,7 @@ This example shows some of the most useful `@Component` configuration options:
 You define a component's view with its companion template.
 A template is a form of HTML that tells Angular how to render the component.
 
-Views are typically arranged hierarchically, allowing you to modify or show and hide entire UI sections or pages as a unit.
+Views are typically organized hierarchically, allowing you to modify or show and hide entire UI sections or pages as a unit.
 The template immediately associated with a component defines that component's *host view*.
 The component can also define a *view hierarchy*, which contains *embedded views*, hosted by other components.
 
@@ -71,7 +75,7 @@ The component can also define a *view hierarchy*, which contains *embedded views
 
 </div>
 
-A view hierarchy can include views from components in the same NgModule, but it can also include views from components that are defined in different NgModules.
+A view hierarchy can include views from components in the same NgModule and from those in different NgModules.
 
 ## Template syntax
 
@@ -89,9 +93,10 @@ The template-syntax elements tell Angular how to render the HTML to the screen, 
 *   `{{hero.name}}`, `(click)`, and `[hero]` bind program data to and from the DOM, responding to user input.
     See more about [data binding](#data-binding) below.
 
-*   The `<app-hero-detail>` tag in the example is an element that represents a new component, `HeroDetailComponent`.
-    `HeroDetailComponent`  defines the hero-detail child view of `HeroListComponent`.
-    Notice how custom components like this mix seamlessly with native HTML in the same layouts.
+*   The `<app-hero-detail>` element tag in the example represents a new component, `HeroDetailComponent`.
+    The `HeroDetailComponent`  defines the `hero-detail` portion of the rendered DOM structure specified by the `HeroListComponent` component.
+
+    Notice how these custom components mix with native HTML.
 
 ### Data binding
 
@@ -220,7 +225,7 @@ The `ngModel` directive, which implements two-way data binding, is an example of
 
 <code-example header="src/app/hero-detail.component.html (ngModel)" path="architecture/src/app/hero-detail.component.html" region="ngModel"></code-example>
 
-Angular has pre-defined directives that change: 
+Angular includes pre-defined directives that change: 
 
 * The layout structure, such as [ngSwitch](guide/built-in-directives#ngSwitch), and
 * Aspects of DOM elements and components, such as [ngStyle](guide/built-in-directives#ngstyle) and [ngClass](guide/built-in-directives#ngClass).

--- a/aio/content/guide/architecture-components.md
+++ b/aio/content/guide/architecture-components.md
@@ -1,16 +1,16 @@
 # Introduction to components and templates
 
 A *component* controls a patch of screen called a [*view*](guide/glossary#view "Definition of view").
-For example, individual components define and control each of the following views from the [Tour of Heroes tutorial](tutorial):
+For example, individual components define and control each of these aspects of an application:
 
 *   The application root with the navigation links
 *   The list of heroes
 *   The hero editor
 
-You define a component's application logic &mdash;what it does to support the view&mdash; inside a class.
+You define a component's application logic that supports the view inside a class.
 The class interacts with the view through an API of properties and methods.
 
-For example, `HeroListComponent` has a `heroes` property that holds an array of heroes.
+In this example, `HeroListComponent` has a `heroes` property that holds an array of heroes.
 Its `selectHero()` method sets a `selectedHero` property when the user clicks to choose a hero from that list.
 The component acquires the heroes from a service, which is a TypeScript [parameter property](https://www.typescriptlang.org/docs/handbook/classes.html#parameter-properties) on the constructor.
 The service is provided to the component through the dependency injection system.
@@ -71,7 +71,7 @@ The component can also define a *view hierarchy*, which contains *embedded views
 
 </div>
 
-A view hierarchy can include views from components in the same NgModule, but it also can \(and often does\) include views from components that are defined in different NgModules.
+A view hierarchy can include views from components in the same NgModule, but it can also include views from components that are defined in different NgModules.
 
 ## Template syntax
 
@@ -90,7 +90,7 @@ The template-syntax elements tell Angular how to render the HTML to the screen, 
     See more about [data binding](#data-binding) below.
 
 *   The `<app-hero-detail>` tag in the example is an element that represents a new component, `HeroDetailComponent`.
-    `HeroDetailComponent` \(code not shown\) defines the hero-detail child view of `HeroListComponent`.
+    `HeroDetailComponent`  defines the hero-detail child view of `HeroListComponent`.
     Notice how custom components like this mix seamlessly with native HTML in the same layouts.
 
 ### Data binding
@@ -220,7 +220,10 @@ The `ngModel` directive, which implements two-way data binding, is an example of
 
 <code-example header="src/app/hero-detail.component.html (ngModel)" path="architecture/src/app/hero-detail.component.html" region="ngModel"></code-example>
 
-Angular has more pre-defined directives that either alter the layout structure \(for example, [ngSwitch](guide/built-in-directives#ngSwitch)\) or modify aspects of DOM elements and components \(for example, [ngStyle](guide/built-in-directives#ngstyle) and [ngClass](guide/built-in-directives#ngClass)\).
+Angular has pre-defined directives that change: 
+
+* The layout structure, such as [ngSwitch](guide/built-in-directives#ngSwitch), and
+* Aspects of DOM elements and components, such as [ngStyle](guide/built-in-directives#ngstyle) and [ngClass](guide/built-in-directives#ngClass).
 
 <div class="alert is-helpful">
 

--- a/aio/content/guide/architecture-services.md
+++ b/aio/content/guide/architecture-services.md
@@ -5,13 +5,11 @@ A service is typically a class with a narrow, well-defined purpose.
 It should do something specific and do it well.
 
 Angular distinguishes components from services to increase modularity and reusability.
-By separating a component's view-related operations from other kinds of processing, you can make your component classes lean and efficient.
 
-Ideally, a component's job is to enable the user experience and nothing more.
+Ideally, a component's job is to enable only the user experience.
 A component should present properties and methods for data binding to mediate between the view and the application logic. The view is what the template renders and the application logic is what includes the notion of a *model*.
 
-A component can delegate certain tasks to services, such as fetching data from the server, validating user input, or logging directly to the console.
-By defining such processing tasks in an *injectable service class*, you make those tasks available to any component.
+A component should use services for tasks that don't involve the view or application logic. Services are good for tasks such as fetching data from the server, validating user input, or logging directly to the console. By defining such processing tasks in an *injectable service class*, you make those tasks available to any component.
 You can also make your application more adaptable by injecting different providers of the same kind of service, as appropriate in different circumstances.
 
 Angular doesn't *enforce* these principles.
@@ -37,11 +35,11 @@ That service in turn might depend on the `HttpClient` service to fetch heroes as
 
 </div>
 
-DI is wired into the Angular framework and used everywhere to provide new components with the services or other things they need.
-Components consume services; that is, you can *inject* a service into a component, giving the component access to that service class.
+Dependency injection (DI) is the part of the Angular framework that provides components with access to services and other resources.
+Angular provides the ability for you to *inject* a service into a component to give that component access to the service.
 
-To define a class as a service in Angular, use the `@Injectable()` decorator to provide the metadata that allows Angular to inject it into a component as a *dependency*.
-Similarly, use the `@Injectable()` decorator to indicate that a component or other class, such as another service, a pipe, or an NgModule, *has* a dependency.
+The `@Injectable()` decorator defines a class as a service in Angular and allows Angular to inject it into a component as a *dependency*.
+Likewise, the `@Injectable()` decorator indicates that a component, class, pipe, or NgModule *has* a dependency on a service.
 
 *   The *injector* is the main mechanism.
     Angular creates an application-wide injector for you during the bootstrap process, and additional injectors as needed.

--- a/aio/content/guide/architecture-services.md
+++ b/aio/content/guide/architecture-services.md
@@ -5,17 +5,17 @@ A service is typically a class with a narrow, well-defined purpose.
 It should do something specific and do it well.
 
 Angular distinguishes components from services to increase modularity and reusability.
-By separating a component's view-related functionality from other kinds of processing, you can make your component classes lean and efficient.
+By separating a component's view-related operations from other kinds of processing, you can make your component classes lean and efficient.
 
 Ideally, a component's job is to enable the user experience and nothing more.
-A component should present properties and methods for data binding, in order to mediate between the view \(rendered by the template\) and the application logic \(which often includes some notion of a *model*\).
+A component should present properties and methods for data binding to mediate between the view and the application logic. The view is what the template renders and the application logic is what includes the notion of a *model*.
 
 A component can delegate certain tasks to services, such as fetching data from the server, validating user input, or logging directly to the console.
 By defining such processing tasks in an *injectable service class*, you make those tasks available to any component.
 You can also make your application more adaptable by injecting different providers of the same kind of service, as appropriate in different circumstances.
 
 Angular doesn't *enforce* these principles.
-Angular does help you *follow* these principles by making it easy to factor your application logic into services and make those services available to components through *dependency injection*.
+Instead, Angular helps you *follow* these principles by making it easy to factor your application logic into services. In Angular, *dependency injection* makes those services available to components.
 
 ## Service examples
 
@@ -41,7 +41,7 @@ DI is wired into the Angular framework and used everywhere to provide new compon
 Components consume services; that is, you can *inject* a service into a component, giving the component access to that service class.
 
 To define a class as a service in Angular, use the `@Injectable()` decorator to provide the metadata that allows Angular to inject it into a component as a *dependency*.
-Similarly, use the `@Injectable()` decorator to indicate that a component or other class \(such as another service, a pipe, or an NgModule\) *has* a dependency.
+Similarly, use the `@Injectable()` decorator to indicate that a component or other class, such as another service, a pipe, or an NgModule, *has* a dependency.
 
 *   The *injector* is the main mechanism.
     Angular creates an application-wide injector for you during the bootstrap process, and additional injectors as needed.

--- a/aio/content/guide/dependency-injection.md
+++ b/aio/content/guide/dependency-injection.md
@@ -14,9 +14,9 @@ See the <live-example></live-example> for a working example containing the code 
 
 ## Creating an injectable service
 
-To create a new `HeroService` class in the `src/app/heroes` directory, use the following [Angular CLI](cli) command.
+To create a new `HeroService` class in the `src/app/heroes` directory, use the following command.
 
-<code-example format="shell" language="shell">
+<code-example format="shell" header="Generate the heroes/hero service" language="shell">
 
 ng generate service heroes/hero
 
@@ -43,7 +43,7 @@ If you define the component before the service, Angular returns a run-time null 
 
 ## Injecting services
 
-Injecting services results in making them visible to a component.
+Injecting services lets a component access their features and data.
 
 To inject a dependency in a component's `constructor()`, supply a constructor argument with the dependency type.
 The following example specifies the `HeroService` in the `HeroListComponent` constructor.
@@ -66,11 +66,10 @@ Next, inject the `Logger` service in the `HeroService` `constructor()` by specif
 
 When you create a class whose `constructor()` has parameters, specify the type and metadata about those parameters so that Angular can inject the correct service.
 
-Here, the `constructor()` specifies a type of `Logger` and stores the instance of `Logger` in a private field called `logger`.
+Here, `constructor()` specifies a type of `Logger` and stores the instance of `Logger` in a private field called `logger`.
 
-The following code tabs feature the `Logger` service and two versions of `HeroService`.
-The first version of `HeroService` doesn't depend on the `Logger` service.
-The revised second version does depend on `Logger` service.
+The following code tabs feature the `Logger` service and two versions of `HeroService`. 
+`HeroService (v2)` depends on `Logger` service, while `HeroService (v1)` doesn't depend on the `Logger` service.
 
 <code-tabs>
     <code-pane header="src/app/heroes/hero.service (v2)" path="dependency-injection/src/app/heroes/hero.service.2.ts"></code-pane>

--- a/aio/content/guide/dependency-injection.md
+++ b/aio/content/guide/dependency-injection.md
@@ -14,7 +14,7 @@ See the <live-example></live-example> for a working example containing the code 
 
 ## Creating an injectable service
 
-To generate a new `HeroService` class in the `src/app/heroes` folder use the following [Angular CLI](cli) command.
+To create a new `HeroService` class in the `src/app/heroes` directory, use the following [Angular CLI](cli) command.
 
 <code-example format="shell" language="shell">
 
@@ -69,7 +69,7 @@ When you create a class whose `constructor()` has parameters, specify the type a
 Here, the `constructor()` specifies a type of `Logger` and stores the instance of `Logger` in a private field called `logger`.
 
 The following code tabs feature the `Logger` service and two versions of `HeroService`.
-The first version of `HeroService` does not depend on the `Logger` service.
+The first version of `HeroService` doesn't depend on the `Logger` service.
 The revised second version does depend on `Logger` service.
 
 <code-tabs>

--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -34,7 +34,7 @@ This glossary lists the most prominent terms and a few less familiar ones with u
 
 <a id="aot"></a>
 
-## ahead-of-time (AOT) compilation
+## Ahead-of-time (AOT) compilation
 
 The Angular ahead-of-time \(AOT\) compiler converts Angular HTML and TypeScript code into efficient JavaScript code during the build phase, before the browser downloads and runs that code.
 This is the best compilation mode for production environments, with decreased load time and increased performance compared to [just-in-time (JIT) compilation][AioGuideGlossaryJustInTimeJitCompilation].
@@ -110,7 +110,7 @@ Learn more in [Bootstrapping][AioGuideBootstrapping].
 
 ## builder
 
-A function that uses the [Architect][AioGuideGlossaryArchitect] API to perform a complex process such as "build" or "test".
+A function that uses the [Architect][AioGuideGlossaryArchitect] API to perform a complex process such as `build` or `test`.
 The builder code is defined in an [npm package][AioGuideGlossaryNpmPackage].
 
 For example, [BrowserBuilder][GithubAngularAngularCliTreePrimaryPackagesAngularDevkitBuildAngularSrcBuildersBrowser] runs a [webpack][JsWebpackMain] build for a browser target and [KarmaBuilder][GithubAngularAngularCliTreePrimaryPackagesAngularDevkitBuildAngularSrcBuildersKarma] starts the Karma server and runs a webpack build for unit tests.
@@ -131,7 +131,7 @@ Here is a summary of the case types:
 |                                                                           | Details                                                                                                                                                                      | example             |
 |:---                                                                       |:---                                                                                                                                                                          |:---                 |
 | camelCase                                                                 | Symbols, properties, methods, pipe names, non-component directive selectors, constants. <br /> Standard or lower camel case uses lowercase on the first letter of the item.  | `selectedHero`      |
-| UpperCamelCase <br /> PascalCase                                          | Class names, including classes that define components, interfaces, NgModules, directives, and pipes. <br /> Upper camel case uses uppercase on the first letter of the item. | `HeroListComponent` |
+| UpperCamelCase <br /> PascalCase                                          | Class names, including classes that define components, interfaces, NgModules, directives, and pipes. <br /> Upper camel case uses uppercase on the first letter of the item. | `HeroComponent` |
 | dash-case <br /> kebab-case                                               | Descriptive part of file names, component selectors.                                                                                                                         | `app-hero-list`     |
 | underscore_case <br /> snake_case                                         | Not typically used in Angular. <br /> Snake case uses words connected with underscores.                                                                                      | `convert_link_mode` |
 | UPPER_UNDERSCORE_CASE <br /> UPPER_SNAKE_CASE <br /> SCREAMING_SNAKE_CASE | Traditional for constants. <br /> This case is acceptable, but camelCase is preferred. <br /> Upper snake case uses words in all capital letters connected with underscores. | `FIX_ME`            |
@@ -290,7 +290,7 @@ A directive class definition is immediately preceded by a `@Directive()` [decora
 A directive class is usually associated with an HTML element or attribute, and that element or attribute is often referred to as the directive itself.
 When Angular finds a directive in an HTML [template][AioGuideGlossaryTemplate], it creates the matching directive class instance and gives the instance control over that portion of the browser DOM.
 
-There are three categories of directive:
+Angular has three categories of directive:
 
 *   [Components][AioGuideGlossaryComponent] use `@Component()` to associate a template with a class.
     `@Component()` is an extension of `@Directive()`.
@@ -1132,6 +1132,7 @@ Learn more about zones in this [Brian Ford video][YoutubeWatchV3iqtmusceU].
 [AioGuideHierarchicalDependencyInjection]: guide/hierarchical-dependency-injection "Hierarchical injectors | Angular"
 
 [AioGuideInterpolation]: guide/interpolation "Text interpolation | Angular"
+
 <!-- [AioGuideInterpolationTemplateExpressions]: guide/interpolation#template-expressions "Template expressions - Text interpolation | Angular" -->
 
 [AioGuideNgmodules]: guide/ngmodules "NgModules | Angular"

--- a/aio/content/guide/glossary.md
+++ b/aio/content/guide/glossary.md
@@ -32,11 +32,13 @@ This glossary lists the most prominent terms and a few less familiar ones with u
 [Y][AioGuideGlossaryY]
 [Z][AioGuideGlossaryZ]
 
+<!-- vale Angular.Google_Headings = NO -->
+
 <a id="aot"></a>
 
-## Ahead-of-time (AOT) compilation
+## ahead-of-time (AOT) compilation
 
-The Angular ahead-of-time \(AOT\) compiler converts Angular HTML and TypeScript code into efficient JavaScript code during the build phase, before the browser downloads and runs that code.
+The Angular ahead-of-time \(AOT\) compiler converts Angular HTML and TypeScript code into efficient JavaScript code during the build phase. The build phase occurs before the browser downloads and runs the rendered code.
 This is the best compilation mode for production environments, with decreased load time and increased performance compared to [just-in-time (JIT) compilation][AioGuideGlossaryJustInTimeJitCompilation].
 
 By compiling your application using the `ngc` command-line tool, you can bootstrap directly to a module factory, so you do not need to include the Angular compiler in your JavaScript bundle.
@@ -967,6 +969,8 @@ An Angular application runs in a zone where it can respond to asynchronous event
 A zone client can take action before and after an async operation completes.
 
 Learn more about zones in this [Brian Ford video][YoutubeWatchV3iqtmusceU].
+
+<!-- vale Angular.Google_Headings = YES -->
 
 <!-- links -->
 

--- a/aio/content/guide/hierarchical-dependency-injection.md
+++ b/aio/content/guide/hierarchical-dependency-injection.md
@@ -1,7 +1,7 @@
 # Hierarchical injectors
 
 Injectors in Angular have rules that you can leverage to achieve the desired visibility of injectables in your applications.
-By understanding these rules, you can determine in which NgModule, Component or Directive you should declare a provider.
+By understanding these rules, you can determine in which NgModule, Component, or Directive you should declare a provider.
 
 <div class="alert is-helpful">
 
@@ -23,7 +23,7 @@ This topic uses the following pictographs.
 
 ## Two injector hierarchies
 
-There are two injector hierarchies in Angular:
+Angular has two injector hierarchies:
 
 | Injector hierarchies        | Details |
 |:---                         |:---     |
@@ -34,16 +34,16 @@ There are two injector hierarchies in Angular:
 
 ### `ModuleInjector`
 
-The `ModuleInjector` can be configured in one of two ways:
+The `ModuleInjector` can be configured in one of two ways by using:
 
-*   Using the `@Injectable()` `providedIn` property to refer to `@NgModule()`, or `root`
-*   Using the `@NgModule()` `providers` array
+*   The `@Injectable()` `providedIn` property to refer to `@NgModule()`, or `root`
+*   The `@NgModule()` `providers` array
 
 <div class="callout is-helpful">
 
 <header>Tree-shaking and &commat;Injectable()</header>
 
-Using the `@Injectable()` `providedIn` property is preferable to the `@NgModule()` `providers` array because with `@Injectable()` `providedIn`, optimization tools can perform tree-shaking, which removes services that your application isn't using and results in smaller bundle sizes.
+Using the `@Injectable()` `providedIn` property is preferable to using the `@NgModule()` `providers` array. With `@Injectable()` `providedIn`, optimization tools can perform tree-shaking, which removes services that your application isn't using. This results in smaller bundle sizes.
 
 Tree-shaking is especially useful for a library because the application which uses the library may not have a need to inject it.
 Read more about [tree-shakable providers](guide/architecture-services#providing-services) in [Introduction to services and dependency injection](guide/architecture-services).
@@ -51,9 +51,9 @@ Read more about [tree-shakable providers](guide/architecture-services#providing-
 </div>
 
 `ModuleInjector` is configured by the `@NgModule.providers` and `NgModule.imports` property.
-`ModuleInjector` is a flattening of all of the providers arrays which can be reached by following the `NgModule.imports` recursively.
+`ModuleInjector` is a flattening of all the providers arrays that can be reached by following the `NgModule.imports` recursively.
 
-Child `ModuleInjector`s are created when lazy loading other `@NgModules`.
+Child `ModuleInjector` hierarchies are created when lazy loading other `@NgModules`.
 
 Provide services with the `providedIn` property of `@Injectable()` as follows:
 
@@ -105,8 +105,8 @@ The following diagram represents the relationship between the `root` `ModuleInje
 
 </div>
 
-While the name `root` is a special alias, other `ModuleInjector`s don't have aliases.
-You have the option to create `ModuleInjector`s whenever a dynamically loaded component is created, such as with the Router, which will create child `ModuleInjector`s.
+While the name `root` is a special alias, other `ModuleInjector` hierarchies don't have aliases.
+You have the option to create `ModuleInjector` hierarchies whenever a dynamically loaded component is created, such as with the Router, which will create child `ModuleInjector` hierarchies.
 
 All requests forward up to the root injector, whether you configured it with the `bootstrapModule()` method, or registered all providers with `root` in their own services.
 
@@ -125,7 +125,7 @@ Here is an example of the case where the component router configuration includes
 
 ### `ElementInjector`
 
-Angular creates `ElementInjector`s implicitly for each DOM element.
+Angular creates `ElementInjector` hierarchies implicitly for each DOM element.
 
 Providing a service in the `@Component()` decorator using its `providers` or `viewProviders` property configures an `ElementInjector`.
 For example, the following `TestComponent` configures the `ElementInjector` by providing the service as follows:
@@ -165,15 +165,15 @@ Components and directives on the same element share an injector.
 
 When resolving a token for a component/directive, Angular resolves it in two phases:
 
-1.  Against the `ElementInjector` hierarchy \(its parents\).
-1.  Against the `ModuleInjector` hierarchy \(its parents\).
+1.  Against its parents in the `ElementInjector` hierarchy.
+2.  Against its parents in the `ModuleInjector` hierarchy.
 
 When a component declares a dependency, Angular tries to satisfy that dependency with its own `ElementInjector`.
 If the component's injector lacks the provider, it passes the request up to its parent component's `ElementInjector`.
 
-The requests keep forwarding up until Angular finds an injector that can handle the request or runs out of ancestor `ElementInjector`s.
+The requests keep forwarding up until Angular finds an injector that can handle the request or runs out of ancestor `ElementInjector` hierarchies.
 
-If Angular doesn't find the provider in any `ElementInjector`s, it goes back to the element where the request originated and looks in the `ModuleInjector` hierarchy.
+If Angular doesn't find the provider in any `ElementInjector` hierarchiess, it goes back to the element where the request originated and looks in the `ModuleInjector` hierarchy.
 If Angular still doesn't find the provider, it throws an error.
 
 If you have registered a provider for the same DI token at different levels, the first one Angular encounters is the one it uses to resolve the dependency.
@@ -196,7 +196,7 @@ Resolution modifiers fall into three categories:
 *   Where to stop looking, `@Host()` and `@Self()`
 
 By default, Angular always starts at the current `Injector` and keeps searching all the way up.
-Modifiers allow you to change the starting \(self\) or ending location.
+Modifiers allow you to change the starting, or _self_, location and the ending location.
 
 Additionally, you can combine all of the modifiers except `@Host()` and `@Self()` and of course `@SkipSelf()` and `@Self()`.
 
@@ -224,7 +224,7 @@ For example, in the following `SelfComponent`, notice the injected `LeafService`
 In this example, there is a parent provider and injecting the service will return the value, however, injecting the service with `@Self()` and `@Optional()` will return `null` because `@Self()` tells the injector to stop searching in the current host element.
 
 Another example shows the component class with a provider for `FlowerService`.
-In this case, the injector looks no further than the current `ElementInjector` because it finds the `FlowerService` and returns the yellow flower \(<code>&#x1F33C;</code>\).
+In this case, the injector looks no further than the current `ElementInjector` because it finds the `FlowerService` and returns the yellow flower <code>&#x1F33C;</code>.
 
 <code-example header="resolution-modifiers/src/app/self/self.component.ts" path="resolution-modifiers/src/app/self/self.component.ts" region="self-component"></code-example>
 
@@ -232,18 +232,18 @@ In this case, the injector looks no further than the current `ElementInjector` b
 
 `@SkipSelf()` is the opposite of `@Self()`.
 With `@SkipSelf()`, Angular starts its search for a service in the parent `ElementInjector`, rather than in the current one.
-So if the parent `ElementInjector` were using the fern \(<code>&#x1F33F;</code>\) value for `emoji`, but you had maple leaf \(<code>&#x1F341;</code>\) in the component's `providers` array, Angular would ignore maple leaf \(<code>&#x1F341;</code>\) and use fern \(<code>&#x1F33F;</code>\).
+So if the parent `ElementInjector` were using the fern <code>&#x1F33F;</code> value for `emoji`, but you had maple leaf <code>&#x1F341;</code> in the component's `providers` array, Angular would ignore maple leaf <code>&#x1F341;</code> and use fern <code>&#x1F33F;</code>.
 
 To see this in code, assume that the following value for `emoji` is what the parent component were using, as in this service:
 
 <code-example header="resolution-modifiers/src/app/leaf.service.ts" path="resolution-modifiers/src/app/leaf.service.ts" region="leafservice"></code-example>
 
-Imagine that in the child component, you had a different value, maple leaf \(<code>&#x1F341;</code>\) but you wanted to use the parent's value instead.
+Imagine that in the child component, you had a different value, maple leaf <code>&#x1F341;</code> but you wanted to use the parent's value instead.
 This is when you'd use `@SkipSelf()`:
 
 <code-example header="resolution-modifiers/src/app/skipself/skipself.component.ts" path="resolution-modifiers/src/app/skipself/skipself.component.ts" region="skipself-component"></code-example>
 
-In this case, the value you'd get for `emoji` would be fern \(<code>&#x1F33F;</code>\), not maple leaf \(<code>&#x1F341;</code>\).
+In this case, the value you'd get for `emoji` would be fern <code>&#x1F33F;</code>, not maple leaf <code>&#x1F341;</code>.
 
 #### `@SkipSelf()` with `@Optional()`
 
@@ -267,7 +267,7 @@ Use `@Host()` as follows:
 
 <code-example header="resolution-modifiers/src/app/host/host.component.ts" path="resolution-modifiers/src/app/host/host.component.ts" region="host-component"></code-example>
 
-Since `HostComponent` has `@Host()` in its constructor, no matter what the parent of `HostComponent` might have as a `flower.emoji` value, the `HostComponent` will use yellow flower \(<code>&#x1F33C;</code>\).
+Since `HostComponent` has `@Host()` in its constructor, no matter what the parent of `HostComponent` might have as a `flower.emoji` value, the `HostComponent` will use yellow flower <code>&#x1F33C;</code>.
 
 ## Logical structure of the template
 
@@ -290,7 +290,7 @@ Components are used in your templates, as in the following example:
 **NOTE**: <br />
 Usually, you declare the components and their templates in separate files.
 For the purposes of understanding how the injection system works, it is useful to look at them from the point of view of a combined logical tree.
-The term logical distinguishes it from the render tree \(your application DOM tree\).
+The term _logical_ distinguishes it from the render tree, which is your application's DOM tree.
 To mark the locations of where the component templates are located, this guide uses the `<#VIEW>` pseudo element, which doesn't actually exist in the render tree and is present for mental model purposes only.
 
 </div>
@@ -342,7 +342,7 @@ In the logical tree, you'll see `@Provide`, `@Inject`, and `@NgModule`, which ar
 
 ### Example app structure
 
-The example application has a `FlowerService` provided in `root` with an `emoji` value of red hibiscus \(<code>&#x1F33A;</code>\).
+The example application has a `FlowerService` provided in `root` with an `emoji` value of red hibiscus <code>&#x1F33A;</code>.
 
 <code-example header="providers-viewproviders/src/app/flower.service.ts" path="providers-viewproviders/src/app/flower.service.ts" region="flowerservice"></code-example>
 
@@ -426,11 +426,11 @@ In the example case, the constraints are:
 
     *   Normally the starting point for search is at the point of injection.
         However, in this case `<app-root>` `@Component`s are special in that they also include their own `viewProviders`, which is why the search starts at `<#VIEW>` belonging to `<app-root>`.
-        \(This would not be the case for a directive matched at the same location.\)
+        This would not be the case for a directive matched at the same location.
 
     *   The ending location happens to be the same as the component itself, because it is the topmost component in this application.
 
-1.  The `AppModule` acts as the fallback injector when the injection token can't be found in the `ElementInjector`s.
+1.  The `AppModule` acts as the fallback injector when the injection token can't be found in the `ElementInjector` hierarchies.
 
 ### Using the `providers` array
 
@@ -438,7 +438,7 @@ Now, in the `ChildComponent` class, add a provider for `FlowerService` to demons
 
 <code-example header="providers-viewproviders/src/app/child.component.ts" path="providers-viewproviders/src/app/child/child.component.1.ts" region="flowerservice"></code-example>
 
-Now that the `FlowerService` is provided in the `@Component()` decorator, when the `<app-child>` requests the service, the injector has only to look as far as the `<app-child>`'s own `ElementInjector`.
+Now that the `FlowerService` is provided in the `@Component()` decorator, when the `<app-child>` requests the service, the injector has only to look as far as the `ElementInjector` in the `<app-child>`.
 It won't have to continue the search any further through the injector tree.
 
 The next step is to add a binding to the `ChildComponent` template.
@@ -475,9 +475,9 @@ In the logical tree, this would be represented as follows:
 </code-example>
 
 When `<app-child>` requests the `FlowerService`, the injector begins its search at the `<#VIEW>` belonging to `<app-child>` \(`<#VIEW>` is included because it is injected from `@Component()`\) and ends with `<app-child>`.
-In this case, the `FlowerService` is resolved in the `<app-child>`'s `providers` array with sunflower \(<code>&#x1F33B;</code>\).
+In this case, the `FlowerService` is resolved in the `providers` array with sunflower <code>&#x1F33B;</code> of the `<app-child>`.
 The injector doesn't have to look any further in the injector tree.
-It stops as soon as it finds the `FlowerService` and never sees the red hibiscus \(<code>&#x1F33A;</code>\).
+It stops as soon as it finds the `FlowerService` and never sees the red hibiscus <code>&#x1F33A;</code>.
 
 <a id="use-view-providers"></a>
 
@@ -497,7 +497,7 @@ If you can set it up on your own, skip ahead to [Modifying service availability]
 
 The example application features a second service, the `AnimalService` to demonstrate `viewProviders`.
 
-First, create an `AnimalService` with an `emoji` property of whale \(<code>&#x1F433;</code>\):
+First, create an `AnimalService` with an `emoji` property of whale <code>&#x1F433;</code>:
 
 <code-example header="providers-viewproviders/src/app/animal.service.ts" path="providers-viewproviders/src/app/animal.service.ts" region="animal-service"></code-example>
 
@@ -513,7 +513,7 @@ You can leave all the `FlowerService` related code in place as it will allow a c
 </div>
 
 Add a `viewProviders` array and inject the `AnimalService` in the `<app-child>` class, too, but give `emoji` a different value.
-Here, it has a value of dog \(<code>&#x1F436;</code>\).
+Here, it has a value of dog <code>&#x1F436;</code>.
 
 <code-example header="providers-viewproviders/src/app/child.component.ts" path="providers-viewproviders/src/app/child/child.component.ts" region="provide-animal-service"></code-example>
 
@@ -558,7 +558,7 @@ The logic tree for this example of `viewProviders` is as follows:
 </code-example>
 
 Just as with the `FlowerService` example, the `AnimalService` is provided in the `<app-child>` `@Component()` decorator.
-This means that since the injector first looks in the `ElementInjector` of the component, it finds the `AnimalService` value of dog \(<code>&#x1F436;</code>\).
+This means that since the injector first looks in the `ElementInjector` of the component, it finds the `AnimalService` value of dog <code>&#x1F436;</code>.
 It doesn't need to continue searching the `ElementInjector` tree, nor does it need to search the `ModuleInjector`.
 
 ### `providers` vs. `viewProviders`
@@ -596,7 +596,7 @@ The browser now renders the following, omitting the previous examples for brevit
 
 //&hellip;Omitting previous examples. The following applies to this section.
 
-Content projection: This is coming from content. Doesn't get to see
+Content projection: this is coming from content. Doesn't get to see
 puppy because the puppy is declared inside the view only.
 
 Emoji from FlowerService: &#x1F33B;
@@ -608,10 +608,10 @@ Emoji from AnimalService: &#x1F436;
 </code-example>
 
 These four bindings demonstrate the difference between `providers` and `viewProviders`.
-Since the dog \(<code>&#x1F436;</code>\) is declared inside the `<#VIEW>`, it isn't visible to the projected content.
-Instead, the projected content sees the whale \(<code>&#x1F433;</code>\).
+Since the dog <code>&#x1F436;</code> is declared inside the `<#VIEW>`, it isn't visible to the projected content.
+Instead, the projected content sees the whale <code>&#x1F433;</code>.
 
-The next section though, where `InspectorComponent` is a child component of `ChildComponent`, `InspectorComponent` is inside the `<#VIEW>`, so when it asks for the `AnimalService`, it sees the dog \(<code>&#x1F436;</code>\).
+The next section though, where `InspectorComponent` is a child component of `ChildComponent`, `InspectorComponent` is inside the `<#VIEW>`, so when it asks for the `AnimalService`, it sees the dog <code>&#x1F436;</code>.
 
 The `AnimalService` in the logical tree would look like this:
 
@@ -640,8 +640,8 @@ The `AnimalService` in the logical tree would look like this:
 
 </code-example>
 
-The projected content of `<app-inspector>` sees the whale \(<code>&#x1F433;</code>\), not the dog \(<code>&#x1F436;</code>\), because the dog \(<code>&#x1F436;</code>\) is inside the `<app-child>` `<#VIEW>`.
-The `<app-inspector>` can only see the dog \(<code>&#x1F436;</code>\) if it is also within the `<#VIEW>`.
+The projected content of `<app-inspector>` sees the whale <code>&#x1F433;</code>, not the dog <code>&#x1F436;</code>, because the dog <code>&#x1F436;</code> is inside the `<app-child>` `<#VIEW>`.
+The `<app-inspector>` can only see the dog <code>&#x1F436;</code> if it is also within the `<#VIEW>`.
 
 <a id="modify-visibility"></a>
 
@@ -664,8 +664,8 @@ constructor(&commat;SkipSelf() public flower : FlowerService) { }
 </code-example>
 
 With `@SkipSelf()`, the `<app-child>` injector doesn't look to itself for the `FlowerService`.
-Instead, the injector starts looking for the `FlowerService` at the `<app-root>`'s `ElementInjector`, where it finds nothing.
-Then, it goes back to the `<app-child>` `ModuleInjector` and finds the red hibiscus \(<code>&#x1F33A;</code>\) value, which is available because the `<app-child>` `ModuleInjector` and the `<app-root>` `ModuleInjector` are flattened into one `ModuleInjector`.
+Instead, the injector starts looking for the `FlowerService` at the `ElementInjector` or the `<app-root>`, where it finds nothing.
+Then, it goes back to the `<app-child>` `ModuleInjector` and finds the red hibiscus <code>&#x1F33A;</code> value, which is available because the `<app-child>` `ModuleInjector` and the `<app-root>` `ModuleInjector` are flattened into one `ModuleInjector`.
 Thus, the UI renders the following:
 
 <code-example format="output" hideCopy language="shell">
@@ -691,7 +691,7 @@ In a logical tree, this same idea might look like this:
 
 </code-example>
 
-Though `<app-child>` provides the sunflower \(<code>&#x1F33B;</code>\), the application renders the red hibiscus \(<code>&#x1F33A;</code>\) because `@SkipSelf()`  causes the current injector to skip itself and look to its parent.
+Though `<app-child>` provides the sunflower <code>&#x1F33B;</code>, the application renders the red hibiscus <code>&#x1F33A;</code> because `@SkipSelf()`  causes the current injector to skip itself and look to its parent.
 
 If you now add `@Host()` \(in addition to the `@SkipSelf()`\) to the `@Inject` of the `FlowerService`, the result will be `null`.
 This is because `@Host()` limits the upper bound of the search to the `<#VIEW>`.
@@ -722,10 +722,10 @@ The example application uses `@Optional()` so the application does not throw an 
 
 ### `@SkipSelf()` and `viewProviders`
 
-The `<app-child>` currently provides the `AnimalService` in the `viewProviders` array with the value of dog \(<code>&#x1F436;</code>\).
-Because the injector has only to look at the `<app-child>`'s `ElementInjector` for the `AnimalService`, it never sees the whale \(<code>&#x1F433;</code>\).
+The `<app-child>` currently provides the `AnimalService` in the `viewProviders` array with the value of dog <code>&#x1F436;</code>.
+Because the injector has only to look at the `ElementInjector` of the `<app-child>` for the `AnimalService`, it never sees the whale <code>&#x1F433;</code>.
 
-As in the `FlowerService` example, if you add `@SkipSelf()` to the constructor for the `AnimalService`, the injector won't look in the current `<app-child>`'s `ElementInjector` for the `AnimalService`.
+As in the `FlowerService` example, if you add `@SkipSelf()` to the constructor for the `AnimalService`, the injector won't look in the  `ElementInjector` oh the current `<app-child>` for the `AnimalService`.
 
 <code-example format="typescript" language="typescript">
 
@@ -739,7 +739,7 @@ export class ChildComponent {
 </code-example>
 
 Instead, the injector will begin at the `<app-root>` `ElementInjector`.
-Remember that the `<app-child>` class provides the `AnimalService` in the `viewProviders` array with a value of dog \(<code>&#x1F436;</code>\):
+Remember that the `<app-child>` class provides the `AnimalService` in the `viewProviders` array with a value of dog <code>&#x1F436;</code>:
 
 <code-example format="typescript" language="typescript">
 
@@ -770,11 +770,11 @@ The logical tree looks like this with `@SkipSelf()` in `<app-child>`:
 
 </code-example>
 
-With `@SkipSelf()` in the `<app-child>`, the injector begins its search for the `AnimalService` in the `<app-root>` `ElementInjector` and finds whale \(<code>&#x1F433;</code>\).
+With `@SkipSelf()` in the `<app-child>`, the injector begins its search for the `AnimalService` in the `<app-root>` `ElementInjector` and finds whale <code>&#x1F433;</code>.
 
 ### `@Host()` and `viewProviders`
 
-If you add `@Host()` to the constructor for `AnimalService`, the result is dog \(<code>&#x1F436;</code>\) because the injector finds the `AnimalService` in the `<app-child>` `<#VIEW>`.
+If you add `@Host()` to the constructor for `AnimalService`, the result is dog <code>&#x1F436;</code> because the injector finds the `AnimalService` in the `<app-child>` `<#VIEW>`.
 Here is the `viewProviders` array in the `<app-child>` class and `@Host()` in the constructor:
 
 <code-example format="typescript" language="typescript">
@@ -809,7 +809,7 @@ export class ChildComponent {
 
 </code-example>
 
-Add a `viewProviders` array with a third animal, hedgehog \(<code>&#x1F994;</code>\), to the `app.component.ts` `@Component()` metadata:
+Add a `viewProviders` array with a third animal, hedgehog <code>&#x1F994;</code>, to the `app.component.ts` `@Component()` metadata:
 
 <code-example format="typescript" language="typescript">
 
@@ -862,7 +862,7 @@ The logical tree representation shows why this is:
 </code-example>
 
 `@SkipSelf()`, causes the injector to start its search for the `AnimalService` at the `<app-root>`, not the `<app-child>`, where the request originates, and `@Host()` stops the search at the `<app-root>` `<#VIEW>`.
-Since `AnimalService` is provided by way of the `viewProviders` array, the injector finds hedgehog \(<code>&#x1F994;</code>\) in the `<#VIEW>`.
+Since `AnimalService` is provided by way of the `viewProviders` array, the injector finds hedgehog <code>&#x1F994;</code> in the `<#VIEW>`.
 
 <a id="component-injectors"></a>
 
@@ -894,8 +894,7 @@ As long as `VillainsListComponent` does not get destroyed it will be the same in
 Many applications allow users to work on several open tasks at the same time.
 For example, in a tax preparation application, the preparer could be working on several tax returns, switching from one to the other throughout the day.
 
-This guide demonstrates that scenario with an example in the Tour of Heroes theme.
-Imagine an outer `HeroListComponent` that displays a list of super heroes.
+To demonstrate that scenario, imagine an outer `HeroListComponent` that displays a list of super heroes.
 
 To open a hero's tax return, the preparer clicks on a hero name, which opens a component for editing that return.
 Each selected hero tax return opens in its own component and multiple returns can be open at the same time.
@@ -940,7 +939,7 @@ To prevent this, configure the component-level injector of `HeroTaxReturnCompone
 
 The `HeroTaxReturnComponent` has its own provider of the `HeroTaxReturnService`.
 Recall that every component *instance* has its own injector.
-Providing the service at the component level ensures that *every* instance of the component gets its own, private instance of the service, and no tax return gets overwritten.
+Providing the service at the component level ensures that *every* instance of the component gets a private instance of the service. This makes sure that no tax return gets overwritten.
 
 <div class="alert is-helpful">
 
@@ -951,16 +950,17 @@ You can review it and download it from the <live-example></live-example>.
 
 ### Scenario: specialized providers
 
-Another reason to re-provide a service at another level is to substitute a *more specialized* implementation of that service, deeper in the component tree.
+Another reason to provide a service again at another level is to substitute a *more specialized* implementation of that service, deeper in the component tree.
 
-Consider a Car component that depends on several services.
-Suppose you configured the root injector \(marked as A\) with *generic* providers for `CarService`, `EngineService` and `TiresService`.
+For example, consider a `Car` component that includes tire service information and depends on other services to provide more details about the car.
 
-You create a car component \(A\) that displays a car constructed from these three generic services.
+The root injector, marked as \(A\), uses *generic* providers for details about `CarService` and `EngineService`.
 
-Then you create a child component \(B\) that defines its own, *specialized* providers for `CarService` and `EngineService` that have special capabilities suitable for whatever is going on in component \(B\).
+1. `Car` component \(A\).  Component \(A\) displays tire service data about a car and specifies generic services to provide more information about the car.
 
-Component \(B\) is the parent of another component \(C\) that defines its own, even *more specialized* provider for `CarService`.
+2. Child component \(B\). Component \(B\) defines its own, *specialized* providers for `CarService` and `EngineService` that have special capabilities suitable for what's going on in component \(B\).
+
+3. Child component \(C\) as a childe of Component \(B\). Component \(C\) defines its own, even *more specialized* provider for `CarService`.
 
 <div class="lightbox">
 
@@ -970,7 +970,11 @@ Component \(B\) is the parent of another component \(C\) that defines its own, e
 
 Behind the scenes, each component sets up its own injector with zero, one, or more providers defined for that component itself.
 
-When you resolve an instance of `Car` at the deepest component \(C\), its injector produces an instance of `Car` resolved by injector \(C\) with an `Engine` resolved by injector \(B\) and `Tires` resolved by the root injector \(A\).
+When you resolve an instance of `Car` at the deepest component \(C\), its injector produces: 
+
+* An instance of `Car` resolved by injector \(C\)
+* An `Engine` resolved by injector \(B\)
+* Its `Tires` resolved by the root injector \(A\).
 
 <div class="lightbox">
 

--- a/aio/content/guide/router-reference.md
+++ b/aio/content/guide/router-reference.md
@@ -1,4 +1,4 @@
-# Router Reference
+# Router reference
 
 The following sections highlight some core router concepts.
 
@@ -7,7 +7,7 @@ The following sections highlight some core router concepts.
 ## Router imports
 
 The Angular Router is an optional service that presents a particular component view for a given URL.
-It is not part of the Angular core and thus is in its own library package, `@angular/router`.
+It isn't part of the Angular core and thus is in its own library package, `@angular/router`.
 
 Import what you need from it as you would from any other Angular package.
 
@@ -27,7 +27,7 @@ A routed Angular application has one singleton instance of the `Router` service.
 When the browser's URL changes, that router looks for a corresponding `Route` from which it can determine the component to display.
 
 A router has no routes until you configure it.
-The following example creates five route definitions, configures the router via the `RouterModule.forRoot()` method, and adds the result to the `AppModule`'s `imports` array.
+The following example creates five route definitions, configures the router via the `RouterModule.forRoot()` method, and adds the result to the `imports` array of the `AppModule`'.
 
 <code-example header="src/app/app.module.ts (excerpt)" path="router/src/app/app.module.0.ts"></code-example>
 
@@ -85,7 +85,7 @@ Consider the following template:
 <code-example header="src/app/app.component.html" path="router/src/app/app.component.1.html"></code-example>
 
 The `RouterLink` directives on the anchor tags give the router control over those elements.
-The navigation paths are fixed, so you can assign a string to the `routerLink` \(a "one-time" binding\).
+The navigation paths are fixed, so you can assign a string as a one-time binding to the `routerLink`.
 
 Had the navigation path been more dynamic, you could have bound to a template expression that returned an array of route link parameters; that is, the [link parameters array](guide/router#link-parameters-array).
 The router resolves that array into a complete URL.
@@ -104,7 +104,7 @@ routerLinkActive="..."
 
 </code-example>
 
-The template expression to the right of the equal sign, `=`, contains a space-delimited string of CSS classes that the Router adds when this link is active \(and removes when the link is inactive\).
+The template expression to the right of the equal sign, `=`, contains a space-delimited string of CSS classes that the Router adds when this link is active and removes when the link is inactive.
 You set the `RouterLinkActive` directive to a string of classes such as `routerLinkActive="active fluffy"` or bind it to a component property that returns such a string.
 For example,
 
@@ -138,7 +138,7 @@ It has a great deal of useful information including:
 
 | Property        | Details |
 |:---             |:---     |
-| `url`           | An `Observable` of the route path(s), represented as an array of strings for each part of the route path.                                                                                                                                                        |
+| `url`           | An `Observable` of the route paths, represented as an array of strings for each part of the route path.                                                                                                                                                        |
 | `data`          | An `Observable` that contains the `data` object provided for the route. Also contains any resolved values from the [resolve guard](guide/router-tutorial-toh#resolve-guard).                                                                                     |
 | `params`        | An `Observable` that contains the required and [optional parameters](guide/router-tutorial-toh#optional-route-parameters) specific to the route.                                                                                                                 |
 | `paramMap`      | An `Observable` that contains a [map](api/router/ParamMap) of the required and [optional parameters](guide/router-tutorial-toh#optional-route-parameters) specific to the route. The map supports retrieving single and multiple values from the same parameter. |
@@ -154,7 +154,7 @@ It has a great deal of useful information including:
 ## Router events
 
 During each navigation, the `Router` emits navigation events through the `Router.events` property.
-These events range from when the navigation starts and ends to many points in between. The full list of navigation events is displayed in the following table.
+These events are shown in the following table.
 
 | Router event                                              | Details |
 |:---                                                       |:---     |
@@ -189,9 +189,9 @@ Here are the key `Router` terms and their meanings:
 | `Routes`              | Defines an array of Routes, each mapping a URL path to a component.                                                                                                                              |
 | `Route`               | Defines how the router should navigate to a component based on a URL pattern. Most routes consist of a path and a component type.                                                                |
 | `RouterOutlet`        | The directive \(`<router-outlet>`\) that marks where the router displays a view.                                                                                                                 |
-| `RouterLink`          | The directive for binding a clickable HTML element to a route. Clicking an element with a `routerLink` directive that is bound to a *string* or a *link parameters array* triggers a navigation. |
+| `RouterLink`          | The directive for binding a clickable HTML element to a route. Clicking an element with a `routerLink` directive that's bound to a *string* or a *link parameters array* triggers a navigation. |
 | `RouterLinkActive`    | The directive for adding/removing classes from an HTML element when an associated `routerLink` contained on or inside the element becomes active/inactive. It can also set the `aria-current` of an active link for better accessibility.                                       |
-| `ActivatedRoute`      | A service that is provided to each route component that contains route specific information such as route parameters, static data, resolve data, global query params, and the global fragment.   |
+| `ActivatedRoute`      | A service that's provided to each route component that contains route specific information such as route parameters, static data, resolve data, global query parameters, and the global fragment.   |
 | `RouterState`         | The current state of the router including a tree of the currently activated routes together with convenience methods for traversing the route tree.                                              |
 | Link parameters array | An array that the router interprets as a routing instruction. You can bind that array to a `RouterLink` or pass the array as an argument to the `Router.navigate` method.                        |
 | Routing component     | An Angular component with a `RouterOutlet` that displays views based on router navigations.                                                                                                      |

--- a/aio/content/guide/testing-components-scenarios.md
+++ b/aio/content/guide/testing-components-scenarios.md
@@ -10,7 +10,7 @@ If you'd like to experiment with the application that this guide describes, <liv
 
 ## Component binding
 
-In the example app, the `BannerComponent` presents static title text in the HTML template.
+In the example application, the `BannerComponent` presents static title text in the HTML template.
 
 After a few changes, the `BannerComponent` presents a dynamic title by binding to the component's `title` property like this.
 
@@ -169,7 +169,7 @@ But not the real `UserService`.
 #### Provide service test doubles
 
 A *component-under-test* doesn't have to be injected with real services.
-In fact, it is usually better if they are test doubles \(stubs, fakes, spies, or mocks\).
+In fact, it is usually better if they are test doubles such as, stubs, fakes, spies, or mocks.
 The purpose of the spec is to test the component, not the service, and real services can be trouble.
 
 Injecting the real `UserService` could be a nightmare.
@@ -185,7 +185,7 @@ This particular test suite supplies a minimal mock of the `UserService` that sat
 
 #### Get injected services
 
-The tests need access to the \(stub\) `UserService` injected into the `WelcomeComponent`.
+The tests need access to the stub `UserService` injected into the `WelcomeComponent`.
 
 Angular has a hierarchical injection system.
 There can be injectors at multiple levels, from the root injector created by the `TestBed` down through the component tree.
@@ -343,14 +343,14 @@ XHR calls within a test are rare, but if you need to call XHR, see the [`waitFor
 
 #### The `tick()` function
 
-You do have to call [tick()](api/core/testing/tick) to advance the \(virtual\) clock.
+You do have to call [tick()](api/core/testing/tick) to advance the virtual clock.
 
 Calling [tick()](api/core/testing/tick) simulates the passage of time until all pending asynchronous activities finish.
 In this case, it waits for the error handler's `setTimeout()`.
 
-The [tick()](api/core/testing/tick) function accepts milliseconds and tickOptions as parameters, the millisecond \(defaults to 0 if not provided\) parameter represents how much the virtual clock advances.
+The [tick()](api/core/testing/tick) function accepts `millis` and `tickOptions` as parameters. The `millis` parameter specifies how much the virtual clock advances and defaults to `0` if not provided.
 For example, if you have a `setTimeout(fn, 100)` in a `fakeAsync()` test, you need to use `tick(100)` to trigger the fn callback.
-The tickOptions is an optional parameter with a property called `processNewMacroTasksSynchronously` \(defaults to true\) that represents whether to invoke new generated macro tasks when ticking.
+The optional `tickOptions` parameter has a property named `processNewMacroTasksSynchronously`. The `processNewMacroTasksSynchronously` property represents whether to invoke new generated macro tasks when ticking and defaults to `true`.
 
 <code-example path="testing/src/app/demo/async-helper.spec.ts" region="fake-async-test-tick"></code-example>
 
@@ -359,13 +359,13 @@ It's a companion to `fakeAsync()` and you can only call it within a `fakeAsync()
 
 #### tickOptions
 
+In this example, you have a new macro task, the nested `setTimeout` function. By default, when the `tick` is setTimeout, `outside` and `nested` will both be triggered.
+
 <code-example path="testing/src/app/demo/async-helper.spec.ts" region="fake-async-test-tick-new-macro-task-sync"></code-example>
 
-In this example, you have a new macro task \(nested setTimeout\), by default, when the `tick` is setTimeout `outside` and `nested` will both be triggered.
+In some case, you don't want to trigger the new macro task when ticking. You can use `tick(millis, {processNewMacroTasksSynchronously: false})` to not invoke a new macro task.
 
 <code-example path="testing/src/app/demo/async-helper.spec.ts" region="fake-async-test-tick-new-macro-task-async"></code-example>
-
-And in some case, you don't want to trigger the new macro task when ticking, you can use `tick(milliseconds, {processNewMacroTasksSynchronously: false})` to not invoke new macro task.
 
 #### Comparing dates inside fakeAsync()
 
@@ -714,12 +714,12 @@ The test triggered a "click" event.
 
 <code-example path="testing/src/app/dashboard/dashboard-hero.component.spec.ts" region="trigger-event-handler"></code-example>
 
-The test assumes \(correctly in this case\) that the runtime event handler &mdash;the component's `click()` method&mdash; doesn't care about the event object.
+In this case, the test correctly assumes that the runtime event handler, the component's `click()` method, doesn't care about the event object.
 
 <div class="alert is-helpful">
 
 Other handlers are less forgiving.
-For example, the `RouterLink` directive expects an object with a `button` property that identifies which mouse button \(if any\) was pressed during the click.
+For example, the `RouterLink` directive expects an object with a `button` property that identifies which mouse button, if any, was pressed during the click.
 The `RouterLink` directive throws an error if the event object is missing.
 
 </div>
@@ -742,7 +742,7 @@ Make that consistent and straightforward by encapsulating the *click-triggering*
 
 The first parameter is the *element-to-click*.
 If you want, pass a custom event object as the second parameter.
-The default is a \(partial\) [left-button mouse event object](https://developer.mozilla.org/docs/Web/API/MouseEvent/button) accepted by many handlers including the `RouterLink` directive.
+The default is a partial [left-button mouse event object](https://developer.mozilla.org/docs/Web/API/MouseEvent/button) accepted by many handlers including the `RouterLink` directive.
 
 <div class="alert is-important">
 
@@ -1263,8 +1263,8 @@ In addition to the support it receives from the default testing module `CommonMo
 
 *   `NgModel` and friends in the `FormsModule` to enable two-way data binding
 *   The `TitleCasePipe` from the `shared` folder
-*   Router services \(which these tests are stubbing\)
-*   Hero data access services \(also stubbed\)
+*   The Router services that these tests are stubbing out
+*   The Hero data access services that are also stubbed out
 
 One approach is to configure the testing module from the individual pieces as in this example:
 
@@ -1286,7 +1286,7 @@ The test configuration can use the `SharedModule` too as seen in this alternativ
 
 <code-example header="app/hero/hero-detail.component.spec.ts (SharedModule setup)" path="testing/src/app/hero/hero-detail.component.spec.ts" region="setup-shared-module"></code-example>
 
-It's a bit tighter and smaller, with fewer import statements \(not shown\).
+It's a bit tighter and smaller, with fewer import statements, which are not shown in this example.
 
 <a id="feature-module-import"></a>
 
@@ -1350,7 +1350,7 @@ The `TestBed.overrideComponent` method can replace the component's `providers` w
 
 <code-example header="app/hero/hero-detail.component.spec.ts (Override setup)" path="testing/src/app/hero/hero-detail.component.spec.ts" region="setup-override"></code-example>
 
-Notice that `TestBed.configureTestingModule` no longer provides a \(fake\) `HeroService` because it's [not needed](#spy-stub).
+Notice that `TestBed.configureTestingModule` no longer provides a fake `HeroService` because it's [not needed](#spy-stub).
 
 <a id="override-component-method"></a>
 


### PR DESCRIPTION
Docs only fix to remove or reframe references to the obsolete HeroListComponent component that was taken from an old version of the Tour of Heroes tutorial. Where possible the references were removed or replaced with the contemporary tutorial. Otherwise, the reference or link to the current tutorial was removed.
 
This PR also includes changes suggested by the documentation lint tool.

Fix #44662
