### PR TITLE
refactor(compiler): Add a new helper method `getPrimaryAngularDecorator`.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -444,6 +444,7 @@ export class ComponentDecoratorHandler implements
         rawImports,
         resolvedImports,
         schemas,
+        decorator: decorator?.node as ts.Decorator | null ?? null,
       },
       diagnostics,
     };
@@ -483,6 +484,7 @@ export class ComponentDecoratorHandler implements
       imports: analysis.resolvedImports,
       animationTriggerNames: analysis.animationTriggerNames,
       schemas: analysis.schemas,
+      decorator: analysis.decorator,
     });
 
     this.resourceRegistry.registerResources(analysis.resources, node);

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -70,6 +70,7 @@ export interface ComponentAnalysisData {
   resolvedImports: Reference<ClassDeclaration>[]|null;
 
   schemas: SchemaMetadata[]|null;
+  decorator: ts.Decorator|null;
 }
 
 export type ComponentResolutionData =

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -41,6 +41,7 @@ export interface DirectiveHandlerData {
   outputs: ClassPropertyMapping;
   isPoisoned: boolean;
   isStructural: boolean;
+  decorator: ts.Decorator|null;
 }
 
 export class DirectiveDecoratorHandler implements
@@ -115,6 +116,7 @@ export class DirectiveDecoratorHandler implements
         providersRequiringFactory,
         isPoisoned: false,
         isStructural: directiveResult.isStructural,
+        decorator: decorator?.node as ts.Decorator | null ?? null,
       }
     };
   }
@@ -149,6 +151,7 @@ export class DirectiveDecoratorHandler implements
       isStandalone: analysis.meta.isStandalone,
       imports: null,
       schemas: null,
+      decorator: analysis.decorator,
     });
 
     this.injectableRegistry.registerInjectable(node);

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -43,6 +43,7 @@ export interface NgModuleAnalysis {
   providersRequiringFactory: Set<Reference<ClassDeclaration>>|null;
   providers: ts.Expression|null;
   remoteScopesMayRequireCycleProtection: boolean;
+  decorator: ts.Decorator|null;
 }
 
 export interface NgModuleResolution {
@@ -442,6 +443,7 @@ export class NgModuleDecoratorHandler implements
             node, this.reflector, this.isCore, this.annotateForClosureCompiler),
         factorySymbolName: node.name.text,
         remoteScopesMayRequireCycleProtection,
+        decorator: decorator?.node as ts.Decorator | null ?? null,
       },
     };
   }
@@ -464,6 +466,7 @@ export class NgModuleDecoratorHandler implements
       rawDeclarations: analysis.rawDeclarations,
       rawImports: analysis.rawImports,
       rawExports: analysis.rawExports,
