### PR TITLE
ci: update payload size for Animations integration test

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -48,7 +48,7 @@
   "animations": {
     "uncompressed": {
       "runtime": 1070,
-      "main": 156225,
+      "main": 156736,
       "polyfills": 33814
     }
   },


### PR DESCRIPTION
This commit updates the payload size for the Animations integration test app. The increase is likely is a result of a number of accumulated changes from various commits merged previously.

## PR Type
What kind of change does this PR introduce?
- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No