### PR TITLE
fix(core): include DI path into cyclic dependency error message

### DIFF
--- a/aio/content/examples/testing/src/app/hero/hero-detail.component.spec.ts
+++ b/aio/content/examples/testing/src/app/hero/hero-detail.component.spec.ts
@@ -276,7 +276,7 @@ function heroModuleSetup() {
         // Throws because `inject` only has access to TestBed's injector
         // which is an ancestor of the component's injector
         inject([HeroDetailService], (hds: HeroDetailService) => service = hds))
-        .toThrowError(/No provider for HeroDetailService/);
+        .toThrowError(/No provider found for `HeroDetailService`/);
 
     // get `HeroDetailService` with component's own injector
     service = fixture.debugElement.injector.get(HeroDetailService);

--- a/aio/content/guide/dependency-injection-navtree.md
+++ b/aio/content/guide/dependency-injection-navtree.md
@@ -153,7 +153,7 @@ It's identical to *Carol*'s constructor except for the additional `@SkipSelf` de
 
     <code-example format="output" hideCopy language="shell">
 
-    NG0200: Circular dependency in DI detected for BethComponent. Dependency path: BethComponent -&gt; Parent -&gt; BethComponent
+    NG0200: Circular dependency in DI detected for BethComponent. Path: BethComponent -&gt; Parent -&gt; BethComponent
 
     </code-example>
 

--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -100,11 +100,6 @@
     "packages/core/src/di/r3_injector.ts"
   ],
   [
-    "packages/core/src/di/r3_injector.ts",
-    "packages/core/src/render3/definition.ts",
-    "packages/core/src/render3/interfaces/definition.ts"
-  ],
-  [
     "packages/core/src/di/reflective_errors.ts",
     "packages/core/src/di/reflective_injector.ts"
   ],

--- a/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/module_spec.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injector_def/ivy_build/app/test/module_spec.ts
@@ -63,8 +63,8 @@ describe('NgModule', () => {
 
       expect(() => createInjector(AModule))
           .toThrowError(
-              'NG0200: Circular dependency in DI detected for AModule. ' +
-              'Dependency path: AModule > BModule > AModule. ' +
+              'NG0200: Circular dependency detected for `AModule`. ' +
+              'Path: AModule -> BModule -> AModule. ' +
               'Find more at https://angular.io/errors/NG0200');
     });
 

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -10,7 +10,6 @@ import '../util/ng_dev_mode';
 
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {Type} from '../interface/type';
-import {stringify} from '../util/stringify';
 
 import {resolveForwardRef} from './forward_ref';
 import {getInjectImplementation, injectRootLimpMode} from './inject_switch';
@@ -28,12 +27,6 @@ export const THROW_IF_NOT_FOUND = _THROW_IF_NOT_FOUND;
  * in the code, thus making them tree-shakable.
  */
 const DI_DECORATOR_FLAG = '__NG_DI_FLAG__';
-
-export const NG_TEMP_TOKEN_PATH = 'ngTempTokenPath';
-const NG_TOKEN_PATH = 'ngTokenPath';
-const NEW_LINE = /\n/gm;
-const NO_NEW_LINE = 'ɵ';
-export const SOURCE = '__source';
 
 /**
  * Current injector value used by `inject`.
@@ -290,37 +283,4 @@ export function attachInjectFlag(decorator: any, flag: InternalInjectFlags|Decor
  */
 export function getInjectFlag(token: any): number|undefined {
   return token[DI_DECORATOR_FLAG];
-}
-
-export function catchInjectorError(
-    e: any, token: any, injectorErrorName: string, source: string|null): never {
-  const tokenPath: any[] = e[NG_TEMP_TOKEN_PATH];
-  if (token[SOURCE]) {
-    tokenPath.unshift(token[SOURCE]);
-  }
-  e.message = formatError('\n' + e.message, tokenPath, injectorErrorName, source);
-  e[NG_TOKEN_PATH] = tokenPath;
-  e[NG_TEMP_TOKEN_PATH] = null;
-  throw e;
-}
-
-export function formatError(
-    text: string, obj: any, injectorErrorName: string, source: string|null = null): string {
-  text = text && text.charAt(0) === '\n' && text.charAt(1) == NO_NEW_LINE ? text.slice(2) : text;
-  let context = stringify(obj);
-  if (Array.isArray(obj)) {
-    context = obj.map(stringify).join(' -> ');
-  } else if (typeof obj === 'object') {
-    let parts = <string[]>[];
-    for (let key in obj) {
-      if (obj.hasOwnProperty(key)) {
-        let value = obj[key];
-        parts.push(
-            key + ':' + (typeof value === 'string' ? JSON.stringify(value) : stringify(value)));
-      }
-    }
-    context = `{${parts.join(', ')}}`;
-  }
-  return `${injectorErrorName}${source ? '(' + source + ')' : ''}[${context}]: ${
-      text.replace(NEW_LINE, '\n  ')}`;
 }

--- a/packages/core/src/di/null_injector.ts
+++ b/packages/core/src/di/null_injector.ts
@@ -6,15 +6,24 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {RuntimeErrorCode} from '../errors';
+import {createRuntimeError} from '../render3/errors_di';
 import {stringify} from '../util/stringify';
