### PR TITLE
ci: fix Renovate post-upgrade task command

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -91,7 +91,7 @@
     {
       "matchPaths": ["aio/tools/examples/shared/*"],
       "postUpgradeTasks": {
-        "commands": ["yarn run sync-deps"],
+        "commands": ["yarn --cwd=aio/tools/examples/shared run sync-deps"],
         "fileFilters": ["aio/tools/examples/shared/boilerplate/**"]
       }
     },


### PR DESCRIPTION
Since Renovate runs from the project directory, it cannot find the `sync-deps` yarn script inside `aio/tools/examples/shared/`: [example failure][1]

Update the post-upgrade task command to run inside that directory instead of the project root.

##
_NOTE:_
_For this to take effect, a corresponding change is needed in [angular/dev-infra > .github/ng-renovate/runner-config.js][2]._

_UPDATE:_
_Candidate `dev-infra` PRs:_
- _angular/dev-infra#754_
- _angular/dev-infra#755_

[1]: https://github.com/angular/angular/pull/46707#issuecomment-1203335639
[2]: https://github.com/angular/dev-infra/blob/d2f9d2f493ec99f89a1db2777e2b27c1f5b278e9/.github/ng-renovate/runner-config.js#L7