### PR TITLE
docs: fix doc linter warnings and errors in various markdown files

### DIFF
--- a/aio/content/guide/accessibility.md
+++ b/aio/content/guide/accessibility.md
@@ -121,7 +121,7 @@ router.events.pipe(filter(e =&gt; e instanceof NavigationEnd)).subscribe(() =&gt
 
 </code-example>
 
-In a real application, the element that receives focus will depend on your specific application structure and layout.
+In a real application, the element that receives focus depends on your specific application structure and layout.
 The focused element should put users in a position to immediately move into the main content that has just been routed into view.
 You should avoid situations where focus returns to the `body` element after a route change.
 
@@ -167,8 +167,12 @@ The following example shows how to apply the `active-page` class to active links
 
 Books
 
+<!-- vale Angular.Google_Quotes = NO -->
+
 *   "A Web for Everyone: Designing Accessible User Experiences", Sarah Horton and Whitney Quesenbery
 *   "Inclusive Design Patterns", Heydon Pickering
+
+<!-- vale Angular.Google_Quotes = YES -->
 
 <!-- links -->
 

--- a/aio/content/guide/angular-compiler-options.md
+++ b/aio/content/guide/angular-compiler-options.md
@@ -47,7 +47,7 @@ One of `static fields` \(the default\) or `decorators`.
     <div class="alert is-helpful">
 
     **NOTE**: <br />
-    That the resulting code will not properly tree-shake.
+    That the resulting code cannot tree-shake properly.
 
     </div>
 
@@ -97,11 +97,11 @@ This allows `$localize` messages in application code to use the same ID as ident
 
 ### `enableResourceInlining`
 
-When `true`, replaces the `templateUrl` and `styleUrls` property in all `@Component` decorators with inlined contents in `template` and `styles` properties.
+When `true`, replaces the `templateUrl` and `styleUrls` properties in all `@Component` decorators with inline content in the `template` and `styles` properties.
 
 When enabled, the `.js` output of `ngc` does not include any lazy-loaded template or style URLs.
 
-For library projects generated with the CLI, the development configuration default is `true`.
+For library projects generated with the Angular CLI, the development configuration default is `true`.
 
 <a id="enablelegacytemplate"></a>
 
@@ -119,12 +119,12 @@ Ignored if `flatModuleOutFile` is `false`.
 
 ### `flatModuleOutFile`
 
-When `true`, generates a flat module index of the given file name and the corresponding flat module metadata.
+When `true`, generates a flat module index of the given filename and the corresponding flat module metadata.
 Use to create flat modules that are packaged similarly to `@angular/core` and `@angular/common`.
 When this option is used, the `package.json` for the library should refer to the generated flat module index instead of the library index file.
 
 Produces only one `.metadata.json` file, which contains all the metadata necessary for symbols exported from the library index.
-In the generated `.ngfactory.js` files, the flat module index is used to import symbols that include both the public API from the library index as well as shrowded internal symbols.
+In the generated `.ngfactory.js` files, the flat module index is used to import symbols that include both the public API from the library index as well as shrouded internal symbols.
 
 By default the `.ts` file supplied in the `files` field is assumed to be the library index.
 If more than one `.ts` file is specified, `libraryIndex` is used to select the file to use.
@@ -141,7 +141,7 @@ The `module` field of the library's `package.json` would be `"index.js"` and the
 When `true` \(recommended\), enables the [binding expression validation](guide/aot-compiler#binding-expression-validation) phase of the template compiler, which uses TypeScript to validate binding expressions.
 For more information, see [Template type checking](guide/template-typecheck).
 
-Default is `false`, but when you use the CLI command `ng new --strict`, it is set to `true` in the generated project's configuration.
+Default is `false`, but when you use the Angular CLI command `ng new --strict`, it is set to `true` in the generated project's configuration.
 
 <div class="alert is-important">
 
@@ -172,7 +172,7 @@ This information includes, for example, the content of annotations \(such as a c
 You can set to `true` when using factory summaries, because the factory summaries include a copy of the information that is in the `.metadata.json` file.
 
 Set to `true` if you are using TypeScript's `--outFile` option, because the metadata files are not valid for this style of TypeScript output.
-However, we do not recommend using `--outFile` with Angular.
+However, the Angular community does not recommend using `--outFile` with Angular.
 Use a bundler, such as [webpack](https://webpack.js.org), instead.
 
 ### `skipTemplateCodegen`
@@ -182,7 +182,7 @@ This turns off most of the template compiler and disables the reporting of templ
 
 Can be used to instruct the template compiler to produce `.metadata.json` files for distribution with an `npm` package while avoiding the production of `.ngfactory.js` and `.ngstyle.js` files that cannot be distributed to `npm`.
 
-For library projects generated with the CLI, the development configuration default is `true`.
+For library projects generated with the Angular CLI, the development configuration default is `true`.
 
 ### `strictMetadataEmit`
 
@@ -202,14 +202,14 @@ The template compiler can then use the error nodes to report an error if these s
 If the client of a library intends to use a symbol in an annotation, the template compiler does not normally report this until the client uses the symbol.
 This option allows detection of these errors during the build phase of the library and is used, for example, in producing Angular libraries themselves.
 
-For library projects generated with the CLI, the development configuration default is `true`.
+For library projects generated with the Angular CLI, the development configuration default is `true`.
 
 ### `strictInjectionParameters`
 
 When `true` \(recommended\), reports an error for a supplied parameter whose injection type cannot be determined.
 When `false` \(currently the default\), constructor parameters of classes marked with `@Injectable` whose type cannot be resolved produce a warning.
 
-When you use the CLI command `ng new --strict`, it is set to `true` in the generated project's configuration.
+When you use the Angular CLI command `ng new --strict`, it is set to `true` in the generated project's configuration.
 
 ### `strictTemplates`
 
@@ -218,7 +218,7 @@ When `true`, enables [strict template type checking](guide/template-typecheck#st
 Additional strictness flags allow you to enable and disable specific types of strict template type checking.
 See [troubleshooting template errors](guide/template-typecheck#troubleshooting-template-errors).
 
-When you use the CLI command `ng new --strict`, it is set to `true` in the generated project's configuration.
+When you use the Angular CLI command `ng new --strict`, it is set to `true` in the generated project's configuration.
 
 ### `trace`
 
@@ -227,7 +227,7 @@ Default is `false`.
 
 <a id="cli-options"></a>
 
-## Command Line Options
+## Command line options
 
 While most of the time you interact with the Angular Compiler indirectly using Angular CLI, when debugging certain issues, you might find it useful to invoke the Angular Compiler directly.
 You can use the `ngc` command provided by the `@angular/compiler-cli` npm package to call the compiler from the command line.

--- a/aio/content/guide/app-shell.md
+++ b/aio/content/guide/app-shell.md
@@ -9,7 +9,7 @@ Learn more in [The App Shell Model](https://developers.google.com/web/fundamenta
 
 ## Step 1: Prepare the application
 
-Do this with the following CLI command:
+Do this with the following Angular CLI command:
 
 <code-example format="shell" language="shell">
 
@@ -19,9 +19,9 @@ ng new my-app --routing
 
 For an existing application, you have to manually add the `RouterModule` and defining a `<router-outlet>` within your application.
 
-## Step 2: Create the app shell
+## Step 2: Create the application shell
 
-Use the CLI to automatically create the application shell.
+Use the Angular CLI to automatically create the application shell.
 
 <code-example format="shell" language="shell">
 
@@ -80,9 +80,9 @@ After running this command you can see that the `angular.json` configuration fil
 
 </code-example>
 
-## Step 3: Verify the app is built with the shell content
+## Step 3: Verify the application is built with the shell content
 
-Use the CLI to build the `app-shell` target.
+Use the Angular CLI to build the `app-shell` target.
 
 <code-example format="shell" language="shell">
 

--- a/aio/tools/doc-linter/styles/Vocab/Names.txt
+++ b/aio/tools/doc-linter/styles/Vocab/Names.txt
@@ -21,6 +21,7 @@ savkin's
 sinatra
 stackblitz
 tolisten
+tsickle
 tslib
 tslint
 vercel


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Issue Number: N/A


## What is the new behavior?
resolved some doc linter warnings and errors in the following files:
- `accessibility.md`
- `angular-compiler-options.md`
- `app-shell.md`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
