### PR TITLE
fix(forms): Move all remaining errors in Forms to use RuntimeErrorCode.

### DIFF
--- a/goldens/public-api/forms/errors.md
+++ b/goldens/public-api/forms/errors.md
@@ -7,6 +7,8 @@
 // @public
 export const enum RuntimeErrorCode {
     // (undocumented)
+    COMPAREWITH_NOT_A_FN = 1201,
+    // (undocumented)
     FORM_ARRAY_NAME_MISSING_PARENT = 1054,
     // (undocumented)
     FORM_CONTROL_NAME_INSIDE_MODEL_GROUP = 1051,
@@ -20,6 +22,18 @@ export const enum RuntimeErrorCode {
     MISSING_CONTROL = 1001,
     // (undocumented)
     MISSING_CONTROL_VALUE = 1002,
+    // (undocumented)
+    NAME_AND_FORM_CONTROL_NAME_MUST_MATCH = 1202,
+    // (undocumented)
+    NG_VALUE_ACCESSOR_NOT_PROVIDED = 1200,
+    // (undocumented)
+    NGMODEL_IN_FORM_GROUP = 1350,
+    // (undocumented)
+    NGMODEL_IN_FORM_GROUP_NAME = 1351,
+    // (undocumented)
+    NGMODEL_WITHOUT_NAME = 1352,
+    // (undocumented)
+    NGMODELGROUP_IN_FORM_GROUP = 1353,
     // (undocumented)
     NO_CONTROLS = 1000,
     // (undocumented)

--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, forwardRef, Injectable, Injector, Input, NgModule, OnDestroy, OnInit, Renderer2} from '@angular/core';
+import {Directive, ElementRef, forwardRef, Injectable, Injector, Input, NgModule, OnDestroy, OnInit, Renderer2, ɵRuntimeError as RuntimeError} from '@angular/core';
+
+import {RuntimeErrorCode} from '../errors';
 
 import {BuiltInControlValueAccessor, ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 import {NgControl} from './ng_control';
@@ -18,7 +20,7 @@ export const RADIO_VALUE_ACCESSOR: any = {
 };
 
 function throwNameError() {
-  throw new Error(`
+  throw new RuntimeError(RuntimeErrorCode.NAME_AND_FORM_CONTROL_NAME_MUST_MATCH, `
       If you define both a name and a formControlName attribute on your radio button, their values
       must match. Ex: <input type="radio" formControlName="food" name="food">
     `);

--- a/packages/forms/src/directives/select_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_control_value_accessor.ts
@@ -6,9 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, forwardRef, Host, Input, OnDestroy, Optional, Renderer2, StaticProvider} from '@angular/core';
+import {Directive, ElementRef, forwardRef, Host, Input, OnDestroy, Optional, Renderer2, StaticProvider, ɵRuntimeError as RuntimeError} from '@angular/core';
+
+import {RuntimeErrorCode} from '../errors';
 
 import {BuiltInControlValueAccessor, ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
+
 
 export const SELECT_VALUE_ACCESSOR: StaticProvider = {
   provide: NG_VALUE_ACCESSOR,
@@ -107,7 +110,9 @@ export class SelectControlValueAccessor extends BuiltInControlValueAccessor impl
   @Input()
   set compareWith(fn: (o1: any, o2: any) => boolean) {
     if (typeof fn !== 'function' && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      throw new Error(`compareWith must be a function, but received ${JSON.stringify(fn)}`);
+      throw new RuntimeError(
+          RuntimeErrorCode.COMPAREWITH_NOT_A_FN,
+          `compareWith must be a function, but received ${JSON.stringify(fn)}`);
     }
     this._compareWith = fn;
   }

--- a/packages/forms/src/directives/select_multiple_control_value_accessor.ts
+++ b/packages/forms/src/directives/select_multiple_control_value_accessor.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, ElementRef, forwardRef, Host, Input, OnDestroy, Optional, Renderer2, StaticProvider} from '@angular/core';
+import {Directive, ElementRef, forwardRef, Host, Input, OnDestroy, Optional, Renderer2, StaticProvider, ɵRuntimeError as RuntimeError} from '@angular/core';
+
+import {RuntimeErrorCode} from '../errors';
 
 import {BuiltInControlValueAccessor, ControlValueAccessor, NG_VALUE_ACCESSOR} from './control_value_accessor';
 
@@ -103,7 +105,9 @@ export class SelectMultipleControlValueAccessor extends BuiltInControlValueAcces
   @Input()
   set compareWith(fn: (o1: any, o2: any) => boolean) {
     if (typeof fn !== 'function' && (typeof ngDevMode === 'undefined' || ngDevMode)) {
-      throw new Error(`compareWith must be a function, but received ${JSON.stringify(fn)}`);
+      throw new RuntimeError(
+          RuntimeErrorCode.COMPAREWITH_NOT_A_FN,
+          `compareWith must be a function, but received ${JSON.stringify(fn)}`);
     }
     this._compareWith = fn;
   }

--- a/packages/forms/src/directives/shared.ts
+++ b/packages/forms/src/directives/shared.ts
@@ -6,6 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ɵRuntimeError as RuntimeError} from '@angular/core';
+
+import {RuntimeErrorCode} from '../errors';
 import {AbstractControl} from '../model/abstract_model';
 import {FormArray} from '../model/form_array';
 import {FormControl} from '../model/form_control';
@@ -292,9 +295,10 @@ function _describeControlLocation(dir: AbstractControlDirective): string {
 
 function _throwInvalidValueAccessorError(dir: AbstractControlDirective) {
   const loc = _describeControlLocation(dir);
-  throw new Error(
+  throw new RuntimeError(
+      RuntimeErrorCode.NG_VALUE_ACCESSOR_NOT_PROVIDED,
       `Value accessor was not provided as an array for form control with ${loc}. ` +
-      `Check that the \`NG_VALUE_ACCESSOR\` token is configured as a \`multi: true\` provider.`);
+          `Check that the \`NG_VALUE_ACCESSOR\` token is configured as a \`multi: true\` provider.`);
 }
 
 export function isPropertyUpdated(changes: {[key: string]: any}, viewModel: any): boolean {

--- a/packages/forms/src/directives/template_driven_errors.ts
+++ b/packages/forms/src/directives/template_driven_errors.ts
@@ -6,11 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ɵRuntimeError as RuntimeError} from '@angular/core';
+
+import {RuntimeErrorCode} from '../errors';
+
 import {formControlNameExample, formGroupNameExample, ngModelGroupExample, ngModelWithFormGroupExample} from './error_examples';
 
 
 export function modelParentException(): Error {
-  return new Error(`
+  return new RuntimeError(RuntimeErrorCode.NGMODEL_IN_FORM_GROUP, `
     ngModel cannot be used to register form controls with a parent formGroup directive.  Try using
     formGroup's partner directive "formControlName" instead.  Example:
 
@@ -24,7 +28,7 @@ export function modelParentException(): Error {
 }
 
 export function formGroupNameException(): Error {
-  return new Error(`
+  return new RuntimeError(RuntimeErrorCode.NGMODEL_IN_FORM_GROUP_NAME, `
     ngModel cannot be used to register form controls with a parent formGroupName or formArrayName directive.
 
     Option 1: Use formControlName instead of ngModel (reactive strategy):
@@ -37,7 +41,8 @@ export function formGroupNameException(): Error {
 }
 
 export function missingNameException(): Error {
-  return new Error(
+  return new RuntimeError(
+      RuntimeErrorCode.NGMODEL_WITHOUT_NAME,
       `If ngModel is used within a form tag, either the name attribute must be set or the form
     control must be defined as 'standalone' in ngModelOptions.
 
@@ -46,7 +51,7 @@ export function missingNameException(): Error {
 }
 
 export function modelGroupParentException(): Error {
-  return new Error(`
+  return new RuntimeError(RuntimeErrorCode.NGMODELGROUP_IN_FORM_GROUP, `
     ngModelGroup cannot be used with a parent formGroup directive.
 
     Option 1: Use formGroupName instead of ngModelGroup (reactive strategy):

--- a/packages/forms/src/errors.ts
+++ b/packages/forms/src/errors.ts
@@ -11,21 +11,31 @@
  * Reserved error code range: 1000-1999.
  */
 export const enum RuntimeErrorCode {
-  // Reactive Forms errors (10xx)
 
-  // Basic structure validation errors
+  // Structure validation errors (10xx)
   NO_CONTROLS = 1000,
   MISSING_CONTROL = 1001,
   MISSING_CONTROL_VALUE = 1002,
 
+  // Reactive Forms errors (1050-1099)
   FORM_CONTROL_NAME_MISSING_PARENT = 1050,
   FORM_CONTROL_NAME_INSIDE_MODEL_GROUP = 1051,
   FORM_GROUP_MISSING_INSTANCE = 1052,
   FORM_GROUP_NAME_MISSING_PARENT = 1053,
   FORM_ARRAY_NAME_MISSING_PARENT = 1054,
 
-  // Validators errors
+  // Validators errors (11xx)
   WRONG_VALIDATOR_RETURN_TYPE = -1101,
 
-  // Template-driven Forms errors (11xx)
+  // Value Accessor Errors (12xx)
+  NG_VALUE_ACCESSOR_NOT_PROVIDED = 1200,
+  COMPAREWITH_NOT_A_FN = 1201,
+  NAME_AND_FORM_CONTROL_NAME_MUST_MATCH = 1202,
+
+  // Template-driven Forms errors (1350-1399)
+  NGMODEL_IN_FORM_GROUP = 1350,
+  NGMODEL_IN_FORM_GROUP_NAME = 1351,
+  NGMODEL_WITHOUT_NAME = 1352,
+  NGMODELGROUP_IN_FORM_GROUP = 1353,
+
 }

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -54,7 +54,7 @@ class CustomValidatorDirective implements Validator {
         it('should throw when accessor is not provided as array', () => {
           expect(() => selectValueAccessor(dir, {} as any[]))
               .toThrowError(
-                  'Value accessor was not provided as an array for form control with unspecified name attribute. Check that the \`NG_VALUE_ACCESSOR\` token is configured as a \`multi: true\` provider.');
+                  'NG01200: Value accessor was not provided as an array for form control with unspecified name attribute. Check that the \`NG_VALUE_ACCESSOR\` token is configured as a \`multi: true\` provider.');
         });
 
         it('should return the default value accessor when no other provided', () => {


### PR DESCRIPTION
RuntimeErrorCode allows for better tree-shaking, and unique codes for each error.
