### PR TITLE
fix(router): Fix route recognition behavior with some versions of rxjs

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1437,6 +1437,9 @@
     "name": "isDirectiveHost"
   },
   {
+    "name": "isEmptyError"
+  },
+  {
     "name": "isFunction"
   },
   {

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -7,7 +7,7 @@
  */
 
 import {EnvironmentInjector, ɵRuntimeError as RuntimeError} from '@angular/core';
-import {EmptyError, from, Observable, of, throwError} from 'rxjs';
+import {from, Observable, of, throwError} from 'rxjs';
 import {catchError, concatMap, first, last, map, mergeMap, scan, switchMap, tap} from 'rxjs/operators';
 
 import {RuntimeErrorCode} from './errors';
@@ -21,6 +21,7 @@ import {createRoot, squashSegmentGroup, UrlSegment, UrlSegmentGroup, UrlSerializ
 import {forEach} from './utils/collection';
 import {getOrCreateRouteInjectorIfNeeded, getOutlet, sortByMatchingOutlets} from './utils/config';
 import {isImmediateMatch, match, matchWithChecks, noLeftoversInUrl, split} from './utils/config_matching';
+import {isEmptyError} from './utils/type_guards';
 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
 
@@ -201,7 +202,7 @@ class ApplyRedirects {
           }));
         }),
         first((s): s is UrlSegmentGroup => !!s), catchError((e: any, _: any) => {
-          if (e instanceof EmptyError || e.name === 'EmptyError') {
+          if (isEmptyError(e)) {
             if (noLeftoversInUrl(segmentGroup, segments, outlet)) {
               return of(new UrlSegmentGroup([], {}));
             }

--- a/packages/router/src/operators/resolve_data.ts
+++ b/packages/router/src/operators/resolve_data.ts
@@ -7,7 +7,7 @@
  */
 
 import {EnvironmentInjector, ProviderToken} from '@angular/core';
-import {EMPTY, EmptyError, from, MonoTypeOperatorFunction, Observable, of, throwError} from 'rxjs';
+import {EMPTY, from, MonoTypeOperatorFunction, Observable, of, throwError} from 'rxjs';
 import {catchError, concatMap, first, map, mapTo, mergeMap, takeLast, tap} from 'rxjs/operators';
 
 import {ResolveData, Route} from '../models';
@@ -17,6 +17,7 @@ import {RouteTitleKey} from '../shared';
 import {wrapIntoObservable} from '../utils/collection';
 import {getClosestRouteInjector} from '../utils/config';
 import {getTokenOrFunctionIdentity} from '../utils/preactivation';
+import {isEmptyError} from '../utils/type_guards';
 
 export function resolveData(
     paramsInheritanceStrategy: 'emptyOnly'|'always',
@@ -74,7 +75,7 @@ function resolveNode(
                            }))),
       takeLast(1),
       mapTo(data),
-      catchError((e: unknown) => e instanceof EmptyError ? EMPTY : throwError(e)),
+      catchError((e: unknown) => isEmptyError(e as Error) ? EMPTY : throwError(e)),
   );
 }
 

--- a/packages/router/src/recognize.ts
+++ b/packages/router/src/recognize.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createEnvironmentInjector, EnvironmentInjector, Type, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {EnvironmentInjector, Type, ɵRuntimeError as RuntimeError} from '@angular/core';
 import {EmptyError, from, Observable, Observer, of} from 'rxjs';
-import {catchError, concatMap, defaultIfEmpty, first, last as rxjsLast, map, scan, startWith, switchMap, takeLast, takeWhile} from 'rxjs/operators';
+import {catchError, concatMap, defaultIfEmpty, first, last as rxjsLast, map, scan, switchMap, takeWhile} from 'rxjs/operators';
 
 import {RuntimeErrorCode} from './errors';
 import {Data, ResolveData, Route, Routes} from './models';
@@ -16,9 +16,10 @@ import {ActivatedRouteSnapshot, inheritedParamsDataResolve, ParamsInheritanceStr
 import {PRIMARY_OUTLET} from './shared';
 import {UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
 import {last} from './utils/collection';
-import {getOrCreateRouteInjectorIfNeeded, getOutlet, sortByMatchingOutlets} from './utils/config';
+import {getOutlet, sortByMatchingOutlets} from './utils/config';
 import {isImmediateMatch, matchWithChecks, noLeftoversInUrl, split} from './utils/config_matching';
 import {TreeNode} from './utils/tree';
+import {isEmptyError} from './utils/type_guards';
 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 
@@ -156,7 +157,7 @@ export class Recognizer {
               r._injector ?? injector, r, segmentGroup, segments, outlet);
         }),
         first((x): x is TreeNode<ActivatedRouteSnapshot>[] => !!x), catchError(e => {
-          if (e instanceof EmptyError) {
+          if (isEmptyError(e)) {
             if (noLeftoversInUrl(segmentGroup, segments, outlet)) {
               return of([]);
             }

--- a/packages/router/src/utils/type_guards.ts
+++ b/packages/router/src/utils/type_guards.ts
@@ -63,5 +63,5 @@ export function isNavigationCancelingError(error: unknown): error is NavigationC
 }
 
 export function isEmptyError(e: Error): e is EmptyError {
-  return e instanceof EmptyError || e.name === 'EmptyError';
+  return e instanceof EmptyError || e?.name === 'EmptyError';
 }

--- a/packages/router/src/utils/type_guards.ts
+++ b/packages/router/src/utils/type_guards.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {EmptyError} from 'rxjs';
+
 import {CanActivate, CanActivateChild, CanDeactivate, CanLoad, CanMatch} from '../models';
 import {NAVIGATION_CANCELING_ERROR, NavigationCancelingError, RedirectingNavigationCancelingError} from '../navigation_canceling_error';
 import {isUrlTree} from '../url_tree';
@@ -58,4 +60,8 @@ export function isRedirectingNavigationCancelingError(
 
 export function isNavigationCancelingError(error: unknown): error is NavigationCancelingError {
   return error && (error as any)[NAVIGATION_CANCELING_ERROR];
+}
+
+export function isEmptyError(e: Error): e is EmptyError {
+  return e instanceof EmptyError || e.name === 'EmptyError';
 }


### PR DESCRIPTION
Some versions of rxjs cause the algorithm used in the Router to not recognize Route configs correctly.
This commit updates the algorithm to be compatible in the same way as other code locations internally.

Context:
https://github.com/angular/angular/commit/1160b8194f78141b40d1d4885ec182d033ff2659

fixes #47089

Note: This does not have a test because I was unable to identify the
version of rxjs that would cause a failure here.
