### PR TITLE
docs: fix packages\docs\di\di.md

### DIFF
--- a/packages/docs/di/di.md
+++ b/packages/docs/di/di.md
@@ -230,7 +230,7 @@ The `resolveAndCreate` and `resolveAndCreateChild` functions resolve passed-in b
 You can create an injector using a list of resolved bindings.
 
 ```
-var listOfResolvingProviders = Injector.resolve([Provider11, Provider2]);
+var listOfResolvingProviders = Injector.resolve([Provider1, Provider2]);
 var inj = Injector.fromResolvedProviders(listOfResolvingProviders);
 inj.createChildFromResolvedProviders(listOfResolvedProviders);
 ```


### PR DESCRIPTION
‘Provider11’ is unreasonable, according to the context, it should be ‘Provider1’

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
