### PR TITLE
refactor(common): Align PathLocationStrategy constructor with default factory

### DIFF
--- a/packages/common/src/location/location_strategy.ts
+++ b/packages/common/src/location/location_strategy.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Inject, Injectable, InjectionToken, OnDestroy, Optional, ɵɵinject} from '@angular/core';
+import {Inject, inject, Injectable, InjectionToken, OnDestroy, Optional} from '@angular/core';
 
 import {DOCUMENT} from '../dom_tokens';
 
@@ -30,7 +30,7 @@ import {joinWithSlash, normalizeQueryParams} from './util';
  *
  * @publicApi
  */
-@Injectable({providedIn: 'root', useFactory: provideLocationStrategy})
+@Injectable({providedIn: 'root', useFactory: () => inject(PathLocationStrategy)})
 export abstract class LocationStrategy {
   abstract path(includeHash?: boolean): string;
   abstract prepareExternalUrl(internal: string): string;
@@ -45,14 +45,6 @@ export abstract class LocationStrategy {
   abstract onPopState(fn: LocationChangeListener): void;
   abstract getBaseHref(): string;
 }
-
-export function provideLocationStrategy() {
-  // See #23917
-  const location = ɵɵinject(DOCUMENT).location;
-  return new PathLocationStrategy(
-      ɵɵinject(PlatformLocation as any), location && location.origin || '');
-}
-
 
 /**
  * A predefined [DI token](guide/glossary#di-token) for the base href
@@ -86,8 +78,8 @@ export const APP_BASE_HREF = new InjectionToken<string>('appBaseHref');
  * [path](https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Syntax) of the
  * browser's URL.
  *
- * If you're using `PathLocationStrategy`, you must provide a {@link APP_BASE_HREF}
- * or add a `<base href>` element to the document.
+ * If you're using `PathLocationStrategy`, you may provide a {@link APP_BASE_HREF}
+ * or add a `<base href>` element to the document to override the default.
  *
  * For instance, if you provide an `APP_BASE_HREF` of `'/my/app/'` and call
  * `location.go('/foo')`, the browser's URL will become
@@ -110,7 +102,7 @@ export const APP_BASE_HREF = new InjectionToken<string>('appBaseHref');
  *
  * @publicApi
  */
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class PathLocationStrategy extends LocationStrategy implements OnDestroy {
   private _baseHref: string;
   private _removeListenerFns: (() => void)[] = [];
@@ -120,16 +112,8 @@ export class PathLocationStrategy extends LocationStrategy implements OnDestroy 
       @Optional() @Inject(APP_BASE_HREF) href?: string) {
     super();
 
-    if (href == null) {
-      href = this._platformLocation.getBaseHrefFromDOM();
-    }
-
-    if (href == null) {
-      throw new Error(
-          `No base href set. Please provide a value for the APP_BASE_HREF token or add a base element to the document.`);
-    }
-
-    this._baseHref = href;
+    this._baseHref = href ?? this._platformLocation.getBaseHrefFromDOM() ??
+        inject(DOCUMENT).location?.origin ?? '';
   }
 
   /** @nodoc */


### PR DESCRIPTION
When using the Angular Router, one of `APP_BASE_HREF` or a `<base>` in
the header must be provided. When _not_ using the `RouterModule`,
injecting the `LocationStrategy` will result in the
`PathLocationStrategy` being provided with a default value used in place
of `APP_BASE_HREF` that is `document?.location?.origin ?? ''`.

It can be quite surprising and annoying that once you add `RouterModule`
to the application, suddenly the `APP_BASE_HREF` must be specifically
provide something new when it could use a sensible default instead.

The current behavior (before this commit) is as follows:

* When `RouterModule` is not provided (or the dev doesn't specifically provide
  `PathLocationStrategy`): use `DOCUMENT.location?.origin ?? ''`.
  Note that the base href in the dom and `APP_BASE_HREF` are not used.
* When `RouterModule` _is_ provided:
   1. APP_BASE_HREF if defined
   2. Get base href from DOM
   3. throw if neither of the two above are defined

This commit updates this behavior to be aligned regardless of `RouterModule`
usage. The order (by default) is now:
  1. Developer provided `APP_BASE_HREF`
  2. base href from the DOM
  3. `location.origin`
  4. If none of the above exist, use `''`

This is slightly different than the behavior before. However, I believe
it is more appropriate. For the case without `RouterModule`, it would
likely be surprising that `APP_BASE_HREF` and the base href from the DOM
are ignored by default. For the case with `RouterModule`, we now have a
more sensible fallback/default when neither `APP_BASE_HREF` nor `<base>`
are defined (instead of just throwing an error).
