### PR TITLE
refactor(router): Update `router.createUrlTree` to be capable of usin…

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -969,6 +969,9 @@
     "name": "createTemplateRef"
   },
   {
+    "name": "createUrlTree"
+  },
+  {
     "name": "deactivateRouteAndItsChildren"
   },
   {

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -74,7 +74,7 @@ export function createUrlTreeFromSnapshot(
   return createUrlTreeFromSegmentGroup(relativeToUrlSegmentGroup, commands, queryParams, fragment);
 }
 
-function createSegmentGroupFromRoute(route: ActivatedRouteSnapshot): UrlSegmentGroup {
+export function createSegmentGroupFromRoute(route: ActivatedRouteSnapshot): UrlSegmentGroup {
   let targetGroup: UrlSegmentGroup|undefined;
 
   function createSegmentGroupFromRouteRecursive(currentRoute: ActivatedRouteSnapshot) {

--- a/packages/router/src/router_create_url_tree_flag.ts
+++ b/packages/router/src/router_create_url_tree_flag.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * This flag supports easier migration to the new API. Flipping this flag with an internal patch
+ * means it can land ahead of upstream `main` targetting v15.
+ */
+export const USE_NEW_ROUTER_CREATE_URL_TREE_IMPLEMENTATION = false;


### PR DESCRIPTION
…g fixed behavior

This change is makes the new `createUrlTreeFromSnapshot` API available
in `router.createUrlTree` ahead of `main` targetting v15. Since this is
a breaking change, it would otherwise be blocked on the branch target
updates. The commit message for flipping the flag/removing it in v15
will be:

fix(router): `router.createUrlTree` works correctly in more scenarios

This commit updates the `router.createUrlTree` to internally use the
`createUrlTreeFromSnapshot` method introduced in https://github.com/angular/angular/commit/53ca936366fb908278571bae5fcc7fa08b19a5a0.
This fixes many URL creation scenarios like #42191, #38276, and #22763.
It also opens the door for us to combine the `apply_redirects` and
`recognize` stages in the router to reduce code size, maintenance
burden, and the need to call `UrlMatcher` and `canMatch` guards twice (#26081).

BRKNG CHNG (misspelled so changelog doesn't pick it up now):
Tests which mock `ActivatedRoute` instances may need to be adjusted
because `Router.createUrlTree` now does the right thing in more
scenarios. This means that tests with invalid/incomplete `ActivatedRoute` mocks
may behave differently than before.
