### PR TITLE
refactor(compiler-cli): remove `enableIvy` option

### DIFF
--- a/devtools/tsconfig.json
+++ b/devtools/tsconfig.json
@@ -52,7 +52,6 @@
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,
-    "strictInjectionParameters": true,
-    "enableIvy": true
+    "strictInjectionParameters": true
   }
 }

--- a/goldens/public-api/compiler-cli/compiler_options.md
+++ b/goldens/public-api/compiler-cli/compiler_options.md
@@ -58,7 +58,6 @@ export interface MiscOptions {
 
 // @public
 export interface NgcCompatibilityOptions {
-    enableIvy?: boolean | 'ngtsc';
     generateNgFactoryShims?: boolean;
     generateNgSummaryShims?: boolean;
 }

--- a/integration/ivy-i18n/tsconfig.legacy-xmb.json
+++ b/integration/ivy-i18n/tsconfig.legacy-xmb.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.app.json",
   "angularCompilerOptions": {
-    "enableIvy": true,
     "i18nInFormat": "xmb"
   }
 }

--- a/integration/ivy-i18n/tsconfig.legacy.json
+++ b/integration/ivy-i18n/tsconfig.legacy.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.app.json",
   "angularCompilerOptions": {
-    "enableIvy": true,
     "i18nInFormat": "xlf"
   }
 }

--- a/integration/ngcc/tsconfig-app.json
+++ b/integration/ngcc/tsconfig-app.json
@@ -13,8 +13,5 @@
   },
   "files": [
     "src/main.ts"
-  ],
-  "angularCompilerOptions": {
-    "enableIvy": "ngtsc"
-  }
+  ]
 }

