### PR TITLE
fix(router): navigate to root if initial navigation fails

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -813,6 +813,9 @@
     "name": "advanceActivatedRoute"
   },
   {
+    "name": "afterNextNavigation"
+  },
+  {
     "name": "allocExpando"
   },
   {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -8,7 +8,7 @@
 
 import {Location} from '@angular/common';
 import {Compiler, Injectable, Injector, NgModuleRef, NgZone, Type, ɵConsole as Console, ɵRuntimeError as RuntimeError} from '@angular/core';
-import {BehaviorSubject, combineLatest, EMPTY, Observable, of, Subject, SubscriptionLike} from 'rxjs';
+import {BehaviorSubject, combineLatest, EMPTY, from, Observable, of, Subject, SubscriptionLike} from 'rxjs';
 import {catchError, defaultIfEmpty, filter, finalize, map, switchMap, take, tap} from 'rxjs/operators';
 
 import {createRouterState} from './create_router_state';

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -530,6 +530,11 @@ export function getBootstrapListener() {
 
     // Default case
     if (injector.get(INITIAL_NAVIGATION, null, InjectFlags.Optional) === null) {
+      afterNextNavigation(router, () => {
+        if (!router.navigated) {
+          router.navigateByUrl('/');
+        }
+      });
       router.initialNavigation();
     }
 
@@ -579,6 +584,38 @@ const BOOTSTRAP_DONE =
       }
     });
 
+/**
+ * Performs the given action once the router finishes its next/current navigation.
+ *
+ * If the navigation is canceled or errors without a redirect, the navigation is considered
+ * complete. If the `NavigationEnd` event emits, the navigation is also considered complete.
+ */
+function afterNextNavigation(router: Router, action: () => void) {
+  router.events
+      .pipe(
+          filter(
+              (e): e is NavigationEnd|NavigationCancel|NavigationError =>
+                  e instanceof NavigationEnd || e instanceof NavigationCancel ||
+                  e instanceof NavigationError),
+          map(e => {
+            if (e instanceof NavigationEnd) {
+              // Navigation assumed to succeed if we get `ActivationStart`
+              return true;
+            }
+            const redirecting = e instanceof NavigationCancel ?
+                (e.code === NavigationCancellationCode.Redirect ||
+                 e.code === NavigationCancellationCode.SupersededByNewNavigation) :
+                false;
+            return redirecting ? null : false;
+          }),
+          filter((result): result is boolean => result !== null),
+          take(1),
+          )
+      .subscribe(() => {
+        action();
+      });
+}
+
 function provideEnabledBlockingInitialNavigation(): Provider {
   return [
     {provide: INITIAL_NAVIGATION, useValue: 'enabledBlocking'},
@@ -591,49 +628,25 @@ function provideEnabledBlockingInitialNavigation(): Provider {
             injector.get(LOCATION_INITIALIZED, Promise.resolve(null));
         let initNavigation = false;
 
-        /**
-         * Performs the given action once the router finishes its next/current navigation.
-         *
-         * If the navigation is canceled or errors without a redirect, the navigation is considered
-         * complete. If the `NavigationEnd` event emits, the navigation is also considered complete.
-         */
-        function afterNextNavigation(action: () => void) {
-          const router = injector.get(Router);
-          router.events
-              .pipe(
-                  filter(
-                      (e): e is NavigationEnd|NavigationCancel|NavigationError =>
-                          e instanceof NavigationEnd || e instanceof NavigationCancel ||
-                          e instanceof NavigationError),
-                  map(e => {
-                    if (e instanceof NavigationEnd) {
-                      // Navigation assumed to succeed if we get `ActivationStart`
-                      return true;
-                    }
-                    const redirecting = e instanceof NavigationCancel ?
-                        (e.code === NavigationCancellationCode.Redirect ||
-                         e.code === NavigationCancellationCode.SupersededByNewNavigation) :
-                        false;
-                    return redirecting ? null : false;
-                  }),
-                  filter((result): result is boolean => result !== null),
-                  take(1),
-                  )
-              .subscribe(() => {
-                action();
-              });
-        }
-
         return () => {
           return locationInitialized.then(() => {
             return new Promise(resolve => {
               const router = injector.get(Router);
               const bootstrapDone = injector.get(BOOTSTRAP_DONE);
-              afterNextNavigation(() => {
-                // Unblock APP_INITIALIZER in case the initial navigation was canceled or errored
-                // without a redirect.
-                resolve(true);
-                initNavigation = true;
+              afterNextNavigation(router, () => {
+                function complete() {
+                  // Unblock APP_INITIALIZER in case the initial navigation was canceled or errored
+                  // without a redirect.
+                  resolve(true);
+                  initNavigation = true;
+                }
+                if (!router.navigated) {
+                  router.navigateByUrl('/').then(() => {
+                    complete();
+                  });
+                } else {
+                  complete();
+                }
               });
 
               router.afterPreactivation = () => {

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -532,6 +532,7 @@ export function getBootstrapListener() {
     if (injector.get(INITIAL_NAVIGATION, null, InjectFlags.Optional) === null) {
       afterNextNavigation(router, () => {
         if (!router.navigated) {
+          NG_DEV_MODE && warnOfFailedInitialNavigation();
           router.navigateByUrl('/');
         }
       });
@@ -641,6 +642,7 @@ function provideEnabledBlockingInitialNavigation(): Provider {
                   initNavigation = true;
                 }
                 if (!router.navigated) {
+                  NG_DEV_MODE && warnOfFailedInitialNavigation();
                   router.navigateByUrl('/').then(() => {
                     complete();
                   });
@@ -669,6 +671,10 @@ function provideEnabledBlockingInitialNavigation(): Provider {
       }
     },
   ];
+}
+
+function warnOfFailedInitialNavigation() {
+  console.warn('Initial navigation failed. Navigating to application root.');
 }
 
 const INITIAL_NAVIGATION =


### PR DESCRIPTION
When a navigation in the router fails, we reset the internal state and
browser URL to the last successful navigation. For the initial
navigation, this does not exist, so `''`/`'/'` is used. Prior to this
commit, the state reset was not also accompanied by a navigation to the
root of the application. This results in a "blank" screen (or rather, it
only shows content that is outside the `router-outlet` such as the
static app header).

With this commit, the router initializer, which includes an `initialNavigation`
call, now tracks whether the initial navigation succeeded (including
redirects). If the navigation did not succeed, a navigation to the root
of the application is triggered (`'/'`). Again, this is in addition to
what the router already does for this failed navigation: setting its internal
state and browser URL to the root.

Fixes #16211