### PR TITLE
refactor(router): Update Router to be `providedIn: 'root'`

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -733,11 +733,11 @@ export class RouterLinkWithHref implements OnChanges, OnDestroy {
 
 // @public
 export class RouterModule {
-    constructor(guard: any, router: Router);
+    constructor(guard: any);
     static forChild(routes: Routes): ModuleWithProviders<RouterModule>;
     static forRoot(routes: Routes, config?: ExtraOptions): ModuleWithProviders<RouterModule>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<RouterModule, [{ optional: true; }, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<RouterModule, [{ optional: true; }]>;
     // (undocumented)
     static ɵinj: i0.ɵɵInjectorDeclaration<RouterModule>;
     // (undocumented)

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1839,6 +1839,9 @@
     "name": "setUpAttributes"
   },
   {
+    "name": "setupRouter"
+  },
+  {
     "name": "shallowEqual"
   },
   {

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -16,8 +16,9 @@ export {CanActivate, CanActivateChild, CanDeactivate, CanLoad, CanMatch, CanMatc
 export {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
 export {BaseRouteReuseStrategy, DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Navigation, NavigationExtras, Router, UrlCreationOptions} from './router';
+export {ExtraOptions, InitialNavigation, ROUTER_CONFIGURATION} from './router_config';
 export {ROUTES} from './router_config_loader';
-export {ExtraOptions, InitialNavigation, provideRoutes, ROUTER_CONFIGURATION, ROUTER_INITIALIZER, RouterModule} from './router_module';
+export {provideRoutes, ROUTER_INITIALIZER, RouterModule} from './router_module';
 export {ChildrenOutletContexts, OutletContext} from './router_outlet_context';
 export {NoPreloading, PreloadAllModules, PreloadingStrategy, RouterPreloader} from './router_preloader';
 export {ActivatedRoute, ActivatedRouteSnapshot, RouterState, RouterStateSnapshot} from './router_state';

--- a/packages/router/src/private_export.ts
+++ b/packages/router/src/private_export.ts
@@ -8,6 +8,6 @@
 
 
 export {ɵEmptyOutletComponent} from './components/empty_outlet';
-export {RestoredState as ɵRestoredState} from './router';
-export {assignExtraOptionsToRouter as ɵassignExtraOptionsToRouter, providePreloading as ɵprovidePreloading, ROUTER_PROVIDERS as ɵROUTER_PROVIDERS} from './router_module';
+export {assignExtraOptionsToRouter as ɵassignExtraOptionsToRouter, RestoredState as ɵRestoredState} from './router';
+export {providePreloading as ɵprovidePreloading, ROUTER_PROVIDERS as ɵROUTER_PROVIDERS} from './router_module';
 export {flatten as ɵflatten} from './utils/collection';

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -1,0 +1,270 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectionToken} from '@angular/core';
+
+import {UrlSerializer, UrlTree} from './url_tree';
+
+const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
+
+/**
+ * Error handler that is invoked when a navigation error occurs.
+ *
+ * If the handler returns a value, the navigation Promise is resolved with this value.
+ * If the handler throws an exception, the navigation Promise is rejected with
+ * the exception.
+ *
+ * @publicApi
+ */
+export type ErrorHandler = (error: any) => any;
+
+/**
+ * Allowed values in an `ExtraOptions` object that configure
+ * when the router performs the initial navigation operation.
+ *
+ * * 'enabledNonBlocking' - (default) The initial navigation starts after the
+ * root component has been created. The bootstrap is not blocked on the completion of the initial
+ * navigation.
+ * * 'enabledBlocking' - The initial navigation starts before the root component is created.
+ * The bootstrap is blocked until the initial navigation is complete. This value is required
+ * for [server-side rendering](guide/universal) to work.
+ * * 'disabled' - The initial navigation is not performed. The location listener is set up before
+ * the root component gets created. Use if there is a reason to have
+ * more control over when the router starts its initial navigation due to some complex
+ * initialization logic.
+ *
+ * The following values have been [deprecated](guide/releases#deprecation-practices) since v11,
+ * and should not be used for new applications.
+ *
+ * @see `forRoot()`
+ *
+ * @publicApi
+ */
+export type InitialNavigation = 'disabled'|'enabledBlocking'|'enabledNonBlocking';
+
+/**
+ * A set of configuration options for a router module, provided in the
+ * `forRoot()` method.
+ *
+ * @see `forRoot()`
+ *
+ *
+ * @publicApi
+ */
+export interface ExtraOptions {
+  /**
+   * When true, log all internal navigation events to the console.
+   * Use for debugging.
+   */
+  enableTracing?: boolean;
+
+  /**
+   * When true, enable the location strategy that uses the URL fragment
+   * instead of the history API.
+   */
+  useHash?: boolean;
+
+  /**
+   * One of `enabled`, `enabledBlocking`, `enabledNonBlocking` or `disabled`.
+   * When set to `enabled` or `enabledBlocking`, the initial navigation starts before the root
+   * component is created. The bootstrap is blocked until the initial navigation is complete. This
+   * value is required for [server-side rendering](guide/universal) to work. When set to
+   * `enabledNonBlocking`, the initial navigation starts after the root component has been created.
+   * The bootstrap is not blocked on the completion of the initial navigation. When set to
+   * `disabled`, the initial navigation is not performed. The location listener is set up before the
+   * root component gets created. Use if there is a reason to have more control over when the router
+   * starts its initial navigation due to some complex initialization logic.
+   */
+  initialNavigation?: InitialNavigation;
+
+  /**
+   * A custom error handler for failed navigations.
+   * If the handler returns a value, the navigation Promise is resolved with this value.
+   * If the handler throws an exception, the navigation Promise is rejected with the exception.
+   *
+   */
+  errorHandler?: ErrorHandler;
+
+  /**
+   * Configures a preloading strategy.
+   * One of `PreloadAllModules` or `NoPreloading` (the default).
+   */
+  preloadingStrategy?: any;
+
+  /**
+   * Define what the router should do if it receives a navigation request to the current URL.
+   * Default is `ignore`, which causes the router ignores the navigation.
+   * This can disable features such as a "refresh" button.
+   * Use this option to configure the behavior when navigating to the
+   * current URL. Default is 'ignore'.
+   */
+  onSameUrlNavigation?: 'reload'|'ignore';
+
+  /**
+   * Configures if the scroll position needs to be restored when navigating back.
+   *
+   * * 'disabled'- (Default) Does nothing. Scroll position is maintained on navigation.
+   * * 'top'- Sets the scroll position to x = 0, y = 0 on all navigation.
+   * * 'enabled'- Restores the previous scroll position on backward navigation, else sets the
+   * position to the anchor if one is provided, or sets the scroll position to [0, 0] (forward
+   * navigation). This option will be the default in the future.
+   *
+   * You can implement custom scroll restoration behavior by adapting the enabled behavior as
+   * in the following example.
+   *
+   * ```typescript
+   * class AppComponent {
+   *   movieData: any;
+   *
+   *   constructor(private router: Router, private viewportScroller: ViewportScroller,
+   * changeDetectorRef: ChangeDetectorRef) {
+   *   router.events.pipe(filter((event: Event): event is Scroll => event instanceof Scroll)
+   *     ).subscribe(e => {
+   *       fetch('http://example.com/movies.json').then(response => {
+   *         this.movieData = response.json();
+   *         // update the template with the data before restoring scroll
+   *         changeDetectorRef.detectChanges();
+   *
+   *         if (e.position) {
+   *           viewportScroller.scrollToPosition(e.position);
+   *         }
+   *       });
+   *     });
+   *   }
+   * }
+   * ```
+   */
+  scrollPositionRestoration?: 'disabled'|'enabled'|'top';
+
+  /**
+   * When set to 'enabled', scrolls to the anchor element when the URL has a fragment.
+   * Anchor scrolling is disabled by default.
+   *
+   * Anchor scrolling does not happen on 'popstate'. Instead, we restore the position
+   * that we stored or scroll to the top.
+   */
+  anchorScrolling?: 'disabled'|'enabled';
+
+  /**
+   * Configures the scroll offset the router will use when scrolling to an element.
+   *
+   * When given a tuple with x and y position value,
+   * the router uses that offset each time it scrolls.
+   * When given a function, the router invokes the function every time
+   * it restores scroll position.
+   */
+  scrollOffset?: [number, number]|(() => [number, number]);
+
+  /**
+   * Defines how the router merges parameters, data, and resolved data from parent to child
+   * routes. By default ('emptyOnly'), inherits parent parameters only for
+   * path-less or component-less routes.
+   *
+   * Set to 'always' to enable unconditional inheritance of parent parameters.
+   *
+   * Note that when dealing with matrix parameters, "parent" refers to the parent `Route`
+   * config which does not necessarily mean the "URL segment to the left". When the `Route` `path`
+   * contains multiple segments, the matrix parameters must appear on the last segment. For example,
+   * matrix parameters for `{path: 'a/b', component: MyComp}` should appear as `a/b;foo=bar` and not
+   * `a;foo=bar/b`.
+   *
+   */
+  paramsInheritanceStrategy?: 'emptyOnly'|'always';
+
+  /**
+   * A custom handler for malformed URI errors. The handler is invoked when `encodedURI` contains
+   * invalid character sequences.
+   * The default implementation is to redirect to the root URL, dropping
+   * any path or parameter information. The function takes three parameters:
+   *
+   * - `'URIError'` - Error thrown when parsing a bad URL.
+   * - `'UrlSerializer'` - UrlSerializer that’s configured with the router.
+   * - `'url'` -  The malformed URL that caused the URIError
+   * */
+  malformedUriErrorHandler?:
+      (error: URIError, urlSerializer: UrlSerializer, url: string) => UrlTree;
+
+  /**
+   * Defines when the router updates the browser URL. By default ('deferred'),
+   * update after successful navigation.
+   * Set to 'eager' if prefer to update the URL at the beginning of navigation.
+   * Updating the URL early allows you to handle a failure of navigation by
+   * showing an error message with the URL that failed.
+   */
+  urlUpdateStrategy?: 'deferred'|'eager';
+
+  /**
+   * Enables a bug fix that corrects relative link resolution in components with empty paths.
+   * Example:
+   *
+   * ```
+   * const routes = [
+   *   {
+   *     path: '',
+   *     component: ContainerComponent,
+   *     children: [
+   *       { path: 'a', component: AComponent },
+   *       { path: 'b', component: BComponent },
+   *     ]
+   *   }
+   * ];
+   * ```
+   *
+   * From the `ContainerComponent`, you should be able to navigate to `AComponent` using
+   * the following `routerLink`, but it will not work if `relativeLinkResolution` is set
+   * to `'legacy'`:
+   *
+   * `<a [routerLink]="['./a']">Link to A</a>`
+   *
+   * However, this will work:
+   *
+   * `<a [routerLink]="['../a']">Link to A</a>`
+   *
+   * In other words, you're required to use `../` rather than `./` when the relative link
+   * resolution is set to `'legacy'`.
+   *
+   * The default in v11 is `corrected`.
+   *
+   * @deprecated
+   */
+  relativeLinkResolution?: 'legacy'|'corrected';
+
+  /**
+   * Configures how the Router attempts to restore state when a navigation is cancelled.
+   *
+   * 'replace' - Always uses `location.replaceState` to set the browser state to the state of the
+   * router before the navigation started. This means that if the URL of the browser is updated
+   * _before_ the navigation is canceled, the Router will simply replace the item in history rather
+   * than trying to restore to the previous location in the session history. This happens most
+   * frequently with `urlUpdateStrategy: 'eager'` and navigations with the browser back/forward
+   * buttons.
+   *
+   * 'computed' - Will attempt to return to the same index in the session history that corresponds
+   * to the Angular route when the navigation gets cancelled. For example, if the browser back
+   * button is clicked and the navigation is cancelled, the Router will trigger a forward navigation
+   * and vice versa.
+   *
+   * Note: the 'computed' option is incompatible with any `UrlHandlingStrategy` which only
+   * handles a portion of the URL because the history restoration navigates to the previous place in
+   * the browser history rather than simply resetting a portion of the URL.
+   *
+   * The default value is `replace` when not set.
+   */
+  canceledNavigationResolution?: 'replace'|'computed';
+}
+
+/**
+ * A [DI token](guide/glossary/#di-token) for the router service.
+ *
+ * @publicApi
+ */
+export const ROUTER_CONFIGURATION =
+    new InjectionToken<ExtraOptions>(NG_DEV_MODE ? 'router config' : '', {
+      providedIn: 'root',
+      factory: () => ({}),
+    });

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -7,7 +7,7 @@
  */
 
 import {HashLocationStrategy, Location, LOCATION_INITIALIZED, LocationStrategy, PathLocationStrategy, ViewportScroller} from '@angular/common';
-import {ANALYZE_FOR_ENTRY_COMPONENTS, APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, ApplicationRef, Compiler, ComponentRef, ENVIRONMENT_INITIALIZER, Inject, inject, InjectFlags, InjectionToken, Injector, ModuleWithProviders, NgModule, NgProbeToken, Optional, Provider, SkipSelf, Type, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {ANALYZE_FOR_ENTRY_COMPONENTS, APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, ApplicationRef, ComponentRef, ENVIRONMENT_INITIALIZER, inject, Inject, InjectFlags, InjectionToken, Injector, ModuleWithProviders, NgModule, NgProbeToken, Optional, Provider, SkipSelf, Type, ɵRuntimeError as RuntimeError} from '@angular/core';
 import {of, Subject} from 'rxjs';
 import {filter, map, take} from 'rxjs/operators';
 
@@ -17,18 +17,15 @@ import {RouterLinkActive} from './directives/router_link_active';
 import {RouterOutlet} from './directives/router_outlet';
 import {RuntimeErrorCode} from './errors';
 import {Event, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, stringifyEvent} from './events';
-import {Route, Routes} from './models';
-import {TitleStrategy} from './page_title_strategy';
-import {RouteReuseStrategy} from './route_reuse_strategy';
-import {ErrorHandler, Router} from './router';
+import {Routes} from './models';
+import {Router, setupRouter} from './router';
+import {ExtraOptions, ROUTER_CONFIGURATION} from './router_config';
 import {RouterConfigLoader, ROUTES} from './router_config_loader';
 import {ChildrenOutletContexts} from './router_outlet_context';
 import {PreloadingStrategy, RouterPreloader} from './router_preloader';
 import {ROUTER_SCROLLER, RouterScroller} from './router_scroller';
 import {ActivatedRoute} from './router_state';
-import {UrlHandlingStrategy} from './url_handling_strategy';
-import {DefaultUrlSerializer, UrlSerializer, UrlTree} from './url_tree';
-import {flatten} from './utils/collection';
+import {DefaultUrlSerializer, UrlSerializer} from './url_tree';
 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
 
@@ -39,17 +36,6 @@ const ROUTER_DIRECTIVES =
     [RouterOutlet, RouterLink, RouterLinkWithHref, RouterLinkActive, EmptyOutletComponent];
 
 /**
- * A [DI token](guide/glossary/#di-token) for the router service.
- *
- * @publicApi
- */
-export const ROUTER_CONFIGURATION =
-    new InjectionToken<ExtraOptions>(NG_DEV_MODE ? 'router config' : 'ROUTER_CONFIGURATION', {
-      providedIn: 'root',
-      factory: () => ({}),
-    });
-
-/**
  * @docsNotRequired
  */
 export const ROUTER_FORROOT_GUARD = new InjectionToken<void>(
@@ -57,22 +43,22 @@ export const ROUTER_FORROOT_GUARD = new InjectionToken<void>(
 
 const ROUTER_PRELOADER = new InjectionToken<RouterPreloader>(NG_DEV_MODE ? 'router preloader' : '');
 
+// TODO(atscott): All of these except `ActivatedRoute` are `providedIn: 'root'`. They are only kept
+// here to avoid a breaking change whereby the provider order matters based on where the
+// `RouterModule`/`RouterTestingModule` is imported. These can/should be removed as a "breaking"
+// change in a major version.
 export const ROUTER_PROVIDERS: Provider[] = [
   Location,
   {provide: UrlSerializer, useClass: DefaultUrlSerializer},
-  {
-    provide: Router,
-    useFactory: setupRouter,
-    deps: [
-      UrlSerializer, ChildrenOutletContexts, Location, Injector, Compiler, ROUTES, TitleStrategy,
-      ROUTER_CONFIGURATION, [UrlHandlingStrategy, new Optional()],
-      [RouteReuseStrategy, new Optional()]
-    ]
-  },
+  {provide: Router, useFactory: setupRouter},
   ChildrenOutletContexts,
   {provide: ActivatedRoute, useFactory: rootRoute, deps: [Router]},
   RouterConfigLoader,
 ];
+
+export function rootRoute(router: Router): ActivatedRoute {
+  return router.routerState.root;
+}
 
 export function routerNgProbeToken() {
   return new NgProbeToken('Router', Router);
@@ -104,8 +90,7 @@ export function routerNgProbeToken() {
   exports: ROUTER_DIRECTIVES,
 })
 export class RouterModule {
-  // Note: We are injecting the Router so it gets created eagerly...
-  constructor(@Optional() @Inject(ROUTER_FORROOT_GUARD) guard: any, @Optional() router: Router) {}
+  constructor(@Optional() @Inject(ROUTER_FORROOT_GUARD) guard: any) {}
 
   /**
    * Creates and configures a module with all the router providers and directives.
@@ -222,298 +207,6 @@ export function provideRoutes(routes: Routes): any {
     {provide: ANALYZE_FOR_ENTRY_COMPONENTS, multi: true, useValue: routes},
     {provide: ROUTES, multi: true, useValue: routes},
   ];
-}
-
-/**
- * Allowed values in an `ExtraOptions` object that configure
- * when the router performs the initial navigation operation.
- *
- * * 'enabledNonBlocking' - (default) The initial navigation starts after the
- * root component has been created. The bootstrap is not blocked on the completion of the initial
- * navigation.
- * * 'enabledBlocking' - The initial navigation starts before the root component is created.
- * The bootstrap is blocked until the initial navigation is complete. This value is required
- * for [server-side rendering](guide/universal) to work.
- * * 'disabled' - The initial navigation is not performed. The location listener is set up before
- * the root component gets created. Use if there is a reason to have
- * more control over when the router starts its initial navigation due to some complex
- * initialization logic.
- *
- * The following values have been [deprecated](guide/releases#deprecation-practices) since v11,
- * and should not be used for new applications.
- *
- * @see `forRoot()`
- *
- * @publicApi
- */
-export type InitialNavigation = 'disabled'|'enabledBlocking'|'enabledNonBlocking';
-
-/**
- * A set of configuration options for a router module, provided in the
- * `forRoot()` method.
- *
- * @see `forRoot()`
- *
- *
- * @publicApi
- */
-export interface ExtraOptions {
-  /**
-   * When true, log all internal navigation events to the console.
-   * Use for debugging.
-   */
-  enableTracing?: boolean;
-
-  /**
-   * When true, enable the location strategy that uses the URL fragment
-   * instead of the history API.
-   */
-  useHash?: boolean;
-
-  /**
-   * One of `enabled`, `enabledBlocking`, `enabledNonBlocking` or `disabled`.
-   * When set to `enabled` or `enabledBlocking`, the initial navigation starts before the root
-   * component is created. The bootstrap is blocked until the initial navigation is complete. This
-   * value is required for [server-side rendering](guide/universal) to work. When set to
-   * `enabledNonBlocking`, the initial navigation starts after the root component has been created.
-   * The bootstrap is not blocked on the completion of the initial navigation. When set to
-   * `disabled`, the initial navigation is not performed. The location listener is set up before the
-   * root component gets created. Use if there is a reason to have more control over when the router
-   * starts its initial navigation due to some complex initialization logic.
-   */
-  initialNavigation?: InitialNavigation;
-
-  /**
-   * A custom error handler for failed navigations.
-   * If the handler returns a value, the navigation Promise is resolved with this value.
-   * If the handler throws an exception, the navigation Promise is rejected with the exception.
-   *
-   */
-  errorHandler?: ErrorHandler;
-
-  /**
-   * Configures a preloading strategy.
-   * One of `PreloadAllModules` or `NoPreloading` (the default).
-   */
-  preloadingStrategy?: any;
-
-  /**
-   * Define what the router should do if it receives a navigation request to the current URL.
-   * Default is `ignore`, which causes the router ignores the navigation.
-   * This can disable features such as a "refresh" button.
-   * Use this option to configure the behavior when navigating to the
-   * current URL. Default is 'ignore'.
-   */
-  onSameUrlNavigation?: 'reload'|'ignore';
-
-  /**
-   * Configures if the scroll position needs to be restored when navigating back.
-   *
-   * * 'disabled'- (Default) Does nothing. Scroll position is maintained on navigation.
-   * * 'top'- Sets the scroll position to x = 0, y = 0 on all navigation.
-   * * 'enabled'- Restores the previous scroll position on backward navigation, else sets the
-   * position to the anchor if one is provided, or sets the scroll position to [0, 0] (forward
-   * navigation). This option will be the default in the future.
-   *
-   * You can implement custom scroll restoration behavior by adapting the enabled behavior as
-   * in the following example.
-   *
-   * ```typescript
-   * class AppComponent {
-   *   movieData: any;
-   *
-   *   constructor(private router: Router, private viewportScroller: ViewportScroller,
-   * changeDetectorRef: ChangeDetectorRef) {
-   *   router.events.pipe(filter((event: Event): event is Scroll => event instanceof Scroll)
-   *     ).subscribe(e => {
-   *       fetch('http://example.com/movies.json').then(response => {
-   *         this.movieData = response.json();
-   *         // update the template with the data before restoring scroll
-   *         changeDetectorRef.detectChanges();
-   *
-   *         if (e.position) {
-   *           viewportScroller.scrollToPosition(e.position);
-   *         }
-   *       });
-   *     });
-   *   }
-   * }
-   * ```
-   */
-  scrollPositionRestoration?: 'disabled'|'enabled'|'top';
-
-  /**
-   * When set to 'enabled', scrolls to the anchor element when the URL has a fragment.
-   * Anchor scrolling is disabled by default.
-   *
-   * Anchor scrolling does not happen on 'popstate'. Instead, we restore the position
-   * that we stored or scroll to the top.
-   */
-  anchorScrolling?: 'disabled'|'enabled';
-
-  /**
-   * Configures the scroll offset the router will use when scrolling to an element.
-   *
-   * When given a tuple with x and y position value,
-   * the router uses that offset each time it scrolls.
-   * When given a function, the router invokes the function every time
-   * it restores scroll position.
-   */
-  scrollOffset?: [number, number]|(() => [number, number]);
-
-  /**
-   * Defines how the router merges parameters, data, and resolved data from parent to child
-   * routes. By default ('emptyOnly'), inherits parent parameters only for
-   * path-less or component-less routes.
-   *
-   * Set to 'always' to enable unconditional inheritance of parent parameters.
-   *
-   * Note that when dealing with matrix parameters, "parent" refers to the parent `Route`
-   * config which does not necessarily mean the "URL segment to the left". When the `Route` `path`
-   * contains multiple segments, the matrix parameters must appear on the last segment. For example,
-   * matrix parameters for `{path: 'a/b', component: MyComp}` should appear as `a/b;foo=bar` and not
-   * `a;foo=bar/b`.
-   *
-   */
-  paramsInheritanceStrategy?: 'emptyOnly'|'always';
-
-  /**
-   * A custom handler for malformed URI errors. The handler is invoked when `encodedURI` contains
-   * invalid character sequences.
-   * The default implementation is to redirect to the root URL, dropping
-   * any path or parameter information. The function takes three parameters:
-   *
-   * - `'URIError'` - Error thrown when parsing a bad URL.
-   * - `'UrlSerializer'` - UrlSerializer that’s configured with the router.
-   * - `'url'` -  The malformed URL that caused the URIError
-   * */
-  malformedUriErrorHandler?:
-      (error: URIError, urlSerializer: UrlSerializer, url: string) => UrlTree;
-
-  /**
-   * Defines when the router updates the browser URL. By default ('deferred'),
-   * update after successful navigation.
-   * Set to 'eager' if prefer to update the URL at the beginning of navigation.
-   * Updating the URL early allows you to handle a failure of navigation by
-   * showing an error message with the URL that failed.
-   */
-  urlUpdateStrategy?: 'deferred'|'eager';
-
-  /**
-   * Enables a bug fix that corrects relative link resolution in components with empty paths.
-   * Example:
-   *
-   * ```
-   * const routes = [
-   *   {
-   *     path: '',
-   *     component: ContainerComponent,
-   *     children: [
-   *       { path: 'a', component: AComponent },
-   *       { path: 'b', component: BComponent },
-   *     ]
-   *   }
-   * ];
-   * ```
-   *
-   * From the `ContainerComponent`, you should be able to navigate to `AComponent` using
-   * the following `routerLink`, but it will not work if `relativeLinkResolution` is set
-   * to `'legacy'`:
-   *
-   * `<a [routerLink]="['./a']">Link to A</a>`
-   *
-   * However, this will work:
-   *
-   * `<a [routerLink]="['../a']">Link to A</a>`
-   *
-   * In other words, you're required to use `../` rather than `./` when the relative link
-   * resolution is set to `'legacy'`.
-   *
-   * The default in v11 is `corrected`.
-   *
-   * @deprecated
-   */
-  relativeLinkResolution?: 'legacy'|'corrected';
-
-  /**
-   * Configures how the Router attempts to restore state when a navigation is cancelled.
-   *
-   * 'replace' - Always uses `location.replaceState` to set the browser state to the state of the
-   * router before the navigation started. This means that if the URL of the browser is updated
-   * _before_ the navigation is canceled, the Router will simply replace the item in history rather
-   * than trying to restore to the previous location in the session history. This happens most
-   * frequently with `urlUpdateStrategy: 'eager'` and navigations with the browser back/forward
-   * buttons.
-   *
-   * 'computed' - Will attempt to return to the same index in the session history that corresponds
-   * to the Angular route when the navigation gets cancelled. For example, if the browser back
-   * button is clicked and the navigation is cancelled, the Router will trigger a forward navigation
-   * and vice versa.
-   *
-   * Note: the 'computed' option is incompatible with any `UrlHandlingStrategy` which only
-   * handles a portion of the URL because the history restoration navigates to the previous place in
-   * the browser history rather than simply resetting a portion of the URL.
-   *
-   * The default value is `replace` when not set.
-   */
-  canceledNavigationResolution?: 'replace'|'computed';
-}
-
-export function setupRouter(
-    urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
-    injector: Injector, compiler: Compiler, config: Route[][], titleStrategy: TitleStrategy,
-    opts: ExtraOptions = {}, urlHandlingStrategy?: UrlHandlingStrategy,
-    routeReuseStrategy?: RouteReuseStrategy) {
-  const router =
-      new Router(null, urlSerializer, contexts, location, injector, compiler, flatten(config));
-
-  if (urlHandlingStrategy) {
-    router.urlHandlingStrategy = urlHandlingStrategy;
-  }
-
-  if (routeReuseStrategy) {
-    router.routeReuseStrategy = routeReuseStrategy;
-  }
-
-  router.titleStrategy = titleStrategy;
-
-  assignExtraOptionsToRouter(opts, router);
-
-  return router;
-}
-
-export function assignExtraOptionsToRouter(opts: ExtraOptions, router: Router): void {
-  if (opts.errorHandler) {
-    router.errorHandler = opts.errorHandler;
-  }
-
-  if (opts.malformedUriErrorHandler) {
-    router.malformedUriErrorHandler = opts.malformedUriErrorHandler;
-  }
-
-  if (opts.onSameUrlNavigation) {
-    router.onSameUrlNavigation = opts.onSameUrlNavigation;
-  }
-
-  if (opts.paramsInheritanceStrategy) {
-    router.paramsInheritanceStrategy = opts.paramsInheritanceStrategy;
-  }
-
-  if (opts.relativeLinkResolution) {
-    router.relativeLinkResolution = opts.relativeLinkResolution;
-  }
-
-  if (opts.urlUpdateStrategy) {
-    router.urlUpdateStrategy = opts.urlUpdateStrategy;
-  }
-
-  if (opts.canceledNavigationResolution) {
-    router.canceledNavigationResolution = opts.canceledNavigationResolution;
-  }
-}
-
-export function rootRoute(router: Router): ActivatedRoute {
-  return router.routerState.root;
 }
 
 export function getBootstrapListener() {


### PR DESCRIPTION
This commit updates the Router itself to be `providedIn: 'root'` with a
factory function rather than provided in the `RouterModule`.

This is a cherry-pick of https://github.com/angular/angular/pull/46824 to 14.1.x