### PR TITLE
refactor(platform-server): add a marker to specify how a page was rendered

### DIFF
--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -58,7 +58,7 @@ export function renderApplication<T>(rootComponent: Type<T>, options: {
 }): Promise<string>;
 
 // @public
-export function renderModule<T>(module: Type<T>, options: {
+export function renderModule<T>(moduleType: Type<T>, options: {
     document?: string | Document;
     url?: string;
     extraProviders?: StaticProvider[];

--- a/packages/platform-server/src/private_export.ts
+++ b/packages/platform-server/src/private_export.ts
@@ -9,3 +9,4 @@
 export {setDomTypes as ɵsetDomTypes} from './domino_adapter';
 export {INTERNAL_SERVER_PLATFORM_PROVIDERS as ɵINTERNAL_SERVER_PLATFORM_PROVIDERS, SERVER_RENDER_PROVIDERS as ɵSERVER_RENDER_PROVIDERS} from './server';
 export {ServerRendererFactory2 as ɵServerRendererFactory2} from './server_renderer';
+export {SERVER_CONTEXT as ɵSERVER_CONTEXT} from './utils';


### PR DESCRIPTION
This commit updates the `renderApplication`, `renderModule` and `renderModuleFactory` functions to append a special marker (in a form of an attribute, called `ng-server-context`) to the component host elements. This marker is needed to analyze how a page was rendered.

## PR Type
What kind of change does this PR introduce?

- [x] Feature


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No