### PR TITLE
docs: add new topics for lifecycle hook methods content

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -273,6 +273,8 @@ groups:
           'aio/content/guide/lazy-loading-ngmodules.md',
           'aio/content/examples/lazy-loading-ngmodules/**/{*,.*}',
           'aio/content/images/guide/lazy-loading-ngmodules/**/{*,.*}',
+          'aio/content/guide/lifecycle-hook/lifecycle-hook-example.md',
+          'aio/content/guide/lifecycle-hook/lifecycle-hook-overview.md',
           'aio/content/guide/lifecycle-hooks.md',
           'aio/content/examples/lifecycle-hooks/**/{*,.*}',
           'aio/content/images/guide/lifecycle-hooks/**/{*,.*}',

--- a/aio/content/guide/lifecycle-hook/lifecycle-hook-example.md
+++ b/aio/content/guide/lifecycle-hook/lifecycle-hook-example.md
@@ -1,0 +1,9 @@
+#
+
+<!-- links -->
+
+<!-- external links -->
+
+<!-- end links -->
+
+@reviewed 2022-08-22

--- a/aio/content/guide/lifecycle-hook/lifecycle-hook-overview.md
+++ b/aio/content/guide/lifecycle-hook/lifecycle-hook-overview.md
@@ -1,0 +1,9 @@
+#
+
+<!-- links -->
+
+<!-- external links -->
+
+<!-- end links -->
+
+@reviewed 2022-08-22


### PR DESCRIPTION
Add new files for lifecycle hook methods content.

This PR represents the first of many PRs to reorganize the lifecycle hook methods content.
The interim PRs will add content that is not visible in the left-nav TOC.
The final PR will add the topics to the left-nav TOC and retire the old, existing topics.

The following branches each focus on a set of changes to follow this PR.

| Branch                                         | changes |
|:---                                            |:---     |
| componentUpdateLifecycleHooksBreakOut2022aug22 | Empty files for lifecycle-hook directory |
| componentUpdateLifecycleHooksMoveOne2022sep02  | Add lifecycle-hook-use |
| componentUpdateLifecycleHooksMoveTwo2022sep02  | Add lifecycle-hook-example |
