### PR TITLE
refactor(language-service): Create helper methods for manipulating object and array ASTs.

### DIFF
--- a/packages/language-service/test/ts_utils_spec.ts
+++ b/packages/language-service/test/ts_utils_spec.ts
@@ -9,10 +9,10 @@
 import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
 import ts from 'typescript';
 
-import {collectMemberMethods, findTightestNode} from '../src/ts_utils';
+import {addElementToArrayLiteral, collectMemberMethods, findTightestNode, objectPropertyAssignmentForKey, updateObjectValueForKey} from '../src/ts_utils';
 import {LanguageServiceTestEnv, OpenBuffer, Project} from '../testing';
 
-describe('ts utils', () => {
+describe('TS util', () => {
   describe('collectMemberMethods', () => {
     beforeEach(() => {
       initMockFileSystem('Native');
@@ -83,5 +83,83 @@ describe('ts utils', () => {
           .map(m => m.name.getText())
           .sort();
     }
+  });
+
+  describe('AST method', () => {
+    let printer: ts.Printer;
+    let sourceFile: ts.SourceFile;
+
+    function print(node: ts.Node): string {
+      return printer.printNode(ts.EmitHint.Unspecified, node, sourceFile);
+    }
+
+    beforeAll(() => {
+      printer = ts.createPrinter();
+      sourceFile =
+          ts.createSourceFile('placeholder.ts', '', ts.ScriptTarget.ESNext, true, ts.ScriptKind.TS);
+    });
+
+    describe('addElementToArrayLiteral', () => {
+      it('transforms an empty array literal expression', () => {
+        const oldArr = ts.factory.createArrayLiteralExpression([], false);
+        const newArr = addElementToArrayLiteral(oldArr, ts.factory.createStringLiteral('a'));
+        expect(print(newArr)).toEqual('["a"]');
+      });
+
+      it('transforms an existing array literal expression', () => {
+        const oldArr =
+            ts.factory.createArrayLiteralExpression([ts.factory.createStringLiteral('a')], false);
+        const newArr = addElementToArrayLiteral(oldArr, ts.factory.createStringLiteral('b'));
+        expect(print(newArr)).toEqual('["a", "b"]');
+      });
+    });
+
+    describe('objectPropertyAssignmentForKey', () => {
+      let oldObj: ts.ObjectLiteralExpression;
+
+      beforeEach(() => {
+        oldObj = ts.factory.createObjectLiteralExpression(
+            [ts.factory.createPropertyAssignment(
+                ts.factory.createIdentifier('foo'), ts.factory.createStringLiteral('bar'))],
+            false);
+      });
+
+      it('returns null when no property exists', () => {
+        const prop = objectPropertyAssignmentForKey(oldObj, 'oops');
+        expect(prop).toBeNull();
+      });
+
+      it('returns the requested property assignment', () => {
+        const prop = objectPropertyAssignmentForKey(oldObj, 'foo');
+        expect(print(prop!)).toEqual('foo: "bar"');
+      });
+    });
+
+    describe('updateObjectValueForKey', () => {
+      let oldObj: ts.ObjectLiteralExpression;
+
+      const valueAppenderFn = (oldValue?: ts.Expression) => {
+        if (!oldValue) return ts.factory.createStringLiteral('baz');
+        if (!ts.isStringLiteral(oldValue)) return oldValue;
+        return ts.factory.createStringLiteral(oldValue.text + 'baz');
+      };
+
+      beforeEach(() => {
+        oldObj = ts.factory.createObjectLiteralExpression(
+            [ts.factory.createPropertyAssignment(
+                ts.factory.createIdentifier('foo'), ts.factory.createStringLiteral('bar'))],
+            false);
+      });
+
+      it('creates a non-existant property', () => {
+        const obj = updateObjectValueForKey(oldObj, 'newKey', valueAppenderFn);
+        expect(print(obj)).toBe('{ foo: "bar", newKey: "baz" }');
+      });
+
+      it('updates an existing property', () => {
+        const obj = updateObjectValueForKey(oldObj, 'foo', valueAppenderFn);
+        expect(print(obj)).toBe('{ foo: "barbaz" }');
+      });
+    });
   });
 });


### PR DESCRIPTION
Create three new helper methods: `addElementToArrayLiteral`, `objectPropertyAssignmentForKey`, and `updateObjectValueForKey`. These methods make interacting with array and object literals easier.

These will be useful for the standalone imports feature, which will need to add new terms to import arrays in Component and NgModule decorators.