### PR TITLE
refactor(bazel): remove `experimental_extended_template_diagnostics` flag

### DIFF
--- a/packages/bazel/src/ng_module/ng_module.bzl
+++ b/packages/bazel/src/ng_module/ng_module.bzl
@@ -191,9 +191,6 @@ def _ngc_tsconfig(ctx, files, srcs, **kwargs):
     if not ctx.attr.type_check and ctx.attr.strict_templates:
         fail("Cannot set type_check = False and strict_templates = True for ng_module()")
 
-    if ctx.attr.experimental_extended_template_diagnostics and not ctx.attr.strict_templates:
-        fail("Cannot set `experimental_extended_template_diagnostics = True` **and** `strict_templates = False` for `ng_module()`")
-
     angular_compiler_options = {
         "enableResourceInlining": ctx.attr.inline_resources,
         "generateCodeForLibraries": False,
@@ -503,10 +500,6 @@ NG_MODULE_ATTRIBUTES = {
     "filter_summaries": attr.bool(default = False),
     "type_check": attr.bool(default = True),
     "strict_templates": attr.bool(default = False),
-    "experimental_extended_template_diagnostics": attr.bool(
-        default = False,
-        doc = "Experimental option, not publicly supported.",
-    ),
     "inline_resources": attr.bool(default = True),
     "no_i18n": attr.bool(default = False),
     "compiler": attr.label(

--- a/packages/bazel/test/ngc-wrapped/ivy_enabled/BUILD.bazel
+++ b/packages/bazel/test/ngc-wrapped/ivy_enabled/BUILD.bazel
@@ -28,7 +28,6 @@ jasmine_node_test(
 ng_module(
     name = "test_module_warnings_lib",
     srcs = ["test_module_warnings.ts"],
-    experimental_extended_template_diagnostics = True,
     strict_templates = True,
     tags = [],
     deps = ["//packages/core"],


### PR DESCRIPTION
Extended diagnostics are enabled by default now and this flag doesn't do anything anymore but I missed it in a previous cleanup.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Refactoring (no functional changes, no api changes)

## What is the current behavior?

`experimental_extended_template_diagnostics` flag exists, but is a no-op because they are enabled by default.

## What is the new behavior?

`experimental_extended_template_diagnostics` flag is removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

The flag was always experimental and not public API.

## Other information
