### PR TITLE
fix(docs-infra): wrap enum values in CLI commands

### DIFF
--- a/aio/tools/transforms/templates/cli/lib/cli.html
+++ b/aio/tools/transforms/templates/cli/lib/cli.html
@@ -75,7 +75,7 @@
 {%- endmacro %}
 
 {%- macro renderValues(values) -%}
-{$ values.join('|') $}
+{$ values.join(' | ') $}
 {%- endmacro -%}
 
 {%- macro renderOptionValues(type, values) -%}


### PR DESCRIPTION
This commit changes the enum seperator in the CLI command overview pages so that wrapping is allowed.


Before
<img width="853" alt="Screenshot 2022-07-01 at 09 31 54" src="https://user-images.githubusercontent.com/17563226/176847097-f4f7a71e-575a-4fdc-b4db-a0f5ccaeede0.png">

After
<img width="815" alt="Screenshot 2022-07-01 at 09 32 28" src="https://user-images.githubusercontent.com/17563226/176847104-977c35aa-1541-40ca-a7be-fb8cd813d7fc.png">
