### PR TITLE
refactor(platform-server): include `TransferState` providers into `ServerModule`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -76,6 +76,7 @@ v14 - v17
 | `@angular/core/testing`             | [`async`](#testing)                                                                                        | <!--  v9 --> v12         |
 | `@angular/forms`                    | [`FormBuilder.group` legacy options parameter](api/forms/FormBuilder#group)                                | <!-- v11 --> v14         |
 | `@angular/platform-server`          | [`renderModuleFactory`](#platform-server)                                                                  | <!-- v13 --> v15         |
+| `@angular/platform-server`          | [`ServerTransferStateModule`](#platform-server)                                                                  | <!-- v14 --> v16         |
 | `@angular/platform-browser`          | [`BrowserTransferStateModule`](#platform-browser)                                                                  | <!-- v14 --> v16         |
 | `@angular/router`                   | [`relativeLinkResolution`](#relativeLinkResolution)                                                        | <!-- v14 --> v16         |
 | `@angular/router`                     | [`resolver` argument in `RouterOutletContract.activateWith`](#router)                                                                        | <!-- v14 --> v16         |
@@ -185,6 +186,7 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 | API                                                              | Replacement                                        | Deprecation announced | Details |
 |:---                                                              |:---                                                |:---                   |:---     |
 | [`renderModuleFactory`](api/platform-server/renderModuleFactory) | [`renderModule`](api/platform-server/renderModule) | v13                   | This symbol is no longer necessary. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context. |
+| [`ServerTransferStateModule`](api/platform-server/ServerTransferStateModule) | No replacement needed.  | v14.1                   | The `TransferState` class is available for injection without importing additional modules during server side rendering, when `ServerModule` is imported or `renderApplication` function is used for bootstrap. |
 
 
 <a id="forms"></a>

--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -81,7 +81,7 @@ export class ServerModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<ServerModule, never, [typeof i1.HttpClientModule, typeof i2.NoopAnimationsModule], [typeof i3.BrowserModule]>;
 }
 
-// @public
+// @public @deprecated
 export class ServerTransferStateModule {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ServerTransferStateModule, never>;

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -22,6 +22,7 @@ import {ServerEventManagerPlugin} from './server_events';
 import {ServerRendererFactory2} from './server_renderer';
 import {ServerStylesHost} from './styles_host';
 import {INITIAL_CONFIG, PlatformConfig} from './tokens';
+import {TRANSFER_STATE_SERIALIZATION_PROVIDERS} from './transfer_state';
 
 export const INTERNAL_SERVER_PLATFORM_PROVIDERS: StaticProvider[] = [
   {provide: DOCUMENT, useFactory: _document, deps: [Injector]},
@@ -68,6 +69,7 @@ export const SERVER_RENDER_PROVIDERS: Provider[] = [
   exports: [BrowserModule],
   imports: [HttpClientModule, NoopAnimationsModule],
   providers: [
+    TRANSFER_STATE_SERIALIZATION_PROVIDERS,
     SERVER_RENDER_PROVIDERS,
     SERVER_HTTP_PROVIDERS,
     {provide: Testability, useValue: null},  // Keep for backwards-compatibility.

--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -19,8 +19,7 @@ export const TRANSFER_STATE_SERIALIZATION_PROVIDERS: Provider[] = [{
   multi: true,
 }];
 
-export function serializeTransferStateFactory(
-    doc: Document, appId: string, transferStore: TransferState) {
+function serializeTransferStateFactory(doc: Document, appId: string, transferStore: TransferState) {
   return () => {
     const store = (transferStore as unknown as {store: {}}).store;
     const isStateEmpty = Object.keys(store).length === 0;
@@ -45,9 +44,9 @@ export function serializeTransferStateFactory(
  * The `renderApplication` makes all providers from this module available in the application.
  *
  * @publicApi
+ * @deprecated no longer needed, you can inject the `TransferState` in an app without providing
+ *     this module.
  */
-@NgModule({
-  providers: TRANSFER_STATE_SERIALIZATION_PROVIDERS,
-})
+@NgModule({})
 export class ServerTransferStateModule {
 }

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -474,7 +474,6 @@ class EscapedComponent {
   imports: [
     BrowserModule.withServerTransition({appId: 'transfer'}),
     ServerModule,
-    ServerTransferStateModule,
   ]
 })
 class TransferStoreModule {
@@ -486,7 +485,6 @@ class TransferStoreModule {
   imports: [
     BrowserModule.withServerTransition({appId: 'transfer'}),
     ServerModule,
-    ServerTransferStateModule,
   ]
 })
 class EscapedTransferStoreModule {


### PR DESCRIPTION
This commit updates the code to include the TransferState providers (used for serialization) into the `ServerModule` instead of having the need to import the `ServerTransferStateModule` separately.

The list of providers in the `ServerTransferStateModule` is now empty and importing it is a noop. This is not a breaking change, since the `ServerModule` must be included anyways to make server rendering work correctly.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No