### PR TITLE
fix(router): Ensure target `RouterStateSnapshot` is defined in `NavigationError`

### DIFF
--- a/packages/router/src/operators/recognize.ts
+++ b/packages/router/src/operators/recognize.ts
@@ -6,14 +6,14 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, Injector, Type} from '@angular/core';
+import {EnvironmentInjector, Type} from '@angular/core';
 import {MonoTypeOperatorFunction} from 'rxjs';
 import {map, mergeMap} from 'rxjs/operators';
 
 import {Route} from '../models';
 import {recognize as recognizeFn} from '../recognize';
 import {NavigationTransition} from '../router';
-import {UrlSerializer, UrlTree} from '../url_tree';
+import {UrlSerializer} from '../url_tree';
 
 export function recognize(
     injector: EnvironmentInjector, rootComponentType: Type<any>|null, config: Route[],

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2245,6 +2245,35 @@ describe('Integration', () => {
          expect(e).toEqual(null);
        })));
 
+    it('should include target snapshot in NavigationError when resolver throws', async () => {
+      const router = TestBed.inject(Router);
+      const errorMessage = 'throwing resolver';
+      @Injectable({providedIn: 'root'})
+      class ThrowingResolver {
+        resolve() {
+          throw new Error(errorMessage);
+        }
+      }
+
+      let caughtError: NavigationError|undefined;
+      router.events.subscribe(e => {
+        if (e instanceof NavigationError) {
+          caughtError = e;
+        }
+      });
+      router.resetConfig(
+          [{path: 'throwing', resolve: {thrower: ThrowingResolver}, component: BlankCmp}]);
+      try {
+        await router.navigateByUrl('/throwing');
+        fail('navigation should throw');
+      } catch (e: unknown) {
+        expect((e as Error).message).toEqual(errorMessage);
+      }
+
+      expect(caughtError).toBeDefined();
+      expect(caughtError?.target).toBeDefined();
+    });
+
     it('should preserve resolved data', fakeAsync(inject([Router], (router: Router) => {
          const fixture = createRoot(router, RootCmp);
 


### PR DESCRIPTION
The Router transition observable pipe keeps an outer reference to a `t`
variable for use in the `catchError` operator. However, this variable is
not updated with intermediate state. This commit fixes that so the
`catchError` can access properties that get updated in intermediate
states. Specifically, `RouterStateSnapshot` in the `NavigationError` for
now but could be more in the future.
