### PR TITLE
feat(common): export createImageLoader function

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/index.ts
+++ b/packages/common/src/directives/ng_optimized_image/index.ts
@@ -9,7 +9,7 @@
 // These exports represent the set of symbols exposed as a public API.
 export {provideCloudflareLoader} from './image_loaders/cloudflare_loader';
 export {provideCloudinaryLoader} from './image_loaders/cloudinary_loader';
-export {IMAGE_LOADER, ImageLoader, ImageLoaderConfig} from './image_loaders/image_loader';
+export {createImageLoader, IMAGE_LOADER, ImageLoader, ImageLoaderConfig} from './image_loaders/image_loader';
 export {provideImageKitLoader} from './image_loaders/imagekit_loader';
 export {provideImgixLoader} from './image_loaders/imgix_loader';
 export {NgOptimizedImage} from './ng_optimized_image';


### PR DESCRIPTION
Export the createImageLoader function so that third party image loaders can be created the same way as the first party image loaders.

Closes #47339

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 47339

Community created image loaders cannot be created the same way as the first party image loaders without duplicating code.

## What is the new behavior?

Image loaders can be created using the same `createImageLoader` function as the built in Angular image loaders.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
