### PR TITLE
feat(forms): Add in toggle for enable/disable

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -83,6 +83,10 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     abstract setValue(value: TRawValue, options?: Object): void;
     readonly status: FormControlStatus;
     readonly statusChanges: Observable<FormControlStatus>;
+    toggle(enable: boolean, opts?: {
+        onlySelf?: boolean;
+        emitEvent?: boolean;
+    }): void;
     readonly touched: boolean;
     get untouched(): boolean;
     get updateOn(): FormHooks;

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -987,6 +987,29 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     this._onDisabledChange.forEach((changeFn) => changeFn(false));
   }
 
+  /**
+   * Toggles the control. This means the control is included in validation checks and
+   * the aggregate value of its parent. Its status recalculates based on its value and
+   * its validators.
+   *
+   * By default, if the control has children, all children are toggled.
+   *
+   * @see {@link AbstractControl.status}
+   *
+   * @param enable A boolean indicating if the control should be enabled.
+   * @param opts Configure options that control how the control propagates changes and
+   * emits events when marked as untouched
+   * * `onlySelf`: When true, mark only this control. When false or not supplied,
+   * marks all direct ancestors. Default is false.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges`
+   * observables emit events with the latest status and value when the control is toggled.
+   * When false, no events are emitted.
+   */
+  toggle(enable: boolean, opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
+    return enable ? this.enable(opts) : this.disable(opts);
+  }
+
   private _updateAncestors(
       opts: {onlySelf?: boolean, emitEvent?: boolean, skipPristineCheck?: boolean}): void {
     if (this._parent && !opts.onlySelf) {

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -1362,6 +1362,49 @@ describe('FormArray', () => {
     });
   });
 
