### PR TITLE
feat(router): Add stable cancellation code to `NavigationCancel` event

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -354,7 +354,6 @@ export class NavigationCancel extends RouterEvent {
     reason: string,
     code?: NavigationCancellationCode | undefined);
     readonly code?: NavigationCancellationCode | undefined;
-    // (undocumented)
     reason: string;
     // (undocumented)
     toString(): string;

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -351,13 +351,23 @@ export class NavigationCancel extends RouterEvent {
     constructor(
     id: number,
     url: string,
-    reason: string);
+    reason: string,
+    code?: NavigationCancellationCode | undefined);
+    readonly code?: NavigationCancellationCode | undefined;
     // (undocumented)
     reason: string;
     // (undocumented)
     toString(): string;
     // (undocumented)
     readonly type = EventType.NavigationCancel;
+}
+
+// @public
+export const enum NavigationCancellationCode {
+    GuardRejected = 3,
+    NoDataFromResolver = 2,
+    Redirect = 0,
+    SupersededByNewNavigation = 1
 }
 
 // @public

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -163,6 +163,31 @@ export class NavigationEnd extends RouterEvent {
 }
 
 /**
+ * A code for the `NavigationCancel` event of the `Router` to indicate the
+ * reason a navigation failed.
+ *
+ * @publicApi
+ */
+export const enum NavigationCancellationCode {
+  /**
+   * A navigation failed because a guard returned a `UrlTree` to redirect.
+   */
+  Redirect,
+  /**
+   * A navigation failed because a more recent navigation started.
+   */
+  SupersededByNewNavigation,
+  /**
+   * A navigation failed because one of the resolvers completed without emiting a value.
+   */
+  NoDataFromResolver,
+  /**
+   * A navigation failed because a guard returned `false`.
+   */
+  GuardRejected,
+}
+
+/**
  * An event triggered when a navigation is canceled, directly or indirectly.
  * This can happen for several reasons including when a route guard
  * returns `false` or initiates a redirect by returning a `UrlTree`.
@@ -182,7 +207,13 @@ export class NavigationCancel extends RouterEvent {
       /** @docsNotRequired */
       url: string,
       /** @docsNotRequired */
-      public reason: string) {
+      public reason: string,
+      /**
+       * A code to indicate why the navigation was canceled. This cancellation code is stable for
+       * the reason and can be relied on whereas the `reason` string could change and should not be
+       * used in production.
+       */
+      readonly code?: NavigationCancellationCode) {
     super(id, url);
   }
 

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -206,7 +206,10 @@ export class NavigationCancel extends RouterEvent {
       id: number,
       /** @docsNotRequired */
       url: string,
-      /** @docsNotRequired */
+      /**
+       * A description of why the navigation was cancelled. For debug purposes only. Use `code`
+       * instead for a stable cancellation reason that can be used in production.
+       */
       public reason: string,
       /**
        * A code to indicate why the navigation was canceled. This cancellation code is stable for

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -11,7 +11,7 @@ export {createUrlTreeFromSnapshot} from './create_url_tree';
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
 export {RouterOutlet, RouterOutletContract} from './directives/router_outlet';
-export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, EventType, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
+export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, EventType, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationCancellationCode as NavigationCancellationCode, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
 export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, CanMatch, CanMatchFn, Data, LoadChildren, LoadChildrenCallback, QueryParamsHandling, Resolve, ResolveData, Route, Routes, RunGuardsAndResolvers, UrlMatcher, UrlMatchResult} from './models';
 export {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
 export {BaseRouteReuseStrategy, DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';


### PR DESCRIPTION
This commit adds a stable cancelation code to the `NavigationCancel`
event. This code is acceptable for use in production whereas parsing the
`reason` string is not. This allows developers to determine more
specifically _why_ a navigation was canceled and perform different
actions in different scenarios.

[related internal issue](http://b/235349774)