### PR TITLE
refactor(animations): refactor non-animatable check to be timeline based

### DIFF
--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -81,13 +81,6 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
             [...context.unsupportedCSSPropertiesFound.keys()],
         );
       }
-
-      if (context.nonAnimatableCSSPropertiesFound.size) {
-        pushNonAnimatablePropertiesWarning(
-            warnings,
-            [...context.nonAnimatableCSSPropertiesFound.keys()],
-        );
-      }
     }
 
     return ast;
@@ -321,15 +314,6 @@ export class AnimationAstBuilderVisitor implements AnimationDslVisitor {
             context.unsupportedCSSPropertiesFound.add(prop);
             return;
           }
-
-          if (this._driver.validateAnimatableStyleProperty) {
-            if (!this._driver.validateAnimatableStyleProperty(prop)) {
-              context.nonAnimatableCSSPropertiesFound.add(prop);
-              // note: non animatable properties are not removed for the tuple just in case they are
-              //       categorized as non animatable but can actually be animated
-              return;
-            }
-          }
         }
 
         // This is guaranteed to have a defined Map at this querySelector location making it
@@ -535,7 +519,6 @@ export class AnimationAstBuilderContext {
   public collectedStyles = new Map<string, Map<string, StyleTimeTuple>>();
   public options: AnimationOptions|null = null;
   public unsupportedCSSPropertiesFound: Set<string> = new Set<string>();
-  public readonly nonAnimatableCSSPropertiesFound: Set<string> = new Set<string>();
   constructor(public errors: Error[]) {}
 }
 

