### PR TITLE
refactor(localize): remove deprecated `canParse` method from TranslationParsers

### DIFF
--- a/goldens/public-api/localize/tools/index.md
+++ b/goldens/public-api/localize/tools/index.md
@@ -23,8 +23,6 @@ import { ɵSourceMessage } from '@angular/localize';
 export class ArbTranslationParser implements TranslationParser<ArbJsonObject> {
     // (undocumented)
     analyze(_filePath: string, contents: string): ParseAnalysis<ArbJsonObject>;
-    // @deprecated (undocumented)
-    canParse(filePath: string, contents: string): ArbJsonObject | false;
     // (undocumented)
     parse(_filePath: string, contents: string, arb?: ArbJsonObject): ParsedTranslationBundle;
 }
@@ -96,8 +94,6 @@ export class MessageExtractor {
 export class SimpleJsonTranslationParser implements TranslationParser<SimpleJsonFile> {
     // (undocumented)
     analyze(filePath: string, contents: string): ParseAnalysis<SimpleJsonFile>;
-    // @deprecated (undocumented)
-    canParse(filePath: string, contents: string): SimpleJsonFile | false;
     // (undocumented)
     parse(_filePath: string, contents: string, json?: SimpleJsonFile): ParsedTranslationBundle;
 }
@@ -131,10 +127,8 @@ export function unwrapSubstitutionsFromLocalizeCall(call: NodePath<t.CallExpress
 export class Xliff1TranslationParser implements TranslationParser<XmlTranslationParserHint> {
     // (undocumented)
     analyze(filePath: string, contents: string): ParseAnalysis<XmlTranslationParserHint>;
-    // @deprecated (undocumented)
-    canParse(filePath: string, contents: string): XmlTranslationParserHint | false;
     // (undocumented)
-    parse(filePath: string, contents: string, hint?: XmlTranslationParserHint): ParsedTranslationBundle;
+    parse(filePath: string, contents: string, hint: XmlTranslationParserHint): ParsedTranslationBundle;
 }
 
 // @public
@@ -148,10 +142,8 @@ export class Xliff1TranslationSerializer implements TranslationSerializer {
 export class Xliff2TranslationParser implements TranslationParser<XmlTranslationParserHint> {
     // (undocumented)
     analyze(filePath: string, contents: string): ParseAnalysis<XmlTranslationParserHint>;
-    // @deprecated (undocumented)
-    canParse(filePath: string, contents: string): XmlTranslationParserHint | false;
     // (undocumented)
-    parse(filePath: string, contents: string, hint?: XmlTranslationParserHint): ParsedTranslationBundle;
+    parse(filePath: string, contents: string, hint: XmlTranslationParserHint): ParsedTranslationBundle;
 }
 
 // @public
@@ -172,10 +164,8 @@ export class XmbTranslationSerializer implements TranslationSerializer {
 export class XtbTranslationParser implements TranslationParser<XmlTranslationParserHint> {
     // (undocumented)
     analyze(filePath: string, contents: string): ParseAnalysis<XmlTranslationParserHint>;
-    // @deprecated (undocumented)
-    canParse(filePath: string, contents: string): XmlTranslationParserHint | false;
     // (undocumented)
-    parse(filePath: string, contents: string, hint?: XmlTranslationParserHint): ParsedTranslationBundle;
+    parse(filePath: string, contents: string, hint: XmlTranslationParserHint): ParsedTranslationBundle;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/localize/tools/src/translate/translation_files/translation_parsers/arb_translation_parser.ts
+++ b/packages/localize/tools/src/translate/translation_files/translation_parsers/arb_translation_parser.ts
@@ -53,14 +53,6 @@ export interface ArbLocation {
  * ```
  */
 export class ArbTranslationParser implements TranslationParser<ArbJsonObject> {
-  /**
-   * @deprecated
-   */
-  canParse(filePath: string, contents: string): ArbJsonObject|false {
-    const result = this.analyze(filePath, contents);
-    return result.canParse && result.hint;
-  }
-
   analyze(_filePath: string, contents: string): ParseAnalysis<ArbJsonObject> {
     const diagnostics = new Diagnostics();
     if (!contents.includes('"@@locale"')) {

--- a/packages/localize/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser.ts
+++ b/packages/localize/tools/src/translate/translation_files/translation_parsers/simple_json_translation_parser.ts
@@ -34,14 +34,6 @@ interface SimpleJsonFile {
  * @publicApi used by CLI
  */
 export class SimpleJsonTranslationParser implements TranslationParser<SimpleJsonFile> {
-  /**
-   * @deprecated
-   */
-  canParse(filePath: string, contents: string): SimpleJsonFile|false {
-    const result = this.analyze(filePath, contents);
-    return result.canParse && result.hint;
-  }
-
   analyze(filePath: string, contents: string): ParseAnalysis<SimpleJsonFile> {
     const diagnostics = new Diagnostics();
     // For this to be parsable, the extension must be `.json` and the contents must include "locale"

--- a/packages/localize/tools/src/translate/translation_files/translation_parsers/translation_parser.ts
+++ b/packages/localize/tools/src/translate/translation_files/translation_parsers/translation_parser.ts
@@ -44,33 +44,21 @@ export interface ParsedTranslationBundle {
 /**
  * Implement this interface to provide a class that can parse the contents of a translation file.
  *
- * The `canParse()` method can return a hint that can be used by the `parse()` method to speed up
- * parsing. This allows the parser to do significant work to determine if the file can be parsed
+ * The `analyze()` method can return a hint that can be used by the `parse()` method to speed
+ * up parsing. This allows the parser to do significant work to determine if the file can be parsed
  * without duplicating the work when it comes to actually parsing the file.
  *
  * Example usage:
  *
  * ```
  * const parser: TranslationParser = getParser();
- * const result = parser.canParse(filePath, content);
- * if (result) {
- *   return parser.parse(filePath, content, result);
+ * const analysis = parser.analyze(filePath, content);
+ * if (analysis.canParse) {
+ *   return parser.parse(filePath, content, analysis.hint);
  * }
  * ```
  */
 export interface TranslationParser<Hint = true> {
-  /**
-   * Can this parser parse the given file?
-   *
-   * @deprecated Use `analyze()` instead
-   *
-   * @param filePath The absolute path to the translation file.
-   * @param contents The contents of the translation file.
-   * @returns A hint, which can be used in doing the actual parsing, if the file can be parsed by
-   * this parser; false otherwise.
-   */
-  canParse(filePath: string, contents: string): Hint|false;
-
   /**
    * Analyze the file to see if this parser can parse the given file.
    *
@@ -89,22 +77,10 @@ export interface TranslationParser<Hint = true> {
    * @param filePath The absolute path to the translation file.
    * @param contents The contents of the translation file.
    * @param hint A value that can be used by the parser to speed up parsing of the file. This will
-   * have been provided as the return result from calling `canParse()`.
+   * have been provided as the return result from calling `analyze()`.
    * @returns The translation bundle parsed from the file.
    * @throws No errors. If there was a problem with parsing the bundle will contain errors
    * in the `diagnostics` property.
    */
   parse(filePath: string, contents: string, hint: Hint): ParsedTranslationBundle;
-  /**
-   * Parses the given file, extracting the target locale and translations.
-   *
-   * @deprecated This overload is kept for backward compatibility. Going forward use the Hint
-   * returned from `canParse()` so that this method can avoid duplicating effort.
-   *
-   * @param filePath The absolute path to the translation file.
-   * @param contents The contents of the translation file.
-   * @returns The translation bundle parsed from the file.
-   * @throws An error if there was a problem parsing this file.
-   */
-  parse(filePath: string, contents: string): ParsedTranslationBundle;
 }

--- a/packages/localize/tools/src/translate/translation_files/translation_parsers/translation_utils.ts
+++ b/packages/localize/tools/src/translate/translation_files/translation_parsers/translation_utils.ts
@@ -59,7 +59,7 @@ function getInnerRange(element: Element): LexerRange {
 }
 
 /**
- * This "hint" object is used to pass information from `canParse()` to `parse()` for
+ * This "hint" object is used to pass information from `analyze()` to `parse()` for
  * `TranslationParser`s that expect XML contents.
  *
  * This saves the `parse()` method from having to re-parse the XML.

--- a/packages/localize/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser.ts
+++ b/packages/localize/tools/src/translate/translation_files/translation_parsers/xliff1_translation_parser.ts
@@ -24,25 +24,13 @@ import {addErrorsToBundle, addParseDiagnostic, addParseError, canParseXml, getAt
  * @publicApi used by CLI
  */
 export class Xliff1TranslationParser implements TranslationParser<XmlTranslationParserHint> {
-  /**
-   * @deprecated
-   */
-  canParse(filePath: string, contents: string): XmlTranslationParserHint|false {
-    const result = this.analyze(filePath, contents);
-    return result.canParse && result.hint;
-  }
-
   analyze(filePath: string, contents: string): ParseAnalysis<XmlTranslationParserHint> {
     return canParseXml(filePath, contents, 'xliff', {version: '1.2'});
   }
 
-  parse(filePath: string, contents: string, hint?: XmlTranslationParserHint):
+  parse(filePath: string, contents: string, hint: XmlTranslationParserHint):
       ParsedTranslationBundle {
-    if (hint) {
-      return this.extractBundle(hint);
-    } else {
-      return this.extractBundleDeprecated(filePath, contents);
-    }
+    return this.extractBundle(hint);
   }
 
   private extractBundle({element, errors}: XmlTranslationParserHint): ParsedTranslationBundle {
@@ -88,28 +76,6 @@ export class Xliff1TranslationParser implements TranslationParser<XmlTranslation
     }
 
     return bundle;
-  }
-
-  private extractBundleDeprecated(filePath: string, contents: string) {
-    const hint = this.canParse(filePath, contents);
-    if (!hint) {
-      throw new Error(`Unable to parse "${filePath}" as XLIFF 1.2 format.`);
-    }
-    const bundle = this.extractBundle(hint);
-    if (bundle.diagnostics.hasErrors) {
-      const message =
-          bundle.diagnostics.formatDiagnostics(`Failed to parse "${filePath}" as XLIFF 1.2 format`);
-      throw new Error(message);
-    }
-    return bundle;
-  }
-}
-
-class XliffFileElementVisitor extends BaseVisitor {
-  override visitElement(fileElement: Element): any {
-    if (fileElement.name === 'file') {
-      return {fileElement, locale: getAttribute(fileElement, 'target-language')};
-    }
   }
 }
 

--- a/packages/localize/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser.ts
+++ b/packages/localize/tools/src/translate/translation_files/translation_parsers/xliff2_translation_parser.ts
@@ -23,25 +23,13 @@ import {addErrorsToBundle, addParseDiagnostic, addParseError, canParseXml, getAt
  * @publicApi used by CLI
  */
 export class Xliff2TranslationParser implements TranslationParser<XmlTranslationParserHint> {
-  /**
-   * @deprecated
-   */
-  canParse(filePath: string, contents: string): XmlTranslationParserHint|false {
-    const result = this.analyze(filePath, contents);
-    return result.canParse && result.hint;
-  }
-
   analyze(filePath: string, contents: string): ParseAnalysis<XmlTranslationParserHint> {
     return canParseXml(filePath, contents, 'xliff', {version: '2.0'});
   }
 
-  parse(filePath: string, contents: string, hint?: XmlTranslationParserHint):
+  parse(filePath: string, contents: string, hint: XmlTranslationParserHint):
       ParsedTranslationBundle {
-    if (hint) {
-      return this.extractBundle(hint);
-    } else {
-      return this.extractBundleDeprecated(filePath, contents);
-    }
+    return this.extractBundle(hint);
   }
 
   private extractBundle({element, errors}: XmlTranslationParserHint): ParsedTranslationBundle {
@@ -64,20 +52,6 @@ export class Xliff2TranslationParser implements TranslationParser<XmlTranslation
     const translationVisitor = new Xliff2TranslationVisitor();
     for (const file of files) {
       visitAll(translationVisitor, file.children, {bundle});
-    }
-    return bundle;
-  }
-
-  private extractBundleDeprecated(filePath: string, contents: string) {
-    const hint = this.canParse(filePath, contents);
-    if (!hint) {
-      throw new Error(`Unable to parse "${filePath}" as XLIFF 2.0 format.`);
-    }
-    const bundle = this.extractBundle(hint);
-    if (bundle.diagnostics.hasErrors) {
-      const message =
-          bundle.diagnostics.formatDiagnostics(`Failed to parse "${filePath}" as XLIFF 2.0 format`);
-      throw new Error(message);
     }
     return bundle;
   }

--- a/packages/localize/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
+++ b/packages/localize/tools/src/translate/translation_files/translation_parsers/xtb_translation_parser.ts
@@ -25,14 +25,6 @@ import {addErrorsToBundle, addParseDiagnostic, addParseError, canParseXml, getAt
  * @publicApi used by CLI
  */
 export class XtbTranslationParser implements TranslationParser<XmlTranslationParserHint> {
-  /**
-   * @deprecated
-   */
-  canParse(filePath: string, contents: string): XmlTranslationParserHint|false {
-    const result = this.analyze(filePath, contents);
-    return result.canParse && result.hint;
-  }
-
   analyze(filePath: string, contents: string): ParseAnalysis<XmlTranslationParserHint> {
     const extension = extname(filePath);
     if (extension !== '.xtb' && extension !== '.xmb') {
@@ -43,13 +35,9 @@ export class XtbTranslationParser implements TranslationParser<XmlTranslationPar
     return canParseXml(filePath, contents, 'translationbundle', {});
   }
 
-  parse(filePath: string, contents: string, hint?: XmlTranslationParserHint):
+  parse(filePath: string, contents: string, hint: XmlTranslationParserHint):
       ParsedTranslationBundle {
-    if (hint) {
-      return this.extractBundle(hint);
-    } else {
-      return this.extractBundleDeprecated(filePath, contents);
-    }
+    return this.extractBundle(hint);
   }
 
   private extractBundle({element, errors}: XmlTranslationParserHint): ParsedTranslationBundle {
@@ -63,20 +51,6 @@ export class XtbTranslationParser implements TranslationParser<XmlTranslationPar
 
     const bundleVisitor = new XtbVisitor();
     visitAll(bundleVisitor, element.children, bundle);
-    return bundle;
-  }
-
-  private extractBundleDeprecated(filePath: string, contents: string) {
-    const hint = this.canParse(filePath, contents);
-    if (!hint) {
-      throw new Error(`Unable to parse "${filePath}" as XMB/XTB format.`);
-    }
-    const bundle = this.extractBundle(hint);
-    if (bundle.diagnostics.hasErrors) {
-      const message =
-          bundle.diagnostics.formatDiagnostics(`Failed to parse "${filePath}" as XMB/XTB format`);
-      throw new Error(message);
-    }
     return bundle;
   }
 }

--- a/packages/localize/tools/test/translate/translation_files/translation_loader_spec.ts
+++ b/packages/localize/tools/test/translate/translation_files/translation_loader_spec.ts
@@ -41,7 +41,7 @@ runInEachFileSystem(() => {
         jsonParser = new SimpleJsonTranslationParser();
       });
 
-      it('should call `canParse()` and `parse()` for each file', () => {
+      it('should call `analyze()` and `parse()` for each file', () => {
         const diagnostics = new Diagnostics();
         const parser = new MockTranslationParser(alwaysCanParse, 'fr');
         const loader = new TranslationLoader(fs, [parser], 'error', diagnostics);
@@ -218,11 +218,6 @@ runInEachFileSystem(() => {
     constructor(
         private _canParse: (filePath: string) => boolean, private _locale?: string,
         private _translations: Record<string, ɵParsedTranslation> = {}) {}
-
-    canParse(filePath: string, fileContents: string) {
-      const result = this.analyze(filePath, fileContents);
-      return result.canParse && result.hint;
-    }
 
     analyze(filePath: string, fileContents: string): ParseAnalysis<true> {
       const diagnostics = new Diagnostics();

--- a/packages/localize/tools/test/translate/translation_files/translation_parsers/arb_translation_parser_spec.ts
+++ b/packages/localize/tools/test/translate/translation_files/translation_parsers/arb_translation_parser_spec.ts
@@ -6,18 +6,21 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵmakeTemplateObject} from '@angular/localize';
+
 import {ArbTranslationParser} from '../../../../src/translate/translation_files/translation_parsers/arb_translation_parser';
 
 describe('SimpleArbTranslationParser', () => {
-  describe('canParse()', () => {
+  describe('analyze()', () => {
     it('should return true if the file extension  is `.json` and contains `@@locale` property',
        () => {
          const parser = new ArbTranslationParser();
-         expect(parser.canParse('/some/file.xlf', '')).toBe(false);
-         expect(parser.canParse('/some/file.json', 'xxx')).toBe(false);
-         expect(parser.canParse('/some/file.json', '{ "someKey": "someValue" }')).toBe(false);
-         expect(parser.canParse('/some/file.json', '{ "@@locale": "en", "someKey": "someValue" }'))
-             .toBeTruthy();
+         expect(parser.analyze('/some/file.xlf', '').canParse).toBeFalse();
+         expect(parser.analyze('/some/file.json', 'xxx').canParse).toBeFalse();
+         expect(parser.analyze('/some/file.json', '{ "someKey": "someValue" }').canParse)
+             .toBeFalse();
+         expect(parser.analyze('/some/file.json', '{ "@@locale": "en", "someKey": "someValue" }')
+                    .canParse)
+             .toBeTrue();
        });
   });
 

--- a/packages/localize/tools/test/translate/translation_files/translation_parsers/xliff1_translation_parser_spec.ts
+++ b/packages/localize/tools/test/translate/translation_files/translation_parsers/xliff1_translation_parser_spec.ts
@@ -6,793 +6,781 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵcomputeMsgId, ɵmakeParsedTranslation} from '@angular/localize';
+
 import {ParseAnalysis, ParsedTranslationBundle} from '../../../../src/translate/translation_files/translation_parsers/translation_parser';
 import {Xliff1TranslationParser} from '../../../../src/translate/translation_files/translation_parsers/xliff1_translation_parser';
 
-describe(
-    'Xliff1TranslationParser', () => {
-      describe('canParse()', () => {
-        it('should return true only if the file contains an <xliff> element with version="1.2" attribute',
-           () => {
-             const parser = new Xliff1TranslationParser();
-             expect(parser.canParse(
+describe('Xliff1TranslationParser', () => {
+  describe('analyze()', () => {
+    it('should return true only if the file contains an <xliff> element with version="1.2" attribute',
+       () => {
+         const parser = new Xliff1TranslationParser();
+         expect(parser
+                    .analyze(
                         '/some/file.xlf',
-                        '<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">'))
-                 .toBeTruthy();
-             expect(parser.canParse(
+                        '<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">')
+                    .canParse)
+             .toBeTrue();
+         expect(parser
+                    .analyze(
                         '/some/file.json',
-                        '<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">'))
-                 .toBeTruthy();
-             expect(parser.canParse('/some/file.xliff', '<xliff version="1.2">')).toBeTruthy();
-             expect(parser.canParse('/some/file.json', '<xliff version="1.2">')).toBeTruthy();
-             expect(parser.canParse('/some/file.xlf', '<xliff>')).toBe(false);
-             expect(parser.canParse('/some/file.xlf', '<xliff version="2.0">')).toBe(false);
-             expect(parser.canParse('/some/file.xlf', '')).toBe(false);
-             expect(parser.canParse('/some/file.json', '')).toBe(false);
-           });
-      });
+                        '<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">')
+                    .canParse)
+             .toBeTrue();
+         expect(parser.analyze('/some/file.xliff', '<xliff version="1.2">').canParse).toBeTrue();
+         expect(parser.analyze('/some/file.json', '<xliff version="1.2">').canParse).toBeTrue();
+         expect(parser.analyze('/some/file.xlf', '<xliff>').canParse).toBeFalse();
+         expect(parser.analyze('/some/file.xlf', '<xliff version="2.0">').canParse).toBeFalse();
+         expect(parser.analyze('/some/file.xlf', '').canParse).toBeFalse();
+         expect(parser.analyze('/some/file.json', '').canParse).toBeFalse();
+       });
+  });
 
-      describe('analyze()', () => {
-        it('should return a success object if the file contains an <xliff> element with version="1.2" attribute',
-           () => {
-             const parser = new Xliff1TranslationParser();
-             expect(parser.analyze('/some/file.xlf', '<xliff version="1.2">'))
-                 .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
-             expect(parser.analyze('/some/file.json', '<xliff version="1.2">'))
-                 .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
-             expect(parser.analyze('/some/file.xliff', '<xliff version="1.2">'))
-                 .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
-             expect(parser.analyze('/some/file.json', '<xliff version="1.2">'))
-                 .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
-           });
+  describe('analyze()', () => {
+    it('should return a success object if the file contains an <xliff> element with version="1.2" attribute',
+       () => {
+         const parser = new Xliff1TranslationParser();
+         expect(parser.analyze('/some/file.xlf', '<xliff version="1.2">'))
+             .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
+         expect(parser.analyze('/some/file.json', '<xliff version="1.2">'))
+             .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
+         expect(parser.analyze('/some/file.xliff', '<xliff version="1.2">'))
+             .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
+         expect(parser.analyze('/some/file.json', '<xliff version="1.2">'))
+             .toEqual(jasmine.objectContaining({canParse: true, hint: jasmine.any(Object)}));
+       });
 
-        it('should return a failure object if the file cannot be parsed as XLIFF 1.2', () => {
-          const parser = new Xliff1TranslationParser();
-          expect(parser.analyze('/some/file.xlf', '<xliff>')).toEqual(jasmine.objectContaining({
-            canParse: false
-          }));
-          expect(parser.analyze('/some/file.xlf', '<xliff version="2.0">'))
-              .toEqual(jasmine.objectContaining({canParse: false}));
-          expect(parser.analyze('/some/file.xlf', '')).toEqual(jasmine.objectContaining({
-            canParse: false
-          }));
-          expect(parser.analyze('/some/file.json', '')).toEqual(jasmine.objectContaining({
-            canParse: false
-          }));
-        });
-
-        it('should return a diagnostics object when the file is not a valid format', () => {
-          let result: ParseAnalysis<any>;
-          const parser = new Xliff1TranslationParser();
-
-          result = parser.analyze('/some/file.xlf', '<moo>');
-          expect(result.diagnostics.messages).toEqual([
-            {type: 'warning', message: 'The XML file does not contain a <xliff> root node.'}
-          ]);
-
-          result = parser.analyze('/some/file.xlf', '<xliff version="2.0">');
-          expect(result.diagnostics.messages).toEqual([{
-            type: 'warning',
-            message:
-                'The <xliff> node does not have the required attribute: version="1.2". ("[WARNING ->]<xliff version="2.0">"): /some/file.xlf@0:0'
-          }]);
-
-          result = parser.analyze('/some/file.xlf', '<xliff version="1.2"></file>');
-          expect(result.diagnostics.messages).toEqual([{
-            type: 'error',
-            message:
-                'Unexpected closing tag "file". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags ("<xliff version="1.2">[ERROR ->]</file>"): /some/file.xlf@0:21'
-          }]);
-        });
-      });
-
-      for (const withHint of [true, false]) {
-        describe(
-            `parse() [${withHint ? 'with' : 'without'} hint]`, () => {
-              const doParse: (fileName: string, XLIFF: string) => ParsedTranslationBundle =
-                  withHint ? (fileName, XLIFF) => {
-                    const parser = new Xliff1TranslationParser();
-                    const hint = parser.canParse(fileName, XLIFF);
-                    if (!hint) {
-                      throw new Error('expected XLIFF to be valid');
-                    }
-                    return parser.parse(fileName, XLIFF, hint);
-                  } : (fileName, XLIFF) => {
-                    const parser = new Xliff1TranslationParser();
-                    return parser.parse(fileName, XLIFF);
-                  };
-
-              const expectToFail: (
-                  fileName: string, XLIFF: string, errorMatcher: RegExp,
-                  diagnosticMessage: string) => void =
-                  withHint ? (fileName, XLIFF, _errorMatcher, diagnosticMessage) => {
-                    const result = doParse(fileName, XLIFF);
-                    expect(result.diagnostics.messages.length).toBeGreaterThan(0);
-                    expect(result.diagnostics.messages.pop()!.message).toEqual(diagnosticMessage);
-                  } : (fileName, XLIFF, errorMatcher, _diagnosticMessage) => {
-                    expect(() => doParse(fileName, XLIFF)).toThrowError(errorMatcher);
-                  };
-
-              it('should extract the locale from the last `<file>` element to contain a `target-language` attribute',
-                 () => {
-                   const XLIFF = [
-                     `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                     `  <file source-language="en" datatype="plaintext" original="ng2.template">`,
-                     `    <body></body>`,
-                     `  </file>`,
-                     `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                     `    <body></body>`,
-                     `  </file>`,
-                     `  <file source-language="en" datatype="plaintext" original="ng2.template">`,
-                     `    <body></body>`,
-                     `  </file>`,
-                     `  <file source-language="en" target-language="de" datatype="plaintext" original="ng2.template">`,
-                     `    <body></body>`,
-                     `  </file>`,
-                     `  <file source-language="en" datatype="plaintext" original="ng2.template">`,
-                     `    <body></body>`,
-                     `  </file>`,
-                     `</xliff>`,
-                   ].join('\n');
-                   const result = doParse('/some/file.xlf', XLIFF);
-                   expect(result.locale).toEqual('de');
-                 });
-
-              it('should return an undefined locale if there is no locale in the file', () => {
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-                expect(result.locale).toBeUndefined();
-              });
-
-              it('should extract basic messages', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * <div i18n>translatable attribute</div>
-                 * ```
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="1933478729560469763" datatype="html">`,
-                  `        <source>translatable attribute</source>`,
-                  `        <target>etubirtta elbatalsnart</target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">1</context>`,
-                  `        </context-group>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-
-                expect(result.translations[ɵcomputeMsgId('translatable attribute')])
-                    .toEqual(ɵmakeParsedTranslation(['etubirtta elbatalsnart']));
-              });
-
-              it('should extract translations with simple placeholders', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * <div i18n>translatable element <b>with placeholders</b> {{ interpolation}}</div>
-                 * ```
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="5057824347511785081" datatype="html">`,
-                  `        <source>translatable element <x id="START_BOLD_TEXT" ctype="b"/>with placeholders<x id="CLOSE_BOLD_TEXT" ctype="b"/> <x id="INTERPOLATION"/></source>`,
-                  `        <target><x id="INTERPOLATION"/> tnemele elbatalsnart <x id="START_BOLD_TEXT" ctype="x-b"/>sredlohecalp htiw<x id="CLOSE_BOLD_TEXT" ctype="x-b"/></target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">2</context>`,
-                  `        </context-group>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-
-                expect(
-                    result.translations[ɵcomputeMsgId(
-                        'translatable element {$START_BOLD_TEXT}with placeholders{$LOSE_BOLD_TEXT} {$INTERPOLATION}')])
-                    .toEqual(ɵmakeParsedTranslation(
-                        ['', ' tnemele elbatalsnart ', 'sredlohecalp htiw', ''],
-                        ['INTERPOLATION', 'START_BOLD_TEXT', 'CLOSE_BOLD_TEXT']));
-              });
-
-              it('should extract nested placeholder containers (i.e. nested HTML elements)', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * <div i18n>
-                 *   translatable <span>element <b>with placeholders</b></span> {{ interpolation}}
-                 * </div>
-                 * ```
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="9051630253697141670" datatype="html">`,
-                  `        <source>translatable <x id="START_TAG_SPAN"/>element <x id="START_BOLD_TEXT"/>with placeholders<x id="CLOSE_BOLD_TEXT"/><x id="CLOSE_TAG_SPAN"/> <x id="INTERPOLATION"/></source>`,
-                  `        <target><x id="START_TAG_SPAN"/><x id="INTERPOLATION"/> tnemele<x id="CLOSE_TAG_SPAN"/> elbatalsnart <x id="START_BOLD_TEXT"/>sredlohecalp htiw<x id="CLOSE_BOLD_TEXT"/></target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">3</context>`,
-                  `        </context-group>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-                expect(
-                    result.translations[ɵcomputeMsgId(
-                        'translatable {$START_TAG_SPAN}element {$START_BOLD_TEXT}with placeholders' +
-                        '{$CLOSE_BOLD_TEXT}{$CLOSE_TAG_SPAN} {$INTERPOLATION}')])
-                    .toEqual(ɵmakeParsedTranslation(
-                        ['', '', ' tnemele', ' elbatalsnart ', 'sredlohecalp htiw', ''], [
-                          'START_TAG_SPAN',
-                          'INTERPOLATION',
-                          'CLOSE_TAG_SPAN',
-                          'START_BOLD_TEXT',
-                          'CLOSE_BOLD_TEXT',
-                        ]));
-              });
-
-              it('should extract translations with placeholders containing hyphens', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * <div i18n><app-my-component></app-my-component> Welcome</div>
-                 * ```
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="2877147807876214810" datatype="html">`,
-                  `        <source><x id="START_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;app-my-component&gt;"/><x id="CLOSE_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;/app-my-component&gt;"/> Welcome</source>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">src/app/app.component.html</context>`,
-                  `          <context context-type="linenumber">1</context>`,
-                  `        </context-group>`,
-                  `        <target><x id="START_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;app-my-component&gt;"/><x id="CLOSE_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;/app-my-component&gt;"/> Translate</target>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-                const id = ɵcomputeMsgId(
-                    '{$START_TAG_APP_MY_COMPONENT}{$CLOSE_TAG_APP_MY_COMPONENT} Welcome');
-                expect(result.translations[id])
-                    .toEqual(ɵmakeParsedTranslation(
-                        ['', '', ' Translate'],
-                        ['START_TAG_APP_MY_COMPONENT', 'CLOSE_TAG_APP_MY_COMPONENT']));
-              });
-
-              it('should extract translations with simple ICU expressions', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * <div i18n>{VAR_PLURAL, plural, =0 {<p>test</p>} }</div>
-                 * ```
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="2874455947211586270" datatype="html">`,
-                  `        <source>{VAR_PLURAL, plural, =0 {<x id="START_PARAGRAPH" ctype="x-p"/>test<x id="CLOSE_PARAGRAPH" ctype="x-p"/>} }</source>`,
-                  `        <target>{VAR_PLURAL, plural, =0 {<x id="START_PARAGRAPH" ctype="x-p"/>TEST<x id="CLOSE_PARAGRAPH" ctype="x-p"/>} }</target>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-
-                expect(result.translations[ɵcomputeMsgId(
-                           '{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}test{CLOSE_PARAGRAPH}}}')])
-                    .toEqual(ɵmakeParsedTranslation(
-                        ['{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}TEST{CLOSE_PARAGRAPH}}}'], []));
-              });
-
-              it('should extract translations with duplicate source messages', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * <div i18n>foo</div>
-                 * <div i18n="m|d@@i">foo</div>
-                 * <div i18=""m|d@@bar>foo</div>
-                 * ```
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="9205907420411818817" datatype="html">`,
-                  `        <source>foo</source>`,
-                  `        <target>oof</target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">3</context>`,
-                  `        </context-group>`,
-                  `        <note priority="1" from="description">d</note>`,
-                  `        <note priority="1" from="meaning">m</note>`,
-                  `      </trans-unit>`,
-                  `      <trans-unit id="i" datatype="html">`,
-                  `        <source>foo</source>`,
-                  `        <target>toto</target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">4</context>`,
-                  `        </context-group>`,
-                  `        <note priority="1" from="description">d</note>`,
-                  `        <note priority="1" from="meaning">m</note>`,
-                  `      </trans-unit>`,
-                  `      <trans-unit id="bar" datatype="html">`,
-                  `        <source>foo</source>`,
-                  `        <target>tata</target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">5</context>`,
-                  `        </context-group>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-
-                expect(result.translations[ɵcomputeMsgId('foo')])
-                    .toEqual(ɵmakeParsedTranslation(['oof']));
-                expect(result.translations['i']).toEqual(ɵmakeParsedTranslation(['toto']));
-                expect(result.translations['bar']).toEqual(ɵmakeParsedTranslation(['tata']));
-              });
-
-              it('should extract translations with only placeholders, which are re-ordered', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * <div i18n><br><img/><img/></div>
-                 * ```
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="7118057989405618448" datatype="html">`,
-                  `      <ph id="1" equiv="TAG_IMG" type="image" disp="&lt;img/&gt;"/><ph id="2" equiv="TAG_IMG_1" type="image" disp="&lt;img/&gt;"/>`,
-                  `        <source><x id="LINE_BREAK" ctype="lb"/><x id="TAG_IMG" ctype="image"/><x id="TAG_IMG_1" ctype="image"/></source>`,
-                  `        <target><x id="TAG_IMG_1" ctype="image"/><x id="TAG_IMG" ctype="image"/><x id="LINE_BREAK" ctype="lb"/></target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">6</context>`,
-                  `        </context-group>`,
-                  `        <note priority="1" from="description">ph names</note>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-
-                expect(result.translations[ɵcomputeMsgId('{$LINE_BREAK}{$TAG_IMG}{$TAG_IMG_1}')])
-                    .toEqual(ɵmakeParsedTranslation(
-                        ['', '', '', ''], ['TAG_IMG_1', 'TAG_IMG', 'LINE_BREAK']));
-              });
-
-              it('should extract translations with empty target', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * <div i18n>hello <span></span></div>
-                 * ```
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="2826198357052921524" datatype="html">`,
-                  `        <source>hello <x id="START_TAG_SPAN" ctype="x-span"/><x id="CLOSE_TAG_SPAN" ctype="x-span"/></source>`,
-                  `        <target/>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">6</context>`,
-                  `        </context-group>`,
-                  `        <note priority="1" from="description">ph names</note>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-
-                expect(
-                    result.translations[ɵcomputeMsgId('hello {$START_TAG_SPAN}{$CLOSE_TAG_SPAN}')])
-                    .toEqual(ɵmakeParsedTranslation(['']));
-              });
-
-              it('should extract translations with deeply nested ICUs', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * Test: { count, plural, =0 { { sex, select, other {<p>deeply nested</p>}} }
-                 * =other {a lot}}
-                 * ```
-                 *
-                 * Note that the message gets split into two translation units:
-                 *  * The first one contains the outer message with an `ICU` placeholder
-                 *  * The second one is the ICU expansion itself
-                 *
-                 * Note that special markers `VAR_PLURAL` and `VAR_SELECT` are added, which are then
-                 * replaced by IVY at runtime with the actual values being rendered by the ICU
-                 * expansion.
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="980940425376233536" datatype="html">`,
-                  `        <source>Test: <x id="ICU" equiv-text="{ count, plural, =0 {...} =other {...}}"/></source>`,
-                  `        <target>Le test: <x id="ICU" equiv-text="{ count, plural, =0 {...} =other {...}}"/></target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">11</context>`,
-                  `        </context-group>`,
-                  `      </trans-unit>`,
-                  `      <trans-unit id="5207293143089349404" datatype="html">`,
-                  `        <source>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<x id="START_PARAGRAPH" ctype="x-p"/>deeply nested<x id="CLOSE_PARAGRAPH" ctype="x-p"/>}}} =other {a lot}}</source>`,
-                  `        <target>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<x id="START_PARAGRAPH" ctype="x-p"/>profondément imbriqué<x id="CLOSE_PARAGRAPH" ctype="x-p"/>}}} =other {beaucoup}}</target>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-
-                expect(result.translations[ɵcomputeMsgId('Test: {$ICU}')])
-                    .toEqual(ɵmakeParsedTranslation(['Le test: ', ''], ['ICU']));
-
-                expect(
-                    result.translations[ɵcomputeMsgId(
-                        '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}deeply nested{CLOSE_PARAGRAPH}}}} =other {beaucoup}}')])
-                    .toEqual(ɵmakeParsedTranslation([
-                      '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}profondément imbriqué{CLOSE_PARAGRAPH}}}} =other {beaucoup}}'
-                    ]));
-              });
-
-              it('should extract translations containing multiple lines', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * <div i18n>multi
-                 * lines</div>
-                 * ```
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="2340165783990709777" datatype="html">`,
-                  `        <source>multi\nlines</source>`,
-                  `        <target>multi\nlignes</target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">12</context>`,
-                  `        </context-group>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-
-                expect(result.translations[ɵcomputeMsgId('multi\nlines')])
-                    .toEqual(ɵmakeParsedTranslation(['multi\nlignes']));
-              });
-
-              it('should extract translations with <mrk> elements', () => {
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit id="mrk-test">`,
-                  `        <source>First sentence.</source>`,
-                  `        <seg-source>`,
-                  `          <invalid-tag>Should not be parsed</invalid-tag>`,
-                  `        </seg-source>`,
-                  `        <target>Translated <mrk mtype="seg" mid="1">first sentence</mrk>.</target>`,
-                  `      </trans-unit>`,
-                  `      <trans-unit id="mrk-test2">`,
-                  `        <source>First sentence. Second sentence.</source>`,
-                  `        <seg-source>`,
-                  `          <invalid-tag>Should not be parsed</invalid-tag>`,
-                  `        </seg-source>`,
-                  `        <target>Translated <mrk mtype="seg" mid="1"><mrk mtype="seg" mid="2">first</mrk> sentence</mrk>.</target>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-
-                expect(result.translations['mrk-test'])
-                    .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
-
-                expect(result.translations['mrk-test2'])
-                    .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
-              });
-
-              it('should ignore alt-trans targets', () => {
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                  `    <body>`,
-                  `      <trans-unit datatype="html" approved="no" id="registration.submit">`,
-                  `        <source>Continue</source>`,
-                  `        <target state="translated" xml:lang="de">Weiter</target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">src/app/auth/registration-form/registration-form.component.html</context>`,
-                  `          <context context-type="linenumber">69</context>`,
-                  `        </context-group>`,
-                  `        <?sid 1110954287-0?>`,
-                  `        <alt-trans origin="autoFuzzy" tool="Swordfish" match-quality="71" ts="63">`,
-                  `          <source xml:lang="en">Content</source>`,
-                  `          <target state="translated" xml:lang="de">Content</target>`,
-                  `        </alt-trans>`,
-                  `    </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-
-                const result = doParse('/some/file.xlf', XLIFF);
-                expect(result.translations['registration.submit'])
-                    .toEqual(ɵmakeParsedTranslation(['Weiter']));
-              });
-
-              it('should merge messages from each `<file>` element', () => {
-                /**
-                 * Source HTML:
-                 *
-                 * ```
-                 * <div i18n>translatable attribute</div>
-                 * ```
-
-                 * ```
-                 * <div i18n>translatable element <b>with placeholders</b> {{ interpolation}}</div>
-                 * ```
-                 */
-                const XLIFF = [
-                  `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="file-1">`,
-                  `    <body>`,
-                  `      <trans-unit id="1933478729560469763" datatype="html">`,
-                  `        <source>translatable attribute</source>`,
-                  `        <target>etubirtta elbatalsnart</target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">1</context>`,
-                  `        </context-group>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `  <file source-language="en" target-language="fr" datatype="plaintext" original="file-2">`,
-                  `    <body>`,
-                  `      <trans-unit id="5057824347511785081" datatype="html">`,
-                  `        <source>translatable element <x id="START_BOLD_TEXT" ctype="b"/>with placeholders<x id="CLOSE_BOLD_TEXT" ctype="b"/> <x id="INTERPOLATION"/></source>`,
-                  `        <target><x id="INTERPOLATION"/> tnemele elbatalsnart <x id="START_BOLD_TEXT" ctype="x-b"/>sredlohecalp htiw<x id="CLOSE_BOLD_TEXT" ctype="x-b"/></target>`,
-                  `        <context-group purpose="location">`,
-                  `          <context context-type="sourcefile">file.ts</context>`,
-                  `          <context context-type="linenumber">2</context>`,
-                  `        </context-group>`,
-                  `      </trans-unit>`,
-                  `    </body>`,
-                  `  </file>`,
-                  `</xliff>`,
-                ].join('\n');
-                const result = doParse('/some/file.xlf', XLIFF);
-                expect(result.translations[ɵcomputeMsgId('translatable attribute')])
-                    .toEqual(ɵmakeParsedTranslation(['etubirtta elbatalsnart']));
-                expect(
-                    result.translations[ɵcomputeMsgId(
-                        'translatable element {$START_BOLD_TEXT}with placeholders{$LOSE_BOLD_TEXT} {$INTERPOLATION}')])
-                    .toEqual(ɵmakeParsedTranslation(
-                        ['', ' tnemele elbatalsnart ', 'sredlohecalp htiw', ''],
-                        ['INTERPOLATION', 'START_BOLD_TEXT', 'CLOSE_BOLD_TEXT']));
-              });
-
-              describe('[structure errors]', () => {
-                it('should warn when a trans-unit has no translation target but does have a source',
-                   () => {
-                     const XLIFF = [
-                       `<?xml version="1.0" encoding="UTF-8" ?>`,
-                       `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                       `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                       `    <body>`,
-                       `      <trans-unit id="missingtarget">`,
-                       `        <source/>`,
-                       `      </trans-unit>`,
-                       `    </body>`,
-                       `  </file>`,
-                       `</xliff>`,
-                     ].join('\n');
-
-                     const result = doParse('/some/file.xlf', XLIFF);
-                     expect(result.diagnostics.messages.length).toEqual(1);
-                     expect(result.diagnostics.messages[0].message).toEqual([
-                       `Missing <target> element ("e-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                       `    <body>`,
-                       `      [WARNING ->]<trans-unit id="missingtarget">`,
-                       `        <source/>`,
-                       `      </trans-unit>`,
-                       `"): /some/file.xlf@4:6`,
-                     ].join('\n'));
-                   });
-
-                it('should fail when a trans-unit has no translation target nor source', () => {
-                  const XLIFF = [
-                    `<?xml version="1.0" encoding="UTF-8" ?>`,
-                    `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                    `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                    `    <body>`,
-                    `      <trans-unit id="missingtarget">`,
-                    `      </trans-unit>`,
-                    `    </body>`,
-                    `  </file>`,
-                    `</xliff>`,
-                  ].join('\n');
-
-                  expectToFail(
-                      '/some/file.xlf', XLIFF,
-                      /Missing required element: one of <target> or <source> is required/, [
-                        `Missing required element: one of <target> or <source> is required ("e-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                        `    <body>`,
-                        `      [ERROR ->]<trans-unit id="missingtarget">`,
-                        `      </trans-unit>`,
-                        `    </body>`,
-                        `"): /some/file.xlf@4:6`,
-                      ].join('\n'));
-                });
-
-                it('should fail when a trans-unit has no id attribute', () => {
-                  const XLIFF = [
-                    `<?xml version="1.0" encoding="UTF-8" ?>`,
-                    `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                    `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                    `    <body>`,
-                    `      <trans-unit datatype="html">`,
-                    `        <source/>`,
-                    `        <target/>`,
-                    `      </trans-unit>`,
-                    `    </body>`,
-                    `  </file>`,
-                    `</xliff>`,
-                  ].join('\n');
-
-                  expectToFail('/some/file.xlf', XLIFF, /Missing required "id" attribute/, [
-                    `Missing required "id" attribute on <trans-unit> element. ("e-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                    `    <body>`,
-                    `      [ERROR ->]<trans-unit datatype="html">`,
-                    `        <source/>`,
-                    `        <target/>`,
-                    `"): /some/file.xlf@4:6`,
-                  ].join('\n'));
-                });
-
-                it('should fail on duplicate trans-unit id', () => {
-                  const XLIFF = [
-                    `<?xml version="1.0" encoding="UTF-8" ?>`,
-                    `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                    `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                    `    <body>`,
-                    `      <trans-unit id="deadbeef">`,
-                    `        <source/>`,
-                    `        <target/>`,
-                    `      </trans-unit>`,
-                    `      <trans-unit id="deadbeef">`,
-                    `        <source/>`,
-                    `        <target/>`,
-                    `      </trans-unit>`,
-                    `    </body>`,
-                    `  </file>`,
-                    `</xliff>`,
-                  ].join('\n');
-
-                  expectToFail(
-                      '/some/file.xlf', XLIFF, /Duplicated translations for message "deadbeef"/, [
-                        `Duplicated translations for message "deadbeef" ("`,
-                        `        <target/>`,
-                        `      </trans-unit>`,
-                        `      [ERROR ->]<trans-unit id="deadbeef">`,
-                        `        <source/>`,
-                        `        <target/>`,
-                        `"): /some/file.xlf@8:6`,
-                      ].join('\n'));
-                });
-              });
-
-              describe('[message errors]', () => {
-                it('should fail on unknown message tags', () => {
-                  const XLIFF = [
-                    `<?xml version="1.0" encoding="UTF-8" ?>`,
-                    `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                    `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                    `    <body>`,
-                    `      <trans-unit id="deadbeef" datatype="html">`,
-                    `        <source/>`,
-                    `        <target><b>msg should contain only ph tags</b></target>`,
-                    `      </trans-unit>`,
-                    `    </body>`,
-                    `  </file>`,
-                    `</xliff>`,
-                  ].join('\n');
-
-                  expectToFail('/some/file.xlf', XLIFF, /Invalid element found in message/, [
-                    `Error: Invalid element found in message.`,
-                    `At /some/file.xlf@6:16:`,
-                    `...`,
-                    `        <source/>`,
-                    `        <target>[ERROR ->]<b>msg should contain only ph tags</b></target>`,
-                    `      </trans-unit>`,
-                    `...`,
-                    ``,
-                  ].join('\n'));
-                });
-
-                it('should fail when a placeholder misses an id attribute', () => {
-                  const XLIFF = [
-                    `<?xml version="1.0" encoding="UTF-8" ?>`,
-                    `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
-                    `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
-                    `    <body>`,
-                    `      <trans-unit id="deadbeef" datatype="html">`,
-                    `        <source/>`,
-                    `        <target><x/></target>`,
-                    `      </trans-unit>`,
-                    `    </body>`,
-                    `  </file>`,
-                    `</xliff>`,
-                  ].join('\n');
-
-                  expectToFail('/some/file.xlf', XLIFF, /required "id" attribute/gi, [
-                    `Error: Missing required "id" attribute:`,
-                    `At /some/file.xlf@6:16:`,
-                    `...`,
-                    `        <source/>`,
-                    `        <target>[ERROR ->]<x/></target>`,
-                    `      </trans-unit>`,
-                    `...`,
-                    ``,
-                  ].join('\n'));
-                });
-              });
-            });
-      }
+    it('should return a failure object if the file cannot be parsed as XLIFF 1.2', () => {
+      const parser = new Xliff1TranslationParser();
+      expect(parser.analyze('/some/file.xlf', '<xliff>')).toEqual(jasmine.objectContaining({
+        canParse: false
+      }));
+      expect(parser.analyze('/some/file.xlf', '<xliff version="2.0">'))
+          .toEqual(jasmine.objectContaining({canParse: false}));
+      expect(parser.analyze('/some/file.xlf', '')).toEqual(jasmine.objectContaining({
+        canParse: false
+      }));
+      expect(parser.analyze('/some/file.json', '')).toEqual(jasmine.objectContaining({
+        canParse: false
+      }));
     });
