### PR TITLE
refactor(router): Move scroller and preloader initializers to be with…

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -483,13 +483,7 @@
     "name": "ROUTER_INITIALIZER"
   },
   {
-    "name": "ROUTER_PRELOADER"
-  },
-  {
     "name": "ROUTER_PROVIDERS"
-  },
-  {
-    "name": "ROUTER_SCROLLER"
   },
   {
     "name": "ROUTES"

--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -7,15 +7,18 @@
  */
 
 import {ViewportScroller} from '@angular/common';
-import {Injectable, InjectionToken, OnDestroy} from '@angular/core';
+import {inject, Injectable, OnDestroy} from '@angular/core';
 import {Unsubscribable} from 'rxjs';
 
 import {NavigationEnd, NavigationStart, Scroll} from './events';
 import {Router} from './router';
+import {ROUTER_CONFIGURATION} from './router_config';
 
-export const ROUTER_SCROLLER = new InjectionToken<RouterScroller>('');
-
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+  useFactory: () =>
+      new RouterScroller(inject(Router), inject(ViewportScroller), inject(ROUTER_CONFIGURATION))
+})
 export class RouterScroller implements OnDestroy {
   // TODO(issue/24571): remove '!'.
   private routerEventsSubscription!: Unsubscribable;


### PR DESCRIPTION
… their providers

This commit breaks up the single APP_BOOTSTRAP_LISTENER into multiple
ones, each with a more focused purpose.

reviewer note: targeting RC instead of `patch` because there are other router refactors that went into the RC release only. There will otherwise be merge conflicts with patch. If this lands after the 14.1 release, the target should be changed to `patch`.