### PR TITLE
fix(common): allow null/undefined to be passed to ngStyle input

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -549,7 +549,7 @@ export class NgStyle implements DoCheck {
     // (undocumented)
     set ngStyle(values: {
         [klass: string]: any;
-    } | null);
+    } | null | undefined);
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<NgStyle, "[ngStyle]", never, { "ngStyle": "ngStyle"; }, {}, never, never, true>;
     // (undocumented)

--- a/packages/common/src/directives/ng_style.ts
+++ b/packages/common/src/directives/ng_style.ts
@@ -49,14 +49,14 @@ import {Directive, DoCheck, ElementRef, Input, KeyValueChanges, KeyValueDiffer, 
   standalone: true,
 })
 export class NgStyle implements DoCheck {
-  private _ngStyle: {[key: string]: string}|null = null;
+  private _ngStyle: {[key: string]: string}|null|undefined = null;
   private _differ: KeyValueDiffer<string, string|number>|null = null;
 
   constructor(
       private _ngEl: ElementRef, private _differs: KeyValueDiffers, private _renderer: Renderer2) {}
 
   @Input('ngStyle')
-  set ngStyle(values: {[klass: string]: any}|null) {
+  set ngStyle(values: {[klass: string]: any}|null|undefined) {
     this._ngStyle = values;
     if (!this._differ && values) {
       this._differ = this._differs.find(values).create();

--- a/packages/common/test/directives/ng_style_spec.ts
+++ b/packages/common/test/directives/ng_style_spec.ts
@@ -55,6 +55,32 @@ import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
          expectNativeEl(fixture).toHaveCssStyle({'max-width': '30%'});
        }));
 
+    it('should remove styles with a null expression', waitForAsync(() => {
+         const template = `<div [ngStyle]="expr"></div>`;
+         fixture = createTestComponent(template);
+
+         getComponent().expr = {'max-width': '40px'};
+         fixture.detectChanges();
+         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
+
+         getComponent().expr = null;
+         fixture.detectChanges();
+         expectNativeEl(fixture).not.toHaveCssStyle('max-width');
+       }));
+
+    it('should remove styles with an undefined expression', waitForAsync(() => {
+         const template = `<div [ngStyle]="expr"></div>`;
+         fixture = createTestComponent(template);
+
+         getComponent().expr = {'max-width': '40px'};
+         fixture.detectChanges();
+         expectNativeEl(fixture).toHaveCssStyle({'max-width': '40px'});
+
+         getComponent().expr = undefined;
+         fixture.detectChanges();
+         expectNativeEl(fixture).not.toHaveCssStyle('max-width');
+       }));
+
     it('should add and remove styles specified using style.unit notation', waitForAsync(() => {
          const template = `<div [ngStyle]="{'max-width.px': expr}"></div>`;
 


### PR DESCRIPTION
This brings the typing of ngStyle into parity with ngClass since commit
e2ab99b95ef. Should help with some strict template checking edge cases.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

`[ngStyle]` does not accept an undefined type when `strictTemplates` is enabled.

## What is the new behavior?

`[ngStyle]` accepts undefined type

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

This was suggested by @AndrewKushnir in https://github.com/angular/angular/pull/46906#issuecomment-1201649957 .