### PR TITLE
fix(docs-infra): convert docs select for versions into navigation

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -64,7 +64,7 @@
     <aio-nav-menu [nodes]="sideNavNodes" [currentNode]="currentNodes?.SideNav" [isWide]="dockSideNav" navLabel="guides and docs"></aio-nav-menu>
 
     <div class="doc-version">
-      <aio-select (optionsToggled)="scrollSelectIntoView()" (change)="onDocVersionChange($event.index)" [options]="docVersions" [selected]="currentDocVersion"></aio-select>
+      <aio-nav-menu [nodes]="docVersions" [isWide]="true" [currentNode]="currentDocsVersionNode" navLabel="docs versions"></aio-nav-menu>
     </div>
   </mat-sidenav>
 

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -22,7 +22,6 @@ import { TocService } from 'app/shared/toc.service';
 import { SwUpdatesService } from 'app/sw-updates/sw-updates.service';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { first, map } from 'rxjs/operators';
-import { SelectComponent } from './shared/select/select.component';
 
 const sideNavView = 'SideNav';
 export const showTopMenuWidth = 1150;
@@ -89,9 +88,9 @@ export class AppComponent implements OnInit {
   tocMaxHeight: string;
   private tocMaxHeightOffset = 0;
 
-  versionInfo: VersionInfo;
+  currentDocsVersionNode?: NavigationNode;
 
-  private currentUrl: string;
+  versionInfo: VersionInfo;
 
   get isOpened() { return this.dockSideNav && this.isSideNavDoc; }
   get mode() { return this.isOpened ? 'side' : 'over'; }
@@ -116,9 +115,6 @@ export class AppComponent implements OnInit {
   @ViewChild('appToolbar', { read: ElementRef }) toolbar: ElementRef;
 
   @ViewChildren('themeToggle, externalIcons', { read: ElementRef }) toolbarIcons: QueryList<ElementRef>;
-
-  @ViewChild(SelectComponent, { read: ElementRef })
-  docVersionSelectElement: ElementRef;
 
   constructor(
     public deployment: Deployment,
@@ -173,7 +169,8 @@ export class AppComponent implements OnInit {
     combineLatest([
       this.navigationService.versionInfo,
       this.navigationService.navigationViews.pipe(map(views => views.docVersions)),
-    ]).subscribe(([versionInfo, versions]) => {
+      this.locationService.currentUrl,
+    ]).subscribe(([versionInfo, versions, currentUrl]) => {
       // TODO(pbd): consider whether we can lookup the stable and next versions from the internet
       const computedVersions: NavigationNode[] = [
         { title: 'next', url: 'https://next.angular.io/' },
@@ -183,13 +180,22 @@ export class AppComponent implements OnInit {
       if (this.deployment.mode === 'archive') {
         computedVersions.push({ title: `v${versionInfo.major}` });
       }
-      this.docVersions = [...computedVersions, ...versions];
-
+      const allDocsVersionNodes = [...computedVersions, ...versions].map(version => ({
+        ...version,
+        // Update the urls so that they point to the same page the user is currently at
+        url: `${version.url}${(version.url?.endsWith('/') ? '' : '/' )}${currentUrl}`,
+      }));
       // Find the current version - either title matches the current deployment mode
       // or its title matches the major version of the current version info
-      this.currentDocVersion = this.docVersions.find(version =>
-        version.title === this.deployment.mode || version.title === `v${versionInfo.major}`) as NavigationNode;
-      this.currentDocVersion.title += ` (v${versionInfo.raw})`;
+      this.currentDocsVersionNode = allDocsVersionNodes.find(
+        version => version.title === this.deployment.mode || version.title === `v${versionInfo.major}`
+      );
+      this.docVersions = [
+        {
+          title: 'Docs Versions',
+          children : allDocsVersionNodes
+        }
+      ];
     });
 
     this.navigationService.navigationViews.subscribe(views => {
@@ -215,8 +221,6 @@ export class AppComponent implements OnInit {
       this.navigationService.currentNodes,   // ...needed to determine `sidenav` state
     ]).pipe(first())
       .subscribe(() => this.updateShell());
-
-    this.locationService.currentUrl.subscribe(url => this.currentUrl = url);
 
     // Start listening for SW version update events.
     this.swUpdatesService.enable();
@@ -258,14 +262,6 @@ export class AppComponent implements OnInit {
     }
 
     this.isTransitioning = false;
-  }
-
-  onDocVersionChange(versionIndex: number) {
-    const version = this.docVersions[versionIndex];
-    if (version.url) {
-      const versionUrl = version.url  + (!version.url.endsWith('/') ? '/' : '');
-      this.locationService.go(`${versionUrl}${this.currentUrl}`);
-    }
   }
 
   @HostListener('window:resize', ['$event.target.innerWidth'])
@@ -480,13 +476,5 @@ export class AppComponent implements OnInit {
         this.focusSearchBox();
       }
     }
-  }
-
-  scrollSelectIntoView() {
-    // this method is used to scroll the select component into view when it is clicked/opened
-    // the setTimeout is needed so that the scroll happens after the component has expanded
-    setTimeout(() =>
-      this.docVersionSelectElement.nativeElement?.scrollIntoView({behavior: 'smooth'})
-    );
   }
 }

--- a/aio/src/app/layout/nav-menu/nav-menu.component.ts
+++ b/aio/src/app/layout/nav-menu/nav-menu.component.ts
@@ -7,15 +7,28 @@ import { CurrentNode, NavigationNode } from 'app/navigation/navigation.service';
   <nav [attr.aria-label]="navLabel || null">
     <aio-nav-item *ngFor="let node of filteredNodes"
       [node]="node"
-      [selectedNodes]="currentNode?.nodes"
+      [selectedNodes]="selectedNodes"
       [isWide]="isWide">
     </aio-nav-item>
   </nav>`
 })
 export class NavMenuComponent {
-  @Input() currentNode: CurrentNode | undefined;
+  @Input() currentNode: CurrentNode | NavigationNode | undefined;
   @Input() isWide = false;
   @Input() nodes: NavigationNode[];
   @Input() navLabel: string;
   get filteredNodes() { return this.nodes ? this.nodes.filter(n => !n.hidden) : []; }
+
+  get selectedNodes(): NavigationNode[]|undefined {
+    if(!this.currentNode) {
+      return undefined;
+    }
+
+    const currentNodeNodes = (this.currentNode as CurrentNode).nodes;
+    if (currentNodeNodes) {
+      return currentNodeNodes;
+    }
+
+    return [this.currentNode as NavigationNode];
+  }
 }

--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -36,11 +36,6 @@ mat-sidenav-container.sidenav-container {
     @media (max-width: 599px) {
       top: 56px;
     }
-
-    // Angular Version Selector
-    .doc-version {
-      padding: 8px;
-    }
   }
 }
 

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,7 +2,7 @@
   "aio": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 461922,
+      "main": 457028,
       "polyfills": 33814,
       "styles": 73640,
       "light-theme": 78276,
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 462546,
+      "main": 457651,
       "polyfills": 33922,
       "styles": 73640,
       "light-theme": 78276,


### PR DESCRIPTION
convert the select for the docs versions into a proper navigation to
make it more clear for users and also to improve its accessibility

resolves #44339

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #44339


## What is the new behavior?

This is the before and after:

![beforeAndAfter](https://user-images.githubusercontent.com/61631103/176941158-c7d94e56-2e7e-491f-8ac5-798cc5f9c8c7.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
- this is just an idea @gkalpak please let me know what you think :slightly_smiling_face: , I think it feels more natural to have it as a nav-menu like the rest in the sidenav