+  describe('toggle()', () => {
+    let c: FormControl;
+    let a: FormArray;
+    let enableSpy: jasmine.Spy;
+    let disableSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      c = new FormControl('value');
+      a = new FormArray([c]);
+      enableSpy = spyOn(a, 'enable');
+      disableSpy = spyOn(a, 'disable');           
+    });
+
+    it('Should call enable if enabled with the opts', () => {
+      const opts = { emitEvent: false, onlySelf: true };
+
+      a.toggle(true, opts);
+
+      expect(enableSpy).toHaveBeenCalledWith(opts);
+      expect(disableSpy).not.toHaveBeenCalled();
+    });
+    it('Should call disable if not enabled with the opts', () => {
+      const opts = { emitEvent: false, onlySelf: true };
+
+      a.toggle(false, opts);
+
+      expect(enableSpy).not.toHaveBeenCalled();
+      expect(disableSpy).toHaveBeenCalledWith(opts);
+    });
+    it('Should call enable if enabled with no opts', () => {     
+      a.toggle(true);
+
+      expect(enableSpy).toHaveBeenCalledWith({});
+      expect(disableSpy).not.toHaveBeenCalled();
+    });
+    it('Should call disable if not enabled with no opts', () => {      
+      a.toggle(false);
+
+      expect(enableSpy).not.toHaveBeenCalled();
+      expect(disableSpy).toHaveBeenCalledWith({});
+    });
+  });
+
   describe('out of bounds positive indices', () => {
     let c1: FormControl = new FormControl(1);
     let c2: FormControl = new FormControl(2);

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -1372,11 +1372,11 @@ describe('FormArray', () => {
       c = new FormControl('value');
       a = new FormArray([c]);
       enableSpy = spyOn(a, 'enable');
-      disableSpy = spyOn(a, 'disable');           
+      disableSpy = spyOn(a, 'disable');
     });
 
     it('Should call enable if enabled with the opts', () => {
-      const opts = { emitEvent: false, onlySelf: true };
+      const opts = {emitEvent: false, onlySelf: true};
 
       a.toggle(true, opts);
 
@@ -1384,20 +1384,20 @@ describe('FormArray', () => {
       expect(disableSpy).not.toHaveBeenCalled();
     });
     it('Should call disable if not enabled with the opts', () => {
-      const opts = { emitEvent: false, onlySelf: true };
+      const opts = {emitEvent: false, onlySelf: true};
 
       a.toggle(false, opts);
 
       expect(enableSpy).not.toHaveBeenCalled();
       expect(disableSpy).toHaveBeenCalledWith(opts);
     });
-    it('Should call enable if enabled with no opts', () => {     
+    it('Should call enable if enabled with no opts', () => {
       a.toggle(true);
 
       expect(enableSpy).toHaveBeenCalledWith({});
       expect(disableSpy).not.toHaveBeenCalled();
     });
-    it('Should call disable if not enabled with no opts', () => {      
+    it('Should call disable if not enabled with no opts', () => {
       a.toggle(false);
 
       expect(enableSpy).not.toHaveBeenCalled();

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -1494,6 +1494,48 @@ describe('FormControl', () => {
       });
     });
   });
+
+  describe('toggle()', () => {
+    let c: FormControl;
+    let enableSpy: jasmine.Spy;
+    let disableSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      c = new FormControl('value');      
+      enableSpy = spyOn(c, 'enable');
+      disableSpy = spyOn(c, 'disable');      
+    });
+
+    it('Should call enable if enabled with the opts', () => {           
+      const opts = { emitEvent: false, onlySelf: true };
+
+      c.toggle(true, opts);
+
+      expect(enableSpy).toHaveBeenCalledWith(opts);
+      expect(disableSpy).not.toHaveBeenCalled();
+    });
+    it('Should call disable if not enabled with the opts', () => {     
+      const opts = { emitEvent: false, onlySelf: true };
+
+      c.toggle(false, opts);
+
+      expect(enableSpy).not.toHaveBeenCalled();
+      expect(disableSpy).toHaveBeenCalledWith(opts);
+    });
+    it('Should call enable if enabled with no opts', () => {                 
+      c.toggle(true);
+
+      expect(enableSpy).toHaveBeenCalledWith({});
+      expect(disableSpy).not.toHaveBeenCalled();
+    });
+    it('Should call disable if not enabled with no opts', () => {                 
+      c.toggle(false);
+
+      expect(enableSpy).not.toHaveBeenCalled();
+      expect(disableSpy).toHaveBeenCalledWith({});
+    });
+  });
+
   describe('pending', () => {
     let c: FormControl;
 

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -1501,34 +1501,34 @@ describe('FormControl', () => {
     let disableSpy: jasmine.Spy;
 
     beforeEach(() => {
-      c = new FormControl('value');      
+      c = new FormControl('value');
       enableSpy = spyOn(c, 'enable');
-      disableSpy = spyOn(c, 'disable');      
+      disableSpy = spyOn(c, 'disable');
     });
 
-    it('Should call enable if enabled with the opts', () => {           
-      const opts = { emitEvent: false, onlySelf: true };
+    it('Should call enable if enabled with the opts', () => {
+      const opts = {emitEvent: false, onlySelf: true};
 
       c.toggle(true, opts);
 
       expect(enableSpy).toHaveBeenCalledWith(opts);
       expect(disableSpy).not.toHaveBeenCalled();
     });
-    it('Should call disable if not enabled with the opts', () => {     
-      const opts = { emitEvent: false, onlySelf: true };
+    it('Should call disable if not enabled with the opts', () => {
+      const opts = {emitEvent: false, onlySelf: true};
 
       c.toggle(false, opts);
 
       expect(enableSpy).not.toHaveBeenCalled();
       expect(disableSpy).toHaveBeenCalledWith(opts);
     });
-    it('Should call enable if enabled with no opts', () => {                 
+    it('Should call enable if enabled with no opts', () => {
       c.toggle(true);
 
       expect(enableSpy).toHaveBeenCalledWith({});
       expect(disableSpy).not.toHaveBeenCalled();
     });
-    it('Should call disable if not enabled with no opts', () => {                 
+    it('Should call disable if not enabled with no opts', () => {
       c.toggle(false);
 
       expect(enableSpy).not.toHaveBeenCalled();

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -1856,6 +1856,49 @@ describe('FormGroup', () => {
     });
   });
 
+  describe('toggle()', () => {
+    let c: FormControl;
+    let fg: FormGroup;
+    let enableSpy: jasmine.Spy;
+    let disableSpy: jasmine.Spy;
+
+    beforeEach(() => {
+      c = new FormControl('value');
+      fg = new FormGroup({'one': c});
+      enableSpy = spyOn(fg, 'enable');
+      disableSpy = spyOn(fg, 'disable');           
+    });
+
+    it('Should call enable if enabled with the opts', () => {     
+      const opts = { emitEvent: false, onlySelf: true };
+
+      fg.toggle(true, opts);
+
+      expect(enableSpy).toHaveBeenCalledWith(opts);
+      expect(disableSpy).not.toHaveBeenCalled();
+    });
+    it('Should call disable if not enabled with the opts', () => {      
+      const opts = { emitEvent: false, onlySelf: true };
+
+      fg.toggle(false, opts);
+
+      expect(enableSpy).not.toHaveBeenCalled();
+      expect(disableSpy).toHaveBeenCalledWith(opts);
+    });
+    it('Should call enable if enabled with no opts', () => {     
+      fg.toggle(true);
+
+      expect(enableSpy).toHaveBeenCalledWith({});
+      expect(disableSpy).not.toHaveBeenCalled();
+    });
+    it('Should call disable if not enabled with no opts', () => {      
+      fg.toggle(false);
+
+      expect(enableSpy).not.toHaveBeenCalled();
+      expect(disableSpy).toHaveBeenCalledWith({});
+    });
+  });
+
   describe('updateTreeValidity()', () => {
     let c: FormControl, c2: FormControl, c3: FormControl;
     let nested: FormGroup, form: FormGroup;

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -1866,32 +1866,32 @@ describe('FormGroup', () => {
       c = new FormControl('value');
       fg = new FormGroup({'one': c});
       enableSpy = spyOn(fg, 'enable');
-      disableSpy = spyOn(fg, 'disable');           
+      disableSpy = spyOn(fg, 'disable');
     });
 
-    it('Should call enable if enabled with the opts', () => {     
-      const opts = { emitEvent: false, onlySelf: true };
+    it('Should call enable if enabled with the opts', () => {
+      const opts = {emitEvent: false, onlySelf: true};
 
       fg.toggle(true, opts);
 
       expect(enableSpy).toHaveBeenCalledWith(opts);
       expect(disableSpy).not.toHaveBeenCalled();
     });
-    it('Should call disable if not enabled with the opts', () => {      
-      const opts = { emitEvent: false, onlySelf: true };
+    it('Should call disable if not enabled with the opts', () => {
+      const opts = {emitEvent: false, onlySelf: true};
 
       fg.toggle(false, opts);
 
       expect(enableSpy).not.toHaveBeenCalled();
       expect(disableSpy).toHaveBeenCalledWith(opts);
     });
-    it('Should call enable if enabled with no opts', () => {     
+    it('Should call enable if enabled with no opts', () => {
       fg.toggle(true);
 
       expect(enableSpy).toHaveBeenCalledWith({});
       expect(disableSpy).not.toHaveBeenCalled();
     });
-    it('Should call disable if not enabled with no opts', () => {      
+    it('Should call disable if not enabled with no opts', () => {
       fg.toggle(false);
 
       expect(enableSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

To run disable/enable for a control based on a variable something like the following may exist:

`enabled ? control.enable({ emitEvent: false }) : control.disable({ emitEvent: false }). `

Or

```
if(enabled){
  control.enable({ emitEvent: false })
}
else{
  control.disable({ emitEvent: false })
}
```

Or

`(enabled ? control.enable : control.disable)({ emitEvent: false })`

## What is the new behavior?

This introduces a new api toggle that can be used like this:

`control.toggle(enabled, { emitEvent: false })`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I'm not sure if toggle is the best name for the api. I also defaulted the value to be: "enabled" instead of "disabled".