### PR TITLE
build(bazel): patch architect to not clear output

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -124,6 +124,7 @@ yarn_install(
     data = [
         YARN_LABEL,
         "//:.yarnrc",
+        "//aio:tools/cli-patches/bazel-architect-output.patch",
         "//aio:tools/cli-patches/patch.js",
     ],
     # Currently disabled due to:

--- a/aio/tools/cli-patches/README.md
+++ b/aio/tools/cli-patches/README.md
@@ -2,4 +2,6 @@
 
 The AIO application is built using the Angular CLI tool. We are often trialling new features for the CLI, which we apply to the library after it is installed.  This folder contains git patch files that contain these new features and a utility to apply those patches to the CLI library.
 
-**Currently, we have no patches to run.**
+# Patches
+
+1. [bazel-architect-output.patch](./bazel-architect-output.patch) - Patch architect to not clear the console before reporting the result of an operation. This makes it easier when working in bazel so that the cause of build and test errors can be seen in the console without needing to search through the command or test logs.

--- a/aio/tools/cli-patches/bazel-architect-output.patch
+++ b/aio/tools/cli-patches/bazel-architect-output.patch
@@ -1,0 +1,13 @@
+diff --git node_modules/@angular-devkit/architect-cli/bin/architect.js node_modules/@angular-devkit/architect-cli/bin/architect.js
+index 27b74b3..96b16a4 100644
+--- node_modules/@angular-devkit/architect-cli/bin/architect.js
++++ node_modules/@angular-devkit/architect-cli/bin/architect.js
+@@ -198,8 +198,6 @@ async function main(args) {
+     // Show usage of deprecated options
+     registry.useXDeprecatedProvider((msg) => logger.warn(msg));
+     const { workspace } = await core_1.workspaces.readWorkspace(configFilePath, core_1.workspaces.createWorkspaceHost(new node_2.NodeJsSyncHost()));
+-    // Clear the console.
+-    process.stdout.write('\u001Bc');
+     return await _executeTarget(logger, workspace, root, argv, registry);
+ }
+ main(process.argv.slice(2)).then((code) => {


### PR DESCRIPTION
@devversion @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The architect rules under bazel cut off output before the final success or failure report, obscuring errors and forcing users to look at the command log for the real error.


## What is the new behavior?

Added an architect patch to not clear stdout.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
