### PR TITLE
Fix syntax error in google3 when TSC emits ES2021 output

### DIFF
--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -98,7 +98,9 @@ export function internalImportProvidersFrom(
     // Narrow `source` to access the internal type analogue for `ModuleWithProviders`.
     const internalSource = source as Type<unknown>| InjectorTypeWithProviders<unknown>;
     if (walkProviderTree(internalSource, providersOut, [], dedup)) {
-      injectorTypesWithProviders ||= [];
+      if (!injectorTypesWithProviders) {
+        injectorTypesWithProviders = [];
+      }
       injectorTypesWithProviders.push(internalSource);
     }
   });
@@ -211,7 +213,9 @@ export function walkProviderTree(
       try {
         deepForEach(injDef.imports, imported => {
           if (walkProviderTree(imported, providersOut, parents, dedup)) {
-            importTypesWithProviders ||= [];
+            if (!importTypesWithProviders) {
+              importTypesWithProviders = [];
+            }
             // If the processed import is an injector type with providers, we store it in the
             // list of import types with providers, so that we can process those afterwards.
             importTypesWithProviders.push(imported);


### PR DESCRIPTION
The TSJS language team is going to update the output from TS Compiler to be more modern JavaScript (ES2021). However, some tests run on older browsers that do not support ES2021. The logical OR operator gets run as  untranspiled tests sources on old browsers that do not support ES2021 syntax. This produces syntax errors when tests execute.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No behavior change. Simply removing the usage of `||=` operator. 

Issue Number: N/A

## What is the new behavior?
No behavior change. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
