### PR TITLE
feat(platform-server): add analytics token for rendering

### DIFF
--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -24,6 +24,9 @@ export const BEFORE_APP_SERIALIZED: InjectionToken<(() => void | Promise<void>)[
 export const INITIAL_CONFIG: InjectionToken<PlatformConfig>;
 
 // @public
+export const SERVER_CONTEXT: InjectionToken<string>;
+
+// @public
 export interface PlatformConfig {
     baseUrl?: string;
     document?: string;

--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -8,7 +8,7 @@
 
 export {PlatformState} from './platform_state';
 export {platformDynamicServer, platformServer, ServerModule} from './server';
-export {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';
+export {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig, SERVER_CONTEXT} from './tokens';
 export {ServerTransferStateModule} from './transfer_state';
 export {renderApplication, renderModule, renderModuleFactory} from './utils';
 

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -21,7 +21,7 @@ import {PlatformState} from './platform_state';
 import {ServerEventManagerPlugin} from './server_events';
 import {ServerRendererFactory2} from './server_renderer';
 import {ServerStylesHost} from './styles_host';
-import {INITIAL_CONFIG, PlatformConfig} from './tokens';
+import {INITIAL_CONFIG, PlatformConfig, SERVER_CONTEXT} from './tokens';
 
 export const INTERNAL_SERVER_PLATFORM_PROVIDERS: StaticProvider[] = [
   {provide: DOCUMENT, useFactory: _document, deps: [Injector]},
@@ -80,8 +80,11 @@ export class ServerModule {
 
 function _document(injector: Injector) {
   let config: PlatformConfig|null = injector.get(INITIAL_CONFIG, null);
-  const document = config && config.document ? parseDocument(config.document, config.url) :
-                                               getDOM().createHtmlDocument();
+  let context: string = injector.get(SERVER_CONTEXT, 'Angular platform-server');
+  const document =
+      config?.document ? parseDocument(config.document, config.url) : getDOM().createHtmlDocument();
+  document.documentElement.appendChild(
+      document.createComment(`This page was rendered with: ${context}.`));
   // Tell ivy about the global document
   ɵsetDocument(document);
   return document;

--- a/packages/platform-server/src/tokens.ts
+++ b/packages/platform-server/src/tokens.ts
@@ -50,6 +50,14 @@ export interface PlatformConfig {
 export const INITIAL_CONFIG = new InjectionToken<PlatformConfig>('Server.INITIAL_CONFIG');
 
 /**
+ * The DI token for setting the server context. This is used to indicate how the page was
+ * generated for analytics purposes.
+ *
+ * @publicApi
+ */
+export const SERVER_CONTEXT = new InjectionToken<string>('Server.SERVER_CONTEXT');
+
+/**
  * A function that will be executed when calling `renderApplication`, `renderModuleFactory` or
  * `renderModule` just before current platform state is rendered to string.
  *


### PR DESCRIPTION
In order to analyze how a page was rendered, we add a new token
that can be populated and inserted into a rendered webpage. By
default, this token is just "platform-server", but can be
customized by the user depending on their given setup.

We do this here instead of in the individual rendering engines in
order to avoid analytics gaps for customers that may not use one
of the popular solutions, and instead opt to roll their own.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
