### PR TITLE
docs: add info about request timeouts

### DIFF
--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-      - uses: angular/dev-infra/github-actions/commit-message-based-labels@fccfadda559f678c60c85e7fe59468e4b1b86105
+      - uses: angular/dev-infra/github-actions/commit-message-based-labels@571134460f8bf9a152b3e38159fa91b92efaf6d1
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
   post_approval_changes:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-      - uses: angular/dev-infra/github-actions/post-approval-changes@fccfadda559f678c60c85e7fe59468e4b1b86105
+      - uses: angular/dev-infra/github-actions/post-approval-changes@571134460f8bf9a152b3e38159fa91b92efaf6d1
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/dev-infra.yml
+++ b/.github/workflows/dev-infra.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-      - uses: angular/dev-infra/github-actions/commit-message-based-labels@571134460f8bf9a152b3e38159fa91b92efaf6d1
+      - uses: angular/dev-infra/github-actions/commit-message-based-labels@fccfadda559f678c60c85e7fe59468e4b1b86105
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
   post_approval_changes:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
-      - uses: angular/dev-infra/github-actions/post-approval-changes@571134460f8bf9a152b3e38159fa91b92efaf6d1
+      - uses: angular/dev-infra/github-actions/post-approval-changes@fccfadda559f678c60c85e7fe59468e4b1b86105
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/feature-requests.yml
+++ b/.github/workflows/feature-requests.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.repository == 'angular/angular'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/feature-request@571134460f8bf9a152b3e38159fa91b92efaf6d1
+      - uses: angular/dev-infra/github-actions/feature-request@fccfadda559f678c60c85e7fe59468e4b1b86105
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/feature-requests.yml
+++ b/.github/workflows/feature-requests.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.repository == 'angular/angular'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/feature-request@fccfadda559f678c60c85e7fe59468e4b1b86105
+      - uses: angular/dev-infra/github-actions/feature-request@571134460f8bf9a152b3e38159fa91b92efaf6d1
         with:
           angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.repository == 'angular/angular'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@fccfadda559f678c60c85e7fe59468e4b1b86105
+      - uses: angular/dev-infra/github-actions/lock-closed@571134460f8bf9a152b3e38159fa91b92efaf6d1
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -14,6 +14,6 @@ jobs:
     if: github.repository == 'angular/angular'
     runs-on: ubuntu-latest
     steps:
-      - uses: angular/dev-infra/github-actions/lock-closed@571134460f8bf9a152b3e38159fa91b92efaf6d1
+      - uses: angular/dev-infra/github-actions/lock-closed@fccfadda559f678c60c85e7fe59468e4b1b86105
         with:
           lock-bot-key: ${{ secrets.LOCK_BOT_PRIVATE_KEY }}

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1062,8 +1062,9 @@ groups:
           ])
     reviewers:
       users:
-        - alxhub
+        - AndrewKushnir
         - gkalpak
+        - jessicajaniuk
         - josephperrott
 
   # =========================================================

--- a/aio/content/examples/getting-started/src/app/cart/cart.component.1.ts
+++ b/aio/content/examples/getting-started/src/app/cart/cart.component.1.ts
@@ -7,6 +7,5 @@ import { Component } from '@angular/core';
 })
 export class CartComponent {
 
-  constructor() { }
 
 }

--- a/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.1.ts
+++ b/aio/content/examples/getting-started/src/app/product-alerts/product-alerts.component.1.ts
@@ -1,11 +1,6 @@
 // #docplaster
-/*
-// #docregion as-generated
-import { Component, OnInit } from '@angular/core';
-// #enddocregion as-generated
-*/
 // #docregion imports
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { Product } from '../products';
 // #enddocregion imports
 // #docregion as-generated
@@ -16,14 +11,10 @@ import { Product } from '../products';
   styleUrls: ['./product-alerts.component.css']
 })
 // #docregion input-decorator