+
 import {Injector} from './injector';
 import {THROW_IF_NOT_FOUND} from './injector_compatibility';
 
 export class NullInjector implements Injector {
   get(token: any, notFoundValue: any = THROW_IF_NOT_FOUND): any {
     if (notFoundValue === THROW_IF_NOT_FOUND) {
-      const error = new Error(`NullInjectorError: No provider for ${stringify(token)}!`);
+      const message = ngDevMode ? `No provider found for \`${stringify(token)}\`.` : '';
+      const error = createRuntimeError(message, RuntimeErrorCode.PROVIDER_NOT_FOUND);
+
+      // Note: this name is unused in the code, but it's retained
+      // for backwards-compatibility reasons in case an app code
+      // relies on the error name.
       error.name = 'NullInjectorError';
+
       throw error;
     }
     return notFoundValue;

--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -10,7 +10,7 @@ import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {Type} from '../interface/type';
 import {getComponentDef} from '../render3/definition';
 import {getFactoryDef} from '../render3/definition_factory';
-import {throwCyclicDependencyError, throwInvalidProviderError} from '../render3/errors_di';
+import {cyclicDependencyErrorWithDetails, throwInvalidProviderError} from '../render3/errors_di';
 import {stringifyForError} from '../render3/util/stringify_utils';
 import {deepForEach} from '../util/array_utils';
 import {getClosureSafeProperty} from '../util/property';
@@ -177,8 +177,8 @@ export function walkProviderTree(
   // Check for circular dependencies.
   if (ngDevMode && parents.indexOf(defType) !== -1) {
     const defName = stringify(defType);
-    const path = parents.map(stringify);
-    throwCyclicDependencyError(defName, path);
+    const path = parents.map(stringify).concat(defName);
+    throw cyclicDependencyErrorWithDetails(defName, path);
   }
 
   // Check for multiple imports of the same module

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -11,9 +11,8 @@ import '../util/ng_dev_mode';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {OnDestroy} from '../interface/lifecycle_hooks';
 import {Type} from '../interface/type';
-import {getComponentDef} from '../render3/definition';
 import {FactoryFn, getFactoryDef} from '../render3/definition_factory';
-import {throwCyclicDependencyError, throwInvalidProviderError, throwMixedMultiProviderError} from '../render3/errors_di';
+import {augmentRuntimeError, cyclicDependencyError, getRuntimeErrorCode, prependTokenToDependencyPath, throwInvalidProviderError, throwMixedMultiProviderError} from '../render3/errors_di';
 import {newArray} from '../util/array_utils';
 import {EMPTY_ARRAY} from '../util/empty';
 import {stringify} from '../util/stringify';
@@ -23,7 +22,7 @@ import {ENVIRONMENT_INITIALIZER} from './initializer_token';
 import {setInjectImplementation} from './inject_switch';
 import {InjectionToken} from './injection_token';
 import {Injector} from './injector';
-import {catchInjectorError, convertToBitFlags, injectArgs, NG_TEMP_TOKEN_PATH, setCurrentInjector, THROW_IF_NOT_FOUND, ɵɵinject} from './injector_compatibility';
+import {convertToBitFlags, injectArgs, setCurrentInjector, THROW_IF_NOT_FOUND, ɵɵinject} from './injector_compatibility';
 import {INJECTOR} from './injector_token';
 import {getInheritedInjectableDef, getInjectableDef, InjectorType, ɵɵInjectableDeclaration} from './interface/defs';
 import {InjectFlags, InjectOptions} from './interface/injector';
@@ -269,19 +268,32 @@ export class R3Injector extends EnvironmentInjector {
           null :
           notFoundValue;
       return nextInjector.get(token, notFoundValue);
-    } catch (e: any) {
-      if (e.name === 'NullInjectorError') {
-        const path: any[] = e[NG_TEMP_TOKEN_PATH] = e[NG_TEMP_TOKEN_PATH] || [];
-        path.unshift(stringify(token));
+    } catch (error: any) {
+      // If there was a cyclic dependency error or a token was not found,
+      // an error is thrown at the level where the problem was detected.
+      // The error propagates up the call stack and the code below appends
+      // the current token into the path. As a result, the full path is assembled
+      // at the very top of the call stack, so the final error message can be
+      // formatted to include that path.
+      //
+      // Note: consider making the entire logic that re-throws the error
+      // tree-shakable by prefixing it with the `ngDevMode` check. In prod mode
+      // we can just use `throw error`, since the original error is also RuntimeError,
+      // just has less info (the dependency path would not be included).
+      const errorCode = getRuntimeErrorCode(error);
+      if (errorCode === RuntimeErrorCode.CYCLIC_DI_DEPENDENCY ||
+          errorCode === RuntimeErrorCode.PROVIDER_NOT_FOUND) {
+        prependTokenToDependencyPath(error, token);
+
         if (previousInjector) {
           // We still have a parent injector, keep throwing
-          throw e;
+          throw error;
         } else {
           // Format & throw the final error message when we don't have any previous injector
-          return catchInjectorError(e, token, 'R3InjectorError', this.source);
+          throw augmentRuntimeError(error, this.source);
         }
       } else {
-        throw e;
+        throw error;
       }
     } finally {
       // Lastly, restore the previous injection context.
@@ -370,7 +382,7 @@ export class R3Injector extends EnvironmentInjector {
 
   private hydrate<T>(token: ProviderToken<T>, record: Record<T>): T {
     if (ngDevMode && record.value === CIRCULAR) {
-      throwCyclicDependencyError(stringify(token));
+      throw cyclicDependencyError(stringify(token));
     } else if (record.value === NOT_YET) {
       record.value = CIRCULAR;
       record.value = record.factory!();

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -19,7 +19,7 @@ import {noSideEffects} from '../util/closure';
 
 import {assertDirectiveDef, assertNodeInjector, assertTNodeForLView} from './assert';
 import {FactoryFn, getFactoryDef} from './definition_factory';
-import {throwCyclicDependencyError, throwProviderNotFoundError} from './errors_di';
+import {cyclicDependencyError, throwProviderNotFoundError} from './errors_di';
 import {NG_ELEMENT_ID, NG_FACTORY_DEF} from './fields';
 import {registerPreOrderHooks} from './hooks';
 import {DirectiveDef} from './interfaces/definition';
@@ -611,7 +611,7 @@ export function getNodeInjectable(
   if (isFactory(value)) {
     const factory: NodeInjectorFactory = value;
     if (factory.resolving) {
-      throwCyclicDependencyError(stringifyForError(tData[index]));
+      throw cyclicDependencyError(stringifyForError(tData[index]));
     }
     const previousIncludeViewProviders = setIncludeViewProviders(factory.canSeeViewProviders);
     factory.resolving = true;

--- a/packages/core/src/render3/errors_di.ts
+++ b/packages/core/src/render3/errors_di.ts
@@ -7,19 +7,25 @@
  */
 
 import {ImportedNgModuleProviders} from '../di/interface/provider';
-import {RuntimeError, RuntimeErrorCode} from '../errors';
+import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from '../errors';
 import {Type} from '../interface/type';
 import {stringify} from '../util/stringify';
 
 import {stringifyForError} from './util/stringify_utils';
 
+const NG_RUNTIME_ERROR_CODE = 'ngErrorCode';
+const NG_RUNTIME_ERROR_MESSAGE = 'ngErrorMessage';
+const NG_TOKEN_PATH = 'ngTokenPath';
 
-/** Called when directives inject each other (creating a circular dependency) */
-export function throwCyclicDependencyError(token: string, path?: string[]): never {
-  const depPath = path ? `. Dependency path: ${path.join(' > ')} > ${token}` : '';
-  throw new RuntimeError(
-      RuntimeErrorCode.CYCLIC_DI_DEPENDENCY,
-      `Circular dependency in DI detected for ${token}${depPath}`);
+/** Creates a circular dependency runtime error. */
+export function cyclicDependencyError(token: string, path?: string[]): Error {
+  const message = ngDevMode ? `Circular dependency detected for \`${token}\`.` : '';
+  return createRuntimeError(message, RuntimeErrorCode.CYCLIC_DI_DEPENDENCY, path);
+}
+
+/** Creates a circular dependency runtime error including a dependency path in the error message. */
+export function cyclicDependencyErrorWithDetails(token: string, path?: string[]): Error {
+  return augmentRuntimeError(cyclicDependencyError(token, path), null);
 }
 
 export function throwMixedMultiProviderError() {
@@ -49,4 +55,76 @@ export function throwProviderNotFoundError(token: any, injectorName?: string): n
   throw new RuntimeError(
       RuntimeErrorCode.PROVIDER_NOT_FOUND,
       ngDevMode && `No provider for ${stringifyForError(token)} found${injectorDetails}`);
+}
+
+
+/**
+ * Given an Error instance and the current token - update the monkey-patched
+ * dependency path info to include that token.
+ *
+ * @param error Current instance of the Error class.
+ * @param token Extra token that should be appended.
+ */
+export function prependTokenToDependencyPath(error: any, token: unknown): void {
+  error[NG_TOKEN_PATH] ??= [];
+  // Append current token to the current token path. Since the error
+  // is bubbling up, add the token in front of other tokens.
+  const currentPath = error[NG_TOKEN_PATH];
+  // Do not append the same token multiple times.
+  if (currentPath[0] !== token) {
+    error[NG_TOKEN_PATH].unshift(token);
+  }
+}
+
+/**
+ * Modifies an Error instance with an updated error message
+ * based on the accumulated dependency path.
+ *
+ * @param error Current instance of the Error class.
+ * @param source Extra info about the injector which started
+ *    the resolution process, which eventually failed.
+ */
+export function augmentRuntimeError(error: any, source: string|null): Error {
+  const tokenPath: string[] = error[NG_TOKEN_PATH];
+  const errorCode = error[NG_RUNTIME_ERROR_CODE];
+  const message = error[NG_RUNTIME_ERROR_MESSAGE] || error.message;
+  error.message = formatErrorMessage(message, errorCode, tokenPath, source);
+  return error;
+}
+
+/**
+ * Creates an initial RuntimeError instance when a problem is detected.
+ * Monkey-patches extra info in the RuntimeError instance, so that it can
+ * be reused later, before throwing the final error.
+ */
+export function createRuntimeError(message: string, code: number, path?: string[]): Error {
+  // Cast to `any`, so that extra info can be monkey-patched onto this instance.
+  const error = new RuntimeError(code, message) as any;
+
+  // Monkey-patch a runtime error code and a path onto an Error instance.
+  error[NG_RUNTIME_ERROR_CODE] = code;
+  error[NG_RUNTIME_ERROR_MESSAGE] = message;
+  if (path) {
+    error[NG_TOKEN_PATH] = path;
+  }
+  return error;
+}
+
+/**
+ * Reads monkey-patched error code from the given Error instance.
+ */
+export function getRuntimeErrorCode(error: any): number|undefined {
+  return error[NG_RUNTIME_ERROR_CODE];
+}
+
+function formatErrorMessage(
+    text: string, code: number, path: string[] = [], source: string|null = null): string {
+  let pathDetails = '';
+  // If the path is empty or contains only one element (self) -
+  // do not append additional info the error message.
+  if (path && path.length > 1) {
+    pathDetails = ` Path: ${path.map(stringifyForError).join(' -> ')}.`;
+  }
+  const sourceDetails = source ? ` Source: ${source}.` : '';
+  return formatRuntimeError(code, `${text}${sourceDetails}${pathDetails}`);
 }

--- a/packages/core/src/render3/features/standalone_feature.ts
+++ b/packages/core/src/render3/features/standalone_feature.ts
@@ -31,8 +31,7 @@ class StandaloneService implements OnDestroy {
     if (!this.cachedInjectors.has(componentDef.id)) {
       const providers = internalImportProvidersFrom(false, componentDef.type);
       const standaloneInjector = providers.length > 0 ?
-          createEnvironmentInjector(
-              [providers], this._injector, `Standalone[${componentDef.type.name}]`) :
+          createEnvironmentInjector([providers], this._injector, componentDef.type.name) :
           null;
       this.cachedInjectors.set(componentDef.id, standaloneInjector);
     }

--- a/packages/core/test/acceptance/di_forward_ref_spec.ts
+++ b/packages/core/test/acceptance/di_forward_ref_spec.ts
@@ -32,7 +32,8 @@ describe('di with forwardRef', () => {
       TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyComp]});
       expect(() => TestBed.createComponent(MyComp))
           .toThrowError(
-              'NG0200: Circular dependency in DI detected for DirectiveA. Find more at https://angular.io/errors/NG0200');
+              'NG0200: Circular dependency detected for `DirectiveA`. ' +
+              'Find more at https://angular.io/errors/NG0200');
     });
 
     describe('flags', () => {

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -837,7 +837,8 @@ describe('di', () => {
       }
 
       TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyComp]});
-      expect(() => TestBed.createComponent(MyComp)).toThrowError(/No provider for DirectiveB/);
+      expect(() => TestBed.createComponent(MyComp))
+          .toThrowError(/NG0201: No provider found for `DirectiveB`/);
     });
 
     it('should throw if directive is not found in ancestor tree', () => {
@@ -856,7 +857,8 @@ describe('di', () => {
       }
 
       TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyComp]});
-      expect(() => TestBed.createComponent(MyComp)).toThrowError(/No provider for DirectiveB/);
+      expect(() => TestBed.createComponent(MyComp))
+          .toThrowError(/NG0201\: No provider found for `DirectiveB`/);
     });
 
     it('should not have access to the directive injector in a standalone injector from within a directive-level provider factory',
@@ -959,7 +961,8 @@ describe('di', () => {
       TestBed.configureTestingModule({declarations: [DirectiveA, DirectiveB, MyComp]});
       expect(() => TestBed.createComponent(MyComp))
           .toThrowError(
-              'NG0200: Circular dependency in DI detected for DirectiveA. Find more at https://angular.io/errors/NG0200');
+              'NG0200: Circular dependency detected for `DirectiveA`. ' +
+              'Find more at https://angular.io/errors/NG0200');
     });
 
     describe('flags', () => {
@@ -1761,7 +1764,7 @@ describe('di', () => {
                TestBed.configureTestingModule({declarations: [MyComp]});
 
                expect(() => TestBed.createComponent(MyComp))
-                   .toThrowError(/No provider for ViewContainerRef/);
+                   .toThrowError(/NG0201\: No provider found for `ViewContainerRef`/);
              });
         });
 
@@ -1839,7 +1842,7 @@ describe('di', () => {
             });
 
             expect(() => TestBed.createComponent(MyComponent))
-                .toThrowError(/No provider for ChangeDetectorRef/);
+                .toThrowError(/NG0201\: No provider found for `ChangeDetectorRef`/);
           });
 
           it('should lookup module injector in case @SkipSelf is used for `ChangeDetectorRef` token and Component has no parent',
@@ -1961,7 +1964,8 @@ describe('di', () => {
 
             TestBed.configureTestingModule({declarations: [Child, Parent, MyApp]});
 
-            expect(() => TestBed.createComponent(MyApp)).toThrowError(/No provider for Bar/);
+            expect(() => TestBed.createComponent(MyApp))
+                .toThrowError(/NG0201\: No provider found for `Bar`/);
           });
 
           it('should not throw when @SkipSelf and @Optional with no accessible viewProvider',
@@ -2001,7 +2005,8 @@ describe('di', () => {
 
                TestBed.configureTestingModule({declarations: [Child, Parent, MyApp]});
 
-               expect(() => TestBed.createComponent(MyApp)).not.toThrowError(/No provider for Bar/);
+               expect(() => TestBed.createComponent(MyApp))
+                   .not.toThrowError(/NG0201\: No provider found for `Bar`/);
              });
         });
       });
