### PR TITLE
fix(common): allow null/undefined to be passed to ngClass input (#39280)

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -403,7 +403,7 @@ export class NgClass implements DoCheck {
     // (undocumented)
     set ngClass(value: string | string[] | Set<string> | {
         [klass: string]: any;
-    });
+    } | null | undefined);
     // (undocumented)
     ngDoCheck(): void;
     // (undocumented)

--- a/packages/common/src/directives/ng_class.ts
+++ b/packages/common/src/directives/ng_class.ts
@@ -61,7 +61,7 @@ export class NgClass implements DoCheck {
   }
 
   @Input('ngClass')
-  set ngClass(value: string|string[]|Set<string>|{[klass: string]: any}) {
+  set ngClass(value: string|string[]|Set<string>|{[klass: string]: any}|null|undefined) {
     this._removeClasses(this._rawClass);
     this._applyClasses(this._initialClasses);
 

--- a/packages/common/test/directives/ng_class_spec.ts
+++ b/packages/common/test/directives/ng_class_spec.ts
@@ -115,6 +115,17 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
            detectChangesAndExpectClassName('bar');
          }));
 
+      it('should remove active classes when expression evaluates to undefined', waitForAsync(() => {
+           fixture = createTestComponent('<div [ngClass]="objExpr"></div>');
+
+           detectChangesAndExpectClassName('foo');
+
+           getComponent().objExpr = undefined;
+           detectChangesAndExpectClassName('');
+
+           getComponent().objExpr = {'foo': false, 'bar': true};
+           detectChangesAndExpectClassName('bar');
+         }));
 
       it('should allow multiple classes per expression', waitForAsync(() => {
            fixture = createTestComponent('<div [ngClass]="objExpr"></div>');
@@ -246,12 +257,30 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
            detectChangesAndExpectClassName('');
          }));
 
+      it('should remove active classes when switching from string to undefined',
+         waitForAsync(() => {
+           fixture = createTestComponent(`<div [ngClass]="strExpr"></div>`);
+           detectChangesAndExpectClassName('foo');
+
+           getComponent().strExpr = undefined;
+           detectChangesAndExpectClassName('');
+         }));
+
       it('should take initial classes into account when switching from string to null',
          waitForAsync(() => {
            fixture = createTestComponent(`<div class="foo" [ngClass]="strExpr"></div>`);
            detectChangesAndExpectClassName('foo');
 
            getComponent().strExpr = null;
+           detectChangesAndExpectClassName('foo');
+         }));
+
+      it('should take initial classes into account when switching from string to undefined',
+         waitForAsync(() => {
+           fixture = createTestComponent(`<div class="foo" [ngClass]="strExpr"></div>`);
+           detectChangesAndExpectClassName('foo');
+
+           getComponent().strExpr = undefined;
            detectChangesAndExpectClassName('foo');
          }));
 
@@ -275,6 +304,9 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
 
            getComponent().objExpr = null;
            detectChangesAndExpectClassName('init foo');
+
+           getComponent().objExpr = undefined;
+           detectChangesAndExpectClassName('init foo');
          }));
 
       it('should co-operate with the interpolated class attribute', waitForAsync(() => {
@@ -288,6 +320,9 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
            detectChangesAndExpectClassName(`init bar`);
 
            getComponent().objExpr = null;
+           detectChangesAndExpectClassName(`init foo`);
+
+           getComponent().objExpr = undefined;
            detectChangesAndExpectClassName(`init foo`);
          }));
 
@@ -314,6 +349,9 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
            detectChangesAndExpectClassName(`init bar`);
 
            getComponent().objExpr = null;
+           detectChangesAndExpectClassName(`init foo`);
+
+           getComponent().objExpr = undefined;
            detectChangesAndExpectClassName(`init foo`);
          }));
 
@@ -350,6 +388,9 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
            detectChangesAndExpectClassName('init bar baz foo');
 
            cmp.objExpr = null;
+           detectChangesAndExpectClassName('init baz');
+
+           cmp.objExpr = undefined;
            detectChangesAndExpectClassName('init baz');
          }));
     });
@@ -419,8 +460,8 @@ class TestComponent {
   items: any[]|undefined;
   arrExpr: string[] = ['foo'];
   setExpr: Set<string> = new Set<string>();
-  objExpr: {[klass: string]: any}|null = {'foo': true, 'bar': false};
-  strExpr: string|null = 'foo';
+  objExpr: {[klass: string]: any}|null|undefined = {'foo': true, 'bar': false};
+  strExpr: string|null|undefined = 'foo';
 
   constructor() {
     this.setExpr.add('foo');


### PR DESCRIPTION
With strict template type checking, a null/undefined value will raise an
error. However the implementation is completely fine with it, and it
would be pointless to "fix" it at the callsite and convert to e.g. an
empty string. Allow all of the "supported types" to be passed in
directly to ngClass.

Fixes #39280

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: #39280

Currently bindings to `[ngClass]` that may return null or undefined are rejected by typescript as a result of enabling `strictTemplates` (e.g. `map.get('foo')` or anything else whose type includes undefined)

## What is the new behavior?

undefined/null are allowed by the `@Input` type and thus `strictTemplate`-enabled builds

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Wasn't sure how to add a test for this specifically, since one has to enable strictTemplates for the source issue to occur. Suggestions welcome.