### PR TITLE
feat(platform-browser): add `isEmpty` method to the `TransferState` class

### DIFF
--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -228,6 +228,7 @@ export class Title {
 export class TransferState {
     get<T>(key: StateKey<T>, defaultValue: T): T;
     hasKey<T>(key: StateKey<T>): boolean;
+    get isEmpty(): boolean;
     onSerialize<T>(key: StateKey<T>, callback: () => T): void;
     remove<T>(key: StateKey<T>): void;
     set<T>(key: StateKey<T>, value: T): void;

--- a/integration/platform-server/src/transferstate/app.ts
+++ b/integration/platform-server/src/transferstate/app.ts
@@ -16,7 +16,6 @@ import {TransferStateComponent} from './transfer-state.component';
   bootstrap: [TransferStateComponent],
   imports: [
     BrowserModule.withServerTransition({appId: 'ts'}),
-    BrowserTransferStateModule,
   ],
 })
 export class TransferStateModule {

--- a/packages/platform-browser/src/browser/transfer_state.ts
+++ b/packages/platform-browser/src/browser/transfer_state.ts
@@ -126,6 +126,13 @@ export class TransferState {
   }
 
   /**
+   * Indicates whether the state is empty.
+   */
+  get isEmpty(): boolean {
+    return Object.keys(this.store).length === 0;
+  }
+
+  /**
    * Register a callback to provide the value for a key when `toJson` is called.
    */
   onSerialize<T>(key: StateKey<T>, callback: () => T): void {

--- a/packages/platform-browser/test/browser/transfer_state_spec.ts
+++ b/packages/platform-browser/test/browser/transfer_state_spec.ts
@@ -44,7 +44,6 @@ describe('TransferState', () => {
     TestBed.configureTestingModule({
       imports: [
         BrowserModule.withServerTransition({appId: APP_ID}),
-        BrowserTransferStateModule,
       ]
     });
     doc = TestBed.inject(DOCUMENT);
@@ -116,6 +115,19 @@ describe('TransferState', () => {
     value = 'changed';
 
     expect(transferState.toJson()).toBe('{"test":20,"delayed":"changed"}');
+  });
+
+  it('should provide an ability to detect whether the state is empty', () => {
+    const transferState = TestBed.inject(TransferState);
+
+    // The state is empty initially.
+    expect(transferState.isEmpty).toBeTrue();
+
+    transferState.set(TEST_KEY, 20);
+    expect(transferState.isEmpty).toBeFalse();
+
+    transferState.remove(TEST_KEY);
+    expect(transferState.isEmpty).toBeTrue();
   });
 });
 

--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -22,9 +22,7 @@ export const TRANSFER_STATE_SERIALIZATION_PROVIDERS: Provider[] = [{
 export function serializeTransferStateFactory(
     doc: Document, appId: string, transferStore: TransferState) {
   return () => {
-    const store = (transferStore as unknown as {store: {}}).store;
-    const isStateEmpty = Object.keys(store).length === 0;
-    if (isStateEmpty) {
+    if (transferStore.isEmpty) {
       // The state is empty, nothing to transfer,
       // avoid creating an extra `<script>` tag in this case.
       return;


### PR DESCRIPTION
This commit adds the `isEmpty` method to the `TransferState` class to make it possible to check whether the state is empty or not. This is helpful in situations when the `TransferState` should be serialized and the content is transferred to the client (if the state is empty - certain operations can be omitted).

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No