### PR TITLE
fix(bazel): allow extendedDiagnostics option to be passed in through tsconfig

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -136,6 +136,7 @@ export async function runOneBuild(
     'i18nInMissingTranslations',
     'preserveWhitespaces',
     'createExternalSymbolFactoryReexports',
+    'extendedDiagnostics',
   ]);
 
   const userOverrides = Object.entries(userOptions)


### PR DESCRIPTION
Adds the `extendedDiagnostics` field to the list of allowed options so that it is picked up from the user's tsconfig.