### PR TITLE
build(bazel): Fix a bug where the aio build artifact didn't include assets

### DIFF
--- a/aio/BUILD.bazel
+++ b/aio/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@aio_npm//@angular-devkit/architect-cli:index.bzl", "architect", "architect_test")
-load("@build_bazel_rules_nodejs//:index.bzl", "npm_package_bin")
+load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin", "npm_package_bin")
 load("//aio/tools:defaults.bzl", "nodejs_binary")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load(":local_packages_util.bzl", "link_local_packages", "substitute_local_packages")
@@ -91,9 +91,6 @@ APPLICATION_FILES = [
     "tsconfig.worker.json",
     "//aio/src/assets",
     "//aio/src/assets/js",
-    ":dgeni",
-    ":stackblitz",
-    ":example-zips",
 ] + glob(
     ["src/**/*"],
     exclude = [
@@ -105,8 +102,11 @@ APPLICATION_FILES = [
     ],
 )
 
-# External dependencies from aio/package.json required to build the docs app.
+# Dependencies required to build the docs app.
 APPLICATION_DEPS = [
+    ":dgeni",
+    ":stackblitz",
+    ":example-zips",
     "@aio_npm//@angular-devkit/build-angular",
     "@aio_npm//@angular/animations",
     "@aio_npm//@angular/cdk",
@@ -138,7 +138,7 @@ TEST_FILES = APPLICATION_FILES + [
     ["src/**/*.spec.ts"],
 )
 
-# External dependencies from aio/package.json required to test the docs app
+# Dependencies required to test the docs app
 TEST_DEPS = APPLICATION_DEPS + [
     "@aio_npm//@angular/dev-infra-private/bazel/browsers/chromium",
     "@aio_npm//@types/jasmine",
@@ -157,7 +157,7 @@ TEST_DEPS = APPLICATION_DEPS + [
 # and run e2e tests against it
 E2E_FILES = APPLICATION_FILES + glob(["tests/e2e/**"])
 
-# External dependencies from aio/package.json required by the e2e tests
+# Dependencies required to run the e2e tests
 E2E_DEPS = APPLICATION_DEPS + [
     "@aio_npm//@angular/dev-infra-private/bazel/browsers/chromium",
     "@aio_npm//@types/jasmine",
@@ -171,15 +171,20 @@ E2E_DEPS = APPLICATION_DEPS + [
 # first-party equivalent pacakge in angular.
 link_local_packages(deps = APPLICATION_DEPS)
 
+copy_to_bin(
+    name = "application_files_bin",
+    srcs = APPLICATION_FILES,
+)
+
 architect(
     name = "build",
     args = [
         "site:build:stable",
-        "--output-path=../$(@D)",
+        "--output-path=build",
     ],
-    chdir = package_name(),
+    chdir = "$(RULEDIR)",
     configuration_env_vars = ["NG_BUILD_CACHE"],
-    data = APPLICATION_FILES + select({
+    data = [":application_files_bin"] + select({
         ":aio_local_deps": substitute_local_packages(APPLICATION_DEPS),
         "//conditions:default": APPLICATION_DEPS,
     }),

--- a/aio/local_packages_util.bzl
+++ b/aio/local_packages_util.bzl
@@ -8,15 +8,16 @@ def link_local_packages(deps):
         deps: list of npm dependency labels
     """
     for dep in deps:
-        label = Label(dep)
-        if label.package in ALL_PACKAGES:
-            npm_link(
-                name = _npm_link_name(dep),
-                target = to_package_label(label.package),
-                package_name = label.package,
-                package_path = native.package_name(),
-                tags = ["manual"],
-            )
+        if dep.startswith("@aio_npm//"):
+            label = Label(dep)
+            if label.package in ALL_PACKAGES:
+                npm_link(
+                    name = _npm_link_name(dep),
+                    target = to_package_label(label.package),
+                    package_name = label.package,
+                    package_path = native.package_name(),
+                    tags = ["manual"],
+                )
 
 def substitute_local_packages(deps):
     """Substitute npm dependencies for their local npm_link equivalent.
@@ -32,11 +33,12 @@ def substitute_local_packages(deps):
     """
     substituted = []
     for dep in deps:
-        label = Label(dep)
-        if label.package in ALL_PACKAGES:
-            substituted.append(_npm_link_name(dep))
-        else:
-            substituted.append(dep)
+        if dep.startswith("@aio_npm//"):
+            label = Label(dep)
+            if label.package in ALL_PACKAGES:
+                substituted.append(_npm_link_name(dep))
+            else:
+                substituted.append(dep)
     return substituted
 
 def _npm_link_name(dep):


### PR DESCRIPTION
@devversion @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The aio build target under bazel doesn't produce an artifact containing assets because the generated assets referenced in angular.json can't be found under the exec root. Either I need to add asset entries to angular.json pointing to the output dirs on each platform, or I just run the build target inside the output tree like I did here.

The test and serve targets do not have this issue because the generatednassets in the output tree are copied to the correct relative path in runfiles.

## What is the new behavior?

The build artifact now contains the assets.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
