### PR TITLE
build: update dev-infra packages and account for build-tooling split from `ng-dev`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -96,11 +96,11 @@ build:remote --cpu=k8
 build:remote --host_cpu=k8
 
 # Toolchain and platform related flags
-build:remote --crosstool_top=@npm//@angular/dev-infra-private/bazel/remote-execution/cpp:cc_toolchain_suite
-build:remote --extra_toolchains=@npm//@angular/dev-infra-private/bazel/remote-execution/cpp:cc_toolchain
-build:remote --extra_execution_platforms=@npm//@angular/dev-infra-private/bazel/remote-execution:platform
-build:remote --host_platform=@npm//@angular/dev-infra-private/bazel/remote-execution:platform
-build:remote --platforms=@npm//@angular/dev-infra-private/bazel/remote-execution:platform
+build:remote --crosstool_top=@npm//@angular/build-tooling/bazel/remote-execution/cpp:cc_toolchain_suite
+build:remote --extra_toolchains=@npm//@angular/build-tooling/bazel/remote-execution/cpp:cc_toolchain
+build:remote --extra_execution_platforms=@npm//@angular/build-tooling/bazel/remote-execution:platform
+build:remote --host_platform=@npm//@angular/build-tooling/bazel/remote-execution:platform
+build:remote --platforms=@npm//@angular/build-tooling/bazel/remote-execution:platform
 
 # Remote instance and caching
 build:remote --remote_instance_name=projects/internal-200822/instances/primary_instance

