### PR TITLE
build: add zone.js to bug-report template for github

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yaml
@@ -23,6 +23,7 @@ body:
         - router
         - service-worker
         - upgrade
+        - zone.js
         - Don't known / other
       multiple: true
     validations:


### PR DESCRIPTION
Add `zone.js` to the `packages options` of the bug report template for
Github.
