### PR TITLE
docs: redirect `/guide/ivy` to the v12 guide

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -75,6 +75,7 @@
       {"type": 301, "source": "/getting-started", "destination": "/start"},
       {"type": 301, "source": "/getting-started/:rest*", "destination": "/start/:rest*"},
       {"type": 301, "source": "/guide/displaying-data", "destination": "/start#template-syntax"},
+      {"type": 301, "source": "/guide/ivy", "destination": "https://v12.angular.io/guide/ivy"},
       {"type": 301, "source": "/guide/updating-to-version-10", "destination": "https://v10.angular.io/guide/updating-to-version-10"},
       {"type": 301, "source": "/guide/updating-to-version-11", "destination": "https://v11.angular.io/guide/updating-to-version-11"},
       {"type": 301, "source": "/guide/updating-to-version-12", "destination": "/guide/update-to-latest-version"},

--- a/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
+++ b/aio/tests/deployment/shared/URLS_TO_REDIRECT.txt
@@ -205,6 +205,7 @@
 /guide/displaying-data --> /start#template-syntax
 /guide/i18n --> /guide/i18n-overview
 /guide --> /docs
+/guide/ivy --> https://v12.angular.io/guide/ivy
 /guide/learning-angular --> /start
 /guide/learning-angular.html --> /start
 /guide/metadata --> /guide/aot-compiler


### PR DESCRIPTION
Since Ivy is the default since v13, the Ivy guide (that used to live at https://angular.io/guide/ivy) has been removed (see #43860). However, there are certain error messages emitted by the CLI that still point to it.

This commit address the problem by adding a redirect from https://angular.io/guide/ivy to https://v12.angular.io/guide/ivy (which is the last version that includes the guide).

Fixes #46717.
