### PR TITLE
docs(router): fix minor typos in tutorial

### DIFF
--- a/aio/content/guide/router-tutorial-toh.md
+++ b/aio/content/guide/router-tutorial-toh.md
@@ -1869,7 +1869,7 @@ To demonstrate the fundamentals, this example only logs to the console, `returns
 
 <code-example header="src/app/auth/auth.guard.ts (excerpt)" path="router/src/app/auth/auth.guard.1.ts"></code-example>
 
-Next, open `admin-routing.module.ts `, import the `AuthGuard` class, and
+Next, open `admin-routing.module.ts`, import the `AuthGuard` class, and
 update the admin route with a `canActivate` guard property that references it:
 
 <code-example header="src/app/admin/admin-routing.module.ts (guarded admin route)" path="router/src/app/admin/admin-routing.module.2.ts" region="admin-route"></code-example>
@@ -1917,7 +1917,7 @@ If the user is logged in, it returns true and the navigation continues.
 
 The `ActivatedRouteSnapshot` contains the *future* route that will be activated and the `RouterStateSnapshot` contains the *future* `RouterState` of the application, should you pass through the guard check.
 
-If the user is not logged in, you store the attempted URL the user came from using the `RouterStateSnapshot.url` and tell the router to redirect to a login page &mdash;a page you haven't created yet.
+If the user is not logged in, you store the attempted URL the user came from using the `RouterStateSnapshot.url` and tell the router to redirect to a login page &mdash; a page you haven't created yet.
 Returning a `UrlTree` tells the `Router` to cancel the current navigation and schedule a new one to redirect the user.
 
 <a id="add-login-component"></a>
@@ -1950,7 +1950,7 @@ In `app.module.ts`, import and add the `AuthModule` to the `AppModule` imports.
 
 As an alternative to using a `CanActivate` guard which redirects the user to a new page if they do not have access, you can instead
 use a `CanMatch` guard to control whether the `Router` even attempts to activate a `Route`. This allows you to have
-multiple `Route` configurations which share the same `path` but are match based on different conditions. In addition, this approach
+multiple `Route` configurations which share the same `path` but are matched based on different conditions. In addition, this approach
 can allow the `Router` to match the wildcard `Route` instead.
 
 <code-example path="router/src/app/auth/auth.guard.2.ts" header="src/app/auth/auth.guard.ts (excerpt)" region="can-match"></code-example>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

There also seems to be a small issue in the code examples for the API of [`CanMatch`](https://next.angular.io/api/router/CanMatch) and `CanLoad`. They follow the same example context as other guards, but since they receive `Route` and not `ActivatedRouteSnapshot` they cannot be used to pass `route.params.id`:

```ts
class Permissions {
  canAccess(user: UserToken, id: string, segments: UrlSegment[]): boolean {
    return true;
  }
}

@Injectable()
class CanMatchTeamSection implements CanMatch {
  constructor(private permissions: Permissions, private currentUser: UserToken) {}

  canMatch(route: Route, segments: UrlSegment[]): Observable<boolean>|Promise<boolean>|boolean {
    // in other guards the example passes route.params.id
    return this.permissions.canAccess(this.currentUser, route, segments);
  }
}
```

I wasn't sure whether `route: Route` can be changed to `route: ActivatedRouteSnapshot` or how to otherwise change the example.