--- a/packages/animations/browser/src/dsl/animation_ast_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_ast_builder.ts
@@ -11,7 +11,7 @@ import {invalidDefinition, invalidKeyframes, invalidOffset, invalidParallelAnima
 import {AnimationDriver} from '../render/animation_driver';
 import {getOrSetDefaultValue} from '../render/shared';
 import {convertToMap, copyObj, extractStyleParams, iteratorToArray, NG_ANIMATING_SELECTOR, NG_TRIGGER_SELECTOR, normalizeAnimationEntry, resolveTiming, SUBSTITUTION_EXPR_START, validateStyleParams, visitDslNode} from '../util';
-import {pushNonAnimatablePropertiesWarning, pushUnrecognizedPropertiesWarning} from '../warning_helpers';
+import {pushUnrecognizedPropertiesWarning} from '../warning_helpers';
 
 import {AnimateAst, AnimateChildAst, AnimateRefAst, Ast, DynamicTimingAst, GroupAst, KeyframesAst, QueryAst, ReferenceAst, SequenceAst, StaggerAst, StateAst, StyleAst, TimingAst, TransitionAst, TriggerAst} from './animation_ast';
 import {AnimationDslVisitor} from './animation_dsl_visitor';

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -119,8 +119,7 @@ export class AnimationTransitionFactory {
  */
 function checkNonAnimatableInTimelines(
     timelines: AnimationTimelineInstruction[], triggerName: string, driver: AnimationDriver): void {
-  const validationFunctionIsUnavailable = !driver.validateAnimatableStyleProperty;
-  if (validationFunctionIsUnavailable) {
+  if (!driver.validateAnimatableStyleProperty) {
     return;
   }
 
@@ -130,8 +129,7 @@ function checkNonAnimatableInTimelines(
     const nonAnimatablePropsValues = new Map<string, Set<string|number>>();
     keyframes.forEach(keyframe => {
       for (const [prop, value] of keyframe.entries()) {
-        const propIsAnimatable = driver.validateAnimatableStyleProperty!(prop);
-        if (!propIsAnimatable) {
+        if (!driver.validateAnimatableStyleProperty!(prop)) {
           if (!nonAnimatablePropsValues.get(prop)) {
             nonAnimatablePropsValues.set(prop, new Set<string>());
           }
@@ -140,8 +138,7 @@ function checkNonAnimatableInTimelines(
       }
     });
     for (const [prop, values] of nonAnimatablePropsValues.entries()) {
-      const propIsBeingAnimated = values.size > 1;
-      if (propIsBeingAnimated) {
+      if (values.size > 1) {
         animatedNonAnimatableProps.add(prop);
       }
     }

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -126,24 +126,24 @@ function checkNonAnimatableInTimelines(
   const invalidNonAnimatableProps = new Set<string>();
 
   timelines.forEach(({keyframes}) => {
-    const nonAnimatablePropsFirstValues = new Map<string, string|number>();
+    const nonAnimatablePropsInitialValues = new Map<string, string|number>();
     keyframes.forEach(keyframe => {
       for (const [prop, value] of keyframe.entries()) {
         if (!driver.validateAnimatableStyleProperty!(prop)) {
-          if (nonAnimatablePropsFirstValues.has(prop) && !invalidNonAnimatableProps.has(prop)) {
-            const propInitialValue = nonAnimatablePropsFirstValues.get(prop);
+          if (nonAnimatablePropsInitialValues.has(prop) && !invalidNonAnimatableProps.has(prop)) {
+            const propInitialValue = nonAnimatablePropsInitialValues.get(prop);
             if (propInitialValue !== value) {
               invalidNonAnimatableProps.add(prop);
             }
           } else {
-            nonAnimatablePropsFirstValues.set(prop, value);
+            nonAnimatablePropsInitialValues.set(prop, value);
           }
         }
       }
     });
   });
 
-  if (invalidNonAnimatableProps.size) {
+  if (invalidNonAnimatableProps.size > 0) {
     console.warn(
         `Warning: The animation trigger "${triggerName}" is attempting to animate the following` +
         ' not animatable properties: ' + Array.from(invalidNonAnimatableProps).join(', ') + '\n' +

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -13,6 +13,7 @@ import {copyObj, interpolateParams, iteratorToArray} from '../util';
 
 import {StyleAst, TransitionAst} from './animation_ast';
 import {buildAnimationTimelines} from './animation_timeline_builder';
+import {AnimationTimelineInstruction} from './animation_timeline_instruction';
 import {TransitionMatcherFn} from './animation_transition_expr';
 import {AnimationTransitionInstruction, createTransitionInstruction} from './animation_transition_instruction';
 import {ElementInstructionMap} from './element_instruction_map';
@@ -91,10 +92,66 @@ export class AnimationTransitionFactory {
       }
     });
 
+    if (typeof ngDevMode === 'undefined' || ngDevMode) {
+      checkNonAnimatableInTimelines(timelines, this._triggerName, driver);
+    }
+
     const queriedElementsList = iteratorToArray(queriedElements.values());
     return createTransitionInstruction(
         element, this._triggerName, currentState, nextState, isRemoval, currentStateStyles,
         nextStateStyles, timelines, queriedElementsList, preStyleMap, postStyleMap, totalTime);
+  }
+}
+
+/**
+ * Checks inside a set of timelines if they try to animate a css property which is not considered
+ * animatable, in that case it prints a warning on the console.
+ * Besides that the function doesn't have any other effect.
+ *
+ * Note: this check is done here after the timelines are built instead of doing on a lower level so
+ * that we can make sure that the warning appears only once per instruction (we can aggregate here
+ * all the issues instead of finding them separately).
+ *
+ * @param timelines The built timelines for the current instruction.
+ * @param triggerName The name of the trigger for the current instruction.
+ * @param driver Animation driver used to perform the check.
+ *
+ */
+function checkNonAnimatableInTimelines(
+    timelines: AnimationTimelineInstruction[], triggerName: string, driver: AnimationDriver): void {
+  const validationFunctionIsUnavailable = !driver.validateAnimatableStyleProperty;
+  if (validationFunctionIsUnavailable) {
+    return;
+  }
+
+  const animatedNonAnimatableProps = new Set<string>();
+
+  timelines.forEach(({keyframes}) => {
+    const nonAnimatablePropsValues = new Map<string, Set<string|number>>();
+    keyframes.forEach(keyframe => {
+      for (const [prop, value] of keyframe.entries()) {
+        const propIsAnimatable = driver.validateAnimatableStyleProperty!(prop);
+        if (!propIsAnimatable) {
+          if (!nonAnimatablePropsValues.get(prop)) {
+            nonAnimatablePropsValues.set(prop, new Set<string>());
+          }
+          nonAnimatablePropsValues.get(prop)!.add(value);
+        }
+      }
+    });
+    for (const [prop, values] of nonAnimatablePropsValues.entries()) {
+      const propIsBeingAnimated = values.size > 1;
+      if (propIsBeingAnimated) {
+        animatedNonAnimatableProps.add(prop);
+      }
+    }
+  });
+
+  if (animatedNonAnimatableProps.size) {
+    console.warn(
+        `Warning: The animation trigger "${triggerName}" is attempting to animate the following` +
+        ' not animatable properties: ' + Array.from(animatedNonAnimatableProps).join(', ') + '\n' +
+        '(to check the list of all animatable properties visit https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties)');
   }
 }
 

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -130,7 +130,7 @@ function checkNonAnimatableInTimelines(
     keyframes.forEach(keyframe => {
       for (const [prop, value] of keyframe.entries()) {
         if (!driver.validateAnimatableStyleProperty!(prop)) {
-          if (!nonAnimatablePropsValues.get(prop)) {
+          if (!nonAnimatablePropsValues.has(prop)) {
             nonAnimatablePropsValues.set(prop, new Set<string>());
           }
           nonAnimatablePropsValues.get(prop)!.add(value);

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -123,31 +123,30 @@ function checkNonAnimatableInTimelines(
     return;
   }
 
-  const animatedNonAnimatableProps = new Set<string>();
+  const invalidNonAnimatableProps = new Set<string>();
 
   timelines.forEach(({keyframes}) => {
-    const nonAnimatablePropsValues = new Map<string, Set<string|number>>();
+    const nonAnimatablePropsFirstValues = new Map<string, string|number>();
     keyframes.forEach(keyframe => {
       for (const [prop, value] of keyframe.entries()) {
         if (!driver.validateAnimatableStyleProperty!(prop)) {
-          if (!nonAnimatablePropsValues.has(prop)) {
-            nonAnimatablePropsValues.set(prop, new Set<string>());
+          if (nonAnimatablePropsFirstValues.has(prop) && !invalidNonAnimatableProps.has(prop)) {
+            const propInitialValue = nonAnimatablePropsFirstValues.get(prop);
+            if (propInitialValue !== value) {
+              invalidNonAnimatableProps.add(prop);
+            }
+          } else {
+            nonAnimatablePropsFirstValues.set(prop, value);
           }
-          nonAnimatablePropsValues.get(prop)!.add(value);
         }
       }
     });
-    for (const [prop, values] of nonAnimatablePropsValues.entries()) {
-      if (values.size > 1) {
-        animatedNonAnimatableProps.add(prop);
-      }
-    }
   });
 
-  if (animatedNonAnimatableProps.size) {
+  if (invalidNonAnimatableProps.size) {
     console.warn(
         `Warning: The animation trigger "${triggerName}" is attempting to animate the following` +
-        ' not animatable properties: ' + Array.from(animatedNonAnimatableProps).join(', ') + '\n' +
+        ' not animatable properties: ' + Array.from(invalidNonAnimatableProps).join(', ') + '\n' +
         '(to check the list of all animatable properties visit https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties)');
   }
 }

--- a/packages/animations/browser/src/warning_helpers.ts
+++ b/packages/animations/browser/src/warning_helpers.ts
@@ -39,11 +39,3 @@ export function pushUnrecognizedPropertiesWarning(warnings: string[], props: str
     warnings.push(`The following provided properties are not recognized: ${props.join(', ')}`);
   }
 }
-
-export function pushNonAnimatablePropertiesWarning(warnings: string[], props: string[]): void {
-  if (props.length) {
-    warnings.push(`The following provided properties are not animatable: ${
-        props.join(
-            ', ')}\n   (see: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties)`);
-  }
-}

--- a/packages/animations/browser/test/dsl/animation_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_spec.ts
@@ -244,56 +244,6 @@ function createDiv() {
            ]);
          });
 
-      it('should provide a warning if a non-animatable CSS property is used in the animation',
-         () => {
-           const steps = [animate(1000, style({display: 'block'}))];
-
-           expect(getValidationWarningsForAnimationSequence(steps)).toEqual([
-             'The following provided properties are not animatable: display' +
-             '\n   (see: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties)'
-           ]);
-         });
-
-      it('should not provide a non-animatable warning if an animatable CSS property is used in the animation',
-         () => {
-           const steps = [animate('1.5s', style({borderRadius: '1rem'}))];
-
-           expect(getValidationWarningsForAnimationSequence(steps)).toEqual([]);
-         });
-
-      it('should provide a warning if multiple non-animatable CSS properties are used in the animation',
-         () => {
-           const steps = [
-             state('state', style({
-                     display: 'block',
-                   })),
-             style({textAlign: 'right'}), animate(1000, style({'font-family': 'sans-serif'}))
-           ];
-
-           expect(getValidationWarningsForAnimationSequence(steps)).toEqual([
-             'The following provided properties are not animatable: display, textAlign, font-family' +
-             '\n   (see: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties)'
-           ]);
-         });
-
-      it('should provide a warnings if both invalid and non-animatable CSS properties are used in the animation',
-         () => {
-           const steps = [
-             state('state', style({
-                     display: 'block',
-                     abc: 123,
-                   })),
-             style({textAlign: 'right'}),
-             animate(1000, style({'font-family': 'sans-serif', xyz: 456}))
-           ];
-
-           expect(getValidationWarningsForAnimationSequence(steps)).toEqual([
-             'The following provided properties are not recognized: abc, xyz',
-             'The following provided properties are not animatable: display, textAlign, font-family' +
-                 '\n   (see: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties)'
-           ]);
-         });
-
       it('should allow a vendor-prefixed property to be used in an animation sequence without throwing an error',
          () => {
            const steps = [


### PR DESCRIPTION
move the check for non-animatable properties from the animation building
phase to the application of the animation's transition instead, in such
a way we can check it against the keyframes of the transition's timeline
in order to only provide warnings for properties which are being
animated, thus not providing any warning for non-animatable properties
being applied to elements via the style function

this change has the benfit just mentioned above but it comes with two
drawbacks:
 - the warning handling is not done in the building time so it is a bit
inconsistent with other type of validations (such as the unsupported css
properties one for example)
 - before the warning was being applied only when the animation's data
was being parsed, so it happed only once but now since it is applied
when the animation is actually being prepared to be played, it happens
each time the animation runs

resolves #46602

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix (sort of?)
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #46602

Using the `style` function on non-animatable properties produces a warning in the console, even thought those properties are only being applied to the elements but not animated

For example:
![before](https://user-images.githubusercontent.com/61631103/176915217-2b748bb9-75c8-40c5-b0a8-0d9ce819bfd7.gif)

## What is the new behavior?

The warning is presented only if the animation tries to animate the non-animatable properties 

For example:
![after](https://user-images.githubusercontent.com/61631103/176915415-52dc5fc1-e1c0-4920-88d8-d8d3322a6feb.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - @jessicajaniuk, please let me know what you think of this possible change :slightly_smiling_face: