### PR TITLE
build(docs-infra): ensure all boilerplate dependencies are in-sync

### DIFF
--- a/aio/tools/examples/shared/package.json
+++ b/aio/tools/examples/shared/package.json
@@ -7,7 +7,7 @@
     "http-server": "http-server",
     "protractor": "protractor",
     "webdriver:update": "node ../../../../scripts/webdriver-manager-update.js",
-    "postinstall": "yarn webdriver:update",
+    "postinstall": "yarn sync-deps && yarn webdriver:update",
     "sync-deps": "node sync-boilerplate-dependencies"
   },
   "//engines-comment": "Keep this in sync with /package.json and /aio/package.json",

--- a/aio/tools/examples/shared/sync-boilerplate-dependencies.js
+++ b/aio/tools/examples/shared/sync-boilerplate-dependencies.js
@@ -9,6 +9,16 @@
  * Updates the dependency versions of the top-level `package.json` files in each sub-folder of
  * `./boilerplate/` to match the ones in `./package.json`.
  */
+
+// !!! WARNING !!!
+//
+// This script is run as a [post-upgrade Renovate task][1]. Therefore, it needs to be able to run
+// even when dependencies are not installed (i.e. only rely on Node.js built-in modules).
+// See [here][2] for more info on why dependencies may not have been installed.
+//
+// [1]: https://docs.renovatebot.com/configuration-options/#postupgradetasks
+// [2]: https://docs.renovatebot.com/self-hosted-configuration/#skipinstalls
+
 const fs = require('fs');
 const path = require('path');
 

--- a/renovate.json
+++ b/renovate.json
@@ -88,6 +88,14 @@
       "groupSlug": "scorecard-action"
     },
 
+    {
+      "matchPaths": ["aio/tools/examples/shared/*"],
+      "postUpgradeTasks": {
+        "commands": ["yarn run sync-deps"],
+        "fileFilters": ["aio/tools/examples/shared/boilerplate/**"]
+      }
+    },
+
     {"matchCurrentVersion": "0.0.0-PLACEHOLDER", "enabled": false},
 
     {"matchPaths": ["integration/**"], "enabled": false},


### PR DESCRIPTION
All docs examples share the same `node_modules/` (symlinked into each example from `aio/tools/examples/shared/node_modules/`). However, each example type has a different `package.json`, which comes from `aio/tools/examples/shared/boilerplate/*`). In order to ensure that the dependencies in each examples `package.json` are the same as the ones in the symlinked `node_modules/` (i.e. the ones that CI tests are run with), we have a script (`yarn run sync deps`) that can sync dependencies from `shared/package.json` into the boilerplate `package.json` files.

Previously, this script had to be run manually, which was easy to forget/not know about. This resulted in the boilerplate dependencies often being out-of-sync with the ones in `shared/package.json` and by extension the ones that were actually installed in `node_modules/`.

This commit helps keep the boilerplate dependencies up-to-date in the following ways:
- Adds the `sync-deps` script to the `postinstall` scripts to ensure dependencies will remain in sync whenever someone manually updates dependencies in `shared/package.json`.
- Runs the `sync-deps` script as a Renovate post-upgrade task to ensure that the depenencies will remain in sync whenever Renovate updates dependencies in `shared/package.json`.
  For more info on configuring post-upgrade tasks in Renovate, see:
  - [postUpgradeTasks][1]
  - [allowedPostUpgradeCommands][2]
  - [allowPostUpgradeCommandTemplating][3]

NOTE:
For the Renovate change to take effect, the [global config][4] in `angular/dev-infra` also needs to be updated. This will be done in a separate PR.

[1]: https://docs.renovatebot.com/configuration-options/#postupgradetasks
[2]: https://docs.renovatebot.com/self-hosted-configuration/#allowedpostupgradecommands
[3]: https://docs.renovatebot.com/self-hosted-configuration/#allowpostupgradecommandtemplating
[4]: https://github.com/angular/dev-infra/blob/22d3067021130271afcfd02d063828c5bdd9c2d7/.github/ng-renovate/runner-config.js
