### PR TITLE
feat(animations): add `provideAnimations()` and `provideNoopAnimations()` functions

### DIFF
--- a/goldens/public-api/platform-browser/animations/index.md
+++ b/goldens/public-api/platform-browser/animations/index.md
@@ -8,6 +8,7 @@ import { ANIMATION_MODULE_TYPE } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/platform-browser';
 import { ModuleWithProviders } from '@angular/core';
+import { Provider } from '@angular/core';
 
 export { ANIMATION_MODULE_TYPE }
 
@@ -36,6 +37,12 @@ export class NoopAnimationsModule {
     // (undocumented)
     static ɵmod: i0.ɵɵNgModuleDeclaration<NoopAnimationsModule, never, never, [typeof i1.BrowserModule]>;
 }
+
+// @public
+export function provideAnimations(): Provider[];
+
+// @public
+export function provideNoopAnimations(): Provider[];
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/platform-browser/animations/src/animations.ts
+++ b/packages/platform-browser/animations/src/animations.ts
@@ -12,6 +12,6 @@
  * Entry point for all animation APIs of the animation browser package.
  */
 export {ANIMATION_MODULE_TYPE} from '@angular/core';
-export {BrowserAnimationsModule, BrowserAnimationsModuleConfig, NoopAnimationsModule} from './module';
+export {BrowserAnimationsModule, BrowserAnimationsModuleConfig, NoopAnimationsModule, provideAnimations, provideNoopAnimations} from './module';
 
 export * from './private_export';

--- a/packages/platform-browser/animations/src/module.ts
+++ b/packages/platform-browser/animations/src/module.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ModuleWithProviders, NgModule} from '@angular/core';
+import {ModuleWithProviders, NgModule, Provider} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 
 import {BROWSER_ANIMATIONS_PROVIDERS, BROWSER_NOOP_ANIMATIONS_PROVIDERS} from './providers';
@@ -59,6 +59,35 @@ export class BrowserAnimationsModule {
 }
 
 /**
+ * Returns the set of [dependency-injection providers](guide/glossary#provider)
+ * to enable animations in an application. See [animations guide](guide/animations)
+ * to learn more about animations in Angular.
+ *
+ * @usageNotes
+ *
+ * The function is useful when you want to enable animations in an application
+ * bootstrapped using the `bootstrapApplication` function. In this scenario there
+ * is no need to import the `BrowserAnimationsModule` NgModule at all, just add
+ * providers returned by this function to the `providers` list as show below.
+ *
+ * ```typescript
+ * bootstrapApplication(RootComponent, {
+ *   providers: [
+ *     provideAnimations()
+ *   ]
+ * });
+ * ```
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export function provideAnimations(): Provider[] {
+  // Return a copy to prevent changes to the original array in case any in-place
+  // alterations are performed to the `provideAnimations` call results in app code.
+  return [...BROWSER_ANIMATIONS_PROVIDERS];
+}
+
+/**
  * A null player that must be imported to allow disabling of animations.
  * @publicApi
  */
@@ -67,4 +96,32 @@ export class BrowserAnimationsModule {
   providers: BROWSER_NOOP_ANIMATIONS_PROVIDERS,
 })
 export class NoopAnimationsModule {
+}
+
+/**
+ * Returns the set of [dependency-injection providers](guide/glossary#provider)
+ * to disable animations in an application. See [animations guide](guide/animations)
+ * to learn more about animations in Angular.
+ *
+ * @usageNotes
+ *
+ * The function is useful when you want to bootstrap an application using
+ * the `bootstrapApplication` function, but you need to disable animations
+ * (for example, when running tests).
+ *
+ * ```typescript
+ * bootstrapApplication(RootComponent, {
+ *   providers: [
+ *     provideNoopAnimations()
+ *   ]
+ * });
+ * ```
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export function provideNoopAnimations(): Provider[] {
+  // Return a copy to prevent changes to the original array in case any in-place
+  // alterations are performed to the `provideNoopAnimations` call results in app code.
+  return [...BROWSER_NOOP_ANIMATIONS_PROVIDERS];
 }

--- a/packages/platform-browser/animations/test/noop_animations_module_spec.ts
+++ b/packages/platform-browser/animations/test/noop_animations_module_spec.ts
@@ -9,7 +9,7 @@ import {animate, style, transition, trigger} from '@angular/animations';
 import {ɵAnimationEngine} from '@angular/animations/browser';
 import {Component} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
-import {BrowserAnimationsModule, NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {BrowserAnimationsModule, NoopAnimationsModule, provideNoopAnimations} from '@angular/platform-browser/animations';
 
 describe('NoopAnimationsModule', () => {
   beforeEach(() => {
@@ -23,6 +23,14 @@ describe('BrowserAnimationsModule with disableAnimations = true', () => {
   beforeEach(() => {
     TestBed.configureTestingModule(
         {imports: [BrowserAnimationsModule.withConfig({disableAnimations: true})]});
+  });
+
+  noopAnimationTests();
+});
+
+describe('provideNoopAnimations()', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({providers: [provideNoopAnimations()]});
   });
 
   noopAnimationTests();


### PR DESCRIPTION
This commit adds the following functions to the public API:

- provideAnimations
- provideNoopAnimations

The goal of those functions is to return a set of providers required to setup animations in an application. The functions are useful when the `bootstrapApplication` function is used to bootstrap an app. The functions allow to avoid the need to import `BrowserAnimationsModule` and `BrowserNoopAnimationsModule` NgModules.

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No