### PR TITLE
docs(service-worker): improve docs related to `SwUpdate` APIs

### DIFF
--- a/aio/content/examples/service-worker-getting-started/src/app/check-for-update.service.ts
+++ b/aio/content/examples/service-worker-getting-started/src/app/check-for-update.service.ts
@@ -13,6 +13,13 @@ export class CheckForUpdateService {
     const everySixHours$ = interval(6 * 60 * 60 * 1000);
     const everySixHoursOnceAppIsStable$ = concat(appIsStable$, everySixHours$);
 
-    everySixHoursOnceAppIsStable$.subscribe(() => updates.checkForUpdate());
+    everySixHoursOnceAppIsStable$.subscribe(async () => {
+      try {
+        const updateFound = await updates.checkForUpdate();
+        console.log(updateFound ? 'A new version is available.' : 'Already on the latest version.');
+      } catch (err) {
+        console.error('Failed to check for updates:', err);
+      }
+    });
   }
 }

--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -64,16 +64,21 @@ Alternatively, you might want to define a different [registration strategy](api/
 
 </div>
 
-### Forcing update activation
+### Updating to the latest version
 
-If the current tab needs to be updated to the latest application version immediately, it can ask to do so with the `activateUpdate()` method:
+You can update an existing tab to the latest version by reloading the page as soon as a new version is ready.
+To avoid disrupting the user's progress, it is generally a good idea to prompt the user and let them confirm it is OK to reload the page and update to the latest version:
 
-<code-example header="prompt-update.service.ts" path="service-worker-getting-started/src/app/prompt-update.service.ts" region="sw-activate"></code-example>
+<code-example header="prompt-update.service.ts" path="service-worker-getting-started/src/app/prompt-update.service.ts" region="sw-version-ready"></code-example>
 
 <div class="alert is-important">
 
-Calling `activateUpdate()` without reloading the page could break lazy-loading in a currently running app, especially if the lazy-loaded chunks use filenames with hashes, which change every version.
-Therefore, it is recommended to reload the page once the promise returned by `activateUpdate()` is resolved.
+It is possible to update a tab to the latest version without reloading the page, by calling {@link SwUpdate#activateUpdate SwUpdate#activateUpdate()}.
+
+However, this can easily lead to version skew.
+For example, it could break lazy-loading in a currently running app, if the lazy-loaded chunks use filenames with hashes, which change every version.
+
+You should only use `activateUpdate()`, if you are certain it is safe for your specific use case.
 
 </div>
 

--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -73,9 +73,9 @@ To avoid disrupting the user's progress, it is generally a good idea to prompt t
 
 <div class="alert is-important">
 
-Calling {@link SwUpdate#activateUpdate SwUpdate#activateUpdate()} updates a tab to the latest version without reloading the page.
+Calling {@link SwUpdate#activateUpdate SwUpdate#activateUpdate()} updates a tab to the latest version without reloading the page, but this could break the application.
 
-However, this can easily result in a broken application due to a version mismatch between the [application shell](guide/glossary#app-shell) and other page resources, such as [lazy-loaded chunks](guide/glossary#lazy-loading), whose filenames may change between versions.
+Updating without reloading can create a version mismatch between the [application shell](guide/glossary#app-shell) and other page resources, such as [lazy-loaded chunks](guide/glossary#lazy-loading), whose filenames may change between versions.
 
 You should only use `activateUpdate()`, if you are certain it is safe for your specific use case.
 

--- a/aio/content/guide/service-worker-communications.md
+++ b/aio/content/guide/service-worker-communications.md
@@ -67,16 +67,15 @@ Alternatively, you might want to define a different [registration strategy](api/
 ### Updating to the latest version
 
 You can update an existing tab to the latest version by reloading the page as soon as a new version is ready.
-To avoid disrupting the user's progress, it is generally a good idea to prompt the user and let them confirm it is OK to reload the page and update to the latest version:
+To avoid disrupting the user's progress, it is generally a good idea to prompt the user and let them confirm that it is OK to reload the page and update to the latest version:
 
 <code-example header="prompt-update.service.ts" path="service-worker-getting-started/src/app/prompt-update.service.ts" region="sw-version-ready"></code-example>
 
 <div class="alert is-important">
 
-It is possible to update a tab to the latest version without reloading the page, by calling {@link SwUpdate#activateUpdate SwUpdate#activateUpdate()}.
+Calling {@link SwUpdate#activateUpdate SwUpdate#activateUpdate()} updates a tab to the latest version without reloading the page.
 
-However, this can easily lead to version skew.
-For example, it could break lazy-loading in a currently running app, if the lazy-loaded chunks use filenames with hashes, which change every version.
+However, this can easily result in a broken application due to a version mismatch between the [application shell](guide/glossary#app-shell) and other page resources, such as [lazy-loaded chunks](guide/glossary#lazy-loading), whose filenames may change between versions.
 
 You should only use `activateUpdate()`, if you are certain it is safe for your specific use case.
 

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -40,7 +40,7 @@ export class SwUpdate {
    *
    * @deprecated Use {@link versionUpdates} instead.
    *
-   * The behavior of `available` can be replicated using `versionUpdates` by filtering for the
+   * The behavior of `available` can be replicated by using `versionUpdates` by filtering for the
    * `VersionReadyEvent`:
    *
    * {@example service-worker-getting-started/src/app/prompt-update.service.ts
@@ -117,15 +117,15 @@ export class SwUpdate {
    * Updates the current client (i.e. browser tab) to the latest version that is ready for
    * activation.
    *
-   * This method can be useful if you want to update a client without reloading the page. However,
-   * this is less safe than just reloading the page, so make sure you understand the implications
-   * before using this method.
+   * In most cases, you do not need to use this method and can update a client by reloading the
+   * page.
    *
    * <div class="alert is-important">
    *
-   * Updating a client without reloading can easily lead to version skew. For example, it could
-   * break lazy-loading in a currently running app, if the lazy-loaded chunks use filenames with
-   * hashes, which change every version.
+   * Updating a client without reloading can easily result in a broken application due to a version
+   * mismatch between the [application shell](guide/glossary#app-shell) and other page resources,
+   * such as [lazy-loaded chunks](guide/glossary#lazy-loading), whose filenames may change between
+   * versions.
    *
    * Only use this method, if you are certain it is safe for your specific use case.
    *

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -117,8 +117,8 @@ export class SwUpdate {
    * Updates the current client (i.e. browser tab) to the latest version that is ready for
    * activation.
    *
-   * In most cases, you do not need to use this method and can update a client by reloading the
-   * page.
+   * In most cases, you should not use this method and instead should update a client by reloading
+   * the page.
    *
    * <div class="alert is-important">
    *

--- a/packages/service-worker/src/update.ts
+++ b/packages/service-worker/src/update.ts
@@ -40,18 +40,11 @@ export class SwUpdate {
    *
    * @deprecated Use {@link versionUpdates} instead.
    *
-   * The of behavior `available` can be rebuild by filtering for the `VersionReadyEvent`:
-   * ```
-   * import {filter, map} from 'rxjs/operators';
-   * // ...
-   * const updatesAvailable = swUpdate.versionUpdates.pipe(
-   *   filter((evt): evt is VersionReadyEvent => evt.type === 'VERSION_READY'),
-   *   map(evt => ({
-   *     type: 'UPDATE_AVAILABLE',
-   *     current: evt.currentVersion,
-   *     available: evt.latestVersion,
-   *   })));
-   * ```
+   * The behavior of `available` can be replicated using `versionUpdates` by filtering for the
+   * `VersionReadyEvent`:
+   *
+   * {@example service-worker-getting-started/src/app/prompt-update.service.ts
+   * region='sw-replicate-available'}
    */
   readonly available: Observable<UpdateAvailableEvent>;
 
@@ -123,6 +116,20 @@ export class SwUpdate {
   /**
    * Updates the current client (i.e. browser tab) to the latest version that is ready for
    * activation.
+   *
+   * This method can be useful if you want to update a client without reloading the page. However,
+   * this is less safe than just reloading the page, so make sure you understand the implications
+   * before using this method.
+   *
+   * <div class="alert is-important">
+   *
+   * Updating a client without reloading can easily lead to version skew. For example, it could
+   * break lazy-loading in a currently running app, if the lazy-loaded chunks use filenames with
+   * hashes, which change every version.
+   *
+   * Only use this method, if you are certain it is safe for your specific use case.
+   *
+   * </div>
    *
    * @returns a promise that
    *  - resolves to `true` if an update was activated successfully


### PR DESCRIPTION
This commit improves documentation related to recently improved or deprecated `SwUpdate` APIs in the following ways:

- Update [check-for-update.service.ts][1] to make use of the return value of [SwUpdate#checkForUpdate()][2].
- Update [prompt-update.service.ts][3] to not call [SwUpdate#activateUpdate()][4] and just reload the page.
- Update the [SwUpdate#activateUpdate()][4] API docs to explain that it is only useful if you want to update a client without reloading and that it can easily lead to version skew.
- Update [a code-snippet][5] to no longer be [hard-coded][6].

[1]: https://github.com/angular/angular/blob/9d9d05911dbd6e2f30e4c7bced0e41fd20ec4285/aio/content/examples/service-worker-getting-started/src/app/check-for-update.service.ts#L16
[2]: https://angular.io/api/service-worker/SwUpdate#checkForUpdate
[3]: https://github.com/angular/angular/blob/9d9d05911dbd6e2f30e4c7bced0e41fd20ec4285/aio/content/examples/service-worker-getting-started/src/app/prompt-update.service.ts#L15
[4]: https://angular.io/api/service-worker/SwUpdate#activateUpdate
[5]: https://github.com/angular/angular/blob/96c6139c9ab35aa6ab2330a5a79a5906d5c2e8be/packages/service-worker/src/update.ts#L44-L54
[6]: https://angular.io/guide/docs-style-guide#hard-coded-snippets

Fixes #43665.
