### PR TITLE
feat(router): Add the target `RouterStateSnapshot` to `NavigationError`

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -388,9 +388,11 @@ export class NavigationError extends RouterEvent {
     constructor(
     id: number,
     url: string,
-    error: any);
+    error: any,
+    target?: RouterStateSnapshot | undefined);
     // (undocumented)
     error: any;
+    readonly target?: RouterStateSnapshot | undefined;
     // (undocumented)
     toString(): string;
     // (undocumented)

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -244,7 +244,14 @@ export class NavigationError extends RouterEvent {
       /** @docsNotRequired */
       url: string,
       /** @docsNotRequired */
-      public error: any) {
+      public error: any,
+      /**
+       * The target of the navigation when the error occurred.
+       *
+       * Note that this can be `undefined` because an error could have occurred before the
+       * `RouterStateSnapshot` was created for the navigation.
+       */
+      readonly target?: RouterStateSnapshot) {
     super(id, url);
   }
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -970,8 +970,9 @@ export class Router {
                           * the pre-error state. */
                        } else {
                          this.restoreHistory(t, true);
-                         const navError =
-                             new NavigationError(t.id, this.serializeUrl(t.extractedUrl), e);
+                         const navError = new NavigationError(
+                             t.id, this.serializeUrl(t.extractedUrl), e,
+                             t.targetSnapshot ?? undefined);
                          eventsSubject.next(navError);
                          try {
                            t.resolve(this.errorHandler(e));


### PR DESCRIPTION
This commit adds the target `RouterStateSnapshot` to the
`NavigationError` so error handlers/subscribers can more easily
determine which navigation failed, including the matched `Route` configs
for the navigation. This information was previously not available
(neither in `NavigationError` nor the `Router#getCurrentNavigation()`).

fixes #27626

This also has an associated internal tracking bug [b/127474584](http://b/127474584)