### PR TITLE
build: use the `create-pr-for-changes` action from `angular/dev-infra`

### DIFF
--- a/.github/workflows/update-events.yml
+++ b/.github/workflows/update-events.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Generate `events.json`
         run: node aio/scripts/generate-events/index.mjs --ignore-invalid-dates
       - name: Create a PR (if necessary)
-        uses: gkalpak/dev-infra/github-actions/create-pr-for-changes@88c198ae1a3462223cb5c1e83338e4b94b435283
+        uses: angular/dev-infra/github-actions/create-pr-for-changes@bf4bb09bb2d32015f71943371c7484cb845f8c33
         with:
           branch-prefix: docs-update-events
           pr-title: 'docs: update events'


### PR DESCRIPTION
Use the `create-pr-for-changes` action of the `angular/dev-infra` repo, instead of the `gkalpak/dev-infra` one. The latter was used during development for debugging purposes during and was accidentally committed to the repo.
