### PR TITLE
fix(core): Fix `runInContext` for `NgModuleRef` injector

### DIFF
--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -98,7 +98,7 @@ export class NgModuleRef<T> extends viewEngine_NgModuleRef<T> implements Interna
   }
 
   runInContext<ReturnT>(fn: () => ReturnT): ReturnT {
-    return this.injector.runInContext(fn);
+    return this._r3Injector.runInContext(fn);
   }
 
   override destroy(): void {

--- a/packages/core/test/acceptance/environment_injector_spec.ts
+++ b/packages/core/test/acceptance/environment_injector_spec.ts
@@ -141,6 +141,12 @@ describe('environment injector', () => {
       expect(returnValue).toBe(3);
     });
 
+    it('works with an NgModuleRef injector', () => {
+      const ref = TestBed.inject(NgModuleRef);
+      const returnValue = ref.injector.runInContext(() => 3);
+      expect(returnValue).toBe(3);
+    });
+
     it('should make inject() available', () => {
       const TOKEN = new InjectionToken<string>('TOKEN');
       const injector = createEnvironmentInjector(


### PR DESCRIPTION
The `runInContext` for `NgModuleRef` was previously an infinite loop.
