### PR TITLE
refactor(router): Move bootstrapDone usage next to where it's required

### DIFF
--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -277,14 +277,8 @@ function provideEnabledBlockingInitialNavigation(): Provider {
       useFactory: () => {
         const bootstrapDone = inject(BOOTSTRAP_DONE);
         return () => {
-          // Note that we emit the done event inside a promise to ensure there are no ordering
-          // issues with other BOOTSTRAP_LISTENERs that might be listening to router events.
-          // Specifically, this includes the RouterScroller. If the initial navigation unblocks and
-          // completes before the `provideRouterScroller`, it will miss the initial navigation.
-          Promise.resolve().then(() => {
-            bootstrapDone.next();
-            bootstrapDone.complete();
-          });
+          bootstrapDone.next();
+          bootstrapDone.complete();
         };
       }
     },


### PR DESCRIPTION
The BOOTSTRAP_DONE/bootstrapDone Subject is only used as part of the
`enabledBlocking` initial navigation. Rather than completing the subject
in a common bootstrap listener, this logic can be done in its own
listener as part of the `provideEnabledBlockingInitialNavigation`
function.