### PR TITLE
[14.2.x] fix(common): rename `rawSrc` -> `ngSrc` in NgOptimizedImage directive (#47362)

### DIFF
--- a/aio/content/guide/image-directive-setup.md
+++ b/aio/content/guide/image-directive-setup.md
@@ -93,4 +93,4 @@ providers: [
 
 A loader function for the `NgOptimizedImage` directive takes an object with the `ImageLoaderConfig` type (from `@angular/common`) as its argument and returns the absolute URL of the image asset. The `ImageLoaderConfig` object contains the `src`and `width` properties.
 
-Note: a custom loader must support requesting images at various widths in order for `rawSrcset` to work properly.
+Note: a custom loader must support requesting images at various widths in order for `ngSrcset` to work properly.

--- a/aio/content/guide/image-directive.md
+++ b/aio/content/guide/image-directive.md
@@ -25,11 +25,11 @@ You will need to import the directive into your application. In addition, you wi
 
 ### Overview
 
-To activate the `NgOptimizedImage` directive, replace your image's `src` attribute with `rawSrc`.
+To activate the `NgOptimizedImage` directive, replace your image's `src` attribute with `ngSrc`.
 
 <code-example format="typescript" language="typescript">
 
-&lt;img rawSrc="cat.jpg" width="400" height="200"&gt;
+&lt;img ngSrc="cat.jpg" width="400" height="200"&gt;
 
 </code-example>
 
@@ -43,7 +43,7 @@ Always mark the [LCP image](https://web.dev/lcp/#what-elements-are-considered) o
 
 <code-example format="typescript" language="typescript">
 
-&lt;img rawSrc="cat.jpg" width="400" height="200" priority&gt;
+&lt;img ngSrc="cat.jpg" width="400" height="200" priority&gt;
 
 </code-example>
 
@@ -84,21 +84,21 @@ You can typically fix this by adding `height: auto` or `width: auto` to your ima
 
 ### Handling `srcset` attributes
 
-If your `<img>` tag defines a `srcset` attribute, replace it with `rawSrcset`.
+If your `<img>` tag defines a `srcset` attribute, replace it with `ngSrcset`.
 
 <code-example format="html" language="html">
 
-&lt;img rawSrc="hero.jpg" rawSrcset="100w, 200w, 300w"&gt;
+&lt;img ngSrc="hero.jpg" ngSrcset="100w, 200w, 300w"&gt;
 
 </code-example>
 
-If the `rawSrcset` attribute is present, `NgOptimizedImage` generates and sets the [`srcset` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset) using the configured image loader. Do not include image file names in `rawSrcset` - the directive infers this information from `rawSrc`. The directive supports both width descriptors (e.g. `100w`) and density descriptors (e.g. `1x`) are supported.
+If the `ngSrcset` attribute is present, `NgOptimizedImage` generates and sets the [`srcset` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset) using the configured image loader. Do not include image file names in `ngSrcset` - the directive infers this information from `ngSrc`. The directive supports both width descriptors (e.g. `100w`) and density descriptors (e.g. `1x`) are supported.
 
-You can also use `rawSrcset` with the standard image [`sizes` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes).
+You can also use `ngSrcset` with the standard image [`sizes` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes).
 
 <code-example format="html" language="html">
 
-&lt;img rawSrc="hero.jpg" rawSrcset="100w, 200w, 300w" sizes="50vw"&gt;
+&lt;img ngSrc="hero.jpg" ngSrcset="100w, 200w, 300w" sizes="50vw"&gt;
 
 </code-example>
 
@@ -108,7 +108,7 @@ By default, `NgOptimizedImage` sets `loading=lazy` for all images that are not m
 
 <code-example format="html" language="html">
 
-&lt;img rawSrc="cat.jpg" width="400" height="200" loading="eager"&gt;
+&lt;img ngSrc="cat.jpg" width="400" height="200" loading="eager"&gt;
 
 </code-example>
 

--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -545,16 +545,18 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     ngOnDestroy(): void;
     // (undocumented)
     ngOnInit(): void;
+    ngSrc: string;
+    ngSrcset: string;
     set priority(value: string | boolean | undefined);
     // (undocumented)
     get priority(): boolean;
-    rawSrc: string;
-    rawSrcset: string;
+    // @deprecated
+    set rawSrc(value: string);
     set width(value: string | number | undefined);
     // (undocumented)
     get width(): number | undefined;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[rawSrc]", never, { "rawSrc": "rawSrc"; "rawSrcset": "rawSrcset"; "width": "width"; "height": "height"; "loading": "loading"; "priority": "priority"; "src": "src"; "srcset": "srcset"; }, {}, never, never, true>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[ngSrc],img[rawSrc]", never, { "rawSrc": "rawSrc"; "ngSrc": "ngSrc"; "ngSrcset": "ngSrcset"; "width": "width"; "height": "height"; "loading": "loading"; "priority": "priority"; "src": "src"; "srcset": "srcset"; }, {}, never, never, true>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgOptimizedImage, never>;
 }

--- a/packages/common/src/directives/ng_optimized_image/error_helper.ts
+++ b/packages/common/src/directives/ng_optimized_image/error_helper.ts
@@ -7,8 +7,8 @@
  */
 
 // Assembles directive details string, useful for error messages.
-export function imgDirectiveDetails(rawSrc: string, includeRawSrc = true) {
-  const rawSrcInfo =
-      includeRawSrc ? `(activated on an <img> element with the \`rawSrc="${rawSrc}"\`) ` : '';
-  return `The NgOptimizedImage directive ${rawSrcInfo}has detected that`;
+export function imgDirectiveDetails(ngSrc: string, includeNgSrc = true) {
+  const ngSrcInfo =
+      includeNgSrc ? `(activated on an <img> element with the \`ngSrc="${ngSrc}"\`) ` : '';
+  return `The NgOptimizedImage directive ${ngSrcInfo}has detected that`;
 }

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
@@ -118,10 +118,10 @@ function throwUnexpectedAbsoluteUrlError(path: string, url: string): never {
   throw new RuntimeError(
       RuntimeErrorCode.INVALID_LOADER_ARGUMENTS,
       ngDevMode &&
-          `Image loader has detected a \`<img>\` tag with an invalid \`rawSrc\` attribute: ${
+          `Image loader has detected a \`<img>\` tag with an invalid \`ngSrc\` attribute: ${
               url}. ` +
-              `This image loader expects \`rawSrc\` to be a relative URL - ` +
+              `This image loader expects \`ngSrc\` to be a relative URL - ` +
               `however the provided value is an absolute URL. ` +
-              `To fix this, provide \`rawSrc\` as a path relative to the base URL ` +
+              `To fix this, provide \`ngSrc\` as a path relative to the base URL ` +
               `configured for this loader (\`${path}\`).`);
 }

--- a/packages/common/src/directives/ng_optimized_image/lcp_image_observer.ts
+++ b/packages/common/src/directives/ng_optimized_image/lcp_image_observer.ts
@@ -27,7 +27,7 @@ import {getUrl} from './url';
  */
 @Injectable({providedIn: 'root'})
 export class LCPImageObserver implements OnDestroy {
-  // Map of full image URLs -> original `rawSrc` values.
+  // Map of full image URLs -> original `ngSrc` values.
   private images = new Map<string, string>();
   // Keep track of images for which `console.warn` was produced.
   private alreadyWarned = new Set<string>();
@@ -65,8 +65,8 @@ export class LCPImageObserver implements OnDestroy {
       // Exclude `data:` and `blob:` URLs, since they are not supported by the directive.
       if (imgSrc.startsWith('data:') || imgSrc.startsWith('blob:')) return;
 
-      const imgRawSrc = this.images.get(imgSrc);
-      if (imgRawSrc && !this.alreadyWarned.has(imgSrc)) {
+      const imgNgSrc = this.images.get(imgSrc);
+      if (imgNgSrc && !this.alreadyWarned.has(imgSrc)) {
         this.alreadyWarned.add(imgSrc);
         logMissingPriorityWarning(imgSrc);
       }
@@ -75,9 +75,9 @@ export class LCPImageObserver implements OnDestroy {
     return observer;
   }
 
-  registerImage(rewrittenSrc: string, rawSrc: string) {
+  registerImage(rewrittenSrc: string, originalNgSrc: string) {
     if (!this.observer) return;
-    this.images.set(getUrl(rewrittenSrc, this.window!).href, rawSrc);
+    this.images.set(getUrl(rewrittenSrc, this.window!).href, originalNgSrc);
   }
 
   unregisterImage(rewrittenSrc: string) {
@@ -93,8 +93,8 @@ export class LCPImageObserver implements OnDestroy {
   }
 }
 
-function logMissingPriorityWarning(rawSrc: string) {
-  const directiveDetails = imgDirectiveDetails(rawSrc);
+function logMissingPriorityWarning(ngSrc: string) {
+  const directiveDetails = imgDirectiveDetails(ngSrc);
   console.warn(formatRuntimeError(
       RuntimeErrorCode.LCP_IMG_MISSING_PRIORITY,
       `${directiveDetails} this image is the Largest Contentful Paint (LCP) ` +

--- a/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
+++ b/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
@@ -96,9 +96,9 @@ export class PreconnectLinkChecker {
    * given src.
    *
    * @param rewrittenSrc src formatted with loader
-   * @param rawSrc rawSrc value
+   * @param originalNgSrc ngSrc value
    */
-  assertPreconnect(rewrittenSrc: string, rawSrc: string): void {
+  assertPreconnect(rewrittenSrc: string, originalNgSrc: string): void {
     if (!this.window) return;
 
     const imgUrl = getUrl(rewrittenSrc, this.window);
@@ -118,8 +118,8 @@ export class PreconnectLinkChecker {
     if (!this.preconnectLinks.has(imgUrl.origin)) {
       console.warn(formatRuntimeError(
           RuntimeErrorCode.PRIORITY_IMG_MISSING_PRECONNECT_TAG,
-          `${imgDirectiveDetails(rawSrc)} there is no preconnect tag present for this image. ` +
-              `Preconnecting to the origin(s) that serve priority images ensures that these ` +
+          `${imgDirectiveDetails(originalNgSrc)} there is no preconnect tag present for this ` +
+              `image. Preconnecting to the origin(s) that serve priority images ensures that these ` +
               `images are delivered as soon as possible. To fix this, please add the following ` +
               `element into the <head> of the document:\n` +
               `  <link rel="preconnect" href="${imgUrl.origin}">`));

--- a/packages/common/test/image_loaders/image_loader_spec.ts
+++ b/packages/common/test/image_loaders/image_loader_spec.ts
@@ -17,9 +17,9 @@ import {TestBed} from '@angular/core/testing';
 
 const absoluteUrlError = (src: string, path: string) =>
     `NG02959: Image loader has detected a \`<img>\` tag with an invalid ` +
-    `\`rawSrc\` attribute: ${src}. This image loader expects \`rawSrc\` ` +
+    `\`ngSrc\` attribute: ${src}. This image loader expects \`ngSrc\` ` +
     `to be a relative URL - however the provided value is an absolute URL. ` +
-    `To fix this, provide \`rawSrc\` as a path relative to the base URL ` +
+    `To fix this, provide \`ngSrc\` as a path relative to the base URL ` +
     `configured for this loader (\`${path}\`).`;
 
 const invalidPathError = (path: string, formats: string) =>

--- a/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
+++ b/packages/core/test/bundling/image-directive/e2e/basic/basic.ts
@@ -13,7 +13,7 @@ import {Component} from '@angular/core';
   selector: 'basic',
   standalone: true,
   imports: [NgOptimizedImage],
-  template: `<img rawSrc="/e2e/a.png" width="150" height="150" priority>`,
+  template: `<img ngSrc="/e2e/a.png" width="150" height="150" priority>`,
   providers: [{
     provide: IMAGE_LOADER,
     useValue: () => 'https://angular.io/assets/images/logos/angular/angular.svg'

--- a/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.e2e-spec.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.e2e-spec.ts
@@ -36,7 +36,7 @@ describe('NgOptimizedImage directive', () => {
     expectErrorMessageInLogs(
         logs,
         'The NgOptimizedImage directive (activated on an \\u003Cimg> element ' +
-            'with the \`rawSrc=\\"/e2e/b.png\\"`) has detected that ' +
+            'with the \`ngSrc=\\"/e2e/b.png\\"`) has detected that ' +
             'the aspect ratio of the image does not match the aspect ratio indicated by the width and height attributes. ' +
             '\\nIntrinsic image size: 250w x 250h (aspect-ratio: 1). ' +
             '\\nSupplied width and height attributes: 26w x 30h (aspect-ratio: 0.8666666666666667). ' +
@@ -45,7 +45,7 @@ describe('NgOptimizedImage directive', () => {
     expectErrorMessageInLogs(
         logs,
         'The NgOptimizedImage directive (activated on an \\u003Cimg> element ' +
-            'with the \`rawSrc=\\"/e2e/b.png\\"`) has detected that ' +
+            'with the \`ngSrc=\\"/e2e/b.png\\"`) has detected that ' +
             'the aspect ratio of the image does not match the aspect ratio indicated by the width and height attributes. ' +
             '\\nIntrinsic image size: 250w x 250h (aspect-ratio: 1). ' +
             '\\nSupplied width and height attributes: 24w x 240h (aspect-ratio: 0.1). ' +
@@ -55,7 +55,7 @@ describe('NgOptimizedImage directive', () => {
     expectErrorMessageInLogs(
         logs,
         'The NgOptimizedImage directive (activated on an \\u003Cimg> element ' +
-            'with the \`rawSrc=\\"/e2e/b.png\\"`) has detected that ' +
+            'with the \`ngSrc=\\"/e2e/b.png\\"`) has detected that ' +
             'the aspect ratio of the rendered image does not match the image\'s intrinsic aspect ratio. ' +
             '\\nIntrinsic image size: 250w x 250h (aspect-ratio: 1). ' +
             '\\nRendered image size: 250w x 30h (aspect-ratio: 8.333333333333334). ' +
@@ -66,7 +66,7 @@ describe('NgOptimizedImage directive', () => {
     expectErrorMessageInLogs(
         logs,
         'The NgOptimizedImage directive (activated on an \\u003Cimg> element ' +
-            'with the \`rawSrc=\\"/e2e/b.png\\"`) has detected that ' +
+            'with the \`ngSrc=\\"/e2e/b.png\\"`) has detected that ' +
             'the aspect ratio of the rendered image does not match the image\'s intrinsic aspect ratio. ' +
             '\\nIntrinsic image size: 250w x 250h (aspect-ratio: 1). ' +
             '\\nRendered image size: 30w x 250h (aspect-ratio: 0.12). ' +
@@ -80,7 +80,7 @@ describe('NgOptimizedImage directive', () => {
     expectErrorMessageInLogs(
         logs,
         'The NgOptimizedImage directive (activated on an \\u003Cimg> element ' +
-            'with the \`rawSrc=\\"/e2e/b.png\\"`) has detected that ' +
+            'with the \`ngSrc=\\"/e2e/b.png\\"`) has detected that ' +
             'the aspect ratio of the image does not match the aspect ratio indicated by the width and height attributes. ' +
             '\\nIntrinsic image size: 250w x 250h (aspect-ratio: 1). ' +
             '\\nSupplied width and height attributes: 150w x 250h (aspect-ratio: 0.6). ' +

--- a/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
@@ -16,33 +16,33 @@ import {Component} from '@angular/core';
   template: `
      <!-- All the images in this template should not throw -->
      <!-- This image is here for the sake of making sure the "LCP image is priority" assertion is passed -->
-     <img rawSrc="/e2e/logo-500w.jpg" width="500" height="500" priority>
+     <img ngSrc="/e2e/logo-500w.jpg" width="500" height="500" priority>
      <br>
      <!-- width and height attributes exactly match the intrinsic size of image -->
-     <img rawSrc="/e2e/a.png" width="25" height="25">
+     <img ngSrc="/e2e/a.png" width="25" height="25">
      <br>
      <!-- supplied aspect ratio exactly matches intrinsic aspect ratio-->
-     <img rawSrc="/e2e/a.png" width="250" height="250">
-     <img rawSrc="/e2e/b.png" width="40" height="40">
-     <img rawSrc="/e2e/b.png" width="240" height="240">
+     <img ngSrc="/e2e/a.png" width="250" height="250">
+     <img ngSrc="/e2e/b.png" width="40" height="40">
+     <img ngSrc="/e2e/b.png" width="240" height="240">
      <br>
      <!-- supplied aspect ratio is similar to intrinsic aspect ratio -->
      <!-- Aspect-ratio: 0.93333333333 -->
-     <img rawSrc="/e2e/b.png" width="28" height="30">
+     <img ngSrc="/e2e/b.png" width="28" height="30">
      <!-- Aspect-ratio: 0.9 -->
-     <img rawSrc="/e2e/b.png" width="27" height="30">
+     <img ngSrc="/e2e/b.png" width="27" height="30">
      <!-- Aspect-ratio: 1.09375 -->
-     <img rawSrc="/e2e/b.png" width="350" height="320">
+     <img ngSrc="/e2e/b.png" width="350" height="320">
      <!-- Aspect-ratio: 1.0652173913 -->
-     <img rawSrc="/e2e/b.png" width="245" height="230">
+     <img ngSrc="/e2e/b.png" width="245" height="230">
      <br>
      <!-- Supplied aspect ratio is correct & image has 0x0 rendered size -->
-     <img rawSrc="/e2e/a.png" width="25" height="25" style="display: none">
+     <img ngSrc="/e2e/a.png" width="25" height="25" style="display: none">
      <br>
      <!-- styling is correct -->
-     <img rawSrc="/e2e/a.png" width="25" height="25" style="width: 100%; height: 100%">
-     <img rawSrc="/e2e/a.png" width="250" height="250" style="max-width: 100%; height: 100%">
-     <img rawSrc="/e2e/a.png" width="25" height="25" style="height: 25%; width: 25%;">
+     <img ngSrc="/e2e/a.png" width="25" height="25" style="width: 100%; height: 100%">
+     <img ngSrc="/e2e/a.png" width="250" height="250" style="max-width: 100%; height: 100%">
+     <img ngSrc="/e2e/a.png" width="25" height="25" style="height: 25%; width: 25%;">
      <br>
     `,
 })
@@ -55,23 +55,23 @@ export class ImageDistortionPassingComponent {
   template: `
      <!-- With the exception of the priority image, all the images in this template should throw -->
      <!-- This image is here for the sake of making sure the "LCP image is priority" assertion is passed -->
-     <img rawSrc="/e2e/logo-500w.jpg" width="500" height="500" priority>
+     <img ngSrc="/e2e/logo-500w.jpg" width="500" height="500" priority>
      <br>
      <!-- These images should throw -->
      <!-- Supplied aspect ratio differs from intrinsic aspect ratio by > .1 -->
      <!-- Aspect-ratio: 0.86666666666 -->
-     <img rawSrc="/e2e/b.png" width="26" height="30">
+     <img ngSrc="/e2e/b.png" width="26" height="30">
      <!-- Aspect-ratio: 0.1 -->
-     <img rawSrc="/e2e/b.png" width="24" height="240">
+     <img ngSrc="/e2e/b.png" width="24" height="240">
      <!-- Supplied aspect ratio is incorrect & image has 0x0 rendered size -->
-     <img rawSrc="/e2e/a.png" width="222" height="25" style="display: none">
+     <img ngSrc="/e2e/a.png" width="222" height="25" style="display: none">
      <br>
      <!-- Image styling is causing distortion -->
      <div style="width: 300px; height: 300px">
-       <img rawSrc="/e2e/b.png" width="250" height="250" style="width: 10%">
-       <img rawSrc="/e2e/b.png" width="250" height="250" style="max-height: 10%">
+       <img ngSrc="/e2e/b.png" width="250" height="250" style="width: 10%">
+       <img ngSrc="/e2e/b.png" width="250" height="250" style="max-height: 10%">
        <!-- Images dimensions are incorrect AND image styling is incorrect -->
-       <img rawSrc="/e2e/b.png" width="150" height="250" style="max-height: 10%">
+       <img ngSrc="/e2e/b.png" width="150" height="250" style="max-height: 10%">
      </div>
      `,
 })

--- a/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/lcp-check/lcp-check.ts
@@ -18,12 +18,12 @@ import {Component} from '@angular/core';
       'b.png' should *not* be treated as an LCP element,
       since there is a bigger one right below it
     -->
-    <img rawSrc="/e2e/b.png" width="5" height="5">
+    <img ngSrc="/e2e/b.png" width="5" height="5">
 
     <br>
 
     <!-- 'a.png' should be treated as an LCP element -->
-    <img rawSrc="/e2e/a.png" width="2500" height="2500">
+    <img ngSrc="/e2e/a.png" width="2500" height="2500">
 
     <br>
 
@@ -31,7 +31,7 @@ import {Component} from '@angular/core';
       'b.png' should *not* be treated as an LCP element here
       as well, since it's below the fold
     -->
-    <img rawSrc="/e2e/b.png" width="10" height="10">
+    <img ngSrc="/e2e/b.png" width="10" height="10">
   `,
 })
 export class LcpCheckComponent {

--- a/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.ts
+++ b/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.ts
@@ -16,12 +16,12 @@ import {Component} from '@angular/core';
   template: `
       <!-- Image is rendered within threshold range-->
       <div style="width: 500px; height: 500px">
-        <img rawSrc="/e2e/logo-500w.jpg" width="200" height="200" priority>
+        <img ngSrc="/e2e/logo-500w.jpg" width="200" height="200" priority>
       </div>
-      <!-- Image is rendered too small but rawSrcset set-->
+      <!-- Image is rendered too small but ngSrcset set-->
       <div style="width: 300px; height: 300px">
-        <img rawSrc="/e2e/logo-1500w.jpg" width="100" height="100" priority
-            rawSrcset="100w, 200w">
+        <img ngSrc="/e2e/logo-1500w.jpg" width="100" height="100" priority
+            ngSrcset="100w, 200w">
       </div>
      `,
 })
@@ -36,7 +36,7 @@ export class OversizedImageComponentPassing {
   template: `
       <!-- Image is rendered too small  -->
       <div style="width: 300px; height: 300px">
-         <img rawSrc="/e2e/logo-1500w.jpg" width="100" height="100" priority>
+         <img ngSrc="/e2e/logo-1500w.jpg" width="100" height="100" priority>
        </div>
       `,
 })

--- a/packages/core/test/bundling/image-directive/e2e/preconnect-check/preconnect-check.ts
+++ b/packages/core/test/bundling/image-directive/e2e/preconnect-check/preconnect-check.ts
@@ -14,9 +14,9 @@ import {Component, Inject} from '@angular/core';
   standalone: true,
   imports: [NgOptimizedImage],
   template: `
-    <img rawSrc="/e2e/a.png" width="50" height="50" priority>
-    <img rawSrc="/e2e/b.png" width="50" height="50" priority>
-    <img rawSrc="/e2e/c.png" width="50" height="50">
+    <img ngSrc="/e2e/a.png" width="50" height="50" priority>
+    <img ngSrc="/e2e/b.png" width="50" height="50" priority>
+    <img ngSrc="/e2e/c.png" width="50" height="50">
   `,
   providers: [{
     provide: IMAGE_LOADER,

--- a/packages/core/test/bundling/image-directive/playground.ts
+++ b/packages/core/test/bundling/image-directive/playground.ts
@@ -34,12 +34,12 @@ import {Component} from '@angular/core';
   `],
   template: `
     <h1> 
-      <img rawSrc="a.png" width="50" height="50" priority rawSrcset="1x, 2x">
+      <img ngSrc="a.png" width="50" height="50" priority ngSrcset="1x, 2x">
       <span>Angular image app</span>
     </h1>
     <main>
       <div class="spacer"></div>
-      <img rawSrc="hermes2.jpeg" rawSrcset="100w, 200w, 1000w, 2000w" width="1791" height="1008">
+      <img ngSrc="hermes2.jpeg" ngSrcset="100w, 200w, 1000w, 2000w" width="1791" height="1008">
     </main>
   `,
   standalone: true,


### PR DESCRIPTION
As an ongoing effort to stabilize the NgOptimizedImage API before existing the Developer Preview, this commit renames the `rawSrc` attribute used for the NgOptimizedImage selector matching to `ngSrc`. The `rawSrcset` is also renamed to `ngSrcset` for consistency.

The motivation for this change is to align the attribute name better with other built-in directives, such as `ngFor`, `ngIf`, `ngClass`, `ngStyle`, etc.

Note: this is technically a breaking change, but since the NgOptimizedImage directive is in the Developer Preview mode, we land the change in a patch branch.