### PR TITLE
build(bazel): stamp targets to build, test, and serve aio against first party deps

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,6 +56,14 @@ build:release --stamp
 build:snapshot --workspace_status_command="yarn -s ng-dev release build-env-stamp --mode=snapshot"
 build:snapshot --stamp
 
+####################################
+# AIO first party dep substitution # 
+# Turn on with                     #
+#  --config=aio_local_deps         #
+####################################
+
+build:aio_local_deps --//aio:flag_aio_local_deps
+
 ###############################
 # Output                      #
 ###############################

--- a/aio/BUILD.bazel
+++ b/aio/BUILD.bazel
@@ -2,6 +2,8 @@ load("@aio_npm//@angular-devkit/architect-cli:index.bzl", "architect", "architec
 load("@build_bazel_rules_nodejs//:index.bzl", "npm_package_bin")
 load("//aio/tools:defaults.bzl", "nodejs_binary")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load(":local_packages_util.bzl", "link_local_packages", "substitute_local_packages")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 
 # The write_source_files macro is used to write bazel outputs to the source tree and test that they are up to date.
 # See: https://docs.aspect.build/aspect-build/bazel-lib/v0.5.0/docs/docs/write_source_files-docgen.html
@@ -11,6 +13,19 @@ exports_files([
     "firebase.json",
     "ngsw-config.template.json",
 ])
+
+# If set will use first party angular deps for aio targets instead of their npm equivalent
+bool_flag(
+    name = "flag_aio_local_deps",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "aio_local_deps",
+    flag_values = {
+        ":flag_aio_local_deps": "true",
+    },
+)
 
 # Generate ngsw-config
 npm_package_bin(
@@ -152,6 +167,10 @@ E2E_DEPS = APPLICATION_DEPS + [
     "@aio_npm//ts-node",
 ]
 
+# Stamp npm_link targets for all dependencies that correspond to a
+# first-party equivalent pacakge in angular.
+link_local_packages(deps = APPLICATION_DEPS)
+
 architect(
     name = "build",
     args = [
@@ -160,7 +179,10 @@ architect(
     ],
     chdir = package_name(),
     configuration_env_vars = ["NG_BUILD_CACHE"],
-    data = APPLICATION_FILES + APPLICATION_DEPS,
+    data = APPLICATION_FILES + select({
+        ":aio_local_deps": substitute_local_packages(APPLICATION_DEPS),
+        "//conditions:default": APPLICATION_DEPS,
+    }),
     output_dir = True,
 )
 
@@ -172,7 +194,10 @@ architect_test(
     ],
     chdir = package_name(),
     configuration_env_vars = ["NG_BUILD_CACHE"],
-    data = TEST_FILES + TEST_DEPS,
+    data = TEST_FILES + select({
+        ":aio_local_deps": substitute_local_packages(TEST_DEPS),
+        "//conditions:default": TEST_DEPS,
+    }),
     env = {
         "CHROME_BIN": "../$(CHROMIUM)",
     },
@@ -186,10 +211,14 @@ architect_test(
     args = [
         "site:e2e",
         "--no-webdriver-update",
+        "--port=0",
     ],
     chdir = package_name(),
     configuration_env_vars = ["NG_BUILD_CACHE"],
-    data = E2E_FILES + E2E_DEPS,
+    data = E2E_FILES + select({
+        ":aio_local_deps": substitute_local_packages(E2E_DEPS),
+        "//conditions:default": E2E_DEPS,
+    }),
     env = {
         "CHROME_BIN": "../$(CHROMIUM)",
         "CHROMEDRIVER_BIN": "../$(CHROMEDRIVER)",
@@ -206,7 +235,10 @@ architect(
         "site:serve",
     ],
     chdir = package_name(),
-    data = APPLICATION_DEPS + APPLICATION_FILES,
+    data = APPLICATION_FILES + select({
+        ":aio_local_deps": substitute_local_packages(APPLICATION_DEPS),
+        "//conditions:default": APPLICATION_DEPS,
+    }),
     tags = ["ibazel_notify_changes"],
 )
 
@@ -214,12 +246,17 @@ architect(
 # rebuild when docs change. Watching and serving is a part of the node script,
 # so there is no need to run with ibazel, which would be slow as it would redo
 # the full dgeni build on each change.
+
 nodejs_binary(
     name = "fast-serve",
     chdir = package_name(),
-    data = APPLICATION_DEPS + APPLICATION_FILES + [
+    data = APPLICATION_FILES + [
         "//aio/scripts:fast-serve-and-watch",
-    ],
+    ] + select({
+        ":aio_local_deps": substitute_local_packages(APPLICATION_DEPS),
+        "//conditions:default": APPLICATION_DEPS,
+    }),
+    enable_linker = True,
     entry_point = "//aio/scripts:fast-serve-and-watch.js",
     env = {
         # Tell dgeni packages where the project root is since we used chdir

--- a/aio/local_packages_util.bzl
+++ b/aio/local_packages_util.bzl
@@ -1,0 +1,44 @@
+load("//:packages.bzl", "ALL_PACKAGES", "to_package_label")
+load("@build_bazel_rules_nodejs//internal/linker:npm_link.bzl", "npm_link")
+
+def link_local_packages(deps):
+    """Stamp npm_link targets for packages in deps that has a local package equivalent.
+
+    Args:
+        deps: list of npm dependency labels
+    """
+    for dep in deps:
+        label = Label(dep)
+        if label.package in ALL_PACKAGES:
+            npm_link(
+                name = _npm_link_name(dep),
+                target = to_package_label(label.package),
+                package_name = label.package,
+                package_path = native.package_name(),
+                tags = ["manual"],
+            )
+
+def substitute_local_packages(deps):
+    """Substitute npm dependencies for their local npm_link equivalent.
+
+    Assumes that link_local_packages() was already called on these dependencies.
+    Dependencies that are not associated with a local package are left alone.
+
+    Args:
+        deps: list of npm dependency labels
+
+    Returns:
+        substituted list of dependencies
+    """
+    substituted = []
+    for dep in deps:
+        label = Label(dep)
+        if label.package in ALL_PACKAGES:
+            substituted.append(_npm_link_name(dep))
+        else:
+            substituted.append(dep)
+    return substituted
+
+def _npm_link_name(dep):
+    label = Label(dep)
+    return "local_%s" % label.package.replace("@", "_").replace("/", "_")

--- a/aio/tools/defaults.bzl
+++ b/aio/tools/defaults.bzl
@@ -1,6 +1,6 @@
 load("@build_bazel_rules_nodejs//:index.bzl", _nodejs_binary = "nodejs_binary", _nodejs_test = "nodejs_test")
 
-def nodejs_binary(data = [], env = {}, templated_args = [], **kwargs):
+def nodejs_binary(data = [], env = {}, templated_args = [], chdir = "", enable_linker = False, **kwargs):
     data = data + [
         "//aio/tools/esm-loader",
         "//aio/tools/esm-loader:esm-loader.mjs",
@@ -8,23 +8,28 @@ def nodejs_binary(data = [], env = {}, templated_args = [], **kwargs):
 
     env = dict(env, **{"NODE_MODULES_WORKSPACE_NAME": "aio_npm"})
 
+    if not enable_linker:
+        templated_args = templated_args + [
+            # Disable the linker and rely on patched resolution which works better on Windows
+            # and is less prone to race conditions when targets build concurrently.
+            "--nobazel_run_linker",
+        ]
+
     templated_args = templated_args + [
-        # Disable the linker and rely on patched resolution which works better on Windows
-        # and is less prone to race conditions when targets build concurrently.
-        "--nobazel_run_linker",
         # Provide a custom esm loader to resolve third-party depenencies. Unlike for cjs
         # modules, rules_nodejs doesn't patch imports when the linker is disabled.
-        "--node_options=--loader=./$(rootpath //aio/tools/esm-loader:esm-loader.mjs)",
+        "--node_options=--loader=%s" % _esm_loader_path(chdir),
     ]
 
     _nodejs_binary(
         data = data,
         env = env,
         templated_args = templated_args,
+        chdir = chdir,
         **kwargs
     )
 
-def nodejs_test(data = [], env = {}, templated_args = [], **kwargs):
+def nodejs_test(data = [], env = {}, templated_args = [], chdir = "", enable_linker = False, **kwargs):
     data = data + [
         "//aio/tools/esm-loader",
         "//aio/tools/esm-loader:esm-loader.mjs",
@@ -32,18 +37,32 @@ def nodejs_test(data = [], env = {}, templated_args = [], **kwargs):
 
     env = dict(env, **{"NODE_MODULES_WORKSPACE_NAME": "aio_npm"})
 
+    if not enable_linker:
+        templated_args = templated_args + [
+            # Disable the linker and rely on patched resolution which works better on Windows
+            # and is less prone to race conditions when targets build concurrently.
+            "--nobazel_run_linker",
+        ]
+
     templated_args = templated_args + [
-        # Disable the linker and rely on patched resolution which works better on Windows
-        # and is less prone to race conditions when targets build concurrently.
-        "--nobazel_run_linker",
         # Provide a custom esm loader to resolve third-party depenencies. Unlike for cjs
         # modules, rules_nodejs doesn't patch imports when the linker is disabled.
-        "--node_options=--loader=./$(rootpath //aio/tools/esm-loader:esm-loader.mjs)",
+        "--node_options=--loader=%s" % _esm_loader_path(chdir),
     ]
 
     _nodejs_test(
         data = data,
         env = env,
         templated_args = templated_args,
+        chdir = chdir,
         **kwargs
     )
+
+def _esm_loader_path(chdir):
+    """Adjust the path provided for the esm loader node option which
+    depends on the value of chdir."""
+    esm_loader_path_prefix = "./"
+    if chdir and len(chdir) > 0:
+        esm_loader_path_prefix = "".join(["../" for segment in chdir.split("/")])
+
+    return "%s$(rootpath //aio/tools/esm-loader:esm-loader.mjs)" % esm_loader_path_prefix

--- a/packages/animations/BUILD.bazel
+++ b/packages/animations/BUILD.bazel
@@ -17,6 +17,7 @@ ng_module(
 
 ng_package(
     name = "npm_package",
+    package_name = "@angular/animations",
     srcs = [
         "package.json",
     ],
@@ -26,6 +27,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",

--- a/packages/bazel/BUILD.bazel
+++ b/packages/bazel/BUILD.bazel
@@ -3,6 +3,7 @@ load("//tools:defaults.bzl", "pkg_npm")
 
 pkg_npm(
     name = "npm_package",
+    package_name = "@angular/bazel",
     srcs = glob(
         ["*"],
         exclude = ["yarn.lock"],
@@ -30,6 +31,7 @@ pkg_npm(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
     ],

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -14,7 +14,7 @@ specification of this format at https://goo.gl/jB3GVv
 """
 
 load("@rules_nodejs//nodejs:providers.bzl", "StampSettingInfo")
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "NpmPackageInfo", "node_modules_aspect")
+load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "LinkablePackageInfo", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "LinkerPackageMappingInfo")
 load(
     "@build_bazel_rules_nodejs//internal/pkg_npm:pkg_npm.bzl",
@@ -542,6 +542,7 @@ def _ng_package_impl(ctx):
         # More details: https://github.com/bazelbuild/rules_nodejs/issues/2941.
         # TODO(devversion): Consider supporting the `package_name` attribute.
         LinkerPackageMappingInfo(mappings = empty_depset, node_modules_roots = empty_depset),
+        LinkablePackageInfo(path = package_dir.path, files = depset([package_dir])),
     ]
 
 _NG_PACKAGE_DEPS_ASPECTS = [ng_package_module_mappings_aspect, node_modules_aspect]

--- a/packages/benchpress/BUILD.bazel
+++ b/packages/benchpress/BUILD.bazel
@@ -20,6 +20,7 @@ ts_library(
 
 ng_package(
     name = "npm_package",
+    package_name = "@angular/benchpress",
     srcs = [
         "README.md",
         "package.json",
@@ -30,7 +31,10 @@ ng_package(
     ],
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
-    visibility = ["//integration:__subpackages__"],
+    visibility = [
+        "//aio:__subpackages__",
+        "//integration:__subpackages__",
+    ],
     deps = [
         ":benchpress",
     ],

--- a/packages/common/BUILD.bazel
+++ b/packages/common/BUILD.bazel
@@ -21,6 +21,7 @@ generated_file_test(
 
 ng_module(
     name = "common",
+    package_name = "@angular/common",
     srcs = glob(
         [
             "*.ts",
@@ -45,6 +46,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
         "//packages/bazel/test/ng_package:__pkg__",

--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -123,6 +123,7 @@ extract_typings(
 
 pkg_npm(
     name = "npm_package",
+    package_name = "@angular/compiler-cli",
     srcs = [
         "package.json",
     ],
@@ -132,6 +133,7 @@ pkg_npm(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",

--- a/packages/compiler/BUILD.bazel
+++ b/packages/compiler/BUILD.bazel
@@ -30,6 +30,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -48,6 +48,7 @@ tsec_test(
 
 ng_package(
     name = "npm_package",
+    package_name = "@angular/core",
     srcs = [
         "package.json",
     ],
@@ -60,6 +61,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
         "//packages/bazel/test/ng_package:__pkg__",

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -11,6 +11,7 @@ pkg_npm(
         "migrations.json",
         "package.json",
     ],
+    validate = False,
     visibility = ["//packages/core:__pkg__"],
     deps = [
         "//packages/core/schematics/migrations/entry-components",

--- a/packages/elements/BUILD.bazel
+++ b/packages/elements/BUILD.bazel
@@ -19,6 +19,7 @@ ng_module(
 
 ng_package(
     name = "npm_package",
+    package_name = "@angular/elements",
     srcs = ["package.json"],
     tags = [
         "release-with-framework",
@@ -26,6 +27,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
     ],

--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -19,6 +19,7 @@ ng_module(
 
 ng_package(
     name = "npm_package",
+    package_name = "@angular/forms",
     srcs = ["package.json"],
     tags = [
         "release-with-framework",
@@ -26,6 +27,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",

--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -18,6 +18,7 @@ ts_library(
 
 pkg_npm(
     name = "npm_package",
+    package_name = "@angular/language-service",
     srcs = ["package.json"],
     tags = [
         "release-with-framework",
@@ -25,6 +26,7 @@ pkg_npm(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
     ],

--- a/packages/localize/BUILD.bazel
+++ b/packages/localize/BUILD.bazel
@@ -19,6 +19,7 @@ ts_library(
 
 ng_package(
     name = "npm_package",
+    package_name = "@angular/localize",
     srcs = [
         "package.json",
     ],

--- a/packages/localize/schematics/BUILD.bazel
+++ b/packages/localize/schematics/BUILD.bazel
@@ -14,6 +14,7 @@ filegroup(
 pkg_npm(
     name = "npm_package",
     srcs = [":package_assets"],
+    validate = False,
     deps = [
         "//packages/localize/schematics/ng-add",
     ],

--- a/packages/misc/angular-in-memory-web-api/BUILD.bazel
+++ b/packages/misc/angular-in-memory-web-api/BUILD.bazel
@@ -4,6 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "angular-in-memory-web-api",
+    package_name = "angular-in-memory-web-api",
     srcs = glob(
         [
             "*.ts",

--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -4,6 +4,7 @@ package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "platform-browser-dynamic",
+    package_name = "@angular/platform-browser-dynamic",
     srcs = glob(
         [
             "*.ts",
@@ -30,6 +31,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "platform-browser",
+    package_name = "@angular/platform-browser",
     srcs = glob(
         [
             "*.ts",
@@ -37,6 +38,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 
 ng_module(
     name = "platform-server",
+    package_name = "@angular/platform-server",
     srcs = glob(
         [
             "*.ts",
@@ -48,6 +49,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -20,6 +20,7 @@ ng_module(
 
 ng_package(
     name = "npm_package",
+    package_name = "@angular/router",
     srcs = [
         "package.json",
     ],
@@ -29,6 +30,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -35,6 +35,7 @@ genrule(
 
 ng_package(
     name = "npm_package",
+    package_name = "@angular/service-worker",
     srcs = [
         "package.json",
         "safety-worker.js",
@@ -48,6 +49,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
     ],

--- a/packages/upgrade/BUILD.bazel
+++ b/packages/upgrade/BUILD.bazel
@@ -20,6 +20,7 @@ ng_module(
 
 ng_package(
     name = "npm_package",
+    package_name = "@angular/upgrade",
     srcs = [
         "package.json",
     ],
@@ -29,6 +30,7 @@ ng_package(
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [
+        "//aio:__pkg__",
         "//aio/tools/examples/shared:__pkg__",
         "//integration:__subpackages__",
     ],

--- a/packages/zone.js/BUILD.bazel
+++ b/packages/zone.js/BUILD.bazel
@@ -48,6 +48,7 @@ generate_rollup_bundle(
 
 pkg_npm(
     name = "npm_package",
+    package_name = "zone.js",
     srcs = [
         "CHANGELOG.md",
         "README.md",

--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -211,21 +211,7 @@ def ng_package(name, readme_md = None, license_banner = None, deps = [], **kwarg
     _ng_package(
         name = name,
         deps = deps,
-        # We never set a `package_name` for NPM packages, neither do we enable validation.
-        # This is necessary because the source targets of the NPM packages all have
-        # package names set and setting a similar `package_name` on the NPM package would
-        # result in duplicate linker mappings that will conflict. e.g. consider the following
-        # scenario: We have a `ts_library` for `@angular/core`. We will configure a package
-        # name for the target so that it can be resolved in NodeJS executions from `node_modules`.
-        # If we'd also set a `package_name` for the associated `pkg_npm` target, there would be
-        # two mappings for `@angular/core` and the linker will complain. For a better development
-        # experience, we want the mapping to resolve to the direct outputs of the `ts_library`
-        # instead of requiring tests and other targets to assemble the NPM package first.
-        # TODO(devversion): consider removing this if `rules_nodejs` allows for duplicate
-        # linker mappings where transitive-determined mappings are skipped on conflicts.
-        # https://github.com/bazelbuild/rules_nodejs/issues/2810.
-        package_name = None,
-        validate = False,
+        validate = True,
         readme_md = readme_md,
         license_banner = license_banner,
         substitutions = select({
@@ -249,7 +235,7 @@ def ng_package(name, readme_md = None, license_banner = None, deps = [], **kwarg
         visibility = visibility,
     )
 
-def pkg_npm(name, use_prodmode_output = False, **kwargs):
+def pkg_npm(name, validate = True, use_prodmode_output = False, **kwargs):
     """Default values for pkg_npm"""
     visibility = kwargs.pop("visibility", None)
 
@@ -283,21 +269,7 @@ def pkg_npm(name, use_prodmode_output = False, **kwargs):
 
     _pkg_npm(
         name = name,
-        # We never set a `package_name` for NPM packages, neither do we enable validation.
-        # This is necessary because the source targets of the NPM packages all have
-        # package names set and setting a similar `package_name` on the NPM package would
-        # result in duplicate linker mappings that will conflict. e.g. consider the following
-        # scenario: We have a `ts_library` for `@angular/core`. We will configure a package
-        # name for the target so that it can be resolved in NodeJS executions from `node_modules`.
-        # If we'd also set a `package_name` for the associated `pkg_npm` target, there would be
-        # two mappings for `@angular/core` and the linker will complain. For a better development
-        # experience, we want the mapping to resolve to the direct outputs of the `ts_library`
-        # instead of requiring tests and other targets to assemble the NPM package first.
-        # TODO(devversion): consider removing this if `rules_nodejs` allows for duplicate
-        # linker mappings where transitive-determined mappings are skipped on conflicts.
-        # https://github.com/bazelbuild/rules_nodejs/issues/2810.
-        package_name = None,
-        validate = False,
+        validate = validate,
         substitutions = select({
             "//:stamp": stamped_substitutions,
             "//conditions:default": substitutions,


### PR DESCRIPTION
@devversion @gkalpak @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

AIO only builds against third party deps from npm.

## What is the new behavior?

Each AIO target now has a `-local` target that builds, tests, or serves against locally built angular packages.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Even though we disable the rules_nodejs the linker by overriding `nodejs_binary`/`nodejs_test` in `aio/defaults.bzl`, the architect targets continue to use the linker because the architect macro doesn't use our overridden defaults. Because the linker is used, in order to link in first party deps we must use `npm_link`.

I did attempt to write my own `architect` macros that use our defaults in `aio/defaults.bzl`, however architect seems to be incompatible with the require patches. As part of the build process architect looks for a `node_modules` folder, which isn't present when only require patches are used. As there were no concurrency issues with the aio app targets, I think we can continue to use the existing architect rules and linker for just those targets.