### PR TITLE
docs: fixed grammar error in vulnerability reporting

### DIFF
--- a/aio/content/guide/security.md
+++ b/aio/content/guide/security.md
@@ -13,7 +13,7 @@ You can run the <live-example></live-example> in Stackblitz and download the cod
 
 <header>Reporting vulnerabilities</header>
 
-Angular is part of Google [Open Source Software Vulnerability Reward Program](https://bughunters.google.com/about/rules/6521337925468160/google-open-source-software-vulnerability-reward-program-rules), for vulnerabilities in Angular please submit your report [here](https://bughunters.google.com/report).
+Angular is part of Google [Open Source Software Vulnerability Reward Program](https://bughunters.google.com/about/rules/6521337925468160/google-open-source-software-vulnerability-reward-program-rules). [For vulnerabilities in Angular, please submit your report at https://bughunters.google.com](https://bughunters.google.com/report).
 
 For more information about how Google handles security issues, see [Google's security philosophy](https://www.google.com/about/appsecurity).
 


### PR DESCRIPTION
Split a run-on sentence into 2 sentences and improved link accessibility.