### PR TITLE
fix(core): do not invoke jasmine done callback multiple times with `waitForAsync`

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "karma": "~6.3.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-firefox-launcher": "^2.1.0",
-    "karma-jasmine": "^4.0.1",
+    "karma-jasmine": "^5.0.0",
     "karma-requirejs": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.7",
     "magic-string": "0.26.2",

--- a/packages/core/test/render3/testing_spec.ts
+++ b/packages/core/test/render3/testing_spec.ts
@@ -44,7 +44,7 @@ describe('testing', () => {
   describe('requestAnimationFrame', () => {
     it('should have requestAnimationFrame', (done) => {
       // In Browser we have requestAnimationFrame, but verify that we also have it node.js
-      requestAnimationFrame(done);
+      requestAnimationFrame(() => done());
     });
   });
 });

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -391,7 +391,7 @@ describe('bootstrap', () => {
      });
 
 
-  it('should restore the scrolling position', async (done) => {
+  it('should restore the scrolling position', async () => {
     @Component({
       selector: 'component-a',
       template: `
@@ -456,7 +456,6 @@ describe('bootstrap', () => {
     await router.navigateByUrl('/aa#marker3');
     expect(window.pageYOffset).toBeGreaterThanOrEqual(8900);
     expect(window.pageYOffset).toBeLessThan(9000);
-    done();
   });
 
   it('should cleanup "popstate" and "hashchange" listeners', async () => {
@@ -486,7 +485,7 @@ describe('bootstrap', () => {
     expect(window.removeEventListener).toHaveBeenCalledWith('hashchange', jasmine.any(Function));
   });
 
-  it('can schedule a navigation from the NavigationEnd event #37460', async (done) => {
+  it('can schedule a navigation from the NavigationEnd event #37460', (done) => {
     @NgModule({
       imports: [
         BrowserModule,
@@ -504,17 +503,19 @@ describe('bootstrap', () => {
     class TestModule {
     }
 
-    const res = await platformBrowserDynamic([]).bootstrapModule(TestModule);
-    const router = res.injector.get(Router);
-    router.events.subscribe(() => {
-      expect(router.getCurrentNavigation()?.id).toBeDefined();
-    });
-    router.events.subscribe(async (e) => {
-      if (e instanceof NavigationEnd && e.url === '/b') {
-        await router.navigate(['a']);
-        done();
-      }
-    });
-    await router.navigateByUrl('/b');
+    (async () => {
+      const res = await platformBrowserDynamic([]).bootstrapModule(TestModule);
+      const router = res.injector.get(Router);
+      router.events.subscribe(() => {
+        expect(router.getCurrentNavigation()?.id).toBeDefined();
+      });
+      router.events.subscribe(async (e) => {
+        if (e instanceof NavigationEnd && e.url === '/b') {
+          await router.navigate(['a']);
+          done();
+        }
+      });
+      await router.navigateByUrl('/b');
+    })();
   });
 });

--- a/packages/zone.js/lib/jasmine/jasmine.ts
+++ b/packages/zone.js/lib/jasmine/jasmine.ts
@@ -349,7 +349,6 @@ Zone.__load_patch('jasmine', (global: any, Zone: ZoneType, api: _ZonePrivate) =>
       this.testProxyZoneSpec = new ProxyZoneSpec();
       this.testProxyZone = ambientZone.fork(this.testProxyZoneSpec);
       if (!Zone.currentTask) {
-        console.error('Scheduling', context, Zone.current.name)
         // if we are not running in a task then if someone would register a
         // element.addEventListener and then calling element.click() the
         // addEventListener callback would think that it is the top most task and would

--- a/packages/zone.js/lib/zone-spec/sync-test.ts
+++ b/packages/zone.js/lib/zone-spec/sync-test.ts
@@ -21,7 +21,7 @@ class SyncTestZoneSpec implements ZoneSpec {
     switch (task.type) {
       case 'microTask':
       case 'macroTask':
-        throw new Error(`Cannot call ${task.source} from within a sync test.`);
+        throw new Error(`Cannot call ${task.source} from within a sync test (${this.name}).`);
       case 'eventTask':
         task = delegate.scheduleTask(target, task);
         break;

--- a/packages/zone.js/test/browser/FileReader.spec.ts
+++ b/packages/zone.js/test/browser/FileReader.spec.ts
@@ -13,7 +13,6 @@ describe('FileReader', ifEnvSupports('FileReader', function() {
            let fileReader: FileReader;
            let blob: Blob;
            const data = 'Hello, World!';
-           const testZone = Zone.current.fork({name: 'TestZone'});
 
            // Android 4.3's native browser doesn't implement add/RemoveEventListener for FileReader
            function supportsEventTargetFns() {
@@ -39,6 +38,8 @@ describe('FileReader', ifEnvSupports('FileReader', function() {
 
            describe('EventTarget methods', ifEnvSupports(supportsEventTargetFns, function() {
                       it('should bind addEventListener listeners', function(done) {
+                        const testZone = Zone.current.fork({name: 'TestZone'});
+
                         testZone.run(function() {
                           fileReader.addEventListener('load', function() {
                             expect(Zone.current).toBe(testZone);
@@ -51,6 +52,7 @@ describe('FileReader', ifEnvSupports('FileReader', function() {
                       });
 
                       it('should remove listeners via removeEventListener', function(done) {
+                        const testZone = Zone.current.fork({name: 'TestZone'});
                         const listenerSpy = jasmine.createSpy('listener');
 
                         testZone.run(function() {
@@ -67,6 +69,7 @@ describe('FileReader', ifEnvSupports('FileReader', function() {
                     }));
 
            it('should bind onEventType listeners', function(done) {
+             const testZone = Zone.current.fork({name: 'TestZone'});
              let listenersCalled = 0;
 
              testZone.run(function() {

--- a/packages/zone.js/test/browser/HTMLImports.spec.ts
+++ b/packages/zone.js/test/browser/HTMLImports.spec.ts
@@ -11,69 +11,70 @@ import {ifEnvSupports} from '../test-util';
 function supportsImports() {
   return 'import' in document.createElement('link');
 }
-(<any>supportsImports).message = 'HTML Imports';
 
-describe('HTML Imports', ifEnvSupports(supportsImports, function() {
-           const testZone = Zone.current.fork({name: 'test'});
+if (supportsImports()) {
+  describe('HTML Imports', function() {
+    const testZone = Zone.current.fork({name: 'test'});
 
-           it('should work with addEventListener', function(done) {
-             let link: HTMLLinkElement;
+    it('should work with addEventListener', function(done) {
+      let link: HTMLLinkElement;
 
-             testZone.run(function() {
-               link = document.createElement('link');
-               link.rel = 'import';
-               link.href = 'someUrl';
-               link.addEventListener('error', function() {
-                 expect(Zone.current).toBe(testZone);
-                 document.head.removeChild(link);
-                 done();
-               });
-             });
+      testZone.run(function() {
+        link = document.createElement('link');
+        link.rel = 'import';
+        link.href = 'someUrl';
+        link.addEventListener('error', function() {
+          expect(Zone.current).toBe(testZone);
+          document.head.removeChild(link);
+          done();
+        });
+      });
 
-             document.head.appendChild(link!);
-           });
+      document.head.appendChild(link!);
+    });
 
-           function supportsOnEvents() {
-             const link = document.createElement('link');
-             const linkPropDesc = Object.getOwnPropertyDescriptor(link, 'onerror');
-             return !(linkPropDesc && linkPropDesc.value === null);
-           }
-           (<any>supportsOnEvents).message = 'Supports HTMLLinkElement#onxxx patching';
+    function supportsOnEvents() {
+      const link = document.createElement('link');
+      const linkPropDesc = Object.getOwnPropertyDescriptor(link, 'onerror');
+      return !(linkPropDesc && linkPropDesc.value === null);
+    }
+    (<any>supportsOnEvents).message = 'Supports HTMLLinkElement#onxxx patching';
 
 
-           ifEnvSupports(supportsOnEvents, function() {
-             it('should work with onerror', function(done) {
-               let link: HTMLLinkElement;
+    ifEnvSupports(supportsOnEvents, function() {
+      it('should work with onerror', function(done) {
+        let link: HTMLLinkElement;
 
-               testZone.run(function() {
-                 link = document.createElement('link');
-                 link.rel = 'import';
-                 link.href = 'anotherUrl';
-                 link.onerror = function() {
-                   expect(Zone.current).toBe(testZone);
-                   document.head.removeChild(link);
-                   done();
-                 };
-               });
+        testZone.run(function() {
+          link = document.createElement('link');
+          link.rel = 'import';
+          link.href = 'anotherUrl';
+          link.onerror = function() {
+            expect(Zone.current).toBe(testZone);
+            document.head.removeChild(link);
+            done();
+          };
+        });
 
-               document.head.appendChild(link!);
-             });
+        document.head.appendChild(link!);
+      });
 
-             it('should work with onload', function(done) {
-               let link: HTMLLinkElement;
+      it('should work with onload', function(done) {
+        let link: HTMLLinkElement;
 
-               testZone.run(function() {
-                 link = document.createElement('link');
-                 link.rel = 'import';
-                 link.href = '/base/angular/packages/zone.js/test/assets/import.html';
-                 link.onload = function() {
-                   expect(Zone.current).toBe(testZone);
-                   document.head.removeChild(link);
-                   done();
-                 };
-               });
+        testZone.run(function() {
+          link = document.createElement('link');
+          link.rel = 'import';
+          link.href = '/base/angular/packages/zone.js/test/assets/import.html';
+          link.onload = function() {
+            expect(Zone.current).toBe(testZone);
+            document.head.removeChild(link);
+            done();
+          };
+        });
 
-               document.head.appendChild(link!);
-             });
-           });
-         }));
+        document.head.appendChild(link!);
+      });
+    });
+  });
+}

--- a/packages/zone.js/test/browser/MutationObserver.spec.ts
+++ b/packages/zone.js/test/browser/MutationObserver.spec.ts
@@ -12,13 +12,13 @@ declare const global: any;
 
 describe('MutationObserver', ifEnvSupports('MutationObserver', function() {
            let elt: HTMLDivElement;
-           const testZone = Zone.current.fork({name: 'test'});
 
            beforeEach(function() {
              elt = document.createElement('div');
            });
 
            it('should run observers within the zone', function(done) {
+             const testZone = Zone.current.fork({name: 'test'});
              let ob;
 
              testZone.run(function() {
@@ -54,9 +54,8 @@ describe('MutationObserver', ifEnvSupports('MutationObserver', function() {
          }));
 
 describe('WebKitMutationObserver', ifEnvSupports('WebKitMutationObserver', function() {
-           const testZone = Zone.current.fork({name: 'test'});
-
            it('should run observers within the zone', function(done) {
+             const testZone = Zone.current.fork({name: 'test'});
              let elt: HTMLDivElement;
 
              testZone.run(function() {

--- a/packages/zone.js/test/browser/XMLHttpRequest.spec.ts
+++ b/packages/zone.js/test/browser/XMLHttpRequest.spec.ts
@@ -334,15 +334,25 @@ describe('XMLHttpRequest', function() {
      function(done) {
        testZone.run(function() {
          const req = new XMLHttpRequest();
+
          req.open('get', '/', true);
          req.send();
+
+         let count = 0;
          const listener = function(ev: any) {
            if (req.readyState >= 2) {
+             const isInitial = count++ === 0;
+
              expect(() => {
+               // this triggers a synchronous dispatch of the state change event.
                req.abort();
              }).not.toThrow();
+
              req.removeEventListener('readystatechange', listener);
-             done();
+
+             if (isInitial) {
+               done();
+             }
            }
          };
          req.addEventListener('readystatechange', listener);

--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -3398,145 +3398,140 @@ describe('Zone', function() {
   });
 
 
-  describe(
-      'pointer event in IE',
-      ifEnvSupports(
-          () => {
-            return getIEVersion() === 11;
-          },
-          () => {
-            const pointerEventsMap: {[key: string]: string} = {
-              'MSPointerCancel': 'pointercancel',
-              'MSPointerDown': 'pointerdown',
-              'MSPointerEnter': 'pointerenter',
-              'MSPointerHover': 'pointerhover',
-              'MSPointerLeave': 'pointerleave',
-              'MSPointerMove': 'pointermove',
-              'MSPointerOut': 'pointerout',
-              'MSPointerOver': 'pointerover',
-              'MSPointerUp': 'pointerup'
-            };
+  if (getIEVersion() === 11) {
+    describe('pointer event in IE', () => {
+      const pointerEventsMap: {[key: string]: string} = {
+        'MSPointerCancel': 'pointercancel',
+        'MSPointerDown': 'pointerdown',
+        'MSPointerEnter': 'pointerenter',
+        'MSPointerHover': 'pointerhover',
+        'MSPointerLeave': 'pointerleave',
+        'MSPointerMove': 'pointermove',
+        'MSPointerOut': 'pointerout',
+        'MSPointerOver': 'pointerover',
+        'MSPointerUp': 'pointerup'
+      };
 
-            let div: HTMLDivElement;
-            beforeEach(() => {
-              div = document.createElement('div');
-              document.body.appendChild(div);
-            });
-            afterEach(() => {
-              document.body.removeChild(div);
-            });
-            Object.keys(pointerEventsMap).forEach(key => {
-              it(`${key} and ${pointerEventsMap[key]} should both be triggered`, (done: DoneFn) => {
-                const logs: string[] = [];
-                div.addEventListener(key, (event: any) => {
-                  expect(event.type).toEqual(pointerEventsMap[key]);
-                  logs.push(`${key} triggered`);
-                });
-                div.addEventListener(pointerEventsMap[key], (event: any) => {
-                  expect(event.type).toEqual(pointerEventsMap[key]);
-                  logs.push(`${pointerEventsMap[key]} triggered`);
-                });
-                const evt1 = document.createEvent('Event');
-                evt1.initEvent(key, true, true);
-                div.dispatchEvent(evt1);
+      let div: HTMLDivElement;
+      beforeEach(() => {
+        div = document.createElement('div');
+        document.body.appendChild(div);
+      });
+      afterEach(() => {
+        document.body.removeChild(div);
+      });
+      Object.keys(pointerEventsMap).forEach(key => {
+        it(`${key} and ${pointerEventsMap[key]} should both be triggered`, (done: DoneFn) => {
+          const logs: string[] = [];
+          div.addEventListener(key, (event: any) => {
+            expect(event.type).toEqual(pointerEventsMap[key]);
+            logs.push(`${key} triggered`);
+          });
+          div.addEventListener(pointerEventsMap[key], (event: any) => {
+            expect(event.type).toEqual(pointerEventsMap[key]);
+            logs.push(`${pointerEventsMap[key]} triggered`);
+          });
+          const evt1 = document.createEvent('Event');
+          evt1.initEvent(key, true, true);
+          div.dispatchEvent(evt1);
 
-                setTimeout(() => {
-                  expect(logs).toEqual([`${key} triggered`, `${pointerEventsMap[key]} triggered`]);
-                });
+          setTimeout(() => {
+            expect(logs).toEqual([`${key} triggered`, `${pointerEventsMap[key]} triggered`]);
+          });
 
-                const evt2 = document.createEvent('Event');
-                evt2.initEvent(pointerEventsMap[key], true, true);
-                div.dispatchEvent(evt2);
+          const evt2 = document.createEvent('Event');
+          evt2.initEvent(pointerEventsMap[key], true, true);
+          div.dispatchEvent(evt2);
 
-                setTimeout(() => {
-                  expect(logs).toEqual([`${key} triggered`, `${pointerEventsMap[key]} triggered`]);
-                });
+          setTimeout(() => {
+            expect(logs).toEqual([`${key} triggered`, `${pointerEventsMap[key]} triggered`]);
+          });
 
-                setTimeout(done);
-              });
+          setTimeout(done);
+        });
 
-              it(`${key} and ${
-                     pointerEventsMap[key]} with same listener should not be triggered twice`,
-                 (done: DoneFn) => {
-                   const logs: string[] = [];
-                   const listener = function(event: any) {
-                     expect(event.type).toEqual(pointerEventsMap[key]);
-                     logs.push(`${key} triggered`);
-                   };
-                   div.addEventListener(key, listener);
-                   div.addEventListener(pointerEventsMap[key], listener);
+        it(`${key} and ${pointerEventsMap[key]} with same listener should not be triggered twice`,
+           (done: DoneFn) => {
+             const logs: string[] = [];
+             const listener = function(event: any) {
+               expect(event.type).toEqual(pointerEventsMap[key]);
+               logs.push(`${key} triggered`);
+             };
+             div.addEventListener(key, listener);
+             div.addEventListener(pointerEventsMap[key], listener);
 
-                   const evt1 = document.createEvent('Event');
-                   evt1.initEvent(key, true, true);
-                   div.dispatchEvent(evt1);
+             const evt1 = document.createEvent('Event');
+             evt1.initEvent(key, true, true);
+             div.dispatchEvent(evt1);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([`${key} triggered`]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([`${key} triggered`]);
+             });
 
-                   const evt2 = document.createEvent('Event');
-                   evt2.initEvent(pointerEventsMap[key], true, true);
-                   div.dispatchEvent(evt2);
+             const evt2 = document.createEvent('Event');
+             evt2.initEvent(pointerEventsMap[key], true, true);
+             div.dispatchEvent(evt2);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([`${pointerEventsMap[key]} triggered`]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([`${pointerEventsMap[key]} triggered`]);
+             });
 
-                   setTimeout(done);
-                 });
+             setTimeout(done);
+           });
 
-              it(`${key} and ${
-                     pointerEventsMap[key]} should be able to be removed with removeEventListener`,
-                 (done: DoneFn) => {
-                   const logs: string[] = [];
-                   const listener1 = function(event: any) {
-                     logs.push(`${key} triggered`);
-                   };
-                   const listener2 = function(event: any) {
-                     logs.push(`${pointerEventsMap[key]} triggered`);
-                   };
-                   div.addEventListener(key, listener1);
-                   div.addEventListener(pointerEventsMap[key], listener2);
+        it(`${key} and ${
+               pointerEventsMap[key]} should be able to be removed with removeEventListener`,
+           (done: DoneFn) => {
+             const logs: string[] = [];
+             const listener1 = function(event: any) {
+               logs.push(`${key} triggered`);
+             };
+             const listener2 = function(event: any) {
+               logs.push(`${pointerEventsMap[key]} triggered`);
+             };
+             div.addEventListener(key, listener1);
+             div.addEventListener(pointerEventsMap[key], listener2);
 
-                   div.removeEventListener(key, listener1);
-                   div.removeEventListener(key, listener2);
+             div.removeEventListener(key, listener1);
+             div.removeEventListener(key, listener2);
 
-                   const evt1 = document.createEvent('Event');
-                   evt1.initEvent(key, true, true);
-                   div.dispatchEvent(evt1);
+             const evt1 = document.createEvent('Event');
+             evt1.initEvent(key, true, true);
+             div.dispatchEvent(evt1);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([]);
+             });
 
-                   const evt2 = document.createEvent('Event');
-                   evt2.initEvent(pointerEventsMap[key], true, true);
-                   div.dispatchEvent(evt2);
+             const evt2 = document.createEvent('Event');
+             evt2.initEvent(pointerEventsMap[key], true, true);
+             div.dispatchEvent(evt2);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([]);
+             });
 
-                   div.addEventListener(key, listener1);
-                   div.addEventListener(pointerEventsMap[key], listener2);
+             div.addEventListener(key, listener1);
+             div.addEventListener(pointerEventsMap[key], listener2);
 
-                   div.removeEventListener(pointerEventsMap[key], listener1);
-                   div.removeEventListener(pointerEventsMap[key], listener2);
+             div.removeEventListener(pointerEventsMap[key], listener1);
+             div.removeEventListener(pointerEventsMap[key], listener2);
 
-                   div.dispatchEvent(evt1);
+             div.dispatchEvent(evt1);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([]);
+             });
 
-                   div.dispatchEvent(evt2);
+             div.dispatchEvent(evt2);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([]);
+             });
 
-                   setTimeout(done);
-                 });
-            });
-          }));
+             setTimeout(done);
+           });
+      });
+    });
+  }
 });

--- a/packages/zone.js/test/browser/registerElement.spec.ts
+++ b/packages/zone.js/test/browser/registerElement.spec.ts
@@ -11,161 +11,159 @@
  * is properly patched
  */
 
-import {ifEnvSupports} from '../test-util';
-
 function registerElement() {
   return ('registerElement' in document) && (typeof customElements === 'undefined');
 }
-(<any>registerElement).message = 'document.registerElement';
 
-describe(
-    'document.registerElement', ifEnvSupports(registerElement, function() {
-      // register a custom element for each callback
-      const callbackNames = ['created', 'attached', 'detached', 'attributeChanged'];
-      const callbacks: any = {};
-      const testZone = Zone.current.fork({name: 'test'});
-      let customElements;
+if (registerElement()) {
+  describe('document.registerElement', function() {
+    // register a custom element for each callback
+    const callbackNames = ['created', 'attached', 'detached', 'attributeChanged'];
+    const callbacks: any = {};
+    const testZone = Zone.current.fork({name: 'test'});
+    let customElements;
 
-      customElements = testZone.run(function() {
-        callbackNames.forEach(function(callbackName) {
-          const fullCallbackName = callbackName + 'Callback';
-          const proto = Object.create(HTMLElement.prototype);
-          (proto as any)[fullCallbackName] = function(arg: any) {
-            callbacks[callbackName](arg);
-          };
-          (<any>document).registerElement('x-' + callbackName.toLowerCase(), {prototype: proto});
-        });
-      });
-
-      it('should work with createdCallback', function(done) {
-        callbacks.created = function() {
-          expect(Zone.current).toBe(testZone);
-          done();
+    customElements = testZone.run(function() {
+      callbackNames.forEach(function(callbackName) {
+        const fullCallbackName = callbackName + 'Callback';
+        const proto = Object.create(HTMLElement.prototype);
+        (proto as any)[fullCallbackName] = function(arg: any) {
+          callbacks[callbackName](arg);
         };
-
-        document.createElement('x-created');
+        (<any>document).registerElement('x-' + callbackName.toLowerCase(), {prototype: proto});
       });
+    });
+
+    it('should work with createdCallback', function(done) {
+      callbacks.created = function() {
+        expect(Zone.current).toBe(testZone);
+        done();
+      };
+
+      document.createElement('x-created');
+    });
 
 
-      it('should work with attachedCallback', function(done) {
-        callbacks.attached = function() {
-          expect(Zone.current).toBe(testZone);
-          done();
-        };
+    it('should work with attachedCallback', function(done) {
+      callbacks.attached = function() {
+        expect(Zone.current).toBe(testZone);
+        done();
+      };
 
-        const elt = document.createElement('x-attached');
-        document.body.appendChild(elt);
-        document.body.removeChild(elt);
-      });
-
-
-      it('should work with detachedCallback', function(done) {
-        callbacks.detached = function() {
-          expect(Zone.current).toBe(testZone);
-          done();
-        };
-
-        const elt = document.createElement('x-detached');
-        document.body.appendChild(elt);
-        document.body.removeChild(elt);
-      });
+      const elt = document.createElement('x-attached');
+      document.body.appendChild(elt);
+      document.body.removeChild(elt);
+    });
 
 
-      it('should work with attributeChanged', function(done) {
-        callbacks.attributeChanged = function() {
-          expect(Zone.current).toBe(testZone);
-          done();
-        };
+    it('should work with detachedCallback', function(done) {
+      callbacks.detached = function() {
+        expect(Zone.current).toBe(testZone);
+        done();
+      };
 
-        const elt = document.createElement('x-attributechanged');
-        elt.id = 'bar';
-      });
+      const elt = document.createElement('x-detached');
+      document.body.appendChild(elt);
+      document.body.removeChild(elt);
+    });
 
 
-      it('should work with non-writable, non-configurable prototypes created with defineProperty',
-         function(done) {
-           testZone.run(function() {
-             const proto = Object.create(HTMLElement.prototype);
+    it('should work with attributeChanged', function(done) {
+      callbacks.attributeChanged = function() {
+        expect(Zone.current).toBe(testZone);
+        done();
+      };
 
-             Object.defineProperty(
-                 proto, 'createdCallback',
-                 <any>{writable: false, configurable: false, value: checkZone});
+      const elt = document.createElement('x-attributechanged');
+      elt.id = 'bar';
+    });
 
-             (<any>document).registerElement('x-prop-desc', {prototype: proto});
 
-             function checkZone() {
-               expect(Zone.current).toBe(testZone);
-               done();
+    it('should work with non-writable, non-configurable prototypes created with defineProperty',
+       function(done) {
+         testZone.run(function() {
+           const proto = Object.create(HTMLElement.prototype);
+
+           Object.defineProperty(
+               proto, 'createdCallback',
+               <any>{writable: false, configurable: false, value: checkZone});
+
+           (<any>document).registerElement('x-prop-desc', {prototype: proto});
+
+           function checkZone() {
+             expect(Zone.current).toBe(testZone);
+             done();
+           }
+         });
+
+         const elt = document.createElement('x-prop-desc');
+       });
+
+
+    it('should work with non-writable, non-configurable prototypes created with defineProperties',
+       function(done) {
+         testZone.run(function() {
+           const proto = Object.create(HTMLElement.prototype);
+
+           Object.defineProperties(proto, {
+             createdCallback: <any> {
+               writable: false, configurable: false, value: checkZone
              }
            });
 
-           const elt = document.createElement('x-prop-desc');
+           (<any>document).registerElement('x-props-desc', {prototype: proto});
+
+           function checkZone() {
+             expect(Zone.current).toBe(testZone);
+             done();
+           }
          });
 
+         const elt = document.createElement('x-props-desc');
+       });
 
-      it('should work with non-writable, non-configurable prototypes created with defineProperties',
-         function(done) {
-           testZone.run(function() {
-             const proto = Object.create(HTMLElement.prototype);
-
-             Object.defineProperties(proto, {
-               createdCallback: <any> {
-                 writable: false, configurable: false, value: checkZone
-               }
-             });
-
-             (<any>document).registerElement('x-props-desc', {prototype: proto});
-
-             function checkZone() {
-               expect(Zone.current).toBe(testZone);
-               done();
-             }
-           });
-
-           const elt = document.createElement('x-props-desc');
-         });
-
-      it('should not throw with frozen prototypes ', function() {
-        testZone.run(function() {
-          const proto = Object.create(HTMLElement.prototype, Object.freeze(<PropertyDescriptorMap>{
-            createdCallback: <PropertyDescriptor> {
-              value: () => {}, writable: true, configurable: true
-            }
-          }));
-
-          Object.defineProperty(
-              proto, 'createdCallback', <any>{writable: false, configurable: false});
-
-          expect(function() {
-            (<any>document).registerElement('x-frozen-desc', {prototype: proto});
-          }).not.toThrow();
-        });
-      });
-
-
-      it('should check bind callback if not own property', function(done) {
-        testZone.run(function() {
-          const originalProto = {createdCallback: checkZone};
-
-          const secondaryProto = Object.create(originalProto);
-          expect(secondaryProto.createdCallback).toBe(originalProto.createdCallback);
-
-          (<any>document).registerElement('x-inherited-callback', {prototype: secondaryProto});
-          expect(secondaryProto.createdCallback).not.toBe(originalProto.createdCallback);
-
-          function checkZone() {
-            expect(Zone.current).toBe(testZone);
-            done();
+    it('should not throw with frozen prototypes ', function() {
+      testZone.run(function() {
+        const proto = Object.create(HTMLElement.prototype, Object.freeze(<PropertyDescriptorMap>{
+          createdCallback: <PropertyDescriptor> {
+            value: () => {}, writable: true, configurable: true
           }
+        }));
 
-          const elt = document.createElement('x-inherited-callback');
-        });
-      });
+        Object.defineProperty(
+            proto, 'createdCallback', <any>{writable: false, configurable: false});
 
-
-      it('should not throw if no options passed to registerElement', function() {
         expect(function() {
-          (<any>document).registerElement('x-no-opts');
+          (<any>document).registerElement('x-frozen-desc', {prototype: proto});
         }).not.toThrow();
       });
-    }));
+    });
+
+
+    it('should check bind callback if not own property', function(done) {
+      testZone.run(function() {
+        const originalProto = {createdCallback: checkZone};
+
+        const secondaryProto = Object.create(originalProto);
+        expect(secondaryProto.createdCallback).toBe(originalProto.createdCallback);
+
+        (<any>document).registerElement('x-inherited-callback', {prototype: secondaryProto});
+        expect(secondaryProto.createdCallback).not.toBe(originalProto.createdCallback);
+
+        function checkZone() {
+          expect(Zone.current).toBe(testZone);
+          done();
+        }
+
+        const elt = document.createElement('x-inherited-callback');
+      });
+    });
+
+
+    it('should not throw if no options passed to registerElement', function() {
+      expect(function() {
+        (<any>document).registerElement('x-no-opts');
+      }).not.toThrow();
+    });
+  });
+}

--- a/packages/zone.js/test/browser/requestAnimationFrame.spec.ts
+++ b/packages/zone.js/test/browser/requestAnimationFrame.spec.ts
@@ -6,53 +6,52 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ifEnvSupports} from '../test-util';
-declare const window: any;
-
 describe('requestAnimationFrame', function() {
   const functions =
       ['requestAnimationFrame', 'webkitRequestAnimationFrame', 'mozRequestAnimationFrame'];
 
   functions.forEach(function(fnName) {
-    describe(fnName, ifEnvSupports(fnName, function() {
-               const originalTimeout: number = (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL;
-               beforeEach(() => {
-                 (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = 10000;
-               });
+    if ((global as any)[fnName] !== undefined) {
+      describe(fnName, function() {
+        const originalTimeout: number = (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL;
+        beforeEach(() => {
+          (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = 10000;
+        });
 
-               afterEach(() => {
-                 (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-               });
-               const rAF = window[fnName];
+        afterEach(() => {
+          (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+        });
+        const requestAnimationFrameFn = (window as any)[fnName];
 
-               it('should be tolerant of invalid arguments', function() {
-                 // rAF throws an error on invalid arguments, so expect that.
-                 expect(function() {
-                   rAF(null);
-                 }).toThrow();
-               });
+        it('should be tolerant of invalid arguments', function() {
+          // requestAnimationFrameFn throws an error on invalid arguments, so expect that.
+          expect(function() {
+            requestAnimationFrameFn(null);
+          }).toThrow();
+        });
 
-               it('should bind to same zone when called recursively', function(done) {
-                 Zone.current.fork({name: 'TestZone'}).run(() => {
-                   let frames = 0;
-                   let previousTimeStamp = 0;
+        it('should bind to same zone when called recursively', function(done) {
+          Zone.current.fork({name: 'TestZone'}).run(() => {
+            let frames = 0;
+            let previousTimeStamp = 0;
 
-                   function frameCallback(timestamp: number) {
-                     expect(timestamp).toMatch(/^[\d.]+$/);
-                     // expect previous <= current
-                     expect(previousTimeStamp).not.toBeGreaterThan(timestamp);
-                     previousTimeStamp = timestamp;
+            function frameCallback(timestamp: number) {
+              expect(timestamp).toMatch(/^[\d.]+$/);
+              // expect previous <= current
+              expect(previousTimeStamp).not.toBeGreaterThan(timestamp);
+              previousTimeStamp = timestamp;
 
-                     if (frames++ > 15) {
-                       (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-                       return done();
-                     }
-                     rAF(frameCallback);
-                   }
+              if (frames++ > 15) {
+                (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+                return done();
+              }
+              requestAnimationFrameFn(frameCallback);
+            }
 
-                   rAF(frameCallback);
-                 });
-               });
-             }));
+            requestAnimationFrameFn(frameCallback);
+          });
+        });
+      });
+    }
   });
 });

--- a/packages/zone.js/test/jasmine-patch.spec.ts
+++ b/packages/zone.js/test/jasmine-patch.spec.ts
@@ -38,7 +38,7 @@ ifEnvSupports(supportJasmineSpec, () => {
 
     it('should throw on async in describe', () => {
       expect(throwOnAsync).toBe(true);
-      expect(syncZone.name).toEqual('syncTestZone for jasmine.describe');
+      expect(syncZone.name).toEqual('syncTestZone for jasmine.describe#jasmine');
       itZone = Zone.current;
     });
 

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -748,92 +748,105 @@ describe('FakeAsyncTestZoneSpec', () => {
     });
   });
 
-  describe('requestAnimationFrame', () => {
-    const functions =
-        ['requestAnimationFrame', 'webkitRequestAnimationFrame', 'mozRequestAnimationFrame'];
-    functions.forEach((fnName) => {
-      if ((global as any)[fnName] !== undefined) {
-        describe(fnName, () => {
-          it('should schedule a requestAnimationFrame with timeout of 16ms', () => {
-            fakeAsyncTestZone.run(() => {
-              let ran = false;
-              requestAnimationFrame(() => {
-                ran = true;
-              });
+  const animationFrameFns = [
+    ['requestAnimationFrame', 'cancelAnimationFrame'],
+    ['webkitRequestAnimationFrame', 'webkitCancelAnimationFrame'],
+    ['mozRequestAnimationFrame', 'mozCancelAnimationFrame'],
+  ];
 
-              testZoneSpec.tick(6);
-              expect(ran).toEqual(false);
+  const availableAnimationFrameFns =
+      animationFrameFns
+          .map(([fnName,
+                 cancelFnName]) => [fnName, (global as any)[fnName], (global as any)[cancelFnName]])
+          .filter(
+              ([_, fn]) => fn !==
+                  undefined) as [string, typeof requestAnimationFrame, typeof cancelAnimationFrame][];
 
-              testZoneSpec.tick(10);
-              expect(ran).toEqual(true);
-            });
-          });
-          it('does not count as a pending timer', () => {
-            fakeAsyncTestZone.run(() => {
-              requestAnimationFrame(() => {});
-            });
-            expect(testZoneSpec.pendingTimers.length).toBe(0);
-            expect(testZoneSpec.pendingPeriodicTimers.length).toBe(0);
-          });
-          it('should cancel a scheduled requestAnimatiomFrame', () => {
-            fakeAsyncTestZone.run(() => {
-              let ran = false;
-              const id = requestAnimationFrame(() => {
-                ran = true;
-              });
+  if (availableAnimationFrameFns.length > 0) {
+    describe('requestAnimationFrame', () => {
+      availableAnimationFrameFns.forEach(
+          ([name, requestAnimationFrameFn, cancelAnimationFrameFn]) => {
+            describe(name, () => {
+              it('should schedule a requestAnimationFrame with timeout of 16ms', () => {
+                fakeAsyncTestZone.run(() => {
+                  let ran = false;
+                  requestAnimationFrameFn(() => {
+                    ran = true;
+                  });
 
-              testZoneSpec.tick(6);
-              expect(ran).toEqual(false);
+                  testZoneSpec.tick(6);
+                  expect(ran).toEqual(false);
 
-              cancelAnimationFrame(id);
-
-              testZoneSpec.tick(10);
-              expect(ran).toEqual(false);
-            });
-          });
-          it('is not flushed when flushPeriodic is false', () => {
-            let ran = false;
-            fakeAsyncTestZone.run(() => {
-              requestAnimationFrame(() => {
-                ran = true;
-              });
-              testZoneSpec.flush(20);
-              expect(ran).toEqual(false);
-            });
-          });
-          it('is flushed when flushPeriodic is true', () => {
-            let ran = false;
-            fakeAsyncTestZone.run(() => {
-              requestAnimationFrame(() => {
-                ran = true;
-              });
-              const elapsed = testZoneSpec.flush(20, true);
-              expect(elapsed).toEqual(16);
-              expect(ran).toEqual(true);
-            });
-          });
-          it('should pass timestamp as parameter', () => {
-            let timestamp = 0;
-            let timestamp1 = 0;
-            fakeAsyncTestZone.run(() => {
-              requestAnimationFrame((ts) => {
-                timestamp = ts;
-                requestAnimationFrame(ts1 => {
-                  timestamp1 = ts1;
+                  testZoneSpec.tick(10);
+                  expect(ran).toEqual(true);
                 });
               });
-              const elapsed = testZoneSpec.flush(20, true);
-              const elapsed1 = testZoneSpec.flush(20, true);
-              expect(elapsed).toEqual(16);
-              expect(elapsed1).toEqual(16);
-              expect(timestamp).toEqual(16);
-              expect(timestamp1).toEqual(32);
+              it('does not count as a pending timer', () => {
+                fakeAsyncTestZone.run(() => {
+                  requestAnimationFrameFn(() => {});
+                });
+                expect(testZoneSpec.pendingTimers.length).toBe(0);
+                expect(testZoneSpec.pendingPeriodicTimers.length).toBe(0);
+              });
+              it('should cancel a scheduled requestAnimationFrame', () => {
+                fakeAsyncTestZone.run(() => {
+                  let ran = false;
+                  const id = requestAnimationFrameFn(() => {
+                    ran = true;
+                  });
+
+                  testZoneSpec.tick(6);
+                  expect(ran).toEqual(false);
+
+                  cancelAnimationFrameFn(id);
+
+                  testZoneSpec.tick(10);
+                  expect(ran).toEqual(false);
+                });
+              });
+              it('is not flushed when flushPeriodic is false', () => {
+                let ran = false;
+                fakeAsyncTestZone.run(() => {
+                  requestAnimationFrameFn(() => {
+                    ran = true;
+                  });
+                  testZoneSpec.flush(20);
+                  expect(ran).toEqual(false);
+                });
+              });
+              it('is flushed when flushPeriodic is true', () => {
+                let ran = false;
+                fakeAsyncTestZone.run(() => {
+                  requestAnimationFrameFn(() => {
+                    ran = true;
+                  });
+                  const elapsed = testZoneSpec.flush(20, true);
+                  expect(elapsed).toEqual(16);
+                  expect(ran).toEqual(true);
+                });
+              });
+              it('should pass timestamp as parameter', () => {
+                let timestamp = 0;
+                let timestamp1 = 0;
+                fakeAsyncTestZone.run(() => {
+                  requestAnimationFrameFn((ts) => {
+                    timestamp = ts;
+                    requestAnimationFrameFn(ts1 => {
+                      timestamp1 = ts1;
+                    });
+                  });
+                  const elapsed = testZoneSpec.flush(20, true);
+                  const elapsed1 = testZoneSpec.flush(20, true);
+                  expect(elapsed).toEqual(16);
+                  expect(elapsed1).toEqual(16);
+                  expect(timestamp).toEqual(16);
+                  expect(timestamp1).toEqual(32);
+                });
+              });
             });
           });
-        });
-      }
     });
-  });
+  }
 
   describe(
       'XHRs', ifEnvSupports('XMLHttpRequest', () => {

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -752,84 +752,86 @@ describe('FakeAsyncTestZoneSpec', () => {
     const functions =
         ['requestAnimationFrame', 'webkitRequestAnimationFrame', 'mozRequestAnimationFrame'];
     functions.forEach((fnName) => {
-      describe(fnName, ifEnvSupports(fnName, () => {
-                 it('should schedule a requestAnimationFrame with timeout of 16ms', () => {
-                   fakeAsyncTestZone.run(() => {
-                     let ran = false;
-                     requestAnimationFrame(() => {
-                       ran = true;
-                     });
+      if ((global as any)[fnName] !== undefined) {
+        describe(fnName, () => {
+          it('should schedule a requestAnimationFrame with timeout of 16ms', () => {
+            fakeAsyncTestZone.run(() => {
+              let ran = false;
+              requestAnimationFrame(() => {
+                ran = true;
+              });
 
-                     testZoneSpec.tick(6);
-                     expect(ran).toEqual(false);
+              testZoneSpec.tick(6);
+              expect(ran).toEqual(false);
 
-                     testZoneSpec.tick(10);
-                     expect(ran).toEqual(true);
-                   });
-                 });
-                 it('does not count as a pending timer', () => {
-                   fakeAsyncTestZone.run(() => {
-                     requestAnimationFrame(() => {});
-                   });
-                   expect(testZoneSpec.pendingTimers.length).toBe(0);
-                   expect(testZoneSpec.pendingPeriodicTimers.length).toBe(0);
-                 });
-                 it('should cancel a scheduled requestAnimatiomFrame', () => {
-                   fakeAsyncTestZone.run(() => {
-                     let ran = false;
-                     const id = requestAnimationFrame(() => {
-                       ran = true;
-                     });
+              testZoneSpec.tick(10);
+              expect(ran).toEqual(true);
+            });
+          });
+          it('does not count as a pending timer', () => {
+            fakeAsyncTestZone.run(() => {
+              requestAnimationFrame(() => {});
+            });
+            expect(testZoneSpec.pendingTimers.length).toBe(0);
+            expect(testZoneSpec.pendingPeriodicTimers.length).toBe(0);
+          });
+          it('should cancel a scheduled requestAnimatiomFrame', () => {
+            fakeAsyncTestZone.run(() => {
+              let ran = false;
+              const id = requestAnimationFrame(() => {
+                ran = true;
+              });
 
-                     testZoneSpec.tick(6);
-                     expect(ran).toEqual(false);
+              testZoneSpec.tick(6);
+              expect(ran).toEqual(false);
 
-                     cancelAnimationFrame(id);
+              cancelAnimationFrame(id);
 
-                     testZoneSpec.tick(10);
-                     expect(ran).toEqual(false);
-                   });
-                 });
-                 it('is not flushed when flushPeriodic is false', () => {
-                   let ran = false;
-                   fakeAsyncTestZone.run(() => {
-                     requestAnimationFrame(() => {
-                       ran = true;
-                     });
-                     testZoneSpec.flush(20);
-                     expect(ran).toEqual(false);
-                   });
-                 });
-                 it('is flushed when flushPeriodic is true', () => {
-                   let ran = false;
-                   fakeAsyncTestZone.run(() => {
-                     requestAnimationFrame(() => {
-                       ran = true;
-                     });
-                     const elapsed = testZoneSpec.flush(20, true);
-                     expect(elapsed).toEqual(16);
-                     expect(ran).toEqual(true);
-                   });
-                 });
-                 it('should pass timestamp as parameter', () => {
-                   let timestamp = 0;
-                   let timestamp1 = 0;
-                   fakeAsyncTestZone.run(() => {
-                     requestAnimationFrame((ts) => {
-                       timestamp = ts;
-                       requestAnimationFrame(ts1 => {
-                         timestamp1 = ts1;
-                       });
-                     });
-                     const elapsed = testZoneSpec.flush(20, true);
-                     const elapsed1 = testZoneSpec.flush(20, true);
-                     expect(elapsed).toEqual(16);
-                     expect(elapsed1).toEqual(16);
-                     expect(timestamp).toEqual(16);
-                     expect(timestamp1).toEqual(32);
-                   });
-                 });
-               }, emptyRun));
+              testZoneSpec.tick(10);
+              expect(ran).toEqual(false);
+            });
+          });
+          it('is not flushed when flushPeriodic is false', () => {
+            let ran = false;
+            fakeAsyncTestZone.run(() => {
+              requestAnimationFrame(() => {
+                ran = true;
+              });
+              testZoneSpec.flush(20);
+              expect(ran).toEqual(false);
+            });
+          });
+          it('is flushed when flushPeriodic is true', () => {
+            let ran = false;
+            fakeAsyncTestZone.run(() => {
+              requestAnimationFrame(() => {
+                ran = true;
+              });
+              const elapsed = testZoneSpec.flush(20, true);
+              expect(elapsed).toEqual(16);
+              expect(ran).toEqual(true);
+            });
+          });
+          it('should pass timestamp as parameter', () => {
+            let timestamp = 0;
+            let timestamp1 = 0;
+            fakeAsyncTestZone.run(() => {
+              requestAnimationFrame((ts) => {
+                timestamp = ts;
+                requestAnimationFrame(ts1 => {
+                  timestamp1 = ts1;
+                });
+              });
+              const elapsed = testZoneSpec.flush(20, true);
+              const elapsed1 = testZoneSpec.flush(20, true);
+              expect(elapsed).toEqual(16);
+              expect(elapsed1).toEqual(16);
+              expect(timestamp).toEqual(16);
+              expect(timestamp1).toEqual(32);
+            });
+          });
+        });
+      }
     });
   });
 

--- a/packages/zone.js/test/zone-spec/sync-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/sync-test.spec.ts
@@ -22,7 +22,9 @@ describe('SyncTestZoneSpec', () => {
     syncTestZone.run(() => {
       expect(() => {
         Promise.resolve().then(function() {});
-      }).toThrow(new Error('Cannot call Promise.then from within a sync test.'));
+      })
+          .toThrow(new Error(
+              'Cannot call Promise.then from within a sync test (syncTestZone for name).'));
     });
   });
 
@@ -30,7 +32,9 @@ describe('SyncTestZoneSpec', () => {
     syncTestZone.run(() => {
       expect(() => {
         setTimeout(() => {}, 100);
-      }).toThrow(new Error('Cannot call setTimeout from within a sync test.'));
+      })
+          .toThrow(
+              new Error('Cannot call setTimeout from within a sync test (syncTestZone for name).'));
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9019,12 +9019,7 @@ jasmine-ajax@^4.0.0:
   resolved "https://registry.yarnpkg.com/jasmine-ajax/-/jasmine-ajax-4.0.0.tgz#7d8ba7e47e3f7e780e155fe9aa563faafa7e1a26"
   integrity sha512-htTxNw38BSHxxmd8RRMejocdPqLalGHU6n3HWFbzp/S8AuTQd1MYjkSH3dYDsbZ7EV1Xqx/b94m3tKaVSVBV2A==
 
-jasmine-core@^3.6.0:
-  version "3.99.1"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.99.1.tgz#5bfa4b2d76618868bfac4c8ff08bb26fffa4120d"
-  integrity sha512-Hu1dmuoGcZ7AfyynN3LsfruwMbxMALMka+YtZeGoLuDEySVmVAPaonkNoBRIw/ectu8b9tVQCJNgp4a4knp+tg==
-
-jasmine-core@^4.0.0, jasmine-core@^4.2.0:
+jasmine-core@^4.0.0, jasmine-core@^4.1.0, jasmine-core@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.2.0.tgz#0605bea284d6d78276f43c47de2532ecd4a73b00"
   integrity sha512-OcFpBrIhnbmb9wfI8cqPSJ50pv3Wg4/NSgoZIqHzIwO/2a9qivJWzv8hUvaREIMYYJBas6AvfXATFdVuzzCqVw==
@@ -9356,12 +9351,12 @@ karma-firefox-launcher@^2.1.0:
     is-wsl "^2.2.0"
     which "^2.0.1"
 
-karma-jasmine@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-4.0.2.tgz#386db2a3e1acc0af5265c711f673f78f1e4938de"
-  integrity sha512-ggi84RMNQffSDmWSyyt4zxzh2CQGwsxvYYsprgyR1j8ikzIduEdOlcLvXjZGwXG/0j41KUXOWsUCBfbEHPWP9g==
+karma-jasmine@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-5.1.0.tgz#3af4558a6502fa16856a0f346ec2193d4b884b2f"
+  integrity sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==
   dependencies:
-    jasmine-core "^3.6.0"
+    jasmine-core "^4.1.0"
 
 karma-requirejs@^1.1.0:
   version "1.1.0"
@@ -12894,7 +12889,6 @@ sass@1.53.0:
 
 "sauce-connect@https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz":
   version "0.0.0"
-  uid e5d7f82ad98251a653d1b0537f1103e49eda5e11
   resolved "https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz#e5d7f82ad98251a653d1b0537f1103e49eda5e11"
 
 saucelabs@7.2.0, saucelabs@^1.5.0, saucelabs@^4.6.3:


### PR DESCRIPTION
See individual commits. This evolved from the simple `karma-jasmine` update (you would think "easy" 😛)

The `zone.js` fix is necessary for us to update `karma-jasmine` where multiple `done` invocations result in runtime errors.