### PR TITLE
docs: Moving a div down in tutorial toh-pt6.md

### DIFF
--- a/aio/content/tutorial/toh-pt6.md
+++ b/aio/content/tutorial/toh-pt6.md
@@ -300,16 +300,6 @@ The component's `delete()` method immediately removes the *hero-to-delete* from 
 
 There's really nothing for the component to do with the `Observable` returned by `heroService.deleteHero()` **but it must subscribe anyway**.
 
-<div class="alert is-important">
-
-If you neglect to `subscribe()`, the service can't send the delete request to the server.
-As a rule, an `Observable` *does nothing* until something subscribes.
-
-Confirm this for yourself by temporarily removing the `subscribe()`, clicking **Dashboard**, then clicking **Heroes**.
-This shows the full list of heroes again.
-
-</div>
-
 Next, add a `deleteHero()` method to `HeroService` like this.
 
 <code-example header="src/app/hero.service.ts (delete)" path="toh-pt6/src/app/hero.service.ts" region="deleteHero"></code-example>
@@ -322,6 +312,16 @@ Notice the following key points:
 *   You still send the `httpOptions`
 
 Refresh the browser and try the new delete capability.
+
+<div class="alert is-important">
+
+If you neglect to `subscribe()`, the service can't send the delete request to the server.
+As a rule, an `Observable` *does nothing* until something subscribes.
+
+Confirm this for yourself by temporarily removing the `subscribe()`, clicking **Dashboard**, then clicking **Heroes**.
+This shows the full list of heroes again.
+
+</div>
 
 ## Search by name
 


### PR DESCRIPTION
At the point the "alert is-important" div is currently displayed, the Tour of Heroes app will not be working because the deleteHero method will not have been added to heroService. Therefore, I moved that div down to a point where it will be working, so the reader can try it out as intended.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
At the point the "alert is-important" div is currently displayed, the Tour of Heroes app will not be working because the deleteHero method will not have been added to heroService.


Issue Number: N/A


## What is the new behavior?
 Therefore, I moved that div down to a point where it will be working, so the reader can try it out as intended.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
