### PR TITLE
ci: do not match dev-infra group for pullapprove owner changes

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1096,7 +1096,7 @@ groups:
     <<: *defaults
     conditions:
       - >
-        contains_any_globs(files, [
+        contains_any_globs(files.exclude('.pullapprove.yml'), [
           '{*,.*}',
           '.circleci/**/{*,.*}',
           '.devcontainer/**/{*,.*}',


### PR DESCRIPTION
Back when we fixed the pullapprove verify command and our config to
properly include dot-prefixed files, we accidentally started matching
the pullapprove file in the dev-infra group.

This commit fixes this so that dev-infra is not triggered for basic
code owner config changes.