### PR TITLE
docs(elements): fix typo in guide (`&commat;` --> `@`)

### DIFF
--- a/aio/content/guide/elements.md
+++ b/aio/content/guide/elements.md
@@ -171,7 +171,7 @@ class MyDialog {
 </code-example>
 
 The most straightforward way to get accurate typings is to cast the return value of the relevant DOM methods to the correct type.
-For that, use the `NgElement` and `WithProperties` types \(both exported from `&commat;angular/elements`\):
+For that, use the `NgElement` and `WithProperties` types \(both exported from `@angular/elements`\):
 
 <code-example format="typescript" language="typescript">
 


### PR DESCRIPTION
HTML entities should not be used inside single backtick code blocks, because they are not automatically decoded.
