### PR TITLE
fix(core): result from createEmbeddedView not an instance of EmbeddedViewRef

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -55,7 +55,7 @@
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 1090,
-      "main": 83515,
+      "main": 84051,
       "polyfills": 33945
     }
   },

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -26,12 +26,12 @@ import {destroyLView, detachView, renderDetachView} from './node_manipulation';
 // the multiple @extends by making the annotation @implements instead
 export interface viewEngine_ChangeDetectorRef_interface extends viewEngine_ChangeDetectorRef {}
 
-export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_InternalViewRef,
-                                   viewEngine_ChangeDetectorRef_interface {
+export class ViewRef<T> extends viewEngine_EmbeddedViewRef<T> implements
+    viewEngine_InternalViewRef, viewEngine_ChangeDetectorRef_interface {
   private _appRef: ViewRefTracker|null = null;
   private _attachedToViewContainer = false;
 
-  get rootNodes(): any[] {
+  override get rootNodes(): any[] {
     const lView = this._lView;
     const tView = lView[TVIEW];
     return collectNativeNodes(tView, lView, tView.firstChild, []);
@@ -57,21 +57,23 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
        *
        * This may be different from `_lView` if the `_cdRefInjectingView` is an embedded view.
        */
-      private _cdRefInjectingView?: LView) {}
+      private _cdRefInjectingView?: LView) {
+    super();
+  }
 
-  get context(): T {
+  override get context(): T {
     return this._lView[CONTEXT] as unknown as T;
   }
 
-  set context(value: T) {
+  override set context(value: T) {
     this._lView[CONTEXT] = value as unknown as {};
   }
 
-  get destroyed(): boolean {
+  override get destroyed(): boolean {
     return (this._lView[FLAGS] & LViewFlags.Destroyed) === LViewFlags.Destroyed;
   }
 
-  destroy(): void {
+  override destroy(): void {
     if (this._appRef) {
       this._appRef.detachView(this);
     } else if (this._attachedToViewContainer) {
@@ -93,7 +95,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
     destroyLView(this._lView[TVIEW], this._lView);
   }
 
-  onDestroy(callback: Function) {
+  override onDestroy(callback: Function) {
     storeCleanupWithContext(this._lView[TVIEW], this._lView, null, callback);
   }
 
@@ -128,7 +130,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
    * }
    * ```
    */
-  markForCheck(): void {
+  override markForCheck(): void {
     markViewDirty(this._cdRefInjectingView || this._lView);
   }
 
@@ -185,7 +187,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
    * }
    * ```
    */
-  detach(): void {
+  override detach(): void {
     this._lView[FLAGS] &= ~LViewFlags.Attached;
   }
 
@@ -245,7 +247,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
    * }
    * ```
    */
-  reattach(): void {
+  override reattach(): void {
     this._lView[FLAGS] |= LViewFlags.Attached;
   }
 
@@ -270,7 +272,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
    *
    * See {@link ChangeDetectorRef#detach detach} for more information.
    */
-  detectChanges(): void {
+  override detectChanges(): void {
     detectChangesInternal(this._lView[TVIEW], this._lView, this.context as unknown as {});
   }
 
@@ -280,7 +282,7 @@ export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_Int
    * This is used in development mode to verify that running change detection doesn't
    * introduce other changes.
    */
-  checkNoChanges(): void {
+  override checkNoChanges(): void {
     if (ngDevMode) {
       checkNoChangesInternal(this._lView[TVIEW], this._lView, this.context as unknown as {});
     }

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -8,7 +8,7 @@
 
 import {CommonModule, DOCUMENT} from '@angular/common';
 import {computeMsgId} from '@angular/compiler';
-import {ChangeDetectorRef, Compiler, Component, ComponentFactoryResolver, Directive, DoCheck, ElementRef, EmbeddedViewRef, ErrorHandler, InjectionToken, Injector, Input, NgModule, NgModuleRef, NO_ERRORS_SCHEMA, OnDestroy, OnInit, Pipe, PipeTransform, QueryList, Renderer2, RendererFactory2, RendererType2, Sanitizer, TemplateRef, ViewChild, ViewChildren, ViewContainerRef, ɵsetDocument} from '@angular/core';
+import {ChangeDetectorRef, Compiler, Component, ComponentFactoryResolver, ComponentRef, Directive, DoCheck, ElementRef, EmbeddedViewRef, ErrorHandler, InjectionToken, Injector, Input, NgModule, NgModuleRef, NO_ERRORS_SCHEMA, OnDestroy, OnInit, Pipe, PipeTransform, QueryList, Renderer2, RendererFactory2, RendererType2, Sanitizer, TemplateRef, ViewChild, ViewChildren, ViewContainerRef, ɵsetDocument} from '@angular/core';
 import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
 import {ComponentFixture, TestBed, TestComponentRenderer} from '@angular/core/testing';
 import {clearTranslations, loadTranslations} from '@angular/localize';
@@ -1226,6 +1226,20 @@ describe('ViewContainerRef', () => {
           .toEqual(
               '<child vcref="">**A**</child><child>**C**</child><child>**C**</child><child>**B**</child>');
     });
+
+    it('should return an EmbeddedViewRef instance', () => {
+      @Component({template: `<ng-template vcref #tplRef [tplRef]="tplRef"></ng-template>`})
+      class TestComponent {
+        @ViewChild(VCRefDirective, {static: true}) vcRef!: VCRefDirective;
+      }
+
+      TestBed.configureTestingModule({declarations: [TestComponent, VCRefDirective]});
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      const ref = fixture.componentInstance.vcRef.createView('');
+
+      expect(ref instanceof EmbeddedViewRef).toBe(true);
+    });
   });
 
   describe('createComponent', () => {
@@ -1687,6 +1701,24 @@ describe('ViewContainerRef', () => {
                   '[Child Component A]');
         });
       });
+    });
+
+    it('should return an instance of ComponentRef', () => {
+      @Component({selector: 'app', template: ''})
+      class App {
+        constructor(public viewContainerRef: ViewContainerRef, public injector: Injector) {}
+      }
+
+      @Component({template: ''})
+      class Child {
+      }
+
+      TestBed.configureTestingModule({declarations: [App, Child]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+      const ref = fixture.componentInstance.viewContainerRef.createComponent(Child);
+
+      expect(ref instanceof ComponentRef).toBe(true);
     });
   });
 

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -114,6 +114,9 @@
     "name": "ChangeDetectionStrategy"
   },
   {
+    "name": "ChangeDetectorRef"
+  },
+  {
     "name": "CommonModule"
   },
   {
@@ -196,6 +199,9 @@
   },
   {
     "name": "ElementRef"
+  },
+  {
+    "name": "EmbeddedViewRef"
   },
   {
     "name": "EmulatedEncapsulationDomRenderer2"
@@ -387,6 +393,9 @@
     "name": "RootComponent"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -484,6 +493,12 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
+  },
+  {
+    "name": "ViewRef2"
   },
   {
     "name": "WebAnimationsPlayer"
@@ -934,6 +949,9 @@
   },
   {
     "name": "injectArgs"
+  },
+  {
+    "name": "injectChangeDetectorRef"
   },
   {
     "name": "injectElementRef"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -51,6 +51,9 @@
     "name": "ChangeDetectionStrategy"
   },
   {
+    "name": "ChangeDetectorRef"
+  },
+  {
     "name": "CommonModule"
   },
   {
@@ -109,6 +112,9 @@
   },
   {
     "name": "ElementRef"
+  },
+  {
+    "name": "EmbeddedViewRef"
   },
   {
     "name": "EmulatedEncapsulationDomRenderer2"
@@ -276,6 +282,9 @@
     "name": "RendererStyleFlags2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -352,6 +361,12 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
+  },
+  {
+    "name": "ViewRef2"
   },
   {
     "name": "_DOM"
@@ -702,6 +717,9 @@
     "name": "injectArgs"
   },
   {
+    "name": "injectChangeDetectorRef"
+  },
+  {
     "name": "injectElementRef"
   },
   {
@@ -736,6 +754,9 @@
   },
   {
     "name": "isComponentDef"
+  },
+  {
+    "name": "isComponentHost"
   },
   {
     "name": "isContentQueryHost"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -75,6 +75,9 @@
     "name": "ChangeDetectionStrategy"
   },
   {
+    "name": "ChangeDetectorRef"
+  },
+  {
     "name": "CheckboxControlValueAccessor"
   },
   {
@@ -151,6 +154,9 @@
   },
   {
     "name": "ElementRef"
+  },
+  {
+    "name": "EmbeddedViewRef"
   },
   {
     "name": "EmulatedEncapsulationDomRenderer2"
@@ -508,6 +514,9 @@
   },
   {
     "name": "ViewRef"
+  },
+  {
+    "name": "ViewRef2"
   },
   {
     "name": "_DOM"
@@ -1033,6 +1042,9 @@
   },
   {
     "name": "injectArgs"
+  },
+  {
+    "name": "injectChangeDetectorRef"
   },
   {
     "name": "injectElementRef"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -156,6 +156,9 @@
     "name": "ElementRef"
   },
   {
+    "name": "EmbeddedViewRef"
+  },
+  {
     "name": "EmulatedEncapsulationDomRenderer2"
   },
   {
@@ -499,6 +502,9 @@
   },
   {
     "name": "ViewRef"
+  },
+  {
+    "name": "ViewRef2"
   },
   {
     "name": "_DOM"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -27,6 +27,9 @@
     "name": "CLEAN_PROMISE"
   },
   {
+    "name": "ChangeDetectorRef"
+  },
+  {
     "name": "ComponentFactory"
   },
   {
@@ -64,6 +67,9 @@
   },
   {
     "name": "ElementRef"
+  },
+  {
+    "name": "EmbeddedViewRef"
   },
   {
     "name": "EnvironmentInjector"
@@ -198,6 +204,9 @@
     "name": "RefCountSubscriber"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -247,6 +256,12 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
+  },
+  {
+    "name": "ViewRef2"
   },
   {
     "name": "_DOM"
@@ -516,6 +531,9 @@
     "name": "injectArgs"
   },
   {
+    "name": "injectChangeDetectorRef"
+  },
+  {
     "name": "injectElementRef"
   },
   {
@@ -544,6 +562,9 @@
   },
   {
     "name": "isComponentDef"
+  },
+  {
+    "name": "isComponentHost"
   },
   {
     "name": "isFunction"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -192,6 +192,9 @@
     "name": "ElementRef"
   },
   {
+    "name": "EmbeddedViewRef"
+  },
+  {
     "name": "EmptyError"
   },
   {
@@ -751,6 +754,9 @@
   },
   {
     "name": "ViewRef"
+  },
+  {
+    "name": "ViewRef2"
   },
   {
     "name": "ViewportScroller"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -39,6 +39,9 @@
     "name": "ChangeDetectionStrategy"
   },
   {
+    "name": "ChangeDetectorRef"
+  },
+  {
     "name": "ComponentFactory"
   },
   {
@@ -88,6 +91,9 @@
   },
   {
     "name": "ElementRef"
+  },
+  {
+    "name": "EmbeddedViewRef"
   },
   {
     "name": "EmulatedEncapsulationDomRenderer2"
@@ -246,6 +252,9 @@
     "name": "RendererStyleFlags2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -304,6 +313,12 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
+  },
+  {
+    "name": "ViewRef2"
   },
   {
     "name": "_DOM"
@@ -594,6 +609,9 @@
     "name": "injectArgs"
   },
   {
+    "name": "injectChangeDetectorRef"
+  },
+  {
     "name": "injectElementRef"
   },
   {
@@ -625,6 +643,9 @@
   },
   {
     "name": "isComponentDef"
+  },
+  {
+    "name": "isComponentHost"
   },
   {
     "name": "isFunction"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -51,6 +51,9 @@
     "name": "ChangeDetectionStrategy"
   },
   {
+    "name": "ChangeDetectorRef"
+  },
+  {
     "name": "CommonModule"
   },
   {
@@ -112,6 +115,9 @@
   },
   {
     "name": "ElementRef"
+  },
+  {
+    "name": "EmbeddedViewRef"
   },
   {
     "name": "EmulatedEncapsulationDomRenderer2"
@@ -427,6 +433,9 @@
   },
   {
     "name": "ViewRef"
+  },
+  {
+    "name": "ViewRef2"
   },
   {
     "name": "_DOM"
@@ -868,6 +877,9 @@
   },
   {
     "name": "injectArgs"
+  },
+  {
+    "name": "injectChangeDetectorRef"
   },
   {
     "name": "injectElementRef"


### PR DESCRIPTION
The value returned from `ViewContainerRef.createEmbeddedView` matches the `EmbeddedViewRef` interface, but it isn't an instance of the class that is exposed publicly. This can cause bugs, because the `instanceof` checks can be used for type narrowing, e.g. I got tripped up by it in  https://github.com/angular/components/pull/25212.

These changes switch to extending the publicly-exposed class and adding a couple of tests to avoid regressions.