### PR TITLE
refactor: improve disabled attribute warning

### DIFF
--- a/packages/forms/src/directives/reactive_errors.ts
+++ b/packages/forms/src/directives/reactive_errors.ts
@@ -77,15 +77,14 @@ export const disabledAttrWarning = `
   you. We recommend using this approach to avoid 'changed after checked' errors.
 
   Example:
+  // Specify the \`disabled\` property at control creation time:
   form = new FormGroup({
     first: new FormControl({value: 'Nancy', disabled: true}, Validators.required),
     last: new FormControl('Drew', Validators.required)
   });
 
-  // To dynamically enable/disable the form control, you can use
+  // Controls can also be enabled/disabled after creation:
   form.get('first')?.enable();
-
-  // Or
   form.get('last')?.disable();
 `;
 

--- a/packages/forms/src/directives/reactive_errors.ts
+++ b/packages/forms/src/directives/reactive_errors.ts
@@ -81,6 +81,12 @@ export const disabledAttrWarning = `
     first: new FormControl({value: 'Nancy', disabled: true}, Validators.required),
     last: new FormControl('Drew', Validators.required)
   });
+
+  // To dynamically enable/disable the form control, you can use
+  form.get('first')?.enable();
+
+  // Or
+  form.get('last')?.disable();
 `;
 
 export const asyncValidatorsDroppedWithOptsWarning = `


### PR DESCRIPTION
Users using the "disabled" property binding on reactive form controls would want to know how to dynamically update the disabled state of a form control when they get a console warning.

At least, I wanted to know this and I had to invest some time to find out how to do it when I got this warning in console. With this PR, I'd like to improve the warning message to help users to easier find what using `[disabled]="..."` would automatically do for them in template driven forms.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
None