### PR TITLE
refactor(compiler): replace most usages of getMutableClone (#47167)

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/metadata.ts
@@ -137,13 +137,12 @@ function decoratorToMetadata(
   }
   // Decorators have a type.
   const properties: ts.ObjectLiteralElementLike[] = [
-    ts.factory.createPropertyAssignment('type', ts.getMutableClone(decorator.identifier)),
+    ts.factory.createPropertyAssignment('type', decorator.identifier),
   ];
   // Sometimes they have arguments.
   if (decorator.args !== null && decorator.args.length > 0) {
     const args = decorator.args.map(arg => {
-      const expr = ts.getMutableClone(arg);
-      return wrapFunctionsInParens ? wrapFunctionExpressionsInParens(expr) : expr;
+      return wrapFunctionsInParens ? wrapFunctionExpressionsInParens(arg) : arg;
     });
     properties.push(
         ts.factory.createPropertyAssignment('args', ts.factory.createArrayLiteralExpression(args)));

--- a/packages/compiler-cli/src/ngtsc/imports/src/default.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/default.ts
@@ -138,6 +138,7 @@ export class DefaultImportTracker {
         //
         // TODO(alxhub): discuss with the TypeScript team and determine if there's a better way to
         // deal with this issue.
+        // tslint:disable-next-line: ban
         stmt = ts.getMutableClone(stmt);
       }
       return stmt;

--- a/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/type_to_value.ts
@@ -267,7 +267,9 @@ function entityNameToValue(node: ts.EntityName): ts.Expression|null {
     const left = entityNameToValue(node.left);
     return left !== null ? ts.factory.createPropertyAccessExpression(left, node.right) : null;
   } else if (ts.isIdentifier(node)) {
-    return ts.getMutableClone(node);
+    const clone = ts.setOriginalNode(ts.factory.createIdentifier(node.text), node);
+    (clone as any).parent = node.parent;
+    return clone;
   } else {
     return null;
   }

--- a/packages/compiler-cli/src/ngtsc/ts_compatibility/src/ts_cross_version_utils.ts
+++ b/packages/compiler-cli/src/ngtsc/ts_compatibility/src/ts_cross_version_utils.ts
@@ -9,7 +9,7 @@
 import ts from 'typescript';
 
 /** Whether the current TypeScript version is after 4.8. */
-export const IS_AFTER_TS_48 = isAfterVersion(4, 8);
+const IS_AFTER_TS_48 = isAfterVersion(4, 8);
 
 /** Whether the current TypeScript version is after 4.7. */
 const IS_AFTER_TS_47 = isAfterVersion(4, 7);
@@ -91,6 +91,24 @@ export const updateClassDeclaration: Ts48UpdateClassDeclarationFn = IS_AFTER_TS_
         ts.factory.updateClassDeclaration as any)(
         node, ...splitModifiers(combinedModifiers), name, typeParameters, heritageClauses, members);
 
+/** Type of `ts.factory.createClassDeclaration` in TS 4.8+. */
+type Ts48CreateClassDeclarationFn =
+    (modifiers: readonly ModifierLike[]|undefined, name: ts.Identifier|undefined,
+     typeParameters: readonly ts.TypeParameterDeclaration[]|undefined,
+     heritageClauses: readonly ts.HeritageClause[]|undefined,
+     members: readonly ts.ClassElement[]) => ts.ClassDeclaration;
+
+/**
+ * Creates a `ts.ClassDeclaration` declaration.
+ *
+ * TODO(crisbeto): this is a backwards-compatibility layer for versions of TypeScript less than 4.8.
+ * We should remove it once we have dropped support for the older versions.
+ */
+export const createClassDeclaration: Ts48CreateClassDeclarationFn = IS_AFTER_TS_48 ?
+    (ts.factory.createClassDeclaration as any) :
+    (combinedModifiers, name, typeParameters, heritageClauses, members) =>
+        (ts.factory.createClassDeclaration as any)(
+            ...splitModifiers(combinedModifiers), name, typeParameters, heritageClauses, members);
 
 /** Type of `ts.factory.updateMethodDeclaration` in TS 4.8+. */
 type Ts48UpdateMethodDeclarationFn =
@@ -114,6 +132,26 @@ export const updateMethodDeclaration: Ts48UpdateMethodDeclarationFn = IS_AFTER_T
             node, ...splitModifiers(modifiers), asteriskToken, name, questionToken, typeParameters,
             parameters, type, body);
 
