### PR TITLE
fix(animations): make sure falsy values are added to _globalTimelineStyles

### DIFF
--- a/packages/animations/browser/src/dsl/animation_timeline_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_builder.ts
@@ -730,7 +730,7 @@ export class TimelineBuilder {
       const val = interpolateParams(value, params, errors);
       this._pendingStyles.set(prop, val);
       if (!this._localTimelineStyles.has(prop)) {
-        this._backFill.set(prop, this._globalTimelineStyles.get(prop) || AUTO_STYLE);
+        this._backFill.set(prop, this._globalTimelineStyles.get(prop) ?? AUTO_STYLE);
       }
       this._updateStyle(prop, val);
     }


### PR DESCRIPTION
style values get added to the `_globalTimelineStyles` map in order to keep
them so that they can be used across different timelines

`_globalTimelineStyles` was previously a plain object but has been
refactored to a map in #44482, as part of the update a check has been
changed from a ternary operation to an or, causing falsy values not to
be added to the map anymore, re-apply a ternary operation check so that
the original behavior is restored

also since this aspect was clearly not covered by tests, add a new test
to ensure that such regression doesn't happen in the future

resolves #46833

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #46833

Falsy values are lost when defined in different timelines, as you can see from the new test failing with the old code:
![before](https://user-images.githubusercontent.com/61631103/179403841-14b43187-489f-4265-9081-e5e79332e776.png)

(basically the issue is that `opacity: 0` is lost and replaced with `opacity: *`)

## What is the new behavior?

Falsy values no longer get lost between timelines (as it was previously in v13)
(also the new test with the new code obviously passes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - @jessicajaniuk :slightly_smiling_face::+1: 