### PR TITLE
refactor(core): generate initial inputs from inputs map

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -48,7 +48,7 @@
   "animations": {
     "uncompressed": {
       "runtime": 1070,
-      "main": 156736,
+      "main": 156816,
       "polyfills": 33814
     }
   },


### PR DESCRIPTION
We have some logic that generates the `InitialInputs` data structure by taking the static attributes of a node and looking them up in the `DirectiveDef.inputs` map to determine if they correspond to an input.

This works fine at the moment, but it will make it trickier to generate the correct `InitialInputs` for host directives, because the `DirectiveDef.inputs` entries might be aliased under a different name.

These changes rework the existing `generateInitialInputs` function so that it does its lookup on the remapped inputs that have accounted for the aliasing process already.