+/** Type of `ts.factory.createMethodDeclaration` in TS 4.8+. */
+type Ts48CreateMethodDeclarationFn =
+    (modifiers: readonly ModifierLike[]|undefined, asteriskToken: ts.AsteriskToken|undefined,
+     name: ts.PropertyName, questionToken: ts.QuestionToken|undefined,
+     typeParameters: readonly ts.TypeParameterDeclaration[]|undefined,
+     parameters: readonly ts.ParameterDeclaration[], type: ts.TypeNode|undefined,
+     body: ts.Block|undefined) => ts.MethodDeclaration;
+
+/**
+ * Creates a `ts.MethodDeclaration` declaration.
+ *
+ * TODO(crisbeto): this is a backwards-compatibility layer for versions of TypeScript less than 4.8.
+ * We should remove it once we have dropped support for the older versions.
+ */
+export const createMethodDeclaration: Ts48CreateMethodDeclarationFn = IS_AFTER_TS_48 ?
+    (ts.factory.createMethodDeclaration as any) :
+    (modifiers, asteriskToken, name, questionToken, typeParameters, parameters, type, body) =>
+        (ts.factory.createMethodDeclaration as any)(
+            ...splitModifiers(modifiers), asteriskToken, name, questionToken, typeParameters,
+            parameters, type, body);
 
 /** Type of `ts.factory.updatePropertyDeclaration` in TS 4.8+. */
 type Ts48UpdatePropertyDeclarationFn =
@@ -153,14 +191,11 @@ export const createPropertyDeclaration: Ts48CreatePropertyDeclarationFn = IS_AFT
         (ts.factory.createPropertyDeclaration as any)(
             ...splitModifiers(modifiers), name, questionOrExclamationToken, type, initializer);
 
-
-
 /** Type of `ts.factory.updateGetAccessorDeclaration` in TS 4.8+. */
 type Ts48UpdateGetAccessorDeclarationFn =
     (node: ts.GetAccessorDeclaration, modifiers: readonly ModifierLike[]|undefined,
      name: ts.PropertyName, parameters: readonly ts.ParameterDeclaration[],
      type: ts.TypeNode|undefined, body: ts.Block|undefined) => ts.GetAccessorDeclaration;
-
 
 /**
  * Updates a `ts.GetAccessorDeclaration` declaration.
@@ -173,6 +208,23 @@ export const updateGetAccessorDeclaration: Ts48UpdateGetAccessorDeclarationFn = 
     (node, modifiers, name, parameters, type, body) =>
         (ts.factory.updateGetAccessorDeclaration as any)(
             node, ...splitModifiers(modifiers), name, parameters, type, body);
+
+/** Type of `ts.factory.createGetAccessorDeclaration` in TS 4.8+. */
+type Ts48CreateGetAccessorDeclarationFn =
+    (modifiers: readonly ModifierLike[]|undefined, name: ts.PropertyName,
+     parameters: readonly ts.ParameterDeclaration[], type: ts.TypeNode|undefined,
+     body: ts.Block|undefined) => ts.GetAccessorDeclaration;
+
+/**
+ * Creates a `ts.GetAccessorDeclaration` declaration.
+ *
+ * TODO(crisbeto): this is a backwards-compatibility layer for versions of TypeScript less than 4.8.
+ * We should remove it once we have dropped support for the older versions.
+ */
+export const createGetAccessorDeclaration: Ts48CreateGetAccessorDeclarationFn = IS_AFTER_TS_48 ?
+    (ts.factory.createGetAccessorDeclaration as any) :
+    (modifiers, name, parameters, type, body) => (ts.factory.createGetAccessorDeclaration as any)(
+        ...splitModifiers(modifiers), name, parameters, type, body);
 
 /** Type of `ts.factory.updateSetAccessorDeclaration` in TS 4.8+. */
 type Ts48UpdateSetAccessorDeclarationFn =
@@ -191,7 +243,22 @@ export const updateSetAccessorDeclaration: Ts48UpdateSetAccessorDeclarationFn = 
     (node, modifiers, name, parameters, body) => (ts.factory.updateSetAccessorDeclaration as any)(
         node, ...splitModifiers(modifiers), name, parameters, body);
 
