### PR TITLE
fix(common): fix formatting on oversized image error

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -628,10 +628,11 @@ function assertNoImageDistortion(
             RuntimeErrorCode.OVERSIZED_IMAGE,
             `${imgDirectiveDetails(dir.rawSrc)} the intrinsic image is significantly ` +
                 `larger than necessary. ` +
-                `Rendered image size: ${renderedWidth}w x ${renderedHeight}h. ` +
-                `Intrinsic image size: ${intrinsicWidth}w x ${intrinsicHeight}h. ` +
-                `Recommended intrinsic image size: ${recommendedWidth}w x ${recommendedHeight}h. ` +
-                `Note: Recommended intrinsic image size is calculated assuming a maximum DPR of ` +
+                `\nRendered image size: ${renderedWidth}w x ${renderedHeight}h. ` +
+                `\nIntrinsic image size: ${intrinsicWidth}w x ${intrinsicHeight}h. ` +
+                `\nRecommended intrinsic image size: ${recommendedWidth}w x ${
+                    recommendedHeight}h. ` +
+                `\nNote: Recommended intrinsic image size is calculated assuming a maximum DPR of ` +
                 `${RECOMMENDED_SRCSET_DENSITY_CAP}. To improve loading time, resize the image ` +
                 `or consider using the "rawSrcset" and "sizes" attributes.`));
       }


### PR DESCRIPTION
This is a tiny commit to add newlines in the image
directive's "oversized image" error. Currently, the
rendered and intrinsic image sizes are printed
mid-line, which make them a little hard to read.
This commit puts them each on their own line.