### PR TITLE
refactor(zone.js): remove leftover debugging code using `Error.stack`

### DIFF
--- a/packages/zone.js/lib/jasmine/jasmine.ts
+++ b/packages/zone.js/lib/jasmine/jasmine.ts
@@ -332,10 +332,6 @@ Zone.__load_patch('jasmine', (global: any, Zone: ZoneType, api: _ZonePrivate) =>
 
       if (!isChildOfAmbientZone) throw new Error('Unexpected Zone: ' + Zone.current.name);
 
-
-      Error.stackTraceLimit = Infinity;
-      let context = new Error().stack;
-
       // This is the zone which will be used for running individual tests.
       // It will be a proxy zone, so that the tests function can retroactively install
       // different zones.


### PR DESCRIPTION
Resolve CORS Error when testing Promise rejections.

Fix Error Like 
```
Access to XMLHttpRequest at 'ng:///ResetPasswordComponent.js' from origin 'http://localhost:9876' has been blocked by CORS policy: Cross origin requests are only supported for protocol schemes: http, data, chrome, chrome-extension, chrome-untrusted, https.
```
When a promise is rejected. As far as I can tell these lines have little/no impact.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [✓] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [I don't see tests] Tests for the changes have been added (for bug fixes / features)
- [I don't see docs] Docs have been added / updated (for bug fixes / features)

If I am missing tests or docs please let me know.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [✓] Bugfix

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: This one :-)

After updating from zone.js 0.11.6 to 0.11.7 some of my tests started reporting Errors in the console which didn't appear to have any impact on tests passing. Tracing through the changes in the `zone-testing.js` file I noticed that these lines:
```
             if (!isChildOfAmbientZone)
                 throw new Error('Unexpected Zone: ' + Zone.current.name);
+            Error.stackTraceLimit = Infinity;
+            new Error().stack;
             // This is the zone which will be used for running individual tests.
             // It will be a proxy zone, so that the tests function can retroactively install
             // different zones.
```
added in #46672 didn't seem to be doing anything (but I cannot be sure). I removed these lines and the errors went away.

## What is the new behavior?

Tests all still work, but no extra outside errors in the console.

## Does this PR introduce a breaking change?

- [ ] Yes
- [✓] No

My guess is that this was some sort of debugging code or half done work that was abandoned. Removing it should be fine IMO.
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
