### PR TITLE
ci: enable renovate dashboard issue

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "semanticCommits": "enabled",
   "semanticCommitScope": "",
   "semanticCommitType": "build",
+  "dependencyDashboard": true,
   "commitBodyTable": true,
   "separateMajorMinor": false,
   "prHourlyLimit": 3,


### PR DESCRIPTION
We want to enable the Renovate dashboard to be able to trigger updates
which might be out of schedule, or to see if some updates are
stuck/pending, or to be able to rebase/try previously closed PRs.