### PR TITLE
docs: fix the lack of a single string in the `dependency injection guide` code snippet.

### DIFF
--- a/aio/content/guide/dependency-injection.md
+++ b/aio/content/guide/dependency-injection.md
@@ -6,7 +6,7 @@ Two main roles exist in the DI system: dependency consumer and dependency provid
 
 Angular facilitates the interaction between dependency consumers and dependency providers using an abstraction called [Injector](guide/glossary#injector). When a dependency is requested, the injector checks its registry to see if there is an instance already available there. If not, a new instance is created and stored in the registry. Angular creates an application-wide injector (also known as "root" injector) during the application bootstrap process, as well as any other injectors as needed. In most cases you don't need to manually create injectors, but you should know that there is a layer that connects providers and consumers.
 
-This topic covers basic scenarios of how a class can act as a dependency. Angular also allows you to use functions, objects, primitive types such as string or Boolean, or any other types as dependencies. For more information, see [Dependency providers](guide/dependency-injection-providers].
+This topic covers basic scenarios of how a class can act as a dependency. Angular also allows you to use functions, objects, primitive types such as string or Boolean, or any other types as dependencies. For more information, see [Dependency providers](guide/dependency-injection-providers).
 
 ## Providing dependency
 
@@ -25,7 +25,7 @@ The next step is to make it available in the DI by providing it.  A dependency c
 
 <code-example language="typescript">
 @Component({
-  selector: 'hero-list,
+  selector: 'hero-list',
   template: '...',
   providers: [HeroService]
 })


### PR DESCRIPTION
Edited:
> I noticed that the broken link in the dependency injection guide, as you will see in my commit, has already been updated by another [PR](https://github.com/angular/angular/pull/47055#issue-1330493170). In spite of that, I also made some changes to the code snippet in the component decorator as it lacks a single string.

## PR Checklist 

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:
   
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
 