### PR TITLE
build(bazel): fix a bug where aio firebase utils tests could not link deps

### DIFF
--- a/aio/tests/deployment/unit/BUILD.bazel
+++ b/aio/tests/deployment/unit/BUILD.bazel
@@ -11,6 +11,7 @@ nodejs_test(
         "//aio:ngsw-config.json",
         "//aio:tsconfig.json",
         "//aio/tests/deployment/shared",
+        "//aio/tools/firebase-test-utils:sources",
         "//packages/service-worker/config:sources",
         "@aio_npm//@types/jasmine",
         "@aio_npm//canonical-path",
@@ -19,5 +20,8 @@ nodejs_test(
         "@aio_npm//ts-node",
         "@aio_npm//xregexp",
     ],
+    # This test script runs ts-node which seems to bypass rules_nodejs require
+    # patching and cannot find deps. Enable the linker for this target.
+    enable_linker = True,
     entry_point = "test.js",
 )

--- a/aio/tests/deployment/unit/test.js
+++ b/aio/tests/deployment/unit/test.js
@@ -14,9 +14,12 @@ const Jasmine = require('jasmine');
 const {join} = require('path');
 const {register} = require('ts-node');
 
-register({project: join(__dirname, 'tsconfig.json')});
+const runfilesRoot = process.cwd();
+const dirname = join(runfilesRoot, 'aio', 'tests', 'deployment', 'unit');
 
-const runner = new Jasmine({projectBaseDir: __dirname});
+register({project: join(dirname, 'tsconfig.json')});
+
+const runner = new Jasmine({projectBaseDir: dirname});
 runner.loadConfig({spec_files: ['**/*.spec.ts']});
 runner.execute().catch((error) => {
   // Something broke so non-zero exit to prevent the process from succeeding.

--- a/aio/tools/firebase-test-utils/BUILD.bazel
+++ b/aio/tools/firebase-test-utils/BUILD.bazel
@@ -1,14 +1,24 @@
 load("//aio/tools:defaults.bzl", "nodejs_test")
 
+filegroup(
+    name = "sources",
+    srcs = glob(["*.ts"]),
+    visibility = ["//aio/tests/deployment/unit:__pkg__"],
+)
+
 nodejs_test(
     name = "test",
     data = [
         "tsconfig.json",
+        ":sources",
         "//aio:tsconfig.json",
         "@aio_npm//@types/jasmine",
         "@aio_npm//jasmine",
         "@aio_npm//ts-node",
         "@aio_npm//xregexp",
-    ] + glob(["*.ts"]),
+    ],
+    # This test script runs ts-node which seems to bypass rules_nodejs require
+    # patching and cannot find deps. Enable the linker for this target.
+    enable_linker = True,
     entry_point = "test.js",
 )

--- a/aio/tools/firebase-test-utils/FirebaseRedirectSource.spec.ts
+++ b/aio/tools/firebase-test-utils/FirebaseRedirectSource.spec.ts
@@ -361,5 +361,5 @@ function testSourceMatch(
     matches: { [url: string]: unknown|undefined }) {
   expect(source.namedGroups).toEqual(captures.named || []);
   expect(source.restNamedGroups).toEqual(captures.rest || []);
-  Object.keys(matches).forEach(url => expect(source.match(url)).toEqual(matches[url]));
+  Object.keys(matches).forEach(url => expect(source.match(url) as any).toEqual(matches[url]));
 }

--- a/aio/tools/firebase-test-utils/test.js
+++ b/aio/tools/firebase-test-utils/test.js
@@ -14,9 +14,12 @@ const Jasmine = require('jasmine');
 const {join} = require('path');
 const {register} = require('ts-node');
 
-register({project: join(__dirname, 'tsconfig.json')});
+const runfilesRoot = process.cwd();
+const dirname = join(runfilesRoot, 'aio', 'tools', 'firebase-test-utils');
 
-const runner = new Jasmine({projectBaseDir: __dirname});
+register({project: join(dirname, 'tsconfig.json')});
+
+const runner = new Jasmine({projectBaseDir: dirname});
 runner.loadConfig({spec_files: ['**/*.spec.ts']});
 runner.execute().catch((error) => {
   // Something broke so non-zero exit to prevent the process from succeeding.


### PR DESCRIPTION
@gkalpak @devversion @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Firebase util tests can't resolve some deps due to using ts-node which doesn't seem to use rules_nodejs's require patches.

## What is the new behavior?

These tests enable the rules_nodejs linker.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


I thought these were passing locally but I noticed errors on CI. IIRC the concurrency issues with enabling the linker on Windows only occurred when the targets were in the same package(?), so I don't think it will be an issue here.
