### PR TITLE
fix(service-worker): export NoNewVersionDetectedEvent

### DIFF
--- a/goldens/public-api/service-worker/index.md
+++ b/goldens/public-api/service-worker/index.md
@@ -8,6 +8,17 @@ import * as i0 from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
 import { Observable } from 'rxjs';
 
+// @public
+export interface NoNewVersionDetectedEvent {
+    // (undocumented)
+    type: 'NO_NEW_VERSION_DETECTED';
+    // (undocumented)
+    version: {
+        hash: string;
+        appData?: Object;
+    };
+}
+
 // @public (undocumented)
 export class ServiceWorkerModule {
     static register(script: string, opts?: SwRegistrationOptions): ModuleWithProviders<ServiceWorkerModule>;

--- a/packages/service-worker/src/index.ts
+++ b/packages/service-worker/src/index.ts
@@ -14,7 +14,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent, VersionDetectedEvent, VersionEvent, VersionInstallationFailedEvent, VersionReadyEvent,} from './low_level';
+export {UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent, VersionDetectedEvent, VersionEvent, VersionInstallationFailedEvent, VersionReadyEvent, NoNewVersionDetectedEvent} from './low_level';
 export {ServiceWorkerModule, SwRegistrationOptions} from './module';
 export {SwPush} from './push';
 export {SwUpdate} from './update';

--- a/packages/service-worker/src/index.ts
+++ b/packages/service-worker/src/index.ts
@@ -14,7 +14,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent, VersionDetectedEvent, VersionEvent, VersionInstallationFailedEvent, VersionReadyEvent, NoNewVersionDetectedEvent} from './low_level';
+export {NoNewVersionDetectedEvent, UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent, VersionDetectedEvent, VersionEvent, VersionInstallationFailedEvent, VersionReadyEvent} from './low_level';
 export {ServiceWorkerModule, SwRegistrationOptions} from './module';
 export {SwPush} from './push';
 export {SwUpdate} from './update';


### PR DESCRIPTION
NoNewVersionDetectedEvent is marked as @publicApi but not exported.

This adds it to the exports from `low_level.ts` in `index.ts`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