-export class ProductAlertsComponent implements OnInit {
+export class ProductAlertsComponent {
 
 // #enddocregion as-generated
   @Input() product!: Product;
 // #docregion as-generated
-  constructor() { }
-
-  ngOnInit() {
-  }
 
 }

--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -1,9 +1,12 @@
 # Service worker configuration
 
+This topic describes the properties of the service worker configuration file.
+
 ## Prerequisites
 
 A basic understanding of the following:
 
+*   [Service worker overview](https://developer.chrome.com/docs/workbox/service-worker-overview/)
 *   [Service Worker in Production](guide/service-worker-devops)
 
 The `ngsw-config.json` configuration file specifies which files and data URLs the Angular service worker should cache and how it should update the cached files and data.
@@ -64,9 +67,11 @@ Example patterns:
 | `/*.html`    | Specifies only HTML files in the root |
 | `!/**/*.map` | Exclude all sourcemaps                |
 
+## Service worker configuration properties
+
 The following sections describe each property of the configuration file.
 
-## `appData`
+### `appData`
 
 This section enables you to pass any data you want that describes this particular version of the application.
 The `SwUpdate` service includes that data in the update notifications.
@@ -74,12 +79,12 @@ Many applications use this section to provide additional information for the dis
 
 <a id="index-file"></a>
 
-## `index`
+### `index`
 
 Specifies the file that serves as the index page to satisfy navigation requests.
 Usually this is `/index.html`.
 
-## `assetGroups`
+### `assetGroups`
 
 *Assets* are resources that are part of the application version that update along with the application.
 They can include resources loaded from the page's origin as well as third-party resources loaded from CDNs and other external URLs.
@@ -134,12 +139,14 @@ interface AssetGroup {
 
 </code-example>
 
-### `name`
+Each `AssetGroup` is defined by the following asset group properties.
+
+#### `name`
 
 A `name` is mandatory.
 It identifies this particular group of assets between versions of the configuration.
 
-### `installMode`
+#### `installMode`
 
 The `installMode` determines how these resources are initially cached.
 The `installMode` can be either of two values:
@@ -151,7 +158,7 @@ The `installMode` can be either of two values:
 
 Defaults to `prefetch`.
 
-### `updateMode`
+#### `updateMode`
 
 For resources already in the cache, the `updateMode` determines the caching behavior when a new version of the application is discovered.
 Any resources in the group that have changed since the previous version are updated in accordance with `updateMode`.
@@ -163,7 +170,7 @@ Any resources in the group that have changed since the previous version are upda
 
 Defaults to the value `installMode` is set to.
 
-### `resources`
+#### `resources`
 
 This section describes the resources to cache, broken up into the following groups:
 
@@ -172,7 +179,7 @@ This section describes the resources to cache, broken up into the following grou
 | `files`         | Lists patterns that match files in the distribution directory. These can be single files or glob-like patterns that match a number of files.                                                                                                                                                                                                                                                                   |
 | `urls`          | Includes both URLs and URL patterns that are matched at runtime. These resources are not fetched directly and do not have content hashes, but they are cached according to their HTTP headers. This is most useful for CDNs such as the Google Fonts service. <br />  *\(Negative glob patterns are not supported and `?` will be matched literally; that is, it will not match any character other than `?`.\)* |
 
-### `cacheQueryOptions`
+#### `cacheQueryOptions`
 
 These options are used to modify the matching behavior of requests.
 They are passed to the browsers `Cache#match` function.
@@ -183,7 +190,7 @@ Currently, only the following options are supported:
 |:---            |:---     |
 | `ignoreSearch` | Ignore query parameters. Defaults to `false`. |
 
-## `dataGroups`
+### `dataGroups`
 
 Unlike asset resources, data requests are not versioned along with the application.
 They're cached according to manually-configured policies that are more useful for situations such as API requests and other data dependencies.
@@ -236,11 +243,13 @@ export interface DataGroup {
 
 </code-example>
 
-### `name`
+Each `DataGroup` is defined by the following data group properties.
+
+#### `name`
 
 Similar to `assetGroups`, every data group has a `name` which uniquely identifies it.
 
-### `urls`
+#### `urls`
 
 A list of URL patterns.
 URLs that match these patterns are cached according to this data group's policy.
@@ -249,7 +258,7 @@ Only non-mutating requests \(GET and HEAD\) are cached.
 *   Negative glob patterns are not supported
 *   `?` is matched literally; that is, it matches *only* the character `?`
 
-### `version`
+#### `version`
 
 Occasionally APIs change formats in a way that is not backward-compatible.
 A new version of the application might not be compatible with the old API format and thus might not be compatible with existing cached resources from that API.
@@ -258,18 +267,22 @@ A new version of the application might not be compatible with the old API format
 
 `version` is an integer field and defaults to `1`.
 
-### `cacheConfig`
+#### `cacheConfig`
 
-This section defines the policy by which matching requests are cached.
+The following properties define the policy by which matching requests are cached.
 
-#### `maxSize`
+##### `maxSize`
 
-\(required\) The maximum number of entries, or responses, in the cache.
+**Required**
+
+The maximum number of entries, or responses, in the cache.
 Open-ended caches can grow in unbounded ways and eventually exceed storage quotas, calling for eviction.
 
-#### `maxAge`
+##### `maxAge`
 
-(required) The `maxAge` parameter indicates how long responses are allowed to remain in the cache before being considered invalid and evicted.
+**Required**
+
+The `maxAge` parameter indicates how long responses are allowed to remain in the cache before being considered invalid and evicted.
 `maxAge` is a duration string, using the following unit suffixes:
 
 | Suffixes | Details |
@@ -282,7 +295,7 @@ Open-ended caches can grow in unbounded ways and eventually exceed storage quota
 
 For example, the string `3d12h` caches content for up to three and a half days.
 
-#### `timeout`
+##### `timeout`
 
 This duration string specifies the network timeout.
 The network timeout is how long the Angular service worker waits for the network to respond before using a cached response, if configured to do so.
@@ -298,7 +311,7 @@ The network timeout is how long the Angular service worker waits for the network
 
 For example, the string `5s30u` translates to five seconds and 30 milliseconds of network timeout.
 
-#### `strategy`
+##### `strategy`
 
 The Angular service worker can use either of two caching strategies for data resources.
 
@@ -309,19 +322,19 @@ The Angular service worker can use either of two caching strategies for data res
 
 <div class="alert is-helpful">
 
-You can also emulate a third strategy, [staleWhileRevalidate](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate), which returns cached data \(if available\), but also fetches fresh data from the network in the background for next time.
+You can also emulate a third strategy, [staleWhileRevalidate](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate), which returns cached data if it is available, but also fetches fresh data from the network in the background for next time.
 To use this strategy set `strategy` to `freshness` and `timeout` to `0u` in `cacheConfig`.
 
 This essentially does the following:
 
 1.  Try to fetch from the network first.
-1.  If the network request does not complete after 0ms \(that is, immediately\), fall back to the cache \(ignoring cache age\).
-1.  Once the network request completes, update the cache for future requests.
-1.  If the resource does not exist in the cache, wait for the network request anyway.
+2.  If the network request does not complete immediately, ignore the cache age and fall back to the cached value.
+3.  Once the network request completes, update the cache for future requests.
+4.  If the resource does not exist in the cache, wait for the network request anyway.
 
 </div>
 
-#### `cacheOpaqueResponses`
+##### `cacheOpaqueResponses`
 
 Whether the Angular service worker should cache opaque responses or not.
 
@@ -329,8 +342,8 @@ If not specified, the default value depends on the data group's configured strat
 
 | Strategies                             | Details |
 |:---                                    |:---     |
-| Groups with the `freshness` strategy   | The default value is `true` \(cache opaque responses\). These groups will request the data anew every time, only falling back to the cached response when offline or on a slow network. Therefore, it doesn't matter if the service worker caches an error response.                                    |
-| Groups with the `performance` strategy | The default value is `false` \(do not cache opaque responses\). These groups would continue to return a cached response until `maxAge` expires, even if the error was due to a temporary network or server issue. Therefore, it would be problematic for the service worker to cache an error response. |
+| Groups with the `freshness` strategy   | The default value is `true` and the service worker caches opaque responses. These groups will request the data every time and only fall back to the cached response when offline or on a slow network. Therefore, it doesn't matter if the service worker caches an error response.                                    |
+| Groups with the `performance` strategy | The default value is `false` and the service work doen't cache opaque responses. These groups would continue to return a cached response until `maxAge` expires, even if the error was due to a temporary network or server issue. Therefore, it would be problematic for the service worker to cache an error response. |
 
 <div class="callout is-important">
 
@@ -344,27 +357,24 @@ If you are not able to implement CORS &mdash;for example, if you don't control t
 
 </div>
 
-### `cacheQueryOptions`
+#### `cacheQueryOptions`
 
 See [assetGroups](#assetgroups) for details.
 
-## `navigationUrls`
+### `navigationUrls`
 
 This optional section enables you to specify a custom list of URLs that will be redirected to the index file.
 
-### Handling navigation requests
+#### Handling navigation requests
 
 The ServiceWorker redirects navigation requests that don't match any `asset` or `data` group to the specified [index file](#index-file).
 A request is considered to be a navigation request if:
 
 *   Its [mode](https://developer.mozilla.org/docs/Web/API/Request/mode) is `navigation`
-*   It accepts a `text/html` response \(as determined by the value of the `Accept` header\)
-*   Its URL matches certain criteria \(see the following\)
-
-By default, these criteria are:
-
-*   The URL must not contain a file extension \(that is, a `.`\) in the last path segment
-*   The URL must not contain `__`
+*   It accepts a `text/html` response as determined by the value of the `Accept` header
+*   Its URL matches the following criteria:
+  *   The URL must not contain a file extension \(that is, a `.`\) in the last path segment
+  *   The URL must not contain `__`
 
 <div class="alert is-helpful">
 
@@ -372,10 +382,10 @@ To configure whether navigation requests are sent through to the network or not,
 
 </div>
 
-### Matching navigation request URLs
+#### Matching navigation request URLs
 
 While these default criteria are fine in most cases, it is sometimes desirable to configure different rules.
-For example, you might want to ignore specific routes \(that are not part of the Angular app\) and pass them through to the server.
+For example, you might want to ignore specific routes, such as those that are not part of the Angular app, and pass them through to the server.
 
 This field contains an array of URLs and [glob-like](#glob-patterns) URL patterns that are matched at runtime.
 It can contain both negative patterns \(that is, patterns starting with `!`\) and non-negative patterns and URLs.
@@ -398,7 +408,7 @@ If the field is omitted, it defaults to:
 
 <a id="navigation-request-strategy"></a>
 
-## `navigationRequestStrategy`
+### `navigationRequestStrategy`
 
 This optional property enables you to configure how the service worker handles navigation requests:
 
@@ -413,7 +423,7 @@ This optional property enables you to configure how the service worker handles n
 | Possible values | Details |
 |:---             |:---     |
 | `'performance'` | The default setting. Serves the specified [index file](#index-file), which is typically cached.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `'freshness'`   | Passes the requests through to the network and falls back to the `performance` behavior when offline. This value is useful when the server redirects the navigation requests elsewhere using an HTTP redirect \(3xx status code\). Reasons for using this value include: <ul> <li> Redirecting to an authentication website when authentication is not handled by the application </li> <li> Redirecting specific URLs to avoid breaking existing links/bookmarks after a website redesign </li> <li> Redirecting to a different website, such as a server-status page, while a page is temporarily down </li> </ul> |
+| `'freshness'`   | Passes the requests through to the network and falls back to the `performance` behavior when offline. This value is useful when the server redirects the navigation requests elsewhere using a `3xx` HTTP redirect status code. Reasons for using this value include: <ul> <li> Redirecting to an authentication website when authentication is not handled by the application </li> <li> Redirecting specific URLs to avoid breaking existing links/bookmarks after a website redesign </li> <li> Redirecting to a different website, such as a server-status page, while a page is temporarily down </li> </ul> |
 
 <div class="alert is-important">
 
@@ -421,6 +431,12 @@ The `freshness` strategy usually results in more requests sent to the server, wh
 It is recommended that you use the default performance strategy whenever possible.
 
 </div>
+
+## Handling errors when the server can't be reached
+
+All requests are passed through the service worker, unless the `ngsw-bypass` request header is added.
+
+When a server can't be reached and the request times out, the service worker returns a [504 Gateway Timeout](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) status. A timeout can happen when either the client is disconnected or the server is offline. Unfortunately, the service worker can't identify which event caused the request to time out.
 
 <!-- links -->
 

--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -328,7 +328,7 @@ To use this strategy set `strategy` to `freshness` and `timeout` to `0u` in `cac
 This essentially does the following:
 
 1.  Try to fetch from the network first.
-2.  If the network request does not complete immediately, ignore the cache age and fall back to the cached value.
+2.  If the network request does not complete immediately, that is after a timeout of 0&nbsp;ms, ignore the cache age and fall back to the cached value.
 3.  Once the network request completes, update the cache for future requests.
 4.  If the resource does not exist in the cache, wait for the network request anyway.
 
@@ -343,7 +343,7 @@ If not specified, the default value depends on the data group's configured strat
 | Strategies                             | Details |
 |:---                                    |:---     |
 | Groups with the `freshness` strategy   | The default value is `true` and the service worker caches opaque responses. These groups will request the data every time and only fall back to the cached response when offline or on a slow network. Therefore, it doesn't matter if the service worker caches an error response.                                    |
-| Groups with the `performance` strategy | The default value is `false` and the service work doen't cache opaque responses. These groups would continue to return a cached response until `maxAge` expires, even if the error was due to a temporary network or server issue. Therefore, it would be problematic for the service worker to cache an error response. |
+| Groups with the `performance` strategy | The default value is `false` and the service work doesn't cache opaque responses. These groups would continue to return a cached response until `maxAge` expires, even if the error was due to a temporary network or server issue. Therefore, it would be problematic for the service worker to cache an error response. |
 
 <div class="callout is-important">
 
@@ -373,8 +373,8 @@ A request is considered to be a navigation request if:
 *   Its [mode](https://developer.mozilla.org/docs/Web/API/Request/mode) is `navigation`
 *   It accepts a `text/html` response as determined by the value of the `Accept` header
 *   Its URL matches the following criteria:
-  *   The URL must not contain a file extension \(that is, a `.`\) in the last path segment
-  *   The URL must not contain `__`
+    *   The URL must not contain a file extension \(that is, a `.`\) in the last path segment
+    *   The URL must not contain `__`
 
 <div class="alert is-helpful">
 
@@ -431,12 +431,6 @@ The `freshness` strategy usually results in more requests sent to the server, wh
 It is recommended that you use the default performance strategy whenever possible.
 
 </div>
-
-## Handling errors when the server can't be reached
-
-All requests are passed through the service worker, unless the `ngsw-bypass` request header is added.
-
-When a server can't be reached and the request times out, the service worker returns a [504 Gateway Timeout](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) status. A timeout can happen when either the client is disconnected or the server is offline. Unfortunately, the service worker can't identify which event caused the request to time out.
 
 <!-- links -->
 

--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -343,7 +343,7 @@ If not specified, the default value depends on the data group's configured strat
 | Strategies                             | Details |
 |:---                                    |:---     |
 | Groups with the `freshness` strategy   | The default value is `true` and the service worker caches opaque responses. These groups will request the data every time and only fall back to the cached response when offline or on a slow network. Therefore, it doesn't matter if the service worker caches an error response.                                    |
-| Groups with the `performance` strategy | The default value is `false` and the service work doesn't cache opaque responses. These groups would continue to return a cached response until `maxAge` expires, even if the error was due to a temporary network or server issue. Therefore, it would be problematic for the service worker to cache an error response. |
+| Groups with the `performance` strategy | The default value is `false` and the service worker doesn't cache opaque responses. These groups would continue to return a cached response until `maxAge` expires, even if the error was due to a temporary network or server issue. Therefore, it would be problematic for the service worker to cache an error response. |
 
 <div class="callout is-important">
 

--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -9,21 +9,21 @@ A basic understanding of the following:
 
 *   [Service Worker Communication](guide/service-worker-communications)
 
-## Service worker and caching of app resources
+## Service worker and caching of application resources
 
-Conceptually, imagine the Angular service worker as a forward cache or a CDN edge that is installed in the end user's web browser.
-The service worker's job is to satisfy requests made by the Angular application for resources or data from a local cache, without needing to wait for the network.
+Imagine the Angular service worker as a forward cache or a Content Delivery Network (CDN) edge that is installed in the end user's web browser.
+The service worker responds to requests made by the Angular application for resources or data from a local cache, without needing to wait for the network.
 Like any cache, it has rules for how content is expired and updated.
 
 <a id="versions"></a>
 
-### App versions
+### Application versions
 
 In the context of an Angular service worker, a "version" is a collection of resources that represent a specific build of the Angular application.
 Whenever a new build of the application is deployed, the service worker treats that build as a new version of the application.
 This is true even if only a single file is updated.
 At any given time, the service worker might have multiple versions of the application in its cache and it might be serving them simultaneously.
-For more information, see the [App tabs](guide/service-worker-devops#tabs) section below.
+For more information, see the [Application tabs](guide/service-worker-devops#tabs) section.
 
 To preserve application integrity, the Angular service worker groups all files into a version together.
 The files grouped into a version usually include HTML, JS, and CSS files.
@@ -35,15 +35,15 @@ In this scenario, it is not valid to serve the old `index.html`, which calls `st
 
 This file integrity is especially important when lazy loading modules.
 A JS bundle might reference many lazy chunks, and the filenames of the lazy chunks are unique to the particular build of the application.
-If a running application at version `X` attempts to load a lazy chunk, but the server has already updated to version `X + 1`, the lazy loading operation will fail.
+If a running application at version `X` attempts to load a lazy chunk, but the server has already updated to version `X + 1`, the lazy loading operation fails.
 
 The version identifier of the application is determined by the contents of all resources, and it changes if any of them change.
 In practice, the version is determined by the contents of the `ngsw.json` file, which includes hashes for all known content.
-If any of the cached files change, the file's hash will change in `ngsw.json`, causing the Angular service worker to treat the active set of files as a new version.
+If any of the cached files change, the file's hash changes in `ngsw.json`. This change causes the Angular service worker to treat the active set of files as a new version.
 
 <div class="alert is-helpful">
 
-`ngsw.json` is the manifest file that is generated at build time based on `ngsw-config.json`.
+`ngsw.json` is the manifest file that is created at build time based on `ngsw-config.json`.
 
 </div>
 
@@ -52,25 +52,25 @@ With the versioning behavior of the Angular service worker, an application serve
 #### Update checks
 
 Every time the user opens or refreshes the application, the Angular service worker checks for updates to the application by looking for updates to the `ngsw.json` manifest.
-If an update is found, it is downloaded and cached automatically, and will be served the next time the application is loaded.
+If an update is found, it is downloaded and cached automatically, and is served the next time the application is loaded.
 
 ### Resource integrity
 
-One of the potential side effects of long caching is inadvertently caching an invalid resource.
-In a normal HTTP cache, a hard refresh or cache expiration limits the negative effects of caching an invalid file.
-A service worker ignores such constraints and effectively long caches the entire application.
-Consequently, it is essential that the service worker gets the correct content.
+One of the potential side effects of long caching is inadvertently caching a resource that's not valid.
+In a normal HTTP cache, a hard refresh or the cache expiring limits the negative effects of caching an file that's not valid.
+A service worker ignores such constraints and effectively long-caches the entire application.
+As a result, the service worker must get the correct content.
 
 To ensure resource integrity, the Angular service worker validates the hashes of all resources for which it has a hash.
 Typically for an application created with the [Angular CLI](cli), this is everything in the `dist` directory covered by the user's `src/ngsw-config.json` configuration.
 
-If a particular file fails validation, the Angular service worker attempts to re-fetch the content using a "cache-busting" URL parameter to eliminate the effects of browser or intermediate caching.
-If that content also fails validation, the service worker considers the entire version of the application to be invalid and it stops serving the application.
-If necessary, the service worker enters a safe mode where requests fall back on the network, opting not to use its cache if the risk of serving invalid, broken, or outdated content is high.
+If a particular file fails validation, the Angular service worker attempts to re-fetch the content using a "cache-busting" URL parameter to prevent browser or intermediate caching.
+If that content also fails validation, the service worker considers the entire version of the application to not be valid and stops serving the application.
+If necessary, the service worker enters a safe mode where requests fall back on the network. The service worker doesn't use its cache if there's a high risk of serving content that is not valid, broken, or outdated.
 
 Hash mismatches can occur for a variety of reasons:
 
-*   Caching layers in between the origin server and the end user could serve stale content
+*   Caching layers between the origin server and the end user could serve stale content
 *   A non-atomic deployment could result in the Angular service worker having visibility of partially updated content
 *   Errors during the build process could result in updated resources without `ngsw.json` being updated.
     The reverse could also happen resulting in an updated `ngsw.json` without updated resources.
@@ -80,36 +80,35 @@ Hash mismatches can occur for a variety of reasons:
 The only resources that have hashes in the `ngsw.json` manifest are resources that were present in the `dist` directory at the time the manifest was built.
 Other resources, especially those loaded from CDNs, have content that is unknown at build time or are updated more frequently than the application is deployed.
 
-If the Angular service worker does not have a hash to validate a given resource, it still caches its contents but it honors the HTTP caching headers by using a policy of "stale while revalidate".
-That is, when HTTP caching headers for a cached resource indicate that the resource has expired, the Angular service worker continues to serve the content and it attempts to refresh the resource in the background.
+If the Angular service worker does not have a hash to verify a resource is valid, it still caches its contents. At the same time, it honors the HTTP caching headers by using a policy of *stale while revalidate*.
+When HTTP caching headers for a cached resource show that the resource has expired, the Angular service worker continues to serve the content. At the same time, it attempts to refresh the resource in the background.
 This way, broken unhashed resources do not remain in the cache beyond their configured lifetimes.
 
 <a id="tabs"></a>
 
-### App tabs
+### Application tabs
 
 It can be problematic for an application if the version of resources it's receiving changes suddenly or without warning.
-See the [App versions](guide/service-worker-devops#versions) section above for a description of such issues.
+See the [Application versions](guide/service-worker-devops#versions) section for a description of such issues.
 
-The Angular service worker provides a guarantee: a running application will continue to run the same version of the application.
-If another instance of the application is opened in a new web browser tab, then the most current version of the app is served.
+The Angular service worker provides a guarantee: a running application continues to run the same version of the application.
+If another instance of the application is opened in a new web browser tab, then the most current version of the application is served.
 As a result, that new tab can be running a different version of the application than the original tab.
 
 <div class="alert is-important">
 
 **IMPORTANT**: <br />
 This guarantee is **stronger** than that provided by the normal web deployment model.
-Without a service worker, there is no guarantee that code lazily loaded later in a running application is from the same version as the initial code for the application.
+Without a service worker, there is no guarantee that lazily loaded code is from the same version as the application's initial code.
 
 </div>
 
-There are a few limited reasons why the Angular service worker might change the version of a running application.
-Some of them are error conditions:
+The Angular service worker might change the version of a running application under error conditions such as:
 
-*   The current version becomes invalid due to a failed hash
-*   An unrelated error causes the service worker to enter safe mode; that is, temporary deactivation
+*   The current version becomes non-valid due to a failed hash
+*   An unrelated error causes the service worker to enter safe mode and deactivates it temporarily
 
-The Angular service worker is aware of which versions are in use at any given moment and it cleans up versions when no tab is using them.
+The Angular service worker cleans up application versions when no tab is using them.
 
 Other reasons the Angular service worker might change the version of a running application are normal events:
 
@@ -119,27 +118,35 @@ Other reasons the Angular service worker might change the version of a running a
 ### Service worker updates
 
 The Angular service worker is a small script that runs in web browsers.
-From time to time, the service worker will be updated with bug fixes and feature improvements.
+From time to time, the service worker is updated with bug fixes and feature improvements.
 
 The Angular service worker is downloaded when the application is first opened and when the application is accessed after a period of inactivity.
-If the service worker has changed, the service worker will be updated in the background.
+If the service worker changes, it's updated in the background.
 
-Most updates to the Angular service worker are transparent to the app &mdash;the old caches are still valid and content is still served
-normally.
-However, occasionally a bugfix or feature in the Angular service worker requires the invalidation of old caches.
-In this case, the application will be refreshed transparently from the network.
+Most updates to the Angular service worker are transparent to the application. The old caches are still valid and content is still served normally.
+Occasionally, a bug fix or feature in the Angular service worker might require the invalidation of old caches.
+In this case, the application transparently refreshes the application from the network.
 
 ### Bypassing the service worker
 
-In some cases, you might want to bypass the service worker entirely and let the browser handle the request instead.
-An example is when you rely on a feature that is currently not supported in service workers \(for example, [reporting progress on uploaded files](https://github.com/w3c/ServiceWorker/issues/1141)\).
+In some cases, you might want to bypass the service worker entirely and let the browser handle the request.
+An example is when you rely on a feature that is currently not supported in service workers, such as [reporting progress on uploaded files](https://github.com/w3c/ServiceWorker/issues/1141).
 
 To bypass the service worker, set `ngsw-bypass` as a request header, or as a query parameter.
-\(The value of the header or query parameter is ignored and can be empty or omitted.\)
+The value of the header or query parameter is ignored and can be empty or omitted.
+
+### Service worker requests when the server can't be reached
+
+All requests pass through the service worker to the service unless
+the [service worker is explicitly bypassed](guide/service-worker-devops#bypassing-the-service-worker).
+The service worker either returns a cached response or sends the request to the server, depending on the state and configuration of the cache. 
+The service worker only caches responses to non-mutating requests, such as `GET` and `HEAD`.
+
+If the service worker doesn't receive a response, it returns a [504 Gateway Timeout](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) status. A `504` status could be returned because the server is offline or the client was disconnected.
 
 ## Debugging the Angular service worker
 
-Occasionally, it might be necessary to examine the Angular service worker in a running state to investigate issues or to ensure that it is operating as designed.
+Occasionally, it might be necessary to examine the Angular service worker in a running state to investigate issues or whether it's operating as designed.
 Browsers provide built-in tools for debugging service workers and the Angular service worker itself includes useful debugging features.
 
 ### Locating and analyzing debugging information
@@ -187,7 +194,7 @@ There are two possible degraded states:
 
 | Degraded states         | Details |
 |:---                     |:---     |
-| `EXISTING_CLIENTS_ONLY` | The service worker does not have a clean copy of the latest known version of the application. Older cached versions are safe to use, so existing tabs continue to run from cache, but new loads of the application will be served from the network. The service worker will try to recover from this state when a new version of the application is detected and installed \(that is, when a new `ngsw.json` is available\). |
+| `EXISTING_CLIENTS_ONLY` | The service worker does not have a clean copy of the latest known version of the application. Older cached versions are safe to use, so existing tabs continue to run from cache, but new loads of the application will be served from the network. The service worker will try to recover from this state when a new version of the application is detected and installed. This happens when a new `ngsw.json` is available. |
 | `SAFE_MODE`             | The service worker cannot guarantee the safety of using cached data. Either an unexpected error occurred or all cached versions are invalid. All traffic will be served from the network, running as little service worker code as possible.                                                                                                                                                                                 |
 
 In both cases, the parenthetical annotation provides the
@@ -269,9 +276,9 @@ Debug log:
 
 </code-example>
 
-Errors that occur within the service worker will be logged here.
+Errors that occur within the service worker are logged here.
 
-### Developer Tools
+### Developer tools
 
 Browsers such as Chrome provide developer tools for interacting with service workers.
 Such tools can be powerful when used properly, but there are a few things to keep in mind.
@@ -282,22 +289,26 @@ Such tools can be powerful when used properly, but there are a few things to kee
 *   If you look in the Cache Storage viewer, the cache is frequently out of date.
     Right click the Cache Storage title and refresh the caches.
 
-*   Stopping and starting the service worker in the Service Worker pane triggers a check for updates
+*   Stopping and starting the service worker in the Service Worker pane checks for updates
 
-## Service Worker Safety
+## Service worker safety
 
-Like any complex system, bugs or broken configurations can cause the Angular service worker to act in unforeseen ways.
-While its design attempts to minimize the impact of such problems, the Angular service worker contains several failsafe mechanisms in case an administrator ever needs to deactivate the service worker quickly.
+Bugs or broken configurations could cause the Angular service worker to act in unexpected ways.
+If this happens, the Angular service worker contains several failsafe mechanisms in case an administrator needs to deactivate the service worker quickly.
 
 ### Fail-safe
 
-To deactivate the service worker, remove or rename the `ngsw.json` file.
-When the service worker's request for `ngsw.json` returns a `404`, then the service worker removes all of its caches and de-registers itself, essentially self-destructing.
+To deactivate the service worker, rename the `ngsw.json` file or delete it.
+When the service worker's request for `ngsw.json` returns a `404`, then the service worker removes all its caches and de-registers itself, essentially self-destructing.
 
-### Safety Worker
+### Safety worker
 
-Also included in the `@angular/service-worker` NPM package is a small script `safety-worker.js`, which when loaded will unregister itself from the browser and remove the service worker caches.
+<!-- vale Angular.Google_Acronyms = NO -->
+
+Also included in the `@angular/service-worker` NPM package is a small script `safety-worker.js`, which when loaded un-registers itself from the browser and remove the service worker caches.
 This script can be used as a last resort to get rid of unwanted service workers already installed on client pages.
+
+<!-- vale Angular.Google_Acronyms = YES -->
 
 <div class="alert is-important">
 
@@ -306,11 +317,11 @@ You cannot register this worker directly, as old clients with cached state might
 
 </div>
 
-Instead, you must serve the contents of `safety-worker.js` at the URL of the Service Worker script you are trying to unregister, and must continue to do so until you are certain all users have successfully unregistered the old worker.
+Instead, you must serve the contents of `safety-worker.js` at the URL of the Service Worker script you are trying to unregister. You must continue to do so until you are certain all users have successfully unregistered the old worker.
 For most sites, this means that you should serve the safety worker at the old Service Worker URL forever.
-This script can be used both to deactivate `@angular/service-worker` \(and remove the corresponding caches\) as well as any other Service Workers which might have been served in the past on your site.
+This script can be used to deactivate `@angular/service-worker` and remove the corresponding caches. It also removes any other Service Workers which might have been served in the past on your site.
 
-### Changing your app's location
+### Changing your application's location
 
 <div class="alert is-important">
 
@@ -321,11 +332,11 @@ You might have already encountered the error `The script resource is behind a re
 </div>
 
 This can be a problem if you have to change your application's location.
-If you setup a redirect from the old location \(for example `example.com`\) to the new location \(for example `www.example.com`\) the worker will stop working.
+If you setup a redirect from the old location, such as `example.com`, to the new location, `www.example.com` in this example, the worker stops working.
 Also, the redirect won't even trigger for users who are loading the site entirely from Service Worker.
-The old worker \(registered at `example.com`\) tries to update and sends requests to the old location `example.com` which get redirected to the new location `www.example.com` and create the error `The script resource is behind a redirect, which is disallowed`.
+The old worker, which was registered at `example.com`, tries to update and sends requests to the old location `example.com`. This request is redirected to the new location `www.example.com` and creates the error: `The script resource is behind a redirect, which is disallowed`.
 
-To remedy this, you might need to deactivate the old worker using one of the above techniques \([Fail-safe](#fail-safe) or [Safety Worker](#safety-worker)\).
+To remedy this, you might need to deactivate the old worker using one of the preceding techniques: [Fail-safe](#fail-safe) or [Safety Worker](#safety-worker).
 
 ## More on Angular service workers
 

--- a/aio/content/guide/typed-forms.md
+++ b/aio/content/guide/typed-forms.md
@@ -171,6 +171,12 @@ Any control of type `string|null` can be added to this `FormRecord`.
 
 If you need a `FormGroup` that is both dynamic (open-ended) and heterogenous (the controls are different types), no improved type safety is possible, and you should use `UntypedFormGroup`.
 
+A `FormRecord` can also be built with the `FormBuilder`:
+
+```ts
+const addresses = fb.record({'Andrew': '2340 Folsom St'});
+```
+
 ## `FormBuilder` and `NonNullableFormBuilder`
 
 The `FormBuilder` class has been upgraded to support the new types as well, in the same manner as the above examples.

--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -64,7 +64,7 @@
     <aio-nav-menu [nodes]="sideNavNodes" [currentNode]="currentNodes?.SideNav" [isWide]="dockSideNav" navLabel="guides and docs"></aio-nav-menu>
 
     <div class="doc-version">
-      <aio-select (optionsToggled)="scrollSelectIntoView()" (change)="onDocVersionChange($event.index)" [options]="docVersions" [selected]="currentDocVersion"></aio-select>
+      <aio-nav-menu [nodes]="docVersions" [isWide]="true" [currentNode]="currentDocsVersionNode" navLabel="docs versions"></aio-nav-menu>
     </div>
   </mat-sidenav>
 

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -22,7 +22,6 @@ import { TocService } from 'app/shared/toc.service';
 import { SwUpdatesService } from 'app/sw-updates/sw-updates.service';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { first, map } from 'rxjs/operators';
-import { SelectComponent } from './shared/select/select.component';
 
 const sideNavView = 'SideNav';
 export const showTopMenuWidth = 1150;
@@ -89,9 +88,9 @@ export class AppComponent implements OnInit {
   tocMaxHeight: string;
   private tocMaxHeightOffset = 0;
 
-  versionInfo: VersionInfo;
+  currentDocsVersionNode?: NavigationNode;
 
-  private currentUrl: string;
+  versionInfo: VersionInfo;
 
   get isOpened() { return this.dockSideNav && this.isSideNavDoc; }
   get mode() { return this.isOpened ? 'side' : 'over'; }
@@ -116,9 +115,6 @@ export class AppComponent implements OnInit {
   @ViewChild('appToolbar', { read: ElementRef }) toolbar: ElementRef;
 
   @ViewChildren('themeToggle, externalIcons', { read: ElementRef }) toolbarIcons: QueryList<ElementRef>;
-
-  @ViewChild(SelectComponent, { read: ElementRef })
-  docVersionSelectElement: ElementRef;
 
   constructor(
     public deployment: Deployment,
@@ -173,7 +169,8 @@ export class AppComponent implements OnInit {
     combineLatest([
       this.navigationService.versionInfo,
       this.navigationService.navigationViews.pipe(map(views => views.docVersions)),
-    ]).subscribe(([versionInfo, versions]) => {
+      this.locationService.currentUrl,
+    ]).subscribe(([versionInfo, versions, currentUrl]) => {
       // TODO(pbd): consider whether we can lookup the stable and next versions from the internet
       const computedVersions: NavigationNode[] = [
         { title: 'next', url: 'https://next.angular.io/' },
@@ -183,13 +180,22 @@ export class AppComponent implements OnInit {
       if (this.deployment.mode === 'archive') {
         computedVersions.push({ title: `v${versionInfo.major}` });
       }
-      this.docVersions = [...computedVersions, ...versions];
-
+      const allDocsVersionNodes = [...computedVersions, ...versions].map(version => ({
+        ...version,
+        // Update the urls so that they point to the same page the user is currently at
+        url: `${version.url}${(version.url?.endsWith('/') ? '' : '/' )}${currentUrl}`,
+      }));
       // Find the current version - either title matches the current deployment mode
       // or its title matches the major version of the current version info
-      this.currentDocVersion = this.docVersions.find(version =>
-        version.title === this.deployment.mode || version.title === `v${versionInfo.major}`) as NavigationNode;
-      this.currentDocVersion.title += ` (v${versionInfo.raw})`;
+      this.currentDocsVersionNode = allDocsVersionNodes.find(
+        version => version.title === this.deployment.mode || version.title === `v${versionInfo.major}`
+      );
+      this.docVersions = [
+        {
+          title: 'Docs Versions',
+          children : allDocsVersionNodes
+        }
+      ];
     });
 
     this.navigationService.navigationViews.subscribe(views => {
@@ -215,8 +221,6 @@ export class AppComponent implements OnInit {
       this.navigationService.currentNodes,   // ...needed to determine `sidenav` state
     ]).pipe(first())
       .subscribe(() => this.updateShell());
-
-    this.locationService.currentUrl.subscribe(url => this.currentUrl = url);
 
     // Start listening for SW version update events.
     this.swUpdatesService.enable();
@@ -258,14 +262,6 @@ export class AppComponent implements OnInit {
     }
 
     this.isTransitioning = false;
-  }
-
-  onDocVersionChange(versionIndex: number) {
-    const version = this.docVersions[versionIndex];
-    if (version.url) {
-      const versionUrl = version.url  + (!version.url.endsWith('/') ? '/' : '');
-      this.locationService.go(`${versionUrl}${this.currentUrl}`);
-    }
   }
 
   @HostListener('window:resize', ['$event.target.innerWidth'])
@@ -480,13 +476,5 @@ export class AppComponent implements OnInit {
         this.focusSearchBox();
       }
     }
-  }
-
-  scrollSelectIntoView() {
-    // this method is used to scroll the select component into view when it is clicked/opened
-    // the setTimeout is needed so that the scroll happens after the component has expanded
-    setTimeout(() =>
-      this.docVersionSelectElement.nativeElement?.scrollIntoView({behavior: 'smooth'})
-    );
   }
 }

--- a/aio/src/app/layout/nav-menu/nav-menu.component.ts
+++ b/aio/src/app/layout/nav-menu/nav-menu.component.ts
@@ -7,15 +7,28 @@ import { CurrentNode, NavigationNode } from 'app/navigation/navigation.service';
   <nav [attr.aria-label]="navLabel || null">
     <aio-nav-item *ngFor="let node of filteredNodes"
       [node]="node"
-      [selectedNodes]="currentNode?.nodes"
+      [selectedNodes]="selectedNodes"
       [isWide]="isWide">
     </aio-nav-item>
   </nav>`
 })
 export class NavMenuComponent {
-  @Input() currentNode: CurrentNode | undefined;
+  @Input() currentNode: CurrentNode | NavigationNode | undefined;
   @Input() isWide = false;
   @Input() nodes: NavigationNode[];
   @Input() navLabel: string;
   get filteredNodes() { return this.nodes ? this.nodes.filter(n => !n.hidden) : []; }
+
+  get selectedNodes(): NavigationNode[]|undefined {
+    if(!this.currentNode) {
+      return undefined;
+    }
+
+    const currentNodeNodes = (this.currentNode as CurrentNode).nodes;
+    if (currentNodeNodes) {
+      return currentNodeNodes;
+    }
+
+    return [this.currentNode as NavigationNode];
+  }
 }

--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -36,11 +36,6 @@ mat-sidenav-container.sidenav-container {
     @media (max-width: 599px) {
       top: 56px;
     }
-
-    // Angular Version Selector
-    .doc-version {
-      padding: 8px;
-    }
   }
 }
 

--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -302,6 +302,9 @@ export class FormBuilder {
         [key: string]: any;
     }): FormGroup;
     get nonNullable(): NonNullableFormBuilder;
+    record<T>(controls: {
+        [key: string]: T;
+    }, options?: AbstractControlOptions | null): FormRecord<ɵElement<T, null>>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FormBuilder, never>;
     // (undocumented)
@@ -505,7 +508,7 @@ export class FormGroupName extends AbstractFormGroupDirective implements OnInit,
 }
 
 // @public
-export class FormRecord<TControl extends AbstractControl<ɵValue<TControl>, ɵRawValue<TControl>> = AbstractControl> extends FormGroup<{
+export class FormRecord<TControl extends AbstractControl = AbstractControl> extends FormGroup<{
     [key: string]: TControl;
 }> {
 }
@@ -723,6 +726,9 @@ export abstract class NonNullableFormBuilder {
     abstract group<T extends {}>(controls: T, options?: AbstractControlOptions | null): FormGroup<{
         [K in keyof T]: ɵElement<T[K], never>;
     }>;
+    abstract record<T>(controls: {
+        [key: string]: T;
+    }, options?: AbstractControlOptions | null): FormRecord<ɵElement<T, never>>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NonNullableFormBuilder, never>;
     // (undocumented)

--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -63,6 +63,9 @@ export class By {
 }
 
 // @public
+export function createApplication(options?: ApplicationConfig): Promise<ApplicationRef>;
+
+// @public
 export function disableDebugTools(): void;
 
 // @public

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -878,6 +878,10 @@ export abstract class TitleStrategy {
     buildTitle(snapshot: RouterStateSnapshot): string | undefined;
     getResolvedTitleForRoute(snapshot: ActivatedRouteSnapshot): any;
     abstract updateTitle(snapshot: RouterStateSnapshot): void;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<TitleStrategy, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<TitleStrategy>;
 }
 
 // @public

--- a/goldens/public-api/router/testing/index.md
+++ b/goldens/public-api/router/testing/index.md
@@ -6,7 +6,6 @@
 
 import { ChildrenOutletContexts } from '@angular/router';
 import { Compiler } from '@angular/core';
-import { DefaultTitleStrategy } from '@angular/router';
 import { ExtraOptions } from '@angular/router';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/router';
@@ -37,7 +36,7 @@ export class RouterTestingModule {
 export function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], opts?: ExtraOptions | UrlHandlingStrategy | null, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy, titleStrategy?: TitleStrategy): Router;
 
 // @public
-export function setupTestingRouterInternal(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], opts?: ExtraOptions | UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy, defaultTitleStrategy?: DefaultTitleStrategy, titleStrategy?: TitleStrategy): Router;
+export function setupTestingRouterInternal(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], titleStrategy: TitleStrategy, opts?: ExtraOptions | UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy): Router;
 
 // (No @packageDocumentation comment for this package)
 

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -15,8 +15,8 @@
       "main": 457651,
       "polyfills": 33922,
       "styles": 73640,
-      "light-theme": 78276,
-      "dark-theme": 78381
+      "light-theme": 78045,
+      "dark-theme": 78177
     }
   }
 }

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,7 +2,7 @@
   "aio": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 461922,
+      "main": 457028,
       "polyfills": 33814,
       "styles": 73640,
       "light-theme": 78276,
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 462546,
+      "main": 457651,
       "polyfills": 33922,
       "styles": 73640,
       "light-theme": 78276,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -41,7 +41,7 @@
   "forms": {
     "uncompressed": {
       "runtime": 1063,
-      "main": 157479,
+      "main": 158224,
       "polyfills": 33804
     }
   },

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -40,9 +40,9 @@
   },
   "forms": {
     "uncompressed": {
-      "runtime": 1063,
-      "main": 158224,
-      "polyfills": 33804
+      "runtime": 1060,
+      "main": 157621,
+      "polyfills": 33915
     }
   },
   "animations": {

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
   },
   "// 2": "devDependencies are not used under Bazel. Many can be removed after test.sh is deleted.",
   "devDependencies": {
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#efc5d56da4f755f2a4bf57e4d835551cc2698115",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#84dd092bab90bbcb746d955234d1e72c3434868f",
     "@bazel/bazelisk": "^1.7.5",
     "@bazel/buildifier": "^5.0.0",
     "@bazel/ibazel": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "karma": "~6.3.0",
     "karma-chrome-launcher": "^3.1.0",
     "karma-firefox-launcher": "^2.1.0",
-    "karma-jasmine": "^4.0.1",
+    "karma-jasmine": "^5.0.0",
     "karma-requirejs": "^1.1.0",
     "karma-sourcemap-loader": "^0.3.7",
     "magic-string": "0.26.2",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
   },
   "// 2": "devDependencies are not used under Bazel. Many can be removed after test.sh is deleted.",
   "devDependencies": {
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#84dd092bab90bbcb746d955234d1e72c3434868f",
+    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#efc5d56da4f755f2a4bf57e4d835551cc2698115",
     "@bazel/bazelisk": "^1.7.5",
     "@bazel/buildifier": "^5.0.0",
     "@bazel/ibazel": "^0.16.0",

--- a/packages/animations/browser/src/dsl/animation_timeline_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_builder.ts
@@ -730,7 +730,7 @@ export class TimelineBuilder {
       const val = interpolateParams(value, params, errors);
       this._pendingStyles.set(prop, val);
       if (!this._localTimelineStyles.has(prop)) {
-        this._backFill.set(prop, this._globalTimelineStyles.get(prop) || AUTO_STYLE);
+        this._backFill.set(prop, this._globalTimelineStyles.get(prop) ?? AUTO_STYLE);
       }
       this._updateStyle(prop, val);
     }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/missing_control_flow_directive/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/checks/missing_control_flow_directive/index.ts
@@ -15,14 +15,18 @@ import {NgTemplateDiagnostic} from '../../../api';
 import {TemplateCheckFactory, TemplateCheckWithVisitor, TemplateContext} from '../../api';
 
 /**
- * The list of known control flow directives present in the `CommonModule`.
+ * The list of known control flow directives present in the `CommonModule`,
+ * and their corresponding imports.
  *
  * Note: there is no `ngSwitch` here since it's typically used as a regular
  * binding (e.g. `[ngSwitch]`), however the `ngSwitchCase` and `ngSwitchDefault`
  * are used as structural directives and a warning would be generated. Once the
  * `CommonModule` is included, the `ngSwitch` would also be covered.
  */
-const KNOWN_CONTROL_FLOW_DIRECTIVES = new Set(['ngIf', 'ngFor', 'ngSwitchCase', 'ngSwitchDefault']);
+export const KNOWN_CONTROL_FLOW_DIRECTIVES = new Map([
+  ['ngIf', 'NgIf'], ['ngFor', 'NgForOf'], ['ngSwitchCase', 'NgSwitchCase'],
+  ['ngSwitchDefault', 'NgSwitchDefault']
+]);
 
 /**
  * Ensures that there are no known control flow directives (such as *ngIf and *ngFor)
@@ -64,9 +68,14 @@ class MissingControlFlowDirectiveCheck extends
     }
 
     const sourceSpan = controlFlowAttr.keySpan || controlFlowAttr.sourceSpan;
-    const errorMessage = `The \`*${controlFlowAttr.name}\` directive was used in the template, ` +
-        `but the \`CommonModule\` was not imported. Please make sure that the \`CommonModule\` ` +
-        `is included into the \`@Component.imports\` array of this component.`;
+    const correspondingImport = KNOWN_CONTROL_FLOW_DIRECTIVES.get(controlFlowAttr.name);
+    const errorMessage =
+        `The \`*${controlFlowAttr.name}\` directive was used in the template, ` +
+        `but neither the \`${
+            correspondingImport}\` directive nor the \`CommonModule\` was imported. ` +
+        `Please make sure that either the \`${
+            correspondingImport}\` directive or the \`CommonModule\` ` +
+        `is included in the \`@Component.imports\` array of this component.`;
     const diagnostic = ctx.makeTemplateDiagnostic(sourceSpan, errorMessage);
     return [diagnostic];
   }

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/missing_control_flow_directive/missing_control_flow_directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/test/checks/missing_control_flow_directive/missing_control_flow_directive_spec.ts
@@ -13,14 +13,12 @@ import {absoluteFrom, getSourceFileOrError} from '../../../../../file_system';
 import {runInEachFileSystem} from '../../../../../file_system/testing';
 import {getSourceCodeForDiagnostic} from '../../../../../testing';
 import {getClass, setup} from '../../../../testing';
-import {factory as missingControlFlowDirectiveCheck} from '../../../checks/missing_control_flow_directive';
+import {factory as missingControlFlowDirectiveCheck, KNOWN_CONTROL_FLOW_DIRECTIVES} from '../../../checks/missing_control_flow_directive';
 import {ExtendedTemplateCheckerImpl} from '../../../src/extended_template_checker';
-
-const KNOWN_CONTROL_FLOW_DIRECTIVES = ['ngIf', 'ngFor', 'ngSwitchCase', 'ngSwitchDefault'];
 
 runInEachFileSystem(() => {
   describe('MissingControlFlowDirectiveCheck', () => {
-    KNOWN_CONTROL_FLOW_DIRECTIVES.forEach(directive => {
+    KNOWN_CONTROL_FLOW_DIRECTIVES.forEach((correspondingImport, directive) => {
       ['div', 'ng-template', 'ng-container', 'ng-content'].forEach(element => {
         it(`should produce a warning when the '${directive}' directive is not imported ` +
                `(when used on the '${element}' element)`,
@@ -47,6 +45,14 @@ runInEachFileSystem(() => {
              expect(diags.length).toBe(1);
              expect(diags[0].category).toBe(ts.DiagnosticCategory.Warning);
              expect(diags[0].code).toBe(ngErrorCode(ErrorCode.MISSING_CONTROL_FLOW_DIRECTIVE));
+             expect(diags[0].messageText)
+                 .toBe(
+                     `The \`*${directive}\` directive was used in the template, ` +
+                     `but neither the \`${
+                         correspondingImport}\` directive nor the \`CommonModule\` was imported. ` +
+                     `Please make sure that either the \`${
+                         correspondingImport}\` directive or the \`CommonModule\` ` +
+                     `is included in the \`@Component.imports\` array of this component.`);
              expect(getSourceCodeForDiagnostic(diags[0])).toBe(directive);
            });
 

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS, internalBootstrapApplication as ɵinternalBootstrapApplication} from './application_ref';
+export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS, internalCreateApplication as ɵinternalCreateApplication} from './application_ref';
 export {APP_ID_RANDOM_PROVIDER as ɵAPP_ID_RANDOM_PROVIDER} from './application_tokens';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {ChangeDetectorStatus as ɵChangeDetectorStatus, isDefaultChangeDetectionStrategy as ɵisDefaultChangeDetectionStrategy} from './change_detection/constants';

--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -333,20 +333,26 @@ class SomeComponent {
          withModule(
              {providers},
              waitForAsync(inject([EnvironmentInjector], (parentInjector: EnvironmentInjector) => {
+               // This is a temporary type to represent an instance of an R3Injector, which
+               // can be destroyed.
+               // The type will be replaced with a different one once destroyable injector
+               // type is available.
+               type DestroyableInjector = EnvironmentInjector&{destroyed?: boolean};
+
                createRootEl();
 
-               const injector = createApplicationRefInjector(parentInjector);
+               const injector = createApplicationRefInjector(parentInjector) as DestroyableInjector;
 
                const appRef = injector.get(ApplicationRef);
                appRef.bootstrap(SomeComponent);
 
                expect(appRef.destroyed).toBeFalse();
-               expect((injector as any).destroyed).toBeFalse();
+               expect(injector.destroyed).toBeFalse();
 
                appRef.destroy();
 
                expect(appRef.destroyed).toBeTrue();
-               expect((injector as any).destroyed).toBeTrue();
+               expect(injector.destroyed).toBeTrue();
              }))));
     });
 

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -507,9 +507,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_contains"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -363,9 +363,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -522,9 +522,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -195,6 +195,9 @@
     "name": "FormGroupName"
   },
   {
+    "name": "FormRecord"
+  },
+  {
     "name": "FormsExampleModule"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -513,9 +513,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -765,9 +765,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -315,9 +315,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -441,9 +441,6 @@
     "name": "__forward_ref__"
   },
   {
-    "name": "_chromeNumKeyPadMap"
-  },
-  {
     "name": "_currentInjector"
   },
   {

--- a/packages/core/test/render3/testing_spec.ts
+++ b/packages/core/test/render3/testing_spec.ts
@@ -44,7 +44,7 @@ describe('testing', () => {
   describe('requestAnimationFrame', () => {
     it('should have requestAnimationFrame', (done) => {
       // In Browser we have requestAnimationFrame, but verify that we also have it node.js
-      requestAnimationFrame(done);
+      requestAnimationFrame(() => done());
     });
   });
 });

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -93,7 +93,7 @@ export interface TestEnvironmentOptions {
  * @publicApi
  */
 export interface ModuleTeardownOptions {
-  /** Whether the test module should be destroyed after every test. */
+  /** Whether the test module should be destroyed after every test. Defaults to `true`. */
   destroyAfterEach: boolean;
 
   /** Whether errors during test module destruction should be re-thrown. Defaults to `true`. */

--- a/packages/elements/test/create-custom-element-env_spec.ts
+++ b/packages/elements/test/create-custom-element-env_spec.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component} from '@angular/core';
+import {createApplication} from '@angular/platform-browser';
+import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
+
+import {createCustomElement} from '../public_api';
+
+if (browserDetection.supportsCustomElements) {
+  describe('createCustomElement with env injector', () => {
+    let testContainer: HTMLDivElement;
+
+    beforeEach(() => {
+      testContainer = document.createElement('div');
+      document.body.appendChild(testContainer);
+    });
+
+    afterEach(() => {
+      document.body.removeChild(testContainer);
+      (testContainer as any) = null;
+    });
+
+    it('should use provided EnvironmentInjector to create a custom element', async () => {
+      @Component({
+        standalone: true,
+        template: `Hello, standalone element!`,
+      })
+      class TestStandaloneCmp {
+      }
+
+      const appRef = await createApplication();
+
+      try {
+        const NgElementCtor = createCustomElement(TestStandaloneCmp, {injector: appRef.injector});
+
+        customElements.define('test-standalone-cmp', NgElementCtor);
+        const customEl = document.createElement('test-standalone-cmp');
+        testContainer.appendChild(customEl);
+
+        expect(testContainer.innerText).toBe('Hello, standalone element!');
+      } finally {
+        appRef.destroy();
+      }
+    });
+  });
+}

--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -190,27 +190,16 @@ export class FormBuilder {
                                                                              any}|null = null):
       FormGroup {
     const reducedControls = this._reduceControls(controls);
-
-    let validators: ValidatorFn|ValidatorFn[]|null = null;
-    let asyncValidators: AsyncValidatorFn|AsyncValidatorFn[]|null = null;
-    let updateOn: FormHooks|undefined = undefined;
-
-    if (options !== null) {
-      if (isAbstractControlOptions(options)) {
-        // `options` are `AbstractControlOptions`
-        validators = options.validators != null ? options.validators : null;
-        asyncValidators = options.asyncValidators != null ? options.asyncValidators : null;
-        updateOn = options.updateOn != null ? options.updateOn : undefined;
-      } else {
-        // `options` are legacy form group options
-        validators = (options as any)['validator'] != null ? (options as any)['validator'] : null;
-        asyncValidators =
-            (options as any)['asyncValidator'] != null ? (options as any)['asyncValidator'] : null;
-      }
+    let newOptions: FormControlOptions = {};
+    if (isAbstractControlOptions(options)) {
+      // `options` are `AbstractControlOptions`
+      newOptions = options;
+    } else if (options !== null) {
+      // `options` are legacy form group options
+      newOptions.validators = (options as any).validator;
+      newOptions.asyncValidators = (options as any).asyncValidator;
     }
-
-    // Cast to `any` because the inferred types are not as specific as Element.
-    return new FormGroup(reducedControls, {asyncValidators, updateOn, validators}) as any;
+    return new FormGroup(reducedControls, newOptions);
   }
 
   /** @deprecated Use `nonNullable` instead. */

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -625,8 +625,7 @@ export const isFormGroup = (control: unknown): control is FormGroup => control i
  *
  * @publicApi
  */
-export class FormRecord<TControl extends AbstractControl<ɵValue<TControl>, ɵRawValue<TControl>> =
-                                             AbstractControl> extends
+export class FormRecord<TControl extends AbstractControl = AbstractControl> extends
     FormGroup<{[key: string]: TControl}> {}
 
 export interface FormRecord<TControl> {

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -68,6 +68,32 @@ describe('Form Builder', () => {
     expect(g.controls['login'].value).toEqual('some value');
   });
 
+  describe('should create control records', () => {
+    it('from simple values', () => {
+      const a = b.record({a: 'one', b: 'two'});
+      expect(a.value).toEqual({a: 'one', b: 'two'});
+    });
+
+    it('from boxed values', () => {
+      const a = b.record({a: 'one', b: {value: 'two', disabled: true}});
+      expect(a.value).toEqual({a: 'one'});
+      a.get('b')?.enable();
+      expect(a.value).toEqual({a: 'one', b: 'two'});
+    });
+
+    it('from an array', () => {
+      const a = b.record({a: ['one']});
+      expect(a.value).toEqual({a: 'one'});
+    });
+
+    it('from controls whose form state is a primitive value', () => {
+      const record = b.record({'login': b.control('some value', syncValidator, asyncValidator)});
+
+      expect(record.controls['login'].value).toEqual('some value');
+      expect(record.controls['login'].validator).toBe(syncValidator);
+      expect(record.controls['login'].asyncValidator).toBe(asyncValidator);
+    });
+  });
   it('should create homogenous control arrays', () => {
     const a = b.array(['one', 'two', 'three']);
     expect(a.value).toEqual(['one', 'two', 'three']);

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -156,6 +156,13 @@ describe('Form Builder', () => {
     expect(g.asyncValidator).toBe(asyncValidator);
   });
 
+  it('should create groups with null options', () => {
+    const g = b.group({'login': 'some value'}, null);
+
+    expect(g.validator).toBe(null);
+    expect(g.asyncValidator).toBe(null);
+  });
+
   it('should create control arrays', () => {
     const c = b.control('three');
     const e = b.control(null);

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -1132,10 +1132,135 @@ describe('Typed Class', () => {
           }
         });
 
+        it('from objects with builder FormRecords', () => {
+          const c = fb.group({foo: fb.record({baz: 'bar'})});
+          {
+            type ControlsType = {foo: FormRecord<FormControl<string|null>>};
+            let t: ControlsType = c.controls;
+            let t1 = c.controls;
+            t1 = null as unknown as ControlsType;
+          }
+        });
+
         it('from objects with builder FormArrays', () => {
           const c = fb.group({foo: fb.array(['bar'])});
           {
             type ControlsType = {foo: FormArray<FormControl<string|null>>};
+            let t: ControlsType = c.controls;
+            let t1 = c.controls;
+            t1 = null as unknown as ControlsType;
+          }
+        });
+      });
+    });
+
+    describe('should build FormRecords', () => {
+      it('from objects with plain values', () => {
+        const c = fb.record({foo: 'bar'});
+        {
+          type ControlsType = {[key: string]: FormControl<string|null>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+      });
+
+      it('from objects with FormControlState', () => {
+        const c = fb.record({foo: {value: 'bar', disabled: false}});
+        {
+          type ControlsType = {[key: string]: FormControl<string|null>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+      });
+
+      it('from objects with ControlConfigs', () => {
+        const c = fb.record({foo: ['bar']});
+        {
+          type ControlsType = {[key: string]: FormControl<string|null>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+      });
+
+      it('from objects with ControlConfigs and validators', () => {
+        const c = fb.record({foo: ['bar', Validators.required]});
+        {
+          type ControlsType = {[key: string]: FormControl<string|null>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+      });
+
+      it('from objects with ControlConfigs and validator lists', () => {
+        const c = fb.record({foo: ['bar', [Validators.required, Validators.email]]});
+        {
+          type ControlsType = {[key: string]: FormControl<string|null>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+      });
+
+      it('from objects with ControlConfigs and explicit types', () => {
+        const c: FormRecord<FormControl<string|null>> =
+            fb.record({foo: ['bar', [Validators.required, Validators.email]]});
+        {
+          type ControlsType = {[key: string]: FormControl<string|null>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+      });
+
+      describe('from objects with FormControls', () => {
+        it('nullably', () => {
+          const c = fb.record({foo: new FormControl('bar')});
+          {
+            type ControlsType = {[key: string]: FormControl<string|null>};
+            let t: ControlsType = c.controls;
+            let t1 = c.controls;
+            t1 = null as unknown as ControlsType;
+          }
+        });
+
+        it('non-nullably', () => {
+          const c = fb.record({foo: new FormControl('bar', {nonNullable: true})});
+          {
+            type ControlsType = {[key: string]: FormControl<string>};
+            let t: ControlsType = c.controls;
+            let t1 = c.controls;
+            t1 = null as unknown as ControlsType;
+          }
+        });
+
+        it('from objects with builder FormGroups', () => {
+          const c = fb.record({foo: fb.group({baz: 'bar'})});
+          {
+            type ControlsType = {[key: string]: FormGroup<{baz: FormControl<string|null>}>};
+            let t: ControlsType = c.controls;
+            let t1 = c.controls;
+            t1 = null as unknown as ControlsType;
+          }
+        });
+
+        it('from objects with builder FormRecords', () => {
+          const c = fb.record({foo: fb.record({baz: 'bar'})});
+          {
+            type ControlsType = {[key: string]: FormRecord<FormControl<string|null>>};
+            let t: ControlsType = c.controls;
+            let t1 = c.controls;
+            t1 = null as unknown as ControlsType;
+          }
+        });
+
+        it('from objects with builder FormArrays', () => {
+          const c = fb.record({foo: fb.array(['bar'])});
+          {
+            type ControlsType = {[key: string]: FormArray<FormControl<string|null>>};
             let t: ControlsType = c.controls;
             let t1 = c.controls;
             t1 = null as unknown as ControlsType;
@@ -1221,6 +1346,16 @@ describe('Typed Class', () => {
         const c = fb.array([fb.group({bar: 'foo'})]);
         {
           type ControlsType = Array<FormGroup<{bar: FormControl<string|null>}>>;
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+      });
+
+      it('from arrays with builder FormRecords', () => {
+        const c = fb.array([fb.record({bar: 'foo'})]);
+        {
+          type ControlsType = Array<FormRecord<FormControl<string|null>>>;
           let t: ControlsType = c.controls;
           let t1 = c.controls;
           t1 = null as unknown as ControlsType;

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, DOCUMENT, XhrFactory, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {APP_ID, ApplicationModule, ApplicationRef, createPlatformFactory, ErrorHandler, ImportedNgModuleProviders, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalBootstrapApplication as internalBootstrapApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
+import {APP_ID, ApplicationModule, ApplicationRef, createPlatformFactory, ErrorHandler, ImportedNgModuleProviders, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalCreateApplication as internalCreateApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
 import {SERVER_TRANSITION_PROVIDERS, TRANSITION_ID} from './browser/server-transition';
@@ -22,7 +22,7 @@ import {DomSharedStylesHost, SharedStylesHost} from './dom/shared_styles_host';
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 
 /**
- * Set of config options available during the bootstrap operation via `bootstrapApplication` call.
+ * Set of config options available during the application bootstrap operation.
  *
  * @developerPreview
  * @publicApi
@@ -96,14 +96,34 @@ export interface ApplicationConfig {
  */
 export function bootstrapApplication(
     rootComponent: Type<unknown>, options?: ApplicationConfig): Promise<ApplicationRef> {
-  return internalBootstrapApplication({
-    rootComponent,
+  return internalCreateApplication({rootComponent, ...createProvidersConfig(options)});
+}
+
+/**
+ * Create an instance of an Angular application without bootstrapping any components. This is useful
+ * for the situation where one wants to decouple application environment creation (a platform and
+ * associated injectors) from rendering components on a screen. Components can be subsequently
+ * bootstrapped on the returned `ApplicationRef`.
+ *
+ * @param options Extra configuration for the application environment, see `ApplicationConfig` for
+ *     additional info.
+ * @returns A promise that returns an `ApplicationRef` instance once resolved.
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export function createApplication(options?: ApplicationConfig) {
+  return internalCreateApplication(createProvidersConfig(options));
+}
+
+function createProvidersConfig(options?: ApplicationConfig) {
+  return {
     appProviders: [
       ...BROWSER_MODULE_PROVIDERS,
       ...(options?.providers ?? []),
     ],
-    platformProviders: INTERNAL_BROWSER_PLATFORM_PROVIDERS,
-  });
+    platformProviders: INTERNAL_BROWSER_PLATFORM_PROVIDERS
+  };
 }
 
 /**

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {ApplicationConfig, bootstrapApplication, BrowserModule, platformBrowser, provideProtractorTestingSupport} from './browser';
+export {ApplicationConfig, bootstrapApplication, BrowserModule, createApplication, platformBrowser, provideProtractorTestingSupport} from './browser';
 export {Meta, MetaDefinition} from './browser/meta';
 export {Title} from './browser/title';
 export {disableDebugTools, enableDebugTools} from './browser/tools/tools';

--- a/packages/platform-browser/test/dom/events/key_events_spec.ts
+++ b/packages/platform-browser/test/dom/events/key_events_spec.ts
@@ -10,12 +10,6 @@ import {KeyEventsPlugin} from '@angular/platform-browser/src/dom/events/key_even
 
 {
   describe('KeyEventsPlugin', () => {
-    if (isNode) {
-      // Jasmine will throw if there are no tests.
-      it('should pass', () => {});
-      return;
-    }
-
     it('should ignore unrecognized events', () => {
       expect(KeyEventsPlugin.parseEventName('keydown')).toEqual(null);
       expect(KeyEventsPlugin.parseEventName('keyup')).toEqual(null);
@@ -54,20 +48,373 @@ import {KeyEventsPlugin} from '@angular/platform-browser/src/dom/events/key_even
           .toEqual({'domEventName': 'keydown', 'fullKey': 'control.shift'});
       expect(KeyEventsPlugin.parseEventName('keyup.control.shift'))
           .toEqual({'domEventName': 'keyup', 'fullKey': 'control.shift'});
+
+      // key code ordering
+      expect(KeyEventsPlugin.parseEventName('keyup.code.control.shift'))
+          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift'});
+      expect(KeyEventsPlugin.parseEventName('keyup.control.code.shift'))
+          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift'});
+      // capitalization gets lowercased
+      expect(KeyEventsPlugin.parseEventName('keyup.control.code.shift.KeyS'))
+          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift.keys'});
+      // user provided order of `code.` does not matter
+      expect(KeyEventsPlugin.parseEventName('keyup.control.shift.code.KeyS'))
+          .toEqual({'domEventName': 'keyup', 'fullKey': 'code.control.shift.keys'});
+      // except for putting `code` at the end
+      expect(KeyEventsPlugin.parseEventName('keyup.control.shift.KeyS.code')).toBeNull();
     });
 
     it('should alias esc to escape', () => {
       expect(KeyEventsPlugin.parseEventName('keyup.control.esc'))
           .toEqual(KeyEventsPlugin.parseEventName('keyup.control.escape'));
+      expect(KeyEventsPlugin.parseEventName('keyup.control.Esc'))
+          .toEqual(KeyEventsPlugin.parseEventName('keyup.control.escape'));
     });
 
-    it('should implement addGlobalEventListener', () => {
-      const plugin = new KeyEventsPlugin(document);
+    if (!isNode) {
+      it('should implement addGlobalEventListener', () => {
+        const plugin = new KeyEventsPlugin(document);
 
-      spyOn(plugin, 'addEventListener').and.callFake(() => () => {});
+        spyOn(plugin, 'addEventListener').and.callFake(() => () => {});
 
-      expect(() => plugin.addGlobalEventListener('window', 'keyup.control.esc', () => {}))
-          .not.toThrowError();
+        expect(() => plugin.addGlobalEventListener('window', 'keyup.control.esc', () => {}))
+            .not.toThrowError();
+      });
+    }
+
+    it('should match key field', () => {
+      const baseKeyboardEvent = {
+        isTrusted: true,
+        bubbles: true,
+        cancelBubble: false,
+        cancelable: true,
+        composed: true,
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        type: 'keydown'
+      };
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
+                 'alt.ß'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'S', code: 'KeyS', altKey: true}),
+                 'alt.s'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'F', code: 'KeyF', metaKey: true}),
+                 'meta.f'))
+          .toBeTruthy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'ArrowUp', code: 'ArrowUp'}),
+              'arrowup'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'ArrowDown', code: 'ArrowDown'}),
+                 'arrowdown'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}), 'a'))
+          .toBeTruthy();
+
+      // special characters
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Esc', code: 'Escape'}),
+                 'escape'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\x1B', code: 'Escape'}),
+                 'escape'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\b', code: 'Backspace'}),
+                 'backspace'))
+          .toBeTruthy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\t', code: 'Tab'}), 'tab'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Del', code: 'Delete'}),
+                 'delete'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: '\x7F', code: 'Delete'}),
+                 'delete'))
+          .toBeTruthy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Left', code: 'ArrowLeft'}),
+              'arrowleft'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'Right', code: 'ArrowRight'}),
+                 'arrowright'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Up', code: 'ArrowUp'}),
+                 'arrowup'))
+          .toBeTruthy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Down', code: 'ArrowDown'}),
+              'arrowdown'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'Menu', code: 'ContextMenu'}),
+                 'contextmenu'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'Scroll', code: 'ScrollLock'}),
+                 'scrolllock'))
+          .toBeTruthy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Win', code: 'OS'}), 'os'))
+          .toBeTruthy();
+    });
+
+    it('should match code field', () => {
+      const baseKeyboardEvent = {
+        isTrusted: true,
+        bubbles: true,
+        cancelBubble: false,
+        cancelable: true,
+        composed: true,
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        type: 'keydown'
+      };
+      // Windows
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 's', code: 'KeyS', altKey: true}),
+                 'code.alt.keys'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 's', code: 'KeyS', altKey: true}),
+                 'alt.s'))
+          .toBeTruthy();
+
+      // MacOS
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
+                 'code.alt.keys'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'ß', code: 'KeyS', altKey: true}),
+                 'alt.s'))
+          .toBeFalsy();
+
+      // Arrow Keys
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'ArrowUp', code: 'ArrowUp'}),
+              'code.arrowup'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown', {...baseKeyboardEvent, key: 'ArrowDown', code: 'ArrowDown'}),
+                 'arrowdown'))
+          .toBeTruthy();
+
+      // Basic key match
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}), 'a'))
+          .toBeTruthy();
+
+      // Basic code match
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}),
+                 'code.a'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'A', code: 'KeyA'}),
+                 'code.keya'))
+          .toBeTruthy();
+
+      // basic special key
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Shift', code: 'LeftShift'}),
+              'code.shift'))
+          .toBeFalsy();
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, key: 'Shift', code: 'LeftShift'}),
+              'code.leftshift'))
+          .toBeTruthy();
+
+      // combination keys with code match
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'AltLeft',
+                   shiftKey: true,
+                   altKey: true
+                 }),
+                 'code.alt.shift.altleft'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'AltLeft',
+                   shiftKey: true,
+                   altKey: true
+                 }),
+                 'code.shift.altleft'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Meta',
+                   code: 'MetaLeft',
+                   shiftKey: true,
+                   metaKey: true
+                 }),
+                 'code.meta.shift.metaleft'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'MetaLeft',
+                   shiftKey: true,
+                   metaKey: true
+                 }),
+                 'code.shift.meta'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown',
+                     {...baseKeyboardEvent, key: 'S', code: 'KeyS', shiftKey: true, metaKey: true}),
+                 'code.meta.shift.keys'))
+          .toBeTruthy();
+
+      // combination keys without code match
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'AltLeft',
+                   shiftKey: true,
+                   altKey: true
+                 }),
+                 'shift.alt'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Meta',
+                   code: 'MetaLeft',
+                   shiftKey: true,
+                   metaKey: true
+                 }),
+                 'shift.meta'))
+          .toBeTruthy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent(
+                     'keydown',
+                     {...baseKeyboardEvent, key: 'S', code: 'KeyS', shiftKey: true, metaKey: true}),
+                 'meta.shift.s'))
+          .toBeTruthy();
+
+      // OS mismatch
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Meta',
+                   code: 'MetaLeft',
+                   shiftKey: true,
+                   metaKey: true
+                 }),
+                 'shift.alt'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'AltLeft',
+                   shiftKey: true,
+                   altKey: true
+                 }),
+                 'shift.meta'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Meta',
+                   code: 'MetaLeft',
+                   shiftKey: true,
+                   metaKey: true
+                 }),
+                 'code.shift.altleft'))
+          .toBeFalsy();
+      expect(KeyEventsPlugin.matchEventFullKeyCode(
+                 new KeyboardEvent('keydown', {
+                   ...baseKeyboardEvent,
+                   key: 'Alt',
+                   code: 'AltLeft',
+                   shiftKey: true,
+                   altKey: true
+                 }),
+                 'code.shift.metaleft'))
+          .toBeFalsy();
+
+      // special key character cases
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent(
+                  'keydown',
+                  {...baseKeyboardEvent, key: ' ', code: 'Space', shiftKey: false, altKey: false}),
+              'space'))
+          .toBeTruthy();
+
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent(
+                  'keydown',
+                  {...baseKeyboardEvent, key: '.', code: 'Period', shiftKey: false, altKey: false}),
+              'dot'))
+          .toBeTruthy();
+    });
+
+    // unidentified key
+    it('should return false when key is unidentified', () => {
+      const baseKeyboardEvent = {
+        isTrusted: true,
+        bubbles: true,
+        cancelBubble: false,
+        cancelable: true,
+        composed: true,
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        type: 'keydown'
+      };
+      expect(
+          KeyEventsPlugin.matchEventFullKeyCode(
+              new KeyboardEvent('keydown', {...baseKeyboardEvent, shiftKey: false, altKey: false}),
+              ''))
+          .toBeFalsy();
     });
   });
 }

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ImportedNgModuleProviders, importProvidersFrom, NgModuleFactory, NgModuleRef, PlatformRef, Provider, StaticProvider, Type, ɵinternalBootstrapApplication as internalBootstrapApplication, ɵisPromise} from '@angular/core';
+import {ApplicationRef, ImportedNgModuleProviders, importProvidersFrom, NgModuleFactory, NgModuleRef, PlatformRef, Provider, StaticProvider, Type, ɵinternalCreateApplication as internalCreateApplication, ɵisPromise} from '@angular/core';
 import {BrowserModule, ɵTRANSITION_ID} from '@angular/platform-browser';
 import {first} from 'rxjs/operators';
 
@@ -152,7 +152,7 @@ export function renderApplication<T>(rootComponent: Type<T>, options: {
     importProvidersFrom(ServerModule),
     ...(options.providers ?? []),
   ];
-  return _render(platform, internalBootstrapApplication({rootComponent, appProviders}));
+  return _render(platform, internalCreateApplication({rootComponent, appProviders}));
 }
 
 /**

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -740,7 +740,8 @@ describe('platform-server integration', () => {
 
     // Run the set of tests with regular and standalone components.
     [true, false].forEach((isStandalone: boolean) => {
-      it('using renderModule should work', waitForAsync(() => {
+      it(`using ${isStandalone ? 'renderApplication' : 'renderModule'} should work`,
+         waitForAsync(() => {
            const options = {document: doc};
            const bootstrap = isStandalone ?
                renderApplication(MyAsyncServerAppStandalone, {...options, appId: 'simple-cmp'}) :

--- a/packages/router/src/page_title_strategy.ts
+++ b/packages/router/src/page_title_strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Injectable} from '@angular/core';
+import {inject, Injectable} from '@angular/core';
 import {Title} from '@angular/platform-browser';
 
 import {RouteTitle as TitleKey} from './operators/resolve_data';
@@ -36,6 +36,7 @@ import {PRIMARY_OUTLET} from './shared';
  * @publicApi
  * @see [Page title guide](guide/router#setting-the-page-title)
  */
+@Injectable({providedIn: 'root', useFactory: () => inject(DefaultTitleStrategy)})
 export abstract class TitleStrategy {
   /** Performs the application title update. */
   abstract updateTitle(snapshot: RouterStateSnapshot): void;

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -18,7 +18,7 @@ import {RouterOutlet} from './directives/router_outlet';
 import {RuntimeErrorCode} from './errors';
 import {Event, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, stringifyEvent} from './events';
 import {Route, Routes} from './models';
-import {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
+import {TitleStrategy} from './page_title_strategy';
 import {RouteReuseStrategy} from './route_reuse_strategy';
 import {ErrorHandler, Router} from './router';
 import {RouterConfigLoader, ROUTES} from './router_config_loader';
@@ -64,9 +64,9 @@ export const ROUTER_PROVIDERS: Provider[] = [
     provide: Router,
     useFactory: setupRouter,
     deps: [
-      UrlSerializer, ChildrenOutletContexts, Location, Injector, Compiler, ROUTES,
-      ROUTER_CONFIGURATION, DefaultTitleStrategy, [TitleStrategy, new Optional()],
-      [UrlHandlingStrategy, new Optional()], [RouteReuseStrategy, new Optional()]
+      UrlSerializer, ChildrenOutletContexts, Location, Injector, Compiler, ROUTES, TitleStrategy,
+      ROUTER_CONFIGURATION, [UrlHandlingStrategy, new Optional()],
+      [RouteReuseStrategy, new Optional()]
     ]
   },
   ChildrenOutletContexts,
@@ -465,9 +465,9 @@ export interface ExtraOptions {
 
 export function setupRouter(
     urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
-    injector: Injector, compiler: Compiler, config: Route[][], opts: ExtraOptions = {},
-    defaultTitleStrategy: DefaultTitleStrategy, titleStrategy?: TitleStrategy,
-    urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy) {
+    injector: Injector, compiler: Compiler, config: Route[][], titleStrategy: TitleStrategy,
+    opts: ExtraOptions = {}, urlHandlingStrategy?: UrlHandlingStrategy,
+    routeReuseStrategy?: RouteReuseStrategy) {
   const router =
       new Router(null, urlSerializer, contexts, location, injector, compiler, flatten(config));
 
@@ -479,7 +479,7 @@ export function setupRouter(
     router.routeReuseStrategy = routeReuseStrategy;
   }
 
-  router.titleStrategy = titleStrategy ?? defaultTitleStrategy;
+  router.titleStrategy = titleStrategy;
 
   assignExtraOptionsToRouter(opts, router);
 

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -391,7 +391,7 @@ describe('bootstrap', () => {
      });
 
 
-  it('should restore the scrolling position', async (done) => {
+  it('should restore the scrolling position', async () => {
     @Component({
       selector: 'component-a',
       template: `
@@ -456,7 +456,6 @@ describe('bootstrap', () => {
     await router.navigateByUrl('/aa#marker3');
     expect(window.pageYOffset).toBeGreaterThanOrEqual(8900);
     expect(window.pageYOffset).toBeLessThan(9000);
-    done();
   });
 
   it('should cleanup "popstate" and "hashchange" listeners', async () => {
@@ -486,7 +485,7 @@ describe('bootstrap', () => {
     expect(window.removeEventListener).toHaveBeenCalledWith('hashchange', jasmine.any(Function));
   });
 
-  it('can schedule a navigation from the NavigationEnd event #37460', async (done) => {
+  it('can schedule a navigation from the NavigationEnd event #37460', (done) => {
     @NgModule({
       imports: [
         BrowserModule,
@@ -504,17 +503,19 @@ describe('bootstrap', () => {
     class TestModule {
     }
 
-    const res = await platformBrowserDynamic([]).bootstrapModule(TestModule);
-    const router = res.injector.get(Router);
-    router.events.subscribe(() => {
-      expect(router.getCurrentNavigation()?.id).toBeDefined();
-    });
-    router.events.subscribe(async (e) => {
-      if (e instanceof NavigationEnd && e.url === '/b') {
-        await router.navigate(['a']);
-        done();
-      }
-    });
-    await router.navigateByUrl('/b');
+    (async () => {
+      const res = await platformBrowserDynamic([]).bootstrapModule(TestModule);
+      const router = res.injector.get(Router);
+      router.events.subscribe(() => {
+        expect(router.getCurrentNavigation()?.id).toBeDefined();
+      });
+      router.events.subscribe(async (e) => {
+        if (e instanceof NavigationEnd && e.url === '/b') {
+          await router.navigate(['a']);
+          done();
+        }
+      });
+      await router.navigateByUrl('/b');
+    })();
   });
 });

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -9,7 +9,7 @@
 import {Location, LocationStrategy} from '@angular/common';
 import {MockLocationStrategy, SpyLocation} from '@angular/common/testing';
 import {Compiler, Injector, ModuleWithProviders, NgModule, Optional} from '@angular/core';
-import {ChildrenOutletContexts, DefaultTitleStrategy, ExtraOptions, NoPreloading, PreloadingStrategy, provideRoutes, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, TitleStrategy, UrlHandlingStrategy, UrlSerializer, ɵassignExtraOptionsToRouter as assignExtraOptionsToRouter, ɵflatten as flatten, ɵprovidePreloading as providePreloading, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS} from '@angular/router';
+import {ChildrenOutletContexts, ExtraOptions, NoPreloading, provideRoutes, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, TitleStrategy, UrlHandlingStrategy, UrlSerializer, ɵassignExtraOptionsToRouter as assignExtraOptionsToRouter, ɵflatten as flatten, ɵprovidePreloading as providePreloading, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS} from '@angular/router';
 
 import {EXTRA_ROUTER_TESTING_PROVIDERS} from './extra_router_testing_providers';
 
@@ -25,14 +25,20 @@ function isUrlHandlingStrategy(opts: ExtraOptions|
  * marked as publicApi cleaner (i.e. not having _both_ `TitleStrategy` and `DefaultTitleStrategy`).
  */
 export function setupTestingRouterInternal(
-    urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
-    compiler: Compiler, injector: Injector, routes: Route[][],
-    opts?: ExtraOptions|UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy,
-    routeReuseStrategy?: RouteReuseStrategy, defaultTitleStrategy?: DefaultTitleStrategy,
-    titleStrategy?: TitleStrategy) {
+    urlSerializer: UrlSerializer,
+    contexts: ChildrenOutletContexts,
+    location: Location,
+    compiler: Compiler,
+    injector: Injector,
+    routes: Route[][],
+    titleStrategy: TitleStrategy,
+    opts?: ExtraOptions|UrlHandlingStrategy,
+    urlHandlingStrategy?: UrlHandlingStrategy,
+    routeReuseStrategy?: RouteReuseStrategy,
+) {
   return setupTestingRouter(
       urlSerializer, contexts, location, compiler, injector, routes, opts, urlHandlingStrategy,
-      routeReuseStrategy, titleStrategy ?? defaultTitleStrategy);
+      routeReuseStrategy, titleStrategy);
 }
 
 /**
@@ -112,11 +118,10 @@ export function setupTestingRouter(
         Compiler,
         Injector,
         ROUTES,
+        TitleStrategy,
         ROUTER_CONFIGURATION,
         [UrlHandlingStrategy, new Optional()],
         [RouteReuseStrategy, new Optional()],
-        [DefaultTitleStrategy, new Optional()],
-        [TitleStrategy, new Optional()],
       ]
     },
     providePreloading(NoPreloading),

--- a/packages/zone.js/lib/jasmine/jasmine.ts
+++ b/packages/zone.js/lib/jasmine/jasmine.ts
@@ -349,7 +349,6 @@ Zone.__load_patch('jasmine', (global: any, Zone: ZoneType, api: _ZonePrivate) =>
       this.testProxyZoneSpec = new ProxyZoneSpec();
       this.testProxyZone = ambientZone.fork(this.testProxyZoneSpec);
       if (!Zone.currentTask) {
-        console.error('Scheduling', context, Zone.current.name)
         // if we are not running in a task then if someone would register a
         // element.addEventListener and then calling element.click() the
         // addEventListener callback would think that it is the top most task and would

--- a/packages/zone.js/lib/zone-spec/sync-test.ts
+++ b/packages/zone.js/lib/zone-spec/sync-test.ts
@@ -21,7 +21,7 @@ class SyncTestZoneSpec implements ZoneSpec {
     switch (task.type) {
       case 'microTask':
       case 'macroTask':
-        throw new Error(`Cannot call ${task.source} from within a sync test.`);
+        throw new Error(`Cannot call ${task.source} from within a sync test (${this.name}).`);
       case 'eventTask':
         task = delegate.scheduleTask(target, task);
         break;

--- a/packages/zone.js/test/browser/FileReader.spec.ts
+++ b/packages/zone.js/test/browser/FileReader.spec.ts
@@ -13,7 +13,6 @@ describe('FileReader', ifEnvSupports('FileReader', function() {
            let fileReader: FileReader;
            let blob: Blob;
            const data = 'Hello, World!';
-           const testZone = Zone.current.fork({name: 'TestZone'});
 
            // Android 4.3's native browser doesn't implement add/RemoveEventListener for FileReader
            function supportsEventTargetFns() {
@@ -39,6 +38,8 @@ describe('FileReader', ifEnvSupports('FileReader', function() {
 
            describe('EventTarget methods', ifEnvSupports(supportsEventTargetFns, function() {
                       it('should bind addEventListener listeners', function(done) {
+                        const testZone = Zone.current.fork({name: 'TestZone'});
+
                         testZone.run(function() {
                           fileReader.addEventListener('load', function() {
                             expect(Zone.current).toBe(testZone);
@@ -51,6 +52,7 @@ describe('FileReader', ifEnvSupports('FileReader', function() {
                       });
 
                       it('should remove listeners via removeEventListener', function(done) {
+                        const testZone = Zone.current.fork({name: 'TestZone'});
                         const listenerSpy = jasmine.createSpy('listener');
 
                         testZone.run(function() {
@@ -67,6 +69,7 @@ describe('FileReader', ifEnvSupports('FileReader', function() {
                     }));
 
            it('should bind onEventType listeners', function(done) {
+             const testZone = Zone.current.fork({name: 'TestZone'});
              let listenersCalled = 0;
 
              testZone.run(function() {

--- a/packages/zone.js/test/browser/HTMLImports.spec.ts
+++ b/packages/zone.js/test/browser/HTMLImports.spec.ts
@@ -11,69 +11,70 @@ import {ifEnvSupports} from '../test-util';
 function supportsImports() {
   return 'import' in document.createElement('link');
 }
-(<any>supportsImports).message = 'HTML Imports';
 
-describe('HTML Imports', ifEnvSupports(supportsImports, function() {
-           const testZone = Zone.current.fork({name: 'test'});
+if (supportsImports()) {
+  describe('HTML Imports', function() {
+    const testZone = Zone.current.fork({name: 'test'});
 
-           it('should work with addEventListener', function(done) {
-             let link: HTMLLinkElement;
+    it('should work with addEventListener', function(done) {
+      let link: HTMLLinkElement;
 
-             testZone.run(function() {
-               link = document.createElement('link');
-               link.rel = 'import';
-               link.href = 'someUrl';
-               link.addEventListener('error', function() {
-                 expect(Zone.current).toBe(testZone);
-                 document.head.removeChild(link);
-                 done();
-               });
-             });
+      testZone.run(function() {
+        link = document.createElement('link');
+        link.rel = 'import';
+        link.href = 'someUrl';
+        link.addEventListener('error', function() {
+          expect(Zone.current).toBe(testZone);
+          document.head.removeChild(link);
+          done();
+        });
+      });
 
-             document.head.appendChild(link!);
-           });
+      document.head.appendChild(link!);
+    });
 
-           function supportsOnEvents() {
-             const link = document.createElement('link');
-             const linkPropDesc = Object.getOwnPropertyDescriptor(link, 'onerror');
-             return !(linkPropDesc && linkPropDesc.value === null);
-           }
-           (<any>supportsOnEvents).message = 'Supports HTMLLinkElement#onxxx patching';
+    function supportsOnEvents() {
+      const link = document.createElement('link');
+      const linkPropDesc = Object.getOwnPropertyDescriptor(link, 'onerror');
+      return !(linkPropDesc && linkPropDesc.value === null);
+    }
+    (<any>supportsOnEvents).message = 'Supports HTMLLinkElement#onxxx patching';
 
 
-           ifEnvSupports(supportsOnEvents, function() {
-             it('should work with onerror', function(done) {
-               let link: HTMLLinkElement;
+    ifEnvSupports(supportsOnEvents, function() {
+      it('should work with onerror', function(done) {
+        let link: HTMLLinkElement;
 
-               testZone.run(function() {
-                 link = document.createElement('link');
-                 link.rel = 'import';
-                 link.href = 'anotherUrl';
-                 link.onerror = function() {
-                   expect(Zone.current).toBe(testZone);
-                   document.head.removeChild(link);
-                   done();
-                 };
-               });
+        testZone.run(function() {
+          link = document.createElement('link');
+          link.rel = 'import';
+          link.href = 'anotherUrl';
+          link.onerror = function() {
+            expect(Zone.current).toBe(testZone);
+            document.head.removeChild(link);
+            done();
+          };
+        });
 
-               document.head.appendChild(link!);
-             });
+        document.head.appendChild(link!);
+      });
 
-             it('should work with onload', function(done) {
-               let link: HTMLLinkElement;
+      it('should work with onload', function(done) {
+        let link: HTMLLinkElement;
 
-               testZone.run(function() {
-                 link = document.createElement('link');
-                 link.rel = 'import';
-                 link.href = '/base/angular/packages/zone.js/test/assets/import.html';
-                 link.onload = function() {
-                   expect(Zone.current).toBe(testZone);
-                   document.head.removeChild(link);
-                   done();
-                 };
-               });
+        testZone.run(function() {
+          link = document.createElement('link');
+          link.rel = 'import';
+          link.href = '/base/angular/packages/zone.js/test/assets/import.html';
+          link.onload = function() {
+            expect(Zone.current).toBe(testZone);
+            document.head.removeChild(link);
+            done();
+          };
+        });
 
-               document.head.appendChild(link!);
-             });
-           });
-         }));
+        document.head.appendChild(link!);
+      });
+    });
+  });
+}

--- a/packages/zone.js/test/browser/MutationObserver.spec.ts
+++ b/packages/zone.js/test/browser/MutationObserver.spec.ts
@@ -12,13 +12,13 @@ declare const global: any;
 
 describe('MutationObserver', ifEnvSupports('MutationObserver', function() {
            let elt: HTMLDivElement;
-           const testZone = Zone.current.fork({name: 'test'});
 
            beforeEach(function() {
              elt = document.createElement('div');
            });
 
            it('should run observers within the zone', function(done) {
+             const testZone = Zone.current.fork({name: 'test'});
              let ob;
 
              testZone.run(function() {
@@ -54,9 +54,8 @@ describe('MutationObserver', ifEnvSupports('MutationObserver', function() {
          }));
 
 describe('WebKitMutationObserver', ifEnvSupports('WebKitMutationObserver', function() {
-           const testZone = Zone.current.fork({name: 'test'});
-
            it('should run observers within the zone', function(done) {
+             const testZone = Zone.current.fork({name: 'test'});
              let elt: HTMLDivElement;
 
              testZone.run(function() {

--- a/packages/zone.js/test/browser/XMLHttpRequest.spec.ts
+++ b/packages/zone.js/test/browser/XMLHttpRequest.spec.ts
@@ -334,15 +334,25 @@ describe('XMLHttpRequest', function() {
      function(done) {
        testZone.run(function() {
          const req = new XMLHttpRequest();
+
          req.open('get', '/', true);
          req.send();
+
+         let count = 0;
          const listener = function(ev: any) {
            if (req.readyState >= 2) {
+             const isInitial = count++ === 0;
+
              expect(() => {
+               // this triggers a synchronous dispatch of the state change event.
                req.abort();
              }).not.toThrow();
+
              req.removeEventListener('readystatechange', listener);
-             done();
+
+             if (isInitial) {
+               done();
+             }
            }
          };
          req.addEventListener('readystatechange', listener);

--- a/packages/zone.js/test/browser/browser.spec.ts
+++ b/packages/zone.js/test/browser/browser.spec.ts
@@ -3398,145 +3398,140 @@ describe('Zone', function() {
   });
 
 
-  describe(
-      'pointer event in IE',
-      ifEnvSupports(
-          () => {
-            return getIEVersion() === 11;
-          },
-          () => {
-            const pointerEventsMap: {[key: string]: string} = {
-              'MSPointerCancel': 'pointercancel',
-              'MSPointerDown': 'pointerdown',
-              'MSPointerEnter': 'pointerenter',
-              'MSPointerHover': 'pointerhover',
-              'MSPointerLeave': 'pointerleave',
-              'MSPointerMove': 'pointermove',
-              'MSPointerOut': 'pointerout',
-              'MSPointerOver': 'pointerover',
-              'MSPointerUp': 'pointerup'
-            };
+  if (getIEVersion() === 11) {
+    describe('pointer event in IE', () => {
+      const pointerEventsMap: {[key: string]: string} = {
+        'MSPointerCancel': 'pointercancel',
+        'MSPointerDown': 'pointerdown',
+        'MSPointerEnter': 'pointerenter',
+        'MSPointerHover': 'pointerhover',
+        'MSPointerLeave': 'pointerleave',
+        'MSPointerMove': 'pointermove',
+        'MSPointerOut': 'pointerout',
+        'MSPointerOver': 'pointerover',
+        'MSPointerUp': 'pointerup'
+      };
 
-            let div: HTMLDivElement;
-            beforeEach(() => {
-              div = document.createElement('div');
-              document.body.appendChild(div);
-            });
-            afterEach(() => {
-              document.body.removeChild(div);
-            });
-            Object.keys(pointerEventsMap).forEach(key => {
-              it(`${key} and ${pointerEventsMap[key]} should both be triggered`, (done: DoneFn) => {
-                const logs: string[] = [];
-                div.addEventListener(key, (event: any) => {
-                  expect(event.type).toEqual(pointerEventsMap[key]);
-                  logs.push(`${key} triggered`);
-                });
-                div.addEventListener(pointerEventsMap[key], (event: any) => {
-                  expect(event.type).toEqual(pointerEventsMap[key]);
-                  logs.push(`${pointerEventsMap[key]} triggered`);
-                });
-                const evt1 = document.createEvent('Event');
-                evt1.initEvent(key, true, true);
-                div.dispatchEvent(evt1);
+      let div: HTMLDivElement;
+      beforeEach(() => {
+        div = document.createElement('div');
+        document.body.appendChild(div);
+      });
+      afterEach(() => {
+        document.body.removeChild(div);
+      });
+      Object.keys(pointerEventsMap).forEach(key => {
+        it(`${key} and ${pointerEventsMap[key]} should both be triggered`, (done: DoneFn) => {
+          const logs: string[] = [];
+          div.addEventListener(key, (event: any) => {
+            expect(event.type).toEqual(pointerEventsMap[key]);
+            logs.push(`${key} triggered`);
+          });
+          div.addEventListener(pointerEventsMap[key], (event: any) => {
+            expect(event.type).toEqual(pointerEventsMap[key]);
+            logs.push(`${pointerEventsMap[key]} triggered`);
+          });
+          const evt1 = document.createEvent('Event');
+          evt1.initEvent(key, true, true);
+          div.dispatchEvent(evt1);
 
-                setTimeout(() => {
-                  expect(logs).toEqual([`${key} triggered`, `${pointerEventsMap[key]} triggered`]);
-                });
+          setTimeout(() => {
+            expect(logs).toEqual([`${key} triggered`, `${pointerEventsMap[key]} triggered`]);
+          });
 
-                const evt2 = document.createEvent('Event');
-                evt2.initEvent(pointerEventsMap[key], true, true);
-                div.dispatchEvent(evt2);
+          const evt2 = document.createEvent('Event');
+          evt2.initEvent(pointerEventsMap[key], true, true);
+          div.dispatchEvent(evt2);
 
-                setTimeout(() => {
-                  expect(logs).toEqual([`${key} triggered`, `${pointerEventsMap[key]} triggered`]);
-                });
+          setTimeout(() => {
+            expect(logs).toEqual([`${key} triggered`, `${pointerEventsMap[key]} triggered`]);
+          });
 
-                setTimeout(done);
-              });
+          setTimeout(done);
+        });
 
-              it(`${key} and ${
-                     pointerEventsMap[key]} with same listener should not be triggered twice`,
-                 (done: DoneFn) => {
-                   const logs: string[] = [];
-                   const listener = function(event: any) {
-                     expect(event.type).toEqual(pointerEventsMap[key]);
-                     logs.push(`${key} triggered`);
-                   };
-                   div.addEventListener(key, listener);
-                   div.addEventListener(pointerEventsMap[key], listener);
+        it(`${key} and ${pointerEventsMap[key]} with same listener should not be triggered twice`,
+           (done: DoneFn) => {
+             const logs: string[] = [];
+             const listener = function(event: any) {
+               expect(event.type).toEqual(pointerEventsMap[key]);
+               logs.push(`${key} triggered`);
+             };
+             div.addEventListener(key, listener);
+             div.addEventListener(pointerEventsMap[key], listener);
 
-                   const evt1 = document.createEvent('Event');
-                   evt1.initEvent(key, true, true);
-                   div.dispatchEvent(evt1);
+             const evt1 = document.createEvent('Event');
+             evt1.initEvent(key, true, true);
+             div.dispatchEvent(evt1);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([`${key} triggered`]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([`${key} triggered`]);
+             });
 
-                   const evt2 = document.createEvent('Event');
-                   evt2.initEvent(pointerEventsMap[key], true, true);
-                   div.dispatchEvent(evt2);
+             const evt2 = document.createEvent('Event');
+             evt2.initEvent(pointerEventsMap[key], true, true);
+             div.dispatchEvent(evt2);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([`${pointerEventsMap[key]} triggered`]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([`${pointerEventsMap[key]} triggered`]);
+             });
 
-                   setTimeout(done);
-                 });
+             setTimeout(done);
+           });
 
-              it(`${key} and ${
-                     pointerEventsMap[key]} should be able to be removed with removeEventListener`,
-                 (done: DoneFn) => {
-                   const logs: string[] = [];
-                   const listener1 = function(event: any) {
-                     logs.push(`${key} triggered`);
-                   };
-                   const listener2 = function(event: any) {
-                     logs.push(`${pointerEventsMap[key]} triggered`);
-                   };
-                   div.addEventListener(key, listener1);
-                   div.addEventListener(pointerEventsMap[key], listener2);
+        it(`${key} and ${
+               pointerEventsMap[key]} should be able to be removed with removeEventListener`,
+           (done: DoneFn) => {
+             const logs: string[] = [];
+             const listener1 = function(event: any) {
+               logs.push(`${key} triggered`);
+             };
+             const listener2 = function(event: any) {
+               logs.push(`${pointerEventsMap[key]} triggered`);
+             };
+             div.addEventListener(key, listener1);
+             div.addEventListener(pointerEventsMap[key], listener2);
 
-                   div.removeEventListener(key, listener1);
-                   div.removeEventListener(key, listener2);
+             div.removeEventListener(key, listener1);
+             div.removeEventListener(key, listener2);
 
-                   const evt1 = document.createEvent('Event');
-                   evt1.initEvent(key, true, true);
-                   div.dispatchEvent(evt1);
+             const evt1 = document.createEvent('Event');
+             evt1.initEvent(key, true, true);
+             div.dispatchEvent(evt1);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([]);
+             });
 
-                   const evt2 = document.createEvent('Event');
-                   evt2.initEvent(pointerEventsMap[key], true, true);
-                   div.dispatchEvent(evt2);
+             const evt2 = document.createEvent('Event');
+             evt2.initEvent(pointerEventsMap[key], true, true);
+             div.dispatchEvent(evt2);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([]);
+             });
 
-                   div.addEventListener(key, listener1);
-                   div.addEventListener(pointerEventsMap[key], listener2);
+             div.addEventListener(key, listener1);
+             div.addEventListener(pointerEventsMap[key], listener2);
 
-                   div.removeEventListener(pointerEventsMap[key], listener1);
-                   div.removeEventListener(pointerEventsMap[key], listener2);
+             div.removeEventListener(pointerEventsMap[key], listener1);
+             div.removeEventListener(pointerEventsMap[key], listener2);
 
-                   div.dispatchEvent(evt1);
+             div.dispatchEvent(evt1);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([]);
+             });
 
-                   div.dispatchEvent(evt2);
+             div.dispatchEvent(evt2);
 
-                   setTimeout(() => {
-                     expect(logs).toEqual([]);
-                   });
+             setTimeout(() => {
+               expect(logs).toEqual([]);
+             });
 
-                   setTimeout(done);
-                 });
-            });
-          }));
+             setTimeout(done);
+           });
+      });
+    });
+  }
 });

--- a/packages/zone.js/test/browser/registerElement.spec.ts
+++ b/packages/zone.js/test/browser/registerElement.spec.ts
@@ -11,161 +11,159 @@
  * is properly patched
  */
 
-import {ifEnvSupports} from '../test-util';
-
 function registerElement() {
   return ('registerElement' in document) && (typeof customElements === 'undefined');
 }
-(<any>registerElement).message = 'document.registerElement';
 
-describe(
-    'document.registerElement', ifEnvSupports(registerElement, function() {
-      // register a custom element for each callback
-      const callbackNames = ['created', 'attached', 'detached', 'attributeChanged'];
-      const callbacks: any = {};
-      const testZone = Zone.current.fork({name: 'test'});
-      let customElements;
+if (registerElement()) {
+  describe('document.registerElement', function() {
+    // register a custom element for each callback
+    const callbackNames = ['created', 'attached', 'detached', 'attributeChanged'];
+    const callbacks: any = {};
+    const testZone = Zone.current.fork({name: 'test'});
+    let customElements;
 
-      customElements = testZone.run(function() {
-        callbackNames.forEach(function(callbackName) {
-          const fullCallbackName = callbackName + 'Callback';
-          const proto = Object.create(HTMLElement.prototype);
-          (proto as any)[fullCallbackName] = function(arg: any) {
-            callbacks[callbackName](arg);
-          };
-          (<any>document).registerElement('x-' + callbackName.toLowerCase(), {prototype: proto});
-        });
-      });
-
-      it('should work with createdCallback', function(done) {
-        callbacks.created = function() {
-          expect(Zone.current).toBe(testZone);
-          done();
+    customElements = testZone.run(function() {
+      callbackNames.forEach(function(callbackName) {
+        const fullCallbackName = callbackName + 'Callback';
+        const proto = Object.create(HTMLElement.prototype);
+        (proto as any)[fullCallbackName] = function(arg: any) {
+          callbacks[callbackName](arg);
         };
-
-        document.createElement('x-created');
+        (<any>document).registerElement('x-' + callbackName.toLowerCase(), {prototype: proto});
       });
+    });
+
+    it('should work with createdCallback', function(done) {
+      callbacks.created = function() {
+        expect(Zone.current).toBe(testZone);
+        done();
+      };
+
+      document.createElement('x-created');
+    });
 
 
-      it('should work with attachedCallback', function(done) {
-        callbacks.attached = function() {
-          expect(Zone.current).toBe(testZone);
-          done();
-        };
+    it('should work with attachedCallback', function(done) {
+      callbacks.attached = function() {
+        expect(Zone.current).toBe(testZone);
+        done();
+      };
 
-        const elt = document.createElement('x-attached');
-        document.body.appendChild(elt);
-        document.body.removeChild(elt);
-      });
-
-
-      it('should work with detachedCallback', function(done) {
-        callbacks.detached = function() {
-          expect(Zone.current).toBe(testZone);
-          done();
-        };
-
-        const elt = document.createElement('x-detached');
-        document.body.appendChild(elt);
-        document.body.removeChild(elt);
-      });
+      const elt = document.createElement('x-attached');
+      document.body.appendChild(elt);
+      document.body.removeChild(elt);
+    });
 
 
-      it('should work with attributeChanged', function(done) {
-        callbacks.attributeChanged = function() {
-          expect(Zone.current).toBe(testZone);
-          done();
-        };
+    it('should work with detachedCallback', function(done) {
+      callbacks.detached = function() {
+        expect(Zone.current).toBe(testZone);
+        done();
+      };
 
-        const elt = document.createElement('x-attributechanged');
-        elt.id = 'bar';
-      });
+      const elt = document.createElement('x-detached');
+      document.body.appendChild(elt);
+      document.body.removeChild(elt);
+    });
 
 
-      it('should work with non-writable, non-configurable prototypes created with defineProperty',
-         function(done) {
-           testZone.run(function() {
-             const proto = Object.create(HTMLElement.prototype);
+    it('should work with attributeChanged', function(done) {
+      callbacks.attributeChanged = function() {
+        expect(Zone.current).toBe(testZone);
+        done();
+      };
 
-             Object.defineProperty(
-                 proto, 'createdCallback',
-                 <any>{writable: false, configurable: false, value: checkZone});
+      const elt = document.createElement('x-attributechanged');
+      elt.id = 'bar';
+    });
 
-             (<any>document).registerElement('x-prop-desc', {prototype: proto});
 
-             function checkZone() {
-               expect(Zone.current).toBe(testZone);
-               done();
+    it('should work with non-writable, non-configurable prototypes created with defineProperty',
+       function(done) {
+         testZone.run(function() {
+           const proto = Object.create(HTMLElement.prototype);
+
+           Object.defineProperty(
+               proto, 'createdCallback',
+               <any>{writable: false, configurable: false, value: checkZone});
+
+           (<any>document).registerElement('x-prop-desc', {prototype: proto});
+
+           function checkZone() {
+             expect(Zone.current).toBe(testZone);
+             done();
+           }
+         });
+
+         const elt = document.createElement('x-prop-desc');
+       });
+
+
+    it('should work with non-writable, non-configurable prototypes created with defineProperties',
+       function(done) {
+         testZone.run(function() {
+           const proto = Object.create(HTMLElement.prototype);
+
+           Object.defineProperties(proto, {
+             createdCallback: <any> {
+               writable: false, configurable: false, value: checkZone
              }
            });
 
-           const elt = document.createElement('x-prop-desc');
+           (<any>document).registerElement('x-props-desc', {prototype: proto});
+
+           function checkZone() {
+             expect(Zone.current).toBe(testZone);
+             done();
+           }
          });
 
+         const elt = document.createElement('x-props-desc');
+       });
 
-      it('should work with non-writable, non-configurable prototypes created with defineProperties',
-         function(done) {
-           testZone.run(function() {
-             const proto = Object.create(HTMLElement.prototype);
-
-             Object.defineProperties(proto, {
-               createdCallback: <any> {
-                 writable: false, configurable: false, value: checkZone
-               }
-             });
-
-             (<any>document).registerElement('x-props-desc', {prototype: proto});
-
-             function checkZone() {
-               expect(Zone.current).toBe(testZone);
-               done();
-             }
-           });
-
-           const elt = document.createElement('x-props-desc');
-         });
-
-      it('should not throw with frozen prototypes ', function() {
-        testZone.run(function() {
-          const proto = Object.create(HTMLElement.prototype, Object.freeze(<PropertyDescriptorMap>{
-            createdCallback: <PropertyDescriptor> {
-              value: () => {}, writable: true, configurable: true
-            }
-          }));
-
-          Object.defineProperty(
-              proto, 'createdCallback', <any>{writable: false, configurable: false});
-
-          expect(function() {
-            (<any>document).registerElement('x-frozen-desc', {prototype: proto});
-          }).not.toThrow();
-        });
-      });
-
-
-      it('should check bind callback if not own property', function(done) {
-        testZone.run(function() {
-          const originalProto = {createdCallback: checkZone};
-
-          const secondaryProto = Object.create(originalProto);
-          expect(secondaryProto.createdCallback).toBe(originalProto.createdCallback);
-
-          (<any>document).registerElement('x-inherited-callback', {prototype: secondaryProto});
-          expect(secondaryProto.createdCallback).not.toBe(originalProto.createdCallback);
-
-          function checkZone() {
-            expect(Zone.current).toBe(testZone);
-            done();
+    it('should not throw with frozen prototypes ', function() {
+      testZone.run(function() {
+        const proto = Object.create(HTMLElement.prototype, Object.freeze(<PropertyDescriptorMap>{
+          createdCallback: <PropertyDescriptor> {
+            value: () => {}, writable: true, configurable: true
           }
+        }));
 
-          const elt = document.createElement('x-inherited-callback');
-        });
-      });
+        Object.defineProperty(
+            proto, 'createdCallback', <any>{writable: false, configurable: false});
 
-
-      it('should not throw if no options passed to registerElement', function() {
         expect(function() {
-          (<any>document).registerElement('x-no-opts');
+          (<any>document).registerElement('x-frozen-desc', {prototype: proto});
         }).not.toThrow();
       });
-    }));
+    });
+
+
+    it('should check bind callback if not own property', function(done) {
+      testZone.run(function() {
+        const originalProto = {createdCallback: checkZone};
+
+        const secondaryProto = Object.create(originalProto);
+        expect(secondaryProto.createdCallback).toBe(originalProto.createdCallback);
+
+        (<any>document).registerElement('x-inherited-callback', {prototype: secondaryProto});
+        expect(secondaryProto.createdCallback).not.toBe(originalProto.createdCallback);
+
+        function checkZone() {
+          expect(Zone.current).toBe(testZone);
+          done();
+        }
+
+        const elt = document.createElement('x-inherited-callback');
+      });
+    });
+
+
+    it('should not throw if no options passed to registerElement', function() {
+      expect(function() {
+        (<any>document).registerElement('x-no-opts');
+      }).not.toThrow();
+    });
+  });
+}

--- a/packages/zone.js/test/browser/requestAnimationFrame.spec.ts
+++ b/packages/zone.js/test/browser/requestAnimationFrame.spec.ts
@@ -6,53 +6,52 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ifEnvSupports} from '../test-util';
-declare const window: any;
-
 describe('requestAnimationFrame', function() {
   const functions =
       ['requestAnimationFrame', 'webkitRequestAnimationFrame', 'mozRequestAnimationFrame'];
 
   functions.forEach(function(fnName) {
-    describe(fnName, ifEnvSupports(fnName, function() {
-               const originalTimeout: number = (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL;
-               beforeEach(() => {
-                 (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = 10000;
-               });
+    if ((global as any)[fnName] !== undefined) {
+      describe(fnName, function() {
+        const originalTimeout: number = (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL;
+        beforeEach(() => {
+          (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = 10000;
+        });
 
-               afterEach(() => {
-                 (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-               });
-               const rAF = window[fnName];
+        afterEach(() => {
+          (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+        });
+        const requestAnimationFrameFn = (window as any)[fnName];
 
-               it('should be tolerant of invalid arguments', function() {
-                 // rAF throws an error on invalid arguments, so expect that.
-                 expect(function() {
-                   rAF(null);
-                 }).toThrow();
-               });
+        it('should be tolerant of invalid arguments', function() {
+          // requestAnimationFrameFn throws an error on invalid arguments, so expect that.
+          expect(function() {
+            requestAnimationFrameFn(null);
+          }).toThrow();
+        });
 
-               it('should bind to same zone when called recursively', function(done) {
-                 Zone.current.fork({name: 'TestZone'}).run(() => {
-                   let frames = 0;
-                   let previousTimeStamp = 0;
+        it('should bind to same zone when called recursively', function(done) {
+          Zone.current.fork({name: 'TestZone'}).run(() => {
+            let frames = 0;
+            let previousTimeStamp = 0;
 
-                   function frameCallback(timestamp: number) {
-                     expect(timestamp).toMatch(/^[\d.]+$/);
-                     // expect previous <= current
-                     expect(previousTimeStamp).not.toBeGreaterThan(timestamp);
-                     previousTimeStamp = timestamp;
+            function frameCallback(timestamp: number) {
+              expect(timestamp).toMatch(/^[\d.]+$/);
+              // expect previous <= current
+              expect(previousTimeStamp).not.toBeGreaterThan(timestamp);
+              previousTimeStamp = timestamp;
 
-                     if (frames++ > 15) {
-                       (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
-                       return done();
-                     }
-                     rAF(frameCallback);
-                   }
+              if (frames++ > 15) {
+                (<any>jasmine).DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+                return done();
+              }
+              requestAnimationFrameFn(frameCallback);
+            }
 
-                   rAF(frameCallback);
-                 });
-               });
-             }));
+            requestAnimationFrameFn(frameCallback);
+          });
+        });
+      });
+    }
   });
 });

--- a/packages/zone.js/test/jasmine-patch.spec.ts
+++ b/packages/zone.js/test/jasmine-patch.spec.ts
@@ -38,7 +38,7 @@ ifEnvSupports(supportJasmineSpec, () => {
 
     it('should throw on async in describe', () => {
       expect(throwOnAsync).toBe(true);
-      expect(syncZone.name).toEqual('syncTestZone for jasmine.describe');
+      expect(syncZone.name).toEqual('syncTestZone for jasmine.describe#jasmine');
       itZone = Zone.current;
     });
 

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -748,92 +748,105 @@ describe('FakeAsyncTestZoneSpec', () => {
     });
   });
 
-  describe('requestAnimationFrame', () => {
-    const functions =
-        ['requestAnimationFrame', 'webkitRequestAnimationFrame', 'mozRequestAnimationFrame'];
-    functions.forEach((fnName) => {
-      if ((global as any)[fnName] !== undefined) {
-        describe(fnName, () => {
-          it('should schedule a requestAnimationFrame with timeout of 16ms', () => {
-            fakeAsyncTestZone.run(() => {
-              let ran = false;
-              requestAnimationFrame(() => {
-                ran = true;
-              });
+  const animationFrameFns = [
+    ['requestAnimationFrame', 'cancelAnimationFrame'],
+    ['webkitRequestAnimationFrame', 'webkitCancelAnimationFrame'],
+    ['mozRequestAnimationFrame', 'mozCancelAnimationFrame'],
+  ];
 
-              testZoneSpec.tick(6);
-              expect(ran).toEqual(false);
+  const availableAnimationFrameFns =
+      animationFrameFns
+          .map(([fnName,
+                 cancelFnName]) => [fnName, (global as any)[fnName], (global as any)[cancelFnName]])
+          .filter(
+              ([_, fn]) => fn !==
+                  undefined) as [string, typeof requestAnimationFrame, typeof cancelAnimationFrame][];
 
-              testZoneSpec.tick(10);
-              expect(ran).toEqual(true);
-            });
-          });
-          it('does not count as a pending timer', () => {
-            fakeAsyncTestZone.run(() => {
-              requestAnimationFrame(() => {});
-            });
-            expect(testZoneSpec.pendingTimers.length).toBe(0);
-            expect(testZoneSpec.pendingPeriodicTimers.length).toBe(0);
-          });
-          it('should cancel a scheduled requestAnimatiomFrame', () => {
-            fakeAsyncTestZone.run(() => {
-              let ran = false;
-              const id = requestAnimationFrame(() => {
-                ran = true;
-              });
+  if (availableAnimationFrameFns.length > 0) {
+    describe('requestAnimationFrame', () => {
+      availableAnimationFrameFns.forEach(
+          ([name, requestAnimationFrameFn, cancelAnimationFrameFn]) => {
+            describe(name, () => {
+              it('should schedule a requestAnimationFrame with timeout of 16ms', () => {
+                fakeAsyncTestZone.run(() => {
+                  let ran = false;
+                  requestAnimationFrameFn(() => {
+                    ran = true;
+                  });
 
-              testZoneSpec.tick(6);
-              expect(ran).toEqual(false);
+                  testZoneSpec.tick(6);
+                  expect(ran).toEqual(false);
 
-              cancelAnimationFrame(id);
-
-              testZoneSpec.tick(10);
-              expect(ran).toEqual(false);
-            });
-          });
-          it('is not flushed when flushPeriodic is false', () => {
-            let ran = false;
-            fakeAsyncTestZone.run(() => {
-              requestAnimationFrame(() => {
-                ran = true;
-              });
-              testZoneSpec.flush(20);
-              expect(ran).toEqual(false);
-            });
-          });
-          it('is flushed when flushPeriodic is true', () => {
-            let ran = false;
-            fakeAsyncTestZone.run(() => {
-              requestAnimationFrame(() => {
-                ran = true;
-              });
-              const elapsed = testZoneSpec.flush(20, true);
-              expect(elapsed).toEqual(16);
-              expect(ran).toEqual(true);
-            });
-          });
-          it('should pass timestamp as parameter', () => {
-            let timestamp = 0;
-            let timestamp1 = 0;
-            fakeAsyncTestZone.run(() => {
-              requestAnimationFrame((ts) => {
-                timestamp = ts;
-                requestAnimationFrame(ts1 => {
-                  timestamp1 = ts1;
+                  testZoneSpec.tick(10);
+                  expect(ran).toEqual(true);
                 });
               });
-              const elapsed = testZoneSpec.flush(20, true);
-              const elapsed1 = testZoneSpec.flush(20, true);
-              expect(elapsed).toEqual(16);
-              expect(elapsed1).toEqual(16);
-              expect(timestamp).toEqual(16);
-              expect(timestamp1).toEqual(32);
+              it('does not count as a pending timer', () => {
+                fakeAsyncTestZone.run(() => {
+                  requestAnimationFrameFn(() => {});
+                });
+                expect(testZoneSpec.pendingTimers.length).toBe(0);
+                expect(testZoneSpec.pendingPeriodicTimers.length).toBe(0);
+              });
+              it('should cancel a scheduled requestAnimationFrame', () => {
+                fakeAsyncTestZone.run(() => {
+                  let ran = false;
+                  const id = requestAnimationFrameFn(() => {
+                    ran = true;
+                  });
+
+                  testZoneSpec.tick(6);
+                  expect(ran).toEqual(false);
+
+                  cancelAnimationFrameFn(id);
+
+                  testZoneSpec.tick(10);
+                  expect(ran).toEqual(false);
+                });
+              });
+              it('is not flushed when flushPeriodic is false', () => {
+                let ran = false;
+                fakeAsyncTestZone.run(() => {
+                  requestAnimationFrameFn(() => {
+                    ran = true;
+                  });
+                  testZoneSpec.flush(20);
+                  expect(ran).toEqual(false);
+                });
+              });
+              it('is flushed when flushPeriodic is true', () => {
+                let ran = false;
+                fakeAsyncTestZone.run(() => {
+                  requestAnimationFrameFn(() => {
+                    ran = true;
+                  });
+                  const elapsed = testZoneSpec.flush(20, true);
+                  expect(elapsed).toEqual(16);
+                  expect(ran).toEqual(true);
+                });
+              });
+              it('should pass timestamp as parameter', () => {
+                let timestamp = 0;
+                let timestamp1 = 0;
+                fakeAsyncTestZone.run(() => {
+                  requestAnimationFrameFn((ts) => {
+                    timestamp = ts;
+                    requestAnimationFrameFn(ts1 => {
+                      timestamp1 = ts1;
+                    });
+                  });
+                  const elapsed = testZoneSpec.flush(20, true);
+                  const elapsed1 = testZoneSpec.flush(20, true);
+                  expect(elapsed).toEqual(16);
+                  expect(elapsed1).toEqual(16);
+                  expect(timestamp).toEqual(16);
+                  expect(timestamp1).toEqual(32);
+                });
+              });
             });
           });
-        });
-      }
     });
-  });
+  }
 
   describe(
       'XHRs', ifEnvSupports('XMLHttpRequest', () => {

--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -752,84 +752,86 @@ describe('FakeAsyncTestZoneSpec', () => {
     const functions =
         ['requestAnimationFrame', 'webkitRequestAnimationFrame', 'mozRequestAnimationFrame'];
     functions.forEach((fnName) => {
-      describe(fnName, ifEnvSupports(fnName, () => {
-                 it('should schedule a requestAnimationFrame with timeout of 16ms', () => {
-                   fakeAsyncTestZone.run(() => {
-                     let ran = false;
-                     requestAnimationFrame(() => {
-                       ran = true;
-                     });
+      if ((global as any)[fnName] !== undefined) {
+        describe(fnName, () => {
+          it('should schedule a requestAnimationFrame with timeout of 16ms', () => {
+            fakeAsyncTestZone.run(() => {
+              let ran = false;
+              requestAnimationFrame(() => {
+                ran = true;
+              });
 
-                     testZoneSpec.tick(6);
-                     expect(ran).toEqual(false);
+              testZoneSpec.tick(6);
+              expect(ran).toEqual(false);
 
-                     testZoneSpec.tick(10);
-                     expect(ran).toEqual(true);
-                   });
-                 });
-                 it('does not count as a pending timer', () => {
-                   fakeAsyncTestZone.run(() => {
-                     requestAnimationFrame(() => {});
-                   });
-                   expect(testZoneSpec.pendingTimers.length).toBe(0);
-                   expect(testZoneSpec.pendingPeriodicTimers.length).toBe(0);
-                 });
-                 it('should cancel a scheduled requestAnimatiomFrame', () => {
-                   fakeAsyncTestZone.run(() => {
-                     let ran = false;
-                     const id = requestAnimationFrame(() => {
-                       ran = true;
-                     });
+              testZoneSpec.tick(10);
+              expect(ran).toEqual(true);
+            });
+          });
+          it('does not count as a pending timer', () => {
+            fakeAsyncTestZone.run(() => {
+              requestAnimationFrame(() => {});
+            });
+            expect(testZoneSpec.pendingTimers.length).toBe(0);
+            expect(testZoneSpec.pendingPeriodicTimers.length).toBe(0);
+          });
+          it('should cancel a scheduled requestAnimatiomFrame', () => {
+            fakeAsyncTestZone.run(() => {
+              let ran = false;
+              const id = requestAnimationFrame(() => {
+                ran = true;
+              });
 
-                     testZoneSpec.tick(6);
-                     expect(ran).toEqual(false);
+              testZoneSpec.tick(6);
+              expect(ran).toEqual(false);
 
-                     cancelAnimationFrame(id);
+              cancelAnimationFrame(id);
 
-                     testZoneSpec.tick(10);
-                     expect(ran).toEqual(false);
-                   });
-                 });
-                 it('is not flushed when flushPeriodic is false', () => {
-                   let ran = false;
-                   fakeAsyncTestZone.run(() => {
-                     requestAnimationFrame(() => {
-                       ran = true;
-                     });
-                     testZoneSpec.flush(20);
-                     expect(ran).toEqual(false);
-                   });
-                 });
-                 it('is flushed when flushPeriodic is true', () => {
-                   let ran = false;
-                   fakeAsyncTestZone.run(() => {
-                     requestAnimationFrame(() => {
-                       ran = true;
-                     });
-                     const elapsed = testZoneSpec.flush(20, true);
-                     expect(elapsed).toEqual(16);
-                     expect(ran).toEqual(true);
-                   });
-                 });
-                 it('should pass timestamp as parameter', () => {
-                   let timestamp = 0;
-                   let timestamp1 = 0;
-                   fakeAsyncTestZone.run(() => {
-                     requestAnimationFrame((ts) => {
-                       timestamp = ts;
-                       requestAnimationFrame(ts1 => {
-                         timestamp1 = ts1;
-                       });
-                     });
-                     const elapsed = testZoneSpec.flush(20, true);
-                     const elapsed1 = testZoneSpec.flush(20, true);
-                     expect(elapsed).toEqual(16);
-                     expect(elapsed1).toEqual(16);
-                     expect(timestamp).toEqual(16);
-                     expect(timestamp1).toEqual(32);
-                   });
-                 });
-               }, emptyRun));
+              testZoneSpec.tick(10);
+              expect(ran).toEqual(false);
+            });
+          });
+          it('is not flushed when flushPeriodic is false', () => {
+            let ran = false;
+            fakeAsyncTestZone.run(() => {
+              requestAnimationFrame(() => {
+                ran = true;
+              });
+              testZoneSpec.flush(20);
+              expect(ran).toEqual(false);
+            });
+          });
+          it('is flushed when flushPeriodic is true', () => {
+            let ran = false;
+            fakeAsyncTestZone.run(() => {
+              requestAnimationFrame(() => {
+                ran = true;
+              });
+              const elapsed = testZoneSpec.flush(20, true);
+              expect(elapsed).toEqual(16);
+              expect(ran).toEqual(true);
+            });
+          });
+          it('should pass timestamp as parameter', () => {
+            let timestamp = 0;
+            let timestamp1 = 0;
+            fakeAsyncTestZone.run(() => {
+              requestAnimationFrame((ts) => {
+                timestamp = ts;
+                requestAnimationFrame(ts1 => {
+                  timestamp1 = ts1;
+                });
+              });
+              const elapsed = testZoneSpec.flush(20, true);
+              const elapsed1 = testZoneSpec.flush(20, true);
+              expect(elapsed).toEqual(16);
+              expect(elapsed1).toEqual(16);
+              expect(timestamp).toEqual(16);
+              expect(timestamp1).toEqual(32);
+            });
+          });
+        });
+      }
     });
   });
 

--- a/packages/zone.js/test/zone-spec/sync-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/sync-test.spec.ts
@@ -22,7 +22,9 @@ describe('SyncTestZoneSpec', () => {
     syncTestZone.run(() => {
       expect(() => {
         Promise.resolve().then(function() {});
-      }).toThrow(new Error('Cannot call Promise.then from within a sync test.'));
+      })
+          .toThrow(new Error(
+              'Cannot call Promise.then from within a sync test (syncTestZone for name).'));
     });
   });
 
@@ -30,7 +32,9 @@ describe('SyncTestZoneSpec', () => {
     syncTestZone.run(() => {
       expect(() => {
         setTimeout(() => {}, 100);
-      }).toThrow(new Error('Cannot call setTimeout from within a sync test.'));
+      })
+          .toThrow(
+              new Error('Cannot call setTimeout from within a sync test (syncTestZone for name).'));
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8917,12 +8917,7 @@ jasmine-ajax@^4.0.0:
   resolved "https://registry.yarnpkg.com/jasmine-ajax/-/jasmine-ajax-4.0.0.tgz#7d8ba7e47e3f7e780e155fe9aa563faafa7e1a26"
   integrity sha512-htTxNw38BSHxxmd8RRMejocdPqLalGHU6n3HWFbzp/S8AuTQd1MYjkSH3dYDsbZ7EV1Xqx/b94m3tKaVSVBV2A==
 
-jasmine-core@^3.6.0:
-  version "3.99.1"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-3.99.1.tgz#5bfa4b2d76618868bfac4c8ff08bb26fffa4120d"
-  integrity sha512-Hu1dmuoGcZ7AfyynN3LsfruwMbxMALMka+YtZeGoLuDEySVmVAPaonkNoBRIw/ectu8b9tVQCJNgp4a4knp+tg==
-
-jasmine-core@^4.0.0, jasmine-core@^4.2.0:
+jasmine-core@^4.0.0, jasmine-core@^4.1.0, jasmine-core@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.2.0.tgz#0605bea284d6d78276f43c47de2532ecd4a73b00"
   integrity sha512-OcFpBrIhnbmb9wfI8cqPSJ50pv3Wg4/NSgoZIqHzIwO/2a9qivJWzv8hUvaREIMYYJBas6AvfXATFdVuzzCqVw==
@@ -9254,12 +9249,12 @@ karma-firefox-launcher@^2.1.0:
     is-wsl "^2.2.0"
     which "^2.0.1"
 
-karma-jasmine@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-4.0.2.tgz#386db2a3e1acc0af5265c711f673f78f1e4938de"
-  integrity sha512-ggi84RMNQffSDmWSyyt4zxzh2CQGwsxvYYsprgyR1j8ikzIduEdOlcLvXjZGwXG/0j41KUXOWsUCBfbEHPWP9g==
+karma-jasmine@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/karma-jasmine/-/karma-jasmine-5.1.0.tgz#3af4558a6502fa16856a0f346ec2193d4b884b2f"
+  integrity sha512-i/zQLFrfEpRyQoJF9fsCdTMOF5c2dK7C7OmsuKg2D0YSsuZSfQDiLuaiktbuio6F2wiCsZSnSnieIQ0ant/uzQ==
   dependencies:
-    jasmine-core "^3.6.0"
+    jasmine-core "^4.1.0"
 
 karma-requirejs@^1.1.0:
   version "1.1.0"
@@ -12792,7 +12787,6 @@ sass@1.53.0:
 
 "sauce-connect@https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz":
   version "0.0.0"
-  uid e5d7f82ad98251a653d1b0537f1103e49eda5e11
   resolved "https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz#e5d7f82ad98251a653d1b0537f1103e49eda5e11"
 
 saucelabs@7.2.0, saucelabs@^1.5.0, saucelabs@^4.6.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,14 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@angular-devkit/architect@0.1401.0-next.4":
+  version "0.1401.0-next.4"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1401.0-next.4.tgz#5e63f645f47c42f9bfe13296cb0c561cc182c284"
+  integrity sha512-jPL5rlJX06J7g7FagL3FGnd/srKlg7TjwgU8EIXyIhZKVzT/jJEjY3esi6n0bBOXsErwU1SuF95s9x0W0vRvRg==
+  dependencies:
+    "@angular-devkit/core" "14.1.0-next.4"
+    rxjs "6.6.7"
+
 "@angular-devkit/architect@0.1401.0-rc.3":
   version "0.1401.0-rc.3"
   resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1401.0-rc.3.tgz#55444857b8c041bfcfa57825047933588e917374"
@@ -17,6 +25,76 @@
   dependencies:
     "@angular-devkit/core" "14.1.0-rc.3"
     rxjs "6.6.7"
+
+"@angular-devkit/build-angular@14.1.0-next.4":
+  version "14.1.0-next.4"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-angular/-/build-angular-14.1.0-next.4.tgz#2c8ac035d757fc44af73943814bc05c7898a31be"
+  integrity sha512-H5WOmUkQpk29GQF2YCfi72fZH1/XVjWRlgoxpV6cP+tmHk5XDH43uSk8lFVGfw+S2+2XguJORYsJgks4CvquIA==
+  dependencies:
+    "@ampproject/remapping" "2.2.0"
+    "@angular-devkit/architect" "0.1401.0-next.4"
+    "@angular-devkit/build-webpack" "0.1401.0-next.4"
+    "@angular-devkit/core" "14.1.0-next.4"
+    "@babel/core" "7.18.6"
+    "@babel/generator" "7.18.7"
+    "@babel/helper-annotate-as-pure" "7.18.6"
+    "@babel/plugin-proposal-async-generator-functions" "7.18.6"
+    "@babel/plugin-transform-async-to-generator" "7.18.6"
+    "@babel/plugin-transform-runtime" "7.18.6"
+    "@babel/preset-env" "7.18.6"
+    "@babel/runtime" "7.18.6"
+    "@babel/template" "7.18.6"
+    "@discoveryjs/json-ext" "0.5.7"
+    "@ngtools/webpack" "14.1.0-next.4"
+    ansi-colors "4.1.3"
+    babel-loader "8.2.5"
+    babel-plugin-istanbul "6.1.1"
+    browserslist "^4.9.1"
+    cacache "16.1.1"
+    copy-webpack-plugin "11.0.0"
+    critters "0.0.16"
+    css-loader "6.7.1"
+    esbuild-wasm "0.14.48"
+    glob "8.0.3"
+    https-proxy-agent "5.0.1"
+    inquirer "8.2.4"
+    jsonc-parser "3.0.0"
+    karma-source-map-support "1.4.0"
+    less "4.1.3"
+    less-loader "11.0.0"
+    license-webpack-plugin "4.0.2"
+    loader-utils "3.2.0"
+    mini-css-extract-plugin "2.6.1"
+    minimatch "5.1.0"
+    open "8.4.0"
+    ora "5.4.1"
+    parse5-html-rewriting-stream "6.0.1"
+    piscina "3.2.0"
+    postcss "8.4.14"
+    postcss-import "14.1.0"
+    postcss-loader "7.0.0"
+    postcss-preset-env "7.7.2"
+    regenerator-runtime "0.13.9"
+    resolve-url-loader "5.0.0"
+    rxjs "6.6.7"
+    sass "1.53.0"
+    sass-loader "13.0.2"
+    semver "7.3.7"
+    source-map-loader "4.0.0"
+    source-map-support "0.5.21"
+    stylus "0.58.1"
+    stylus-loader "7.0.0"
+    terser "5.14.1"
+    text-table "0.2.0"
+    tree-kill "1.2.2"
+    tslib "2.4.0"
+    webpack "5.73.0"
+    webpack-dev-middleware "5.3.3"
+    webpack-dev-server "4.9.3"
+    webpack-merge "5.8.0"
+    webpack-subresource-integrity "5.1.0"
+  optionalDependencies:
+    esbuild "0.14.48"
 
 "@angular-devkit/build-angular@14.1.0-rc.3":
   version "14.1.0-rc.3"
@@ -107,6 +185,14 @@
     typescript "3.2.4"
     webpack-sources "1.3.0"
 
+"@angular-devkit/build-webpack@0.1401.0-next.4":
+  version "0.1401.0-next.4"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.1401.0-next.4.tgz#4d893b086e76114f34ad77f8eb06c082bb924bd5"
+  integrity sha512-/gOTPmc8OZgMP0n8ec/FMfhTveVHIJyPR68/5IARUnpbUHEmJPZL98zahDgcFST3B05Fg8Xq1rmKOq13oV5Khg==
+  dependencies:
+    "@angular-devkit/architect" "0.1401.0-next.4"
+    rxjs "6.6.7"
+
 "@angular-devkit/build-webpack@0.1401.0-rc.3":
   version "0.1401.0-rc.3"
   resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.1401.0-rc.3.tgz#8634d47e669b8a47ece8e12b71e2a2f5726a6a56"
@@ -114,6 +200,17 @@
   dependencies:
     "@angular-devkit/architect" "0.1401.0-rc.3"
     rxjs "6.6.7"
+
+"@angular-devkit/core@14.1.0-next.4":
+  version "14.1.0-next.4"
+  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-14.1.0-next.4.tgz#af9885036517252380ff13817b9c2175f63c26cf"
+  integrity sha512-RU6HIO47jnDr4LmVgwiwxtAh1ZftKKkLTh6JdF3O+TyxVIczXAG9fAv0fGEEocCWXjR3+CNPOizMtpPp9H7Seg==
+  dependencies:
+    ajv "8.11.0"
+    ajv-formats "2.1.1"
+    jsonc-parser "3.0.0"
+    rxjs "6.6.7"
+    source-map "0.7.4"
 
 "@angular-devkit/core@14.1.0-rc.3":
   version "14.1.0-rc.3"
@@ -208,12 +305,12 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#84dd092bab90bbcb746d955234d1e72c3434868f":
-  version "0.0.0-571134460f8bf9a152b3e38159fa91b92efaf6d1"
-  uid "84dd092bab90bbcb746d955234d1e72c3434868f"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#84dd092bab90bbcb746d955234d1e72c3434868f"
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#efc5d56da4f755f2a4bf57e4d835551cc2698115":
+  version "0.0.0-1241c1280f4a2a58eda8c322a0f057840a9d5b6c"
+  uid efc5d56da4f755f2a4bf57e4d835551cc2698115
+  resolved "https://github.com/angular/dev-infra-private-builds.git#efc5d56da4f755f2a4bf57e4d835551cc2698115"
   dependencies:
-    "@angular-devkit/build-angular" "14.1.0-rc.3"
+    "@angular-devkit/build-angular" "14.1.0-next.4"
     "@angular/benchpress" "0.3.0"
     "@babel/core" "^7.16.0"
     "@bazel/buildifier" "5.1.0"
@@ -1628,6 +1725,11 @@
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz#155ef21065427901994e765da8a0ba0eaae8b8bd"
   integrity sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==
+
+"@ngtools/webpack@14.1.0-next.4":
+  version "14.1.0-next.4"
+  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-14.1.0-next.4.tgz#94cebdff456ba4169d19a2741cc787748547b3eb"
+  integrity sha512-ziW+ElIhgrwFLM7nBkcwtli7iA6RMzZnvBAgQAEkRhyi9l969m/LSidAC73U0l06JiBWOzZAiGBgR/kd3uFW+w==
 
 "@ngtools/webpack@14.1.0-rc.3":
   version "14.1.0-rc.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,14 +10,6 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@angular-devkit/architect@0.1401.0-next.4":
-  version "0.1401.0-next.4"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1401.0-next.4.tgz#5e63f645f47c42f9bfe13296cb0c561cc182c284"
-  integrity sha512-jPL5rlJX06J7g7FagL3FGnd/srKlg7TjwgU8EIXyIhZKVzT/jJEjY3esi6n0bBOXsErwU1SuF95s9x0W0vRvRg==
-  dependencies:
-    "@angular-devkit/core" "14.1.0-next.4"
-    rxjs "6.6.7"
-
 "@angular-devkit/architect@0.1401.0-rc.3":
   version "0.1401.0-rc.3"
   resolved "https://registry.yarnpkg.com/@angular-devkit/architect/-/architect-0.1401.0-rc.3.tgz#55444857b8c041bfcfa57825047933588e917374"
@@ -25,76 +17,6 @@
   dependencies:
     "@angular-devkit/core" "14.1.0-rc.3"
     rxjs "6.6.7"
-
-"@angular-devkit/build-angular@14.1.0-next.4":
-  version "14.1.0-next.4"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-angular/-/build-angular-14.1.0-next.4.tgz#2c8ac035d757fc44af73943814bc05c7898a31be"
-  integrity sha512-H5WOmUkQpk29GQF2YCfi72fZH1/XVjWRlgoxpV6cP+tmHk5XDH43uSk8lFVGfw+S2+2XguJORYsJgks4CvquIA==
-  dependencies:
-    "@ampproject/remapping" "2.2.0"
-    "@angular-devkit/architect" "0.1401.0-next.4"
-    "@angular-devkit/build-webpack" "0.1401.0-next.4"
-    "@angular-devkit/core" "14.1.0-next.4"
-    "@babel/core" "7.18.6"
-    "@babel/generator" "7.18.7"
-    "@babel/helper-annotate-as-pure" "7.18.6"
-    "@babel/plugin-proposal-async-generator-functions" "7.18.6"
-    "@babel/plugin-transform-async-to-generator" "7.18.6"
-    "@babel/plugin-transform-runtime" "7.18.6"
-    "@babel/preset-env" "7.18.6"
-    "@babel/runtime" "7.18.6"
-    "@babel/template" "7.18.6"
-    "@discoveryjs/json-ext" "0.5.7"
-    "@ngtools/webpack" "14.1.0-next.4"
-    ansi-colors "4.1.3"
-    babel-loader "8.2.5"
-    babel-plugin-istanbul "6.1.1"
-    browserslist "^4.9.1"
-    cacache "16.1.1"
-    copy-webpack-plugin "11.0.0"
-    critters "0.0.16"
-    css-loader "6.7.1"
-    esbuild-wasm "0.14.48"
-    glob "8.0.3"
-    https-proxy-agent "5.0.1"
-    inquirer "8.2.4"
-    jsonc-parser "3.0.0"
-    karma-source-map-support "1.4.0"
-    less "4.1.3"
-    less-loader "11.0.0"
-    license-webpack-plugin "4.0.2"
-    loader-utils "3.2.0"
-    mini-css-extract-plugin "2.6.1"
-    minimatch "5.1.0"
-    open "8.4.0"
-    ora "5.4.1"
-    parse5-html-rewriting-stream "6.0.1"
-    piscina "3.2.0"
-    postcss "8.4.14"
-    postcss-import "14.1.0"
-    postcss-loader "7.0.0"
-    postcss-preset-env "7.7.2"
-    regenerator-runtime "0.13.9"
-    resolve-url-loader "5.0.0"
-    rxjs "6.6.7"
-    sass "1.53.0"
-    sass-loader "13.0.2"
-    semver "7.3.7"
-    source-map-loader "4.0.0"
-    source-map-support "0.5.21"
-    stylus "0.58.1"
-    stylus-loader "7.0.0"
-    terser "5.14.1"
-    text-table "0.2.0"
-    tree-kill "1.2.2"
-    tslib "2.4.0"
-    webpack "5.73.0"
-    webpack-dev-middleware "5.3.3"
-    webpack-dev-server "4.9.3"
-    webpack-merge "5.8.0"
-    webpack-subresource-integrity "5.1.0"
-  optionalDependencies:
-    esbuild "0.14.48"
 
 "@angular-devkit/build-angular@14.1.0-rc.3":
   version "14.1.0-rc.3"
@@ -185,14 +107,6 @@
     typescript "3.2.4"
     webpack-sources "1.3.0"
 
-"@angular-devkit/build-webpack@0.1401.0-next.4":
-  version "0.1401.0-next.4"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.1401.0-next.4.tgz#4d893b086e76114f34ad77f8eb06c082bb924bd5"
-  integrity sha512-/gOTPmc8OZgMP0n8ec/FMfhTveVHIJyPR68/5IARUnpbUHEmJPZL98zahDgcFST3B05Fg8Xq1rmKOq13oV5Khg==
-  dependencies:
-    "@angular-devkit/architect" "0.1401.0-next.4"
-    rxjs "6.6.7"
-
 "@angular-devkit/build-webpack@0.1401.0-rc.3":
   version "0.1401.0-rc.3"
   resolved "https://registry.yarnpkg.com/@angular-devkit/build-webpack/-/build-webpack-0.1401.0-rc.3.tgz#8634d47e669b8a47ece8e12b71e2a2f5726a6a56"
@@ -200,17 +114,6 @@
   dependencies:
     "@angular-devkit/architect" "0.1401.0-rc.3"
     rxjs "6.6.7"
-
-"@angular-devkit/core@14.1.0-next.4":
-  version "14.1.0-next.4"
-  resolved "https://registry.yarnpkg.com/@angular-devkit/core/-/core-14.1.0-next.4.tgz#af9885036517252380ff13817b9c2175f63c26cf"
-  integrity sha512-RU6HIO47jnDr4LmVgwiwxtAh1ZftKKkLTh6JdF3O+TyxVIczXAG9fAv0fGEEocCWXjR3+CNPOizMtpPp9H7Seg==
-  dependencies:
-    ajv "8.11.0"
-    ajv-formats "2.1.1"
-    jsonc-parser "3.0.0"
-    rxjs "6.6.7"
-    source-map "0.7.4"
 
 "@angular-devkit/core@14.1.0-rc.3":
   version "14.1.0-rc.3"
@@ -305,12 +208,12 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#efc5d56da4f755f2a4bf57e4d835551cc2698115":
-  version "0.0.0-1241c1280f4a2a58eda8c322a0f057840a9d5b6c"
-  uid efc5d56da4f755f2a4bf57e4d835551cc2698115
-  resolved "https://github.com/angular/dev-infra-private-builds.git#efc5d56da4f755f2a4bf57e4d835551cc2698115"
+"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#84dd092bab90bbcb746d955234d1e72c3434868f":
+  version "0.0.0-571134460f8bf9a152b3e38159fa91b92efaf6d1"
+  uid "84dd092bab90bbcb746d955234d1e72c3434868f"
+  resolved "https://github.com/angular/dev-infra-private-builds.git#84dd092bab90bbcb746d955234d1e72c3434868f"
   dependencies:
-    "@angular-devkit/build-angular" "14.1.0-next.4"
+    "@angular-devkit/build-angular" "14.1.0-rc.3"
     "@angular/benchpress" "0.3.0"
     "@babel/core" "^7.16.0"
     "@bazel/buildifier" "5.1.0"
@@ -1725,11 +1628,6 @@
   version "0.14.1"
   resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.14.1.tgz#155ef21065427901994e765da8a0ba0eaae8b8bd"
   integrity sha512-6Wci+Tp3CgPt/B9B0a3J4s3yMgLNSku6w5TV6mN+61C71UqsRBv2FUibBf3tPGlNxebgPHMEUzKpb1ggE8KCKw==
-
-"@ngtools/webpack@14.1.0-next.4":
-  version "14.1.0-next.4"
-  resolved "https://registry.yarnpkg.com/@ngtools/webpack/-/webpack-14.1.0-next.4.tgz#94cebdff456ba4169d19a2741cc787748547b3eb"
-  integrity sha512-ziW+ElIhgrwFLM7nBkcwtli7iA6RMzZnvBAgQAEkRhyi9l969m/LSidAC73U0l06JiBWOzZAiGBgR/kd3uFW+w==
 
 "@ngtools/webpack@14.1.0-rc.3":
   version "14.1.0-rc.3"


### PR DESCRIPTION
Docs-only change that:

* Adds a short note about how service workers report request timeouts
* Updated heading levels to present a clearer hierarchy and cleaner local TOC
* Removed documentation lint errors
* Fixes #46445
