### PR TITLE
fix(docs-infra): avoid distorting contributor images

### DIFF
--- a/aio/src/styles/2-modules/contributor/_contributor.scss
+++ b/aio/src/styles/2-modules/contributor/_contributor.scss
@@ -48,6 +48,7 @@ aio-contributor {
       width: calc(100% - 4px);
       height: calc(100% - 4px);
       clip-path: $angular-shape-polygon;
+      object-fit: cover;
     }
 
     .contributor-social-links {


### PR DESCRIPTION
Ensure contributor images are not distorted.
This was accidentally broken in #46347.

##
_Compare: [Before][1] vs [After][2]_

[1]: https://angular.io/about?group=Angular
[2]: https://pr47215-83ed4f6.ngbuilds.io/about?group=Angular