+
+    it('should return a diagnostics object when the file is not a valid format', () => {
+      let result: ParseAnalysis<any>;
+      const parser = new Xliff1TranslationParser();
+
+      result = parser.analyze('/some/file.xlf', '<moo>');
+      expect(result.diagnostics.messages).toEqual([
+        {type: 'warning', message: 'The XML file does not contain a <xliff> root node.'}
+      ]);
+
+      result = parser.analyze('/some/file.xlf', '<xliff version="2.0">');
+      expect(result.diagnostics.messages).toEqual([{
+        type: 'warning',
+        message:
+            'The <xliff> node does not have the required attribute: version="1.2". ("[WARNING ->]<xliff version="2.0">"): /some/file.xlf@0:0'
+      }]);
+
+      result = parser.analyze('/some/file.xlf', '<xliff version="1.2"></file>');
+      expect(result.diagnostics.messages).toEqual([{
+        type: 'error',
+        message:
+            'Unexpected closing tag "file". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags ("<xliff version="1.2">[ERROR ->]</file>"): /some/file.xlf@0:21'
+      }]);
+    });
+  });
+
+  describe(`parse()`, () => {
+    const doParse: (fileName: string, XLIFF: string) => ParsedTranslationBundle =
+        (fileName, XLIFF) => {
+          const parser = new Xliff1TranslationParser();
+          const analysis = parser.analyze(fileName, XLIFF);
+          if (!analysis.canParse) {
+            throw new Error('expected XLIFF to be valid');
+          }
+          return parser.parse(fileName, XLIFF, analysis.hint);
+        };
+
+    const expectToFail:
+        (fileName: string, XLIFF: string, errorMatcher: RegExp, diagnosticMessage: string) => void =
+            (fileName, XLIFF, _errorMatcher, diagnosticMessage) => {
+              const result = doParse(fileName, XLIFF);
+              expect(result.diagnostics.messages.length).toBeGreaterThan(0);
+              expect(result.diagnostics.messages.pop()!.message).toEqual(diagnosticMessage);
+            };
+
+    it('should extract the locale from the last `<file>` element to contain a `target-language` attribute',
+       () => {
+         const XLIFF = `
+            <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+             <file source-language="en" datatype="plaintext" original="ng2.template">
+               <body></body>
+             </file>
+             <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+               <body></body>
+             </file>
+             <file source-language="en" datatype="plaintext" original="ng2.template">
+               <body></body>
+             </file>
+             <file source-language="en" target-language="de" datatype="plaintext" original="ng2.template">
+               <body></body>
+             </file>
+             <file source-language="en" datatype="plaintext" original="ng2.template">
+               <body></body>
+             </file>
+           </xliff>
+           `;
+         const result = doParse('/some/file.xlf', XLIFF);
+         expect(result.locale).toEqual('de');
+       });
+
+    it('should return an undefined locale if there is no locale in the file', () => {
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" datatype="plaintext" original="ng2.template">
+            <body>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.locale).toBeUndefined();
+    });
+
+    it('should extract basic messages', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>translatable attribute</div>
+       * ```
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="1933478729560469763" datatype="html">
+                <source>translatable attribute</source>
+                <target>etubirtta elbatalsnart</target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">1</context>
+                </context-group>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+
+      expect(result.translations[ɵcomputeMsgId('translatable attribute')])
+          .toEqual(ɵmakeParsedTranslation(['etubirtta elbatalsnart']));
+    });
+
+    it('should extract translations with simple placeholders', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>translatable element <b>with placeholders</b> {{ interpolation}}</div>
+       * ```
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="5057824347511785081" datatype="html">
+                <source>translatable element <x id="START_BOLD_TEXT" ctype="b"/>with placeholders<x id="CLOSE_BOLD_TEXT" ctype="b"/> <x id="INTERPOLATION"/></source>
+                <target><x id="INTERPOLATION"/> tnemele elbatalsnart <x id="START_BOLD_TEXT" ctype="x-b"/>sredlohecalp htiw<x id="CLOSE_BOLD_TEXT" ctype="x-b"/></target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">2</context>
+                </context-group>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+
+      expect(
+          result.translations[ɵcomputeMsgId(
+              'translatable element {$START_BOLD_TEXT}with placeholders{$LOSE_BOLD_TEXT} {$INTERPOLATION}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['', ' tnemele elbatalsnart ', 'sredlohecalp htiw', ''],
+              ['INTERPOLATION', 'START_BOLD_TEXT', 'CLOSE_BOLD_TEXT']));
+    });
+
+    it('should extract nested placeholder containers (i.e. nested HTML elements)', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>
+       *   translatable <span>element <b>with placeholders</b></span> {{ interpolation}}
+       * </div>
+       * ```
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="9051630253697141670" datatype="html">
+                <source>translatable <x id="START_TAG_SPAN"/>element <x id="START_BOLD_TEXT"/>with placeholders<x id="CLOSE_BOLD_TEXT"/><x id="CLOSE_TAG_SPAN"/> <x id="INTERPOLATION"/></source>
+                <target><x id="START_TAG_SPAN"/><x id="INTERPOLATION"/> tnemele<x id="CLOSE_TAG_SPAN"/> elbatalsnart <x id="START_BOLD_TEXT"/>sredlohecalp htiw<x id="CLOSE_BOLD_TEXT"/></target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">3</context>
+                </context-group>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId(
+                 'translatable {$START_TAG_SPAN}element {$START_BOLD_TEXT}with placeholders' +
+                 '{$CLOSE_BOLD_TEXT}{$CLOSE_TAG_SPAN} {$INTERPOLATION}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['', '', ' tnemele', ' elbatalsnart ', 'sredlohecalp htiw', ''], [
+                'START_TAG_SPAN',
+                'INTERPOLATION',
+                'CLOSE_TAG_SPAN',
+                'START_BOLD_TEXT',
+                'CLOSE_BOLD_TEXT',
+              ]));
+    });
+
+    it('should extract translations with placeholders containing hyphens', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n><app-my-component></app-my-component> Welcome</div>
+       * ```
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="2877147807876214810" datatype="html">
+                <source><x id="START_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;app-my-component&gt;"/><x id="CLOSE_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;/app-my-component&gt;"/> Welcome</source>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">src/app/app.component.html</context>
+                  <context context-type="linenumber">1</context>
+                </context-group>
+                <target><x id="START_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;app-my-component&gt;"/><x id="CLOSE_TAG_APP-MY-COMPONENT" ctype="x-app-my-component" equiv-text="&lt;/app-my-component&gt;"/> Translate</target>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      const id =
+          ɵcomputeMsgId('{$START_TAG_APP_MY_COMPONENT}{$CLOSE_TAG_APP_MY_COMPONENT} Welcome');
+      expect(result.translations[id]).toEqual(ɵmakeParsedTranslation(['', '', ' Translate'], [
+        'START_TAG_APP_MY_COMPONENT', 'CLOSE_TAG_APP_MY_COMPONENT'
+      ]));
+    });
+
+    it('should extract translations with simple ICU expressions', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>{VAR_PLURAL, plural, =0 {<p>test</p>} }</div>
+       * ```
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="2874455947211586270" datatype="html">
+                <source>{VAR_PLURAL, plural, =0 {<x id="START_PARAGRAPH" ctype="x-p"/>test<x id="CLOSE_PARAGRAPH" ctype="x-p"/>} }</source>
+                <target>{VAR_PLURAL, plural, =0 {<x id="START_PARAGRAPH" ctype="x-p"/>TEST<x id="CLOSE_PARAGRAPH" ctype="x-p"/>} }</target>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+
+      expect(result.translations[ɵcomputeMsgId(
+                 '{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}test{CLOSE_PARAGRAPH}}}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}TEST{CLOSE_PARAGRAPH}}}'], []));
+    });
+
+    it('should extract translations with duplicate source messages', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>foo</div>
+       * <div i18n="m|d@@i">foo</div>
+       * <div i18=""m|d@@bar>foo</div>
+       * ```
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="9205907420411818817" datatype="html">
+                <source>foo</source>
+                <target>oof</target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">3</context>
+                </context-group>
+                <note priority="1" from="description">d</note>
+                <note priority="1" from="meaning">m</note>
+              </trans-unit>
+              <trans-unit id="i" datatype="html">
+                <source>foo</source>
+                <target>toto</target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">4</context>
+                </context-group>
+                <note priority="1" from="description">d</note>
+                <note priority="1" from="meaning">m</note>
+              </trans-unit>
+              <trans-unit id="bar" datatype="html">
+                <source>foo</source>
+                <target>tata</target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">5</context>
+                </context-group>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+
+      expect(result.translations[ɵcomputeMsgId('foo')]).toEqual(ɵmakeParsedTranslation(['oof']));
+      expect(result.translations['i']).toEqual(ɵmakeParsedTranslation(['toto']));
+      expect(result.translations['bar']).toEqual(ɵmakeParsedTranslation(['tata']));
+    });
+
+    it('should extract translations with only placeholders, which are re-ordered', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n><br><img/><img/></div>
+       * ```
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="7118057989405618448" datatype="html">
+              <ph id="1" equiv="TAG_IMG" type="image" disp="&lt;img/&gt;"/><ph id="2" equiv="TAG_IMG_1" type="image" disp="&lt;img/&gt;"/>
+                <source><x id="LINE_BREAK" ctype="lb"/><x id="TAG_IMG" ctype="image"/><x id="TAG_IMG_1" ctype="image"/></source>
+                <target><x id="TAG_IMG_1" ctype="image"/><x id="TAG_IMG" ctype="image"/><x id="LINE_BREAK" ctype="lb"/></target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">6</context>
+                </context-group>
+                <note priority="1" from="description">ph names</note>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+
+      expect(result.translations[ɵcomputeMsgId('{$LINE_BREAK}{$TAG_IMG}{$TAG_IMG_1}')])
+          .toEqual(
+              ɵmakeParsedTranslation(['', '', '', ''], ['TAG_IMG_1', 'TAG_IMG', 'LINE_BREAK']));
+    });
+
+    it('should extract translations with empty target', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>hello <span></span></div>
+       * ```
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="2826198357052921524" datatype="html">
+                <source>hello <x id="START_TAG_SPAN" ctype="x-span"/><x id="CLOSE_TAG_SPAN" ctype="x-span"/></source>
+                <target/>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">6</context>
+                </context-group>
+                <note priority="1" from="description">ph names</note>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+
+      expect(result.translations[ɵcomputeMsgId('hello {$START_TAG_SPAN}{$CLOSE_TAG_SPAN}')])
+          .toEqual(ɵmakeParsedTranslation(['']));
+    });
+
+    it('should extract translations with deeply nested ICUs', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * Test: { count, plural, =0 { { sex, select, other {<p>deeply nested</p>}} }
+       * =other {a lot}}
+       * ```
+       *
+       * Note that the message gets split into two translation units:
+       *  * The first one contains the outer message with an `ICU` placeholder
+       *  * The second one is the ICU expansion itself
+       *
+       * Note that special markers `VAR_PLURAL` and `VAR_SELECT` are added, which are then
+       * replaced by IVY at runtime with the actual values being rendered by the ICU
+       * expansion.
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="980940425376233536" datatype="html">
+                <source>Test: <x id="ICU" equiv-text="{ count, plural, =0 {...} =other {...}}"/></source>
+                <target>Le test: <x id="ICU" equiv-text="{ count, plural, =0 {...} =other {...}}"/></target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">11</context>
+                </context-group>
+              </trans-unit>
+              <trans-unit id="5207293143089349404" datatype="html">
+                <source>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<x id="START_PARAGRAPH" ctype="x-p"/>deeply nested<x id="CLOSE_PARAGRAPH" ctype="x-p"/>}}} =other {a lot}}</source>
+                <target>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<x id="START_PARAGRAPH" ctype="x-p"/>profondément imbriqué<x id="CLOSE_PARAGRAPH" ctype="x-p"/>}}} =other {beaucoup}}</target>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+
+      expect(result.translations[ɵcomputeMsgId('Test: {$ICU}')])
+          .toEqual(ɵmakeParsedTranslation(['Le test: ', ''], ['ICU']));
+
+      expect(
+          result.translations[ɵcomputeMsgId(
+              '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}deeply nested{CLOSE_PARAGRAPH}}}} =other {beaucoup}}')])
+          .toEqual(ɵmakeParsedTranslation([
+            '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}profondément imbriqué{CLOSE_PARAGRAPH}}}} =other {beaucoup}}'
+          ]));
+    });
+
+    it('should extract translations containing multiple lines', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>multi
+       * lines</div>
+       * ```
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="2340165783990709777" datatype="html">
+                <source>multi\nlines</source>
+                <target>multi\nlignes</target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">12</context>
+                </context-group>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+
+      expect(result.translations[ɵcomputeMsgId('multi\nlines')])
+          .toEqual(ɵmakeParsedTranslation(['multi\nlignes']));
+    });
+
+    it('should extract translations with <mrk> elements', () => {
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit id="mrk-test">
+                <source>First sentence.</source>
+                <seg-source>
+                  <invalid-tag>Should not be parsed</invalid-tag>
+                </seg-source>
+                <target>Translated <mrk mtype="seg" mid="1">first sentence</mrk>.</target>
+              </trans-unit>
+              <trans-unit id="mrk-test2">
+                <source>First sentence. Second sentence.</source>
+                <seg-source>
+                  <invalid-tag>Should not be parsed</invalid-tag>
+                </seg-source>
+                <target>Translated <mrk mtype="seg" mid="1"><mrk mtype="seg" mid="2">first</mrk> sentence</mrk>.</target>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+
+      expect(result.translations['mrk-test'])
+          .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
+
+      expect(result.translations['mrk-test2'])
+          .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
+    });
+
+    it('should ignore alt-trans targets', () => {
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">
+            <body>
+              <trans-unit datatype="html" approved="no" id="registration.submit">
+                <source>Continue</source>
+                <target state="translated" xml:lang="de">Weiter</target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">src/app/auth/registration-form/registration-form.component.html</context>
+                  <context context-type="linenumber">69</context>
+                </context-group>
+                <?sid 1110954287-0?>
+                <alt-trans origin="autoFuzzy" tool="Swordfish" match-quality="71" ts="63">
+                  <source xml:lang="en">Content</source>
+                  <target state="translated" xml:lang="de">Content</target>
+                </alt-trans>
+            </trans-unit>
+            </body>
+          </file>
+        </xliff>
+     `;
+
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations['registration.submit'])
+          .toEqual(ɵmakeParsedTranslation(['Weiter']));
+    });
+
+    it('should merge messages from each `<file>` element', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>translatable attribute</div>
+       * ```
+
+       * ```
+       * <div i18n>translatable element <b>with placeholders</b> {{ interpolation}}</div>
+       * ```
+       */
+      const XLIFF = `
+        <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+          <file source-language="en" target-language="fr" datatype="plaintext" original="file-1">
+            <body>
+              <trans-unit id="1933478729560469763" datatype="html">
+                <source>translatable attribute</source>
+                <target>etubirtta elbatalsnart</target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">1</context>
+                </context-group>
+              </trans-unit>
+            </body>
+          </file>
+          <file source-language="en" target-language="fr" datatype="plaintext" original="file-2">
+            <body>
+              <trans-unit id="5057824347511785081" datatype="html">
+                <source>translatable element <x id="START_BOLD_TEXT" ctype="b"/>with placeholders<x id="CLOSE_BOLD_TEXT" ctype="b"/> <x id="INTERPOLATION"/></source>
+                <target><x id="INTERPOLATION"/> tnemele elbatalsnart <x id="START_BOLD_TEXT" ctype="x-b"/>sredlohecalp htiw<x id="CLOSE_BOLD_TEXT" ctype="x-b"/></target>
+                <context-group purpose="location">
+                  <context context-type="sourcefile">file.ts</context>
+                  <context context-type="linenumber">2</context>
+                </context-group>
+              </trans-unit>
+            </body>
+          </file>
+        </xliff>
+      `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId('translatable attribute')])
+          .toEqual(ɵmakeParsedTranslation(['etubirtta elbatalsnart']));
+      expect(
+          result.translations[ɵcomputeMsgId(
+              'translatable element {$START_BOLD_TEXT}with placeholders{$LOSE_BOLD_TEXT} {$INTERPOLATION}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['', ' tnemele elbatalsnart ', 'sredlohecalp htiw', ''],
+              ['INTERPOLATION', 'START_BOLD_TEXT', 'CLOSE_BOLD_TEXT']));
+    });
+
+    describe('[structure errors]', () => {
+      it('should warn when a trans-unit has no translation target but does have a source', () => {
+        const XLIFF = [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
+          `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
+          `    <body>`,
+          `      <trans-unit id="missingtarget">`,
+          `        <source/>`,
+          `      </trans-unit>`,
+          `    </body>`,
+          `  </file>`,
+          `</xliff>`,
+        ].join('\n');
+        const result = doParse('/some/file.xlf', XLIFF);
+        expect(result.diagnostics.messages.length).toEqual(1);
+        expect(result.diagnostics.messages[0].message).toEqual([
+          `Missing <target> element ("e-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
+          `    <body>`,
+          `      [WARNING ->]<trans-unit id="missingtarget">`,
+          `        <source/>`,
+          `      </trans-unit>`,
+          `"): /some/file.xlf@4:6`,
+        ].join('\n'));
+      });
+
+      it('should fail when a trans-unit has no translation target nor source', () => {
+        const XLIFF = [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
+          `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
+          `    <body>`,
+          `      <trans-unit id="missingtarget">`,
+          `      </trans-unit>`,
+          `    </body>`,
+          `  </file>`,
+          `</xliff>`,
+        ].join('\n');
+
+        expectToFail(
+            '/some/file.xlf', XLIFF,
+            /Missing required element: one of <target> or <source> is required/, [
+              `Missing required element: one of <target> or <source> is required ("e-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
+              `    <body>`,
+              `      [ERROR ->]<trans-unit id="missingtarget">`,
+              `      </trans-unit>`,
+              `    </body>`,
+              `"): /some/file.xlf@4:6`,
+            ].join('\n'));
+      });
+
+      it('should fail when a trans-unit has no id attribute', () => {
+        const XLIFF = [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
+          `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
+          `    <body>`,
+          `      <trans-unit datatype="html">`,
+          `        <source/>`,
+          `        <target/>`,
+          `      </trans-unit>`,
+          `    </body>`,
+          `  </file>`,
+          `</xliff>`,
+        ].join('\n');
+
+        expectToFail('/some/file.xlf', XLIFF, /Missing required "id" attribute/, [
+          `Missing required "id" attribute on <trans-unit> element. ("e-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
+          `    <body>`,
+          `      [ERROR ->]<trans-unit datatype="html">`,
+          `        <source/>`,
+          `        <target/>`,
+          `"): /some/file.xlf@4:6`,
+        ].join('\n'));
+      });
+
+      it('should fail on duplicate trans-unit id', () => {
+        const XLIFF = [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
+          `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
+          `    <body>`,
+          `      <trans-unit id="deadbeef">`,
+          `        <source/>`,
+          `        <target/>`,
+          `      </trans-unit>`,
+          `      <trans-unit id="deadbeef">`,
+          `        <source/>`,
+          `        <target/>`,
+          `      </trans-unit>`,
+          `    </body>`,
+          `  </file>`,
+          `</xliff>`,
+        ].join('\n');
+
+        expectToFail('/some/file.xlf', XLIFF, /Duplicated translations for message "deadbeef"/, [
+          `Duplicated translations for message "deadbeef" ("`,
+          `        <target/>`,
+          `      </trans-unit>`,
+          `      [ERROR ->]<trans-unit id="deadbeef">`,
+          `        <source/>`,
+          `        <target/>`,
+          `"): /some/file.xlf@8:6`,
+        ].join('\n'));
+      });
+    });
+
+    describe('[message errors]', () => {
+      it('should fail on unknown message tags', () => {
+        const XLIFF = [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
+          `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
+          `    <body>`,
+          `      <trans-unit id="deadbeef" datatype="html">`,
+          `        <source/>`,
+          `        <target><b>msg should contain only ph tags</b></target>`,
+          `      </trans-unit>`,
+          `    </body>`,
+          `  </file>`,
+          `</xliff>`,
+        ].join('\n');
+
+        expectToFail('/some/file.xlf', XLIFF, /Invalid element found in message/, [
+          `Error: Invalid element found in message.`,
+          `At /some/file.xlf@6:16:`,
+          `...`,
+          `        <source/>`,
+          `        <target>[ERROR ->]<b>msg should contain only ph tags</b></target>`,
+          `      </trans-unit>`,
+          `...`,
+          ``,
+        ].join('\n'));
+      });
+
+      it('should fail when a placeholder misses an id attribute', () => {
+        const XLIFF = [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">`,
+          `  <file source-language="en" target-language="fr" datatype="plaintext" original="ng2.template">`,
+          `    <body>`,
+          `      <trans-unit id="deadbeef" datatype="html">`,
+          `        <source/>`,
+          `        <target><x/></target>`,
+          `      </trans-unit>`,
+          `    </body>`,
+          `  </file>`,
+          `</xliff>`,
+        ].join('\n');
+
+        expectToFail('/some/file.xlf', XLIFF, /required "id" attribute/gi, [
+          `Error: Missing required "id" attribute:`,
+          `At /some/file.xlf@6:16:`,
+          `...`,
+          `        <source/>`,
+          `        <target>[ERROR ->]<x/></target>`,
+          `      </trans-unit>`,
+          `...`,
+          ``,
+        ].join('\n'));
+      });
+    });
+  });
+});

