### PR TITLE
fix(core): only set input on specific instance in ComponentRef.setInput

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1992,17 +1992,33 @@ export function handleError(lView: LView, error: any): void {
  */
 export function setInputsForProperty(
     tView: TView, lView: LView, inputs: PropertyAliasValue, publicName: string, value: any): void {
-  for (let i = 0; i < inputs.length;) {
-    const index = inputs[i++] as number;
-    const privateName = inputs[i++] as string;
+  for (let i = 0; i < inputs.length; i += 2) {
+    const index = inputs[i] as number;
+    const privateName = inputs[i + 1] as string;
     const instance = lView[index];
     ngDevMode && assertIndexInRange(lView, index);
-    const def = tView.data[index] as DirectiveDef<any>;
-    if (def.setInput !== null) {
-      def.setInput!(instance, value, publicName, privateName);
-    } else {
-      instance[privateName] = value;
-    }
+    setInput(tView, instance, index, publicName, privateName, value);
+  }
+}
+
+/**
+ * Sets a single input on a directive instance.
+ *
+ * @param tView Current TView.
+ * @param instance Directive instance to which to write the input.
+ * @param index Index at which to find the directive's defintion in the TView.
+ * @param publicName Public name of the input.
+ * @param privateName Private name of the input.
+ * @param value New value that should be assigned.
+ */
+export function setInput(
+    tView: TView, instance: any, index: number, publicName: string, privateName: string,
+    value: unknown) {
+  const def = tView.data[index] as DirectiveDef<any>;
+  if (def.setInput !== null) {
+    def.setInput(instance, value, publicName, privateName);
+  } else {
+    instance[privateName] = value;
   }
 }
 

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1284,6 +1284,9 @@
     "name": "setInjectImplementation"
   },
   {
+    "name": "setInput"
+  },
+  {
     "name": "setInputsForProperty"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -813,6 +813,9 @@
     "name": "markAsComponentHost"
   },
   {
+    "name": "markDirtyIfOnPush"
+  },
+  {
     "name": "maybeWrapInNotSelector"
   },
   {
@@ -966,7 +969,7 @@
     "name": "setInjectImplementation"
   },
   {
-    "name": "setInputsForProperty"
+    "name": "setInput"
   },
   {
     "name": "setInputsFromAttrs"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1431,6 +1431,9 @@
     "name": "setInjectImplementation"
   },
   {
+    "name": "setInput"
+  },
+  {
     "name": "setInputsForProperty"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1407,6 +1407,9 @@
     "name": "setInjectImplementation"
   },
   {
+    "name": "setInput"
+  },
+  {
     "name": "setInputsForProperty"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -600,6 +600,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "markDirtyIfOnPush"
+  },
+  {
     "name": "maybeWrapInNotSelector"
   },
   {
@@ -712,6 +715,9 @@
   },
   {
     "name": "setInjectImplementation"
+  },
+  {
+    "name": "setInput"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1560,6 +1560,9 @@
     "name": "markAsComponentHost"
   },
   {
+    "name": "markDirtyIfOnPush"
+  },
+  {
     "name": "markViewDirty"
   },
   {
@@ -1824,7 +1827,7 @@
     "name": "setInjectImplementation"
   },
   {
-    "name": "setInputsForProperty"
+    "name": "setInput"
   },
   {
     "name": "setInputsFromAttrs"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -684,6 +684,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "markDirtyIfOnPush"
+  },
+  {
     "name": "maybeWrapInNotSelector"
   },
   {
@@ -802,6 +805,9 @@
   },
   {
     "name": "setInjectImplementation"
+  },
+  {
+    "name": "setInput"
   },
   {
     "name": "setSelectedIndex"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1194,6 +1194,9 @@
     "name": "setInjectImplementation"
   },
   {
+    "name": "setInput"
+  },
+  {
     "name": "setInputsForProperty"
   },
   {


### PR DESCRIPTION
`ComponentRef.setInput` works by calling `setInputsForProperty` internally. It can be problematic, because it will set the all inputs on the specific node matching the passed-in name, including other directives that aren't associated with the `ComponentRef`. Currently this isn't a problem, because the only way to get a `ComponentRef` is as a result of `ComponentFactory.create` and there is no way to apply other directives through there, however I see a couple of ways that it can manifest itself in the future:
1. Once the runtime for host directives is implemented (after #46868), users will be able to apply directives to the root component.
2. If we were to make it possible to inject `ComponentRef` in the future.

These changes add some extra logic so that the input is only assigned to the component instance that is associated with the `ComponentRef`.