### PR TITLE
fix(service-worker): include headers in requests for assets

### DIFF
--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -194,7 +194,7 @@ export class AppVersion implements UpdateSource {
       }
 
       // This was a navigation request. Re-enter `handleFetch` with a request for
-      // the URL.
+      // the index URL.
       return this.handleFetch(this.adapter.newRequest(this.indexUrl), event);
     }
 

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -32,6 +32,7 @@ const dist =
         .addFile('/qux.txt', 'this is qux')
         .addFile('/quux.txt', 'this is quux')
         .addFile('/quuux.txt', 'this is quuux')
+        .addFile('/redirect-target.txt', 'this was a redirect')
         .addFile('/lazy/unchanged1.txt', 'this is unchanged (1)')
         .addFile('/lazy/unchanged2.txt', 'this is unchanged (2)')
         .addUnhashedFile('/unhashed/a.txt', 'this is unhashed', {'Cache-Control': 'max-age=10'})
@@ -48,6 +49,7 @@ const distUpdate =
         .addFile('/qux.txt', 'this is qux v2')
         .addFile('/quux.txt', 'this is quux v2')
         .addFile('/quuux.txt', 'this is quuux v2')
+        .addFile('/redirect-target.txt', 'this was a redirect')
         .addFile('/lazy/unchanged1.txt', 'this is unchanged (1)')
         .addFile('/lazy/unchanged2.txt', 'this is unchanged (2)')
         .addUnhashedFile('/unhashed/a.txt', 'this is unhashed v2', {'Cache-Control': 'max-age=10'})
@@ -265,23 +267,21 @@ const manifestUpdate: Manifest = {
   hashTable: tmpHashTableForFs(distUpdate),
 };
 
-const serverBuilderBase =
-    new MockServerStateBuilder()
-        .withStaticFiles(dist)
-        .withRedirect('/redirected.txt', '/redirect-target.txt', 'this was a redirect')
-        .withError('/error.txt');
+const serverBuilderBase = new MockServerStateBuilder()
+                              .withStaticFiles(dist)
+                              .withRedirect('/redirected.txt', '/redirect-target.txt')
+                              .withError('/error.txt');
 
 const server = serverBuilderBase.withManifest(manifest).build();
 
 const serverRollback =
     serverBuilderBase.withManifest({...manifest, timestamp: manifest.timestamp + 1}).build();
 
-const serverUpdate =
-    new MockServerStateBuilder()
-        .withStaticFiles(distUpdate)
-        .withManifest(manifestUpdate)
-        .withRedirect('/redirected.txt', '/redirect-target.txt', 'this was a redirect')
-        .build();
+const serverUpdate = new MockServerStateBuilder()
+                         .withStaticFiles(distUpdate)
+                         .withManifest(manifestUpdate)
+                         .withRedirect('/redirected.txt', '/redirect-target.txt')
+                         .build();
 
 const brokenServer =
     new MockServerStateBuilder().withStaticFiles(brokenFs).withManifest(brokenManifest).build();

--- a/packages/service-worker/worker/testing/fetch.ts
+++ b/packages/service-worker/worker/testing/fetch.ts
@@ -100,7 +100,7 @@ export class MockRequest extends MockBody implements Request {
   readonly isHistoryNavigation: boolean = false;
   readonly isReloadNavigation: boolean = false;
   readonly cache: RequestCache = 'default';
-  readonly credentials: RequestCredentials = 'omit';
+  readonly credentials: RequestCredentials = 'same-origin';
   readonly destination: RequestDestination = 'document';
   readonly headers: Headers = new MockHeaders();
   readonly integrity: string = '';

--- a/packages/service-worker/worker/testing/mock.ts
+++ b/packages/service-worker/worker/testing/mock.ts
@@ -104,9 +104,8 @@ export class MockServerStateBuilder {
     return this;
   }
 
-  withRedirect(from: string, to: string, toContents: string): MockServerStateBuilder {
-    this.resources.set(from, new MockResponse(toContents, {redirected: true, url: to}));
-    this.resources.set(to, new MockResponse(toContents));
+  withRedirect(from: string, to: string): MockServerStateBuilder {
+    this.resources.set(from, new MockResponse('', {redirected: true, url: to}));
     return this;
   }
 

--- a/packages/service-worker/worker/testing/mock.ts
+++ b/packages/service-worker/worker/testing/mock.ts
@@ -179,6 +179,10 @@ export class MockServerState {
     this.resolve = null;
   }
 
+  getRequestsFor(url: string): Request[] {
+    return this.requests.filter(req => req.url.split('?')[0] === url);
+  }
+
   assertSawRequestFor(url: string): void {
     if (!this.sawRequestFor(url)) {
       throw new Error(`Expected request for ${url}, got none.`);
@@ -192,7 +196,7 @@ export class MockServerState {
   }
 
   sawRequestFor(url: string): boolean {
-    const matching = this.requests.filter(req => req.url.split('?')[0] === url);
+    const matching = this.getRequestsFor(url);
     if (matching.length > 0) {
       this.requests = this.requests.filter(req => req !== matching[0]);
       return true;


### PR DESCRIPTION
Previously, when requesting non-cached asset resources from the network, the ServiceWorker would strip off all request metadata (including headers). This was done in order to avoid issues with opaque responses, but it turned out to be overly aggressive, breaking/worsening legit usecases (such as requesting compressed data).

This commit fixes this by preserving the headers of such requests.

For reference, Workbox passes the original request as is. (See for example the [NetworkFirst][1] strategy).

> **Note**
> Data requests (i.e. requests for URLs that belong to a data-group) are not affected by this. They already use the original resource as is.

##
Fixes #24227

[1]: https://github.com/GoogleChrome/workbox/blob/95f97a207fd51efb3f8a653f6e3e58224183a778/packages/workbox-strategies/src/NetworkFirst.ts#L90