--- a/packages/localize/tools/test/translate/translation_files/translation_parsers/xliff2_translation_parser_spec.ts
+++ b/packages/localize/tools/test/translate/translation_files/translation_parsers/xliff2_translation_parser_spec.ts
@@ -6,28 +6,33 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵcomputeMsgId, ɵmakeParsedTranslation} from '@angular/localize';
+
 import {ParseAnalysis, ParsedTranslationBundle} from '../../../../src/translate/translation_files/translation_parsers/translation_parser';
 import {Xliff2TranslationParser} from '../../../../src/translate/translation_files/translation_parsers/xliff2_translation_parser';
 
 describe('Xliff2TranslationParser', () => {
-  describe('canParse()', () => {
+  describe('analyze()', () => {
     it('should return true if the file contains an <xliff> element with version="2.0" attribute',
        () => {
          const parser = new Xliff2TranslationParser();
-         expect(parser.canParse(
-                    '/some/file.xlf',
-                    '<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0">'))
-             .toBeTruthy();
-         expect(parser.canParse(
-                    '/some/file.json',
-                    '<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0">'))
-             .toBeTruthy();
-         expect(parser.canParse('/some/file.xliff', '<xliff version="2.0">')).toBeTruthy();
-         expect(parser.canParse('/some/file.json', '<xliff version="2.0">')).toBeTruthy();
-         expect(parser.canParse('/some/file.xlf', '<xliff>')).toBe(false);
-         expect(parser.canParse('/some/file.xlf', '<xliff version="1.2">')).toBe(false);
-         expect(parser.canParse('/some/file.xlf', '')).toBe(false);
-         expect(parser.canParse('/some/file.json', '')).toBe(false);
+         expect(parser
+                    .analyze(
+                        '/some/file.xlf',
+                        '<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0">')
+                    .canParse)
+             .toBeTrue();
+         expect(parser
+                    .analyze(
+                        '/some/file.json',
+                        '<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0">')
+                    .canParse)
+             .toBeTrue();
+         expect(parser.analyze('/some/file.xliff', '<xliff version="2.0">').canParse).toBeTrue();
+         expect(parser.analyze('/some/file.json', '<xliff version="2.0">').canParse).toBeTrue();
+         expect(parser.analyze('/some/file.xlf', '<xliff>').canParse).toBeFalse();
+         expect(parser.analyze('/some/file.xlf', '<xliff version="1.2">').canParse).toBeFalse();
+         expect(parser.analyze('/some/file.xlf', '').canParse).toBeFalse();
+         expect(parser.analyze('/some/file.json', '').canParse).toBeFalse();
        });
   });
 
@@ -89,631 +94,617 @@ describe('Xliff2TranslationParser', () => {
     });
   });
 
-  for (const withHint of [true, false]) {
-    describe(
-        `parse() [${withHint ? 'with' : 'without'} hint]`, () => {
-          const doParse: (fileName: string, XLIFF: string) => ParsedTranslationBundle =
-              withHint ? (fileName, XLIFF) => {
-                const parser = new Xliff2TranslationParser();
-                const hint = parser.canParse(fileName, XLIFF);
-                if (!hint) {
-                  throw new Error('expected XLIFF to be valid');
-                }
-                return parser.parse(fileName, XLIFF, hint);
-              } : (fileName, XLIFF) => {
-                const parser = new Xliff2TranslationParser();
-                return parser.parse(fileName, XLIFF);
-              };
+  describe(`parse()`, () => {
+    const doParse: (fileName: string, XLIFF: string) => ParsedTranslationBundle =
+        (fileName, XLIFF) => {
+          const parser = new Xliff2TranslationParser();
+          const analysis = parser.analyze(fileName, XLIFF);
+          if (!analysis.canParse) {
+            throw new Error('expected XLIFF to be valid');
+          }
+          return parser.parse(fileName, XLIFF, analysis.hint);
+        };
 
-          const expectToFail:
-              (fileName: string, XLIFF: string, errorMatcher: RegExp, diagnosticMessage: string) =>
-                  void = withHint ? (fileName, XLIFF, _errorMatcher, diagnosticMessage) => {
-                    const result = doParse(fileName, XLIFF);
-                    expect(result.diagnostics.messages.length).toBeGreaterThan(0);
-                    expect(result.diagnostics.messages.pop()!.message).toEqual(diagnosticMessage);
-                  } : (fileName, XLIFF, errorMatcher, _diagnosticMessage) => {
-                    expect(() => doParse(fileName, XLIFF)).toThrowError(errorMatcher);
-                  };
+    const expectToFail:
+        (fileName: string, XLIFF: string, errorMatcher: RegExp, diagnosticMessage: string) => void =
+            (fileName, XLIFF, _errorMatcher, diagnosticMessage) => {
+              const result = doParse(fileName, XLIFF);
+              expect(result.diagnostics.messages.length).toBeGreaterThan(0);
+              expect(result.diagnostics.messages.pop()!.message).toEqual(diagnosticMessage);
+            };
 
-          it('should extract the locale from the file contents', () => {
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.locale).toEqual('fr');
-          });
+    it('should extract the locale from the file contents', () => {
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="ngi18n">
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.locale).toEqual('fr');
+    });
 
-          it('should return undefined locale if there is no locale in the file', () => {
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.locale).toBeUndefined();
-          });
+    it('should return undefined locale if there is no locale in the file', () => {
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en">
+                  <file original="ng.template" id="ngi18n">
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.locale).toBeUndefined();
+    });
 
-          it('should extract basic messages', () => {
-            /**
-             * Source HTML:
-             *
-             * ```
-             * <div i18n>translatable attribute</div>
-             * ```
-             */
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `    <unit id="1933478729560469763">`,
-              `      <notes>`,
-              `        <note category="location">file.ts:2</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>translatable attribute</source>`,
-              `        <target>etubirtta elbatalsnart</target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.translations[ɵcomputeMsgId('translatable attribute', '')])
-                .toEqual(ɵmakeParsedTranslation(['etubirtta elbatalsnart']));
-          });
+    it('should extract basic messages', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>translatable attribute</div>
+       * ```
+       */
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="ngi18n">
+                    <unit id="1933478729560469763">
+                      <notes>
+                        <note category="location">file.ts:2</note>
+                      </notes>
+                      <segment>
+                        <source>translatable attribute</source>
+                        <target>etubirtta elbatalsnart</target>
+                      </segment>
+                    </unit>
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId('translatable attribute', '')])
+          .toEqual(ɵmakeParsedTranslation(['etubirtta elbatalsnart']));
+    });
 
-          it('should extract translations with simple placeholders', () => {
-            /**
-             * Source HTML:
-             *
-             * ```
-             * <div i18n>translatable element <b>with placeholders</b> {{ interpolation}}</div>
-             * ```
-             */
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `    <unit id="6949438802869886378">`,
-              `      <notes>`,
-              `        <note category="location">file.ts:3</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>translatable element <pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">with placeholders</pc> <ph id="1" equiv="INTERPOLATION" disp="{{ interpolation}}"/></source>`,
-              `        <target><ph id="1" equiv="INTERPOLATION" disp="{{ interpolation}}"/> tnemele elbatalsnart <pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">sredlohecalp htiw</pc></target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(
-                result.translations[ɵcomputeMsgId(
-                    'translatable element {$START_BOLD_TEXT}with placeholders{$CLOSE_BOLD_TEXT} {$INTERPOLATION}')])
-                .toEqual(ɵmakeParsedTranslation(
-                    ['', ' tnemele elbatalsnart ', 'sredlohecalp htiw', ''],
-                    ['INTERPOLATION', 'START_BOLD_TEXT', 'CLOSE_BOLD_TEXT']));
-          });
+    it('should extract translations with simple placeholders', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>translatable element <b>with placeholders</b> {{ interpolation}}</div>
+       * ```
+       */
+      const XLIFF = [
+        `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
+        `  <file original="ng.template" id="ngi18n">`,
+        `    <unit id="6949438802869886378">`,
+        `      <notes>`,
+        `        <note category="location">file.ts:3</note>`,
+        `      </notes>`,
+        `      <segment>`,
+        `        <source>translatable element <pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">with placeholders</pc> <ph id="1" equiv="INTERPOLATION" disp="{{ interpolation}}"/></source>`,
+        `        <target><ph id="1" equiv="INTERPOLATION" disp="{{ interpolation}}"/> tnemele elbatalsnart <pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">sredlohecalp htiw</pc></target>`,
+        `      </segment>`,
+        `    </unit>`,
+        `  </file>`,
+        `</xliff>`,
+      ].join('\n');
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(
+          result.translations[ɵcomputeMsgId(
+              'translatable element {$START_BOLD_TEXT}with placeholders{$CLOSE_BOLD_TEXT} {$INTERPOLATION}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['', ' tnemele elbatalsnart ', 'sredlohecalp htiw', ''],
+              ['INTERPOLATION', 'START_BOLD_TEXT', 'CLOSE_BOLD_TEXT']));
+    });
 
-          it('should extract nested placeholder containers (i.e. nested HTML elements)', () => {
-            /**
-             * Source HTML:
-             *
-             * ```
-             * <div i18n>
-             *   translatable <span>element <b>with placeholders</b></span> {{ interpolation}}
-             * </div>
-             * ```
-             */
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `    <unit id="9051630253697141670">`,
-              `      <notes>`,
-              `        <note category="location">file.ts:3</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>translatable <pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other"` +
-                  ` dispStart="&lt;span&gt;" dispEnd="&lt;/span&gt;">element <pc id="1" equivStart="START_BOLD_TEXT" equivEnd=` +
-                  `"CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">with placeholders</pc></pc>` +
-                  ` <ph id="2" equiv="INTERPOLATION" disp="{{ interpolation}}"/></source>`,
-              `        <target><pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="fmt" dispStart="&lt;` +
-                  `span&gt;" dispEnd="&lt;/span&gt;"><ph id="2" equiv="INTERPOLATION" disp="{{ interpolation}}"/> tnemele</pc>` +
-                  ` elbatalsnart <pc id="1" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart=` +
-                  `"&lt;b&gt;" dispEnd="&lt;/b&gt;">sredlohecalp htiw</pc></target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.translations[ɵcomputeMsgId(
-                       'translatable {$START_TAG_SPAN}element {$START_BOLD_TEXT}with placeholders' +
-                       '{$CLOSE_BOLD_TEXT}{$CLOSE_TAG_SPAN} {$INTERPOLATION}')])
-                .toEqual(ɵmakeParsedTranslation(
-                    ['', '', ' tnemele', ' elbatalsnart ', 'sredlohecalp htiw', ''], [
-                      'START_TAG_SPAN',
-                      'INTERPOLATION',
-                      'CLOSE_TAG_SPAN',
-                      'START_BOLD_TEXT',
-                      'CLOSE_BOLD_TEXT',
-                    ]));
-          });
+    it('should extract nested placeholder containers (i.e. nested HTML elements)', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>
+       *   translatable <span>element <b>with placeholders</b></span> {{ interpolation}}
+       * </div>
+       * ```
+       */
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="ngi18n">
+                    <unit id="9051630253697141670">
+                      <notes>
+                        <note category="location">file.ts:3</note>
+                      </notes>
+                      <segment>
+                        <source>translatable <pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other" dispStart="&lt;span&gt;"
+                        dispEnd="&lt;/span&gt;">element <pc id="1" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;"
+                         dispEnd="&lt;/b&gt;">with placeholders</pc></pc>
+                          <ph id="2" equiv="INTERPOLATION" disp="{{ interpolation}}"/></source><target><pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="fmt" dispStart="&lt;span&gt;" dispEnd="&lt;/span&gt;"><ph id="2" equiv="INTERPOLATION" disp="{{ interpolation}}"/> tnemele</pc> elbatalsnart <pc id="1" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">sredlohecalp htiw</pc></target>
+                      </segment>
+                    </unit>
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId(
+                 'translatable {$START_TAG_SPAN}element {$START_BOLD_TEXT}with placeholders' +
+                 '{$CLOSE_BOLD_TEXT}{$CLOSE_TAG_SPAN} {$INTERPOLATION}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['', '', ' tnemele', ' elbatalsnart ', 'sredlohecalp htiw', ''], [
+                'START_TAG_SPAN',
+                'INTERPOLATION',
+                'CLOSE_TAG_SPAN',
+                'START_BOLD_TEXT',
+                'CLOSE_BOLD_TEXT',
+              ]));
+    });
 
