### PR TITLE
docs: change "zone" to "ngZone" in Plotly example

### DIFF
--- a/aio/content/guide/change-detection-zone-pollution.md
+++ b/aio/content/guide/change-detection-zone-pollution.md
@@ -46,7 +46,7 @@ import * as Plotly from 'plotly.js-dist-min';
 class AppComponent implements OnInit {
   constructor(private ngZone: NgZone) {}
   ngOnInit() {
-    this.zone.runOutsideAngular(() => {
+    this.ngZone.runOutsideAngular(() => {
       Plotly.newPlot('chart', data);
     });
   }


### PR DESCRIPTION
Change requesting "this.zone" to "this.ngZone" in the Plotly example, as it corresponds to the name declared in the constructor.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the example "this.zone" is referenced, which does not exist in the scope of the example.

Issue Number: N/A


## What is the new behavior?
Using "this.ngZone" instead of "this.zone", as it declared in the constructor.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
