### PR TITLE
refactor(compiler): /a/.exec() returns RegExpExecArray

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -304,7 +304,7 @@ export class ShadowCss {
       // `:host-context(.one):host-context(.two)`.
       // Execute `_cssColonHostContextRe` over and over until we have extracted all the
       // `:host-context` selectors from this selector.
-      let match: RegExpMatchArray|null;
+      let match: RegExpExecArray|null;
       while (match = _cssColonHostContextRe.exec(selectorText)) {
         // `match` = [':host-context(<selectors>)<rest>', <selectors>, <rest>]
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

(No tests, yet. Is there a way to build Angular with TypeScript nightly in tests?)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

TypeScript added a field `0` to `RegExpMatchArray` in https://github.com/microsoft/TypeScript/commit/3b80ddca212959ae5dcf2f48704be627283c6468. Before that, `RegExpMatchArray` and `RegExpExecArray` were identical.

In one place Angular incorrectly expects `RegExpMatchArray` as the result of a RegExp#exec() call. This assignment fails on TypeScript nightly with the error:

    Property '0' is missing in type 'RegExpExecArray' but required in type 'RegExpMatchArray'.

## What is the new behavior?

Compilation succeeds in TypeScript nightly as well as older TypeScript versions.

## Does this PR introduce a breaking change?

- [x] No