### PR TITLE
docs: update the prompts in the doc issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/3-docs-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/3-docs-bug.yaml
@@ -5,38 +5,54 @@ body:
   - type: textarea
     id: description
     attributes:
-      label: Description
+      label: Describe the problem that you experienced
     validations:
       required: true
 
   - type: input
     id: affected-url
     attributes:
-      label: What is the affected URL?
+      label: Enter the URL of the topic with the problem
+
+  - type: textarea
+    id: documentation-goal
+    attributes:
+      label: Describe what you were looking for in the documentation
 
   - type: textarea
     id: reproduction-steps
     attributes:
-      label: Please provide the steps to reproduce the issue
+      label: Describe the actions that led you to experience the problem
 
   - type: textarea
     id: expected-vs-actual-behavior
     attributes:
-      label: Please provide the expected behavior vs the actual behavior you encountered
+      label: Describe what you want to experience that would fix the problem
 
   - type: textarea
     id: screenshot
     attributes:
-      label: Please provide a screenshot if possible
+      label: Add a screenshot if that helps illustrate the problem
 
   - type: textarea
     id: exception-or-error
     attributes:
-      label: Please provide the exception or error you saw
+      label: If this problem caused an exception or error, please paste it here
       render: true
+      placeholder: |
+        ```
+        Paste the exception or error here inside a markdown code block,
+        which is annotated by three grave \(&grave;\) characters before and after the text block.
+        ```
 
   - type: textarea
     id: browser-info
     attributes:
-      label: Is this a browser-specific issue? If so, please specify the device, browser, and version.
+      label: If the problem is browser-specific, please specify the device, OS, browser, and version
+      render: true
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Provide any additional information here in as much as detail as you can
       render: true


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [X] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The prompts in the "Create a doc bug" template don't all make sense in a documentation issue context.

Issue Number: N/A


## What is the new behavior?
The prompts are more aligned with what you'd find in a documentation issue

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
