### PR TITLE
feat(platform-browser): include Location mocks into testing environment by default

### DIFF
--- a/packages/platform-browser/testing/BUILD.bazel
+++ b/packages/platform-browser/testing/BUILD.bazel
@@ -8,6 +8,8 @@ ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
     deps = [
+        "//packages/common",
+        "//packages/common/testing",
         "//packages/core",
         "//packages/core/testing",
         "//packages/platform-browser",

--- a/packages/platform-browser/testing/src/browser.ts
+++ b/packages/platform-browser/testing/src/browser.ts
@@ -5,6 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {PlatformLocation} from '@angular/common';
+import {MockPlatformLocation} from '@angular/common/testing';
 import {APP_ID, createPlatformFactory, NgModule, NgZone, PLATFORM_INITIALIZER, platformCore, StaticProvider} from '@angular/core';
 import {BrowserModule, ɵBrowserDomAdapter as BrowserDomAdapter} from '@angular/platform-browser';
 
@@ -36,6 +38,7 @@ export const platformBrowserTesting =
   providers: [
     {provide: APP_ID, useValue: 'a'},
     {provide: NgZone, useFactory: createNgZone},
+    {provide: PlatformLocation, useClass: MockPlatformLocation},
   ]
 })
 export class BrowserTestingModule {


### PR DESCRIPTION
Currently, the `Location` and `LocationStrategy` mocks are added by the Router's testing module (the `RouterTestingModule`). However, the `Location` and `LocationStrategy` abstractions are parts of the `@angular/common` package and can be used outside of the Router logic to interact with the location.

This PR adds the `Location` and `LocationStrategy` mocks into the `BrowserTestingModule` NgModule, which is used for environment setup in TestBed. Adding the mocks there has 2 main advantages:

- `Location` and `LocationStrategy` mocks will always be setup when you use TestBed (note: if you provide location mocks in the TestBed.configureTestingModule, custom mocks would still be used), which would cover cases when the `Location` is used in apps code directly.
- The Router would not need to provide the mocks for abstractions that belong to the different package (`@angular/common`), which should help simplify the standalone Router APIs for testing.

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No