### PR TITLE
ci: switch to explicit commit message body for renovate

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -119,20 +119,6 @@ overrides:
 
 groups:
   # =========================================================
-  #  Renovate PRs
-  #
-  #  All renovate PRs will be assigned to the current
-  #  caretakers for review.
-  # =========================================================
-  renovate-changes:
-    <<: *defaults
-    conditions:
-      - author in ["renovate[bot]"]
-    reviewers:
-      teams:
-        - angular-caretaker
-
-  # =========================================================
   #  Framework: Animations
   # =========================================================
   fw-animations:

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "semanticCommitScope": "",
   "semanticCommitType": "build",
   "dependencyDashboard": true,
-  "commitBodyTable": true,
+  "commitBody": "See associated pull request for more information.",
   "separateMajorMinor": false,
   "prHourlyLimit": 3,
   "timezone": "America/Tijuana",


### PR DESCRIPTION
The commit body table by Renovate is sometimes not generated e.g. when
just dev-infra is being updated. In order to make our lint job happy
for such dev-infra updates, we should use an explicit message that is
at least 20 characters long.