+/** Type of `ts.factory.createSetAccessorDeclaration` in TS 4.8+. */
+type Ts48CreateSetAccessorDeclarationFn =
+    (modifiers: readonly ModifierLike[]|undefined, name: ts.PropertyName,
+     parameters: readonly ts.ParameterDeclaration[], body: ts.Block|undefined) =>
+        ts.SetAccessorDeclaration;
 
+/**
+ * Creates a `ts.GetAccessorDeclaration` declaration.
+ *
+ * TODO(crisbeto): this is a backwards-compatibility layer for versions of TypeScript less than 4.8.
+ * We should remove it once we have dropped support for the older versions.
+ */
+export const createSetAccessorDeclaration: Ts48CreateSetAccessorDeclarationFn = IS_AFTER_TS_48 ?
+    (ts.factory.createSetAccessorDeclaration as any) :
+    (modifiers, name, parameters, body) => (ts.factory.createSetAccessorDeclaration as any)(
+        ...splitModifiers(modifiers), name, parameters, body);
 
 /** Type of `ts.factory.updateConstructorDeclaration` in TS 4.8+. */
 type Ts48UpdateConstructorDeclarationFn =

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_emitter.ts
@@ -121,7 +121,22 @@ export class TypeEmitter {
           // issue the literal is cloned and explicitly marked as synthesized by setting its text
           // range to a negative range, forcing TypeScript to determine the node's literal text from
           // the synthesized node's text instead of the incorrect source file.
-          const clone = ts.getMutableClone(node);
+          let clone: ts.LiteralExpression;
+
+          if (ts.isStringLiteral(node)) {
+            clone = ts.factory.createStringLiteral(node.text);
+          } else if (ts.isNumericLiteral(node)) {
+            clone = ts.factory.createNumericLiteral(node.text);
+          } else if (ts.isBigIntLiteral(node)) {
+            clone = ts.factory.createBigIntLiteral(node.text);
+          } else if (ts.isNoSubstitutionTemplateLiteral(node)) {
+            clone = ts.factory.createNoSubstitutionTemplateLiteral(node.text, node.rawText);
+          } else if (ts.isRegularExpressionLiteral(node)) {
+            clone = ts.factory.createRegularExpressionLiteral(node.text);
+          } else {
+            throw new Error(`Unsupported literal kind ${ts.SyntaxKind[node.kind]}`);
+          }
+
           ts.setTextRange(clone, {pos: -1, end: -1});
           return clone;
         } else {

--- a/packages/compiler-cli/test/downlevel_decorators_transform_spec.ts
+++ b/packages/compiler-cli/test/downlevel_decorators_transform_spec.ts
@@ -649,11 +649,10 @@ describe('downlevel decorator transform', () => {
     const stripAllDecoratorsTransform: ts.TransformerFactory<ts.SourceFile> = context => {
       return (sourceFile: ts.SourceFile) => {
         const visitNode = (node: ts.Node): ts.Node => {
-          if (ts.isClassDeclaration(node) || ts.isClassElement(node)) {
-            const cloned = ts.getMutableClone(node);
-            (cloned.decorators as undefined) = undefined;
-            (cloned.modifiers as undefined) = undefined;
-            return cloned;
+          if (ts.isClassDeclaration(node)) {
+            return ts.factory.createClassDeclaration(
+                ts.getModifiers(node), node.name, node.typeParameters, node.heritageClauses,
+                node.members);
           }
           return ts.visitEachChild(node, visitNode, context);
         };

--- a/tslint.json
+++ b/tslint.json
@@ -78,7 +78,8 @@
     "ban": [
       true,
       {"name": "fdescribe", "message": "Don't keep jasmine focus methods."},
-      {"name": "fit", "message": "Don't keep jasmine focus methods."}
+      {"name": "fit", "message": "Don't keep jasmine focus methods."},
+      {"name": ["*", "getMutableClone"], "message": "Use a ts.factory.update* or ts.factory.create* method instead."}
     ]
   },
   "jsRules": {


### PR DESCRIPTION
This is a cherry-pick of #47167 into the patch branch.

Replaces (almost) all of the usages of the deprecated `getMutableClone` function from TypeScript which has started to log deprecation warnings in version 4.8 and will likely be removed in version 5.0. The one place we have left is in the default import handling of ngtsc which will be more difficult to remove.

PR Close #47167