### PR TITLE
refactor(router): Cherry-pick Router services to be providedIn: 'root'

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -179,6 +179,10 @@ export class ChildrenOutletContexts {
     onOutletDeactivated(): Map<string, OutletContext>;
     // (undocumented)
     onOutletReAttached(contexts: Map<string, OutletContext>): void;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<ChildrenOutletContexts, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<ChildrenOutletContexts>;
 }
 
 // @public
@@ -946,6 +950,10 @@ export class UrlSegmentGroup {
 export abstract class UrlSerializer {
     abstract parse(url: string): UrlTree;
     abstract serialize(tree: UrlTree): string;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<UrlSerializer, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<UrlSerializer>;
 }
 
 // @public

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -31,7 +31,7 @@ export const ROUTES = new InjectionToken<Route[][]>('ROUTES');
 
 type ComponentLoader = Observable<Type<unknown>>;
 
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class RouterConfigLoader {
   private componentLoaders = new WeakMap<Route, ComponentLoader>();
   private childrenLoaders = new WeakMap<Route, Observable<LoadedRouterConfig>>();

--- a/packages/router/src/router_outlet_context.ts
+++ b/packages/router/src/router_outlet_context.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentFactoryResolver, ComponentRef, EnvironmentInjector} from '@angular/core';
+import {ComponentFactoryResolver, ComponentRef, EnvironmentInjector, Injectable} from '@angular/core';
 
 import {RouterOutletContract} from './directives/router_outlet';
 import {ActivatedRoute} from './router_state';
@@ -35,6 +35,7 @@ export class OutletContext {
  *
  * @publicApi
  */
+@Injectable({providedIn: 'root'})
 export class ChildrenOutletContexts {
   // contexts for child outlets, by name.
   private contexts = new Map<string, OutletContext>();

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵRuntimeError as RuntimeError} from '@angular/core';
+import {Injectable, ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {RuntimeErrorCode} from './errors';
 import {convertToParamMap, ParamMap, Params, PRIMARY_OUTLET} from './shared';
@@ -356,6 +356,7 @@ export function mapChildrenIntoArray<T>(
  *
  * @publicApi
  */
+@Injectable({providedIn: 'root', useFactory: () => new DefaultUrlSerializer()})
 export abstract class UrlSerializer {
   /** Parse a url into a `UrlTree` */
   abstract parse(url: string): UrlTree;

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -25,6 +25,9 @@ import {TreeNode} from '../src/utils/tree';
 import {createActivatedRouteSnapshot, Logger, provideTokenLogger} from './helpers';
 
 describe('Router', () => {
+  it('can be injected without RouterModule', () => {
+    expect(() => TestBed.inject(Router)).not.toThrow();
+  });
   describe('resetConfig', () => {
     class TestComponent {}
 


### PR DESCRIPTION
Recent refactoring in the Router made services available via
`providedIn: 'root'`. However, some of these changes were not merged to
the patch branch. This commit updates the remaining services needed to
create the `Router` without `RouterModule` and adds a test to ensure it
works.

Note: These changes are already on the `main` branch
https://github.com/angular/angular/blob/main/packages/router/src/router_config_loader.ts#L34
https://github.com/angular/angular/blob/main/packages/router/src/url_tree.ts#L359
https://github.com/angular/angular/blob/main/packages/router/src/router_outlet_context.ts#L38