### PR TITLE
feat(platform-server): support document reference in render functions

### DIFF
--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -51,7 +51,7 @@ export class PlatformState {
 // @public
 export function renderApplication<T>(rootComponent: Type<T>, options: {
     appId: string;
-    document?: string;
+    document?: string | Document;
     url?: string;
     providers?: Array<Provider | ImportedNgModuleProviders>;
     platformProviders?: Provider[];
@@ -59,7 +59,7 @@ export function renderApplication<T>(rootComponent: Type<T>, options: {
 
 // @public
 export function renderModule<T>(module: Type<T>, options: {
-    document?: string;
+    document?: string | Document;
     url?: string;
     extraProviders?: StaticProvider[];
 }): Promise<string>;

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -81,9 +81,14 @@ export class ServerModule {
 }
 
 function _document(injector: Injector) {
-  let config: PlatformConfig|null = injector.get(INITIAL_CONFIG, null);
-  const document = config && config.document ? parseDocument(config.document, config.url) :
-                                               getDOM().createHtmlDocument();
+  const config: PlatformConfig|null = injector.get(INITIAL_CONFIG, null);
+  let document: Document;
+  if (config && config.document) {
+    document = typeof config.document === 'string' ? parseDocument(config.document, config.url) :
+                                                     config.document;
+  } else {
+    document = getDOM().createHtmlDocument();
+  }
   // Tell ivy about the global document
   ɵsetDocument(document);
   return document;

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -16,7 +16,7 @@ import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG} from './tokens';
 import {TRANSFER_STATE_SERIALIZATION_PROVIDERS} from './transfer_state';
 
 interface PlatformOptions {
-  document?: string;
+  document?: string|Document;
   url?: string;
   platformProviders?: Provider[];
 }
@@ -95,14 +95,16 @@ the server-rendered app can be properly bootstrapped into a client app.`);
 /**
  * Renders a Module to string.
  *
- * `document` is the full document HTML of the page to render, as a string.
+ * `document` is the document of the page to render, either as an HTML string or
+ *  as a reference to the `document` instance.
  * `url` is the URL for the current render request.
  * `extraProviders` are the platform level providers for the current render request.
  *
  * @publicApi
  */
 export function renderModule<T>(
-    module: Type<T>, options: {document?: string, url?: string, extraProviders?: StaticProvider[]}):
+    module: Type<T>,
+    options: {document?: string|Document, url?: string, extraProviders?: StaticProvider[]}):
     Promise<string> {
   const {document, url, extraProviders: platformProviders} = options;
   const platform = _getPlatform(platformDynamicServer, {document, url, platformProviders});
@@ -130,7 +132,8 @@ export function renderModule<T>(
  *  - `appId` - a string identifier of this application. The appId is used to prefix all
  *              server-generated stylings and state keys of the application in TransferState
  *              use-cases.
- *  - `document` - the full document HTML of the page to render, as a string.
+ *  - `document` - the document of the page to render, either as an HTML string or
+ *                 as a reference to the `document` instance.
  *  - `url` - the URL for the current render request.
  *  - `providers` - set of application level providers for the current render request.
  *  - `platformProviders` - the platform level providers for the current render request.
@@ -141,7 +144,7 @@ export function renderModule<T>(
  */
 export function renderApplication<T>(rootComponent: Type<T>, options: {
   appId: string,
-  document?: string,
+  document?: string|Document,
   url?: string,
   providers?: Array<Provider|ImportedNgModuleProviders>,
   platformProviders?: Provider[],


### PR DESCRIPTION
This commit updates the `renderModule` and `renderApplication` functions to also accept a document reference (in addition to the serialized document contents as a string). This should provide the necessary flexibility to NgUniversal (and other API consumers) to structure the logic to avoid serializing and parsing document multiple times during the SSR request.

This PR should unblock further steps described in https://github.com/angular/angular/pull/46887#issuecomment-1204393041.

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No