-          it('should extract translations with simple ICU expressions', () => {
-            /**
-             * Source HTML:
-             *
-             * ```
-             * <div i18n>{VAR_PLURAL, plural, =0 {<p>test</p>} }</div>
-             * ```
-             */
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `    <unit id="2874455947211586270">`,
-              `      <notes>`,
-              `        <note category="location">file.ts:4</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>{VAR_PLURAL, plural, =0 {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">test</pc>} }</source>`,
-              `        <target>{VAR_PLURAL, plural, =0 {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">TEST</pc>} }</target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.translations[ɵcomputeMsgId(
-                       '{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}test{CLOSE_PARAGRAPH}}}')])
-                .toEqual(ɵmakeParsedTranslation(
-                    ['{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}TEST{CLOSE_PARAGRAPH}}}'], []));
-          });
+    it('should extract translations with simple ICU expressions', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>{VAR_PLURAL, plural, =0 {<p>test</p>} }</div>
+       * ```
+       */
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="ngi18n">
+                    <unit id="2874455947211586270">
+                      <notes>
+                        <note category="location">file.ts:4</note>
+                      </notes>
+                      <segment>
+                        <source>{VAR_PLURAL, plural, =0 {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">test</pc>} }</source>
+                        <target>{VAR_PLURAL, plural, =0 {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">TEST</pc>} }</target>
+                      </segment>
+                    </unit>
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId(
+                 '{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}test{CLOSE_PARAGRAPH}}}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['{VAR_PLURAL, plural, =0 {{START_PARAGRAPH}TEST{CLOSE_PARAGRAPH}}}'], []));
+    });
 
-          it('should extract translations with duplicate source messages', () => {
-            /**
-             * Source HTML:
-             *
-             * ```
-             * <div i18n>foo</div>
-             * <div i18n="m|d@@i">foo</div>
-             * <div i18=""m|d@@bar>foo</div>
-             * ```
-             */
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `    <unit id="9205907420411818817">`,
-              `      <notes>`,
-              `        <note category="description">d</note>`,
-              `        <note category="meaning">m</note>`,
-              `        <note category="location">file.ts:5</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>foo</source>`,
-              `        <target>oof</target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `    <unit id="i">`,
-              `      <notes>`,
-              `        <note category="description">d</note>`,
-              `        <note category="meaning">m</note>`,
-              `        <note category="location">file.ts:5</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>foo</source>`,
-              `        <target>toto</target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `    <unit id="bar">`,
-              `      <notes>`,
-              `        <note category="description">d</note>`,
-              `        <note category="meaning">m</note>`,
-              `        <note category="location">file.ts:5</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>foo</source>`,
-              `        <target>tata</target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.translations[ɵcomputeMsgId('foo')])
-                .toEqual(ɵmakeParsedTranslation(['oof']));
-            expect(result.translations['i']).toEqual(ɵmakeParsedTranslation(['toto']));
-            expect(result.translations['bar']).toEqual(ɵmakeParsedTranslation(['tata']));
-          });
+    it('should extract translations with duplicate source messages', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>foo</div>
+       * <div i18n="m|d@@i">foo</div>
+       * <div i18=""m|d@@bar>foo</div>
+       * ```
+       */
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="ngi18n">
+                    <unit id="9205907420411818817">
+                      <notes>
+                        <note category="description">d</note>
+                        <note category="meaning">m</note>
+                        <note category="location">file.ts:5</note>
+                      </notes>
+                      <segment>
+                        <source>foo</source>
+                        <target>oof</target>
+                      </segment>
+                    </unit>
+                    <unit id="i">
+                      <notes>
+                        <note category="description">d</note>
+                        <note category="meaning">m</note>
+                        <note category="location">file.ts:5</note>
+                      </notes>
+                      <segment>
+                        <source>foo</source>
+                        <target>toto</target>
+                      </segment>
+                    </unit>
+                    <unit id="bar">
+                      <notes>
+                        <note category="description">d</note>
+                        <note category="meaning">m</note>
+                        <note category="location">file.ts:5</note>
+                      </notes>
+                      <segment>
+                        <source>foo</source>
+                        <target>tata</target>
+                      </segment>
+                    </unit>
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId('foo')]).toEqual(ɵmakeParsedTranslation(['oof']));
+      expect(result.translations['i']).toEqual(ɵmakeParsedTranslation(['toto']));
+      expect(result.translations['bar']).toEqual(ɵmakeParsedTranslation(['tata']));
+    });
 
-          it('should extract translations with only placeholders, which are re-ordered', () => {
-            /**
-             * Source HTML:
-             *
-             * ```
-             * <div i18n><br><img/><img/></div>
-             * ```
-             */
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `    <unit id="7118057989405618448">`,
-              `      <notes>`,
-              `        <note category="description">ph names</note>`,
-              `        <note category="location">file.ts:7</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source><ph id="0" equiv="LINE_BREAK" type="fmt" disp="&lt;br/&gt;"/><ph id="1" equiv="TAG_IMG" type="image" disp="&lt;img/&gt;"/><ph id="2" equiv="TAG_IMG_1" type="image" disp="&lt;img/&gt;"/></source>`,
-              `        <target><ph id="2" equiv="TAG_IMG_1" type="image" disp="&lt;img/&gt;"/><ph id="1" equiv="TAG_IMG" type="image" disp="&lt;img/&gt;"/><ph id="0" equiv="LINE_BREAK" type="fmt" disp="&lt;br/&gt;"/></target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.translations[ɵcomputeMsgId('{$LINE_BREAK}{$TAG_IMG}{$TAG_IMG_1}')])
-                .toEqual(ɵmakeParsedTranslation(
-                    ['', '', '', ''], ['TAG_IMG_1', 'TAG_IMG', 'LINE_BREAK']));
-          });
+    it('should extract translations with only placeholders, which are re-ordered', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n><br><img/><img/></div>
+       * ```
+       */
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="ngi18n">
+                    <unit id="7118057989405618448">
+                      <notes>
+                        <note category="description">ph names</note>
+                        <note category="location">file.ts:7</note>
+                      </notes>
+                      <segment>
+                        <source><ph id="0" equiv="LINE_BREAK" type="fmt" disp="&lt;br/&gt;"/><ph id="1" equiv="TAG_IMG" type="image" disp="&lt;img/&gt;"/><ph id="2" equiv="TAG_IMG_1" type="image" disp="&lt;img/&gt;"/></source>
+                        <target><ph id="2" equiv="TAG_IMG_1" type="image" disp="&lt;img/&gt;"/><ph id="1" equiv="TAG_IMG" type="image" disp="&lt;img/&gt;"/><ph id="0" equiv="LINE_BREAK" type="fmt" disp="&lt;br/&gt;"/></target>
+                      </segment>
+                    </unit>
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId('{$LINE_BREAK}{$TAG_IMG}{$TAG_IMG_1}')])
+          .toEqual(
+              ɵmakeParsedTranslation(['', '', '', ''], ['TAG_IMG_1', 'TAG_IMG', 'LINE_BREAK']));
+    });
 
-          it('should extract translations with empty target', () => {
-            /**
-             * Source HTML:
-             *
-             * ```
-             * <div i18n>hello <span></span></div>
-             * ```
-             */
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `    <unit id="2826198357052921524">`,
-              `      <notes>`,
-              `        <note category="description">empty element</note>`,
-              `        <note category="location">file.ts:8</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>hello <pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other" dispStart="&lt;span&gt;" dispEnd="&lt;/span&gt;"></pc></source>`,
-              `        <target></target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.translations[ɵcomputeMsgId('hello {$START_TAG_SPAN}{$CLOSE_TAG_SPAN}')])
-                .toEqual(ɵmakeParsedTranslation(['']));
-          });
+    it('should extract translations with empty target', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>hello <span></span></div>
+       * ```
+       */
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="ngi18n">
+                    <unit id="2826198357052921524">
+                      <notes>
+                        <note category="description">empty element</note>
+                        <note category="location">file.ts:8</note>
+                      </notes>
+                      <segment>
+                        <source>hello <pc id="0" equivStart="START_TAG_SPAN" equivEnd="CLOSE_TAG_SPAN" type="other" dispStart="&lt;span&gt;" dispEnd="&lt;/span&gt;"></pc></source>
+                        <target></target>
+                      </segment>
+                    </unit>
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId('hello {$START_TAG_SPAN}{$CLOSE_TAG_SPAN}')])
+          .toEqual(ɵmakeParsedTranslation(['']));
+    });
 
