### PR TITLE
build(bazel): run aio systemjs example e2es concurrently

### DIFF
--- a/aio/content/examples/examples.bzl
+++ b/aio/content/examples/examples.bzl
@@ -99,13 +99,12 @@ EXAMPLES = {
     "what-is-angular": {"stackblitz": True, "zip": True},
 }
 
-def docs_example(name, test = True, test_tags = []):
+def docs_example(name, test = True):
     """Stamp targets for adding boilerplate to examples, creating live examples, and creating zips.
 
     Args:
         name: name of the example
         test: whether to run e2e tests
-        test_tags: tags to add to e2e tests
     """
     if name not in EXAMPLES:
         # buildifier: disable=print
@@ -218,5 +217,5 @@ def docs_example(name, test = True, test_tags = []):
             ],
             # RBE complains about superseeding the max inputs limit (70,000) due to the
             # size of the input tree.
-            tags = test_tags + ["no-remote-exec"],
+            tags = ["no-remote-exec"],
         )

--- a/aio/content/examples/upgrade-module/BUILD.bazel
+++ b/aio/content/examples/upgrade-module/BUILD.bazel
@@ -4,5 +4,4 @@ package(default_visibility = ["//visibility:public"])
 
 docs_example(
     name = "upgrade-module",
-    test_tags = ["exclusive"],  # Cannot run concurrently as it uses a hardcoded port for lite-server
 )

--- a/aio/content/examples/upgrade-phonecat-1-typescript/BUILD.bazel
+++ b/aio/content/examples/upgrade-phonecat-1-typescript/BUILD.bazel
@@ -4,5 +4,4 @@ package(default_visibility = ["//visibility:public"])
 
 docs_example(
     name = "upgrade-phonecat-1-typescript",
-    test_tags = ["exclusive"],  # Cannot run concurrently as it uses a hardcoded port for lite-server
 )

--- a/aio/content/examples/upgrade-phonecat-1-typescript/e2e-spec.ts
+++ b/aio/content/examples/upgrade-phonecat-1-typescript/e2e-spec.ts
@@ -6,7 +6,8 @@ import { browser, element, by, ElementArrayFinder, ElementFinder } from 'protrac
 describe('PhoneCat Application', () => {
 
   beforeAll(() => {
-    browser.baseUrl = 'http://localhost:8080/app/';
+    browser.baseUrl = `${browser.baseUrl}/app/`;
+
     // protractor.config.js is set to ng2 mode by default, so we must manually change it
     browser.rootEl = 'body';
   });

--- a/aio/content/examples/upgrade-phonecat-2-hybrid/BUILD.bazel
+++ b/aio/content/examples/upgrade-phonecat-2-hybrid/BUILD.bazel
@@ -4,5 +4,4 @@ package(default_visibility = ["//visibility:public"])
 
 docs_example(
     name = "upgrade-phonecat-2-hybrid",
-    test_tags = ["exclusive"],  # Cannot run concurrently as it uses a hardcoded port for lite-server
 )

--- a/aio/content/examples/upgrade-phonecat-3-final/BUILD.bazel
+++ b/aio/content/examples/upgrade-phonecat-3-final/BUILD.bazel
@@ -4,5 +4,4 @@ package(default_visibility = ["//visibility:public"])
 
 docs_example(
     name = "upgrade-phonecat-3-final",
-    test_tags = ["exclusive"],  # Cannot run concurrently as it uses a hardcoded port for lite-server
 )

--- a/aio/package.json
+++ b/aio/package.json
@@ -130,6 +130,7 @@
     "find-free-port": "^2.0.0",
     "firebase-tools": "^11.0.0",
     "fs-extra": "^10.0.0",
+    "get-port": "^6.1.2",
     "globby": "^13.0.0",
     "hast-util-has-property": "^1.0.4",
     "hast-util-is-element": "^1.1.0",

--- a/aio/tools/examples/BUILD.bazel
+++ b/aio/tools/examples/BUILD.bazel
@@ -68,6 +68,7 @@ js_library(
         "@aio_npm//cjson",
         "@aio_npm//cross-spawn",
         "@aio_npm//fs-extra",
+        "@aio_npm//get-port",
         "@aio_npm//globby",
         "@aio_npm//shelljs",
         "@aio_npm//tree-kill",

--- a/aio/yarn.lock
+++ b/aio/yarn.lock
@@ -7603,6 +7603,11 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-port@^6.1.2:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/get-port/-/get-port-6.1.2.tgz#c1228abb67ba0e17fb346da33b15187833b9c08a"
+  integrity sha512-BrGGraKm2uPqurfGVj/z97/zv8dPleC6x9JBNRTrDNtCkkRF4rPwrQXFgL7+I+q8QSdU4ntLQX2D7KIxSy8nGw==
+
 get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"


### PR DESCRIPTION
@devversion @gkalpak @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The systemjs example e2es had to be run exclusively under bazel due to hardcoded ports.


## What is the new behavior?

All example e2es can now run concurrently.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
