### PR TITLE
fix(zone.js): update unhandled rejection case after update jasmine to 4.3

### DIFF
--- a/packages/zone.js/test/common/Promise.spec.ts
+++ b/packages/zone.js/test/common/Promise.spec.ts
@@ -361,38 +361,50 @@ describe(
 
           it('should output error to console if ignoreConsoleErrorUncaughtError is false',
              (done) => {
-               Zone.current.fork({name: 'promise-error'}).run(() => {
-                 (Zone as any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] = false;
-                 const originalConsoleError = console.error;
-                 console.error = jasmine.createSpy('consoleErr');
-                 const p = new Promise((resolve, reject) => {
-                   throw new Error('promise error');
-                 });
-                 setTimeout(() => {
-                   expect(console.error).toHaveBeenCalled();
-                   console.error = originalConsoleError;
-                   done();
-                 }, 10);
-               });
+               (jasmine as any)
+                   .spyOnGlobalErrorsAsync(async function() {
+                     Zone.current.fork({name: 'promise-error'}).run(() => {
+                       (Zone as any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] = false;
+                       const originalConsoleError = console.error;
+                       const hookSpy = jasmine.createSpy();
+                       console.error = jasmine.createSpy('consoleErr').and.callFake(() => {
+                         hookSpy();
+                       });
+                       const p = new Promise((resolve, reject) => {
+                         throw new Error('promise error');
+                       });
+                       setTimeout(() => {
+                         expect(hookSpy).toHaveBeenCalled();
+                         console.error = originalConsoleError;
+                       }, 10);
+                     });
+                   })
+                   .then(() => done());
              });
 
           it('should not output error to console if ignoreConsoleErrorUncaughtError is true',
-             (done) => {
-               Zone.current.fork({name: 'promise-error'}).run(() => {
-                 (Zone as any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] = true;
-                 const originalConsoleError = console.error;
-                 console.error = jasmine.createSpy('consoleErr');
-                 const p = new Promise((resolve, reject) => {
-                   throw new Error('promise error');
-                 });
-                 setTimeout(() => {
-                   expect(console.error).not.toHaveBeenCalled();
-                   console.error = originalConsoleError;
-                   (Zone as any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] = false;
-                   done();
-                 }, 10);
-               });
-             });
+             (done) => {(jasmine as any)
+                            .spyOnGlobalErrorsAsync(async function() {
+                              Zone.current.fork({name: 'promise-error'}).run(() => {
+                                (Zone as any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] =
+                                    true;
+                                const originalConsoleError = console.error;
+                                const hookSpy = jasmine.createSpy();
+                                console.error = jasmine.createSpy('consoleErr').and.callFake(() => {
+                                  hookSpy();
+                                });
+                                const p = new Promise((resolve, reject) => {
+                                  throw new Error('promise error');
+                                });
+                                setTimeout(() => {
+                                  expect(hookSpy).not.toHaveBeenCalled();
+                                  console.error = originalConsoleError;
+                                  (Zone as
+                                   any)[Zone.__symbol__('ignoreConsoleErrorUncaughtError')] = false;
+                                }, 10);
+                              });
+                            })
+                            .then(() => done())});
 
           it('should notify Zone.onHandleError if no one catches promise', (done) => {
             let promiseError: Error|null = null;

--- a/packages/zone.js/test/node/console.spec.ts
+++ b/packages/zone.js/test/node/console.spec.ts
@@ -28,7 +28,7 @@ describe('node console', () => {
       console.info('test');
       console.trace('test');
       try {
-        console.assert(false, 'test');
+        console.assert(true, 'test');
       } catch (error) {
       }
       console.dir('.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -9418,7 +9418,12 @@ jasmine-ajax@^4.0.0:
   resolved "https://registry.yarnpkg.com/jasmine-ajax/-/jasmine-ajax-4.0.0.tgz#7d8ba7e47e3f7e780e155fe9aa563faafa7e1a26"
   integrity sha512-htTxNw38BSHxxmd8RRMejocdPqLalGHU6n3HWFbzp/S8AuTQd1MYjkSH3dYDsbZ7EV1Xqx/b94m3tKaVSVBV2A==
 
-jasmine-core@^4.0.0, jasmine-core@^4.1.0, jasmine-core@^4.2.0:
+jasmine-core@^4.0.0, jasmine-core@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.3.0.tgz#aee841fbe7373c2586ed8d8d48f5cc4a88be8390"
+  integrity sha512-qybtBUesniQdW6n+QIHMng2vDOHscIC/dEXjW+JzO9+LoAZMb03RCUC5xFOv/btSKPm1xL42fn+RjlU4oB42Lg==
+
+jasmine-core@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.2.0.tgz#0605bea284d6d78276f43c47de2532ecd4a73b00"
   integrity sha512-OcFpBrIhnbmb9wfI8cqPSJ50pv3Wg4/NSgoZIqHzIwO/2a9qivJWzv8hUvaREIMYYJBas6AvfXATFdVuzzCqVw==
@@ -9446,12 +9451,12 @@ jasmine@2.8.0:
     jasmine-core "~2.8.0"
 
 jasmine@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-4.2.1.tgz#55f81ab9d5d32f2645aa598d1356b6858407f4a9"
-  integrity sha512-LNZEKcScnjPRj5J92I1P515bxTvaHMRAERTyCoaGnWr87eOT6zv+b3M+kxKdH/06Gz4TnnXyHbXLiPtMHZ0ncw==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/jasmine/-/jasmine-4.3.0.tgz#f99e9bc2a94e8281d2490482d53a3406760bd7f4"
+  integrity sha512-ieBmwkd8L1DXnvSnxx7tecXgA0JDgMXPAwBcqM4lLPedJeI9hTHuWifPynTC+dLe4Y+GkSPSlbqqrmYIgGzYUw==
   dependencies:
     glob "^7.1.6"
-    jasmine-core "^4.2.0"
+    jasmine-core "^4.3.0"
 
 jasminewd2@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
From jasmine 4.3, the way to handle `unhandledrejection` is changed,
jasmine provides a new function to handle it. https://jasmine.github.io/api/4.3/jasmine.html#.spyOnGlobalErrorsAsync

So the related test cases need to be updated based on this changes.
The `@types/jasmine` has not been updated yet, will update and remove
`as any` cast after that.