-          it('should extract translations with deeply nested ICUs', () => {
-            /**
-             * Source HTML:
-             *
-             * ```
-             * Test: { count, plural, =0 { { sex, select, other {<p>deeply nested</p>}} }
-             * =other {a lot}}
-             * ```
-             *
-             * Note that the message gets split into two translation units:
-             *  * The first one contains the outer message with an `ICU` placeholder
-             *  * The second one is the ICU expansion itself
-             *
-             * Note that special markers `VAR_PLURAL` and `VAR_SELECT` are added, which are then
-             * replaced by IVY at runtime with the actual values being rendered by the ICU
-             * expansion.
-             */
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `    <unit id="980940425376233536">`,
-              `      <notes>`,
-              `        <note category="location">file.ts:10</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>Test: <ph id="0" equiv="ICU" disp="{ count, plural, =0 {...} =other {...}}"/></source>`,
-              `        <target>Le test: <ph id="0" equiv="ICU" disp="{ count, plural, =0 {...} =other {...}}"/></target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `    <unit id="5207293143089349404">`,
-              `      <notes>`,
-              `        <note category="location">file.ts:10</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">deeply nested</pc>}}} =other {a lot}}</source>`,
-              `        <target>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">profondément imbriqué</pc>}}} =other {beaucoup}}</target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.translations[ɵcomputeMsgId('Test: {$ICU}')])
-                .toEqual(ɵmakeParsedTranslation(['Le test: ', ''], ['ICU']));
-            expect(
-                result.translations[ɵcomputeMsgId(
-                    '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}deeply nested{CLOSE_PARAGRAPH}}}} =other {beaucoup}}')])
-                .toEqual(ɵmakeParsedTranslation([
-                  '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}profondément imbriqué{CLOSE_PARAGRAPH}}}} =other {beaucoup}}'
-                ]));
-          });
+    it('should extract translations with deeply nested ICUs', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * Test: { count, plural, =0 { { sex, select, other {<p>deeply nested</p>}} }
+       * =other {a lot}}
+       * ```
+       *
+       * Note that the message gets split into two translation units:
+       *  * The first one contains the outer message with an `ICU` placeholder
+       *  * The second one is the ICU expansion itself
+       *
+       * Note that special markers `VAR_PLURAL` and `VAR_SELECT` are added, which are then
+       * replaced by IVY at runtime with the actual values being rendered by the ICU
+       * expansion.
+       */
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="ngi18n">
+                    <unit id="980940425376233536">
+                      <notes>
+                        <note category="location">file.ts:10</note>
+                      </notes>
+                      <segment>
+                        <source>Test: <ph id="0" equiv="ICU" disp="{ count, plural, =0 {...} =other {...}}"/></source>
+                        <target>Le test: <ph id="0" equiv="ICU" disp="{ count, plural, =0 {...} =other {...}}"/></target>
+                      </segment>
+                    </unit>
+                    <unit id="5207293143089349404">
+                      <notes>
+                        <note category="location">file.ts:10</note>
+                      </notes>
+                      <segment>
+                        <source>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">deeply nested</pc>}}} =other {a lot}}</source>
+                        <target>{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<pc id="0" equivStart="START_PARAGRAPH" equivEnd="CLOSE_PARAGRAPH" type="other" dispStart="&lt;p&gt;" dispEnd="&lt;/p&gt;">profondément imbriqué</pc>}}} =other {beaucoup}}</target>
+                      </segment>
+                    </unit>
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId('Test: {$ICU}')])
+          .toEqual(ɵmakeParsedTranslation(['Le test: ', ''], ['ICU']));
+      expect(
+          result.translations[ɵcomputeMsgId(
+              '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}deeply nested{CLOSE_PARAGRAPH}}}} =other {beaucoup}}')])
+          .toEqual(ɵmakeParsedTranslation([
+            '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}profondément imbriqué{CLOSE_PARAGRAPH}}}} =other {beaucoup}}'
+          ]));
+    });
 
