### PR TITLE
Remove unnecessary null argument to Promise.resolve

### DIFF
--- a/packages/animations/src/util.ts
+++ b/packages/animations/src/util.ts
@@ -6,5 +6,5 @@
  * found in the LICENSE file at https://angular.io/license
  */
 export function scheduleMicroTask(cb: () => any) {
-  Promise.resolve(null).then(cb);
+  Promise.resolve().then(cb);
 }

--- a/packages/animations/test/util_spec.ts
+++ b/packages/animations/test/util_spec.ts
@@ -14,7 +14,7 @@ import {scheduleMicroTask} from '../src/util';
       scheduleMicroTask(() => count++);
 
       expect(count).toEqual(0);
-      Promise.resolve(null).then(() => {
+      Promise.resolve().then(() => {
         expect(count).toEqual(1);
         done();
       });

--- a/packages/common/testing/src/mock_platform_location.ts
+++ b/packages/common/testing/src/mock_platform_location.ts
@@ -240,5 +240,5 @@ export class MockPlatformLocation implements PlatformLocation {
 }
 
 export function scheduleMicroTask(cb: () => any) {
-  Promise.resolve(null).then(cb);
+  Promise.resolve().then(cb);
 }

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -26,7 +26,7 @@ export const formDirectiveProvider: any = {
   useExisting: forwardRef(() => NgForm)
 };
 
-const resolvedPromise = (() => Promise.resolve(null))();
+const resolvedPromise = (() => Promise.resolve())();
 
 /**
  * @description

--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -44,7 +44,7 @@ export const formControlBinding: any = {
  * - this is just one extra run no matter how many `ngModel`s have been changed.
  * - this is a general problem when using `exportAs` for directives!
  */
-const resolvedPromise = (() => Promise.resolve(null))();
+const resolvedPromise = (() => Promise.resolve())();
 
 /**
  * @description

--- a/packages/forms/test/util.ts
+++ b/packages/forms/test/util.ts
@@ -80,7 +80,7 @@ export function currentStateOf(controls: AbstractControl[]):
  */
 export function asyncValidatorReturningObservable(c: AbstractControl): EventEmitter<any> {
   const e = new EventEmitter();
-  Promise.resolve(null).then(() => {
+  Promise.resolve().then(() => {
     e.emit({'async': true});
   });
   return e;

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -290,7 +290,7 @@ export function withEnabledBlockingInitialNavigation(): EnabledBlockingInitialNa
       deps: [Injector],
       useFactory: (injector: Injector) => {
         const locationInitialized: Promise<any> =
-            injector.get(LOCATION_INITIALIZED, Promise.resolve(null));
+            injector.get(LOCATION_INITIALIZED, Promise.resolve());
         let initNavigation = false;
 
         /**


### PR DESCRIPTION
These null values are unused and unnecessary. I suspect it's a remnant from when the codebase was transpiled to Dart.