@@ -4216,7 +4221,8 @@ describe('di', () => {
     }
 
     TestBed.configureTestingModule({declarations: [App]});
-    expect(() => TestBed.createComponent(App)).toThrowError(/NullInjectorError/);
+    expect(() => TestBed.createComponent(App))
+        .toThrowError(/NG0201\: No provider found for `ViewRef`/);
   });
 
   describe('injector when creating embedded view', () => {
@@ -5049,5 +5055,148 @@ describe('di', () => {
         createInjector(ModuleWithProvider, null, [{provide: token, useValue: 'additional'}]);
 
     expect(injector.get(token)).toBe('module');
+  });
+
+  describe('cyclic dependency detector', () => {
+    it('should detect cyclic dependency in Module/Environment injector when @Inject is used',
+       () => {
+         const A = new InjectionToken('A');
+         const B = new InjectionToken('B');
+         @Injectable()
+         class ServiceB {
+           constructor(@Inject(A) svc: any) {}
+         }
+
+         @Injectable()
+         class ServiceA {
+           constructor(@Inject(B) svc: any) {}
+         }
+
+         @Component({
+           selector: 'my-comp',
+           template: '...',
+         })
+         class MyComp {
+           constructor(@Inject(A) svc: any) {}
+         }
+
+         TestBed.configureTestingModule({
+           declarations: [MyComp],
+           providers: [
+             {provide: A, useClass: ServiceA},
+             {provide: B, useClass: ServiceB},
+           ],
+         });
+
+         expect(() => TestBed.createComponent(MyComp))
+             .toThrowError(
+                 'NG0200: Circular dependency detected for `InjectionToken A`. ' +
+                 'Source: DynamicTestModule. ' +
+                 'Path: InjectionToken A -> InjectionToken B -> InjectionToken A. ' +
+                 'Find more at https://angular.io/errors/NG0200');
+       });
+
+    it('should detect cyclic dependency in Module/Environment injector when `inject` is used',
+       () => {
+         const A = new InjectionToken('A');
+         const B = new InjectionToken('B');
+         @Injectable()
+         class ServiceB {
+           a = inject(A);
+         }
+
+         @Injectable()
+         class ServiceA {
+           b = inject(B);
+         }
+
+         @Component({
+           selector: 'my-comp',
+           template: '...',
+         })
+         class MyComp {
+           a = inject(A);
+         }
+
+         TestBed.configureTestingModule({
+           declarations: [MyComp],
+           providers: [
+             {provide: A, useClass: ServiceA},
+             {provide: B, useClass: ServiceB},
+           ],
+         });
+
+         expect(() => TestBed.createComponent(MyComp))
+             .toThrowError(
+                 'NG0200: Circular dependency detected for `InjectionToken A`. ' +
+                 'Source: DynamicTestModule. ' +
+                 'Path: InjectionToken A -> InjectionToken B -> InjectionToken A. ' +
+                 'Find more at https://angular.io/errors/NG0200');
+       });
+
+    it('should detect cyclic dependency in Module/Environment injector when `Injector.get` is used',
+       () => {
+         const A = new InjectionToken('A');
+         const B = new InjectionToken('B');
+         @Injectable()
+         class ServiceB {
+           a = inject(A);
+         }
+
+         @Injectable()
+         class ServiceA {
+           b = inject(B);
+         }
+
+         @Component({
+           selector: 'my-comp',
+           template: '...',
+         })
+         class MyComp {
+           constructor(private injector: Injector) {}
+
+           readTokenA() {
+             this.injector.get(A);
+           }
+         }
+
+         TestBed.configureTestingModule({
+           declarations: [MyComp],
+           providers: [
+             {provide: A, useClass: ServiceA},
+             {provide: B, useClass: ServiceB},
+           ],
+         });
+
+         const fixture = TestBed.createComponent(MyComp);
+         fixture.detectChanges();
+
+         expect(() => fixture.componentInstance.readTokenA())
+             .toThrowError(
+                 'NG0200: Circular dependency detected for `InjectionToken A`. ' +
+                 'Source: DynamicTestModule. ' +
+                 'Path: InjectionToken A -> InjectionToken B -> InjectionToken A. ' +
+                 'Find more at https://angular.io/errors/NG0200');
+       });
+
+    it('throws an error on circular module dependencies', () => {
+      @NgModule({
+        imports: [forwardRef(() => BModule)],
+      })
+      class AModule {
+      }
+
+      @NgModule({
+        imports: [AModule],
+      })
+      class BModule {
+      }
+
+      expect(() => createInjector(AModule))
+          .toThrowError(
+              'NG0200: Circular dependency detected for `AModule`. ' +
+              'Path: AModule -> BModule -> AModule. ' +
+              'Find more at https://angular.io/errors/NG0200');
+    });
   });
 });