-          it('should extract translations containing multiple lines', () => {
-            /**
-             * Source HTML:
-             *
-             * ```
-             * <div i18n>multi
-             * lines</div>
-             * ```
-             */
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `    <unit id="2340165783990709777">`,
-              `      <notes>`,
-              `        <note category="location">file.ts:11,12</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>multi\nlines</source>`,
-              `        <target>multi\nlignes</target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.translations[ɵcomputeMsgId('multi\nlines')])
-                .toEqual(ɵmakeParsedTranslation(['multi\nlignes']));
-          });
+    it('should extract translations containing multiple lines', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>multi
+       * lines</div>
+       * ```
+       */
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="ngi18n">
+                    <unit id="2340165783990709777">
+                      <notes>
+                        <note category="location">file.ts:11,12</note>
+                      </notes>
+                      <segment>
+                        <source>multi\nlines</source>
+                        <target>multi\nlignes</target>
+                      </segment>
+                    </unit>
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId('multi\nlines')])
+          .toEqual(ɵmakeParsedTranslation(['multi\nlignes']));
+    });
 
-          it('should extract translations with <mrk> elements', () => {
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="ngi18n">`,
-              `    <unit id="mrk-test">`,
-              `      <segment>`,
-              `        <source>First sentence.</source>`,
-              `        <target>Translated <mrk id="m1" type="comment" ref="#n1">first sentence</mrk>.</target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `    <unit id="mrk-test2">`,
-              `      <segment>`,
-              `        <source>First sentence. Second sentence.</source>`,
-              `        <target>Translated <mrk id="m1" type="comment" ref="#n1"><mrk id="m2" type="comment" ref="#n1">first</mrk> sentence</mrk>.</target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.translations['mrk-test'])
-                .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
-            expect(result.translations['mrk-test2'])
-                .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
-          });
+    it('should extract translations with <mrk> elements', () => {
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="ngi18n">
+                    <unit id="mrk-test">
+                      <segment>
+                        <source>First sentence.</source>
+                        <target>Translated <mrk id="m1" type="comment" ref="#n1">first sentence</mrk>.</target>
+                      </segment>
+                    </unit>
+                    <unit id="mrk-test2">
+                      <segment>
+                        <source>First sentence. Second sentence.</source>
+                        <target>Translated <mrk id="m1" type="comment" ref="#n1"><mrk id="m2" type="comment" ref="#n1">first</mrk> sentence</mrk>.</target>
+                      </segment>
+                    </unit>
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations['mrk-test'])
+          .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
+      expect(result.translations['mrk-test2'])
+          .toEqual(ɵmakeParsedTranslation(['Translated first sentence.']));
+    });
 
-          it('should merge messages from each `<file>` element', () => {
-            /**
-             * Source HTML:
-             *
-             * ```
-             * <div i18n>translatable attribute</div>
-             * ```
-             *
-             * ```
-             * <div i18n>translatable element <b>with placeholders</b> {{ interpolation}}</div>
-             * ```
-             */
-            const XLIFF = [
-              `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-              `  <file original="ng.template" id="file-1">`,
-              `    <unit id="1933478729560469763">`,
-              `      <notes>`,
-              `        <note category="location">file.ts:2</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>translatable attribute</source>`,
-              `        <target>etubirtta elbatalsnart</target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `  <file original="ng.template" id="file-2">`,
-              `    <unit id="5057824347511785081">`,
-              `      <notes>`,
-              `        <note category="location">file.ts:3</note>`,
-              `      </notes>`,
-              `      <segment>`,
-              `        <source>translatable element <pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">with placeholders</pc> <ph id="1" equiv="INTERPOLATION" disp="{{ interpolation}}"/></source>`,
-              `        <target><ph id="1" equiv="INTERPOLATION" disp="{{ interpolation}}"/> tnemele elbatalsnart <pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">sredlohecalp htiw</pc></target>`,
-              `      </segment>`,
-              `    </unit>`,
-              `  </file>`,
-              `</xliff>`,
-            ].join('\n');
-            const result = doParse('/some/file.xlf', XLIFF);
-            expect(result.translations[ɵcomputeMsgId('translatable attribute', '')])
-                .toEqual(ɵmakeParsedTranslation(['etubirtta elbatalsnart']));
-            expect(
-                result.translations[ɵcomputeMsgId(
-                    'translatable element {$START_BOLD_TEXT}with placeholders{$LOSE_BOLD_TEXT} {$INTERPOLATION}')])
-                .toEqual(ɵmakeParsedTranslation(
-                    ['', ' tnemele elbatalsnart ', 'sredlohecalp htiw', ''],
-                    ['INTERPOLATION', 'START_BOLD_TEXT', 'CLOSE_BOLD_TEXT']));
-          });
+    it('should merge messages from each `<file>` element', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>translatable attribute</div>
+       * ```
+       *
+       * ```
+       * <div i18n>translatable element <b>with placeholders</b> {{ interpolation}}</div>
+       * ```
+       */
+      const XLIFF = `
+                <xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+                  <file original="ng.template" id="file-1">
+                    <unit id="1933478729560469763">
+                      <notes>
+                        <note category="location">file.ts:2</note>
+                      </notes>
+                      <segment>
+                        <source>translatable attribute</source>
+                        <target>etubirtta elbatalsnart</target>
+                      </segment>
+                    </unit>
+                  </file>
+                  <file original="ng.template" id="file-2">
+                    <unit id="5057824347511785081">
+                      <notes>
+                        <note category="location">file.ts:3</note>
+                      </notes>
+                      <segment>
+                        <source>translatable element <pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">with placeholders</pc> <ph id="1" equiv="INTERPOLATION" disp="{{ interpolation}}"/></source>
+                        <target><ph id="1" equiv="INTERPOLATION" disp="{{ interpolation}}"/> tnemele elbatalsnart <pc id="0" equivStart="START_BOLD_TEXT" equivEnd="CLOSE_BOLD_TEXT" type="fmt" dispStart="&lt;b&gt;" dispEnd="&lt;/b&gt;">sredlohecalp htiw</pc></target>
+                      </segment>
+                    </unit>
+                  </file>
+                </xliff>
+              `;
+      const result = doParse('/some/file.xlf', XLIFF);
+      expect(result.translations[ɵcomputeMsgId('translatable attribute', '')])
+          .toEqual(ɵmakeParsedTranslation(['etubirtta elbatalsnart']));
+      expect(
+          result.translations[ɵcomputeMsgId(
+              'translatable element {$START_BOLD_TEXT}with placeholders{$LOSE_BOLD_TEXT} {$INTERPOLATION}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['', ' tnemele elbatalsnart ', 'sredlohecalp htiw', ''],
+              ['INTERPOLATION', 'START_BOLD_TEXT', 'CLOSE_BOLD_TEXT']));
+    });
 
-          describe('[structure errors]', () => {
-            it('should provide a diagnostic warning when a trans-unit has no translation target but does have a source',
-               () => {
-                 const XLIFF = [
-                   `<?xml version="1.0" encoding="UTF-8" ?>`,
-                   `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-                   `  <file original="ng.template" id="ngi18n">`,
-                   `    <unit id="missingtarget">`,
-                   `      <segment>`,
-                   `        <source/>`,
-                   `      </segment>`,
-                   `    </unit>`,
-                   `  </file>`,
-                   `</xliff>`,
-                 ].join('\n');
+    describe('[structure errors]', () => {
+      it('should provide a diagnostic warning when a trans-unit has no translation target but does have a source',
+         () => {
+           const XLIFF = [
+             `<?xml version="1.0" encoding="UTF-8" ?>`,
+             `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
+             `  <file original="ng.template" id="ngi18n">`,
+             `    <unit id="missingtarget">`,
+             `      <segment>`,
+             `        <source/>`,
+             `      </segment>`,
+             `    </unit>`,
+             `  </file>`,
+             `</xliff>`,
+           ].join('\n');
 
-                 const result = doParse('/some/file.xlf', XLIFF);
-                 expect(result.diagnostics.messages.length).toEqual(1);
-                 expect(result.diagnostics.messages[0].message).toEqual([
-                   `Missing <target> element ("`,
-                   `  <file original="ng.template" id="ngi18n">`,
-                   `    <unit id="missingtarget">`,
-                   `      [WARNING ->]<segment>`,
-                   `        <source/>`,
-                   `      </segment>`,
-                   `"): /some/file.xlf@4:6`,
-                 ].join('\n'));
-               });
+           const result = doParse('/some/file.xlf', XLIFF);
+           expect(result.diagnostics.messages.length).toEqual(1);
+           expect(result.diagnostics.messages[0].message).toEqual([
+             `Missing <target> element ("`,
+             `  <file original="ng.template" id="ngi18n">`,
+             `    <unit id="missingtarget">`,
+             `      [WARNING ->]<segment>`,
+             `        <source/>`,
+             `      </segment>`,
+             `"): /some/file.xlf@4:6`,
+           ].join('\n'));
+         });
 
-            it('should provide a diagnostic error when a trans-unit has no translation target nor source',
-               () => {
-                 const XLIFF = [
-                   `<?xml version="1.0" encoding="UTF-8" ?>`,
-                   `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-                   `  <file original="ng.template" id="ngi18n">`,
-                   `    <unit id="missingtarget">`,
-                   `      <segment>`,
-                   `      </segment>`,
-                   `    </unit>`,
-                   `  </file>`,
-                   `</xliff>`,
-                 ].join('\n');
+      it('should provide a diagnostic error when a trans-unit has no translation target nor source',
+         () => {
+           const XLIFF = [
+             `<?xml version="1.0" encoding="UTF-8" ?>`,
+             `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
+             `  <file original="ng.template" id="ngi18n">`,
+             `    <unit id="missingtarget">`,
+             `      <segment>`,
+             `      </segment>`,
+             `    </unit>`,
+             `  </file>`,
+             `</xliff>`,
+           ].join('\n');
 
-                 expectToFail(
-                     '/some/file.xlf', XLIFF,
-                     /Missing required element: one of <target> or <source> is required/, [
-                       `Missing required element: one of <target> or <source> is required ("`,
-                       `  <file original="ng.template" id="ngi18n">`,
-                       `    <unit id="missingtarget">`,
-                       `      [ERROR ->]<segment>`,
-                       `      </segment>`,
-                       `    </unit>`,
-                       `"): /some/file.xlf@4:6`,
-                     ].join('\n'));
-               });
+           expectToFail(
+               '/some/file.xlf', XLIFF,
+               /Missing required element: one of <target> or <source> is required/, [
+                 `Missing required element: one of <target> or <source> is required ("`,
+                 `  <file original="ng.template" id="ngi18n">`,
+                 `    <unit id="missingtarget">`,
+                 `      [ERROR ->]<segment>`,
+                 `      </segment>`,
+                 `    </unit>`,
+                 `"): /some/file.xlf@4:6`,
+               ].join('\n'));
+         });
 
 
-            it('should provide a diagnostic error when a trans-unit has no id attribute', () => {
-              const XLIFF = [
-                `<?xml version="1.0" encoding="UTF-8" ?>`,
-                `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-                `  <file original="ng.template" id="ngi18n">`,
-                `    <unit>`,
-                `      <segment>`,
-                `        <source/>`,
-                `        <target/>`,
-                `      </segment>`,
-                `    </unit>`,
-                `  </file>`,
-                `</xliff>`,
-              ].join('\n');
+      it('should provide a diagnostic error when a trans-unit has no id attribute', () => {
+        const XLIFF = [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
+          `  <file original="ng.template" id="ngi18n">`,
+          `    <unit>`,
+          `      <segment>`,
+          `        <source/>`,
+          `        <target/>`,
+          `      </segment>`,
+          `    </unit>`,
+          `  </file>`,
+          `</xliff>`,
+        ].join('\n');
 
-              expectToFail('/some/file.xlf', XLIFF, /Missing required "id" attribute/, [
-                `Missing required "id" attribute on <trans-unit> element. ("s:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-                `  <file original="ng.template" id="ngi18n">`,
-                `    [ERROR ->]<unit>`,
-                `      <segment>`,
-                `        <source/>`,
-                `"): /some/file.xlf@3:4`,
-              ].join('\n'));
-            });
+        expectToFail('/some/file.xlf', XLIFF, /Missing required "id" attribute/, [
+          `Missing required "id" attribute on <trans-unit> element. ("s:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
+          `  <file original="ng.template" id="ngi18n">`,
+          `    [ERROR ->]<unit>`,
+          `      <segment>`,
+          `        <source/>`,
+          `"): /some/file.xlf@3:4`,
+        ].join('\n'));
+      });
 
-            it('should provide a diagnostic error on duplicate trans-unit id', () => {
-              const XLIFF = [
-                `<?xml version="1.0" encoding="UTF-8" ?>`,
-                `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-                `  <file original="ng.template" id="ngi18n">`,
-                `    <unit id="deadbeef">`,
-                `      <segment>`,
-                `        <source/>`,
-                `        <target/>`,
-                `      </segment>`,
-                `    </unit>`,
-                `    <unit id="deadbeef">`,
-                `      <segment>`,
-                `        <source/>`,
-                `        <target/>`,
-                `      </segment>`,
-                `    </unit>`,
-                `  </file>`,
-                `</xliff>`,
-              ].join('\n');
+      it('should provide a diagnostic error on duplicate trans-unit id', () => {
+        const XLIFF = [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
+          `  <file original="ng.template" id="ngi18n">`,
+          `    <unit id="deadbeef">`,
+          `      <segment>`,
+          `        <source/>`,
+          `        <target/>`,
+          `      </segment>`,
+          `    </unit>`,
+          `    <unit id="deadbeef">`,
+          `      <segment>`,
+          `        <source/>`,
+          `        <target/>`,
+          `      </segment>`,
+          `    </unit>`,
+          `  </file>`,
+          `</xliff>`,
+        ].join('\n');
 
-              expectToFail(
-                  '/some/file.xlf', XLIFF, /Duplicated translations for message "deadbeef"/, [
-                    `Duplicated translations for message "deadbeef" ("`,
-                    `      </segment>`,
-                    `    </unit>`,
-                    `    [ERROR ->]<unit id="deadbeef">`,
-                    `      <segment>`,
-                    `        <source/>`,
-                    '"): /some/file.xlf@9:4',
-                  ].join('\n'));
-            });
-          });
+        expectToFail('/some/file.xlf', XLIFF, /Duplicated translations for message "deadbeef"/, [
+          `Duplicated translations for message "deadbeef" ("`,
+          `      </segment>`,
+          `    </unit>`,
+          `    [ERROR ->]<unit id="deadbeef">`,
+          `      <segment>`,
+          `        <source/>`,
+          '"): /some/file.xlf@9:4',
+        ].join('\n'));
+      });
+    });
 
