### PR TITLE
docs: add link to YouTube video of Typed Forms

### DIFF
--- a/aio/content/guide/typed-forms.md
+++ b/aio/content/guide/typed-forms.md
@@ -12,6 +12,8 @@ As background for this guide, you should already be familiar with [Angular React
 
 ## Overview of Typed Forms
 
+<iframe width="560" height="315" src="https://www.youtube.com/embed/L-odCf4MfJc" title="YouTube video player" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
 With Angular reactive forms, you explicitly specify a *form model*. As a simple example, consider this basic user login form:
 
 ```ts


### PR DESCRIPTION
Fix: #47360

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

https://angular.io/guide/typed-forms doesn't have a link to the intro video

Issue Number: #47360

## What is the new behavior?

https://angular.io/guide/typed-forms has a link to the intro video

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No