### PR TITLE
build(bazel): enable remote-exec on aio example e2es

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,10 +126,6 @@ yarn_install(
         "//:.yarnrc",
         "//aio:tools/cli-patches/patch.js",
     ],
-    # Currently disabled due to:
-    #  1. Missing Windows support currently.
-    #  2. Incompatibilites with the `ts_library` rule.
-    exports_directories_only = False,
     manual_build_file_contents = npm_package_archives(),
     package_json = "//aio:package.json",
     # We prefer to symlink the `node_modules` to only maintain a single install.

--- a/aio/BUILD.bazel
+++ b/aio/BUILD.bazel
@@ -195,8 +195,6 @@ architect(
     }),
     output_dir = True,
     # AIO build makes a network call to download fonts, which is prohibited on remote executors.
-    # Further, when building with local packages (--config=aio_local_deps), RBE complains about
-    # the input tree being too large (> 70,000 files).
     tags = ["no-remote-exec"],
 )
 

--- a/aio/content/examples/examples.bzl
+++ b/aio/content/examples/examples.bzl
@@ -207,7 +207,7 @@ def docs_example(name, test = True):
                 "//conditions:default": [],
             }),
             configuration_env_vars = ["NG_BUILD_CACHE"],
-            entry_point = "//aio/tools/examples:run-example-e2e",
+            entry_point = "//aio/tools/examples:run-example-e2e.mjs",
             env = {
                 "CHROME_BIN": "$(CHROMIUM)",
                 "CHROMEDRIVER_BIN": "$(CHROMEDRIVER)",
@@ -215,7 +215,4 @@ def docs_example(name, test = True):
             toolchains = [
                 "@aio_npm//@angular/build-tooling/bazel/browsers/chromium:toolchain_alias",
             ],
-            # RBE complains about superseeding the max inputs limit (70,000) due to the
-            # size of the input tree.
-            tags = ["no-remote-exec"],
         )

--- a/aio/content/examples/examples.bzl
+++ b/aio/content/examples/examples.bzl
@@ -171,7 +171,9 @@ def docs_example(name, test = True):
                 "$(execpath :%s)" % name,
                 "$(RULEDIR)",
             ],
-            data = [":%s" % name],
+            data = [
+                ":%s" % name,
+            ],
             outs = outs,
             tool = "//aio/tools/example-zipper:generate-example-zip",
         )

--- a/aio/tools/esm-loader/esm-loader.mjs
+++ b/aio/tools/esm-loader/esm-loader.mjs
@@ -17,12 +17,7 @@ export async function resolve(specifier, context, defaultResolve) {
       return defaultResolve(specifier, context, defaultResolve);
     }
 
-    let nodeModules;
-    if (isBazelRunOrTestAction()) {
-      nodeModules = path.resolve('../', process.env.NODE_MODULES_WORKSPACE_NAME, 'node_modules');
-    } else {
-      nodeModules = path.resolve('external', process.env.NODE_MODULES_WORKSPACE_NAME, 'node_modules');
-    }
+    const nodeModules = path.resolve(process.env.RUNFILES_DIR, process.env.NODE_MODULES_WORKSPACE_NAME, 'node_modules');
 
     const packageImport = parsePackageImport(specifier);
     const pathToNodeModule = path.join(nodeModules, packageImport.packageName);
@@ -58,8 +53,4 @@ function resolvePackageLocalFilepath(packageImport, packageJson) {
     }
 
     return packageImport.pathInPackage || packageJson.module || packageJson.main || 'index.js';
-}
-
-function isBazelRunOrTestAction() {
-  return process.env.TEST_WORKSPACE || process.env.BUILD_WORKSPACE_DIRECTORY;
 }

--- a/aio/tools/example-zipper/exampleZipper.mjs
+++ b/aio/tools/example-zipper/exampleZipper.mjs
@@ -182,6 +182,12 @@ export class ExampleZipper {
       // zip.append(fs.createReadStream(fileName), { name: relativePath });
       let output = regionExtractor()(content, extn).contents;
 
+      // For some unknown reason, after flipping exports_directories_only to True
+      // in the aio yarn_install, attempting to archive empty files fails. As a
+      // workaround, whenever the file is empty instead archive a file with a newline.
+      if (!output.length) {
+        output = "\n";
+      }
       zip.append(output, { name: relativePath } );
     });
 

--- a/aio/tools/examples/BUILD.bazel
+++ b/aio/tools/examples/BUILD.bazel
@@ -4,6 +4,10 @@ load("@aio_npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 
 package(default_visibility = ["//visibility:public"])
 
+exports_files([
+    "run-example-e2e.mjs",
+])
+
 EXAMPLE_BOILERPLATE_SRCS = [
     "example-boilerplate.js",
     "constants.js",


### PR DESCRIPTION
@devversion @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Remote exec was disabled for example e2es because the input tree was too large (>70,000 files).

## What is the new behavior?

Flipped `exports_directories_only` to True to reduce the size of the input tree.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
