### PR TITLE
fix(router): fix = not parsed in router segment name

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -324,6 +324,9 @@
     "name": "LocationStrategy"
   },
   {
+    "name": "MATRIX_PARAM_SEGMENT_RE"
+  },
+  {
     "name": "MODIFIER_KEYS"
   },
   {
@@ -1678,6 +1681,9 @@
   },
   {
     "name": "match"
+  },
+  {
+    "name": "matchMatrixParamSegments"
   },
   {
     "name": "matchSegments"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1683,9 +1683,6 @@
     "name": "match"
   },
   {
-    "name": "matchMatrixParamSegments"
-  },
-  {
     "name": "matchSegments"
   },
   {

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -513,9 +513,15 @@ function serializeQueryParams(params: {[key: string]: any}): string {
   return strParams.length ? `?${strParams.join('&')}` : '';
 }
 
-const SEGMENT_RE = /^[^\/()?;=#]+/;
+const SEGMENT_RE = /^[^\/()?;#]+/;
 function matchSegments(str: string): string {
   const match = str.match(SEGMENT_RE);
+  return match ? match[0] : '';
+}
+
+const MATRIX_PARAM_SEGMENT_RE = /^[^\/()?;=#]+/;
+function matchMatrixParamSegments(str: string): string {
+  const match = str.match(MATRIX_PARAM_SEGMENT_RE);
   return match ? match[0] : '';
 }
 
@@ -624,14 +630,14 @@ class UrlParser {
   }
 
   private parseParam(params: {[key: string]: string}): void {
-    const key = matchSegments(this.remaining);
+    const key = matchMatrixParamSegments(this.remaining);
     if (!key) {
       return;
     }
     this.capture(key);
     let value: any = '';
     if (this.consumeOptional('=')) {
-      const valueMatch = matchSegments(this.remaining);
+      const valueMatch = matchMatrixParamSegments(this.remaining);
       if (valueMatch) {
         value = valueMatch;
         this.capture(value);

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -520,7 +520,7 @@ function matchSegments(str: string): string {
 }
 
 const MATRIX_PARAM_SEGMENT_RE = /^[^\/()?;=#]+/;
-function matchMatrixParamSegments(str: string): string {
+function matchMatrixKeySegments(str: string): string {
   const match = str.match(MATRIX_PARAM_SEGMENT_RE);
   return match ? match[0] : '';
 }
@@ -630,14 +630,14 @@ class UrlParser {
   }
 
   private parseParam(params: {[key: string]: string}): void {
-    const key = matchMatrixParamSegments(this.remaining);
+    const key = matchMatrixKeySegments(this.remaining);
     if (!key) {
       return;
     }
     this.capture(key);
     let value: any = '';
     if (this.consumeOptional('=')) {
-      const valueMatch = matchMatrixParamSegments(this.remaining);
+      const valueMatch = matchSegments(this.remaining);
       if (valueMatch) {
         value = valueMatch;
         this.capture(value);

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -445,7 +445,8 @@ function encodeUriString(s: string): string {
       .replace(/%40/g, '@')
       .replace(/%3A/gi, ':')
       .replace(/%24/g, '$')
-      .replace(/%2C/gi, ',');
+      .replace(/%2C/gi, ',')
+      .replace(/%3D/gi, '=');
 }
 
 /**

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -445,8 +445,7 @@ function encodeUriString(s: string): string {
       .replace(/%40/g, '@')
       .replace(/%3A/gi, ':')
       .replace(/%24/g, '$')
-      .replace(/%2C/gi, ',')
-      .replace(/%3D/gi, '=');
+      .replace(/%2C/gi, ',');
 }
 
 /**

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -266,9 +266,9 @@ describe('url serializer', () => {
     });
 
     it('should encode query params leaving sub-delimiters intact', () => {
-      const percentChars = '/?#&+[] ';
-      const percentCharsEncoded = '%2F%3F%23%26%2B%5B%5D%20';
-      const intactChars = '!$\'()*,;:=';
+      const percentChars = '/?#&+=[] ';
+      const percentCharsEncoded = '%2F%3F%23%26%2B%3D%5B%5D%20';
+      const intactChars = '!$\'()*,;:';
       const params = percentChars + intactChars;
       const paramsEncoded = percentCharsEncoded + intactChars;
       const mixedCaseString = 'sTrInG';
@@ -339,9 +339,9 @@ describe('url serializer', () => {
     const unreserved = `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~`;
 
     it('should encode a minimal set of special characters in queryParams', () => {
-      const notEncoded = unreserved + `:@!$'*,();=`;
-      const encode = ` +%&#[]/?`;
-      const encoded = `%20%2B%25%26%23%5B%5D%2F%3F`;
+      const notEncoded = unreserved + `:@!$'*,();`;
+      const encode = ` +%&=#[]/?`;
+      const encoded = `%20%2B%25%26%3D%23%5B%5D%2F%3F`;
 
       const parsed = url.parse('/foo');
 
@@ -364,34 +364,27 @@ describe('url serializer', () => {
 
     it('should encode minimal special characters plus parens and semi-colon in matrix params',
        () => {
-         const notEncoded = unreserved + `:@!$'*,&=`;
-         const encode = ` /%#()[];?+`;
-         const encoded = `%20%2F%25%23%28%29%5B%5D%3B%3F%2B`;
+         const notEncoded = unreserved + `:@!$'*,&`;
+         const encode = ` /%=#()[];?+`;
+         const encoded = `%20%2F%25%3D%23%28%29%5B%5D%3B%3F%2B`;
 
          const parsed = url.parse('/foo');
 
          parsed.root.children[PRIMARY_OUTLET].segments[0].parameters = {notEncoded, encode};
+
          expect(url.serialize(parsed)).toBe(`/foo;notEncoded=${notEncoded};encode=${encoded}`);
        });
 
     it('should encode special characters in the path the same as matrix params', () => {
-      const notEncoded = unreserved + `:@!$'*,&=`;
-      const encode = ` /%#()[];?+`;
-      const encoded = `%20%2F%25%23%28%29%5B%5D%3B%3F%2B`;
+      const notEncoded = unreserved + `:@!$'*,&`;
+      const encode = ` /%=#()[];?+`;
+      const encoded = `%20%2F%25%3D%23%28%29%5B%5D%3B%3F%2B`;
 
       const parsed = url.parse('/foo');
 
       parsed.root.children[PRIMARY_OUTLET].segments[0].path = notEncoded + encode;
 
       expect(url.serialize(parsed)).toBe(`/${notEncoded}${encoded}`);
-    });
-
-    it('should preserve = when encoding segments', () => {
-      const testUrl = '/foo===bar';
-
-      const parsed = url.parse(testUrl);
-
-      expect(url.serialize(parsed)).toBe(testUrl);
     });
 
     it('should correctly encode ampersand in segments', () => {

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -266,9 +266,9 @@ describe('url serializer', () => {
     });
 
     it('should encode query params leaving sub-delimiters intact', () => {
-      const percentChars = '/?#&+=[] ';
-      const percentCharsEncoded = '%2F%3F%23%26%2B%3D%5B%5D%20';
-      const intactChars = '!$\'()*,;:';
+      const percentChars = '/?#&+[] ';
+      const percentCharsEncoded = '%2F%3F%23%26%2B%5B%5D%20';
+      const intactChars = '!$\'()*,;:=';
       const params = percentChars + intactChars;
       const paramsEncoded = percentCharsEncoded + intactChars;
       const mixedCaseString = 'sTrInG';
@@ -339,9 +339,9 @@ describe('url serializer', () => {
     const unreserved = `abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~`;
 
     it('should encode a minimal set of special characters in queryParams', () => {
-      const notEncoded = unreserved + `:@!$'*,();`;
-      const encode = ` +%&=#[]/?`;
-      const encoded = `%20%2B%25%26%3D%23%5B%5D%2F%3F`;
+      const notEncoded = unreserved + `:@!$'*,();=`;
+      const encode = ` +%&#[]/?`;
+      const encoded = `%20%2B%25%26%23%5B%5D%2F%3F`;
 
       const parsed = url.parse('/foo');
 
@@ -364,27 +364,34 @@ describe('url serializer', () => {
 
     it('should encode minimal special characters plus parens and semi-colon in matrix params',
        () => {
-         const notEncoded = unreserved + `:@!$'*,&`;
-         const encode = ` /%=#()[];?+`;
-         const encoded = `%20%2F%25%3D%23%28%29%5B%5D%3B%3F%2B`;
+         const notEncoded = unreserved + `:@!$'*,&=`;
+         const encode = ` /%#()[];?+`;
+         const encoded = `%20%2F%25%23%28%29%5B%5D%3B%3F%2B`;
 
          const parsed = url.parse('/foo');
 
          parsed.root.children[PRIMARY_OUTLET].segments[0].parameters = {notEncoded, encode};
-
          expect(url.serialize(parsed)).toBe(`/foo;notEncoded=${notEncoded};encode=${encoded}`);
        });
 
     it('should encode special characters in the path the same as matrix params', () => {
-      const notEncoded = unreserved + `:@!$'*,&`;
-      const encode = ` /%=#()[];?+`;
-      const encoded = `%20%2F%25%3D%23%28%29%5B%5D%3B%3F%2B`;
+      const notEncoded = unreserved + `:@!$'*,&=`;
+      const encode = ` /%#()[];?+`;
+      const encoded = `%20%2F%25%23%28%29%5B%5D%3B%3F%2B`;
 
       const parsed = url.parse('/foo');
 
       parsed.root.children[PRIMARY_OUTLET].segments[0].path = notEncoded + encode;
 
       expect(url.serialize(parsed)).toBe(`/${notEncoded}${encoded}`);
+    });
+
+    it('should preserve = when encoding segments', () => {
+      const testUrl = '/foo===bar';
+
+      const parsed = url.parse(testUrl);
+
+      expect(url.serialize(parsed)).toBe(testUrl);
     });
 
     it('should correctly encode ampersand in segments', () => {

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -56,6 +56,14 @@ describe('url serializer', () => {
     expect(tree.root.children.primary.segments[2].path).toEqual('=');
   });
 
+  it('should parse segments with matrix parameter values containing an =', () => {
+    const tree = url.parse('/path/to/something;query=file=test;query2=test2');
+    expect(tree.root.children.primary.segments[2].path).toEqual('something');
+    expect(tree.root.children.primary.segments[2].parameterMap.keys).toHaveSize(2);
+    expect(tree.root.children.primary.segments[2].parameterMap.get('query')).toEqual('file=test');
+    expect(tree.root.children.primary.segments[2].parameterMap.get('query2')).toEqual('test2');
+  });
+
   it('should parse top-level nodes with only secondary segment', () => {
     const tree = url.parse('/(left:one)');
 

--- a/packages/router/test/url_serializer.spec.ts
+++ b/packages/router/test/url_serializer.spec.ts
@@ -34,6 +34,28 @@ describe('url serializer', () => {
     expect(url.serialize(tree)).toEqual('/one/two(left:three//right:four)');
   });
 
+  it('should parse secondary segments with an = in the name', () => {
+    const tree = url.parse('/path/to/some=file');
+    expect(tree.root.children.primary.segments[2].path).toEqual('some=file');
+  });
+
+  it('should parse segments with matrix parameters when the name contains an =', () => {
+    const tree = url.parse('/path/to/some=file;test=11');
+    expect(tree.root.children.primary.segments[2].path).toEqual('some=file');
+    expect(tree.root.children.primary.segments[2].parameterMap.keys).toHaveSize(1);
+    expect(tree.root.children.primary.segments[2].parameterMap.get('test')).toEqual('11');
+  });
+
+  it('should parse segments that end with an =', () => {
+    const tree = url.parse('/password/de/MDAtMNTk=');
+    expect(tree.root.children.primary.segments[2].path).toEqual('MDAtMNTk=');
+  });
+
+  it('should parse segments that only contain an =', () => {
+    const tree = url.parse('example.com/prefix/=');
+    expect(tree.root.children.primary.segments[2].path).toEqual('=');
+  });
+
   it('should parse top-level nodes with only secondary segment', () => {
     const tree = url.parse('/(left:one)');
 


### PR DESCRIPTION
fix router segment name parsing to allow segements to container an unscaped = character. Currently if you have a url like /some-site/folder=/some-file then then middle segment "folder=" will stop parsing at the = sign and register that part of the path as just "folder"

Fixes #21381

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
As outlined in this issue (https://github.com/angular/angular/issues/21381) when you have a url where a path segment contains an = character angular will parse that segment as only the characters before the =. For example **password/de/MDAtMNTk=** the last segment will be parsed in angular as only **MDAtMNTk** without the = character

Issue Number: 21381


## What is the new behavior?
After this change you may include any number of = characters in a segment name and correspondingly define those as route paths in your route configuration. 

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

I think this PR could potentially be a breaking change since someone might have specifically handled cases where = was ignored by angular. Suppose they had path segments that were base 64 encoded strings for example **IMz3bg==**, those could possibly end with one or two = characters. It is therefore conceivable that someone might have implemented a workaround where if they received the id as **IMz3bg** they could infer based on the missing bit count that two == characters should be added. In that case if angular now accepted = their resource names could suddenly become **IMz3bg====** 

A counter argument would be that if you had logic to determine the number of missing bits if angular now parsed the = there wouldn't be any missing bits and your logic would not trigger

## Other information

Based off of comments in the issue here (https://github.com/angular/angular/issues/21381#issuecomment-783761338) and (https://github.com/angular/angular/issues/21381#issuecomment-953948114) I looked into [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986) and [RFC 1630]() and it would seem that there isn't any specific limitation on using = in a segment name. Consider this excerpt from RFC 3986: 

> For example, the semicolon (";") and equals ("=") reserved characters are often used to delimit parameters and parameter values applicable to that segment. The comma (",") reserved character is often used for similar purposes.  For example, one URI producer might use a segment such as "name;v=1.1" to indicate a reference to version 1.1 of "name", whereas another might use a segment such as "name,1.1" to indicate the same.  Parameter types may be defined by scheme-specific semantics, but in most cases the syntax of a parameter is specific to the implementation of the URI's dereferencing algorithm.

This seems to clearly indicate that you can use = and that is further substantiated by angulars special handling of matric parameters which uses the **name;v=1.1** syntax from this excerpt