-          describe('[message errors]', () => {
-            it('should provide a diagnostic error on unknown message tags', () => {
-              const XLIFF = [
-                `<?xml version="1.0" encoding="UTF-8" ?>`,
-                `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-                `  <file original="ng.template" id="ngi18n">`,
-                `    <unit id="deadbeef">`,
-                `      <segment>`,
-                `        <source/>`,
-                `        <target><b>msg should contain only ph and pc tags</b></target>`,
-                `      </segment>`,
-                `    </unit>`,
-                `  </file>`,
-                `</xliff>`,
-              ].join('\n');
+    describe('[message errors]', () => {
+      it('should provide a diagnostic error on unknown message tags', () => {
+        const XLIFF = [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
+          `  <file original="ng.template" id="ngi18n">`,
+          `    <unit id="deadbeef">`,
+          `      <segment>`,
+          `        <source/>`,
+          `        <target><b>msg should contain only ph and pc tags</b></target>`,
+          `      </segment>`,
+          `    </unit>`,
+          `  </file>`,
+          `</xliff>`,
+        ].join('\n');
 
-              expectToFail('/some/file.xlf', XLIFF, /Invalid element found in message/, [
-                `Error: Invalid element found in message.`,
-                `At /some/file.xlf@6:16:`,
-                `...`,
-                `        <source/>`,
-                `        <target>[ERROR ->]<b>msg should contain only ph and pc tags</b></target>`,
-                `      </segment>`,
-                `...`,
-                ``,
-              ].join('\n'));
-            });
+        expectToFail('/some/file.xlf', XLIFF, /Invalid element found in message/, [
+          `Error: Invalid element found in message.`,
+          `At /some/file.xlf@6:16:`,
+          `...`,
+          `        <source/>`,
+          `        <target>[ERROR ->]<b>msg should contain only ph and pc tags</b></target>`,
+          `      </segment>`,
+          `...`,
+          ``,
+        ].join('\n'));
+      });
 
-            it('should provide a diagnostic error when a placeholder misses an id attribute', () => {
-              const XLIFF = [
-                `<?xml version="1.0" encoding="UTF-8" ?>`,
-                `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
-                `  <file original="ng.template" id="ngi18n">`,
-                `    <unit id="deadbeef">`,
-                `      <segment>`,
-                `        <source/>`,
-                `        <target><ph/></target>`,
-                `      </segment>`,
-                `    </unit>`,
-                `  </file>`,
-                `</xliff>`,
-              ].join('\n');
+      it('should provide a diagnostic error when a placeholder misses an id attribute', () => {
+        const XLIFF = [
+          `<?xml version="1.0" encoding="UTF-8" ?>`,
+          `<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">`,
+          `  <file original="ng.template" id="ngi18n">`,
+          `    <unit id="deadbeef">`,
+          `      <segment>`,
+          `        <source/>`,
+          `        <target><ph/></target>`,
+          `      </segment>`,
+          `    </unit>`,
+          `  </file>`,
+          `</xliff>`,
+        ].join('\n');
 
-              expectToFail('/some/file.xlf', XLIFF, /Missing required "equiv" attribute/, [
-                `Error: Missing required "equiv" attribute:`,
-                `At /some/file.xlf@6:16:`,
-                `...`,
-                `        <source/>`,
-                `        <target>[ERROR ->]<ph/></target>`,
-                `      </segment>`,
-                `...`,
-                ``,
-              ].join('\n'));
-            });
-          });
-        });
-  }
+        expectToFail('/some/file.xlf', XLIFF, /Missing required "equiv" attribute/, [
+          `Error: Missing required "equiv" attribute:`,
+          `At /some/file.xlf@6:16:`,
+          `...`,
+          `        <source/>`,
+          `        <target>[ERROR ->]<ph/></target>`,
+          `      </segment>`,
+          `...`,
+          ``,
+        ].join('\n'));
+      });
+    });
+  });
 });

