### PR TITLE
refactor(router): Update error message when Router is provided twice

### DIFF
--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -181,7 +181,8 @@ export function provideForRootGuard(router: Router): any {
   if (NG_DEV_MODE && router) {
     throw new RuntimeError(
         RuntimeErrorCode.FOR_ROOT_CALLED_TWICE,
-        `RouterModule.forRoot() called twice. Lazy loaded modules should use RouterModule.forChild() instead.`);
+        `The Router was provided more than once. This can happen if 'forRoot' is used outside of the root injector.` +
+            ` Lazy loaded modules should use RouterModule.forChild() instead.`);
   }
   return 'guarded';
 }

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -5806,7 +5806,7 @@ describe('Integration', () => {
          let recordedError: any = null;
          router.navigateByUrl('/lazy/loaded')!.catch(err => recordedError = err);
          advance(fixture);
-         expect(recordedError.message).toContain(`RouterModule.forRoot() called twice.`);
+         expect(recordedError.message).toContain(`NG04007`);
        })));
 
     it('should combine routes from multiple modules into a single configuration',


### PR DESCRIPTION
The current error message is absolute in that it thinks there is only
one possible way to provide Router twice. In fact, you can get a new
instance of the Router in several ways so the error message should
indicate the exact failure case with a _potential_ cause.

Based on findings in thread https://github.com/angular/angular/commit/0cbbd6aeecda8ea994f1086727e580b813a53d79#commitcomment-80900192