+      decorator: analysis.decorator,
     });
 
     if (this.factoryTracker !== null) {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -24,6 +24,7 @@ export interface PipeHandlerData {
   meta: R3PipeMetadata;
   classMetadata: R3ClassMetadata|null;
   pipeNameExpr: ts.Expression;
+  decorator: ts.Decorator|null;
 }
 
 /**
@@ -143,6 +144,7 @@ export class PipeDecoratorHandler implements
         },
         classMetadata: extractClassMetadata(clazz, this.reflector, this.isCore),
         pipeNameExpr,
+        decorator: decorator?.node as ts.Decorator | null ?? null,
       },
     };
   }
@@ -159,6 +161,7 @@ export class PipeDecoratorHandler implements
       name: analysis.meta.pipeName,
       nameExpr: analysis.pipeNameExpr,
       isStandalone: analysis.meta.isStandalone,
+      decorator: analysis.decorator,
     });
 
     this.injectableRegistry.registerInjectable(node);

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -26,6 +26,11 @@ export interface TestOnlyOptions {
   _useHostForImportGeneration?: boolean;
 
   /**
+   * Enable the Language Service APIs for template type-checking for tests.
+   */
+  _enableTemplateTypeChecker?: boolean;
+
+  /**
    * An option to enable ngtsc's internal performance tracing.
    *
    * This should be a path to a JSON file where trace information will be written. This is sensitive

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -255,6 +255,7 @@ export class NgCompiler {
   private cycleAnalyzer: CycleAnalyzer;
   readonly ignoreForDiagnostics: Set<ts.SourceFile>;
   readonly ignoreForEmit: Set<ts.SourceFile>;
+  readonly enableTemplateTypeChecker: boolean;
 
   /**
    * `NgCompiler` can be reused for multiple compilations (for resource-only changes), and each
@@ -313,10 +314,12 @@ export class NgCompiler {
       readonly programDriver: ProgramDriver,
       readonly incrementalStrategy: IncrementalBuildStrategy,
       readonly incrementalCompilation: IncrementalCompilation,
-      readonly enableTemplateTypeChecker: boolean,
+      enableTemplateTypeChecker: boolean,
       readonly usePoisonedData: boolean,
       private livePerfRecorder: ActivePerfRecorder,
   ) {
+    this.enableTemplateTypeChecker =
+        enableTemplateTypeChecker || (options._enableTemplateTypeChecker ?? false);
     this.constructionDiagnostics.push(
         ...this.adapter.constructionDiagnostics, ...verifyCompatibleTypeCheckOptions(this.options));
 
@@ -1063,8 +1066,8 @@ export class NgCompiler {
 
     const templateTypeChecker = new TemplateTypeCheckerImpl(
         this.inputProgram, notifyingDriver, traitCompiler, this.getTypeCheckingConfig(), refEmitter,
-        reflector, this.adapter, this.incrementalCompilation, scopeReader, typeCheckScopeRegistry,
-        this.delegatingPerfRecorder);
+        reflector, this.adapter, this.incrementalCompilation, metaReader, scopeReader,
+        typeCheckScopeRegistry, this.delegatingPerfRecorder);
 
     // Only construct the extended template checker if the configuration is valid and usable.
     const extendedTemplateChecker = this.constructionDiagnostics.length === 0 ?

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -48,6 +48,13 @@ export interface NgModuleMeta {
    * because the module came from a .d.ts file).
    */
   rawExports: ts.Expression|null;
+
+  /**
+   * The primary decorator associated with this `ngModule`.
+   *
+   * If this is `null`, no decorator exists, meaning it's probably from a .d.ts file.
+   */
+  decorator: ts.Decorator|null;
 }
 
 /**
@@ -161,6 +168,13 @@ export interface DirectiveMeta extends T2DirectiveMeta, DirectiveTypeCheckMeta {
    * For standalone components, the list of schemas declared.
    */
   schemas: SchemaMetadata[]|null;
