### PR TITLE
docs: Add BootstrapOptions to publicApi

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -115,6 +115,13 @@ export interface AttributeDecorator {
 }
 
 // @public
+export interface BootstrapOptions {
+    ngZone?: NgZone | 'zone.js' | 'noop';
+    ngZoneEventCoalescing?: boolean;
+    ngZoneRunCoalescing?: boolean;
+}
+
+// @public
 export enum ChangeDetectionStrategy {
     Default = 1,
     OnPush = 0

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -342,6 +342,8 @@ export function getPlatform(): PlatformRef|null {
 
 /**
  * Provides additional options to the bootstraping process.
+ *
+ * @publicApi
  */
 export interface BootstrapOptions {
   /**

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -15,7 +15,7 @@ export * from './metadata';
 export * from './version';
 export {TypeDecorator} from './util/decorators';
 export * from './di';
-export {createPlatform, assertPlatform, destroyPlatform, getPlatform, PlatformRef, ApplicationRef, createPlatformFactory, NgProbeToken} from './application_ref';
+export {createPlatform, assertPlatform, destroyPlatform, getPlatform, BootstrapOptions, PlatformRef, ApplicationRef, createPlatformFactory, NgProbeToken} from './application_ref';
 export {enableProdMode, isDevMode} from './util/is_dev_mode';
 export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, PLATFORM_ID, APP_BOOTSTRAP_LISTENER, ANIMATION_MODULE_TYPE} from './application_tokens';
 export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';


### PR DESCRIPTION
`BootstrapOptions` is exposed through `PlatformRef#bootstrapModule` but
is not included in the public API so you cannot find it on angular.io.
This commit simply marks the interface as public API (as it should be).
