### PR TITLE
refactor(docs-infra): remove code that prints debug info

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,7 +2,7 @@
   "aio": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 457028,
+      "main": 454820,
       "polyfills": 33814,
       "styles": 73640,
       "light-theme": 78276,
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 457651,
+      "main": 455179,
       "polyfills": 33922,
       "styles": 73640,
       "light-theme": 78045,


### PR DESCRIPTION
In #41106, code was added in angular.io to print info that would help us investigate and debug a ServiceWorker issue (#28114). Since the fix for the issue was deployed on October 6th, 2021, the related error rate has dropped dramatically:

![ChunkLoadError rate](https://user-images.githubusercontent.com/8604205/181502119-64ffb5de-f38e-4414-abcd-0fada29fd6d5.png)

Additionally, there have been no known occurrences or reports of the issue in the last several months.

The remaining occurrences could be attributed to older versions still being around on people's devices (due to the ServiceWorker caching) and other circumstances not related to the ServiceWorker, for which there is not much we can do. For example, a user could keep a tab open with an older version of the app, which requests hashed files that no longer exist on the server. If the ServiceWorker is not activated on such a tab (either because the browser does not support it or because the user has disabled it, for example), then it is expected that these requests would fail.

This commit removes the code that prints ServiceWorker-related debug info to reduce the payload size of the app.

Fixes #41117.
