### PR TITLE
refactor(router): Simplify the prioritizeGuardValue logic

### DIFF
--- a/packages/router/test/operators/prioritized_guard_value.spec.ts
+++ b/packages/router/test/operators/prioritized_guard_value.spec.ts
@@ -9,13 +9,10 @@
 
 import {TestBed} from '@angular/core/testing';
 import {RouterTestingModule} from '@angular/router/testing';
-import {Observable, Observer, of} from 'rxjs';
-import {every, mergeMap} from 'rxjs/operators';
 import {TestScheduler} from 'rxjs/testing';
 
 import {prioritizedGuardValue} from '../../src/operators/prioritized_guard_value';
 import {Router} from '../../src/router';
-import {UrlTree} from '../../src/url_tree';
 
 
 describe('prioritizedGuardValue operator', () => {
@@ -173,6 +170,31 @@ describe('prioritizedGuardValue operator', () => {
           .toBe(
               expected,
               urlLookup,
+              /* an error here maybe */);
+    });
+  });
+
+  it('should ignore invalid values', () => {
+    testScheduler.run(({hot, cold, expectObservable}) => {
+      const resultLookup = {
+        T: true,
+        U: undefined as any,
+        S: 'I am not a valid guard result' as any
+      };
+
+      const a = cold('       ----------(T|)', resultLookup);
+      const b = cold('       -----(U|)', resultLookup);
+      const c = cold('       -----(S|)', resultLookup);
+      const d = cold('       --(T|)', resultLookup);
+
+      const source = hot('---o---', {o: [a, b, c, d]});
+
+      const expected = '  -------------T---';
+
+      expectObservable(source.pipe(prioritizedGuardValue()))
+          .toBe(
+              expected,
+              resultLookup,
               /* an error here maybe */);
     });
   });


### PR DESCRIPTION
The existing logic does something similar but in a more roundabout way.
It reads _the whole array_. If it encounters a pending value, it ignores
the remaining ones. If it hasn't encountered a pending value by the time
it hits false/UrlTree, it returns that result.

The new logic is the same, but reverses what we're looking for. Instead
of processing the whole array, we stop when we encounter an initial
value. When we encounter one that isn't `true`, that gets returned. If
we get to the end and everything was `true`, return `true`.