--- a/packages/compiler-cli/integrationtest/flat_module/tsconfig-build.json
+++ b/packages/compiler-cli/integrationtest/flat_module/tsconfig-build.json
@@ -2,8 +2,7 @@
   "angularCompilerOptions": {
     "flatModuleId": "flat_module",
     "flatModuleOutFile": "index.js",
-    "skipTemplateCodegen": true,
-    "enableIvy": false
+    "skipTemplateCodegen": true
   },
 
   "compilerOptions": {

--- a/packages/compiler-cli/integrationtest/ngtools_src/tsconfig-build.json
+++ b/packages/compiler-cli/integrationtest/ngtools_src/tsconfig-build.json
@@ -1,7 +1,6 @@
 {
   "angularCompilerOptions": {
-    "debug": true,
-    "enableIvy": false
+    "debug": true
   },
 
   "compilerOptions": {

--- a/packages/compiler-cli/integrationtest/third_party_src/tsconfig-build.json
+++ b/packages/compiler-cli/integrationtest/third_party_src/tsconfig-build.json
@@ -1,7 +1,6 @@
 {
   "angularCompilerOptions": {
-    "skipTemplateCodegen": true,
-    "enableIvy": false
+    "skipTemplateCodegen": true
   },
 
   "compilerOptions": {

--- a/packages/compiler-cli/integrationtest/tsconfig-build.json
+++ b/packages/compiler-cli/integrationtest/tsconfig-build.json
@@ -4,8 +4,7 @@
     "annotationsAs": "static fields",
     "debug": true,
     "enableSummariesForJit": true,
-    "i18nFormat": "xlf",
-    "enableIvy": false
+    "i18nFormat": "xlf"
   },
 
   "compilerOptions": {

--- a/packages/compiler-cli/integrationtest/tsconfig-xi18n.json
+++ b/packages/compiler-cli/integrationtest/tsconfig-xi18n.json
@@ -1,8 +1,7 @@
 {
   "angularCompilerOptions": {
     "debug": true,
-    "enableSummariesForJit": true,
-    "enableIvy": false
+    "enableSummariesForJit": true
   },
 
   "compilerOptions": {

--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -12,7 +12,6 @@ import yargs from 'yargs';
 import {exitCodeFromResult, formatDiagnostics, ParsedConfiguration, performCompilation, readConfiguration} from './perform_compile';
 import {createPerformWatchHost, performWatchCompilation} from './perform_watch';
 import * as api from './transformers/api';
-import {GENERATED_FILES} from './transformers/util';
 
 type TsickleModule = typeof import('tsickle');
 
@@ -106,9 +105,7 @@ function createEmitCallback(
       'fileNameToModuleId'|'googmodule'|'untyped'|'convertIndexImportShorthand'|
       'transformDecorators'|'transformTypesToClosure'|'generateExtraSuppressions'|
       'rootDirsRelative'> = {
-    shouldSkipTsickleProcessing: (fileName) => /\.d\.ts$/.test(fileName) ||
-        // View Engine's generated files were never intended to be processed with tsickle.
-        (!options.enableIvy && GENERATED_FILES.test(fileName)),
+    shouldSkipTsickleProcessing: (fileName) => fileName.endsWith('.d.ts'),
     pathToModuleName: (context, importPath) => '',
     shouldIgnoreWarningsForPath: (filePath) => false,
     fileNameToModuleId: (fileName) => fileName,

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -110,18 +110,6 @@ export interface NgcCompatibilityOptions {
    * `TestBed`, which is a no-op in Ivy.
    */
   generateNgSummaryShims?: boolean;
-
-  /**
-   * Tells the compiler to generate definitions using the Render3 style code generation.
-   * This option defaults to `true`.
-   *
-   * Acceptable values are as follows:
-   *
-   * `false` - run ngc normally
-   * `true` - run the ngtsc compiler instead of the normal ngc compiler
-   * `ngtsc` - alias for `true`
-   */
-  enableIvy?: boolean|'ngtsc';
 }
 
 /**
@@ -385,7 +373,6 @@ export interface I18nOptions {
   /**
    * Render `$localize` messages with legacy format ids.
    *
-   * This is only active if we are building with `enableIvy: true`.
    * The default value for now is `true`.
    *
    * Use this option when use are using the `$localize` based localization messages but
@@ -437,7 +424,7 @@ export interface TargetOptions {
 export interface MiscOptions {
   /**
    * Whether the compiler should avoid generating code for classes that haven't been exported.
-   * This is only active when building with `enableIvy: true`. Defaults to `true`.
+   * Defaults to `true`.
    */
   compileNonExportedClasses?: boolean;
 

--- a/packages/compiler-cli/src/perform_compile.ts
+++ b/packages/compiler-cli/src/perform_compile.ts
@@ -119,9 +119,6 @@ export function readConfiguration(
         ts.parseJsonConfigFileContent(
             config, parseConfigHost, basePath, existingCompilerOptions, configFileName);
 
-    // Coerce to boolean as `enableIvy` can be `ngtsc|true|false|undefined` here.
-    options.enableIvy = !!(options.enableIvy ?? true);
-
     let emitFlags = api.EmitFlags.Default;
     if (!(options.skipMetadataEmit || options.flatModuleOutFile)) {
       emitFlags |= api.EmitFlags.Metadata;

--- a/packages/compiler-cli/src/transformers/util.ts
+++ b/packages/compiler-cli/src/transformers/util.ts
@@ -8,9 +8,8 @@
 
 import ts from 'typescript';
 
-import {CompilerOptions, DEFAULT_ERROR_CODE, SOURCE} from './api';
+import {DEFAULT_ERROR_CODE, SOURCE} from './api';
 
-export const GENERATED_FILES = /(.*?)\.(ngfactory|shim\.ngstyle|ngstyle|ngsummary)\.(js|d\.ts|ts)$/;
 
 export function error(msg: string): never {
   throw new Error(`Internal error: ${msg}`);

--- a/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/compile_test.ts
@@ -117,7 +117,6 @@ function getOptions(
     moduleResolution: ts.ModuleResolutionKind.NodeJs,
     typeRoots: ['node_modules/@types'],
     ...convertedCompilerOptions.options,
-    enableIvy: true,
     enableI18nLegacyMessageIdFormat: false,
     ...angularCompilerOptions,
   };

--- a/packages/compiler-cli/test/ngtsc/env.ts
+++ b/packages/compiler-cli/test/ngtsc/env.ts
@@ -78,9 +78,6 @@ export class NgtscTestEnvironment {
         "lib": ["es2015", "dom"],
         "typeRoots": ["node_modules/@types"]
       },
-      "angularCompilerOptions": {
-        "enableIvy": true,
-      },
       "exclude": [
         "built"
       ]
@@ -195,7 +192,7 @@ export class NgtscTestEnvironment {
   tsconfig(extraOpts: TsConfigOptions = {}, extraRootDirs?: string[], files?: string[]): void {
     const tsconfig: {[key: string]: any} = {
       extends: './tsconfig-base.json',
-      angularCompilerOptions: {...extraOpts, enableIvy: true},
+      angularCompilerOptions: extraOpts,
     };
     if (files !== undefined) {
       tsconfig['files'] = files;

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -1905,7 +1905,6 @@ function allTests(os: string) {
       it('should be able to use abstract directive in other compilation units', () => {
         env.write('tsconfig.json', JSON.stringify({
           extends: './tsconfig-base.json',
-          angularCompilerOptions: {enableIvy: true},
           compilerOptions: {rootDir: '.', outDir: '../node_modules/lib1_built'},
         }));
         env.write('index.ts', `

--- a/packages/compiler-cli/test/perform_compile_spec.ts
+++ b/packages/compiler-cli/test/perform_compile_spec.ts
@@ -51,33 +51,31 @@ describe('perform_compile', () => {
   it('should merge tsconfig "angularCompilerOptions"', () => {
     writeSomeConfigs();
     const {options} = readConfiguration(path.resolve(basePath, 'tsconfig-level-1.json'));
-    expect(options.annotateForClosureCompiler).toBe(true);
+    expect(options.annotateForClosureCompiler).toBeTrue();
     expect(options.annotationsAs).toBe('decorators');
-    expect(options.skipMetadataEmit).toBe(true);
+    expect(options.skipMetadataEmit).toBeTrue();
   });
 
-  it(`should return 'enableIvy: true' when enableIvy is not defined in "angularCompilerOptions"`,
-     () => {
-       writeSomeConfigs();
-       const {options} = readConfiguration(path.resolve(basePath, 'tsconfig-level-1.json'));
-       expect(options.enableIvy).toBe(true);
-     });
+  it(`should return undefined when debug is not defined in "angularCompilerOptions"`, () => {
+    writeSomeConfigs();
+    const {options} = readConfiguration(path.resolve(basePath, 'tsconfig-level-1.json'));
+    expect(options.debug).toBeUndefined();
+  });
 
-  it(`should return 'enableIvy: false' when enableIvy is disabled in "angularCompilerOptions"`,
-     () => {
-       writeSomeConfigs();
-       support.writeFiles({
-         'tsconfig-level-3.json': `{
+  it(`should return 'debug: false' when debug is disabled in "angularCompilerOptions"`, () => {
+    writeSomeConfigs();
+    support.writeFiles({
+      'tsconfig-level-3.json': `{
           "angularCompilerOptions": {
-            "enableIvy": false
+            "debug": false
           }
         }
       `,
-       });
+    });
 
-       const {options} = readConfiguration(path.resolve(basePath, 'tsconfig-level-1.json'));
-       expect(options.enableIvy).toBe(false);
-     });
+    const {options} = readConfiguration(path.resolve(basePath, 'tsconfig-level-1.json'));
+    expect(options.debug).toBeFalse();
+  });
 
   it('should override options defined in tsconfig with those defined in `existingOptions`', () => {
     support.writeFiles({
@@ -89,15 +87,17 @@ describe('perform_compile', () => {
             "annotateForClosureCompiler": true
           }
         }
-      `
+      `,
     });
 
-    const {options} = readConfiguration(
-        path.resolve(basePath, 'tsconfig-level-1.json'),
-        {annotateForClosureCompiler: false, target: ts.ScriptTarget.ES2015, enableIvy: false});
+    const {options} = readConfiguration(path.resolve(basePath, 'tsconfig-level-1.json'), {
+      annotateForClosureCompiler: false,
+      target: ts.ScriptTarget.ES2015,
+      debug: false,
+    });
 
     expect(options).toEqual(jasmine.objectContaining({
-      enableIvy: false,
+      debug: false,
       target: ts.ScriptTarget.ES2015,
       annotateForClosureCompiler: false,
     }));
@@ -108,7 +108,7 @@ describe('perform_compile', () => {
       'tsconfig-level-1.json': `{
           "extends": "@angular-ru/tsconfig",
           "angularCompilerOptions": {
-            "enableIvy": false
+            "debug": false
           }
         }
       `,
@@ -133,7 +133,7 @@ describe('perform_compile', () => {
     expect(options).toEqual(jasmine.objectContaining({
       strict: true,
       skipMetadataEmit: true,
-      enableIvy: false,
+      debug: false,
     }));
   });
 
@@ -143,7 +143,7 @@ describe('perform_compile', () => {
          'tsconfig-level-1.json': `{
             "extends": "@1stg/tsconfig/angular",
             "angularCompilerOptions": {
-              "enableIvy": false
+              "debug": false
             }
           }`,
          'node_modules/@1stg/tsconfig/angular.json': `{
@@ -164,7 +164,7 @@ describe('perform_compile', () => {
        expect(options).toEqual(jasmine.objectContaining({
          strict: true,
          skipMetadataEmit: true,
-         enableIvy: false,
+         debug: false,
        }));
      });
 
@@ -174,7 +174,7 @@ describe('perform_compile', () => {
          'tsconfig-level-1.json': `{
             "extends": "./tsconfig.app",
             "angularCompilerOptions": {
-              "enableIvy": false
+              "debug": false
             }
           }`,
          'tsconfig.app.json': `{
@@ -191,7 +191,7 @@ describe('perform_compile', () => {
        expect(options).toEqual(jasmine.objectContaining({
          strict: true,
          skipMetadataEmit: true,
-         enableIvy: false,
+         debug: false,
        }));
      });
 });

--- a/packages/language-service/test/legacy/language_service_spec.ts
+++ b/packages/language-service/test/legacy/language_service_spec.ts
@@ -34,7 +34,6 @@ describe('language service adapter', () => {
   describe('parse compiler options', () => {
     it('should initialize with angularCompilerOptions from tsconfig.json', () => {
       expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
-        enableIvy: true,  // default for ivy is true
         strictTemplates: true,
         strictInjectionParameters: true,
       }));
@@ -42,7 +41,6 @@ describe('language service adapter', () => {
 
     it('should reparse angularCompilerOptions on tsconfig.json change', () => {
       expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
-        enableIvy: true,  // default for ivy is true
         strictTemplates: true,
         strictInjectionParameters: true,
       }));
@@ -66,7 +64,6 @@ describe('language service adapter', () => {
 
       // First make sure the default for strictTemplates is true
       expect(ngLS.getCompilerOptions()).toEqual(jasmine.objectContaining({
-        enableIvy: true,  // default for ivy is true
         strictTemplates: true,
         strictInjectionParameters: true,
       }));


### PR DESCRIPTION
This option has no longer any effect as Ivy is the only rendering engine.


BREAKING CHANGE: Angular compiler option `enableIvy` has been removed as Ivy is the only rendering engine.