### PR TITLE
docs: fix text formatting for paragraph in Hierarchical injectors

### DIFF
--- a/aio/content/guide/hierarchical-dependency-injection.md
+++ b/aio/content/guide/hierarchical-dependency-injection.md
@@ -20,6 +20,7 @@ This topic uses the following pictographs.
 | <code>&#x1F994;</code> | hedgehog \(`🦔`\)       |
 
 </div>
+
 The applications you build with Angular can become quite large, and one way to manage this complexity is to split up the application into many small well encapsulated modules, that are by themselves split up into a well-defined tree of components.
 The applications you build with Angular can become quite large, and one way to manage this complexity is to split up the application into many small well-encapsulated modules, that are by themselves split up into a well-defined tree of components.
 


### PR DESCRIPTION
Paragraph of text is not wrapped into `p` tag due to missing empty line after the `div` block. The fix is just add an empty line.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Please see below the issue with text formatting:

![Screenshot 2022-08-07 at 12 29 11](https://user-images.githubusercontent.com/1313221/183286663-b9ed6876-60fe-4e0b-81d8-69d8043170db.png)

Issue Number: N/A


## What is the new behavior?

Please see below the fixed formatting:

![Screenshot 2022-08-07 at 12 28 47](https://user-images.githubusercontent.com/1313221/183286642-b6f3213e-4713-454e-9597-e3979b14306c.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