--- a/packages/localize/tools/test/translate/translation_files/translation_parsers/xtb_translation_parser_spec.ts
+++ b/packages/localize/tools/test/translate/translation_files/translation_parsers/xtb_translation_parser_spec.ts
@@ -6,21 +6,24 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ɵcomputeMsgId, ɵmakeParsedTranslation} from '@angular/localize';
-import {ParseAnalysis, ParsedTranslationBundle} from '../../../../src/translate/translation_files/translation_parsers/translation_parser';
+
+import {ParseAnalysis, ParsedTranslationBundle,} from '../../../../src/translate/translation_files/translation_parsers/translation_parser';
 import {XtbTranslationParser} from '../../../../src/translate/translation_files/translation_parsers/xtb_translation_parser';
 
 describe('XtbTranslationParser', () => {
-  describe('canParse()', () => {
+  describe('analyze()', () => {
     it('should return true if the file extension is `.xtb` or `.xmb` and it contains the `<translationbundle>` tag',
        () => {
          const parser = new XtbTranslationParser();
-         expect(parser.canParse('/some/file.xtb', '<translationbundle>')).toBeTruthy();
-         expect(parser.canParse('/some/file.xmb', '<translationbundle>')).toBeTruthy();
-         expect(parser.canParse('/some/file.xtb', '<translationbundle lang="en">')).toBeTruthy();
-         expect(parser.canParse('/some/file.xmb', '<translationbundle lang="en">')).toBeTruthy();
-         expect(parser.canParse('/some/file.json', '<translationbundle>')).toBe(false);
-         expect(parser.canParse('/some/file.xmb', '')).toBe(false);
-         expect(parser.canParse('/some/file.xtb', '')).toBe(false);
+         expect(parser.analyze('/some/file.xtb', '<translationbundle>').canParse).toBeTrue();
+         expect(parser.analyze('/some/file.xmb', '<translationbundle>').canParse).toBeTrue();
+         expect(parser.analyze('/some/file.xtb', '<translationbundle lang="en">').canParse)
+             .toBeTrue();
+         expect(parser.analyze('/some/file.xmb', '<translationbundle lang="en">').canParse)
+             .toBeTrue();
+         expect(parser.analyze('/some/file.json', '<translationbundle>').canParse).toBeFalse();
+         expect(parser.analyze('/some/file.xmb', '').canParse).toBeFalse();
+         expect(parser.analyze('/some/file.xtb', '').canParse).toBeFalse();
        });
   });
 
@@ -43,10 +46,10 @@ describe('XtbTranslationParser', () => {
       expect(parser.analyze('/some/file.json', '<translationbundle>'))
           .toEqual(jasmine.objectContaining({canParse: false}));
       expect(parser.analyze('/some/file.xmb', '')).toEqual(jasmine.objectContaining({
-        canParse: false
+        canParse: false,
       }));
       expect(parser.analyze('/some/file.xtb', '')).toEqual(jasmine.objectContaining({
-        canParse: false
+        canParse: false,
       }));
     });
 
@@ -56,188 +59,183 @@ describe('XtbTranslationParser', () => {
 
       results = parser.analyze('/some/file.xtb', '<moo>');
       expect(results.diagnostics.messages).toEqual([
-        {type: 'warning', message: 'The XML file does not contain a <translationbundle> root node.'}
+        {
+          type: 'warning',
+          message: 'The XML file does not contain a <translationbundle> root node.',
+        },
       ]);
 
       results = parser.analyze('/some/file.xtb', '<translationbundle></translation>');
-      expect(results.diagnostics.messages).toEqual([{
-        type: 'error',
-        message:
-            'Unexpected closing tag "translation". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags ("<translationbundle>[ERROR ->]</translation>"): /some/file.xtb@0:19'
-      }]);
+      expect(results.diagnostics.messages).toEqual([
+        {
+          type: 'error',
+          message:
+              'Unexpected closing tag "translation". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags ("<translationbundle>[ERROR ->]</translation>"): /some/file.xtb@0:19',
+        },
+      ]);
     });
   });
 
-  for (const withHint of [true, false]) {
-    describe(`parse() [${withHint ? 'with' : 'without'} hint]`, () => {
-      const doParse: (fileName: string, XTB: string) => ParsedTranslationBundle =
-          withHint ? (fileName, XTB) => {
-            const parser = new XtbTranslationParser();
-            const hint = parser.canParse(fileName, XTB);
-            if (!hint) {
-              throw new Error('expected XTB to be valid');
-            }
-            return parser.parse(fileName, XTB, hint);
-          } : (fileName, XTB) => {
-            const parser = new XtbTranslationParser();
-            return parser.parse(fileName, XTB);
-          };
+  describe(`parse()`, () => {
+    const doParse: (fileName: string, XTB: string) => ParsedTranslationBundle = (fileName, XTB) => {
+      const parser = new XtbTranslationParser();
+      const analysis = parser.analyze(fileName, XTB);
+      if (!analysis.canParse) {
+        throw new Error('expected XTB to be valid');
+      }
+      return parser.parse(fileName, XTB, analysis.hint);
+    };
 
-      const expectToFail:
-          (fileName: string, XLIFF: string, errorMatcher: RegExp, diagnosticMessage: string) =>
-              void = withHint ? (fileName, XLIFF, _errorMatcher, diagnosticMessage) => {
-                const result = doParse(fileName, XLIFF);
-                expect(result.diagnostics.messages.length).toEqual(1);
-                expect(result.diagnostics.messages[0].message).toEqual(diagnosticMessage);
-              } : (fileName, XLIFF, errorMatcher, _diagnosticMessage) => {
-                expect(() => doParse(fileName, XLIFF)).toThrowError(errorMatcher);
-              };
+    const expectToFail:
+        (fileName: string, XLIFF: string, errorMatcher: RegExp, diagnosticMessage: string) => void =
+            (fileName, XLIFF, _errorMatcher, diagnosticMessage) => {
+              const result = doParse(fileName, XLIFF);
+              expect(result.diagnostics.messages.length).toEqual(1);
+              expect(result.diagnostics.messages[0].message).toEqual(diagnosticMessage);
+            };
 
-      it('should extract the locale from the file contents', () => {
-        const XTB = [
-          `<?xml version="1.0" encoding="UTF-8"?>`,
-          `<translationbundle lang='fr'>`,
-          `  <translation id="8841459487341224498">rab</translation>`,
-          `</translationbundle>`,
-        ].join('\n');
-        const result = doParse('/some/file.xtb', XTB);
-        expect(result.locale).toEqual('fr');
-      });
+    it('should extract the locale from the file contents', () => {
+      const XTB = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <translationbundle lang='fr'>
+          <translation id="8841459487341224498">rab</translation>
+        </translationbundle>
+      `;
+      const result = doParse('/some/file.xtb', XTB);
+      expect(result.locale).toEqual('fr');
+    });
 
-      it('should extract basic messages', () => {
-        const XTB = [
-          `<?xml version="1.0" encoding="UTF-8"?>`,
-          `<!DOCTYPE translationbundle [`,
-          `  <!ELEMENT translationbundle (translation)*>`,
-          `  <!ATTLIST translationbundle lang CDATA #REQUIRED>`,
-          ``,
-          `  <!ELEMENT translation (#PCDATA|ph)*>`,
-          `  <!ATTLIST translation id CDATA #REQUIRED>`,
-          ``,
-          `  <!ELEMENT ph EMPTY>`,
-          `  <!ATTLIST ph name CDATA #REQUIRED>`,
-          `]>`,
-          `<translationbundle>`,
-          `  <translation id="8841459487341224498">rab</translation>`,
-          `</translationbundle>`,
-        ].join('\n');
-        const result = doParse('/some/file.xtb', XTB);
+    it('should extract basic messages', () => {
+      const XTB = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE translationbundle [
+          <!ELEMENT translationbundle (translation)*>
+          <!ATTLIST translationbundle lang CDATA #REQUIRED>
+          <!ELEMENT translation (#PCDATA|ph)*>
+          <!ATTLIST translation id CDATA #REQUIRED>
+          <!ELEMENT ph EMPTY>
+          <!ATTLIST ph name CDATA #REQUIRED>
+        ]>
+        <translationbundle>
+          <translation id="8841459487341224498">rab</translation>
+        </translationbundle>
+      `;
+      const result = doParse('/some/file.xtb', XTB);
 
-        expect(result.translations['8841459487341224498']).toEqual(ɵmakeParsedTranslation(['rab']));
-      });
+      expect(result.translations['8841459487341224498']).toEqual(ɵmakeParsedTranslation(['rab']));
+    });
 
-      it('should extract translations with simple placeholders', () => {
-        const XTB = [
-          `<?xml version="1.0" encoding="UTF-8"?>`,
-          `<translationbundle>`,
-          `  <translation id="8877975308926375834"><ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/></translation>`,
-          `</translationbundle>`,
-        ].join('\n');
-        const result = doParse('/some/file.xtb', XTB);
+    it('should extract translations with simple placeholders', () => {
+      const XTB = `
+        <?xml version="1.0" encoding="UTF-8"?>
+        <translationbundle>
+          <translation id="8877975308926375834"><ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/></translation>
+        </translationbundle>
+      `;
+      const result = doParse('/some/file.xtb', XTB);
 
-        expect(result.translations['8877975308926375834'])
-            .toEqual(
-                ɵmakeParsedTranslation(['', 'rab', ''], ['START_PARAGRAPH', 'CLOSE_PARAGRAPH']));
-      });
+      expect(result.translations['8877975308926375834'])
+          .toEqual(ɵmakeParsedTranslation(['', 'rab', ''], ['START_PARAGRAPH', 'CLOSE_PARAGRAPH']));
+    });
 
-      it('should extract nested placeholder containers (i.e. nested HTML elements)', () => {
-        /**
-         * Source HTML:
-         *
-         * ```
-         * <div i18n>
-         *   translatable <span>element <b>with placeholders</b></span> {{ interpolation}}
-         * </div>
-         * ```
-         */
-        const XLIFF = [
-          `<?xml version="1.0" encoding="UTF-8"?>`,
-          `<translationbundle>`,
-          `  <translation id="9051630253697141670">` +
-              `<ph name="START_TAG_SPAN"/><ph name="INTERPOLATION"/> tnemele<ph name="CLOSE_TAG_SPAN"/> elbatalsnart <ph name="START_BOLD_TEXT"/>sredlohecalp htiw<ph name="CLOSE_BOLD_TEXT"/>` +
-              `</translation>`,
-          `</translationbundle>`,
-        ].join('\n');
-        const result = doParse('/some/file.xtb', XLIFF);
-        expect(result.translations[ɵcomputeMsgId(
-                   'translatable {$START_TAG_SPAN}element {$START_BOLD_TEXT}with placeholders' +
-                   '{$CLOSE_BOLD_TEXT}{$CLOSE_TAG_SPAN} {$INTERPOLATION}')])
-            .toEqual(ɵmakeParsedTranslation(
-                ['', '', ' tnemele', ' elbatalsnart ', 'sredlohecalp htiw', ''], [
-                  'START_TAG_SPAN',
-                  'INTERPOLATION',
-                  'CLOSE_TAG_SPAN',
-                  'START_BOLD_TEXT',
-                  'CLOSE_BOLD_TEXT',
-                ]));
-      });
+    it('should extract nested placeholder containers (i.e. nested HTML elements)', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>
+       *   translatable <span>element <b>with placeholders</b></span> {{ interpolation}}
+       * </div>
+       * ```
+       */
+      const XLIFF = [
+        `<?xml version="1.0" encoding="UTF-8"?>`,
+        `<translationbundle>`,
+        `  <translation id="9051630253697141670">` +
+            `<ph name="START_TAG_SPAN"/><ph name="INTERPOLATION"/> tnemele<ph name="CLOSE_TAG_SPAN"/> elbatalsnart <ph name="START_BOLD_TEXT"/>sredlohecalp htiw<ph name="CLOSE_BOLD_TEXT"/>` +
+            `</translation>`,
+        `</translationbundle>`,
+      ].join('\n');
+      const result = doParse('/some/file.xtb', XLIFF);
+      expect(result.translations[ɵcomputeMsgId(
+                 'translatable {$START_TAG_SPAN}element {$START_BOLD_TEXT}with placeholders' +
+                 '{$CLOSE_BOLD_TEXT}{$CLOSE_TAG_SPAN} {$INTERPOLATION}')])
+          .toEqual(ɵmakeParsedTranslation(
+              ['', '', ' tnemele', ' elbatalsnart ', 'sredlohecalp htiw', ''], [
+                'START_TAG_SPAN',
+                'INTERPOLATION',
+                'CLOSE_TAG_SPAN',
+                'START_BOLD_TEXT',
+                'CLOSE_BOLD_TEXT',
+              ]));
+    });
 
-      it('should extract translations with simple ICU expressions', () => {
-        const XTB = [
-          `<?xml version="1.0" encoding="UTF-8" ?>`,
-          `<translationbundle>`,
-          `  <translation id="7717087045075616176">*<ph name="ICU"/>*</translation>`,
-          `  <translation id="5115002811911870583">{VAR_PLURAL, plural, =1 {<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>}}</translation>`,
-          `</translationbundle>`,
-        ].join('\n');
-        const result = doParse('/some/file.xtb', XTB);
+    it('should extract translations with simple ICU expressions', () => {
+      const XTB = `
+        <?xml version="1.0" encoding="UTF-8" ?>
+        <translationbundle>
+          <translation id="7717087045075616176">*<ph name="ICU"/>*</translation>
+          <translation id="5115002811911870583">{VAR_PLURAL, plural, =1 {<ph name="START_PARAGRAPH"/>rab<ph name="CLOSE_PARAGRAPH"/>}}</translation>
+        </translationbundle>
+      `;
+      const result = doParse('/some/file.xtb', XTB);
 
-        expect(result.translations['7717087045075616176'])
-            .toEqual(ɵmakeParsedTranslation(['*', '*'], ['ICU']));
-        expect(result.translations['5115002811911870583'])
-            .toEqual(ɵmakeParsedTranslation(
-                ['{VAR_PLURAL, plural, =1 {{START_PARAGRAPH}rab{CLOSE_PARAGRAPH}}}'], []));
-      });
+      expect(result.translations['7717087045075616176'])
+          .toEqual(ɵmakeParsedTranslation(['*', '*'], ['ICU']));
+      expect(result.translations['5115002811911870583'])
+          .toEqual(ɵmakeParsedTranslation(
+              ['{VAR_PLURAL, plural, =1 {{START_PARAGRAPH}rab{CLOSE_PARAGRAPH}}}'], []));
+    });
 
-      it('should extract translations with duplicate source messages', () => {
-        const XTB = [
-          `<translationbundle>`,
-          `  <translation id="9205907420411818817">oof</translation>`,
-          `  <translation id="i">toto</translation>`,
-          `  <translation id="bar">tata</translation>`,
-          `</translationbundle>`,
-        ].join('\n');
-        const result = doParse('/some/file.xtb', XTB);
+    it('should extract translations with duplicate source messages', () => {
+      const XTB = `
+        <translationbundle>
+          <translation id="9205907420411818817">oof</translation>
+          <translation id="i">toto</translation>
+          <translation id="bar">tata</translation>
+        </translationbundle>
+      `;
+      const result = doParse('/some/file.xtb', XTB);
 
-        expect(result.translations[ɵcomputeMsgId('foo')]).toEqual(ɵmakeParsedTranslation(['oof']));
-        expect(result.translations['i']).toEqual(ɵmakeParsedTranslation(['toto']));
-        expect(result.translations['bar']).toEqual(ɵmakeParsedTranslation(['tata']));
-      });
+      expect(result.translations[ɵcomputeMsgId('foo')]).toEqual(ɵmakeParsedTranslation(['oof']));
+      expect(result.translations['i']).toEqual(ɵmakeParsedTranslation(['toto']));
+      expect(result.translations['bar']).toEqual(ɵmakeParsedTranslation(['tata']));
+    });
 
-      it('should extract translations with only placeholders, which are re-ordered', () => {
-        const XTB = [
-          `<translationbundle>`,
-          `  <translation id="7118057989405618448"><ph name="TAG_IMG_1"/><ph name="TAG_IMG"/><ph name="LINE_BREAK"/></translation>`,
-          `</translationbundle>`,
-        ].join('\n');
-        const result = doParse('/some/file.xtb', XTB);
+    it('should extract translations with only placeholders, which are re-ordered', () => {
+      const XTB = `
+        <translationbundle>,
+          <translation id="7118057989405618448"><ph name="TAG_IMG_1"/><ph name="TAG_IMG"/><ph name="LINE_BREAK"/></translation>
+        </translationbundle>
+      `;
+      const result = doParse('/some/file.xtb', XTB);
 
-        expect(result.translations[ɵcomputeMsgId('{$LINE_BREAK}{$TAG_IMG}{$TAG_IMG_1}')])
-            .toEqual(
-                ɵmakeParsedTranslation(['', '', '', ''], ['TAG_IMG_1', 'TAG_IMG', 'LINE_BREAK']));
-      });
+      expect(result.translations[ɵcomputeMsgId('{$LINE_BREAK}{$TAG_IMG}{$TAG_IMG_1}')])
+          .toEqual(
+              ɵmakeParsedTranslation(['', '', '', ''], ['TAG_IMG_1', 'TAG_IMG', 'LINE_BREAK']));
+    });
 
-      it('should extract translations with empty target', () => {
-        /**
-         * Source HTML:
-         *
-         * ```
-         * <div i18n>hello <span></span></div>
-         * ```
-         */
-        const XTB = [
-          `<translationbundle>`,
-          `  <translation id="2826198357052921524"></translation>`,
-          `</translationbundle>`,
-        ].join('\n');
-        const result = doParse('/some/file.xtb', XTB);
+    it('should extract translations with empty target', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>hello <span></span></div>
+       * ```
+       */
+      const XTB = `
+        <translationbundle>
+          <translation id="2826198357052921524"></translation>
+        </translationbundle>
+      `;
+      const result = doParse('/some/file.xtb', XTB);
 
-        expect(result.translations[ɵcomputeMsgId('hello {$START_TAG_SPAN}{$CLOSE_TAG_SPAN}')])
-            .toEqual(ɵmakeParsedTranslation(['']));
-      });
+      expect(result.translations[ɵcomputeMsgId('hello {$START_TAG_SPAN}{$CLOSE_TAG_SPAN}')])
+          .toEqual(ɵmakeParsedTranslation(['']));
+    });
 
-      it('should extract translations with deeply nested ICUs', () => {
-        /**
+    it('should extract translations with deeply nested ICUs', () => {
+      /**
          * Source HTML:
          *
          * ```
@@ -252,157 +250,156 @@ describe('XtbTranslationParser', () => {
          * Note that special markers `VAR_PLURAL` and `VAR_SELECT` are added, which are then
          replaced by IVY at runtime with the actual values being rendered by the ICU expansion.
          */
-        const XTB = [
-          `<translationbundle>`,
-          `  <translation id="980940425376233536">Le test: <ph name="ICU" equiv-text="{ count, plural, =0 {...} =other {...}}"/></translation>`,
-          `  <translation id="5207293143089349404">{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<ph name="START_PARAGRAPH"/>profondément imbriqué<ph name="CLOSE_PARAGRAPH"/>}}} =other {beaucoup}}</translation>`,
-          `</translationbundle>`,
-        ].join('\n');
-        const result = doParse('/some/file.xtb', XTB);
+      const XTB = `
+        <translationbundle>
+          <translation id="980940425376233536">Le test: <ph name="ICU" equiv-text="{ count, plural, =0 {...} =other {...}}"/></translation>
+          <translation id="5207293143089349404">{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {<ph name="START_PARAGRAPH"/>profondément imbriqué<ph name="CLOSE_PARAGRAPH"/>}}} =other {beaucoup}}</translation>
+        </translationbundle>
+      `;
+      const result = doParse('/some/file.xtb', XTB);
 
-        expect(result.translations[ɵcomputeMsgId('Test: {$ICU}')])
-            .toEqual(ɵmakeParsedTranslation(['Le test: ', ''], ['ICU']));
+      expect(result.translations[ɵcomputeMsgId('Test: {$ICU}')])
+          .toEqual(ɵmakeParsedTranslation(['Le test: ', ''], ['ICU']));
 
-        expect(
-            result.translations[ɵcomputeMsgId(
-                '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}deeply nested{CLOSE_PARAGRAPH}}}} =other {beaucoup}}')])
-            .toEqual(ɵmakeParsedTranslation([
-              '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}profondément imbriqué{CLOSE_PARAGRAPH}}}} =other {beaucoup}}'
-            ]));
-      });
+      expect(
+          result.translations[ɵcomputeMsgId(
+              '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}deeply nested{CLOSE_PARAGRAPH}}}} =other {beaucoup}}')])
+          .toEqual(ɵmakeParsedTranslation([
+            '{VAR_PLURAL, plural, =0 {{VAR_SELECT, select, other {{START_PARAGRAPH}profondément imbriqué{CLOSE_PARAGRAPH}}}} =other {beaucoup}}',
+          ]));
+    });
 
-      it('should extract translations containing multiple lines', () => {
-        /**
-         * Source HTML:
-         *
-         * ```
-         * <div i18n>multi
-         * lines</div>
-         * ```
-         */
-        const XTB = [
-          `<translationbundle>`,
-          `  <translation id="2340165783990709777">multi\nlignes</translation>`,
-          `</translationbundle>`,
-        ].join('\n');
-        const result = doParse('/some/file.xtb', XTB);
+    it('should extract translations containing multiple lines', () => {
+      /**
+       * Source HTML:
+       *
+       * ```
+       * <div i18n>multi
+       * lines</div>
+       * ```
+       */
+      const XTB = `
+        <translationbundle>
+          <translation id="2340165783990709777">multi\nlignes</translation>
+        </translationbundle>
+        `;
+      const result = doParse('/some/file.xtb', XTB);
 
-        expect(result.translations[ɵcomputeMsgId('multi\nlines')])
-            .toEqual(ɵmakeParsedTranslation(['multi\nlignes']));
-      });
+      expect(result.translations[ɵcomputeMsgId('multi\nlines')])
+          .toEqual(ɵmakeParsedTranslation(['multi\nlignes']));
+    });
 
-      it('should warn on unrecognised ICU messages', () => {
-        // See https://github.com/angular/angular/issues/14046
+    it('should warn on unrecognised ICU messages', () => {
+      // See https://github.com/angular/angular/issues/14046
 
-        const XTB = [
-          `<translationbundle>`,
-          `  <translation id="valid">This is a valid message</translation>`,
-          `  <translation id="invalid">{REGION_COUNT_1, plural, =0 {unused plural form} =1 {1 region} other {{REGION_COUNT_2} regions}}</translation>`,
-          `</translationbundle>`,
-        ].join('\n');
+      const XTB = [
+        `<translationbundle>`,
+        `  <translation id="valid">This is a valid message</translation>`,
+        `  <translation id="invalid">{REGION_COUNT_1, plural, =0 {unused plural form} =1 {1 region} other {{REGION_COUNT_2} regions}}</translation>`,
+        `</translationbundle>`,
+      ].join('\n');
 
-        // Parsing the file should not fail
-        const result = doParse('/some/file.xtb', XTB);
+      // Parsing the file should not fail
+      const result = doParse('/some/file.xtb', XTB);
 
-        // We should be able to read the valid message
-        expect(result.translations['valid'])
-            .toEqual(ɵmakeParsedTranslation(['This is a valid message']));
+      // We should be able to read the valid message
+      expect(result.translations['valid'])
+          .toEqual(ɵmakeParsedTranslation(['This is a valid message']));
 
-        // Trying to access the invalid message should fail
-        expect(result.translations['invalid']).toBeUndefined();
-        expect(result.diagnostics.messages).toContain({
-          type: 'warning',
-          message: [
-            `Could not parse message with id "invalid" - perhaps it has an unrecognised ICU format?`,
-            `Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ '{' }}") to escape it.) ("id">{REGION_COUNT_1, plural, =0 {unused plural form} =1 {1 region} other {{REGION_COUNT_2} regions}}[ERROR ->]</translation>`,
-            `</translationbundle>"): /some/file.xtb@2:124`,
-            `Invalid ICU message. Missing '}'. ("n>`,
-            `  <translation id="invalid">{REGION_COUNT_1, plural, =0 {unused plural form} =1 {1 region} other [ERROR ->]{{REGION_COUNT_2} regions}}</translation>`,
-            `</translationbundle>"): /some/file.xtb@2:97`,
-          ].join('\n')
-        });
-      });
-
-      describe('[structure errors]', () => {
-        it('should throw when there are nested translationbundle tags', () => {
-          const XTB =
-              '<translationbundle><translationbundle></translationbundle></translationbundle>';
-
-          expectToFail(
-              '/some/file.xtb', XTB, /Failed to parse "\/some\/file.xtb" as XMB\/XTB format/,
-              `Unexpected <translationbundle> tag. ("<translationbundle>[ERROR ->]<translationbundle></translationbundle></translationbundle>"): /some/file.xtb@0:19`);
-        });
-
-        it('should throw when a translation has no id attribute', () => {
-          const XTB = [
-            `<translationbundle>`,
-            `  <translation></translation>`,
-            `</translationbundle>`,
-          ].join('\n');
-
-          expectToFail('/some/file.xtb', XTB, /Missing required "id" attribute/, [
-            `Missing required "id" attribute on <translation> element. ("<translationbundle>`,
-            `  [ERROR ->]<translation></translation>`,
-            `</translationbundle>"): /some/file.xtb@1:2`,
-          ].join('\n'));
-        });
-
-        it('should throw on duplicate translation id', () => {
-          const XTB = [
-            `<translationbundle>`,
-            `  <translation id="deadbeef"></translation>`,
-            `  <translation id="deadbeef"></translation>`,
-            `</translationbundle>`,
-          ].join('\n');
-
-          expectToFail('/some/file.xtb', XTB, /Duplicated translations for message "deadbeef"/, [
-            `Duplicated translations for message "deadbeef" ("<translationbundle>`,
-            `  <translation id="deadbeef"></translation>`,
-            `  [ERROR ->]<translation id="deadbeef"></translation>`,
-            `</translationbundle>"): /some/file.xtb@2:2`,
-          ].join('\n'));
-        });
-      });
-
-      describe('[message errors]', () => {
-        it('should throw on unknown message tags', () => {
-          const XTB = [
-            `<translationbundle>`,
-            `  <translation id="deadbeef">`,
-            `    <source/>`,
-            `  </translation>`,
-            `</translationbundle>`,
-          ].join('\n');
-
-          expectToFail('/some/file.xtb', XTB, /Invalid element found in message/, [
-            `Error: Invalid element found in message.`,
-            `At /some/file.xtb@2:4:`,
-            `...`,
-            `  <translation id="deadbeef">`,
-            `    [ERROR ->]<source/>`,
-            `  </translation>`,
-            `...`,
-            ``,
-          ].join('\n'));
-        });
-
-        it('should throw when a placeholder misses a name attribute', () => {
-          const XTB = [
-            `<translationbundle>`,
-            `  <translation id="deadbeef"><ph/></translation>`,
-            `</translationbundle>`,
-          ].join('\n');
-
-          expectToFail('/some/file.xtb', XTB, /required "name" attribute/gi, [
-            `Error: Missing required "name" attribute:`,
-            `At /some/file.xtb@1:29:`,
-            `...<translationbundle>`,
-            `  <translation id="deadbeef">[ERROR ->]<ph/></translation>`,
-            `</translationbundle>...`,
-            ``,
-          ].join('\n'));
-        });
+      // Trying to access the invalid message should fail
+      expect(result.translations['invalid']).toBeUndefined();
+      expect(result.diagnostics.messages).toContain({
+        type: 'warning',
+        message: [
+          `Could not parse message with id "invalid" - perhaps it has an unrecognised ICU format?`,
+          `Unexpected character "EOF" (Do you have an unescaped "{" in your template? Use "{{ '{' }}") to escape it.) ("id">{REGION_COUNT_1, plural, =0 {unused plural form} =1 {1 region} other {{REGION_COUNT_2} regions}}[ERROR ->]</translation>`,
+          `</translationbundle>"): /some/file.xtb@2:124`,
+          `Invalid ICU message. Missing '}'. ("n>`,
+          `  <translation id="invalid">{REGION_COUNT_1, plural, =0 {unused plural form} =1 {1 region} other [ERROR ->]{{REGION_COUNT_2} regions}}</translation>`,
+          `</translationbundle>"): /some/file.xtb@2:97`,
+        ].join('\n'),
       });
     });
-  }
+
+    describe('[structure errors]', () => {
+      it('should throw when there are nested translationbundle tags', () => {
+        const XTB =
+            '<translationbundle><translationbundle></translationbundle></translationbundle>';
+
+        expectToFail(
+            '/some/file.xtb', XTB, /Failed to parse "\/some\/file.xtb" as XMB\/XTB format/,
+            `Unexpected <translationbundle> tag. ("<translationbundle>[ERROR ->]<translationbundle></translationbundle></translationbundle>"): /some/file.xtb@0:19`);
+      });
+
+      it('should throw when a translation has no id attribute', () => {
+        const XTB = [
+          `<translationbundle>`,
+          `  <translation></translation>`,
+          `</translationbundle>`,
+        ].join('\n');
+
+        expectToFail('/some/file.xtb', XTB, /Missing required "id" attribute/, [
+          `Missing required "id" attribute on <translation> element. ("<translationbundle>`,
+          `  [ERROR ->]<translation></translation>`,
+          `</translationbundle>"): /some/file.xtb@1:2`,
+        ].join('\n'));
+      });
+
+      it('should throw on duplicate translation id', () => {
+        const XTB = [
+          `<translationbundle>`,
+          `  <translation id="deadbeef"></translation>`,
+          `  <translation id="deadbeef"></translation>`,
+          `</translationbundle>`,
+        ].join('\n');
+
+        expectToFail('/some/file.xtb', XTB, /Duplicated translations for message "deadbeef"/, [
+          `Duplicated translations for message "deadbeef" ("<translationbundle>`,
+          `  <translation id="deadbeef"></translation>`,
+          `  [ERROR ->]<translation id="deadbeef"></translation>`,
+          `</translationbundle>"): /some/file.xtb@2:2`,
+        ].join('\n'));
+      });
+    });
+
+    describe('[message errors]', () => {
+      it('should throw on unknown message tags', () => {
+        const XTB = [
+          `<translationbundle>`,
+          `  <translation id="deadbeef">`,
+          `    <source/>`,
+          `  </translation>`,
+          `</translationbundle>`,
+        ].join('\n');
+
+        expectToFail('/some/file.xtb', XTB, /Invalid element found in message/, [
+          `Error: Invalid element found in message.`,
+          `At /some/file.xtb@2:4:`,
+          `...`,
+          `  <translation id="deadbeef">`,
+          `    [ERROR ->]<source/>`,
+          `  </translation>`,
+          `...`,
+          ``,
+        ].join('\n'));
+      });
+
+      it('should throw when a placeholder misses a name attribute', () => {
+        const XTB = [
+          `<translationbundle>`,
+          `  <translation id="deadbeef"><ph/></translation>`,
+          `</translationbundle>`,
+        ].join('\n');
+
+        expectToFail('/some/file.xtb', XTB, /required "name" attribute/gi, [
+          `Error: Missing required "name" attribute:`,
+          `At /some/file.xtb@1:29:`,
+          `...<translationbundle>`,
+          `  <translation id="deadbeef">[ERROR ->]<ph/></translation>`,
+          `</translationbundle>...`,
+          ``,
+        ].join('\n'));
+      });
+    });
+  });
 });


### PR DESCRIPTION
This change removed the deprecated `canParse` method from all the TranslationParsers.

BREAKING CHANGE: 

- `canParse` method has been removed from all translation parsers in `@angular/localize/tools`. `analyze` should be used instead. 
-  the `hint` parameter in the `parse` methods is now mandatory.