### PR TITLE
feat(core): options object to supersede bit flags for `inject()`

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -600,8 +600,16 @@ export const Inject: InjectDecorator;
 // @public (undocumented)
 export function inject<T>(token: ProviderToken<T>): T;
 
-// @public (undocumented)
+// @public @deprecated (undocumented)
 export function inject<T>(token: ProviderToken<T>, flags?: InjectFlags): T | null;
+
+// @public (undocumented)
+export function inject<T>(token: ProviderToken<T>, options: InjectOptions & {
+    optional?: false;
+}): T;
+
+// @public (undocumented)
+export function inject<T>(token: ProviderToken<T>, options: InjectOptions): T | null;
 
 // @public
 export interface Injectable {
@@ -641,7 +649,7 @@ export interface InjectDecorator {
     new (token: any): Inject;
 }
 
-// @public
+// @public @deprecated
 export enum InjectFlags {
     Default = 0,
     Host = 1,
@@ -662,6 +670,14 @@ export class InjectionToken<T> {
     toString(): string;
     // (undocumented)
     readonly ɵprov: unknown;
+}
+
+// @public
+export interface InjectOptions {
+    host?: boolean;
+    optional?: boolean;
+    self?: boolean;
+    skipSelf?: boolean;
 }
 
 // @public

--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -22,7 +22,7 @@ export {EnvironmentInjector} from './r3_injector';
 export {importProvidersFrom, ImportProvidersSource} from './provider_collection';
 export {ENVIRONMENT_INITIALIZER} from './initializer_token';
 export {ProviderToken} from './provider_token';
-export {ɵɵinject, inject, ɵɵinvalidFactoryDep} from './injector_compatibility';
+export {ɵɵinject, inject, InjectOptions, ɵɵinvalidFactoryDep} from './injector_compatibility';
 export {INJECTOR} from './injector_token';
 export {ReflectiveInjector} from './reflective_injector';
 export {ClassProvider, ModuleWithProviders, ClassSansProvider, ImportedNgModuleProviders, ConstructorProvider, ConstructorSansProvider, ExistingProvider, ExistingSansProvider, FactoryProvider, FactorySansProvider, Provider, StaticClassProvider, StaticClassSansProvider, StaticProvider, TypeProvider, ValueProvider, ValueSansProvider} from './interface/provider';

--- a/packages/core/src/di/interface/injector.ts
+++ b/packages/core/src/di/interface/injector.ts
@@ -20,6 +20,7 @@ export const enum DecoratorFlags {
  * Injection flags for DI.
  *
  * @publicApi
+ * @deprecated use an options object for `inject` instead.
  */
 export enum InjectFlags {
   // TODO(alxhub): make this 'const' (and remove `InternalInjectFlags` enum) when ngc no longer


### PR DESCRIPTION
`inject()` originated as a private API and was made public to support
`InjectionToken` factories in Ivy. For code-size and performance reasons,
when we code generate `inject()` calls we use a bit field to indicate the
various injection modes (optional, skip-self, etc). However, this doesn't
make for a very nice public API.

This commit introduces an alternative object-based API for options. All 4
flags are supported as `boolean` fields on an options object, and converted
to bit flags internally. If TypeScript can prove that `optional` injection
is not requested, it can narrow the return type and remove the `null` type.

DEPRECATION:

The bit field signature of `inject()` has been deprecated, in favor of the
new options object.

Fixes #46251
