### PR TITLE
docs: link fix from google.developers to web.dev

### DIFF
--- a/aio/content/guide/service-worker-intro.md
+++ b/aio/content/guide/service-worker-intro.md
@@ -1,7 +1,7 @@
 # Angular service worker introduction
 
 Service workers augment the traditional web deployment model and empower applications to deliver a user experience with the reliability and performance on par with code that is written to run on your operating system and hardware.
-Adding a service worker to an Angular application is one of the steps for turning an application into a [Progressive Web App](https://developers.google.com/web/progressive-web-apps) \(also known as a PWA\).
+Adding a service worker to an Angular application is one of the steps for turning an application into a [Progressive Web App](https://web.dev/progressive-web-apps/) \(also known as a PWA\).
 
 At its simplest, a service worker is a script that runs in the web browser and manages caching for an application.
 


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Most of the links from google.developers redirect to web.dev, but this isn't. After clicking https://developers.google.com/web/progressive-web-apps you will get 404 status code. 


## What is the new behavior?
After pressing https://web.dev/progressive-web-apps/ a link to "Progressive Web Apps" will be opened. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Not sure about other links on google.developers domain, maybe they also should be manually switched to web.dev to avoid further misconceptions with 404 errors.