### PR TITLE
feat(core): expose EnvironmentInjector on ApplicationRef

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -84,6 +84,7 @@ export class ApplicationRef {
     destroy(): void;
     get destroyed(): boolean;
     detachView(viewRef: ViewRef): void;
+    get injector(): EnvironmentInjector;
     readonly isStable: Observable<boolean>;
     tick(): void;
     get viewCount(): number;

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -740,15 +740,17 @@ export class ApplicationRef {
   // TODO(issue/24571): remove '!'.
   public readonly isStable!: Observable<boolean>;
 
-  /** @internal */
-  get injector(): Injector {
+  /**
+   * The `EnvironmentInjector` used to create this application.
+   */
+  get injector(): EnvironmentInjector {
     return this._injector;
   }
 
   /** @internal */
   constructor(
       private _zone: NgZone,
-      private _injector: Injector,
+      private _injector: EnvironmentInjector,
       private _exceptionHandler: ErrorHandler,
   ) {
     this._onMicrotaskEmptySubscription = this._zone.onMicrotaskEmpty.subscribe({

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ImportedNgModuleProviders, importProvidersFrom, Injector, NgModuleFactory, NgModuleRef, PlatformRef, Provider, StaticProvider, Type, ɵinternalBootstrapApplication as internalBootstrapApplication, ɵisPromise} from '@angular/core';
+import {ApplicationRef, ImportedNgModuleProviders, importProvidersFrom, NgModuleFactory, NgModuleRef, PlatformRef, Provider, StaticProvider, Type, ɵinternalBootstrapApplication as internalBootstrapApplication, ɵisPromise} from '@angular/core';
 import {BrowserModule, ɵTRANSITION_ID} from '@angular/platform-browser';
 import {first} from 'rxjs/operators';
 
@@ -34,7 +34,7 @@ function _render<T>(
     platform: PlatformRef,
     bootstrapPromise: Promise<NgModuleRef<T>|ApplicationRef>): Promise<string> {
   return bootstrapPromise.then((moduleOrApplicationRef) => {
-    const environmentInjector = (moduleOrApplicationRef as {injector: Injector}).injector;
+    const environmentInjector = moduleOrApplicationRef.injector;
     const transitionId = environmentInjector.get(ɵTRANSITION_ID, null);
     if (!transitionId) {
       throw new Error(


### PR DESCRIPTION
There are legitimate cases where access to an EnvironmentInjector
of a bootstrapped application is required / convenient. It will be also
required for support of standalone components with Angular elements.
