### PR TITLE
Revert "fix(animations): enable shadowElements to leave when their parent does (#46459)"

### DIFF
--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -314,13 +314,11 @@ export class AnimationTransitionNamespace {
 
   private _signalRemovalForInnerTriggers(rootElement: any, context: any) {
     const elements = this._engine.driver.query(rootElement, NG_TRIGGER_SELECTOR, true);
-    const shadowElements = rootElement.shadowRoot ?
-        this._engine.driver.query(rootElement.shadowRoot, NG_TRIGGER_SELECTOR, true) :
-        [];
+
     // emulate a leave animation for all inner nodes within this node.
     // If there are no animations found for any of the nodes then clear the cache
     // for the element.
-    [...elements, ...shadowElements].forEach(elm => {
+    elements.forEach(elm => {
       // this means that an inner remove() operation has already kicked off
       // the animation on this element...
       if (elm[REMOVAL_FLAG]) return;
@@ -404,9 +402,7 @@ export class AnimationTransitionNamespace {
 
   removeNode(element: any, context: any): void {
     const engine = this._engine;
-    const elementHasChildren = !!element.childElementCount;
-    const elementHasShadowChildren = !!(element.shadowRoot && element.shadowRoot.childElementCount);
-    if (elementHasChildren || elementHasShadowChildren) {
+    if (element.childElementCount) {
       this._signalRemovalForInnerTriggers(element, context);
     }
 

--- a/packages/core/test/animation/animation_query_integration_spec.ts
+++ b/packages/core/test/animation/animation_query_integration_spec.ts
@@ -5,13 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {animate, animateChild, AnimationEvent, AnimationPlayer, AUTO_STYLE, group, query, sequence, stagger, state, style, transition, trigger, ɵAnimationGroupPlayer as AnimationGroupPlayer} from '@angular/animations';
+import {animate, animateChild, AnimationPlayer, AUTO_STYLE, group, query, sequence, stagger, state, style, transition, trigger, ɵAnimationGroupPlayer as AnimationGroupPlayer} from '@angular/animations';
 import {AnimationDriver, ɵAnimationEngine, ɵnormalizeKeyframes as normalizeKeyframes} from '@angular/animations/browser';
 import {TransitionAnimationPlayer} from '@angular/animations/browser/src/render/transition_animation_engine';
 import {ENTER_CLASSNAME, LEAVE_CLASSNAME} from '@angular/animations/browser/src/util';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
 import {CommonModule} from '@angular/common';
-import {Component, HostBinding, ViewChild, ViewEncapsulation} from '@angular/core';
+import {Component, HostBinding, ViewChild} from '@angular/core';
 import {fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 
@@ -2830,64 +2830,6 @@ describe('animation query tests', function() {
          expect(cmp.log).toEqual([
            'c1-start', 'c1-done', 'c2-start', 'c2-done', 'p-start', 'c3-start', 'c3-done', 'p-done'
          ]);
-       }));
-
-    it(`should emulate a leave animation on a child elements when a parent component using shadowDom leaves the DOM`,
-       fakeAsync(() => {
-         let childLeaveLog = 0;
-
-         @Component({
-           selector: 'ani-host',
-           template: `<ani-parent *ngIf="exp"></ani-parent>`,
-         })
-         class HostCmp {
-           public exp: boolean = false;
-         }
-
-         @Component({
-           selector: 'ani-parent',
-           encapsulation: ViewEncapsulation.ShadowDom,
-           template: `
-              <div @childAnimation (@childAnimation.start)="logChildLeave($event)"></div>
-          `,
-           animations: [
-             trigger(
-                 'childAnimation',
-                 [
-                   transition(':leave', []),
-                 ]),
-           ]
-         })
-         class ParentCmp {
-           logChildLeave(event: AnimationEvent) {
-             if (event.toState === 'void') {
-               childLeaveLog++;
-             }
-           }
-         }
-
-         TestBed.configureTestingModule({declarations: [ParentCmp, HostCmp]});
-
-         const fixture = TestBed.createComponent(HostCmp);
-         const cmp = fixture.componentInstance;
-
-         const updateExpAndFlush = (value: boolean) => {
-           cmp.exp = value;
-           fixture.detectChanges();
-           flushMicrotasks();
-         };
-
-         updateExpAndFlush(true);
-         expect(childLeaveLog).toEqual(0);
-
-         updateExpAndFlush(false);
-         expect(childLeaveLog).toEqual(1);
-
-         updateExpAndFlush(true);
-         expect(childLeaveLog).toEqual(1);
-
-         updateExpAndFlush(false);
-         expect(childLeaveLog).toEqual(2);
        }));
 
     it('should build, but not run sub triggers when a parent animation is scheduled', () => {


### PR DESCRIPTION
This reverts commit b41737038377af480763226a904b67e7d8e283ae.

The change applied is no longer appropriate since the use of animations
and shadow dom components is discouraged (as of #46738)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe: reverting a previously made change which is no longer appropriate


## Issue

Issue Number: N/A

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - @jessicajaniuk 
 - As I mentioned, given the decision made in #46738 I think that the change I applied in #46459 needs to be reverted to keep things clean and simpler (since we are discouraging the use of animations and shadow dom components, I don't think it makes sense to have this change in, as it just makes the incompatibility weirder/more confusing in my opinion)
 - The commit message does not follow the guidelines, this seemed the cleanest way to revert the commit, but if you prefer please let me know and I will update the commit message to follow the guidelines
