### PR TITLE
fix(router): Use correct return type for provideRoutes function

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -489,7 +489,7 @@ export abstract class PreloadingStrategy {
 export const PRIMARY_OUTLET = "primary";
 
 // @public
-export function provideRoutes(routes: Routes): any;
+export function provideRoutes(routes: Routes): Provider[];
 
 // @public
 export type QueryParamsHandling = 'merge' | 'preserve' | '';

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -202,7 +202,7 @@ export function provideForRootGuard(router: Router): any {
  *
  * @publicApi
  */
-export function provideRoutes(routes: Routes): any {
+export function provideRoutes(routes: Routes): Provider[] {
   return [
     {provide: ANALYZE_FOR_ENTRY_COMPONENTS, multi: true, useValue: routes},
     {provide: ROUTES, multi: true, useValue: routes},
@@ -250,7 +250,7 @@ function provideInitialNavigation(config: Pick<ExtraOptions, 'initialNavigation'
   ];
 }
 
-function provideRouterInitializer(): ReadonlyArray<Provider> {
+function provideRouterInitializer(): Provider[] {
   return [
     // ROUTER_INITIALIZER token should be removed. It's public API but shouldn't be. We can just
     // have `getBootstrapListener` directly attached to APP_BOOTSTRAP_LISTENER.


### PR DESCRIPTION
The provideRoutes function of the Router returns a Provider array and should not be typed as 'any'


~~Note: need to run global presubmit to determine if this needs to be considered a breaking change. Generally these type changes are, but due to the nature of how this is likely to be used, it's possible it won't need to be.~~

TGP came back green for this change so it should be safe to land in patch (or minor if we want to be more conservative).