### PR TITLE
refactor(common): make NgOptimizedImage directive standalone

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/index.ts
+++ b/packages/common/src/directives/ng_optimized_image/index.ts
@@ -7,5 +7,5 @@
  */
 export {IMAGE_LOADER, ImageLoader, ImageLoaderConfig} from './image_loaders/image_loader';
 export {provideImgixLoader} from './image_loaders/imgix_loader';
-export {NgOptimizedImage, NgOptimizedImageModule} from './ng_optimized_image';
+export {NgOptimizedImage} from './ng_optimized_image';
 export {PRECONNECT_CHECK_BLOCKLIST} from './preconnect_link_checker';

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -63,6 +63,7 @@ const ASPECT_RATIO_TOLERANCE = .1;
  * TODO: add Image directive usage notes.
  */
 @Directive({
+  standalone: true,
   selector: 'img[rawSrc]',
 })
 export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
@@ -240,22 +241,6 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
   private setHostAttribute(name: string, value: string): void {
     this.renderer.setAttribute(this.imgElement.nativeElement, name, value);
   }
-}
-
-
-/**
- * NgModule that declares and exports the `NgOptimizedImage` directive.
- * This NgModule is a compatibility layer for apps that use pre-v14
- * versions of Angular (before the `standalone` flag became available).
- *
- * The `NgOptimizedImage` will become a standalone directive in v14 and
- * this NgModule will be removed.
- */
-@NgModule({
-  declarations: [NgOptimizedImage],
-  exports: [NgOptimizedImage],
-})
-export class NgOptimizedImageModule {
 }
 
 /***** Helpers *****/

--- a/packages/common/src/private_export.ts
+++ b/packages/common/src/private_export.ts
@@ -6,6 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {IMAGE_LOADER as ɵIMAGE_LOADER, ImageLoader as ɵImageLoader, ImageLoaderConfig as ɵImageLoaderConfig, NgOptimizedImage as ɵNgOptimizedImage, NgOptimizedImageModule as ɵNgOptimizedImageModule, PRECONNECT_CHECK_BLOCKLIST as ɵPRECONNECT_CHECK_BLOCKLIST, provideImgixLoader as ɵprovideImgixLoader} from './directives/ng_optimized_image/index';
+export {IMAGE_LOADER as ɵIMAGE_LOADER, ImageLoader as ɵImageLoader, ImageLoaderConfig as ɵImageLoaderConfig, NgOptimizedImage as ɵNgOptimizedImage, PRECONNECT_CHECK_BLOCKLIST as ɵPRECONNECT_CHECK_BLOCKLIST, provideImgixLoader as ɵprovideImgixLoader} from './directives/ng_optimized_image/index';
 export {DomAdapter as ɵDomAdapter, getDOM as ɵgetDOM, setRootDomAdapter as ɵsetRootDomAdapter} from './dom_adapter';
 export {BrowserPlatformLocation as ɵBrowserPlatformLocation} from './location/platform_location';

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -14,7 +14,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {withHead} from '@angular/private/testing';
 
 import {IMAGE_LOADER, ImageLoader, ImageLoaderConfig} from '../../src/directives/ng_optimized_image/image_loaders/image_loader';
