### PR TITLE
docs: add standalone component intro video

### DIFF
--- a/aio/content/guide/standalone-components.md
+++ b/aio/content/guide/standalone-components.md
@@ -11,6 +11,8 @@ It's ready for you to try; but it might change before it is stable.
 
 ## Creating standalone components
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/x5PZwb4XurU" title="YouTube video player" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 ### The `standalone` flag and component `imports`
 
 Components, directives, and pipes can now be marked as `standalone: true`. Angular classes marked as standalone do not need to be declared in an `NgModule` (the Angular compiler will report an error if you try).


### PR DESCRIPTION
Fix: #47358

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Open  Standalone Components topic and see no video

Issue Number: #47358

## What is the new behavior?

Open Standalone Components topic and see video frame

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

## Other information
