### PR TITLE
refactor(platform-server): make `TransferState` standalone-friendly

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -76,6 +76,7 @@ v14 - v17
 | `@angular/core/testing`             | [`async`](#testing)                                                                                        | <!--  v9 --> v12         |
 | `@angular/forms`                    | [`FormBuilder.group` legacy options parameter](api/forms/FormBuilder#group)                                | <!-- v11 --> v14         |
 | `@angular/platform-server`          | [`renderModuleFactory`](#platform-server)                                                                  | <!-- v13 --> v15         |
+| `@angular/platform-browser`          | [`BrowserTransferStateModule`](#platform-browser)                                                                  | <!-- v14 --> v16         |
 | `@angular/router`                   | [`relativeLinkResolution`](#relativeLinkResolution)                                                        | <!-- v14 --> v16         |
 | `@angular/router`                     | [`resolver` argument in `RouterOutletContract.activateWith`](#router)                                                                        | <!-- v14 --> v16         |
 | `@angular/router`                     | [`resolver` field of the `OutletContext` class](#router)                                                                        | <!-- v14 --> v16         |
@@ -159,6 +160,15 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 | [`resolver` field of the `OutletContext` class](api/router/OutletContext#resolver) | No replacement needed | v14                   | Component factories are not required to create an instance of a component dynamically. Passing a factory resolver via `resolver` class field is no longer needed. |
 
 
+<a id="platform-browser"></a>
+
+### &commat;angular/platform-browser
+
+| API                                                              | Replacement                                        | Deprecation announced | Details |
+|:---                                                              |:---                                                |:---                   |:---     |
+| [`BrowserTransferStateModule`](api/platform-browser/BrowserTransferStateModule) | No replacement needed.  | v14.1                   | The `TransferState` class is available for injection without importing additional modules on the client side of a server-rendered application. |
+
+
 <a id="platform-browser-dynamic"></a>
 
 ### &commat;angular/platform-browser-dynamic
@@ -175,6 +185,7 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 | API                                                              | Replacement                                        | Deprecation announced | Details |
 |:---                                                              |:---                                                |:---                   |:---     |
 | [`renderModuleFactory`](api/platform-server/renderModuleFactory) | [`renderModule`](api/platform-server/renderModule) | v13                   | This symbol is no longer necessary. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context. |
+
 
 <a id="forms"></a>
 

--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -45,7 +45,7 @@ export class BrowserModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<BrowserModule, never, never, [typeof i1.CommonModule, typeof i0.ApplicationModule]>;
 }
 
-// @public
+// @public @deprecated
 export class BrowserTransferStateModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<BrowserTransferStateModule, never>;

--- a/packages/platform-browser/src/browser/transfer_state.ts
+++ b/packages/platform-browser/src/browser/transfer_state.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {APP_ID, Injectable, NgModule} from '@angular/core';
+import {APP_ID, inject, Injectable, NgModule} from '@angular/core';
 
 export function escapeHtml(text: string): string {
   const escapedText: {[k: string]: string} = {
@@ -72,8 +72,10 @@ export function makeStateKey<T = void>(key: string): StateKey<T> {
  * A key value store that is transferred from the application on the server side to the application
  * on the client side.
  *
- * `TransferState` will be available as an injectable token. To use it import
- * `ServerTransferStateModule` on the server and `BrowserTransferStateModule` on the client.
+ * The `TransferState` is available as an injectable token.
+ * On the client, just inject this token using DI and use it, it will be lazily initialized.
+ * On the server it's already included if `renderApplication` function is used. Otherwise, import
+ * the `ServerTransferStateModule` module to make the `TransferState` available.
  *
  * The values in the store are serialized/deserialized using JSON.stringify/JSON.parse. So only
  * boolean, number, string, null and non-class objects will be serialized and deserialized in a
@@ -81,17 +83,19 @@ export function makeStateKey<T = void>(key: string): StateKey<T> {
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+  useFactory: () => {
+    const doc = inject(DOCUMENT);
+    const appId = inject(APP_ID);
+    const state = new TransferState();
+    state.store = retrieveTransferredState(doc, appId);
+    return state;
+  }
+})
 export class TransferState {
   private store: {[k: string]: unknown|undefined} = {};
   private onSerializeCallbacks: {[k: string]: () => unknown | undefined} = {};
-
-  /** @internal */
-  static init(initState: {}) {
-    const transferState = new TransferState();
-    transferState.store = initState;
-    return transferState;
-  }
 
   /**
    * Get the value corresponding to a key. Return `defaultValue` if key is not found.
@@ -146,7 +150,7 @@ export class TransferState {
   }
 }
 
-export function initTransferState(doc: Document, appId: string) {
+export function retrieveTransferredState(doc: Document, appId: string) {
   // Locate the script tag with the JSON data transferred from the server.
   // The id of the script tag is set to the Angular appId + 'state'.
   const script = doc.getElementById(appId + '-state');
@@ -159,7 +163,7 @@ export function initTransferState(doc: Document, appId: string) {
       console.warn('Exception while restoring TransferState for app ' + appId, e);
     }
   }
-  return TransferState.init(initialState);
+  return initialState;
 }
 
 /**
@@ -167,9 +171,9 @@ export function initTransferState(doc: Document, appId: string) {
  * server to client.
  *
  * @publicApi
+ * @deprecated no longer needed, you can inject the `TransferState` in an app without providing
+ *     this module.
  */
-@NgModule({
-  providers: [{provide: TransferState, useFactory: initTransferState, deps: [DOCUMENT, APP_ID]}],
-})
+@NgModule({})
 export class BrowserTransferStateModule {
 }

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -14,7 +14,7 @@ import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
 import {inject, TestBed} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
-import {BrowserModule} from '@angular/platform-browser';
+import {BrowserModule, TransferState} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {provideAnimations, provideNoopAnimations} from '@angular/platform-browser/animations';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -317,6 +317,23 @@ function bootstrap(
         expect(() => bootstrapApplication(NonAnnotatedClass)).toThrowError(msg);
       });
 
+      it('should have the TransferState token available', async () => {
+        let state: TransferState|undefined;
+        @Component({
+          selector: 'hello-app',
+          standalone: true,
+          template: '...',
+        })
+        class StandaloneComponent {
+          constructor() {
+            state = _inject(TransferState);
+          }
+        }
+
+        await bootstrapApplication(StandaloneComponent);
+        expect(state).toBeInstanceOf(TransferState);
+      });
+
       describe('with animations', () => {
         @Component({
           standalone: true,
@@ -381,6 +398,22 @@ function bootstrap(
             new Error(`HelloRootDirectiveIsNotCmp cannot be used as an entry component.`));
         done();
       });
+    });
+
+    it('should have the TransferState token available in NgModule bootstrap', async () => {
+      let state: TransferState|undefined;
+      @Component({
+        selector: 'hello-app',
+        template: '...',
+      })
+      class NonStandaloneComponent {
+        constructor() {
+          state = _inject(TransferState);
+        }
+      }
+
+      await bootstrap(NonStandaloneComponent);
+      expect(state).toBeInstanceOf(TransferState);
     });
 
     it('should retrieve sanitizer', inject([Injector], (injector: Injector) => {

--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -7,14 +7,28 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {APP_ID, NgModule} from '@angular/core';
+import {APP_ID, NgModule, Provider} from '@angular/core';
 import {TransferState, ɵescapeHtml as escapeHtml} from '@angular/platform-browser';
 
 import {BEFORE_APP_SERIALIZED} from './tokens';
 
+export const TRANSFER_STATE_SERIALIZATION_PROVIDERS: Provider[] = [{
+  provide: BEFORE_APP_SERIALIZED,
+  useFactory: serializeTransferStateFactory,
+  deps: [DOCUMENT, APP_ID, TransferState],
+  multi: true,
+}];
+
 export function serializeTransferStateFactory(
     doc: Document, appId: string, transferStore: TransferState) {
   return () => {
+    const store = (transferStore as unknown as {store: {}}).store;
+    const isStateEmpty = Object.keys(store).length === 0;
+    if (isStateEmpty) {
+      // The state is empty, nothing to transfer,
+      // avoid creating an extra `<script>` tag in this case.
+      return;
+    }
     const script = doc.createElement('script');
     script.id = appId + '-state';
     script.setAttribute('type', 'application/json');
@@ -27,17 +41,13 @@ export function serializeTransferStateFactory(
  * NgModule to install on the server side while using the `TransferState` to transfer state from
  * server to client.
  *
+ * Note: this module is not needed if the `renderApplication` function is used.
+ * The `renderApplication` makes all providers from this module available in the application.
+ *
  * @publicApi
  */
 @NgModule({
-  providers: [
-    TransferState, {
-      provide: BEFORE_APP_SERIALIZED,
-      useFactory: serializeTransferStateFactory,
-      deps: [DOCUMENT, APP_ID, TransferState],
-      multi: true,
-    }
-  ]
+  providers: TRANSFER_STATE_SERIALIZATION_PROVIDERS,
 })
 export class ServerTransferStateModule {
 }

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -13,6 +13,7 @@ import {first} from 'rxjs/operators';
 import {PlatformState} from './platform_state';
 import {platformDynamicServer, platformServer, ServerModule} from './server';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG} from './tokens';
+import {TRANSFER_STATE_SERIALIZATION_PROVIDERS} from './transfer_state';
 
 interface PlatformOptions {
   document?: string;
@@ -150,6 +151,7 @@ export function renderApplication<T>(rootComponent: Type<T>, options: {
   const appProviders = [
     importProvidersFrom(BrowserModule.withServerTransition({appId})),
     importProvidersFrom(ServerModule),
+    ...TRANSFER_STATE_SERIALIZATION_PROVIDERS,
     ...(options.providers ?? []),
   ];
   return _render(platform, internalCreateApplication({rootComponent, appProviders}));


### PR DESCRIPTION
This commit updates the `TransferState` to make it `providedIn: 'root'`. This makes the entire `BrowserTransferStateModule` module unnecessary, so it got deprecated as well.

The `ServerTransferStateModule` is still retained, but the `renderApplication` function now also includes the necessary tokens to serialize the `TransferState` automatically, so when using the `renderApplication` function, there is no need to include `ServerTransferStateModule` as well.

This change is a part of the ongoing efforts to update the shape of the FW APIs to make them standalone-friendly (so there is no need to import any NgModules).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No