### PR TITLE
fix(common): remove duplicate deepForEach

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/url.ts
+++ b/packages/common/src/directives/ng_optimized_image/url.ts
@@ -17,12 +17,6 @@ export function isAbsoluteUrl(src: string): boolean {
   return /^https?:\/\//.test(src);
 }
 
-// Invokes a callback for each element in the array. Also invokes a callback
-// recursively for each nested array.
-export function deepForEach<T>(input: (T|any[])[], fn: (value: T) => void): void {
-  input.forEach(value => Array.isArray(value) ? deepForEach(value, fn) : fn(value));
-}
-
 // Given a URL, extract the hostname part.
 // If a URL is a relative one - the URL is returned as is.
 export function extractHostname(url: string): string {


### PR DESCRIPTION
This commit removes a duplicate deepForEach
function from url.ts. It is also in the
preconnect_link_checker, where it is actually
used.
