### PR TITLE
feat(core): allow ngOnInit hooks to return destroy logic

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -930,7 +930,7 @@ export interface OnDestroy {
 
 // @public
 export interface OnInit {
-    ngOnInit(): void;
+    ngOnInit(): void | (() => void);
 }
 
 // @public

--- a/packages/core/src/interface/lifecycle_hooks.ts
+++ b/packages/core/src/interface/lifecycle_hooks.ts
@@ -60,8 +60,10 @@ export interface OnInit {
    * data-bound properties for the first time,
    * and before any of the view or content children have been checked.
    * It is invoked only once when the directive is instantiated.
+   * This callback method can, optionally, return a function that will be interpreted as the
+   * `OnDestroy` lifecycle hook.
    */
-  ngOnInit(): void;
+  ngOnInit(): void|(() => void);
 }
 
 /**

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -19,7 +19,8 @@ import {profiler, ProfilerEvent} from '../profiler';
 import {getCurrentDirectiveDef, getCurrentTNode, getLView, getTView} from '../state';
 import {getComponentLViewByIndex, getNativeByTNode, unwrapRNode} from '../util/view_utils';
 
-import {getOrCreateLViewCleanup, getOrCreateTViewCleanup, handleError, loadComponentRenderer, markViewDirty} from './shared';
+import {handleError, loadComponentRenderer, markViewDirty} from './shared';
+import {getOrCreateLViewCleanup, getOrCreateTViewCleanup} from './view_cleanup';
 
 
 

--- a/packages/core/src/render3/instructions/lview_debug.ts
+++ b/packages/core/src/render3/instructions/lview_debug.ts
@@ -376,8 +376,6 @@ export class MatchesArray extends Array {}
 export class TViewComponents extends Array {}
 export class TNodeLocalNames extends Array {}
 export class TNodeInitialInputs extends Array {}
-export class LCleanup extends Array {}
-export class TCleanup extends Array {}
 
 export function attachLViewDebug(lView: LView) {
   attachDebugObject(lView, new LViewDebug(lView));

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -33,7 +33,7 @@ import {Renderer, RendererFactory} from '../interfaces/renderer';
 import {RComment, RElement, RNode, RText} from '../interfaces/renderer_dom';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {isComponentDef, isComponentHost, isContentQueryHost, isRootView} from '../interfaces/type_checks';
-import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, EMBEDDED_VIEW_INJECTOR, FLAGS, HEADER_OFFSET, HOST, HostBindingOpCodes, ID, InitPhaseState, INJECTOR, LView, LViewFlags, NEXT, PARENT, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, T_HOST, TData, TRANSPLANTED_VIEWS_TO_REFRESH, TVIEW, TView, TViewType} from '../interfaces/view';
+import {CHILD_HEAD, CHILD_TAIL, CONTEXT, DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, EMBEDDED_VIEW_INJECTOR, FLAGS, HEADER_OFFSET, HOST, HostBindingOpCodes, ID, InitPhaseState, INJECTOR, LView, LViewFlags, NEXT, PARENT, RENDERER, RENDERER_FACTORY, RootContext, RootContextFlags, SANITIZER, T_HOST, TData, TRANSPLANTED_VIEWS_TO_REFRESH, TVIEW, TView, TViewType} from '../interfaces/view';
 import {assertPureTNodeType, assertTNodeType} from '../node_assert';
 import {updateTextNode} from '../node_manipulation';
 import {isInlineTemplate, isNodeMatchingSelectorList} from '../node_selector_matcher';
@@ -49,7 +49,7 @@ import {getComponentLViewByIndex, getNativeByIndex, getNativeByTNode, isCreation
 import {selectIndexInternal} from './advance';
 import {ɵɵdirectiveInject} from './di';
 import {handleUnknownPropertyError, isPropertyValid, matchingSchemas} from './element_validation';
-import {attachLContainerDebug, attachLViewDebug, cloneToLViewFromTViewBlueprint, cloneToTViewData, LCleanup, LViewBlueprint, MatchesArray, TCleanup, TNodeDebug, TNodeInitialInputs, TNodeLocalNames, TViewComponents, TViewConstructor} from './lview_debug';
+import {attachLContainerDebug, attachLViewDebug, cloneToLViewFromTViewBlueprint, cloneToTViewData, LViewBlueprint, MatchesArray, TNodeDebug, TNodeInitialInputs, TNodeLocalNames, TViewComponents, TViewConstructor} from './lview_debug';
 
 /**
  * A permanent marker promise which signifies that the current CD tree is
@@ -743,34 +743,7 @@ export function locateHostElement(
   return renderer.selectRootElement(elementOrSelector, preserveContent);
 }
 
-/**
- * Saves context for this cleanup function in LView.cleanupInstances.
- *
- * On the first template pass, saves in TView:
- * - Cleanup function
- * - Index of context we just saved in LView.cleanupInstances
- *
- * This function can also be used to store instance specific cleanup fns. In that case the `context`
- * is `null` and the function is store in `LView` (rather than it `TView`).
- */
-export function storeCleanupWithContext(
-    tView: TView, lView: LView, context: any, cleanupFn: Function): void {
-  const lCleanup = getOrCreateLViewCleanup(lView);
-  if (context === null) {
-    // If context is null that this is instance specific callback. These callbacks can only be
-    // inserted after template shared instances. For this reason in ngDevMode we freeze the TView.
-    if (ngDevMode) {
-      Object.freeze(getOrCreateTViewCleanup(tView));
-    }
-    lCleanup.push(cleanupFn);
-  } else {
-    lCleanup.push(context);
 
-    if (tView.firstCreatePass) {
-      getOrCreateTViewCleanup(tView).push(cleanupFn, lCleanup.length - 1);
-    }
-  }
-}
 
 /**
  * Constructs a TNode object from the arguments.
@@ -1945,15 +1918,6 @@ export function storePropertyBindingMetadata(
 }
 
 export const CLEAN_PROMISE = _CLEAN_PROMISE;
-
-export function getOrCreateLViewCleanup(view: LView): any[] {
-  // top level variables should not be exported for performance reasons (PERF_NOTES.md)
-  return view[CLEANUP] || (view[CLEANUP] = ngDevMode ? new LCleanup() : []);
-}
-
-export function getOrCreateTViewCleanup(tView: TView): any[] {
-  return tView.cleanup || (tView.cleanup = ngDevMode ? new TCleanup() : []);
-}
 
 /**
  * There are cases where the sub component's renderer needs to be included

--- a/packages/core/src/render3/instructions/view_cleanup.ts
+++ b/packages/core/src/render3/instructions/view_cleanup.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {CLEANUP, LView, TView} from '../interfaces/view';
+
+class LCleanup extends Array {}
+class TCleanup extends Array {}
+
+export function getOrCreateLViewCleanup(view: LView): any[] {
+  // top level variables should not be exported for performance reasons (PERF_NOTES.md)
+  return view[CLEANUP] || (view[CLEANUP] = ngDevMode ? new LCleanup() : []);
+}
+
+export function getOrCreateTViewCleanup(tView: TView): any[] {
+  return tView.cleanup || (tView.cleanup = ngDevMode ? new TCleanup() : []);
+}
+
+/**
+ * Saves context for this cleanup function in LView.cleanupInstances.
+ *
+ * On the first template pass, saves in TView:
+ * - Cleanup function
+ * - Index of context we just saved in LView.cleanupInstances
+ *
+ * This function can also be used to store instance specific cleanup fns. In that case the `context`
+ * is `null` and the function is store in `LView` (rather than it `TView`).
+ */
+export function storeCleanupWithContext(
+    tView: TView, lView: LView, context: any, cleanupFn: Function): void {
+  const lCleanup = getOrCreateLViewCleanup(lView);
+  if (context === null) {
+    // If context is null that this is instance specific callback. These callbacks can only be
+    // inserted after template shared instances. For this reason in ngDevMode we freeze the TView.
+    if (ngDevMode) {
+      Object.freeze(getOrCreateTViewCleanup(tView));
+    }
+    lCleanup.push(cleanupFn);
+  } else {
+    lCleanup.push(context);
+
+    if (tView.firstCreatePass) {
+      getOrCreateTViewCleanup(tView).push(cleanupFn, lCleanup.length - 1);
+    }
+  }
+}

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -16,9 +16,10 @@ import {createTemplateRef, TemplateRef as ViewEngine_TemplateRef} from '../linke
 import {createContainerRef, ViewContainerRef} from '../linker/view_container_ref';
 import {assertDefined, assertIndexInRange, assertNumber, throwError} from '../util/assert';
 import {stringify} from '../util/stringify';
+
 import {assertFirstCreatePass, assertLContainer} from './assert';
 import {getNodeInjectable, locateDirectiveOrProvider} from './di';
-import {storeCleanupWithContext} from './instructions/shared';
+import {storeCleanupWithContext} from './instructions/view_cleanup';
 import {CONTAINER_HEADER_OFFSET, LContainer, MOVED_VIEWS} from './interfaces/container';
 import {unusedValueExportToPlacateAjd as unused1} from './interfaces/definition';
 import {unusedValueExportToPlacateAjd as unused2} from './interfaces/injector';

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -13,7 +13,8 @@ import {removeFromArray} from '../util/array_utils';
 import {assertEqual} from '../util/assert';
 
 import {collectNativeNodes} from './collect_native_nodes';
-import {checkNoChangesInRootView, checkNoChangesInternal, detectChangesInRootView, detectChangesInternal, markViewDirty, storeCleanupWithContext} from './instructions/shared';
+import {checkNoChangesInRootView, checkNoChangesInternal, detectChangesInRootView, detectChangesInternal, markViewDirty} from './instructions/shared';
+import {storeCleanupWithContext} from './instructions/view_cleanup';
 import {CONTAINER_HEADER_OFFSET, VIEW_REFS} from './interfaces/container';
 import {isLContainer} from './interfaces/type_checks';
 import {CONTEXT, FLAGS, LView, LViewFlags, PARENT, TVIEW} from './interfaces/view';

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {AfterViewInit, ChangeDetectorRef, Component, ComponentFactoryResolver, ContentChildren, Directive, DoCheck, Input, NgModule, OnChanges, QueryList, SimpleChange, SimpleChanges, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {AfterViewInit, ChangeDetectorRef, Component, ComponentFactoryResolver, ContentChildren, Directive, DoCheck, Input, NgModule, OnChanges, OnInit, QueryList, SimpleChange, SimpleChanges, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -1959,6 +1959,34 @@ describe('onInit', () => {
       'child of parent 0',
       'child of parent 1',
     ]);
+  });
+});
+
+describe('destroy hook from onInit', () => {
+  it('should allow returning a destroy hook from the onInit one', () => {
+    const hooksLog: string[] = [];
+
+    @Component({
+      template: ``,
+    })
+    class OnInitWithDestroyCmp implements OnInit {
+      ngOnInit() {
+        hooksLog.push('init');
+
+        // functions returned from ngOnInit are interpreted as an instance-specific destroy hooks
+        return () => {
+          hooksLog.push('destroy');
+        };
+      }
+    }
+
+    const fixture = TestBed.createComponent(OnInitWithDestroyCmp);
+    fixture.detectChanges();
+
+    expect(hooksLog).toEqual(['init']);
+
+    fixture.destroy();
+    expect(hooksLog).toEqual(['init', 'destroy']);
   });
 });
 

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1302,6 +1302,9 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "storeCleanupWithContext"
+  },
+  {
     "name": "stringify"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -981,6 +981,9 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "storeCleanupWithContext"
+  },
+  {
     "name": "stringify"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1458,6 +1458,9 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "storeCleanupWithContext"
+  },
+  {
     "name": "stringify"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1437,6 +1437,9 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "storeCleanupWithContext"
+  },
+  {
     "name": "stringify"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -720,6 +720,9 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "storeCleanupWithContext"
+  },
+  {
     "name": "stringify"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -813,6 +813,9 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "storeCleanupWithContext"
+  },
+  {
     "name": "stringify"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1218,6 +1218,9 @@
     "name": "shouldSearchParent"
   },
   {
+    "name": "storeCleanupWithContext"
+  },
+  {
     "name": "stringify"
   },
   {


### PR DESCRIPTION
EXPLORATION: still unsure if this is a good idea as the per-instance destroy hooks are a bit less performant. Still, the ergonomics are great so it might be worth it.

With this change the `ngOnInit` lifecycle hook can, optionally,
return a function that will be interpreted as the `OnDestroy`
hook. This makes it easy to collocate the initialisation and
destruction logic.

**Before**:

```typescript
@Component({...})
class WithTimerCmp implements OnInit, OnDestroy {
    timerId;
    
    ngOnInit() {
        this.timerId = setInterval(() => {
            ...
        }, 1000);
    }
    
    ngOnDestroy() {
       clearInterval(this.timerId);
    }
}
```

**After**:

(Notice how initialization and cleanup functionality is in one place. We also do avoid adding component state (`timerId`) .

```typescript
@Component({...})
class WithTimerCmp implements OnInit {
    
    ngOnInit() {
        const timerId = setInterval(() => {
            ...
        }, 1000);
        
        // can return a destroy function
        return () =>  clearInterval(timerId);
    }
}
```