-import {ABSOLUTE_SRCSET_DENSITY_CAP, assertValidRawSrcset, NgOptimizedImage, NgOptimizedImageModule, RECOMMENDED_SRCSET_DENSITY_CAP} from '../../src/directives/ng_optimized_image/ng_optimized_image';
+import {ABSOLUTE_SRCSET_DENSITY_CAP, assertValidRawSrcset, NgOptimizedImage, RECOMMENDED_SRCSET_DENSITY_CAP} from '../../src/directives/ng_optimized_image/ng_optimized_image';
 import {PRECONNECT_CHECK_BLOCKLIST} from '../../src/directives/ng_optimized_image/preconnect_link_checker';
 
 describe('Image directive', () => {
@@ -995,7 +995,7 @@ function setupTestingModule(config?: {imageLoader?: ImageLoader, extraProviders?
     declarations: [TestComponent],
     // Note: the `NgOptimizedImage` directive is experimental and is not a part of the
     // `CommonModule` yet, so it's imported separately.
-    imports: [CommonModule, NgOptimizedImageModule],
+    imports: [CommonModule, NgOptimizedImage],
     providers,
   });
 }

--- a/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
+++ b/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImageModule as NgOptimizedImageModule} from '@angular/common';
+import {ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImage as NgOptimizedImage} from '@angular/common';
 import {Component} from '@angular/core';
 
 @Component({
   selector: 'basic',
   standalone: true,
-  imports: [NgOptimizedImageModule],
+  imports: [NgOptimizedImage],
   template: `<img rawSrc="/e2e/a.png" width="150" height="150" priority>`,
   providers: [{
     provide: IMAGE_LOADER,

--- a/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵNgOptimizedImageModule as NgOptimizedImageModule} from '@angular/common';
+import {ɵNgOptimizedImage as NgOptimizedImage} from '@angular/common';
 import {Component} from '@angular/core';
 
 @Component({
   selector: 'image-distortion-passing',
   standalone: true,
-  imports: [NgOptimizedImageModule],
+  imports: [NgOptimizedImage],
   template: `
      <!-- All the images in this template should not throw -->
      <!-- This image is here for the sake of making sure the "LCP image is priority" assertion is passed -->
@@ -51,7 +51,7 @@ export class ImageDistortionPassingComponent {
 @Component({
   selector: 'image-distortion-failing',
   standalone: true,
-  imports: [NgOptimizedImageModule],
+  imports: [NgOptimizedImage],
   template: `
      <!-- With the exception of the priority image, all the images in this template should throw -->
      <!-- This image is here for the sake of making sure the "LCP image is priority" assertion is passed -->

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵNgOptimizedImageModule as NgOptimizedImageModule} from '@angular/common';
+import {ɵNgOptimizedImage as NgOptimizedImage} from '@angular/common';
 import {Component} from '@angular/core';
 
 @Component({
   selector: 'lcp-check',
   standalone: true,
-  imports: [NgOptimizedImageModule],
+  imports: [NgOptimizedImage],
   template: `
     <!--
       'b.png' should *not* be treated as an LCP element,

--- a/packages/core/test/bundling/image-directive/e2e/preconnect-check/preconnect-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/preconnect-check/preconnect-check.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DOCUMENT, ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImageModule as NgOptimizedImageModule} from '@angular/common';
+import {DOCUMENT, ɵIMAGE_LOADER as IMAGE_LOADER, ɵNgOptimizedImage as NgOptimizedImage} from '@angular/common';
 import {Component, Inject} from '@angular/core';
 
 @Component({
   selector: 'preconnect-check',
   standalone: true,
-  imports: [NgOptimizedImageModule],
+  imports: [NgOptimizedImage],
   template: `
     <img rawSrc="/e2e/a.png" width="50" height="50" priority>
     <img rawSrc="/e2e/b.png" width="50" height="50" priority>

--- a/packages/core/test/bundling/image-directive/playground.ts
+++ b/packages/core/test/bundling/image-directive/playground.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵNgOptimizedImageModule as NgOptimizedImageModule, ɵprovideImgixLoader as provideImgixLoader} from '@angular/common';
+import {ɵNgOptimizedImage as NgOptimizedImage, ɵprovideImgixLoader as provideImgixLoader} from '@angular/common';
 import {Component} from '@angular/core';
 
 @Component({
@@ -43,7 +43,7 @@ import {Component} from '@angular/core';
     </main>
   `,
   standalone: true,
-  imports: [NgOptimizedImageModule],
+  imports: [NgOptimizedImage],
   providers: [provideImgixLoader('https://aurora-project.imgix.net')],
 })
 export class PlaygroundComponent {


### PR DESCRIPTION
This commit updates the NgOptimizedImage directive to become standalone and removes no longer needed NgOptimizedImageModule class.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No