+
+  /**
+   * The primary decorator associated with this directive.
+   *
+   * If this is `null`, no decorator exists, meaning it's probably from a .d.ts file.
+   */
+  decorator: ts.Decorator|null;
 }
 
 /**
@@ -191,6 +205,7 @@ export interface PipeMeta {
   name: string;
   nameExpr: ts.Expression|null;
   isStandalone: boolean;
+  decorator: ts.Decorator|null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -58,6 +58,7 @@ export class DtsMetadataReader implements MetadataReader {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     };
   }
 
@@ -119,6 +120,7 @@ export class DtsMetadataReader implements MetadataReader {
       imports: null,
       // The same goes for schemas.
       schemas: null,
+      decorator: null,
     };
   }
 
@@ -153,6 +155,7 @@ export class DtsMetadataReader implements MetadataReader {
       name,
       nameExpr: null,
       isStandalone,
+      decorator: null,
     };
   }
 }

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -57,6 +57,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
 
     const scope = scopeRegistry.getScopeOfModule(Module.node) as LocalModuleScope;
@@ -77,6 +78,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -88,6 +90,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -99,6 +102,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -119,6 +123,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -130,6 +135,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -150,6 +156,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -161,6 +168,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -172,6 +180,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
 
     const scope = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -199,6 +208,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
 
     const scope = scopeRegistry.getScopeOfModule(Module.node) as LocalModuleScope;
@@ -218,6 +228,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -229,6 +240,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -248,6 +260,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -259,6 +272,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawDeclarations: null,
       rawImports: null,
       rawExports: null,
+      decorator: null,
     });
 
     expect(scopeRegistry.getScopeOfModule(ModuleA.node)!.compilation.isPoisoned).toBeTrue();
@@ -297,6 +311,7 @@ function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
     isStandalone: false,
     imports: null,
     schemas: null,
+    decorator: null,
   };
 }
 
@@ -308,6 +323,7 @@ function fakePipe(ref: Reference<ClassDeclaration>): PipeMeta {
     name,
     nameExpr: null,
     isStandalone: false,
+    decorator: null,
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -146,6 +146,12 @@ export interface TemplateTypeChecker {
   getPotentialElementTags(component: ts.ClassDeclaration): Map<string, DirectiveInScope|null>;
 
   /**
+   * Get the primary decorator for an Angular class (such as @Component). This does not work for
+   * `@Injectable`.
+   */
+  getPrimaryAngularDecorator(target: ts.ClassDeclaration): ts.Decorator|null;
+
+  /**
    * Retrieve any potential DOM bindings for the given element.
    *
    * This returns an array of objects which list both the attribute and property names of each

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -554,7 +554,8 @@ export function setup(targets: TypeCheckingTarget[], overrides: {
 
   const templateTypeChecker = new TemplateTypeCheckerImpl(
       program, programStrategy, checkAdapter, fullConfig, emitter, reflectionHost, host,
-      NOOP_INCREMENTAL_BUILD, fakeScopeReader, typeCheckScopeRegistry, NOOP_PERF_RECORDER);
+      NOOP_INCREMENTAL_BUILD, fakeMetadataReader, fakeScopeReader, typeCheckScopeRegistry,
+      NOOP_PERF_RECORDER);
   return {
     templateTypeChecker,
     program,
@@ -665,6 +666,7 @@ function makeScope(program: ts.Program, sf: ts.SourceFile, decls: TestDeclaratio
         isStandalone: false,
         imports: null,
         schemas: null,
+        decorator: null,
       });
     } else if (decl.type === 'pipe') {
       scope.dependencies.push({
@@ -673,6 +675,7 @@ function makeScope(program: ts.Program, sf: ts.SourceFile, decls: TestDeclaratio
         name: decl.pipeName,
         nameExpr: null,
         isStandalone: false,
+        decorator: null,
       });
     }
   }

--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -14,6 +14,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/indexer",
         "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/testing",
+        "//packages/compiler-cli/src/ngtsc/typecheck/api",
         "//packages/compiler-cli/src/ngtsc/typecheck/extended/checks/invalid_banana_in_box",
         "//packages/compiler-cli/src/ngtsc/util",
         "//packages/compiler-cli/test:test_utils",

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -20,6 +20,7 @@ import {IndexedComponent} from '../../src/ngtsc/indexer';
 import {NgtscProgram} from '../../src/ngtsc/program';
 import {DeclarationNode} from '../../src/ngtsc/reflection';
 import {NgtscTestCompilerHost} from '../../src/ngtsc/testing';
+import {TemplateTypeChecker} from '../../src/ngtsc/typecheck/api';
 import {setWrapHostForTest} from '../../src/transformers/compiler_host';
 
 type TsConfigOptionsValue =
@@ -269,6 +270,17 @@ export class NgtscTestEnvironment {
 
     // ngtsc only produces ts.Diagnostic messages.
     return defaultGatherDiagnostics(program as api.Program) as ts.Diagnostic[];
+  }
+
+  driveTemplateTypeChecker(): {program: ts.Program, checker: TemplateTypeChecker} {
+    const {rootNames, options} = readNgcCommandLineAndConfiguration(this.commandLineArgs);
+    const host = createCompilerHost({options});
+    const program = createProgram({rootNames, host, options});
+    const checker = (program as NgtscProgram).compiler.getTemplateTypeChecker();
+    return {
+      program: program.getTsProgram(),
+      checker,
+    };
   }
 
   driveIndexer(): Map<DeclarationNode, IndexedComponent> {

--- a/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import ts from 'typescript';
+
+import {DiagnosticCategoryLabel} from '../../src/ngtsc/core/api';
+import {ErrorCode, ngErrorCode} from '../../src/ngtsc/diagnostics';
+import {absoluteFrom as _, getSourceFileOrError} from '../../src/ngtsc/file_system';
+import {runInEachFileSystem} from '../../src/ngtsc/file_system/testing';
+import {expectCompleteReuse, getSourceCodeForDiagnostic, loadStandardTestFiles} from '../../src/ngtsc/testing';
+import {factory as invalidBananaInBoxFactory} from '../../src/ngtsc/typecheck/extended/checks/invalid_banana_in_box';
+
+import {NgtscTestEnvironment} from './env';
+import {getClass} from './util';
+
+const testFiles = loadStandardTestFiles({fakeCore: true, fakeCommon: true});
+
+
+
+runInEachFileSystem(() => {
+  describe('full type checking', () => {
+    let env!: NgtscTestEnvironment;
+
+    beforeEach(() => {
+      env = NgtscTestEnvironment.setup(testFiles);
+      env.tsconfig({strictTemplates: true, _enableTemplateTypeChecker: true});
+    });
+
+
+    describe('supports `getPrimaryAngularDecorator()` ', () => {
+      it('for components', () => {
+        env.write('test.ts', `
+		import {Component} from '@angular/core';
+
+		@Component({
+			standalone: true,
+			selector: 'test-cmp',
+			template: '<div></div>',
+		})
+		export class TestCmp {}
+		`);
+        const {program, checker} = env.driveTemplateTypeChecker();
+        const sf = program.getSourceFile(_('/test.ts'));
+        expect(sf).not.toBeNull();
+        const decorator = checker.getPrimaryAngularDecorator(getClass(sf!, 'TestCmp'));
+        expect(decorator?.getText()).toContain(`selector: 'test-cmp'`);
+      });
+
+      it('for pipes', () => {
+        env.write('test.ts', `
+		import {Pipe, PipeTransform} from '@angular/core';
+
+		@Pipe({name: 'expPipe'})
+		export class ExpPipe implements PipeTransform {
+			transform(value: number, exponent = 1): number {
+				return Math.pow(value, exponent);
+			}
+		}
+		`);
+        const {program, checker} = env.driveTemplateTypeChecker();
+        const sf = program.getSourceFile(_('/test.ts'));
+        expect(sf).not.toBeNull();
+        const decorator = checker.getPrimaryAngularDecorator(getClass(sf!, 'ExpPipe'));
+        expect(decorator?.getText()).toContain(`name: 'expPipe'`);
+      });
+
+      it('for NgModules', () => {
+        env.write('test.ts', `
+			import {NgModule} from '@angular/core';
+
+			@NgModule({
+				declarations: [],
+				imports: [],
+				providers: [],
+				bootstrap: []
+			})
+			export class AppModule {}
+		  `);
+        const {program, checker} = env.driveTemplateTypeChecker();
+        const sf = program.getSourceFile(_('/test.ts'));
+        expect(sf).not.toBeNull();
+        const decorator = checker.getPrimaryAngularDecorator(getClass(sf!, 'AppModule'));
+        expect(decorator?.getText()).toContain(`declarations: []`);
+      });
+    });
+  });
+});

--- a/packages/compiler-cli/test/ngtsc/util.ts
+++ b/packages/compiler-cli/test/ngtsc/util.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import {ClassDeclaration, isNamedClassDeclaration} from '@angular/compiler-cli/src/ngtsc/reflection';
+import ts from 'typescript';
+
+export function getClass(sf: ts.SourceFile, name: string): ClassDeclaration<ts.ClassDeclaration> {
+  for (const stmt of sf.statements) {
+    if (isNamedClassDeclaration(stmt) && stmt.name.text === name) {
+      return stmt;
+    }
+  }
+  throw new Error(`Class ${name} not found in file: ${sf.fileName}: ${sf.text}`);
+}


### PR DESCRIPTION
This helper accepts a class, and returns the primary Angular Decorator associated with that trait (e.g. the Component, Pipe, Directive, or NgModule decorator). This will be useful for the language service import project, which needs to edit import arrays inside the decorator.