### PR TITLE
refactor(core): remove `destroy` from the EnvironmentInjector's public API

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -466,8 +466,6 @@ export const ENVIRONMENT_INITIALIZER: InjectionToken<() => void>;
 
 // @public
 export abstract class EnvironmentInjector implements Injector {
-    // (undocumented)
-    abstract destroy(): void;
     abstract get<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
     // @deprecated (undocumented)
     abstract get(token: any, notFoundValue?: any): any;

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -101,6 +101,9 @@ export abstract class EnvironmentInjector implements Injector {
    */
   abstract runInContext<ReturnT>(fn: () => ReturnT): ReturnT;
 
+  /**
+   * @internal
+   */
   abstract destroy(): void;
 
   /**

--- a/packages/core/test/acceptance/environment_injector_spec.ts
+++ b/packages/core/test/acceptance/environment_injector_spec.ts
@@ -205,7 +205,7 @@ describe('environment injector', () => {
 
     it('should not function on a destroyed injector', () => {
       const injector = createEnvironmentInjector([], TestBed.inject(EnvironmentInjector));
-      injector.destroy();
+      (injector as unknown as {destroy: Function}).destroy();
       expect(() => injector.runInContext(() => {})).toThrow();
     });
   });


### PR DESCRIPTION
This commit updates the `EnvironmentInjector` class to annotate the `destroy` method as internal. This change aligns the `EnvironmentInjector` with the general `Injector` interface. It also avoids a situation when an injector in a hierarchy becomes destroyed, but child injectors remain active, which may result in errors thrown by the framework (when lookup happens in a parent injector). 

The `destroy` function may be added back to the public API later after additional analysis.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes). Note: technically the public API is updated, but since the `EnvironmentInjector` is in the "developer preview" at this moment, this change can be considered non-break'y. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No