### PR TITLE
feat(core): improve typings to allow for multi provided ProviderToken

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -637,18 +637,18 @@ export interface Inject {
 export const Inject: InjectDecorator;
 
 // @public (undocumented)
-export function inject<T>(token: ProviderToken<T>): T;
+export function inject<T>(token: ProviderToken<T extends (infer K)[] ? K : T>): T;
 
 // @public @deprecated (undocumented)
-export function inject<T>(token: ProviderToken<T>, flags?: InjectFlags): T | null;
+export function inject<T>(token: ProviderToken<T extends (infer K)[] ? K : T>, flags?: InjectFlags): T | null;
 
 // @public (undocumented)
-export function inject<T>(token: ProviderToken<T>, options: InjectOptions & {
+export function inject<T>(token: ProviderToken<T extends (infer K)[] ? K : T>, options: InjectOptions & {
     optional?: false;
 }): T;
 
 // @public (undocumented)
-export function inject<T>(token: ProviderToken<T>, options: InjectOptions): T | null;
+export function inject<T>(token: ProviderToken<T extends (infer K)[] ? K : T>, options: InjectOptions): T | null;
 
 // @public
 export interface Injectable {
@@ -1513,10 +1513,10 @@ export function ɵɵdefineInjectable<T>(opts: {
 }): unknown;
 
 // @public
-export function ɵɵinject<T>(token: ProviderToken<T>): T;
+export function ɵɵinject<T>(token: ProviderToken<T extends (infer K)[] ? K : T>): T;
 
 // @public (undocumented)
-export function ɵɵinject<T>(token: ProviderToken<T>, flags?: InjectFlags): T | null;
+export function ɵɵinject<T>(token: ProviderToken<T extends (infer K)[] ? K : T>, flags?: InjectFlags): T | null;
 
 // @public
 export function ɵɵinjectAttribute(attrNameToInject: string): string | null;

--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -115,9 +115,9 @@ export interface TestBed {
     get(token: any, notFoundValue?: any): any;
     initTestEnvironment(ngModule: Type<any> | Type<any>[], platform: PlatformRef, options?: TestEnvironmentOptions): void;
     // (undocumented)
-    inject<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
+    inject<T>(token: ProviderToken<T extends (infer K)[] ? K : T>, notFoundValue?: T, flags?: InjectFlags): T;
     // (undocumented)
-    inject<T>(token: ProviderToken<T>, notFoundValue: null, flags?: InjectFlags): T | null;
+    inject<T>(token: ProviderToken<T extends (infer K)[] ? K : T>, notFoundValue: null, flags?: InjectFlags): T | null;
     // (undocumented)
     get ngModule(): Type<any> | Type<any>[];
     // (undocumented)

--- a/packages/core/src/di/inject_switch.ts
+++ b/packages/core/src/di/inject_switch.ts
@@ -24,7 +24,8 @@ import {ProviderToken} from './provider_token';
  *  1. `Injector` should not depend on ivy logic.
  *  2. To maintain tree shake-ability we don't want to bring in unnecessary code.
  */
-let _injectImplementation: (<T>(token: ProviderToken<T>, flags?: InjectFlags) => T | null)|
+let _injectImplementation:
+    (<T>(token: ProviderToken<T extends(infer K)[] ? K : T>, flags?: InjectFlags) => T | null)|
     undefined;
 export function getInjectImplementation() {
   return _injectImplementation;
@@ -34,9 +35,11 @@ export function getInjectImplementation() {
 /**
  * Sets the current inject implementation.
  */
-export function setInjectImplementation(
-    impl: (<T>(token: ProviderToken<T>, flags?: InjectFlags) => T | null)|
-    undefined): (<T>(token: ProviderToken<T>, flags?: InjectFlags) => T | null)|undefined {
+export function setInjectImplementation(impl: (
+    <T>(token: ProviderToken<T extends(infer K)[] ? K : T>, flags?: InjectFlags) => T | null)|
+                                        undefined):
+    (<T>(token: ProviderToken<T extends(infer K)[] ? K : T>, flags?: InjectFlags) => T | null)|
+    undefined {
   const previous = _injectImplementation;
   _injectImplementation = impl;
   return previous;
@@ -51,7 +54,8 @@ export function setInjectImplementation(
  * injectable definition.
  */
 export function injectRootLimpMode<T>(
-    token: ProviderToken<T>, notFoundValue: T|undefined, flags: InjectFlags): T|null {
+    token: ProviderToken<T extends(infer K)[] ? K : T>, notFoundValue: T|undefined,
+    flags: InjectFlags): T|null {
   const injectableDef: ɵɵInjectableDeclaration<T>|null = getInjectableDef(token);
   if (injectableDef && injectableDef.providedIn == 'root') {
     return injectableDef.value === undefined ? injectableDef.value = injectableDef.factory() :
@@ -70,8 +74,8 @@ export function injectRootLimpMode<T>(
  *
  * @param fn Function which it should not equal to
  */
-export function assertInjectImplementationNotEqual(
-    fn: (<T>(token: ProviderToken<T>, flags?: InjectFlags) => T | null)) {
+export function assertInjectImplementationNotEqual(fn: (
+    <T>(token: ProviderToken<T extends(infer K)[] ? K : T>, flags?: InjectFlags) => T | null)) {
   ngDevMode &&
       assertNotEqual(_injectImplementation, fn, 'Calling ɵɵinject would cause infinite recursion');
 }

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -49,10 +49,11 @@ export function setCurrentInjector(injector: Injector|null|undefined): Injector|
   return former;
 }
 
-export function injectInjectorOnly<T>(token: ProviderToken<T>): T;
-export function injectInjectorOnly<T>(token: ProviderToken<T>, flags?: InjectFlags): T|null;
-export function injectInjectorOnly<T>(token: ProviderToken<T>, flags = InjectFlags.Default): T|
-    null {
+export function injectInjectorOnly<T>(token: ProviderToken<T extends(infer K)[] ? K : T>): T;
+export function injectInjectorOnly<T>(
+    token: ProviderToken<T extends(infer K)[] ? K : T>, flags?: InjectFlags): T|null;
+export function injectInjectorOnly<T>(
+    token: ProviderToken<T extends(infer K)[] ? K : T>, flags = InjectFlags.Default): T|null {
   if (_currentInjector === undefined) {
     throw new RuntimeError(
         RuntimeErrorCode.MISSING_INJECTION_CONTEXT,
@@ -61,7 +62,8 @@ export function injectInjectorOnly<T>(token: ProviderToken<T>, flags = InjectFla
   } else if (_currentInjector === null) {
     return injectRootLimpMode(token, undefined, flags);
   } else {
-    return _currentInjector.get(token, flags & InjectFlags.Optional ? null : undefined, flags);
+    return _currentInjector.get(
+        token as ProviderToken<T>, flags & InjectFlags.Optional ? null : undefined, flags);
   }
 }
 
@@ -75,9 +77,11 @@ export function injectInjectorOnly<T>(token: ProviderToken<T>, flags = InjectFla
  * @codeGenApi
  * @publicApi This instruction has been emitted by ViewEngine for some time and is deployed to npm.
  */
-export function ɵɵinject<T>(token: ProviderToken<T>): T;
-export function ɵɵinject<T>(token: ProviderToken<T>, flags?: InjectFlags): T|null;
-export function ɵɵinject<T>(token: ProviderToken<T>, flags = InjectFlags.Default): T|null {
+export function ɵɵinject<T>(token: ProviderToken<T extends(infer K)[] ? K : T>): T;
+export function ɵɵinject<T>(
+    token: ProviderToken<T extends(infer K)[] ? K : T>, flags?: InjectFlags): T|null;
+export function ɵɵinject<T>(
+    token: ProviderToken<T extends(infer K)[] ? K : T>, flags = InjectFlags.Default): T|null {
   return (getInjectImplementation() || injectInjectorOnly)(resolveForwardRef(token), flags);
 }
 
@@ -138,7 +142,7 @@ export interface InjectOptions {
  *
  * @publicApi
  */
-export function inject<T>(token: ProviderToken<T>): T;
+export function inject<T>(token: ProviderToken<T extends(infer K)[] ? K : T>): T;
 /**
  * @param token A token that represents a dependency that should be injected.
  * @param flags Control how injection is executed. The flags correspond to injection strategies that
@@ -149,7 +153,8 @@ export function inject<T>(token: ProviderToken<T>): T;
  * @publicApi
  * @deprecated prefer an options object instead of `InjectFlags`
  */
-export function inject<T>(token: ProviderToken<T>, flags?: InjectFlags): T|null;
+export function inject<T>(
+    token: ProviderToken<T extends(infer K)[] ? K : T>, flags?: InjectFlags): T|null;
 /**
  * @param token A token that represents a dependency that should be injected.
  * @param options Control how injection is executed. Options correspond to injection strategies
@@ -160,7 +165,9 @@ export function inject<T>(token: ProviderToken<T>, flags?: InjectFlags): T|null;
  *
  * @publicApi
  */
-export function inject<T>(token: ProviderToken<T>, options: InjectOptions&{optional?: false}): T;
+export function inject<T>(
+    token: ProviderToken<T extends(infer K)[] ? K : T>,
+    options: InjectOptions&{optional?: false}): T;
 /**
  * @param token A token that represents a dependency that should be injected.
  * @param options Control how injection is executed. Options correspond to injection strategies
@@ -173,7 +180,8 @@ export function inject<T>(token: ProviderToken<T>, options: InjectOptions&{optio
  *
  * @publicApi
  */
-export function inject<T>(token: ProviderToken<T>, options: InjectOptions): T|null;
+export function inject<T>(
+    token: ProviderToken<T extends(infer K)[] ? K : T>, options: InjectOptions): T|null;
 /**
  * Injects a token from the currently active injector.
  * `inject` is only supported during instantiation of a dependency by the DI system. It can be used
@@ -239,7 +247,8 @@ export function inject<T>(token: ProviderToken<T>, options: InjectOptions): T|nu
  * @publicApi
  */
 export function inject<T>(
-    token: ProviderToken<T>, flags: InjectFlags|InjectOptions = InjectFlags.Default): T|null {
+    token: ProviderToken<T extends(infer K)[] ? K : T>,
+    flags: InjectFlags|InjectOptions = InjectFlags.Default): T|null {
   if (typeof flags !== 'number') {
     // While TypeScript doesn't accept it without a cast, bitwise OR with false-y values in
     // JavaScript is a no-op. We can use that for a very codesize-efficient conversion from

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -206,7 +206,7 @@ export class R3Injector extends EnvironmentInjector {
   }
 
   override get<T>(
-      token: ProviderToken<T>, notFoundValue: any = THROW_IF_NOT_FOUND,
+      token: ProviderToken<T extends(infer K)[]? K : T>, notFoundValue: any = THROW_IF_NOT_FOUND,
       flags = InjectFlags.Default): T {
     this.assertNotDestroyed();
     // Set the injection context.
@@ -344,7 +344,7 @@ export class R3Injector extends EnvironmentInjector {
     this.records.set(token, record);
   }
 
-  private hydrate<T>(token: ProviderToken<T>, record: Record<T>): T {
+  private hydrate<T>(token: ProviderToken<T extends(infer K)[]? K : T>, record: Record<T>): T {
     if (ngDevMode && record.value === CIRCULAR) {
       throwCyclicDependencyError(stringify(token));
     } else if (record.value === NOT_YET) {

--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -333,7 +333,8 @@ export function injectAttributeImpl(tNode: TNode, attrNameToInject: string): str
 
 
 function notFoundValueOrThrow<T>(
-    notFoundValue: T|null, token: ProviderToken<T>, flags: InjectFlags): T|null {
+    notFoundValue: T|null, token: ProviderToken<T extends(infer K)[] ? K : T>,
+    flags: InjectFlags): T|null {
   if ((flags & InjectFlags.Optional) || notFoundValue !== undefined) {
     return notFoundValue;
   } else {
@@ -351,7 +352,8 @@ function notFoundValueOrThrow<T>(
  * @returns the value from the injector or throws an exception
  */
 function lookupTokenUsingModuleInjector<T>(
-    lView: LView, token: ProviderToken<T>, flags: InjectFlags, notFoundValue?: any): T|null {
+    lView: LView, token: ProviderToken<T extends(infer K)[] ? K : T>, flags: InjectFlags,
+    notFoundValue?: any): T|null {
   if ((flags & InjectFlags.Optional) && notFoundValue === undefined) {
     // This must be set or the NullInjector will throw for optional deps
     notFoundValue = null;
@@ -393,8 +395,9 @@ function lookupTokenUsingModuleInjector<T>(
  * @returns the value from the injector, `null` when not found, or `notFoundValue` if provided
  */
 export function getOrCreateInjectable<T>(
-    tNode: TDirectiveHostNode|null, lView: LView, token: ProviderToken<T>,
-    flags: InjectFlags = InjectFlags.Default, notFoundValue?: any): T|null {
+    tNode: TDirectiveHostNode|null, lView: LView,
+    token: ProviderToken<T extends(infer K)[] ? K : T>, flags: InjectFlags = InjectFlags.Default,
+    notFoundValue?: any): T|null {
   if (tNode !== null) {
     // If the view or any of its ancestors have an embedded
     // view injector, we have to look it up there first.
@@ -428,8 +431,8 @@ export function getOrCreateInjectable<T>(
  * @returns the value from the injector, `null` when not found, or `notFoundValue` if provided
  */
 function lookupTokenUsingNodeInjector<T>(
-    tNode: TDirectiveHostNode, lView: LView, token: ProviderToken<T>, flags: InjectFlags,
-    notFoundValue?: any) {
+    tNode: TDirectiveHostNode, lView: LView, token: ProviderToken<T extends(infer K)[] ? K : T>,
+    flags: InjectFlags, notFoundValue?: any) {
   const bloomHash = bloomHashBitOrFactory(token);
   // If the ID stored here is a function, this is a special object like ElementRef or TemplateRef
   // so just call the factory function to create it.
@@ -519,8 +522,8 @@ function lookupTokenUsingNodeInjector<T>(
 }
 
 function searchTokensOnInjector<T>(
-    injectorIndex: number, lView: LView, token: ProviderToken<T>, previousTView: TView|null,
-    flags: InjectFlags, hostTElementNode: TNode|null) {
+    injectorIndex: number, lView: LView, token: ProviderToken<T extends(infer K)[] ? K : T>,
+    previousTView: TView|null, flags: InjectFlags, hostTElementNode: TNode|null) {
   const currentTView = lView[TVIEW];
   const tNode = currentTView.data[injectorIndex + NodeInjectorOffset.TNODE] as TNode;
   // First, we need to determine if view providers can be accessed by the starting element.
@@ -566,8 +569,8 @@ function searchTokensOnInjector<T>(
  * @returns Index of a found directive or provider, or null when none found.
  */
 export function locateDirectiveOrProvider<T>(
-    tNode: TNode, tView: TView, token: ProviderToken<T>|string, canAccessViewProviders: boolean,
-    isHostSpecialCase: boolean|number): number|null {
+    tNode: TNode, tView: TView, token: ProviderToken<T extends(infer K)[] ? K : T>|string,
+    canAccessViewProviders: boolean, isHostSpecialCase: boolean|number): number|null {
   const nodeProviderIndexes = tNode.providerIndexes;
   const tInjectables = tView.data;
 
@@ -769,8 +772,8 @@ function getFactoryOf<T>(type: Type<any>): ((type?: Type<T>) => T | null)|null {
  * @returns the value from the injector, `null` when not found, or `notFoundValue` if provided
  */
 function lookupTokenUsingEmbeddedInjector<T>(
-    tNode: TDirectiveHostNode, lView: LView, token: ProviderToken<T>, flags: InjectFlags,
-    notFoundValue?: any) {
+    tNode: TDirectiveHostNode, lView: LView, token: ProviderToken<T extends(infer K)[] ? K : T>,
+    flags: InjectFlags, notFoundValue?: any) {
   let currentTNode: TDirectiveHostNode|null = tNode;
   let currentLView: LView|null = lView;
 
@@ -804,7 +807,7 @@ function lookupTokenUsingEmbeddedInjector<T>(
       const embeddedViewInjector = currentLView[EMBEDDED_VIEW_INJECTOR];
       if (embeddedViewInjector) {
         const embeddedViewInjectorValue =
-            embeddedViewInjector.get(token, NOT_FOUND as T | {}, flags);
+            embeddedViewInjector.get(token as ProviderToken<T>, NOT_FOUND as T | {}, flags);
         if (embeddedViewInjectorValue !== NOT_FOUND) {
           return embeddedViewInjectorValue;
         }

--- a/packages/core/src/render3/instructions/di.ts
+++ b/packages/core/src/render3/instructions/di.ts
@@ -37,9 +37,11 @@ import {getCurrentTNode, getLView} from '../state';
  *
  * @codeGenApi
  */
-export function ɵɵdirectiveInject<T>(token: ProviderToken<T>): T;
-export function ɵɵdirectiveInject<T>(token: ProviderToken<T>, flags: InjectFlags): T;
-export function ɵɵdirectiveInject<T>(token: ProviderToken<T>, flags = InjectFlags.Default): T|null {
+export function ɵɵdirectiveInject<T>(token: ProviderToken<T extends(infer K)[] ? K : T>): T;
+export function ɵɵdirectiveInject<T>(
+    token: ProviderToken<T extends(infer K)[] ? K : T>, flags: InjectFlags): T;
+export function ɵɵdirectiveInject<T>(
+    token: ProviderToken<T extends(infer K)[] ? K : T>, flags = InjectFlags.Default): T|null {
   const lView = getLView();
   // Fall back to inject() if view hasn't been created. This situation can happen in tests
   // if inject utilities are used before bootstrapping.

--- a/packages/core/src/render3/interfaces/injector.ts
+++ b/packages/core/src/render3/interfaces/injector.ts
@@ -175,7 +175,8 @@ export class NodeInjectorFactory {
   /**
    * The inject implementation to be activated when using the factory.
    */
-  injectImpl: null|(<T>(token: ProviderToken<T>, flags?: InjectFlags) => T);
+  injectImpl: null|
+      (<T>(token: ProviderToken<T extends(infer K)[]? K : T>, flags?: InjectFlags) => T);
 
   /**
    * Marker set to true during factory invocation to see if we get into recursive loop.
@@ -278,7 +279,8 @@ export class NodeInjectorFactory {
        * Set to `true` if the token is declared in `viewProviders` (or if it is component).
        */
       isViewProvider: boolean,
-      injectImplementation: null|(<T>(token: ProviderToken<T>, flags?: InjectFlags) => T)) {
+      injectImplementation: null|
+      (<T>(token: ProviderToken<T extends(infer K)[]? K : T>, flags?: InjectFlags) => T)) {
     ngDevMode && assertDefined(factory, 'Factory not specified');
     ngDevMode && assertEqual(typeof factory, 'function', 'Expected factory function.');
     this.canSeeViewProviders = isViewProvider;

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -87,8 +87,11 @@ export interface TestBed {
 
   compileComponents(): Promise<any>;
 
-  inject<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
-  inject<T>(token: ProviderToken<T>, notFoundValue: null, flags?: InjectFlags): T|null;
+  inject<T>(
+      token: ProviderToken<T extends(infer K)[]? K : T>, notFoundValue?: T, flags?: InjectFlags): T;
+  inject<T>(
+      token: ProviderToken<T extends(infer K)[]? K : T>, notFoundValue: null,
+      flags?: InjectFlags): T|null;
 
   /** @deprecated from v9.0.0 use TestBed.inject */
   get<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
@@ -290,9 +293,14 @@ export class TestBedImpl implements TestBed {
     return TestBedImpl.INSTANCE.overrideProvider(token, provider);
   }
 
-  static inject<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
-  static inject<T>(token: ProviderToken<T>, notFoundValue: null, flags?: InjectFlags): T|null;
-  static inject<T>(token: ProviderToken<T>, notFoundValue?: T|null, flags?: InjectFlags): T|null {
+  static inject<T>(
+      token: ProviderToken<T extends(infer K)[]? K : T>, notFoundValue?: T, flags?: InjectFlags): T;
+  static inject<T>(
+      token: ProviderToken<T extends(infer K)[]? K : T>, notFoundValue: null,
+      flags?: InjectFlags): T|null;
+  static inject<T>(
+      token: ProviderToken<T extends(infer K)[]? K : T>, notFoundValue?: T|null,
+      flags?: InjectFlags): T|null {
     return TestBedImpl.INSTANCE.inject(token, notFoundValue, flags);
   }
 
@@ -468,16 +476,22 @@ export class TestBedImpl implements TestBed {
     return this.compiler.compileComponents();
   }
 
-  inject<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
-  inject<T>(token: ProviderToken<T>, notFoundValue: null, flags?: InjectFlags): T|null;
-  inject<T>(token: ProviderToken<T>, notFoundValue?: T|null, flags?: InjectFlags): T|null {
+  inject<T>(
+      token: ProviderToken<T extends(infer K)[]? K : T>, notFoundValue?: T, flags?: InjectFlags): T;
+  inject<T>(
+      token: ProviderToken<T extends(infer K)[]? K : T>, notFoundValue: null,
+      flags?: InjectFlags): T|null;
+  inject<T>(
+      token: ProviderToken<T extends(infer K)[]? K : T>, notFoundValue?: T|null,
+      flags?: InjectFlags): T|null {
     if (token as unknown === TestBed) {
       return this as any;
     }
     const UNDEFINED = {} as unknown as T;
-    const result = this.testModuleRef.injector.get(token, UNDEFINED, flags);
-    return result === UNDEFINED ? this.compiler.injector.get(token, notFoundValue, flags) as any :
-                                  result;
+    const result = this.testModuleRef.injector.get(token as ProviderToken<T>, UNDEFINED, flags);
+    return result === UNDEFINED ?
+        this.compiler.injector.get(token as ProviderToken<T>, notFoundValue, flags) as any :
+        result;
   }
 
   /** @deprecated from v9.0.0 use TestBed.inject */


### PR DESCRIPTION
Multi-provided tokens (`multi` option, see e.g. ClassProvider) causes the injector to return an array of provided instances. 
Currently, this behavior is not being correctly reflected in the injector method typings. 

This PR ensures the consumers of applicable methods (i.e. methods were the returned type of the injector is concerned) can define that the token is being multi-provided and hence the injectors return is an array instead of just one instance.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [] Other... Please describe:


## What is the current behavior?

For example the Testbed's static `inject` method.
```javascript
describe('AppComponent', () => {
  let textProviders: RandomTextProvider[] | null = null;
  let textProvidersCurrentWorkaround: RandomTextProvider[] | null = null;

...

  beforeEach(async () => {
    await TestBed.configureTestingModule({
      declarations: [AppComponent],
      providers: [
        {
          provide: RandomTextProvider,
          useClass: BuzzwordService,
          multi: true,
        },
        {
          provide: RandomTextProvider,
          useClass: LoremIpsumService,
          multi: true,
        },
      ],
    }).compileComponents();

    /*
      Does not work!
      Argument of type 'typeof RandomTextProvider' is not assignable to parameter of type 'ProviderToken<RandomTextProvider[]>'.
      Type 'typeof RandomTextProvider' is not assignable to type 'Type<RandomTextProvider[]>'.
    */
    textProviders = TestBed.inject<RandomTextProvider[]>(RandomTextProvider);

    // this workaround works
    textProvidersCurrentWorkaround = TestBed.inject(
      RandomTextProvider as unknown as ProviderToken<RandomTextProvider[]>
    );
```

Issue Number: N/A


## What is the new behavior?

Consumers of the Testbed `inject` can specify that the requested Token is being multi-provided.

```javascript
    /*
      Does work!
    */
    textProviders = TestBed.inject<RandomTextProvider[]>(RandomTextProvider);
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
