### PR TITLE
fix(core): remove `@internal` annotation from `ApplicationRef.injector`

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -84,6 +84,7 @@ export class ApplicationRef {
     destroy(): void;
     get destroyed(): boolean;
     detachView(viewRef: ViewRef): void;
+    get injector(): Injector;
     readonly isStable: Observable<boolean>;
     tick(): void;
     get viewCount(): number;

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -742,7 +742,9 @@ export class ApplicationRef {
   // TODO(issue/24571): remove '!'.
   public readonly isStable!: Observable<boolean>;
 
-  /** @internal */
+  /**
+   * The root injector that contains all of the root providers.
+   */
   get injector(): Injector {
     return this._injector;
   }


### PR DESCRIPTION
The `injector` getter is annotated with `@internal` and is removed from declarations.
This commit removes the annotation thus it's possible to access the `injector` on the
`ApplicationRef`, e.g., after calling `bootstrapApplication`.

Currently, it requires casting `ApplicationRef` to `{ injector: Injector }` after calling the `bootstrapApplication`, e.g.:
```ts
bootstrapApplication(...).then((appRef) => {
  const injector = (appRef as unknown as { injector: Injector }).injector;
  const router = injector.get(Router);
  ...
});
```

`NgModuleRef` prior to `ApplicationRef` has a public `injector` property which allows the above behavior:
```ts
platformBrowserDynamic()
  .bootstrapModule(...)
  .then((ngModuleRef) => {
    const router = ngModuleRef.injector.get(Router);
    ...
  });
```

This change also allows a more straightforward setup for micro-frontend adapters (e.g., single-spa-angular). The micro-frontend bootstrap function can resolve to `ApplicationRef | NgModuleRef<T>`; they both have the `destroy` method now, and having `injector` on both types doesn't require type cast for `ApplicationRef`.