--- a/packages/core/test/acceptance/view_insertion_spec.ts
+++ b/packages/core/test/acceptance/view_insertion_spec.ts
@@ -906,8 +906,8 @@ describe('view insertion', () => {
       fixture.detectChanges();
 
       // We try to render the same template twice to ensure that we get consistent error messages.
-      expect(tryRender).toThrowError(/No provider for DoesNotExist/);
-      expect(tryRender).toThrowError(/No provider for DoesNotExist/);
+      expect(tryRender).toThrowError(/NG0201\: No provider found for `DoesNotExist`/);
+      expect(tryRender).toThrowError(/NG0201\: No provider found for `DoesNotExist`/);
     });
   });
 });

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -264,9 +264,6 @@
     "name": "NAMESPACE_URIS"
   },
   {
-    "name": "NEW_LINE"
-  },
-  {
     "name": "NG_COMP_DEF"
   },
   {
@@ -693,6 +690,9 @@
     "name": "createPlatformFactory"
   },
   {
+    "name": "createRuntimeError"
+  },
+  {
     "name": "createTView"
   },
   {
@@ -769,6 +769,9 @@
   },
   {
     "name": "forEachSingleProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -1306,6 +1309,9 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "style"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -174,9 +174,6 @@
     "name": "NAMESPACE_URIS"
   },
   {
-    "name": "NEW_LINE"
-  },
-  {
     "name": "NG_COMP_DEF"
   },
   {
@@ -489,6 +486,9 @@
     "name": "createPlatformFactory"
   },
   {
+    "name": "createRuntimeError"
+  },
+  {
     "name": "createTView"
   },
   {
@@ -547,6 +547,9 @@
   },
   {
     "name": "forEachSingleProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -985,6 +988,9 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "subscribeTo"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -252,9 +252,6 @@
     "name": "NAMESPACE_URIS"
   },
   {
-    "name": "NEW_LINE"
-  },
-  {
     "name": "NG_ASYNC_VALIDATORS"
   },
   {
@@ -714,6 +711,9 @@
     "name": "createPlatformFactory"
   },
   {
+    "name": "createRuntimeError"
+  },
+  {
     "name": "createTView"
   },
   {
@@ -805,6 +805,9 @@
   },
   {
     "name": "formGroupNameProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -1462,6 +1465,9 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "subscribeTo"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -237,9 +237,6 @@
     "name": "NAMESPACE_URIS"
   },
   {
-    "name": "NEW_LINE"
-  },
-  {
     "name": "NG_ASYNC_VALIDATORS"
   },
   {
@@ -684,6 +681,9 @@
     "name": "createPlatformFactory"
   },
   {
+    "name": "createRuntimeError"
+  },
+  {
     "name": "createTView"
   },
   {
@@ -772,6 +772,9 @@
   },
   {
     "name": "formDirectiveProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -1438,6 +1441,9 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "subscribeTo"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -108,9 +108,6 @@
     "name": "MergeMapSubscriber"
   },
   {
-    "name": "NEW_LINE"
-  },
-  {
     "name": "NG_COMP_DEF"
   },
   {
@@ -354,6 +351,9 @@
     "name": "createPlatformFactory"
   },
   {
+    "name": "createRuntimeError"
+  },
+  {
     "name": "createTView"
   },
   {
@@ -397,6 +397,9 @@
   },
   {
     "name": "forEachSingleProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -745,6 +748,9 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "subscribeTo"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -27,9 +27,6 @@
     "name": "InjectionToken"
   },
   {
-    "name": "NEW_LINE"
-  },
-  {
     "name": "NG_COMP_DEF"
   },
   {
@@ -85,6 +82,9 @@
   },
   {
     "name": "forEachSingleProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -148,6 +148,9 @@
   },
   {
     "name": "stringify"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "walkProviderTree"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -282,9 +282,6 @@
     "name": "NAMESPACE_URIS"
   },
   {
-    "name": "NEW_LINE"
-  },
-  {
     "name": "NG_COMP_DEF"
   },
   {
@@ -867,6 +864,9 @@
     "name": "createRoot"
   },
   {
+    "name": "createRuntimeError"
+  },
+  {
     "name": "createTView"
   },
   {
@@ -1021,6 +1021,9 @@
   },
   {
     "name": "forEachSingleProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -1761,10 +1764,13 @@
     "name": "stringify"
   },
   {
-    "name": "stringify10"
+    "name": "stringify11"
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "stripTrailingSlash"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -153,9 +153,6 @@
     "name": "NAMESPACE_URIS"
   },
   {
-    "name": "NEW_LINE"
-  },
-  {
     "name": "NG_COMP_DEF"
   },
   {
@@ -420,6 +417,9 @@
     "name": "createNodeInjector"
   },
   {
+    "name": "createRuntimeError"
+  },
+  {
     "name": "createTView"
   },
   {
@@ -472,6 +472,9 @@
   },
   {
     "name": "forEachSingleProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -838,6 +841,9 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "subscribeTo"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -180,9 +180,6 @@
     "name": "NAMESPACE_URIS"
   },
   {
-    "name": "NEW_LINE"
-  },
-  {
     "name": "NG_COMP_DEF"
   },
   {
@@ -594,6 +591,9 @@
     "name": "createPlatformFactory"
   },
   {
+    "name": "createRuntimeError"
+  },
+  {
     "name": "createTView"
   },
   {
@@ -667,6 +667,9 @@
   },
   {
     "name": "forEachSingleProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -1219,6 +1222,9 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "subscribeTo"

--- a/packages/core/test/di/injector_spec.ts
+++ b/packages/core/test/di/injector_spec.ts
@@ -13,12 +13,16 @@ import {Injector} from '@angular/core';
   describe('Injector.NULL', () => {
     it('should throw if no arg is given', () => {
       expect(() => Injector.NULL.get('someToken'))
-          .toThrowError('NullInjectorError: No provider for someToken!');
+          .toThrowError(
+              'NG0201: No provider found for `someToken`. ' +
+              'Find more at https://angular.io/errors/NG0201');
     });
 
     it('should throw if THROW_IF_NOT_FOUND is given', () => {
       expect(() => Injector.NULL.get('someToken', Injector.THROW_IF_NOT_FOUND))
-          .toThrowError('NullInjectorError: No provider for someToken!');
+          .toThrowError(
+              'NG0201: No provider found for `someToken`. ' +
+              'Find more at https://angular.io/errors/NG0201');
     });
 
     it('should return the default value', () => {

--- a/packages/core/test/di/r3_injector_spec.ts
+++ b/packages/core/test/di/r3_injector_spec.ts
@@ -330,24 +330,27 @@ describe('InjectorDef-based createInjector()', () => {
   it('should throw when no provider defined', () => {
     expect(() => injector.get(ServiceTwo))
         .toThrowError(
-            `R3InjectorError(Module)[ServiceTwo]: \n` +
-            `  NullInjectorError: No provider for ServiceTwo!`);
+            'NG0201: No provider found for `ServiceTwo`. ' +
+            'Source: Module. ' +
+            'Find more at https://angular.io/errors/NG0201');
   });
 
   it('should throw without the module name when no module', () => {
     const injector = createInjector([ServiceTwo]);
     expect(() => injector.get(ServiceTwo))
         .toThrowError(
-            `R3InjectorError[ServiceTwo]: \n` +
-            `  NullInjectorError: No provider for ServiceTwo!`);
+            'NG0201: No provider found for `ServiceTwo`. ' +
+            'Find more at https://angular.io/errors/NG0201');
   });
 
   it('should throw with the full path when no provider', () => {
     const injector = createInjector(ModuleWithMissingDep);
     expect(() => injector.get(ServiceWithMissingDep))
         .toThrowError(
-            `R3InjectorError(ModuleWithMissingDep)[ServiceWithMissingDep -> Service]: \n` +
-            `  NullInjectorError: No provider for Service!`);
+            'NG0201: No provider found for `Service`. ' +
+            'Source: ModuleWithMissingDep. ' +
+            'Path: ServiceWithMissingDep -> Service. ' +
+            'Find more at https://angular.io/errors/NG0201');
   });
 
   it('injects a service with dependencies', () => {

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -104,8 +104,9 @@ class SportsCar extends Car {
 
         expect(() => child.get(Car))
             .toThrowError(
-                `R3InjectorError[${stringify(Car)} -> ${stringify(Engine)}]: \n` +
-                '  NullInjectorError: No provider for Engine!');
+                'NG0201: No provider found for `Engine`. ' +
+                'Path: Car -> Engine. ' +
+                'Find more at https://angular.io/errors/NG0201');
       });
 
       it('should return a default value when not requested provider on self', () => {
@@ -132,8 +133,8 @@ class SportsCar extends Car {
         const injector = Injector.create([]);
         expect(() => injector.get(Car, undefined, InjectFlags.Self))
             .toThrowError(
-                `R3InjectorError[${stringify(Car)}]: \n` +
-                `  NullInjectorError: No provider for ${stringify(Car)}!`);
+                'NG0201: No provider found for `Car`. ' +
+                'Find more at https://angular.io/errors/NG0201');
       });
     });
 

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -705,8 +705,9 @@ describe('NgModule', () => {
 
     it('should throw when the aliased provider does not exist', () => {
       const injector = createInjector([{provide: 'car', useExisting: SportsCar}]);
-      const errorMsg = `R3InjectorError(SomeModule)[car -> ${stringify(SportsCar)}]: \n  ` +
-          `NullInjectorError: No provider for ${stringify(SportsCar)}!`;
+      const errorMsg = 'NG0201: No provider found for `SportsCar`. ' +
+          'Source: SomeModule. Path: car -> SportsCar. ' +
+          'Find more at https://angular.io/errors/NG0201';
       expect(() => injector.get('car')).toThrowError(errorMsg);
     });
 
@@ -900,14 +901,15 @@ describe('NgModule', () => {
 
     it('should throw when no provider defined', () => {
       const injector = createInjector([]);
-      const errorMsg = `R3InjectorError(SomeModule)[NonExisting]: \n  ` +
-          'NullInjectorError: No provider for NonExisting!';
+      const errorMsg = 'NG0201: No provider found for `NonExisting`. ' +
+          'Source: SomeModule. ' +
+          'Find more at https://angular.io/errors/NG0201';
       expect(() => injector.get('NonExisting')).toThrowError(errorMsg);
     });
 
     it('should throw when trying to instantiate a cyclic dependency', () => {
       expect(() => createInjector([Car, {provide: Engine, useClass: CyclicEngine}]).get(Car))
-          .toThrowError(/NG0200: Circular dependency in DI detected for Car/g);
+          .toThrowError(/NG0200: Circular dependency detected for `Car`/g);
     });
 
     it('should support null values', () => {

--- a/packages/core/test/linker/view_injector_integration_spec.ts
+++ b/packages/core/test/linker/view_injector_integration_spec.ts
@@ -547,7 +547,7 @@ describe('View injector', () => {
          TestBed.overrideComponent(
              SimpleComponent, {set: {viewProviders: [{provide: 'service', useValue: 'service'}]}});
          expect(() => createComponent('<div simpleComponent needsService></div>'))
-             .toThrowError(/No provider for service!/);
+             .toThrowError(/NG0201: No provider found for `service`\./);
        });
 
     it('should not instantiate other directives that depend on viewProviders providers (child element)',
@@ -556,7 +556,7 @@ describe('View injector', () => {
          TestBed.overrideComponent(
              SimpleComponent, {set: {viewProviders: [{provide: 'service', useValue: 'service'}]}});
          expect(() => createComponent('<div simpleComponent><div needsService></div></div>'))
-             .toThrowError(/No provider for service!/);
+             .toThrowError(/NG0201: No provider found for `service`\./);
        });
 
     it('should instantiate directives that depend on providers of other directives', () => {
@@ -619,7 +619,7 @@ describe('View injector', () => {
       TestBed.configureTestingModule({declarations: [CycleDirective]});
       expect(() => createComponent('<div cycleDirective></div>'))
           .toThrowError(
-              'NG0200: Circular dependency in DI detected for CycleDirective. Find more at https://angular.io/errors/NG0200');
+              'NG0200: Circular dependency detected for `CycleDirective`. Find more at https://angular.io/errors/NG0200');
     });
 
     it('should not instantiate a directive in a view that has a host dependency on providers' +
@@ -673,7 +673,7 @@ describe('View injector', () => {
          TestBed.configureTestingModule({declarations: [NeedsService]});
 
          expect(() => createComponent('<div needsService></div>'))
-             .toThrowError(/No provider for service!/);
+             .toThrowError(/NG0201: No provider found for `service`\./);
        }));
 
     it('should inject null when an optional dependency cannot be resolved', () => {

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -463,7 +463,8 @@ function bootstrap(
       bootstrap(RootCmp, [{provide: ErrorHandler, useValue: errorHandler}], [], [
         CustomModule
       ]).then(null, (e: Error) => {
-        const errorMsg = `R3InjectorError(TestModule)[IDontExist -> IDontExist -> IDontExist]: \n`;
+        const errorMsg = `NG0201: No provider found for \`IDontExist\`. ` +
+            `Source: TestModule. Find more at https://angular.io/errors/NG0201`;
         expect(e.message).toContain(errorMsg);
         done();
         return null;

--- a/packages/platform-browser/test/browser/bootstrap_standalone_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_standalone_spec.ts
@@ -114,7 +114,12 @@ describe('bootstrapApplication for standalone components', () => {
          fail('Expected to throw');
        } catch (e: unknown) {
          expect(e).toBeInstanceOf(Error);
-         expect((e as Error).message).toContain('No provider for InjectionToken ambient token!');
+         expect((e as Error).message)
+             .toContain(
+                 'NG0201: No provider found for `InjectionToken ambient token`. ' +
+                 'Source: StandaloneCmp. ' +
+                 'Path: NeedsAmbientProvider -> InjectionToken ambient token. ' +
+                 'Find more at https://angular.io/errors/NG0201');
        }
      }));
 


### PR DESCRIPTION
This commit updates the logic to better handle a situation when there is a cyclic DI dependency detected. Previously, the error message used to contain the name of the token that triggered the problem. With this change, the DI resolution path would also be included, so that it's easier to find and resolve the cycle.

Note: this change updates the Module/Environment part of the hierarchy. The Node/Element injector tree logic would be updated in a followup PR.

This PR partially resolves #46189 and #43300, but additional changes are required for the Node/Element injector tree logic as mentioned above.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No