### PR TITLE
feat(compiler-cli): support more recent version of `tsickle`

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "tmp": "0.2.1",
     "todomvc-app-css": "^2.3.0",
     "todomvc-common": "^1.0.5",
-    "tsickle": "0.38.1",
+    "tsickle": "0.46.3",
     "tslib": "^2.3.0",
     "tslint": "6.1.3",
     "typescript": "~4.7.2",

--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@microsoft/api-extractor": "^7.24.2",
     "shelljs": "^0.8.5",
-    "tsickle": "^0.38.0",
+    "tsickle": "^0.46.3",
     "tslib": "^2.3.0"
   },
   "peerDependencies": {

--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -104,7 +104,8 @@ function createEmitCallback(
       TsickleHost,
       'shouldSkipTsickleProcessing'|'pathToModuleName'|'shouldIgnoreWarningsForPath'|
       'fileNameToModuleId'|'googmodule'|'untyped'|'convertIndexImportShorthand'|
-      'transformDecorators'|'transformTypesToClosure'> = {
+      'transformDecorators'|'transformTypesToClosure'|'generateExtraSuppressions'|
+      'rootDirsRelative'> = {
     shouldSkipTsickleProcessing: (fileName) => /\.d\.ts$/.test(fileName) ||
         // View Engine's generated files were never intended to be processed with tsickle.
         (!options.enableIvy && GENERATED_FILES.test(fileName)),
@@ -118,6 +119,11 @@ function createEmitCallback(
     // conflicts, we disable decorator transformations for tsickle.
     transformDecorators: false,
     transformTypesToClosure: true,
+    generateExtraSuppressions: true,
+    // Only used by the http://go/tsjs-migration-independent-javascript-imports migration in
+    // tsickle. This migration is not relevant externally and is only enabled when users
+    // would explicitly invoke `goog.tsMigrationExportsShim` (which is internal-only).
+    rootDirsRelative: (fileName) => fileName,
   };
 
   return ({

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -6135,7 +6135,7 @@ function allTests(os: string) {
         /**
          * @fileoverview added by tsickle
          * Generated from: test.ts
-         * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+         * @suppress {checkTypes,const,extraRequire,missingOverride,missingRequire,missingReturn,unusedPrivateMembers,uselessCode}
          */
       `;
           expect(trim(jsContents).startsWith(trim(fileoverview))).toBeTruthy();
@@ -6153,7 +6153,7 @@ function allTests(os: string) {
         /**
          * @fileoverview added by tsickle
          * Generated from: test.ts
-         * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+         * @suppress {checkTypes,const,extraRequire,missingOverride,missingRequire,missingReturn,unusedPrivateMembers,uselessCode}
          */
       `;
           expect(trim(jsContents).startsWith(trim(fileoverview))).toBeTruthy();
@@ -6179,7 +6179,7 @@ function allTests(os: string) {
         /**
          * @fileoverview added by tsickle
          * Generated from: test.ngfactory.ts
-         * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+         * @suppress {checkTypes,const,extraRequire,missingOverride,missingRequire,missingReturn,unusedPrivateMembers,uselessCode}
          */
       `;
           expect(trim(jsContents).startsWith(trim(fileoverview))).toBeTruthy();
@@ -6212,7 +6212,7 @@ function allTests(os: string) {
          * Generated from: test.ts
          * @modName {some_comp}
          *
-         * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+         * @suppress {checkTypes,const,extraRequire,missingOverride,missingRequire,missingReturn,unusedPrivateMembers,uselessCode}
          */
       `;
           expect(trim(jsContents).startsWith(trim(fileoverview))).toBeTruthy();
@@ -6242,7 +6242,7 @@ function allTests(os: string) {
          * Generated from: test.ts
          * @modName {some_comp}
          *
-         * @suppress {checkTypes,constantProperty,extraRequire,missingOverride,missingReturn,unusedPrivateMembers,uselessCode} checked by tsc
+         * @suppress {checkTypes,const,extraRequire,missingOverride,missingRequire,missingReturn,unusedPrivateMembers,uselessCode}
          */
       `;
              expect(trim(jsContents).startsWith(trim(fileoverview))).toBeTruthy();

--- a/tools/postinstall-patches.js
+++ b/tools/postinstall-patches.js
@@ -139,6 +139,10 @@ for (const [fileName, patches] of ngDevPatches.entries()) {
   }
 }
 
+// TODO: Remove when https://github.com/bazelbuild/rules_nodejs/pull/3517 is available.
+sed('-i', 'private rootDirsRelative;', 'rootDirsRelative(fileName: string): string;',
+    'node_modules/@bazel/concatjs/internal/tsc_wrapped/compiler_host.d.ts');
+
 log('\n# patch: delete d.ts files referring to rxjs-compat');
 // more info in https://github.com/angular/angular/pull/33786
 rm('-rf', [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2712,7 +2712,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
-"@types/minimist@^1.2.0":
+"@types/minimist@^1.2.0", "@types/minimist@^1.2.1":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
@@ -14628,10 +14628,12 @@ tsec@0.2.5:
     glob "^7.1.1"
     minimatch "^3.0.3"
 
-tsickle@0.38.1:
-  version "0.38.1"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.38.1.tgz#30762db759d40c435943093b6972c7f2efb384ef"
-  integrity sha512-4xZfvC6+etRu6ivKCNqMOd1FqcY/m6JY3Y+yr5+Xw+i751ciwrWINi6x/3l1ekcODH9GZhlf0ny2LpzWxnjWYA==
+tsickle@0.46.3:
+  version "0.46.3"
+  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.46.3.tgz#b74918a77e3ca1310a2ce4d019f5d6294360b56d"
+  integrity sha512-9PDXxOrtn2AdpvDin6FLGveXVGg8ec3ga8fh8mPR5lz9KtitW6riVgxgagicdfF1rgiBxDeH+5hVowPXhmZbYQ==
+  dependencies:
+    "@types/minimist" "^1.2.1"
 
 tslib@1.9.0:
   version "1.9.0"


### PR DESCRIPTION
Updates the tsickle version in the repository and accounts for its changes in
the `compiler-cli` package. Tsickle made a breaking change in the minor version
segment bump that would break the use with `@angular/compiler-cli`

Additionally the tsickle version for `@angular/bazel` is updated since
we updated `@bazel/typescript` to also account for the breaking changes.

See: https://github.com/bazelbuild/rules_nodejs/commit/78a05281075c50ee31658bc48dd852e35b973496

Another unblock PR for #46707