### PR TITLE
docs: add info about request timeouts

### DIFF
--- a/aio/content/guide/service-worker-config.md
+++ b/aio/content/guide/service-worker-config.md
@@ -1,9 +1,12 @@
 # Service worker configuration
 
+This topic describes the properties of the service worker configuration file.
+
 ## Prerequisites
 
 A basic understanding of the following:
 
+*   [Service worker overview](https://developer.chrome.com/docs/workbox/service-worker-overview/)
 *   [Service Worker in Production](guide/service-worker-devops)
 
 The `ngsw-config.json` configuration file specifies which files and data URLs the Angular service worker should cache and how it should update the cached files and data.
@@ -64,9 +67,11 @@ Example patterns:
 | `/*.html`    | Specifies only HTML files in the root |
 | `!/**/*.map` | Exclude all sourcemaps                |
 
+## Service worker configuration properties
+
 The following sections describe each property of the configuration file.
 
-## `appData`
+### `appData`
 
 This section enables you to pass any data you want that describes this particular version of the application.
 The `SwUpdate` service includes that data in the update notifications.
@@ -74,12 +79,12 @@ Many applications use this section to provide additional information for the dis
 
 <a id="index-file"></a>
 
-## `index`
+### `index`
 
 Specifies the file that serves as the index page to satisfy navigation requests.
 Usually this is `/index.html`.
 
-## `assetGroups`
+### `assetGroups`
 
 *Assets* are resources that are part of the application version that update along with the application.
 They can include resources loaded from the page's origin as well as third-party resources loaded from CDNs and other external URLs.
@@ -134,12 +139,14 @@ interface AssetGroup {
 
 </code-example>
 
-### `name`
+Each `AssetGroup` is defined by the following asset group properties.
+
+#### `name`
 
 A `name` is mandatory.
 It identifies this particular group of assets between versions of the configuration.
 
-### `installMode`
+#### `installMode`
 
 The `installMode` determines how these resources are initially cached.
 The `installMode` can be either of two values:
@@ -151,7 +158,7 @@ The `installMode` can be either of two values:
 
 Defaults to `prefetch`.
 
-### `updateMode`
+#### `updateMode`
 
 For resources already in the cache, the `updateMode` determines the caching behavior when a new version of the application is discovered.
 Any resources in the group that have changed since the previous version are updated in accordance with `updateMode`.
@@ -163,7 +170,7 @@ Any resources in the group that have changed since the previous version are upda
 
 Defaults to the value `installMode` is set to.
 
-### `resources`
+#### `resources`
 
 This section describes the resources to cache, broken up into the following groups:
 
@@ -172,7 +179,7 @@ This section describes the resources to cache, broken up into the following grou
 | `files`         | Lists patterns that match files in the distribution directory. These can be single files or glob-like patterns that match a number of files.                                                                                                                                                                                                                                                                   |
 | `urls`          | Includes both URLs and URL patterns that are matched at runtime. These resources are not fetched directly and do not have content hashes, but they are cached according to their HTTP headers. This is most useful for CDNs such as the Google Fonts service. <br />  *\(Negative glob patterns are not supported and `?` will be matched literally; that is, it will not match any character other than `?`.\)* |
 
-### `cacheQueryOptions`
+#### `cacheQueryOptions`
 
 These options are used to modify the matching behavior of requests.
 They are passed to the browsers `Cache#match` function.
@@ -183,7 +190,7 @@ Currently, only the following options are supported:
 |:---            |:---     |
 | `ignoreSearch` | Ignore query parameters. Defaults to `false`. |
 
-## `dataGroups`
+### `dataGroups`
 
 Unlike asset resources, data requests are not versioned along with the application.
 They're cached according to manually-configured policies that are more useful for situations such as API requests and other data dependencies.
@@ -236,11 +243,13 @@ export interface DataGroup {
 
 </code-example>
 
-### `name`
+Each `DataGroup` is defined by the following data group properties.
+
+#### `name`
 
 Similar to `assetGroups`, every data group has a `name` which uniquely identifies it.
 
-### `urls`
+#### `urls`
 
 A list of URL patterns.
 URLs that match these patterns are cached according to this data group's policy.
@@ -249,7 +258,7 @@ Only non-mutating requests \(GET and HEAD\) are cached.
 *   Negative glob patterns are not supported
 *   `?` is matched literally; that is, it matches *only* the character `?`
 
-### `version`
+#### `version`
 
 Occasionally APIs change formats in a way that is not backward-compatible.
 A new version of the application might not be compatible with the old API format and thus might not be compatible with existing cached resources from that API.
@@ -258,18 +267,22 @@ A new version of the application might not be compatible with the old API format
 
 `version` is an integer field and defaults to `1`.
 
-### `cacheConfig`
+#### `cacheConfig`
 
-This section defines the policy by which matching requests are cached.
+The following properties define the policy by which matching requests are cached.
 
-#### `maxSize`
+##### `maxSize`
 
-\(required\) The maximum number of entries, or responses, in the cache.
+**Required**
+
+The maximum number of entries, or responses, in the cache.
 Open-ended caches can grow in unbounded ways and eventually exceed storage quotas, calling for eviction.
 
-#### `maxAge`
+##### `maxAge`
 
-(required) The `maxAge` parameter indicates how long responses are allowed to remain in the cache before being considered invalid and evicted.
+**Required**
+
+The `maxAge` parameter indicates how long responses are allowed to remain in the cache before being considered invalid and evicted.
 `maxAge` is a duration string, using the following unit suffixes:
 
 | Suffixes | Details |
@@ -282,7 +295,7 @@ Open-ended caches can grow in unbounded ways and eventually exceed storage quota
 
 For example, the string `3d12h` caches content for up to three and a half days.
 
-#### `timeout`
+##### `timeout`
 
 This duration string specifies the network timeout.
 The network timeout is how long the Angular service worker waits for the network to respond before using a cached response, if configured to do so.
@@ -298,7 +311,7 @@ The network timeout is how long the Angular service worker waits for the network
 
 For example, the string `5s30u` translates to five seconds and 30 milliseconds of network timeout.
 
-#### `strategy`
+##### `strategy`
 
 The Angular service worker can use either of two caching strategies for data resources.
 
@@ -309,19 +322,19 @@ The Angular service worker can use either of two caching strategies for data res
 
 <div class="alert is-helpful">
 
-You can also emulate a third strategy, [staleWhileRevalidate](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate), which returns cached data \(if available\), but also fetches fresh data from the network in the background for next time.
+You can also emulate a third strategy, [staleWhileRevalidate](https://developers.google.com/web/fundamentals/instant-and-offline/offline-cookbook/#stale-while-revalidate), which returns cached data if it is available, but also fetches fresh data from the network in the background for next time.
 To use this strategy set `strategy` to `freshness` and `timeout` to `0u` in `cacheConfig`.
 
 This essentially does the following:
 
 1.  Try to fetch from the network first.
-1.  If the network request does not complete after 0ms \(that is, immediately\), fall back to the cache \(ignoring cache age\).
-1.  Once the network request completes, update the cache for future requests.
-1.  If the resource does not exist in the cache, wait for the network request anyway.
+2.  If the network request does not complete immediately, that is after a timeout of 0&nbsp;ms, ignore the cache age and fall back to the cached value.
+3.  Once the network request completes, update the cache for future requests.
+4.  If the resource does not exist in the cache, wait for the network request anyway.
 
 </div>
 
-#### `cacheOpaqueResponses`
+##### `cacheOpaqueResponses`
 
 Whether the Angular service worker should cache opaque responses or not.
 
@@ -329,8 +342,8 @@ If not specified, the default value depends on the data group's configured strat
 
 | Strategies                             | Details |
 |:---                                    |:---     |
-| Groups with the `freshness` strategy   | The default value is `true` \(cache opaque responses\). These groups will request the data anew every time, only falling back to the cached response when offline or on a slow network. Therefore, it doesn't matter if the service worker caches an error response.                                    |
-| Groups with the `performance` strategy | The default value is `false` \(do not cache opaque responses\). These groups would continue to return a cached response until `maxAge` expires, even if the error was due to a temporary network or server issue. Therefore, it would be problematic for the service worker to cache an error response. |
+| Groups with the `freshness` strategy   | The default value is `true` and the service worker caches opaque responses. These groups will request the data every time and only fall back to the cached response when offline or on a slow network. Therefore, it doesn't matter if the service worker caches an error response.                                    |
+| Groups with the `performance` strategy | The default value is `false` and the service worker doesn't cache opaque responses. These groups would continue to return a cached response until `maxAge` expires, even if the error was due to a temporary network or server issue. Therefore, it would be problematic for the service worker to cache an error response. |
 
 <div class="callout is-important">
 
@@ -344,27 +357,24 @@ If you are not able to implement CORS &mdash;for example, if you don't control t
 
 </div>
 
-### `cacheQueryOptions`
+#### `cacheQueryOptions`
 
 See [assetGroups](#assetgroups) for details.
 
-## `navigationUrls`
+### `navigationUrls`
 
 This optional section enables you to specify a custom list of URLs that will be redirected to the index file.
 
-### Handling navigation requests
+#### Handling navigation requests
 
 The ServiceWorker redirects navigation requests that don't match any `asset` or `data` group to the specified [index file](#index-file).
 A request is considered to be a navigation request if:
 
 *   Its [mode](https://developer.mozilla.org/docs/Web/API/Request/mode) is `navigation`
-*   It accepts a `text/html` response \(as determined by the value of the `Accept` header\)
-*   Its URL matches certain criteria \(see the following\)
-
-By default, these criteria are:
-
-*   The URL must not contain a file extension \(that is, a `.`\) in the last path segment
-*   The URL must not contain `__`
+*   It accepts a `text/html` response as determined by the value of the `Accept` header
+*   Its URL matches the following criteria:
+    *   The URL must not contain a file extension \(that is, a `.`\) in the last path segment
+    *   The URL must not contain `__`
 
 <div class="alert is-helpful">
 
@@ -372,10 +382,10 @@ To configure whether navigation requests are sent through to the network or not,
 
 </div>
 
-### Matching navigation request URLs
+#### Matching navigation request URLs
 
 While these default criteria are fine in most cases, it is sometimes desirable to configure different rules.
-For example, you might want to ignore specific routes \(that are not part of the Angular app\) and pass them through to the server.
+For example, you might want to ignore specific routes, such as those that are not part of the Angular app, and pass them through to the server.
 
 This field contains an array of URLs and [glob-like](#glob-patterns) URL patterns that are matched at runtime.
 It can contain both negative patterns \(that is, patterns starting with `!`\) and non-negative patterns and URLs.
@@ -398,7 +408,7 @@ If the field is omitted, it defaults to:
 
 <a id="navigation-request-strategy"></a>
 
-## `navigationRequestStrategy`
+### `navigationRequestStrategy`
 
 This optional property enables you to configure how the service worker handles navigation requests:
 
@@ -413,7 +423,7 @@ This optional property enables you to configure how the service worker handles n
 | Possible values | Details |
 |:---             |:---     |
 | `'performance'` | The default setting. Serves the specified [index file](#index-file), which is typically cached.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `'freshness'`   | Passes the requests through to the network and falls back to the `performance` behavior when offline. This value is useful when the server redirects the navigation requests elsewhere using an HTTP redirect \(3xx status code\). Reasons for using this value include: <ul> <li> Redirecting to an authentication website when authentication is not handled by the application </li> <li> Redirecting specific URLs to avoid breaking existing links/bookmarks after a website redesign </li> <li> Redirecting to a different website, such as a server-status page, while a page is temporarily down </li> </ul> |
+| `'freshness'`   | Passes the requests through to the network and falls back to the `performance` behavior when offline. This value is useful when the server redirects the navigation requests elsewhere using a `3xx` HTTP redirect status code. Reasons for using this value include: <ul> <li> Redirecting to an authentication website when authentication is not handled by the application </li> <li> Redirecting specific URLs to avoid breaking existing links/bookmarks after a website redesign </li> <li> Redirecting to a different website, such as a server-status page, while a page is temporarily down </li> </ul> |
 
 <div class="alert is-important">
 

--- a/aio/content/guide/service-worker-devops.md
+++ b/aio/content/guide/service-worker-devops.md
@@ -9,21 +9,21 @@ A basic understanding of the following:
 
 *   [Service Worker Communication](guide/service-worker-communications)
 
-## Service worker and caching of app resources
+## Service worker and caching of application resources
 
-Conceptually, imagine the Angular service worker as a forward cache or a CDN edge that is installed in the end user's web browser.
-The service worker's job is to satisfy requests made by the Angular application for resources or data from a local cache, without needing to wait for the network.
+Imagine the Angular service worker as a forward cache or a Content Delivery Network (CDN) edge that is installed in the end user's web browser.
+The service worker responds to requests made by the Angular application for resources or data from a local cache, without needing to wait for the network.
 Like any cache, it has rules for how content is expired and updated.
 
 <a id="versions"></a>
 
-### App versions
+### Application versions
 
 In the context of an Angular service worker, a "version" is a collection of resources that represent a specific build of the Angular application.
 Whenever a new build of the application is deployed, the service worker treats that build as a new version of the application.
 This is true even if only a single file is updated.
 At any given time, the service worker might have multiple versions of the application in its cache and it might be serving them simultaneously.
-For more information, see the [App tabs](guide/service-worker-devops#tabs) section below.
+For more information, see the [Application tabs](guide/service-worker-devops#tabs) section.
 
 To preserve application integrity, the Angular service worker groups all files into a version together.
 The files grouped into a version usually include HTML, JS, and CSS files.
@@ -35,15 +35,15 @@ In this scenario, it is not valid to serve the old `index.html`, which calls `st
 
 This file integrity is especially important when lazy loading modules.
 A JS bundle might reference many lazy chunks, and the filenames of the lazy chunks are unique to the particular build of the application.
-If a running application at version `X` attempts to load a lazy chunk, but the server has already updated to version `X + 1`, the lazy loading operation will fail.
+If a running application at version `X` attempts to load a lazy chunk, but the server has already updated to version `X + 1`, the lazy loading operation fails.
 
 The version identifier of the application is determined by the contents of all resources, and it changes if any of them change.
 In practice, the version is determined by the contents of the `ngsw.json` file, which includes hashes for all known content.
-If any of the cached files change, the file's hash will change in `ngsw.json`, causing the Angular service worker to treat the active set of files as a new version.
+If any of the cached files change, the file's hash changes in `ngsw.json`. This change causes the Angular service worker to treat the active set of files as a new version.
 
 <div class="alert is-helpful">
 
-`ngsw.json` is the manifest file that is generated at build time based on `ngsw-config.json`.
+The build process creates the manifest file, `ngsw.json`, using information from `ngsw-config.json`.
 
 </div>
 
@@ -52,25 +52,27 @@ With the versioning behavior of the Angular service worker, an application serve
 #### Update checks
 
 Every time the user opens or refreshes the application, the Angular service worker checks for updates to the application by looking for updates to the `ngsw.json` manifest.
-If an update is found, it is downloaded and cached automatically, and will be served the next time the application is loaded.
+If an update is found, it is downloaded and cached automatically, and is served the next time the application is loaded.
 
 ### Resource integrity
 
-One of the potential side effects of long caching is inadvertently caching an invalid resource.
-In a normal HTTP cache, a hard refresh or cache expiration limits the negative effects of caching an invalid file.
-A service worker ignores such constraints and effectively long caches the entire application.
-Consequently, it is essential that the service worker gets the correct content.
+One of the potential side effects of long caching is inadvertently caching a resource that's not valid.
+In a normal HTTP cache, a hard refresh or the cache expiring limits the negative effects of caching a file that's not valid.
+A service worker ignores such constraints and effectively long-caches the entire application.
+It's important that the service worker gets the correct content, so it keeps hashes of the resources to maintain their integrity.
+
+#### Hashed content
 
 To ensure resource integrity, the Angular service worker validates the hashes of all resources for which it has a hash.
-Typically for an application created with the [Angular CLI](cli), this is everything in the `dist` directory covered by the user's `src/ngsw-config.json` configuration.
+For an application created with the [Angular CLI](cli), this is everything in the `dist` directory covered by the user's `src/ngsw-config.json` configuration.
 
-If a particular file fails validation, the Angular service worker attempts to re-fetch the content using a "cache-busting" URL parameter to eliminate the effects of browser or intermediate caching.
-If that content also fails validation, the service worker considers the entire version of the application to be invalid and it stops serving the application.
-If necessary, the service worker enters a safe mode where requests fall back on the network, opting not to use its cache if the risk of serving invalid, broken, or outdated content is high.
+If a particular file fails validation, the Angular service worker attempts to re-fetch the content using a "cache-busting" URL parameter to prevent browser or intermediate caching.
+If that content also fails validation, the service worker considers the entire version of the application to not be valid and stops serving the application.
+If necessary, the service worker enters a safe mode where requests fall back on the network. The service worker doesn't use its cache if there's a high risk of serving content that is broken, outdated, or not valid.
 
 Hash mismatches can occur for a variety of reasons:
 
-*   Caching layers in between the origin server and the end user could serve stale content
+*   Caching layers between the origin server and the end user could serve stale content
 *   A non-atomic deployment could result in the Angular service worker having visibility of partially updated content
 *   Errors during the build process could result in updated resources without `ngsw.json` being updated.
     The reverse could also happen resulting in an updated `ngsw.json` without updated resources.
@@ -80,36 +82,36 @@ Hash mismatches can occur for a variety of reasons:
 The only resources that have hashes in the `ngsw.json` manifest are resources that were present in the `dist` directory at the time the manifest was built.
 Other resources, especially those loaded from CDNs, have content that is unknown at build time or are updated more frequently than the application is deployed.
 
-If the Angular service worker does not have a hash to validate a given resource, it still caches its contents but it honors the HTTP caching headers by using a policy of "stale while revalidate".
-That is, when HTTP caching headers for a cached resource indicate that the resource has expired, the Angular service worker continues to serve the content and it attempts to refresh the resource in the background.
+If the Angular service worker does not have a hash to verify a resource is valid, it still caches its contents. At the same time, it honors the HTTP caching headers by using a policy of *stale while revalidate*.
+The Angular service worker continues to serve a resource even after its HTTP caching headers indicate
+that it is no longer valid. At the same time, it attempts to refresh the expired resource in the background.
 This way, broken unhashed resources do not remain in the cache beyond their configured lifetimes.
 
 <a id="tabs"></a>
 
-### App tabs
+### Application tabs
 
 It can be problematic for an application if the version of resources it's receiving changes suddenly or without warning.
-See the [App versions](guide/service-worker-devops#versions) section above for a description of such issues.
+See the [Application versions](guide/service-worker-devops#versions) section for a description of such issues.
 
-The Angular service worker provides a guarantee: a running application will continue to run the same version of the application.
-If another instance of the application is opened in a new web browser tab, then the most current version of the app is served.
+The Angular service worker provides a guarantee: a running application continues to run the same version of the application.
+If another instance of the application is opened in a new web browser tab, then the most current version of the application is served.
 As a result, that new tab can be running a different version of the application than the original tab.
 
 <div class="alert is-important">
 
 **IMPORTANT**: <br />
 This guarantee is **stronger** than that provided by the normal web deployment model.
-Without a service worker, there is no guarantee that code lazily loaded later in a running application is from the same version as the initial code for the application.
+Without a service worker, there is no guarantee that lazily loaded code is from the same version as the application's initial code.
 
 </div>
 
-There are a few limited reasons why the Angular service worker might change the version of a running application.
-Some of them are error conditions:
+The Angular service worker might change the version of a running application under error conditions such as:
 
-*   The current version becomes invalid due to a failed hash
-*   An unrelated error causes the service worker to enter safe mode; that is, temporary deactivation
+*   The current version becomes non-valid due to a failed hash
+*   An unrelated error causes the service worker to enter safe mode and deactivates it temporarily
 
-The Angular service worker is aware of which versions are in use at any given moment and it cleans up versions when no tab is using them.
+The Angular service worker cleans up application versions when no tab is using them.
 
 Other reasons the Angular service worker might change the version of a running application are normal events:
 
@@ -119,27 +121,35 @@ Other reasons the Angular service worker might change the version of a running a
 ### Service worker updates
 
 The Angular service worker is a small script that runs in web browsers.
-From time to time, the service worker will be updated with bug fixes and feature improvements.
+From time to time, the service worker is updated with bug fixes and feature improvements.
 
 The Angular service worker is downloaded when the application is first opened and when the application is accessed after a period of inactivity.
-If the service worker has changed, the service worker will be updated in the background.
+If the service worker changes, it's updated in the background.
 
-Most updates to the Angular service worker are transparent to the app &mdash;the old caches are still valid and content is still served
-normally.
-However, occasionally a bugfix or feature in the Angular service worker requires the invalidation of old caches.
-In this case, the application will be refreshed transparently from the network.
+Most updates to the Angular service worker are transparent to the application. The old caches are still valid and content is still served normally.
+Occasionally, a bug fix or feature in the Angular service worker might require the invalidation of old caches.
+In this case, the service worker transparently refreshes the application from the network.
 
 ### Bypassing the service worker
 
-In some cases, you might want to bypass the service worker entirely and let the browser handle the request instead.
-An example is when you rely on a feature that is currently not supported in service workers \(for example, [reporting progress on uploaded files](https://github.com/w3c/ServiceWorker/issues/1141)\).
+In some cases, you might want to bypass the service worker entirely and let the browser handle the request.
+An example is when you rely on a feature that is currently not supported in service workers, such as [reporting progress on uploaded files](https://github.com/w3c/ServiceWorker/issues/1141).
 
 To bypass the service worker, set `ngsw-bypass` as a request header, or as a query parameter.
-\(The value of the header or query parameter is ignored and can be empty or omitted.\)
+The value of the header or query parameter is ignored and can be empty or omitted.
+
+### Service worker requests when the server can't be reached
+
+The service worker processes all requests unless the [service worker is explicitly bypassed](#bypassing-the-service-worker).
+The service worker either returns a cached response or sends the request to the server, depending on the state and configuration of the cache. 
+The service worker only caches responses to non-mutating requests, such as `GET` and `HEAD`.
+
+If the service worker receives an error from the server or it doesn't receive a response, it returns an error status that indicates the result of the call.
+For example, if the service worker doesn't receive a response, it creates a [504 Gateway Timeout](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/504) status to return. The `504` status in this example could be returned because the server is offline or the client is disconnected.
 
 ## Debugging the Angular service worker
 
-Occasionally, it might be necessary to examine the Angular service worker in a running state to investigate issues or to ensure that it is operating as designed.
+Occasionally, it might be necessary to examine the Angular service worker in a running state to investigate issues or whether it's operating as designed.
 Browsers provide built-in tools for debugging service workers and the Angular service worker itself includes useful debugging features.
 
 ### Locating and analyzing debugging information
@@ -187,7 +197,7 @@ There are two possible degraded states:
 
 | Degraded states         | Details |
 |:---                     |:---     |
-| `EXISTING_CLIENTS_ONLY` | The service worker does not have a clean copy of the latest known version of the application. Older cached versions are safe to use, so existing tabs continue to run from cache, but new loads of the application will be served from the network. The service worker will try to recover from this state when a new version of the application is detected and installed \(that is, when a new `ngsw.json` is available\). |
+| `EXISTING_CLIENTS_ONLY` | The service worker does not have a clean copy of the latest known version of the application. Older cached versions are safe to use, so existing tabs continue to run from cache, but new loads of the application will be served from the network. The service worker will try to recover from this state when a new version of the application is detected and installed. This happens when a new `ngsw.json` is available. |
 | `SAFE_MODE`             | The service worker cannot guarantee the safety of using cached data. Either an unexpected error occurred or all cached versions are invalid. All traffic will be served from the network, running as little service worker code as possible.                                                                                                                                                                                 |
 
 In both cases, the parenthetical annotation provides the
@@ -269,9 +279,9 @@ Debug log:
 
 </code-example>
 
-Errors that occur within the service worker will be logged here.
+Errors that occur within the service worker are logged here.
 
-### Developer Tools
+### Developer tools
 
 Browsers such as Chrome provide developer tools for interacting with service workers.
 Such tools can be powerful when used properly, but there are a few things to keep in mind.
@@ -282,22 +292,27 @@ Such tools can be powerful when used properly, but there are a few things to kee
 *   If you look in the Cache Storage viewer, the cache is frequently out of date.
     Right click the Cache Storage title and refresh the caches.
 
-*   Stopping and starting the service worker in the Service Worker pane triggers a check for updates
+*   Stopping and starting the service worker in the Service Worker pane checks for updates
 
-## Service Worker Safety
+## Service worker safety
 
-Like any complex system, bugs or broken configurations can cause the Angular service worker to act in unforeseen ways.
-While its design attempts to minimize the impact of such problems, the Angular service worker contains several failsafe mechanisms in case an administrator ever needs to deactivate the service worker quickly.
+Bugs or broken configurations could cause the Angular service worker to act in unexpected ways.
+If this happens, the Angular service worker contains several failsafe mechanisms in case an administrator needs to deactivate the service worker quickly.
 
 ### Fail-safe
 
-To deactivate the service worker, remove or rename the `ngsw.json` file.
-When the service worker's request for `ngsw.json` returns a `404`, then the service worker removes all of its caches and de-registers itself, essentially self-destructing.
+To deactivate the service worker, rename the `ngsw.json` file or delete it.
+When the service worker's request for `ngsw.json` returns a `404`, then the service worker removes all its caches and de-registers itself, essentially self-destructing.
 
-### Safety Worker
+### Safety worker
 
-Also included in the `@angular/service-worker` NPM package is a small script `safety-worker.js`, which when loaded will unregister itself from the browser and remove the service worker caches.
+<!-- vale Angular.Google_Acronyms = NO -->
+
+A small script, `safety-worker.js`, is also included in the `@angular/service-worker` NPM package.
+When loaded, it un-registers itself from the browser and removes the service worker caches.
 This script can be used as a last resort to get rid of unwanted service workers already installed on client pages.
+
+<!-- vale Angular.Google_Acronyms = YES -->
 
 <div class="alert is-important">
 
@@ -306,11 +321,11 @@ You cannot register this worker directly, as old clients with cached state might
 
 </div>
 
-Instead, you must serve the contents of `safety-worker.js` at the URL of the Service Worker script you are trying to unregister, and must continue to do so until you are certain all users have successfully unregistered the old worker.
+Instead, you must serve the contents of `safety-worker.js` at the URL of the Service Worker script you are trying to unregister. You must continue to do so until you are certain all users have successfully unregistered the old worker.
 For most sites, this means that you should serve the safety worker at the old Service Worker URL forever.
-This script can be used both to deactivate `@angular/service-worker` \(and remove the corresponding caches\) as well as any other Service Workers which might have been served in the past on your site.
+This script can be used to deactivate `@angular/service-worker` and remove the corresponding caches. It also removes any other Service Workers which might have been served in the past on your site.
 
-### Changing your app's location
+### Changing your application's location
 
 <div class="alert is-important">
 
@@ -321,11 +336,11 @@ You might have already encountered the error `The script resource is behind a re
 </div>
 
 This can be a problem if you have to change your application's location.
-If you setup a redirect from the old location \(for example `example.com`\) to the new location \(for example `www.example.com`\) the worker will stop working.
+If you setup a redirect from the old location, such as `example.com`, to the new location, `www.example.com` in this example, the worker stops working.
 Also, the redirect won't even trigger for users who are loading the site entirely from Service Worker.
-The old worker \(registered at `example.com`\) tries to update and sends requests to the old location `example.com` which get redirected to the new location `www.example.com` and create the error `The script resource is behind a redirect, which is disallowed`.
+The old worker, which was registered at `example.com`, tries to update and sends a request to the old location `example.com`. This request is redirected to the new location `www.example.com` and creates the error: `The script resource is behind a redirect, which is disallowed`.
 
-To remedy this, you might need to deactivate the old worker using one of the above techniques \([Fail-safe](#fail-safe) or [Safety Worker](#safety-worker)\).
+To remedy this, you might need to deactivate the old worker using one of the preceding techniques: [Fail-safe](#fail-safe) or [Safety Worker](#safety-worker).
 
 ## More on Angular service workers
 


### PR DESCRIPTION
Docs-only change that:

* Adds a short note about how service workers report request timeouts
* Updated heading levels to present a clearer hierarchy and cleaner local TOC
* Removed documentation lint errors
* Fixes #46445

This is a cleaner branch that the original for PR #46803. 
This branch addresses the comments from the most recent review in #46803