--- a/.ng-dev/caretaker.mts
+++ b/.ng-dev/caretaker.mts
@@ -1,4 +1,4 @@
-import {CaretakerConfig} from '@angular/dev-infra-private/ng-dev';
+import {CaretakerConfig} from '@angular/ng-dev';
 
 /** The configuration for `ng-dev caretaker` commands. */
 export const caretaker: CaretakerConfig = {

--- a/.ng-dev/commit-message.mts
+++ b/.ng-dev/commit-message.mts
@@ -1,4 +1,4 @@
-import {CommitMessageConfig} from '@angular/dev-infra-private/ng-dev';
+import {CommitMessageConfig} from '@angular/ng-dev';
 
 /**
  * The configuration for `ng-dev commit-message` commands.

--- a/.ng-dev/format.mts
+++ b/.ng-dev/format.mts
@@ -1,4 +1,4 @@
-import {FormatConfig} from '@angular/dev-infra-private/ng-dev';
+import {FormatConfig} from '@angular/ng-dev';
 
 /**
  * Configuration for the `ng-dev format` command.

--- a/.ng-dev/github.mts
+++ b/.ng-dev/github.mts
@@ -1,4 +1,4 @@
-import {GithubConfig} from '@angular/dev-infra-private/ng-dev';
+import {GithubConfig} from '@angular/ng-dev';
 
 /**
  * Github configuration for the `ng-dev` command. This repository is used as

--- a/.ng-dev/pull-request.mts
+++ b/.ng-dev/pull-request.mts
@@ -1,4 +1,4 @@
-import {PullRequestConfig} from '@angular/dev-infra-private/ng-dev';
+import {PullRequestConfig} from '@angular/ng-dev';
 
 /**
  * Configuration for the merge tool in `ng-dev`. This sets up the labels which

--- a/.ng-dev/release.mts
+++ b/.ng-dev/release.mts
@@ -1,4 +1,4 @@
-import {ReleaseConfig} from '@angular/dev-infra-private/ng-dev';
+import {ReleaseConfig} from '@angular/ng-dev';
 
 /** Configuration for the `ng-dev release` command. */
 export const release: ReleaseConfig = {

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -123,7 +123,7 @@ load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories"
 
 web_test_repositories()
 
-load("@npm//@angular/dev-infra-private/bazel/browsers:browser_repositories.bzl", "browser_repositories")
+load("@npm//@angular/build-tooling/bazel/browsers:browser_repositories.bzl", "browser_repositories")
 
 browser_repositories()
 

--- a/devtools/tools/defaults.bzl
+++ b/devtools/tools/defaults.bzl
@@ -1,8 +1,8 @@
 # Re-export of Bazel rules with devtools-wide defaults
 
-load("@npm//@angular/dev-infra-private/bazel/spec-bundling:index.bzl", "spec_bundle")
-load("@npm//@angular/dev-infra-private/bazel/karma:index.bzl", _karma_web_test_suite = "karma_web_test_suite")
-load("@npm//@angular/dev-infra-private/bazel:extract_js_module_output.bzl", "extract_js_module_output")
+load("@npm//@angular/build-tooling/bazel/spec-bundling:index.bzl", "spec_bundle")
+load("@npm//@angular/build-tooling/bazel/karma:index.bzl", _karma_web_test_suite = "karma_web_test_suite")
+load("@npm//@angular/build-tooling/bazel:extract_js_module_output.bzl", "extract_js_module_output")
 
 def karma_web_test_suite(name, **kwargs):
     test_deps = kwargs.get("deps", [])
@@ -35,10 +35,10 @@ def karma_web_test_suite(name, **kwargs):
     if not hasattr(kwargs, "browsers"):
         kwargs["tags"] = ["native"] + kwargs.get("tags", [])
         kwargs["browsers"] = [
-            "@npm//@angular/dev-infra-private/bazel/browsers/chromium:chromium",
+            "@npm//@angular/build-tooling/bazel/browsers/chromium:chromium",
 
             # todo(aleksanderbodurri): enable when firefox support is done
-            # "@npm//@angular/dev-infra-private/bazel/browsers/firefox:firefox",
+            # "@npm//@angular/build-tooling/bazel/browsers/firefox:firefox",
         ]
 
     # Default test suite with all configured browsers.

--- a/devtools/tools/esbuild/BUILD.bazel
+++ b/devtools/tools/esbuild/BUILD.bazel
@@ -13,7 +13,7 @@ esbuild_config(
     config_file = "esbuild-esm.config.mjs",
     deps = [
         ":esbuild_base",
-        "@npm//@angular/dev-infra-private/shared-scripts/angular-linker:js_lib",
+        "@npm//@angular/build-tooling/shared-scripts/angular-linker:js_lib",
     ],
 )
 
@@ -23,8 +23,8 @@ esbuild_config(
     deps = [
         ":esbuild_base",
         "//packages/compiler-cli/private",
-        "@npm//@angular/dev-infra-private/shared-scripts/angular-linker:js_lib",
-        "@npm//@angular/dev-infra-private/shared-scripts/angular-optimization:js_lib",
+        "@npm//@angular/build-tooling/shared-scripts/angular-linker:js_lib",
+        "@npm//@angular/build-tooling/shared-scripts/angular-optimization:js_lib",
     ],
 )
 
@@ -42,7 +42,7 @@ esbuild_config(
     config_file = "esbuild-spec.config.mjs",
     deps = [
         ":esbuild_base",
-        "@npm//@angular/dev-infra-private/shared-scripts/angular-linker:js_lib",
+        "@npm//@angular/build-tooling/shared-scripts/angular-linker:js_lib",
     ],
 )
 

--- a/devtools/tools/esbuild/esbuild-esm-prod.config.mjs
+++ b/devtools/tools/esbuild/esbuild-esm-prod.config.mjs
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { createLinkerEsbuildPlugin } from '@angular/dev-infra-private/shared-scripts/angular-linker/esbuild-plugin.mjs';
-import { createEsbuildAngularOptimizePlugin } from '@angular/dev-infra-private/shared-scripts/angular-optimization/esbuild-plugin.mjs';
+import { createLinkerEsbuildPlugin } from '@angular/build-tooling/shared-scripts/angular-linker/esbuild-plugin.mjs';
+import { createEsbuildAngularOptimizePlugin } from '@angular/build-tooling/shared-scripts/angular-optimization/esbuild-plugin.mjs';
 import { GLOBAL_DEFS_FOR_TERSER_WITH_AOT } from '@angular/compiler-cli/private/tooling.js';
 import baseEsbuildConfig from './esbuild-base.config.mjs';
 
@@ -26,7 +26,7 @@ export default {
       // DevTools also relies on Angular CDK and Material packages that are consumed via npm.
       // Because of this, we set unknownDeclarationVersionHandling to ignore so that we bypass
       // selecting a linker for our CDK and Material dependencies based on our local framework
-      // version (0.0.0-PLACEHOLDER). 
+      // version (0.0.0-PLACEHOLDER).
       // Instead this option defaults to the latest linker version, which should
       // be correct, except for the small time interval where we rollout a new
       // declaration version and target a material release that hasn't been compiled

--- a/devtools/tools/esbuild/esbuild-esm.config.mjs
+++ b/devtools/tools/esbuild/esbuild-esm.config.mjs
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createLinkerEsbuildPlugin} from '@angular/dev-infra-private/shared-scripts/angular-linker/esbuild-plugin.mjs';
+import {createLinkerEsbuildPlugin} from '@angular/build-tooling/shared-scripts/angular-linker/esbuild-plugin.mjs';
 import baseEsbuildConfig from './esbuild-base.config.mjs';
-  
+
 export default {
   ...baseEsbuildConfig,
   format: 'esm',
@@ -24,7 +24,7 @@ export default {
       // DevTools also relies on Angular CDK and Material packages that are consumed via npm.
       // Because of this, we set unknownDeclarationVersionHandling to ignore so that we bypass
       // selecting a linker for our CDK and Material dependencies based on our local framework
-      // version (0.0.0-PLACEHOLDER). 
+      // version (0.0.0-PLACEHOLDER).
       // Instead this option defaults to the latest linker version, which should
       // be correct, except for the small time interval where we rollout a new
       // declaration version and target a material release that hasn't been compiled

--- a/devtools/tools/esbuild/esbuild-spec.config.mjs
+++ b/devtools/tools/esbuild/esbuild-spec.config.mjs
@@ -18,19 +18,19 @@ import baseEsbuildConfig from './esbuild-base.config.mjs';
   // Note: This needs to be a NPM module path as this ESBuild config is generated and can
   // end up in arbitrary Bazel packages or differently-named consumer workspaces.
   const {createLinkerEsbuildPlugin} = await import(
-    '@angular/dev-infra-private/shared-scripts/angular-linker/esbuild-plugin.mjs'
+    '@angular/build-tooling/shared-scripts/angular-linker/esbuild-plugin.mjs'
   );
 
   return await createLinkerEsbuildPlugin(
     /.*/,
     /* ensureNoPartialDeclaration */ true,
-    
+
     // DevTools relies on angular framework packages that are consumed,
     // locally via bazel. These packages have a version of 0.0.0-PLACEHOLDER.
     // DevTools also relies on Angular CDK and Material packages that are consumed via npm.
     // Because of this, we set unknownDeclarationVersionHandling to ignore so that we bypass
     // selecting a linker for our CDK and Material dependencies based on our local framework
-    // version (0.0.0-PLACEHOLDER). 
+    // version (0.0.0-PLACEHOLDER).
     // Instead this option defaults to the latest linker version, which should
     // be correct, except for the small time interval where we rollout a new
     // declaration version and target a Material release that hasn't been compiled

--- a/devtools/tools/esbuild/index.bzl
+++ b/devtools/tools/esbuild/index.bzl
@@ -1,5 +1,5 @@
 load("//devtools:packages.bzl", "ANGULAR_PACKAGES")
-load("@npm//@angular/dev-infra-private/bazel/esbuild:index.bzl", "esbuild")
+load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", "esbuild")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "LinkerPackageMappingInfo")
 load("@build_bazel_rules_nodejs//:providers.bzl", "ExternalNpmPackageInfo", "JSModuleInfo")
 

--- a/integration/index.bzl
+++ b/integration/index.bzl
@@ -6,7 +6,7 @@
 """
 
 load("//integration:npm_package_archives.bzl", "NPM_PACKAGE_ARCHIVES", "npm_package_archive_label")
-load("@npm//@angular/dev-infra-private/bazel/integration:index.bzl", "integration_test")
+load("@npm//@angular/build-tooling/bazel/integration:index.bzl", "integration_test")
 
 # The generated npm packages should ALWAYS be replaced in integration tests
 # so we pass them to the `check_npm_packages` attribute of npm_integration_test
@@ -41,8 +41,8 @@ def _ng_integration_test(name, setup_chromium = False, **kwargs):
     data = kwargs.pop("data", [])
 
     if setup_chromium:
-        data.append("@npm//@angular/dev-infra-private/bazel/browsers/chromium")
-        toolchains.append("@npm//@angular/dev-infra-private/bazel/browsers/chromium:toolchain_alias")
+        data.append("@npm//@angular/build-tooling/bazel/browsers/chromium")
+        toolchains.append("@npm//@angular/build-tooling/bazel/browsers/chromium:toolchain_alias")
         environment.update({
             "CHROMEDRIVER_BIN": "$(CHROMEDRIVER)",
             "CHROME_BIN": "$(CHROMIUM)",

--- a/modules/benchmarks/e2e_test.bzl
+++ b/modules/benchmarks/e2e_test.bzl
@@ -9,7 +9,7 @@ load("//tools:defaults.bzl", "protractor_web_test_suite")
 def e2e_test(name, server, **kwargs):
     protractor_web_test_suite(
         name = name,
-        on_prepare = "@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:start-server.js",
+        on_prepare = "@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:start-server.js",
         server = server,
         **kwargs
     )

--- a/modules/benchmarks/src/change_detection/BUILD.bazel
+++ b/modules/benchmarks/src/change_detection/BUILD.bazel
@@ -15,7 +15,7 @@ ts_library(
     srcs = ["change_detection.perf-spec.ts"],
     tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
     deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
     ],
 )
@@ -26,7 +26,7 @@ ts_library(
     srcs = ["change_detection.e2e-spec.ts"],
     tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
     deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
     ],
 )

--- a/modules/benchmarks/src/change_detection/change_detection.e2e-spec.ts
+++ b/modules/benchmarks/src/change_detection/change_detection.e2e-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {openBrowser, verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {openBrowser, verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$} from 'protractor';
 
 describe('change detection benchmark', () => {

--- a/modules/benchmarks/src/change_detection/change_detection.perf-spec.ts
+++ b/modules/benchmarks/src/change_detection/change_detection.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark, verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/change_detection/transplanted_views/BUILD.bazel
+++ b/modules/benchmarks/src/change_detection/transplanted_views/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "app_bundle", "ng_module", "ts_devserver")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/class_bindings/BUILD.bazel
+++ b/modules/benchmarks/src/class_bindings/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:component_benchmark.bzl", "component_benchmark")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 
@@ -6,7 +6,7 @@ component_benchmark(
     name = "benchmark",
     driver = ":class_bindings.perf-spec.ts",
     driver_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//@types/jasmine",
         "@npm//protractor",
     ],

--- a/modules/benchmarks/src/class_bindings/class_bindings.perf-spec.ts
+++ b/modules/benchmarks/src/class_bindings/class_bindings.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$, browser} from 'protractor';
 
 describe('class bindings perf', () => {

--- a/modules/benchmarks/src/expanding_rows/BUILD.bazel
+++ b/modules/benchmarks/src/expanding_rows/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "app_bundle", "ng_module", "ts_devserver", "ts_library")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 
@@ -26,7 +26,7 @@ ts_library(
     srcs = ["expanding_rows.perf-spec.ts"],
     tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
     deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
     ],
 )

--- a/modules/benchmarks/src/expanding_rows/expanding_rows.perf-spec.ts
+++ b/modules/benchmarks/src/expanding_rows/expanding_rows.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$, browser} from 'protractor';
 
 describe('benchmarks', () => {

--- a/modules/benchmarks/src/js-web-frameworks/BUILD.bazel
+++ b/modules/benchmarks/src/js-web-frameworks/BUILD.bazel
@@ -8,7 +8,7 @@ ts_library(
     srcs = ["js-web-frameworks.perf-spec.ts"],
     tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
     deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
     ],
 )

--- a/modules/benchmarks/src/js-web-frameworks/js-web-frameworks.perf-spec.ts
+++ b/modules/benchmarks/src/js-web-frameworks/js-web-frameworks.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark, verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/js-web-frameworks/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/js-web-frameworks/ng2/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "app_bundle", "ng_module", "ts_devserver")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 

--- a/modules/benchmarks/src/largeform/BUILD.bazel
+++ b/modules/benchmarks/src/largeform/BUILD.bazel
@@ -8,7 +8,7 @@ ts_library(
     srcs = ["largeform.perf-spec.ts"],
     tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
     deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
     ],
 )
@@ -19,7 +19,7 @@ ts_library(
     srcs = ["largeform.e2e-spec.ts"],
     tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
     deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
     ],
 )

--- a/modules/benchmarks/src/largeform/largeform.e2e-spec.ts
+++ b/modules/benchmarks/src/largeform/largeform.e2e-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {openBrowser, verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {openBrowser, verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$, By, element} from 'protractor';
 
 describe('largeform benchmark', () => {

--- a/modules/benchmarks/src/largeform/largeform.perf-spec.ts
+++ b/modules/benchmarks/src/largeform/largeform.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark, verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/largeform/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/largeform/ng2/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ng_module", "ts_devserver")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/largetable/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/BUILD.bazel
@@ -15,7 +15,7 @@ ts_library(
     srcs = ["largetable.perf-spec.ts"],
     tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
     deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
     ],
 )
@@ -26,7 +26,7 @@ ts_library(
     srcs = ["largetable.e2e-spec.ts"],
     tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
     deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
     ],
 )

--- a/modules/benchmarks/src/largetable/baseline/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/baseline/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ts_devserver", "ts_library")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/largetable/incremental_dom/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/incremental_dom/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ts_devserver", "ts_library")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/largetable/iv/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/iv/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ts_devserver")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/largetable/largetable.e2e-spec.ts
+++ b/modules/benchmarks/src/largetable/largetable.e2e-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {openBrowser, verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {openBrowser, verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$} from 'protractor';
 
 describe('largetable benchmark', () => {

--- a/modules/benchmarks/src/largetable/largetable.perf-spec.ts
+++ b/modules/benchmarks/src/largetable/largetable.perf-spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {runBenchmark, verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {runBenchmark, verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$} from 'protractor';
 
 interface Worker {

--- a/modules/benchmarks/src/largetable/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/ng2/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "app_bundle", "ng_module", "ts_devserver")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/largetable/ng2_switch/BUILD.bazel
+++ b/modules/benchmarks/src/largetable/ng2_switch/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ng_module", "ts_devserver")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/styling/BUILD.bazel
+++ b/modules/benchmarks/src/styling/BUILD.bazel
@@ -8,7 +8,7 @@ ts_library(
     srcs = ["styling_perf.spec.ts"],
     tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
     deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
     ],
 )

--- a/modules/benchmarks/src/styling/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/styling/ng2/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "app_bundle", "ng_module", "ts_devserver")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])
 

--- a/modules/benchmarks/src/styling/styling_perf.spec.ts
+++ b/modules/benchmarks/src/styling/styling_perf.spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {openBrowser, runBenchmark, verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {openBrowser, runBenchmark, verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$, by, element} from 'protractor';
 
 /** List of possible scenarios that should be tested.  */

--- a/modules/benchmarks/src/tree/BUILD.bazel
+++ b/modules/benchmarks/src/tree/BUILD.bazel
@@ -15,7 +15,7 @@ ts_library(
     srcs = ["test_utils.ts"],
     tsconfig = "//modules/benchmarks:tsconfig-e2e.json",
     deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "@npm//protractor",
     ],
 )

--- a/modules/benchmarks/src/tree/baseline/BUILD.bazel
+++ b/modules/benchmarks/src/tree/baseline/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ts_devserver", "ts_library")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/tree/incremental_dom/BUILD.bazel
+++ b/modules/benchmarks/src/tree/incremental_dom/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ts_devserver", "ts_library")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/tree/iv/BUILD.bazel
+++ b/modules/benchmarks/src/tree/iv/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ts_devserver")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/tree/ng1/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng1/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ts_devserver", "ts_library")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/tree/ng2/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "app_bundle", "ng_module", "ts_devserver")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/tree/ng2_static/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2_static/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ts_devserver", "ts_library")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/tree/ng2_switch/BUILD.bazel
+++ b/modules/benchmarks/src/tree/ng2_switch/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "ng_module", "ts_devserver")
-load("@npm//@angular/dev-infra-private/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
+load("@npm//@angular/build-tooling/bazel/benchmark/component_benchmark:benchmark_test.bzl", "benchmark_test")
 load("//modules/benchmarks:e2e_test.bzl", "e2e_test")
 
 package(default_visibility = ["//modules/benchmarks:__subpackages__"])

--- a/modules/benchmarks/src/tree/test_utils.ts
+++ b/modules/benchmarks/src/tree/test_utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {openBrowser, runBenchmark} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {openBrowser, runBenchmark} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser} from 'protractor';
 
 export function runTreeBenchmark({id, prepare, setup, work}: {

--- a/modules/benchmarks/tsconfig.json
+++ b/modules/benchmarks/tsconfig.json
@@ -31,5 +31,5 @@
     "no-unused-expression": true,
     "no-unused-variable": true
   },
-  "include": ["../../node_modules/@angular/dev-infra-private/bazel/benchmark/driver-utilities/"]
+  "include": ["../../node_modules/@angular/build-tooling/bazel/benchmark/driver-utilities/"]
 }

--- a/modules/playground/e2e_test/async/async_spec.ts
+++ b/modules/playground/e2e_test/async/async_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$, browser} from 'protractor';
 import {promise} from 'selenium-webdriver';
 

--- a/modules/playground/e2e_test/example_test.bzl
+++ b/modules/playground/e2e_test/example_test.bzl
@@ -2,7 +2,7 @@ load("//tools:defaults.bzl", "protractor_web_test_suite", "ts_library")
 
 def example_test(name, srcs, server, data = [], deps = [], use_legacy_webdriver_types = True, **kwargs):
     ts_deps = [
-        "@npm//@angular/dev-infra-private/bazel/benchmark/driver-utilities",
+        "@npm//@angular/build-tooling/bazel/benchmark/driver-utilities",
         "//packages/private/testing",
         "@npm//@types/selenium-webdriver",
         "@npm//protractor",

--- a/modules/playground/e2e_test/hello_world/hello_world_spec.ts
+++ b/modules/playground/e2e_test/hello_world/hello_world_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser} from 'protractor';
 
 describe('hello world', function() {

--- a/modules/playground/e2e_test/http/http_spec.ts
+++ b/modules/playground/e2e_test/http/http_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser} from 'protractor';
 
 describe('http', function() {

--- a/modules/playground/e2e_test/jsonp/jsonp_spec.ts
+++ b/modules/playground/e2e_test/jsonp/jsonp_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser} from 'protractor';
 
 describe('jsonp', function() {

--- a/modules/playground/e2e_test/key_events/key_events_spec.ts
+++ b/modules/playground/e2e_test/key_events/key_events_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser, by, element, protractor} from 'protractor';
 
 const Key = protractor.Key;

--- a/modules/playground/e2e_test/model_driven_forms/model_driven_forms_spec.ts
+++ b/modules/playground/e2e_test/model_driven_forms/model_driven_forms_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser, by, element} from 'protractor';
 
 describe('Model-Driven Forms', function() {

--- a/modules/playground/e2e_test/order_management/order_management_spec.ts
+++ b/modules/playground/e2e_test/order_management/order_management_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser} from 'protractor';
 
 describe('Order Management CRUD', function() {

--- a/modules/playground/e2e_test/person_management/person_management_spec.ts
+++ b/modules/playground/e2e_test/person_management/person_management_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser} from 'protractor';
 
 describe('Person Management CRUD', function() {

--- a/modules/playground/e2e_test/relative_assets/assets_spec.ts
+++ b/modules/playground/e2e_test/relative_assets/assets_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$, browser, by, element, ExpectedConditions} from 'protractor';
 
 function waitForElement(selector: string) {

--- a/modules/playground/e2e_test/routing/routing_spec.ts
+++ b/modules/playground/e2e_test/routing/routing_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {$, browser, by, element, ExpectedConditions} from 'protractor';
 
 function waitForElement(selector: string) {

--- a/modules/playground/e2e_test/svg/svg_spec.ts
+++ b/modules/playground/e2e_test/svg/svg_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser, by, element} from 'protractor';
 
 describe('SVG', function() {

--- a/modules/playground/e2e_test/template_driven_forms/template_driven_forms_spec.ts
+++ b/modules/playground/e2e_test/template_driven_forms/template_driven_forms_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser, by, element} from 'protractor';
 
 describe('Template-Driven Forms', function() {

--- a/modules/playground/e2e_test/upgrade/upgrade_spec.ts
+++ b/modules/playground/e2e_test/upgrade/upgrade_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser, by, element} from 'protractor';
 
 describe('ngUpgrade', function() {

--- a/modules/playground/e2e_test/zippy_component/zippy_spec.ts
+++ b/modules/playground/e2e_test/zippy_component/zippy_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {verifyNoBrowserErrors} from '@angular/dev-infra-private/bazel/benchmark/driver-utilities';
+import {verifyNoBrowserErrors} from '@angular/build-tooling/bazel/benchmark/driver-utilities';
 import {browser, by, element} from 'protractor';
 
 describe('Zippy Component', function() {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "/ ": "",
     "postinstall": "node scripts/webdriver-manager-update.js && node --preserve-symlinks --preserve-symlinks-main ./tools/postinstall-patches.js",
     "prepare": "husky install",
-    "ng-dev": "cross-env TS_NODE_PROJECT=$PWD/.ng-dev/tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node --no-warnings --loader ts-node/esm node_modules/@angular/dev-infra-private/ng-dev/bundles/cli.mjs",
+    "ng-dev": "cross-env TS_NODE_PROJECT=$PWD/.ng-dev/tsconfig.json TS_NODE_TRANSPILE_ONLY=1 node --no-warnings --loader ts-node/esm node_modules/@angular/ng-dev/bundles/cli.mjs",
     "build": "ts-node --esm --project scripts/tsconfig.json scripts/build/build-packages-dist.mts",
     "test": "bazelisk test",
     "test:ci": "bazelisk test -- //... -//devtools/... -//aio/...",
@@ -179,7 +179,8 @@
   },
   "// 2": "devDependencies are not used under Bazel. Many can be removed after test.sh is deleted.",
   "devDependencies": {
-    "@angular/dev-infra-private": "https://github.com/angular/dev-infra-private-builds.git#6d9c069f7ba8bedd07d376444d65472154026ce8",
+    "@angular/build-tooling": "https://github.com/angular/dev-infra-private-build-tooling-builds.git#1addc303bef0b6acc0dca0961e9e642629f3a5cd",
+    "@angular/ng-dev": "https://github.com/angular/dev-infra-private-ng-dev-builds.git#865c7687cdca2bd512040330e1677eecaa26e46a",
     "@bazel/bazelisk": "^1.7.5",
     "@bazel/buildifier": "^5.0.0",
     "@bazel/ibazel": "^0.16.0",

--- a/packages/core/test/bundling/core_all/BUILD.bazel
+++ b/packages/core/test/bundling/core_all/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//tools:defaults.bzl", "app_bundle", "ts_library")
-load("@npm//@angular/dev-infra-private/bazel/map-size-tracking:index.bzl", "js_mapping_size_test")
+load("@npm//@angular/build-tooling/bazel/map-size-tracking:index.bzl", "js_mapping_size_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/packages/zone.js/test/karma_test.bzl
+++ b/packages/zone.js/test/karma_test.bzl
@@ -71,7 +71,7 @@ def karma_test(name, env_srcs, env_deps, env_entry_point, test_srcs, test_deps, 
                             ":" + name + "_env_rollup.umd",
                         ] + bootstrap +
                         _karma_test_required_dist_files,
-            browsers = ["@npm//@angular/dev-infra-private/bazel/browsers/chromium:chromium"],
+            browsers = ["@npm//@angular/build-tooling/bazel/browsers/chromium:chromium"],
             static_files = [
                 ":assets/sample.json",
                 ":assets/worker.js",
@@ -94,7 +94,7 @@ def karma_test(name, env_srcs, env_deps, env_entry_point, test_srcs, test_deps, 
                     ":" + name + "_env_rollup.umd",
                     "//packages/zone.js/bundles:zone-testing-bundle.umd.min.js",
                 ] + _karma_test_required_dist_files,
-                browsers = ["@npm//@angular/dev-infra-private/bazel/browsers/chromium:chromium"],
+                browsers = ["@npm//@angular/build-tooling/bazel/browsers/chromium:chromium"],
                 config_file = "//:karma-js.conf.js",
                 configuration_env_vars = ["KARMA_WEB_TEST_MODE"],
                 data = [

--- a/scripts/build/package-builder.mts
+++ b/scripts/build/package-builder.mts
@@ -8,7 +8,7 @@
 
 import {execSync} from 'child_process';
 import {join, dirname} from 'path';
-import {BuiltPackage} from '@angular/dev-infra-private/ng-dev';
+import {BuiltPackage} from '@angular/ng-dev';
 import {fileURLToPath} from 'url';
 import sh from 'shelljs';
 

--- a/scripts/ci/update-framework-deps-to-dist-packages.js
+++ b/scripts/ci/update-framework-deps-to-dist-packages.js
@@ -30,10 +30,10 @@ const skipped = [];
 function updateDeps(dependencies) {
   for (const packageName of Object.keys(dependencies)) {
     // We're only interested to update packages in the `@angular` scope and `zone.js`.
-    // The shared dev-infra package is not updated as it's not a package that is part of
-    // the Angular framework.
+    // The shared dev-infra packages are not updated as it's not a package that is part
+    // of the Angular framework.
     if ((!packageName.startsWith('@angular/') && packageName !== 'zone.js') ||
-        packageName === '@angular/dev-infra-private') {
+        packageName === '@angular/build-tooling' || packageName === '@angular/ng-dev') {
       continue;
     }
 

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -9,13 +9,13 @@ load("@npm//@bazel/terser:index.bzl", "terser_minified")
 load("@npm//@bazel/protractor:index.bzl", _protractor_web_test_suite = "protractor_web_test_suite")
 load("@npm//typescript:index.bzl", "tsc")
 load("//packages/bazel:index.bzl", _ng_module = "ng_module", _ng_package = "ng_package")
-load("@npm//@angular/dev-infra-private/bazel/app-bundling:index.bzl", _app_bundle = "app_bundle")
-load("@npm//@angular/dev-infra-private/bazel/http-server:index.bzl", _http_server = "http_server")
-load("@npm//@angular/dev-infra-private/bazel/karma:index.bzl", _karma_web_test = "karma_web_test", _karma_web_test_suite = "karma_web_test_suite")
-load("@npm//@angular/dev-infra-private/bazel/api-golden:index.bzl", _api_golden_test = "api_golden_test", _api_golden_test_npm_package = "api_golden_test_npm_package")
-load("@npm//@angular/dev-infra-private/bazel:extract_js_module_output.bzl", "extract_js_module_output")
-load("@npm//@angular/dev-infra-private/bazel:extract_types.bzl", _extract_types = "extract_types")
-load("@npm//@angular/dev-infra-private/bazel/esbuild:index.bzl", _esbuild = "esbuild", _esbuild_config = "esbuild_config")
+load("@npm//@angular/build-tooling/bazel/app-bundling:index.bzl", _app_bundle = "app_bundle")
+load("@npm//@angular/build-tooling/bazel/http-server:index.bzl", _http_server = "http_server")
+load("@npm//@angular/build-tooling/bazel/karma:index.bzl", _karma_web_test = "karma_web_test", _karma_web_test_suite = "karma_web_test_suite")
+load("@npm//@angular/build-tooling/bazel/api-golden:index.bzl", _api_golden_test = "api_golden_test", _api_golden_test_npm_package = "api_golden_test_npm_package")
+load("@npm//@angular/build-tooling/bazel:extract_js_module_output.bzl", "extract_js_module_output")
+load("@npm//@angular/build-tooling/bazel:extract_types.bzl", _extract_types = "extract_types")
+load("@npm//@angular/build-tooling/bazel/esbuild:index.bzl", _esbuild = "esbuild", _esbuild_config = "esbuild_config")
 load("@npm//tsec:index.bzl", _tsec_test = "tsec_test")
 
 _DEFAULT_TSCONFIG_TEST = "//packages:tsconfig-test"
@@ -350,8 +350,8 @@ def karma_web_test_suite(name, **kwargs):
         bootstrap = bootstrap,
         deps = deps,
         browsers = [
-            "@npm//@angular/dev-infra-private/bazel/browsers/chromium:chromium",
-            "@npm//@angular/dev-infra-private/bazel/browsers/firefox:firefox",
+            "@npm//@angular/build-tooling/bazel/browsers/chromium:chromium",
+            "@npm//@angular/build-tooling/bazel/browsers/firefox:firefox",
         ],
         data = data,
         tags = tags,
@@ -388,7 +388,7 @@ def protractor_web_test_suite(**kwargs):
     """Default values for protractor_web_test_suite"""
 
     _protractor_web_test_suite(
-        browsers = ["@npm//@angular/dev-infra-private/bazel/browsers/chromium:chromium"],
+        browsers = ["@npm//@angular/build-tooling/bazel/browsers/chromium:chromium"],
         **kwargs
     )
 

--- a/tools/postinstall-patches.js
+++ b/tools/postinstall-patches.js
@@ -61,7 +61,7 @@ ls('node_modules/@types').filter(f => f.startsWith('babel__')).forEach(pkg => {
   }
 });
 
-log('\n# patch: use local version of @angular/* and zone.js in Starlark files from @angular/dev-infra-private');
+log('\n# patch: use local version of @angular/* and zone.js in Starlark files from dev-infra');
 
 const ngDevPatches = new Map();
 const captureNgDevPatches = (files, patches) =>
@@ -77,7 +77,7 @@ const _captureNgDevPatch = (search, replace, files) => {
 // Patches for the component benchmark rule.
 captureNgDevPatches(
     [
-      'node_modules/@angular/dev-infra-private/bazel/benchmark/component_benchmark/component_benchmark.bzl',
+      'node_modules/@angular/build-tooling/bazel/benchmark/component_benchmark/component_benchmark.bzl',
     ],
     [
       ['@npm//@angular/platform-browser', '@angular//packages/platform-browser'],
@@ -92,8 +92,8 @@ captureNgDevPatches(
 // Patches for the app bundling
 captureNgDevPatches(
     [
-      'node_modules/@angular/dev-infra-private/bazel/app-bundling/index.bzl',
-      'node_modules/@angular/dev-infra-private/bazel/app-bundling/esbuild.config-tmpl.mjs',
+      'node_modules/@angular/build-tooling/bazel/app-bundling/index.bzl',
+      'node_modules/@angular/build-tooling/bazel/app-bundling/esbuild.config-tmpl.mjs',
     ],
     [
       // The app bundle config accesses the linker entry-point as well, so we need
@@ -118,8 +118,8 @@ captureNgDevPatches(
 // Patches for angular linker
 captureNgDevPatches(
     [
-      'node_modules/@angular/dev-infra-private/shared-scripts/angular-linker/BUILD.bazel',
-      'node_modules/@angular/dev-infra-private/shared-scripts/angular-linker/esbuild-plugin.mjs',
+      'node_modules/@angular/build-tooling/shared-scripts/angular-linker/BUILD.bazel',
+      'node_modules/@angular/build-tooling/shared-scripts/angular-linker/esbuild-plugin.mjs',
     ],
     [
       [
@@ -132,7 +132,7 @@ captureNgDevPatches(
       ],
     ]);
 
-// Apply the captured patches for the `@angular/dev-infra-private` package.
+// Apply the captured patches for the `@angular/build-tooling` package.
 for (const [fileName, patches] of ngDevPatches.entries()) {
   for (const patch of patches) {
     sed('-i', patch[0], patch[1], fileName);

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,7 @@
 {
   "rulesDirectory": [
     "tools/tslint",
-    "node_modules/@angular/dev-infra-private/tslint-rules",
+    "node_modules/@angular/build-tooling/tslint-rules",
     "node_modules/vrsource-tslint-rules/rules",
     "node_modules/tslint-eslint-rules/dist/rules",
     "node_modules/tslint-no-toplevel-property-access/rules"
@@ -13,26 +13,38 @@
     // Custom rules written in TypeScript.
     "require-internal-with-underscore": true,
     "no-implicit-override-abstract": true,
-    "validate-import-for-esm-cjs-interop": [true, {
-      // The following CommonJS modules have type definitions that suggest the existence of
-      // named exports. This is not true at runtime when imported from an ES module (because
-      // the ESM interop only exposes statically-discoverable named exports). Instead
-      // default imports should be used to ensure compatibility with both ESM or CommonJS.
-      "noNamedExports": ["typescript", "minimist", "magic-string", "semver", "yargs", "glob", "cluster", "convert-source-map"],
-      // The following CommonJS modules appear to have a default export available (due to the `esModuleInterop` flag),
-      // but at runtime with CJS (e.g. for devmode output/tests) there is no default export as these modules set
-      // `__esModule`. This does not match with what happens in ESM NodeJS runtime where NodeJS exposes
-      // `module.exports` as `export default`. Instead, named exports should be used for compat with CJS/ESM.
-      "noDefaultExport": [],
-      // List of modules which are incompatible and should never be imported at all.
-      "incompatibleModules": {
-        // `@babel/core` and `@babel/types` suggest named exports which do not exist at runtime within ESM
-        // (as these named exports are not statically discoverable by NodeJS). At the same time, these modules
-        // set `__esModule` and the default import does not exist for CJS at runtime (e.g. breaking tests).
-        "@babel/core": "This module is incompatible with the ESM/CJS interop. Use the custom interop file.",
-        "@babel/types": "This module is incompatible with the ESM/CJS interop. Use the custom interop file and import the `types` namespace."
+    "validate-import-for-esm-cjs-interop": [
+      true,
+      {
+        // The following CommonJS modules have type definitions that suggest the existence of
+        // named exports. This is not true at runtime when imported from an ES module (because
+        // the ESM interop only exposes statically-discoverable named exports). Instead
+        // default imports should be used to ensure compatibility with both ESM or CommonJS.
+        "noNamedExports": [
+          "typescript",
+          "minimist",
+          "magic-string",
+          "semver",
+          "yargs",
+          "glob",
+          "cluster",
+          "convert-source-map"
+        ],
+        // The following CommonJS modules appear to have a default export available (due to the `esModuleInterop` flag),
+        // but at runtime with CJS (e.g. for devmode output/tests) there is no default export as these modules set
+        // `__esModule`. This does not match with what happens in ESM NodeJS runtime where NodeJS exposes
+        // `module.exports` as `export default`. Instead, named exports should be used for compat with CJS/ESM.
+        "noDefaultExport": [],
+        // List of modules which are incompatible and should never be imported at all.
+        "incompatibleModules": {
+          // `@babel/core` and `@babel/types` suggest named exports which do not exist at runtime within ESM
+          // (as these named exports are not statically discoverable by NodeJS). At the same time, these modules
+          // set `__esModule` and the default import does not exist for CJS at runtime (e.g. breaking tests).
+          "@babel/core": "This module is incompatible with the ESM/CJS interop. Use the custom interop file.",
+          "@babel/types": "This module is incompatible with the ESM/CJS interop. Use the custom interop file and import the `types` namespace."
+        }
       }
-    }],
+    ],
     "eofline": true,
     "file-header": [
       true,
@@ -42,18 +54,12 @@
         "default": "@license\nCopyright Google LLC All Rights Reserved.\n\nUse of this source code is governed by an MIT-style license that can be\nfound in the LICENSE file at https://angular.io/license"
       }
     ],
-    "no-console": [
-      true,
-      "log"
-    ],
+    "no-console": [true, "log"],
     "no-construct": true,
     "no-duplicate-imports": true,
     "no-duplicate-variable": true,
     "no-var-keyword": true,
-    "prefer-literal": [
-      true,
-      "object"
-    ],
+    "prefer-literal": [true, "object"],
     "no-toplevel-property-access": [
       true,
       "packages/animations/src/",
@@ -65,17 +71,9 @@
       "packages/platform-browser/src/",
       "packages/router/src/"
     ],
-    "semicolon": [
-      true
-    ],
-    "variable-name": [
-      true,
-      "ban-keywords"
-    ],
-    "no-inner-declarations": [
-      true,
-      "function"
-    ],
+    "semicolon": [true],
+    "variable-name": [true, "ban-keywords"],
+    "no-inner-declarations": [true, "function"],
     "no-debugger": true,
     "ban": [
       true,
@@ -99,23 +97,12 @@
         "default": "@license\nCopyright Google LLC All Rights Reserved.\n\nUse of this source code is governed by an MIT-style license that can be\nfound in the LICENSE file at https://angular.io/license"
       }
     ],
-    "no-console": [
-      true,
-      "log"
-    ],
+    "no-console": [true, "log"],
     "no-duplicate-imports": true,
     "no-duplicate-variable": true,
-    "semicolon": [
-      true
-    ],
-    "variable-name": [
-      true,
-      "ban-keywords"
-    ],
-    "no-inner-declarations": [
-      true,
-      "function"
-    ],
+    "semicolon": [true],
+    "variable-name": [true, "ban-keywords"],
+    "no-inner-declarations": [true, "function"],
     "ban": [
       true,
       {"name": "fdescribe", "message": "Don't keep jasmine focus methods."},

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,6 +152,42 @@
     "@angular/core" "^13.0.0 || ^14.0.0-0"
     reflect-metadata "^0.1.13"
 
+"@angular/build-tooling@https://github.com/angular/dev-infra-private-build-tooling-builds.git#1addc303bef0b6acc0dca0961e9e642629f3a5cd":
+  version "0.0.0-fa61d03a603e04af2b66f3598f1af01da1e1cfb1"
+  resolved "https://github.com/angular/dev-infra-private-build-tooling-builds.git#1addc303bef0b6acc0dca0961e9e642629f3a5cd"
+  dependencies:
+    "@angular-devkit/build-angular" "14.1.0-rc.3"
+    "@angular/benchpress" "0.3.0"
+    "@babel/core" "^7.16.0"
+    "@bazel/buildifier" "5.1.0"
+    "@bazel/concatjs" "5.5.2"
+    "@bazel/esbuild" "5.5.2"
+    "@bazel/protractor" "5.5.2"
+    "@bazel/runfiles" "5.5.2"
+    "@bazel/terser" "5.5.2"
+    "@bazel/typescript" "5.5.2"
+    "@microsoft/api-extractor" "7.28.4"
+    "@types/browser-sync" "^2.26.3"
+    "@types/node" "16.10.9"
+    "@types/selenium-webdriver" "^4.0.18"
+    "@types/send" "^0.17.1"
+    "@types/tmp" "^0.2.1"
+    "@types/uuid" "^8.3.1"
+    "@types/yargs" "^17.0.0"
+    browser-sync "^2.27.7"
+    clang-format "1.8.0"
+    prettier "2.7.1"
+    protractor "^7.0.0"
+    selenium-webdriver "4.3.1"
+    send "^0.18.0"
+    source-map "^0.7.4"
+    tmp "^0.2.1"
+    "true-case-path" "^2.2.1"
+    tslib "^2.3.0"
+    typescript "~4.7.3"
+    uuid "^8.3.2"
+    yargs "^17.0.0"
+
 "@angular/cdk@14.1.0-rc.0":
   version "14.1.0-rc.0"
   resolved "https://registry.yarnpkg.com/@angular/cdk/-/cdk-14.1.0-rc.0.tgz#ab41784f05848a4a9f72b398592c740c92e2f6c8"
@@ -208,44 +244,6 @@
   dependencies:
     tslib "^2.3.0"
 
-"@angular/dev-infra-private@https://github.com/angular/dev-infra-private-builds.git#6d9c069f7ba8bedd07d376444d65472154026ce8":
-  version "0.0.0-e5a5a4c9edf515bcafb9b72a90fe2ad3e811df1d"
-  uid "6d9c069f7ba8bedd07d376444d65472154026ce8"
-  resolved "https://github.com/angular/dev-infra-private-builds.git#6d9c069f7ba8bedd07d376444d65472154026ce8"
-  dependencies:
-    "@angular-devkit/build-angular" "14.1.0-rc.3"
-    "@angular/benchpress" "0.3.0"
-    "@babel/core" "^7.16.0"
-    "@bazel/buildifier" "5.1.0"
-    "@bazel/concatjs" "5.5.2"
-    "@bazel/esbuild" "5.5.2"
-    "@bazel/protractor" "5.5.2"
-    "@bazel/runfiles" "5.5.2"
-    "@bazel/terser" "5.5.2"
-    "@bazel/typescript" "5.5.2"
-    "@microsoft/api-extractor" "7.28.4"
-    "@types/browser-sync" "^2.26.3"
-    "@types/node" "16.10.9"
-    "@types/selenium-webdriver" "^4.0.18"
-    "@types/send" "^0.17.1"
-    "@types/tmp" "^0.2.1"
-    "@types/uuid" "^8.3.1"
-    "@types/yargs" "^17.0.0"
-    "@yarnpkg/lockfile" "^1.1.0"
-    browser-sync "^2.27.7"
-    clang-format "1.8.0"
-    prettier "2.7.1"
-    protractor "^7.0.0"
-    selenium-webdriver "4.3.1"
-    send "^0.18.0"
-    source-map "^0.7.4"
-    tmp "^0.2.1"
-    "true-case-path" "^2.2.1"
-    tslib "^2.3.0"
-    typescript "~4.7.3"
-    uuid "^8.3.2"
-    yargs "^17.0.0"
-
 "@angular/forms-12@npm:@angular/forms@12.2.13":
   version "12.2.13"
   resolved "https://registry.yarnpkg.com/@angular/forms/-/forms-12.2.13.tgz#4de90e88991c274b5d5e3ab0300267e161ba78f2"
@@ -259,6 +257,13 @@
   integrity sha512-1Cu1+tiVBO/c9Tm8LL68T/HajqLTMUMcmtPUw0yS1vJBtOfuLESm/9/p60bzrZLdMg8a5u3gMB+kaAj0jRzwJA==
   dependencies:
     tslib "^2.3.0"
+
+"@angular/ng-dev@https://github.com/angular/dev-infra-private-ng-dev-builds.git#865c7687cdca2bd512040330e1677eecaa26e46a":
+  version "0.0.0-fa61d03a603e04af2b66f3598f1af01da1e1cfb1"
+  resolved "https://github.com/angular/dev-infra-private-ng-dev-builds.git#865c7687cdca2bd512040330e1677eecaa26e46a"
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    typescript "~4.7.3"
 
 "@angular/platform-browser-12@npm:@angular/platform-browser@12.2.13":
   version "12.2.13"


### PR DESCRIPTION
The dev-infra build tooling is now decoupled from `ng-dev`. This will
make it easier to update `ng-dev` without necessarily needing to upgrade
the whole build system, Bazel etc. This is useful when e.g. new release
tool features have been added and should also be ported to active LTS
branches.