### PR TITLE
fix(localize): add `--project` option to `ng-add` schematic

### DIFF
--- a/packages/localize/schematics/ng-add/index.ts
+++ b/packages/localize/schematics/ng-add/index.ts
@@ -115,14 +115,14 @@ function moveToDependencies(host: Tree, context: SchematicContext) {
 
 export default function(options: Schema): Rule {
   return async (host: Tree) => {
-    if (!options.name) {
-      throw new SchematicsException('Option "name" is required.');
+    if (!options.project) {
+      throw new SchematicsException('Option "project" is required.');
     }
 
     const workspace = await getWorkspace(host);
-    const project: workspaces.ProjectDefinition|undefined = workspace.projects.get(options.name);
+    const project: workspaces.ProjectDefinition|undefined = workspace.projects.get(options.project);
     if (!project) {
-      throw new SchematicsException(`Invalid project name (${options.name})`);
+      throw new SchematicsException(`Invalid project name (${options.project})`);
     }
 
     const localizeStr =

--- a/packages/localize/schematics/ng-add/index.ts
+++ b/packages/localize/schematics/ng-add/index.ts
@@ -17,7 +17,6 @@ import {Builders} from '@schematics/angular/utility/workspace-models';
 
 import {Schema} from './schema';
 
-
 export const localizePolyfill = `import '@angular/localize/init';`;
 
 function getRelevantTargetDefinitions(
@@ -115,14 +114,18 @@ function moveToDependencies(host: Tree, context: SchematicContext) {
 
 export default function(options: Schema): Rule {
   return async (host: Tree) => {
-    if (!options.project) {
+    // We favor the name option because the project option has a
+    // smart default which can be populated even when unspecified by the user.
+    const projectName = options.name ?? options.project;
+
+    if (!projectName) {
       throw new SchematicsException('Option "project" is required.');
     }
 
     const workspace = await getWorkspace(host);
-    const project: workspaces.ProjectDefinition|undefined = workspace.projects.get(options.project);
+    const project: workspaces.ProjectDefinition|undefined = workspace.projects.get(projectName);
     if (!project) {
-      throw new SchematicsException(`Invalid project name (${options.project})`);
+      throw new SchematicsException(`Invalid project name (${projectName})`);
     }
 
     const localizeStr =
@@ -137,7 +140,7 @@ ${localizePolyfill}
       prependToTargetFiles(project, Builders.Server, 'main', localizeStr),
       // If `$localize` will be used at runtime then must install `@angular/localize`
       // into `dependencies`, rather than the default of `devDependencies`.
-      options.useAtRuntime ? moveToDependencies : noop()
+      options.useAtRuntime ? moveToDependencies : noop(),
     ]);
   };
 }

--- a/packages/localize/schematics/ng-add/index_spec.ts
+++ b/packages/localize/schematics/ng-add/index_spec.ts
@@ -14,7 +14,7 @@ import {localizePolyfill} from './index';
 
 describe('ng-add schematic', () => {
   const countInstances = (str: string, substr: string) => str.split(substr).length - 1;
-  const defaultOptions = {name: 'demo'};
+  const defaultOptions = {project: 'demo'};
   let host: UnitTestTree;
   let schematicRunner: SchematicTestRunner;
   // The real polyfills file is bigger than this, but for the test it shouldn't matter.

--- a/packages/localize/schematics/ng-add/schema.d.ts
+++ b/packages/localize/schematics/ng-add/schema.d.ts
@@ -12,6 +12,11 @@ export interface Schema {
    */
   project?: string;
   /**
+   * The name of the project.
+   * @deprecated use the `project` option instead.
+   */
+  name?: string;
+  /**
    * Will this project use $localize at runtime?
    *
    * If true then the dependency is included in the `dependencies` section of package.json, rather

--- a/packages/localize/schematics/ng-add/schema.d.ts
+++ b/packages/localize/schematics/ng-add/schema.d.ts
@@ -10,7 +10,7 @@ export interface Schema {
   /**
    * The name of the project.
    */
-  name?: string;
+  project?: string;
   /**
    * Will this project use $localize at runtime?
    *

--- a/packages/localize/schematics/ng-add/schema.json
+++ b/packages/localize/schematics/ng-add/schema.json
@@ -4,9 +4,10 @@
   "title": "Angular Localize Ng Add Schema",
   "type": "object",
   "properties": {
-    "name": {
+    "project": {
       "type": "string",
       "description": "The name of the project.",
+      "alias": "name",
       "$default": {
         "$source": "projectName"
       }

--- a/packages/localize/schematics/ng-add/schema.json
+++ b/packages/localize/schematics/ng-add/schema.json
@@ -7,10 +7,14 @@
     "project": {
       "type": "string",
       "description": "The name of the project.",
-      "alias": "name",
       "$default": {
         "$source": "projectName"
       }
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the project.",
+      "x-deprecated": "Use the \"project\" option instead."
     },
     "useAtRuntime": {
       "type": "boolean",


### PR DESCRIPTION
`--project` is unwritten standard to provide the project name. With this change we allow the project name to be provided using the `--project` command line argument and remove the ambiguity with other schematics.
