### PR TITLE
fix(common): use DOCUMENT token to query for preconnect links

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
+++ b/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
@@ -49,6 +49,8 @@ export const PRECONNECT_CHECK_BLOCKLIST =
  */
 @Injectable({providedIn: 'root'})
 export class PreconnectLinkChecker {
+  private document = inject(DOCUMENT);
+
   /**
    * Set of <link rel="preconnect"> tags found on this page.
    * The `null` value indicates that there was no DOM query operation performed.
@@ -66,7 +68,7 @@ export class PreconnectLinkChecker {
 
   constructor() {
     assertDevMode('preconnect link checker');
-    const win = inject(DOCUMENT).defaultView;
+    const win = this.document.defaultView;
     if (typeof win !== 'undefined') {
       this.window = win;
     }
@@ -127,7 +129,7 @@ export class PreconnectLinkChecker {
   private queryPreconnectLinks(): Set<string> {
     const preconnectUrls = new Set<string>();
     const selector = 'link[rel=preconnect]';
-    const links: HTMLLinkElement[] = Array.from(document.querySelectorAll(selector));
+    const links: HTMLLinkElement[] = Array.from(this.document.querySelectorAll(selector));
     for (let link of links) {
       const url = getUrl(link.href, this.window!);
       preconnectUrls.add(url.origin);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`PreconnectLinkChecker` checks to see if preconnect links have been added to the `<head>` element but uses `document` directly which does not exist when rendering in Angular Universal.

Issue Number: N/A


## What is the new behavior?

switches the `PreconnectLinkChecker` to use the `DOCUMENT` token instead so that the query works when SSR'ing

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
