### PR TITLE
feat(core): introduce `EnvironmentInjector.runInContext` API

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -457,6 +457,7 @@ export abstract class EnvironmentInjector implements Injector {
     abstract get<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
     // @deprecated (undocumented)
     abstract get(token: any, notFoundValue?: any): any;
+    abstract runInContext<ReturnT>(fn: () => ReturnT): ReturnT;
 }
 
 // @public

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -86,6 +86,10 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
     return this._r3Injector.get(token, notFoundValue, injectFlags);
   }
 
+  runInContext<ReturnT>(fn: () => ReturnT): ReturnT {
+    return this.injector.runInContext(fn);
+  }
+
   override destroy(): void {
     ngDevMode && assertDefined(this.destroyCbs, 'NgModule already destroyed');
     const injector = this._r3Injector;


### PR DESCRIPTION
This commit introduces a new API on `EnvironmentInjector` to run a function
in the context of the injector. This makes `inject()` available within the
body of the function to inject dependencies. We expect this functionality to
be very useful for designing ergonomic APIs both in and out of Angular, as
it should allow for a smaller and more functional API style.

Note that it's possible to implement nearly identical functionality in user
code already today:

 ```typescript
function runInContext<T>(injector: EnvironmentInjector, fn: () => T): T {
  const token = new InjectionToken<T>('TOKEN');
  const tmpInjector = createEnvironmentInjector([
    {provide: token, useFactory: () => fn()},
  ], injector);

  return tmpInjector.get(token);
}
```
    
The factory provider for `token` in this example runs in the context of the
`tmpInjector`, giving it access to `inject` that can retrieve values from
`injector` as well. This is nearly identical, although because of the child
injector `self` and `skipSelf` injection options don't function correctly.
