### PR TITLE
fix(zone.js): Fix ConsoleTask interface typo

### DIFF
--- a/packages/zone.js/lib/zone-spec/async-stack-tagging.ts
+++ b/packages/zone.js/lib/zone-spec/async-stack-tagging.ts
@@ -11,7 +11,7 @@ interface Console {
 }
 
 interface ConsoleTask {
-  run<T>(f: () => T): void;
+  run<T>(f: () => T): T;
 }
 
 interface Task {


### PR DESCRIPTION
Signed-off-by: Victor Porof <victorporof@chromium.org>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:

This PR updates a TypeScript interface.

## What is the current behavior?

`ConsoleTask::run` is typed as returning `void`.


## What is the new behavior?

`ConsoleTask::run` is typed returning the same value from invoking the function that was passed in as an argument.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

According to the [V8 implementation](https://chromium-review.googlesource.com/c/v8/v8/+/3776678), the Async Stack Tagging API's task `run` function is transparent and equivalent to changing `f()` to `task.run(f)`. The return value of `f` won't be lost. This PR updates the interface to reflect that.