### PR TITLE
build: Fix Angular CLI issue template link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://angular.io/guide/security#report-issues
     about: Report a security issue in Angular Framework, CDK, Material, or CLI
   - name: Angular CLI
-    url: https://github.com/angular/angular/issues/new/choose
+    url: https://github.com/angular/angular-cli/issues/new/choose
     about: Issues and feature requests for Angular CLI
   - name: Angular Material and Components Development Kit (CDK)
     url: https://github.com/angular/components/issues/new/choose


### PR DESCRIPTION
This fixes the issue template link to the Angular CLI repository instead of staying in the Angular repository.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Links to the Angular CLI repository if the user intends to open an Angular CLI issue.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
