### PR TITLE
docs: fix selector in Component Interaction guide

### DIFF
--- a/aio/content/guide/component-interaction.md
+++ b/aio/content/guide/component-interaction.md
@@ -165,7 +165,7 @@ The `CountdownLocalVarParentComponent` that hosts the timer component is as foll
 
 The parent component cannot data bind to the child's `start` and `stop` methods nor to its `seconds` property.
 
-Place a local variable, `#timer`, on the tag `<countdown-timer>` representing the child component.
+Place a local variable, `#timer`, on the tag `<app-countdown-timer>` representing the child component.
 That gives you a reference to the child component and the ability to access *any of its properties or methods* from within the parent template.
 
 This example wires parent buttons to the child's `start` and `stop` and uses interpolation to display the child's `seconds` property.


### PR DESCRIPTION
The selector for the `CountdownTimerComponent` is `app-countdown-timer`
not `countdown-timer`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Component Interaction guide contains incorrect selector `countdown-timer` for the component `CountdownTimerComponent`. 

Issue Number: N/A


## What is the new behavior?
Correct selector `app-countdown-timer` should be used in Component Interaction guide.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Previously there was a pull request to update the selector - https://github.com/angular/angular/pull/42891. For some reason the commit was not merged.