### PR TITLE
refactor(core): drop `RootContext` object

### DIFF
--- a/goldens/public-api/core/global_utils.md
+++ b/goldens/public-api/core/global_utils.md
@@ -27,7 +27,7 @@ export interface DirectiveDebugMetadata {
 export function getComponent<T>(element: Element): T | null;
 
 // @public
-export function getContext<T extends ({} | RootContext)>(element: Element): T | null;
+export function getContext<T extends {}>(element: Element): T | null;
 
 // @public
 export function getDirectiveMetadata(directiveOrComponentInstance: any): ComponentDebugMetadata | DirectiveDebugMetadata | null;

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 455179,
+      "main": 454655,
       "polyfills": 33922,
       "styles": 73640,
       "light-theme": 78045,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,7 +2,7 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 1083,
-      "main": 125276,
+      "main": 124633,
       "polyfills": 33824
     }
   },
@@ -19,15 +19,15 @@
   "cli-hello-world-ivy-compat": {
     "uncompressed": {
       "runtime": 1102,
-      "main": 132262,
+      "main": 131619,
       "polyfills": 33957
     }
   },
   "cli-hello-world-ivy-i18n": {
     "uncompressed": {
       "runtime": 926,
-      "main": 124860,
-      "polyfills": 35246
+      "main": 124269,
+      "polyfills": 35252
     }
   },
   "cli-hello-world-lazy": {
@@ -41,21 +41,21 @@
   "forms": {
     "uncompressed": {
       "runtime": 1060,
-      "main": 157621,
+      "main": 156626,
       "polyfills": 33915
     }
   },
   "animations": {
     "uncompressed": {
       "runtime": 1070,
-      "main": 156816,
+      "main": 156225,
       "polyfills": 33814
     }
   },
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 1090,
-      "main": 83515,
+      "main": 82906,
       "polyfills": 33945
     }
   },

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -175,8 +175,8 @@ export interface LView<T = unknown> extends Array<any> {
   /**
    * - For dynamic views, this is the context with which to render the template (e.g.
    *   `NgForContext`), or `{}` if not defined explicitly.
-   * - For root view of the root component the context contains change detection data.
-   * - For non-root components, the context is the component instance,
+   * - For root view of the root component it's a reference to the component instance itself.
+   * - For components, the context is a reference to the component instance itself.
    * - For inline views, the context is null.
    */
   [CONTEXT]: T;
@@ -787,16 +787,6 @@ export interface TView {
    * view. This means that the view is likely corrupted and we should try to recover it.
    */
   incompleteFirstPass: boolean;
-}
-
-/**
- * Contains information which is shared for all bootstrapped components.
- */
-export interface RootContext<T = unknown> {
-  /**
-   * The components that were instantiated within this context.
-   */
-  components: T[];
 }
 
 /** Single hook callback function. */

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -15,13 +15,11 @@ import {discoverLocalRefs, getComponentAtNodeIndex, getDirectivesAtNodeIndex, ge
 import {getComponentDef, getDirectiveDef} from '../definition';
 import {NodeInjector} from '../di';
 import {buildDebugNode} from '../instructions/lview_debug';
-import {LContext} from '../interfaces/context';
 import {DirectiveDef} from '../interfaces/definition';
 import {TElementNode, TNode, TNodeProviderIndexes} from '../interfaces/node';
 import {isLView} from '../interfaces/type_checks';
-import {CLEANUP, CONTEXT, DebugNode, FLAGS, LView, LViewFlags, RootContext, T_HOST, TVIEW, TViewType} from '../interfaces/view';
+import {CLEANUP, CONTEXT, DebugNode, FLAGS, LView, LViewFlags, T_HOST, TVIEW, TViewType} from '../interfaces/view';
 
-import {stringifyForError} from './stringify_utils';
 import {getLViewParent, getRootContext} from './view_traversal_utils';
 import {getTNode, unwrapRNode} from './view_utils';
 
@@ -83,7 +81,7 @@ export function getComponent<T>(element: Element): T|null {
  * @publicApi
  * @globalApi ng
  */
-export function getContext<T extends({} | RootContext)>(element: Element): T|null {
+export function getContext<T extends {}>(element: Element): T|null {
   assertDomElement(element);
   const context = getLContext(element)!;
   const lView = context ? context.lView : null;
@@ -130,7 +128,7 @@ export function getOwningComponent<T>(elementOrDir: Element|{}): T|null {
  */
 export function getRootComponents(elementOrDir: Element|{}): {}[] {
   const lView = readPatchedLView<{}>(elementOrDir);
-  return lView !== null ? [...getRootContext(lView).components as unknown as {}[]] : [];
+  return lView !== null ? [getRootContext(lView)] : [];
 }
 
 /**

--- a/packages/core/src/render3/util/view_traversal_utils.ts
+++ b/packages/core/src/render3/util/view_traversal_utils.ts
@@ -11,7 +11,7 @@ import {assertLView} from '../assert';
 import {readPatchedLView} from '../context_discovery';
 import {LContainer} from '../interfaces/container';
 import {isLContainer, isLView} from '../interfaces/type_checks';
-import {CHILD_HEAD, CONTEXT, FLAGS, LView, LViewFlags, NEXT, PARENT, RootContext} from '../interfaces/view';
+import {CHILD_HEAD, CONTEXT, FLAGS, LView, LViewFlags, NEXT, PARENT} from '../interfaces/view';
 
 
 /**
@@ -42,17 +42,17 @@ export function getRootView<T>(componentOrLView: LView|{}): LView<T> {
 }
 
 /**
- * Returns the `RootContext` instance that is associated with
- * the application where the target is situated. It does this by walking the parent views until it
- * gets to the root view, then getting the context off of that.
+ * Returns the context information associated with the application where the target is situated. It
+ * does this by walking the parent views until it gets to the root view, then getting the context
+ * off of that.
  *
  * @param viewOrComponent the `LView` or component to get the root context for.
  */
-export function getRootContext<T>(viewOrComponent: LView<T>|{}): RootContext {
+export function getRootContext<T>(viewOrComponent: LView<T>|{}): T {
   const rootView = getRootView(viewOrComponent);
   ngDevMode &&
-      assertDefined(rootView[CONTEXT], 'RootView has no context. Perhaps it is disconnected?');
-  return rootView[CONTEXT] as RootContext;
+      assertDefined(rootView[CONTEXT], 'Root view has no context. Perhaps it is disconnected?');
+  return rootView[CONTEXT] as T;
 }
 
 

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -13,7 +13,7 @@ import {removeFromArray} from '../util/array_utils';
 import {assertEqual} from '../util/assert';
 
 import {collectNativeNodes} from './collect_native_nodes';
-import {checkNoChangesInRootView, checkNoChangesInternal, detectChangesInRootView, detectChangesInternal, markViewDirty, storeCleanupWithContext} from './instructions/shared';
+import {checkNoChangesInternal, detectChangesInternal, markViewDirty, storeCleanupWithContext} from './instructions/shared';
 import {CONTAINER_HEADER_OFFSET, VIEW_REFS} from './interfaces/container';
 import {isLContainer} from './interfaces/type_checks';
 import {CONTEXT, FLAGS, LView, LViewFlags, PARENT, TVIEW} from './interfaces/view';
@@ -317,12 +317,18 @@ export class RootViewRef<T> extends ViewRef<T> {
   }
 
   override detectChanges(): void {
-    detectChangesInRootView(this._view);
+    const lView = this._view;
+    const tView = lView[TVIEW];
+    const context = lView[CONTEXT];
+    detectChangesInternal(tView, lView, context, false);
   }
 
   override checkNoChanges(): void {
     if (ngDevMode) {
-      checkNoChangesInRootView(this._view);
+      const lView = this._view;
+      const tView = lView[TVIEW];
+      const context = lView[CONTEXT];
+      checkNoChangesInternal(tView, lView, context, false);
     }
   }
 

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -708,6 +708,9 @@
     "name": "detachMovedView"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -834,13 +837,13 @@
     "name": "getNullInjector"
   },
   {
+    "name": "getOrCreateComponentTView"
+  },
+  {
     "name": "getOrCreateInjectable"
   },
   {
     "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTComponentView"
   },
   {
     "name": "getOrCreateTNode"
@@ -1161,9 +1164,6 @@
     "name": "promise"
   },
   {
-    "name": "readPatchedLView"
-  },
-  {
     "name": "refCount"
   },
   {
@@ -1204,9 +1204,6 @@
   },
   {
     "name": "renderComponent"
-  },
-  {
-    "name": "renderComponentOrTemplate"
   },
   {
     "name": "renderView"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -495,6 +495,9 @@
     "name": "detachMovedView"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -612,13 +615,13 @@
     "name": "getNullInjector"
   },
   {
+    "name": "getOrCreateComponentTView"
+  },
+  {
     "name": "getOrCreateInjectable"
   },
   {
     "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTComponentView"
   },
   {
     "name": "getOrCreateTNode"
@@ -867,9 +870,6 @@
     "name": "promise"
   },
   {
-    "name": "readPatchedLView"
-  },
-  {
     "name": "refCount"
   },
   {
@@ -904,9 +904,6 @@
   },
   {
     "name": "renderComponent"
-  },
-  {
-    "name": "renderComponentOrTemplate"
   },
   {
     "name": "renderView"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -729,6 +729,9 @@
     "name": "detachView"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -888,6 +891,9 @@
     "name": "getNullInjector"
   },
   {
+    "name": "getOrCreateComponentTView"
+  },
+  {
     "name": "getOrCreateInjectable"
   },
   {
@@ -895,9 +901,6 @@
   },
   {
     "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTComponentView"
   },
   {
     "name": "getOrCreateTNode"
@@ -1305,9 +1308,6 @@
     "name": "providerToFactory"
   },
   {
-    "name": "readPatchedLView"
-  },
-  {
     "name": "refCount"
   },
   {
@@ -1354,9 +1354,6 @@
   },
   {
     "name": "renderComponent"
-  },
-  {
-    "name": "renderComponentOrTemplate"
   },
   {
     "name": "renderView"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -699,6 +699,9 @@
     "name": "detachView"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -849,6 +852,9 @@
     "name": "getNullInjector"
   },
   {
+    "name": "getOrCreateComponentTView"
+  },
+  {
     "name": "getOrCreateInjectable"
   },
   {
@@ -856,9 +862,6 @@
   },
   {
     "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTComponentView"
   },
   {
     "name": "getOrCreateTNode"
@@ -1269,9 +1272,6 @@
     "name": "providerToFactory"
   },
   {
-    "name": "readPatchedLView"
-  },
-  {
     "name": "refCount"
   },
   {
@@ -1318,9 +1318,6 @@
   },
   {
     "name": "renderComponent"
-  },
-  {
-    "name": "renderComponentOrTemplate"
   },
   {
     "name": "renderStringify"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -354,6 +354,9 @@
     "name": "detachMovedView"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "empty"
   },
   {
@@ -636,9 +639,6 @@
     "name": "promise"
   },
   {
-    "name": "readPatchedLView"
-  },
-  {
     "name": "refCount"
   },
   {
@@ -667,9 +667,6 @@
   },
   {
     "name": "renderComponent"
-  },
-  {
-    "name": "renderComponentOrTemplate"
   },
   {
     "name": "renderView"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -906,6 +906,9 @@
     "name": "detachView"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -1116,6 +1119,9 @@
     "name": "getNullInjector"
   },
   {
+    "name": "getOrCreateComponentTView"
+  },
+  {
     "name": "getOrCreateInjectable"
   },
   {
@@ -1126,9 +1132,6 @@
   },
   {
     "name": "getOrCreateRouteInjectorIfNeeded"
-  },
-  {
-    "name": "getOrCreateTComponentView"
   },
   {
     "name": "getOrCreateTNode"
@@ -1312,9 +1315,6 @@
   },
   {
     "name": "isContentQueryHost"
-  },
-  {
-    "name": "isCreationMode"
   },
   {
     "name": "isCssClassMatching"
@@ -1560,9 +1560,6 @@
     "name": "provideRoutes"
   },
   {
-    "name": "readPatchedLView"
-  },
-  {
     "name": "redirectIfUrlTree"
   },
   {
@@ -1603,9 +1600,6 @@
   },
   {
     "name": "renderComponent"
-  },
-  {
-    "name": "renderComponentOrTemplate"
   },
   {
     "name": "renderStringify"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -423,6 +423,9 @@
     "name": "detachMovedView"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "empty"
   },
   {
@@ -723,9 +726,6 @@
     "name": "promise"
   },
   {
-    "name": "readPatchedLView"
-  },
-  {
     "name": "refCount"
   },
   {
@@ -757,9 +757,6 @@
   },
   {
     "name": "renderComponent"
-  },
-  {
-    "name": "renderComponentOrTemplate"
   },
   {
     "name": "renderView"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -609,6 +609,9 @@
     "name": "detachView"
   },
   {
+    "name": "detectChangesInternal"
+  },
+  {
     "name": "diPublicInInjector"
   },
   {
@@ -741,6 +744,9 @@
     "name": "getNullInjector"
   },
   {
+    "name": "getOrCreateComponentTView"
+  },
+  {
     "name": "getOrCreateInjectable"
   },
   {
@@ -748,9 +754,6 @@
   },
   {
     "name": "getOrCreateNodeInjectorForNode"
-  },
-  {
-    "name": "getOrCreateTComponentView"
   },
   {
     "name": "getOrCreateTNode"
@@ -1080,9 +1083,6 @@
     "name": "promise"
   },
   {
-    "name": "readPatchedLView"
-  },
-  {
     "name": "refCount"
   },
   {
@@ -1117,9 +1117,6 @@
   },
   {
     "name": "renderComponent"
-  },
-  {
-    "name": "renderComponentOrTemplate"
   },
   {
     "name": "renderStringify"


### PR DESCRIPTION
In a previous refactor, the `RootContext` was update to only contain a reference to a component. This commit perform further refactoring to get rid of the `RootContext` altogether, while storing component reference directly on the root view (without the `RootContext` wrapper).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No