### PR TITLE
refactor(core): Async tagging zone dev

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -33,7 +33,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2835,
-      "main": 226893,
+      "main": 226324,
       "polyfills": 33842,
       "src_app_lazy_lazy_routes_ts": 487
     }

--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -12,6 +12,7 @@ import {global} from '../util/global';
 import {noop} from '../util/noop';
 import {getNativeRequestAnimationFrame} from '../util/raf';
 
+import {AsyncStackTaggingZoneSpec} from './async-stack-tagging';
 
 /**
  * An injectable service for executing work inside or outside of the Angular zone.
@@ -138,8 +139,12 @@ export class NgZone {
 
     self._outer = self._inner = Zone.current;
 
-    if ((Zone as any)['AsyncStackTaggingZoneSpec']) {
-      const AsyncStackTaggingZoneSpec = (Zone as any)['AsyncStackTaggingZoneSpec'];
+    // AsyncStackTaggingZoneSpec provides `linked stack traces` to show
+    // where the async operation is scheduled. For more details, refer
+    // to this article, https://developer.chrome.com/blog/devtools-better-angular-debugging/
+    // And we only import this AsyncStackTaggingZoneSpec in development mode,
+    // in the production mode, the AsyncStackTaggingZoneSpec will be tree shaken away.
+    if (ngDevMode) {
       self._inner = self._inner.fork(new AsyncStackTaggingZoneSpec('Angular'));
     }
 

--- a/packages/zone.js/bundles.bzl
+++ b/packages/zone.js/bundles.bzl
@@ -19,9 +19,6 @@ BUNDLES_ENTRY_POINTS = {
     "async-test": {
         "entrypoint": _DIR + "testing/async-testing",
     },
-    "async-stack-tagging": {
-        "entrypoint": _DIR + "zone-spec/async-stack-tagging",
-    },
     "fake-async-test": {
         "entrypoint": _DIR + "testing/fake-async",
     },

--- a/packages/zone.js/dist/BUILD.bazel
+++ b/packages/zone.js/dist/BUILD.bazel
@@ -45,8 +45,6 @@ js_library(
 filegroup(
     name = "dist_bundle_group",
     srcs = [
-        ":async-stack-tagging.js",
-        ":async-stack-tagging.min.js",
         ":async-test.js",
         ":async-test.min.js",
         ":fake-async-test.js",

--- a/packages/zone.js/dist/tools.bzl
+++ b/packages/zone.js/dist/tools.bzl
@@ -4,7 +4,6 @@ ES5_BUNDLES = [
     "zone-node",
     "zone-testing-node-bundle",
     "async-test",
-    "async-stack-tagging",
     "fake-async-test",
     "long-stack-trace-zone",
     "proxy",

--- a/packages/zone.js/plugins/BUILD.bazel
+++ b/packages/zone.js/plugins/BUILD.bazel
@@ -3,8 +3,6 @@ package(default_visibility = ["//visibility:public"])
 filegroup(
     name = "plugin_bundle_group",
     srcs = [
-        "//packages/zone.js/plugins:async-stack-tagging.min/package.json",
-        "//packages/zone.js/plugins:async-stack-tagging/package.json",
         "//packages/zone.js/plugins:async-test.min/package.json",
         "//packages/zone.js/plugins:async-test/package.json",
         "//packages/zone.js/plugins:fake-async-test.min/package.json",

--- a/packages/zone.js/plugins/async-stack-tagging.min/package.json
+++ b/packages/zone.js/plugins/async-stack-tagging.min/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "zone.js/async-stack-tagging.min",
-  "main": "../../bundles/async-stack-tagging.umd.min.js",
-  "fesm2015": "../../fesm2015/async-stack-tagging.min.js",
-  "es2015": "../../fesm2015/async-stack-tagging.min.js",
-  "module": "../../fesm2015/async-stack-tagging.min.js"
-}

--- a/packages/zone.js/plugins/async-stack-tagging/package.json
+++ b/packages/zone.js/plugins/async-stack-tagging/package.json
@@ -1,7 +1,0 @@
-{
-  "name": "zone.js/async-stack-tagging",
-  "main": "../../bundles/async-stack-tagging.umd.js",
-  "fesm2015": "../../fesm2015/async-stack-tagging.js",
-  "es2015": "../../fesm2015/async-stack-tagging.js",
-  "module": "../../fesm2015/async-stack-tagging.js"
-}

--- a/packages/zone.js/test/BUILD.bazel
+++ b/packages/zone.js/test/BUILD.bazel
@@ -34,7 +34,6 @@ ts_library(
         exclude = [
             "common/Error.spec.ts",
             "common/promise-disable-wrap-uncaught-promise-rejection.spec.ts",
-            "zone-spec/async-tagging-console.spec.ts",
         ],
     ),
     deps = [
@@ -265,7 +264,6 @@ test_srcs = glob(
     "jasmine-patch.spec.ts",
     "common_tests.ts",
     "browser_entry_point.ts",
-    "zone-spec/async-tagging-console.spec.ts",
 ]
 
 test_deps = [

--- a/packages/zone.js/test/browser-zone-setup.ts
+++ b/packages/zone.js/test/browser-zone-setup.ts
@@ -21,7 +21,6 @@ import '../lib/browser/webapis-media-query';
 import '../lib/testing/zone-testing';
 import '../lib/zone-spec/task-tracking';
 import '../lib/zone-spec/wtf';
-import '../lib/zone-spec/async-stack-tagging';
 import '../lib/extra/cordova';
 import '../lib/testing/promise-testing';
 import '../lib/testing/async-testing';

--- a/packages/zone.js/test/browser_entry_point.ts
+++ b/packages/zone.js/test/browser_entry_point.ts
@@ -29,4 +29,3 @@ import './jasmine-patch.spec';
 import './browser/messageport.spec';
 import './extra/cordova.spec';
 import './browser/queue-microtask.spec';
-import './zone-spec/async-tagging-console.spec';

--- a/packages/zone.js/test/karma_test.bzl
+++ b/packages/zone.js/test/karma_test.bzl
@@ -58,7 +58,6 @@ def karma_test(name, env_srcs, env_deps, env_entry_point, test_srcs, test_deps, 
             "//packages/zone.js/bundles:zone-patch-resize-observer.umd.js",
             "//packages/zone.js/bundles:zone-patch-message-port.umd.js",
             "//packages/zone.js/bundles:zone-patch-user-media.umd.js",
-            "//packages/zone.js/bundles:async-stack-tagging.umd.js",
             ":" + name + "_rollup.umd",
         ]
 

--- a/packages/zone.js/test/npm_package/npm_package.spec.ts
+++ b/packages/zone.js/test/npm_package/npm_package.spec.ts
@@ -115,8 +115,6 @@ describe('Zone.js npm_package', () => {
     describe('plugins folder check', () => {
       it('should contain all plugin folders in ./plugins', () => {
         const expected = [
-          'async-stack-tagging',
-          'async-stack-tagging.min',
           'async-test',
           'async-test.min',
           'fake-async-test',
@@ -197,8 +195,6 @@ describe('Zone.js npm_package', () => {
     describe('bundles file list', () => {
       it('should contain all files', () => {
         const expected = [
-          'async-stack-tagging.js',
-          'async-stack-tagging.min.js',
           'async-test.js',
           'async-test.min.js',
           'fake-async-test.js',
@@ -293,8 +289,6 @@ describe('Zone.js npm_package', () => {
       it('should contain all original folders in /dist', () => {
         const list = shx.ls('./dist').stdout.split('\n').sort().slice(1);
         const expected = [
-          'async-stack-tagging.js',
-          'async-stack-tagging.min.js',
           'async-test.js',
           'async-test.min.js',
           'fake-async-test.js',


### PR DESCRIPTION
1. Remove `zone-async-tagging` implementation from zone.js and move the
implementation to `@angular/core`, so `@angular/core` can import this
package more easily for better treeshaking.
2. Add `async tagging zone` implemenation into `@angular/core` package.
So we don't need to get the `AsyncStackTaggingZoneSpec` from `global`
instance, we can import the `class` directly for better treeshaking.
3. Only load this ZoneSpec when `ngDevMode` is `true`.