### PR TITLE
build(bazel): avoid network call during aio build by not inlining fonts

### DIFF
--- a/aio/BUILD.bazel
+++ b/aio/BUILD.bazel
@@ -194,8 +194,7 @@ architect(
         "//conditions:default": APPLICATION_DEPS,
     }),
     output_dir = True,
-    # AIO build makes a network call to download fonts, which is prohibited on remote executors.
-    # Further, when building with local packages (--config=aio_local_deps), RBE complains about
+    # When building with local packages (--config=aio_local_deps), RBE complains about
     # the input tree being too large (> 70,000 files).
     tags = ["no-remote-exec"],
 )

--- a/aio/angular.json
+++ b/aio/angular.json
@@ -36,7 +36,9 @@
             "tsConfig": "tsconfig.app.json",
             "webWorkerTsConfig": "tsconfig.worker.json",
             "optimization": {
-              "fonts": true,
+              "fonts": {
+                "inline": false
+              },
               "scripts": true,
               "styles": {
                 "inlineCritical": false,


### PR DESCRIPTION
@devversion @gkalpak @alan-agius4 @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`//aio:build` requires network access which is not hermetic.


## What is the new behavior?

Disabled font inlining to avoid network call.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This is an alternative to vendoring fonts: https://github.com/angular/angular/pull/47394
