### PR TITLE
refactor(core): invoke basic host directives

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -41,7 +41,7 @@
   "forms": {
     "uncompressed": {
       "runtime": 1060,
-      "main": 156626,
+      "main": 157136,
       "polyfills": 33915
     }
   },

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -327,6 +327,7 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
       schemas: componentDefinition.schemas || null,
       tView: null,
       applyHostDirectives: null,
+      hostDirectives: null,
     };
     const dependencies = componentDefinition.dependencies;
     const feature = componentDefinition.features;

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -326,7 +326,7 @@ export function ɵɵdefineComponent<T>(componentDefinition: {
       setInput: null,
       schemas: componentDefinition.schemas || null,
       tView: null,
-      applyHostDirectives: null,
+      findHostDirectiveDefs: null,
       hostDirectives: null,
     };
     const dependencies = componentDefinition.dependencies;

--- a/packages/core/src/render3/features/host_directives_feature.ts
+++ b/packages/core/src/render3/features/host_directives_feature.ts
@@ -5,14 +5,16 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {resolveForwardRef} from '../../di';
 import {Type} from '../../interface/type';
 import {EMPTY_OBJ} from '../../util/empty';
+import {getDirectiveDef} from '../definition';
 import {DirectiveDef} from '../interfaces/definition';
 import {TContainerNode, TElementContainerNode, TElementNode} from '../interfaces/node';
 import {LView, TView} from '../interfaces/view';
 
 /** Values that can be used to define a host directive through the `HostDirectivesFeature`. */
-type HostDirectiveDefiniton = Type<unknown>|{
+type HostDirectiveConfig = Type<unknown>|{
   directive: Type<unknown>;
   inputs?: string[];
   outputs?: string[];
@@ -38,23 +40,39 @@ type HostDirectiveDefiniton = Type<unknown>|{
  *
  * @codeGenApi
  */
-export function ɵɵHostDirectivesFeature(rawHostDirectives: HostDirectiveDefiniton[]|
-                                        (() => HostDirectiveDefiniton[])) {
-  const unwrappedHostDirectives =
-      Array.isArray(rawHostDirectives) ? rawHostDirectives : rawHostDirectives();
-  const hostDirectives = unwrappedHostDirectives.map(
-      dir => typeof dir === 'function' ? {directive: dir, inputs: EMPTY_OBJ, outputs: EMPTY_OBJ} : {
-        directive: dir.directive,
-        inputs: bindingArrayToMap(dir.inputs),
-        outputs: bindingArrayToMap(dir.outputs)
-      });
-
+export function ɵɵHostDirectivesFeature(rawHostDirectives: HostDirectiveConfig[]|
+                                        (() => HostDirectiveConfig[])) {
   return (definition: DirectiveDef<unknown>) => {
-    // TODO(crisbeto): implement host directive matching logic.
-    definition.applyHostDirectives =
-        (tView: TView, viewData: LView, tNode: TElementNode|TContainerNode|TElementContainerNode,
-         matches: any[]) => {};
+    definition.applyHostDirectives = applyHostDirectives;
+    definition.hostDirectives =
+        (Array.isArray(rawHostDirectives) ? rawHostDirectives : rawHostDirectives()).map(dir => {
+          return typeof dir === 'function' ?
+              {directive: resolveForwardRef(dir), inputs: EMPTY_OBJ, outputs: EMPTY_OBJ} :
+              {
+                directive: resolveForwardRef(dir.directive),
+                inputs: bindingArrayToMap(dir.inputs),
+                outputs: bindingArrayToMap(dir.outputs)
+              };
+        });
   };
+}
+
+function applyHostDirectives(
+    matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, viewData: LView,
+    tNode: TElementNode|TContainerNode|TElementContainerNode): void {
+  if (def.hostDirectives !== null) {
+    for (const hostDirectiveConfig of def.hostDirectives) {
+      const hostDirectiveDef = getDirectiveDef(hostDirectiveConfig.directive)!;
+
+      // TODO(crisbeto): assert that the def exists.
+
+      // Host directives execute before the host so that its host bindings can be overwritten.
+      applyHostDirectives(matches, hostDirectiveDef, tView, viewData, tNode);
+    }
+  }
+
+  // Push the def itself at the end since it needs to execute after the host directives.
+  matches.push(def);
 }
 
 /**
@@ -62,14 +80,14 @@ export function ɵɵHostDirectivesFeature(rawHostDirectives: HostDirectiveDefini
  * a map in the form of `{publicName: 'alias', otherPublicName: 'otherAlias'}`.
  */
 function bindingArrayToMap(bindings: string[]|undefined) {
-  if (!bindings || bindings.length === 0) {
+  if (bindings === undefined || bindings.length === 0) {
     return EMPTY_OBJ;
   }
 
   const result: {[publicName: string]: string} = {};
 
-  for (let i = 1; i < bindings.length; i += 2) {
-    result[bindings[i - 1]] = bindings[i];
+  for (let i = 0; i < bindings.length; i += 2) {
+    result[bindings[i]] = bindings[i + 1];
   }
 
   return result;

--- a/packages/core/src/render3/features/host_directives_feature.ts
+++ b/packages/core/src/render3/features/host_directives_feature.ts
@@ -58,7 +58,7 @@ export function ɵɵHostDirectivesFeature(rawHostDirectives: HostDirectiveConfig
 }
 
 function applyHostDirectives(
-    matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, viewData: LView,
+    matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, lView: LView,
     tNode: TElementNode|TContainerNode|TElementContainerNode): void {
   if (def.hostDirectives !== null) {
     for (const hostDirectiveConfig of def.hostDirectives) {
@@ -67,7 +67,7 @@ function applyHostDirectives(
       // TODO(crisbeto): assert that the def exists.
 
       // Host directives execute before the host so that its host bindings can be overwritten.
-      applyHostDirectives(matches, hostDirectiveDef, tView, viewData, tNode);
+      applyHostDirectives(matches, hostDirectiveDef, tView, lView, tNode);
     }
   }
 

--- a/packages/core/src/render3/features/host_directives_feature.ts
+++ b/packages/core/src/render3/features/host_directives_feature.ts
@@ -43,7 +43,7 @@ type HostDirectiveConfig = Type<unknown>|{
 export function ɵɵHostDirectivesFeature(rawHostDirectives: HostDirectiveConfig[]|
                                         (() => HostDirectiveConfig[])) {
   return (definition: DirectiveDef<unknown>) => {
-    definition.applyHostDirectives = applyHostDirectives;
+    definition.findHostDirectiveDefs = findHostDirectiveDefs;
     definition.hostDirectives =
         (Array.isArray(rawHostDirectives) ? rawHostDirectives : rawHostDirectives()).map(dir => {
           return typeof dir === 'function' ?
@@ -57,7 +57,7 @@ export function ɵɵHostDirectivesFeature(rawHostDirectives: HostDirectiveConfig
   };
 }
 
-function applyHostDirectives(
+function findHostDirectiveDefs(
     matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, lView: LView,
     tNode: TElementNode|TContainerNode|TElementContainerNode): void {
   if (def.hostDirectives !== null) {
@@ -67,7 +67,7 @@ function applyHostDirectives(
       // TODO(crisbeto): assert that the def exists.
 
       // Host directives execute before the host so that its host bindings can be overwritten.
-      applyHostDirectives(matches, hostDirectiveDef, tView, lView, tNode);
+      findHostDirectiveDefs(matches, hostDirectiveDef, tView, lView, tNode);
     }
   }
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1062,7 +1062,9 @@ export function resolveDirectives(
 
   let hasDirectives = false;
   if (getBindingsEnabled()) {
-    const directiveDefs: DirectiveDef<any>[]|null = findDirectiveDefMatches(tView, lView, tNode);
+    const selectorMatches = findDirectiveDefMatches(tView, lView, tNode);
+    const directiveDefs =
+        selectorMatches ? applyHostDirectives(selectorMatches, tView, lView, tNode) : null;
     const exportsMap: ({[key: string]: number}|null) = localRefs === null ? null : {'': -1};
 
     if (directiveDefs !== null) {
@@ -1288,8 +1290,6 @@ function findDirectiveDefMatches(
         } else {
           matches.push(def);
         }
-
-        def.applyHostDirectives?.(tView, viewData, tNode, matches);
       }
     }
   }
@@ -1308,6 +1308,29 @@ export function markAsComponentHost(tView: TView, hostTNode: TNode): void {
       .push(hostTNode.index);
 }
 
+/**
+ * Given an array of directives that were matched by their selectors, this function
+ * produces a new array that also includes any host directives that have to be applied.
+ * @param selectorMatches Directives matched in a template based on their selectors.
+ * @param tView Current TView.
+ * @param lView Current LView.
+ * @param tNode Current TNode that is being matched.
+ */
+function applyHostDirectives(
+    selectorMatches: DirectiveDef<unknown>[], tView: TView, lView: LView,
+    tNode: TElementNode|TContainerNode|TElementContainerNode): DirectiveDef<unknown>[] {
+  const matches: DirectiveDef<unknown>[] = [];
+
+  for (const def of selectorMatches) {
+    if (def.applyHostDirectives === null) {
+      matches.push(def);
+    } else {
+      def.applyHostDirectives(matches, def, tView, lView, tNode);
+    }
+  }
+
+  return matches;
+}
 
 /** Caches local names and their matching directive indices for query and template lookups. */
 function cacheMatchingLocalNames(

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1064,7 +1064,7 @@ export function resolveDirectives(
   if (getBindingsEnabled()) {
     const directiveDefsMatchedBySelectors = findDirectiveDefMatches(tView, lView, tNode);
     const directiveDefs = directiveDefsMatchedBySelectors ?
-        applyHostDirectives(directiveDefsMatchedBySelectors, tView, lView, tNode) :
+        findHostDirectiveDefs(directiveDefsMatchedBySelectors, tView, lView, tNode) :
         null;
     const exportsMap: ({[key: string]: number}|null) = localRefs === null ? null : {'': -1};
 
@@ -1317,16 +1317,16 @@ export function markAsComponentHost(tView: TView, hostTNode: TNode): void {
  * @param lView Current LView.
  * @param tNode Current TNode that is being matched.
  */
-function applyHostDirectives(
+function findHostDirectiveDefs(
     selectorMatches: DirectiveDef<unknown>[], tView: TView, lView: LView,
     tNode: TElementNode|TContainerNode|TElementContainerNode): DirectiveDef<unknown>[] {
   const matches: DirectiveDef<unknown>[] = [];
 
   for (const def of selectorMatches) {
-    if (def.applyHostDirectives === null) {
+    if (def.findHostDirectiveDefs === null) {
       matches.push(def);
     } else {
-      def.applyHostDirectives(matches, def, tView, lView, tNode);
+      def.findHostDirectiveDefs(matches, def, tView, lView, tNode);
     }
   }
 

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1062,9 +1062,10 @@ export function resolveDirectives(
 
   let hasDirectives = false;
   if (getBindingsEnabled()) {
-    const selectorMatches = findDirectiveDefMatches(tView, lView, tNode);
-    const directiveDefs =
-        selectorMatches ? applyHostDirectives(selectorMatches, tView, lView, tNode) : null;
+    const directiveDefsMatchedBySelectors = findDirectiveDefMatches(tView, lView, tNode);
+    const directiveDefs = directiveDefsMatchedBySelectors ?
+        applyHostDirectives(directiveDefsMatchedBySelectors, tView, lView, tNode) :
+        null;
     const exportsMap: ({[key: string]: number}|null) = localRefs === null ? null : {'': -1};
 
     if (directiveDefs !== null) {

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -207,10 +207,10 @@ export interface DirectiveDef<T> {
   readonly features: DirectiveDefFeature[]|null;
 
   /**
-   * Function that will apply the host directives to the list of matches during directive matching.
+   * Function that will add the host directives to the list of matches during directive matching.
    * Patched onto the definition by the `HostDirectivesFeature`.
    */
-  applyHostDirectives:
+  findHostDirectiveDefs:
       ((matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, lView: LView,
         tNode: TElementNode|TContainerNode|TElementContainerNode) => void)|null;
 

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -211,8 +211,11 @@ export interface DirectiveDef<T> {
    * Patched onto the definition by the `HostDirectivesFeature`.
    */
   applyHostDirectives:
-      ((tView: TView, viewData: LView, tNode: TElementNode|TContainerNode|TElementContainerNode,
-        matches: any[]) => void)|null;
+      ((matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, viewData: LView,
+        tNode: TElementNode|TContainerNode|TElementContainerNode) => void)|null;
+
+  /** Additional directives to be applied whenever the directive has been matched. */
+  hostDirectives: HostDirectiveDef[]|null;
 
   setInput:
       (<U extends T>(
@@ -401,6 +404,18 @@ export interface DirectiveDefFeature {
    * every bundle.
    */
   ngInherit?: true;
+}
+
+/** Runtime information used to configure a host directive. */
+export interface HostDirectiveDef<T = unknown> {
+  /** Class representing the host directive. */
+  directive: Type<T>;
+
+  /** Directive inputs that have been exposed. */
+  inputs: {[publicName: string]: string};
+
+  /** Directive outputs that have been exposed. */
+  outputs: {[publicName: string]: string};
 }
 
 export interface ComponentDefFeature {

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -211,7 +211,7 @@ export interface DirectiveDef<T> {
    * Patched onto the definition by the `HostDirectivesFeature`.
    */
   applyHostDirectives:
-      ((matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, viewData: LView,
+      ((matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, lView: LView,
         tNode: TElementNode|TContainerNode|TElementContainerNode) => void)|null;
 
   /** Additional directives to be applied whenever the directive has been matched. */

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -416,9 +416,9 @@ export function directiveMetadata(type: Type<any>, metadata: Directive): R3Direc
     providers: metadata.providers || null,
     viewQueries: extractQueriesMetadata(type, propMetadata, isViewQuery),
     isStandalone: !!metadata.standalone,
-    // TODO(crisbeto): remove the `as any` usages here once
-    // host directives are exposed in the public API.
     hostDirectives:
+        // TODO(crisbeto): remove the `as any` usage here and down in the `map` call once
+        // host directives are exposed in the public API.
         (metadata as any)
             .hostDirectives?.map(
                 (directive: any) => typeof directive === 'function' ? {directive} : directive) ||

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -416,7 +416,13 @@ export function directiveMetadata(type: Type<any>, metadata: Directive): R3Direc
     providers: metadata.providers || null,
     viewQueries: extractQueriesMetadata(type, propMetadata, isViewQuery),
     isStandalone: !!metadata.standalone,
-    hostDirectives: null,
+    // TODO(crisbeto): remove the `as any` usages here once
+    // host directives are exposed in the public API.
+    hostDirectives:
+        (metadata as any)
+            .hostDirectives?.map(
+                (directive: any) => typeof directive === 'function' ? {directive} : directive) ||
+        null
   };
 }
 

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -1,0 +1,646 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {AfterViewChecked, AfterViewInit, Component, Directive, forwardRef, inject, Inject, InjectionToken, OnInit, ViewChild} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+
+/**
+ * Temporary `any` used for metadata until `hostDirectives` is enabled publicly.
+ * TODO(crisbeto): remove this once host directives are enabled in the public API.
+ */
+type HostDirectiveAny = any;
+
+describe('host directives', () => {
+  it('should apply a basic host directive', () => {
+    const logs: string[] = [];
+
+    @Directive({
+      standalone: true,
+      host: {'host-dir-attr': '', 'class': 'host-dir', 'style': 'height: 50px'}
+    })
+    class HostDir {
+      constructor() {
+        logs.push('HostDir');
+      }
+    }
+
+    @Directive({
+      selector: '[dir]',
+      host: {'host-attr': '', 'class': 'dir', 'style': 'width: 50px'},
+      hostDirectives: [HostDir]
+    } as HostDirectiveAny)
+    class Dir {
+      constructor() {
+        logs.push('Dir');
+      }
+    }
+
+    @Component({template: '<div dir></div>'})
+    class App {
+    }
+
+    TestBed.configureTestingModule({declarations: [App, Dir]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(logs).toEqual(['HostDir', 'Dir']);
+    expect(fixture.nativeElement.innerHTML)
+        .toBe(
+            '<div host-dir-attr="" host-attr="" dir="" ' +
+            'class="host-dir dir" style="height: 50px; width: 50px;"></div>');
+  });
+
+  it('should apply a host directive referenced through a forwardRef', () => {
+    const logs: string[] = [];
+
+    @Directive({
+      selector: '[dir]',
+      hostDirectives: [forwardRef(() => HostDir), {directive: forwardRef(() => OtherHostDir)}]
+    } as HostDirectiveAny)
+    class Dir {
+      constructor() {
+        logs.push('Dir');
+      }
+    }
+
+    @Directive({standalone: true})
+    class HostDir {
+      constructor() {
+        logs.push('HostDir');
+      }
+    }
+
+    @Directive({standalone: true})
+    class OtherHostDir {
+      constructor() {
+        logs.push('OtherHostDir');
+      }
+    }
+
+    @Component({template: '<div dir></div>'})
+    class App {
+    }
+
+    TestBed.configureTestingModule({declarations: [App, Dir]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(logs).toEqual(['HostDir', 'OtherHostDir', 'Dir']);
+  });
+
+  it('should apply a chain of host directives', () => {
+    const logs: string[] = [];
+    const token = new InjectionToken('message');
+    let diTokenValue: string;
+
+    @Directive({
+      host: {
+        'class': 'leaf',
+        'id': 'leaf-id',
+      },
+      providers: [{provide: token, useValue: 'leaf value'}],
+      standalone: true
+    })
+    class Chain1_3 {
+      constructor(@Inject(token) tokenValue: string) {
+        diTokenValue = tokenValue;
+        logs.push('Chain1 - level 3');
+      }
+    }
+
+    @Directive({
+      standalone: true,
+      hostDirectives: [Chain1_3],
+    } as HostDirectiveAny)
+    class Chain1_2 {
+      constructor() {
+        logs.push('Chain1 - level 2');
+      }
+    }
+
+    @Directive({
+      standalone: true,
+      hostDirectives: [Chain1_2],
+    } as HostDirectiveAny)
+    class Chain1 {
+      constructor() {
+        logs.push('Chain1 - level 1');
+      }
+    }
+
+    @Directive({
+      standalone: true,
+      host: {
+        'class': 'middle',
+        'id': 'middle-id',
+      },
+      providers: [{provide: token, useValue: 'middle value'}],
+    })
+    class Chain2_2 {
+      constructor() {
+        logs.push('Chain2 - level 2');
+      }
+    }
+
+    @Directive({
+      standalone: true,
+      hostDirectives: [Chain2_2],
+    } as HostDirectiveAny)
+    class Chain2 {
+      constructor() {
+        logs.push('Chain2 - level 1');
+      }
+    }
+
+    @Directive({standalone: true})
+    class Chain3_2 {
+      constructor() {
+        logs.push('Chain3 - level 2');
+      }
+    }
+
+    @Directive({standalone: true, hostDirectives: [Chain3_2]} as HostDirectiveAny)
+    class Chain3 {
+      constructor() {
+        logs.push('Chain3 - level 1');
+      }
+    }
+
+    @Component({
+      selector: 'my-comp',
+      host: {
+        'class': 'host',
+        'id': 'host-id',
+      },
+      template: '',
+      hostDirectives: [Chain1, Chain2, Chain3],
+      providers: [{provide: token, useValue: 'host value'}],
+    } as HostDirectiveAny)
+    class MyComp {
+      constructor() {
+        logs.push('host');
+      }
+    }
+    @Component({template: '<my-comp></my-comp>'})
+    class App {
+    }
+
+    TestBed.configureTestingModule({declarations: [App, MyComp]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(diTokenValue!).toBe('host value');
+    expect(fixture.nativeElement.innerHTML)
+        .toBe('<my-comp id="host-id" class="leaf middle host"></my-comp>');
+    expect(logs).toEqual([
+      'Chain1 - level 3',
+      'Chain1 - level 2',
+      'Chain1 - level 1',
+      'Chain2 - level 2',
+      'Chain2 - level 1',
+      'Chain3 - level 2',
+      'Chain3 - level 1',
+      'host',
+    ]);
+  });
+
+  it('should be able to query for the host directives', () => {
+    let hostInstance!: Host;
+    let firstHostDirInstance!: FirstHostDir;
+    let secondHostDirInstance!: SecondHostDir;
+
+    @Directive({standalone: true})
+    class SecondHostDir {
+      constructor() {
+        secondHostDirInstance = this;
+      }
+    }
+
+    @Directive({standalone: true, hostDirectives: [SecondHostDir]} as HostDirectiveAny)
+    class FirstHostDir {
+      constructor() {
+        firstHostDirInstance = this;
+      }
+    }
+
+    @Directive({selector: '[dir]', hostDirectives: [FirstHostDir]} as HostDirectiveAny)
+    class Host {
+      constructor() {
+        hostInstance = this;
+      }
+    }
+
+    @Component({template: '<div dir></div>'})
+    class App {
+      @ViewChild(FirstHostDir) firstHost!: FirstHostDir;
+      @ViewChild(SecondHostDir) secondHost!: SecondHostDir;
+    }
+
+    TestBed.configureTestingModule({declarations: [App, Host]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(hostInstance instanceof Host).toBe(true);
+    expect(firstHostDirInstance instanceof FirstHostDir).toBe(true);
+    expect(secondHostDirInstance instanceof SecondHostDir).toBe(true);
+
+    expect(fixture.componentInstance.firstHost).toBe(firstHostDirInstance);
+    expect(fixture.componentInstance.secondHost).toBe(secondHostDirInstance);
+  });
+
+  it('should be able to reference exported host directives', () => {
+    @Directive({standalone: true, exportAs: 'secondHost'})
+    class SecondHostDir {
+      name = 'SecondHost';
+    }
+
+    @Directive(
+        {standalone: true, hostDirectives: [SecondHostDir], exportAs: 'firstHost'} as
+        HostDirectiveAny)
+    class FirstHostDir {
+      name = 'FirstHost';
+    }
+
+    @Directive({selector: '[dir]', hostDirectives: [FirstHostDir]} as HostDirectiveAny)
+    class Host {
+    }
+
+    @Component({
+      template: `
+        <div
+          dir
+          #firstHost="firstHost"
+          #secondHost="secondHost">{{firstHost.name}} | {{secondHost.name}}</div>
+      `
+    })
+    class App {
+    }
+
+    TestBed.configureTestingModule({declarations: [App, Host]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('FirstHost | SecondHost');
+  });
+
+  it('should invoke lifecycle hooks from the host directives', () => {
+    const logs: string[] = [];
+
+    @Directive({standalone: true})
+    class HostDir implements OnInit, AfterViewInit, AfterViewChecked {
+      ngOnInit() {
+        logs.push('HostDir - ngOnInit');
+      }
+
+      ngAfterViewInit() {
+        logs.push('HostDir - ngAfterViewInit');
+      }
+
+      ngAfterViewChecked() {
+        logs.push('HostDir - ngAfterViewChecked');
+      }
+    }
+
+    @Directive({standalone: true})
+    class OtherHostDir implements OnInit, AfterViewInit, AfterViewChecked {
+      ngOnInit() {
+        logs.push('OtherHostDir - ngOnInit');
+      }
+
+      ngAfterViewInit() {
+        logs.push('OtherHostDir - ngAfterViewInit');
+      }
+
+      ngAfterViewChecked() {
+        logs.push('OtherHostDir - ngAfterViewChecked');
+      }
+    }
+
+    @Directive({selector: '[dir]', hostDirectives: [HostDir, OtherHostDir]} as HostDirectiveAny)
+    class Dir implements OnInit, AfterViewInit, AfterViewChecked {
+      ngOnInit() {
+        logs.push('Dir - ngOnInit');
+      }
+
+      ngAfterViewInit() {
+        logs.push('Dir - ngAfterViewInit');
+      }
+
+      ngAfterViewChecked() {
+        logs.push('Dir - ngAfterViewChecked');
+      }
+    }
+
+    @Component({template: '<div dir></div>'})
+    class App {
+    }
+
+    TestBed.configureTestingModule({declarations: [App, Dir]});
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    expect(logs).toEqual([
+      'HostDir - ngOnInit',
+      'OtherHostDir - ngOnInit',
+      'Dir - ngOnInit',
+      'HostDir - ngAfterViewInit',
+      'HostDir - ngAfterViewChecked',
+      'OtherHostDir - ngAfterViewInit',
+      'OtherHostDir - ngAfterViewChecked',
+      'Dir - ngAfterViewInit',
+      'Dir - ngAfterViewChecked',
+    ]);
+  });
+
+  describe('host bindings', () => {
+    it('should apply the host bindings from all host directives', () => {
+      const clicks: string[] = [];
+
+      @Directive({standalone: true, host: {'host-dir-attr': 'true', '(click)': 'handleClick()'}})
+      class HostDir {
+        handleClick() {
+          clicks.push('HostDir');
+        }
+      }
+
+      @Directive(
+          {standalone: true, host: {'other-host-dir-attr': 'true', '(click)': 'handleClick()'}})
+      class OtherHostDir {
+        handleClick() {
+          clicks.push('OtherHostDir');
+        }
+      }
+
+      @Directive({
+        selector: '[dir]',
+        host: {'host-attr': 'true', '(click)': 'handleClick()'},
+        hostDirectives: [HostDir, OtherHostDir]
+      } as HostDirectiveAny)
+      class Dir {
+        handleClick() {
+          clicks.push('Dir');
+        }
+      }
+
+      @Component({template: '<button dir></button>'})
+      class App {
+      }
+
+      TestBed.configureTestingModule({declarations: [App, Dir]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      const host = fixture.nativeElement.querySelector('[dir]');
+
+      expect(host.outerHTML)
+          .toBe(
+              '<button host-dir-attr="true" other-host-dir-attr="true" host-attr="true" dir=""></button>');
+
+      host.click();
+      fixture.detectChanges();
+
+      expect(clicks).toEqual(['HostDir', 'OtherHostDir', 'Dir']);
+    });
+
+    it('should have the host bindings take precedence over the ones from the host directives',
+       () => {
+         @Directive({standalone: true, host: {'id': 'host-dir'}})
+         class HostDir {
+         }
+
+         @Directive({standalone: true, host: {'id': 'other-host-dir'}})
+         class OtherHostDir {
+         }
+
+         @Directive(
+             {selector: '[dir]', host: {'id': 'host'}, hostDirectives: [HostDir, OtherHostDir]} as
+             HostDirectiveAny)
+         class Dir {
+         }
+
+         @Component({template: '<div dir></div>'})
+         class App {
+         }
+
+         TestBed.configureTestingModule({declarations: [App, Dir]});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         expect(fixture.nativeElement.querySelector('[dir]').getAttribute('id')).toBe('host');
+       });
+  });
+
+  describe('dependency injection', () => {
+    it('should allow the host directives to inject their host', () => {
+      let hostInstance!: Host;
+      let firstHostDirInstance!: FirstHostDir;
+      let secondHostDirInstance!: SecondHostDir;
+
+      @Directive({standalone: true})
+      class SecondHostDir {
+        host = inject(Host);
+
+        constructor() {
+          secondHostDirInstance = this;
+        }
+      }
+
+      @Directive({standalone: true, hostDirectives: [SecondHostDir]} as HostDirectiveAny)
+      class FirstHostDir {
+        host = inject(Host);
+
+        constructor() {
+          firstHostDirInstance = this;
+        }
+      }
+
+      @Directive({selector: '[dir]', hostDirectives: [FirstHostDir]} as HostDirectiveAny)
+      class Host {
+        constructor() {
+          hostInstance = this;
+        }
+      }
+
+      @Component({template: '<div dir></div>'})
+      class App {
+      }
+
+      TestBed.configureTestingModule({declarations: [App, Host]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(hostInstance instanceof Host).toBe(true);
+      expect(firstHostDirInstance instanceof FirstHostDir).toBe(true);
+      expect(secondHostDirInstance instanceof SecondHostDir).toBe(true);
+
+      expect(firstHostDirInstance.host).toBe(hostInstance);
+      expect(secondHostDirInstance.host).toBe(hostInstance);
+    });
+
+    it('should give precedence to the DI tokens from the host over the host directive tokens',
+       () => {
+         const token = new InjectionToken<string>('token');
+         let hostInstance!: Host;
+         let firstHostDirInstance!: FirstHostDir;
+         let secondHostDirInstance!: SecondHostDir;
+
+         @Directive({standalone: true, providers: [{provide: token, useValue: 'SecondDir'}]})
+         class SecondHostDir {
+           tokenValue = inject(token);
+
+           constructor() {
+             secondHostDirInstance = this;
+           }
+         }
+
+         @Directive({
+           standalone: true,
+           hostDirectives: [SecondHostDir],
+           providers: [{provide: token, useValue: 'FirstDir'}]
+         } as HostDirectiveAny)
+         class FirstHostDir {
+           tokenValue = inject(token);
+
+           constructor() {
+             firstHostDirInstance = this;
+           }
+         }
+
+         @Directive({
+           selector: '[dir]',
+           hostDirectives: [FirstHostDir],
+           providers: [{provide: token, useValue: 'HostDir'}]
+         } as HostDirectiveAny)
+         class Host {
+           tokenValue = inject(token);
+
+           constructor() {
+             hostInstance = this;
+           }
+         }
+
+         @Component({template: '<div dir></div>'})
+         class App {
+         }
+
+         TestBed.configureTestingModule({declarations: [App, Host]});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         expect(hostInstance instanceof Host).toBe(true);
+         expect(firstHostDirInstance instanceof FirstHostDir).toBe(true);
+         expect(secondHostDirInstance instanceof SecondHostDir).toBe(true);
+
+         expect(hostInstance.tokenValue).toBe('HostDir');
+         expect(firstHostDirInstance.tokenValue).toBe('HostDir');
+         expect(secondHostDirInstance.tokenValue).toBe('HostDir');
+       });
+
+    it('should allow the host to inject tokens from the host directives', () => {
+      const firstToken = new InjectionToken<string>('firstToken');
+      const secondToken = new InjectionToken<string>('secondToken');
+
+      @Directive({standalone: true, providers: [{provide: secondToken, useValue: 'SecondDir'}]})
+      class SecondHostDir {
+      }
+
+      @Directive({
+        standalone: true,
+        hostDirectives: [SecondHostDir],
+        providers: [{provide: firstToken, useValue: 'FirstDir'}]
+      } as HostDirectiveAny)
+      class FirstHostDir {
+      }
+
+      @Directive({selector: '[dir]', hostDirectives: [FirstHostDir]} as HostDirectiveAny)
+      class Host {
+        firstTokenValue = inject(firstToken);
+        secondTokenValue = inject(secondToken);
+      }
+
+      @Component({template: '<div dir></div>'})
+      class App {
+        @ViewChild(Host) host!: Host;
+      }
+
+      TestBed.configureTestingModule({declarations: [App, Host]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.host.firstTokenValue).toBe('FirstDir');
+      expect(fixture.componentInstance.host.secondTokenValue).toBe('SecondDir');
+    });
+
+    it('should not give precedence to tokens from host directives over ones in viewProviders',
+       () => {
+         const token = new InjectionToken<string>('token');
+         let tokenValue: string|undefined;
+
+         @Directive({standalone: true, providers: [{provide: token, useValue: 'host-dir'}]})
+         class HostDir {
+         }
+
+         @Component({
+           selector: 'host',
+           hostDirectives: [HostDir],
+           providers: [{provide: token, useValue: 'host'}],
+           template: '<span child></span>',
+         } as HostDirectiveAny)
+         class Host {
+         }
+
+         @Directive({selector: '[child]'})
+         class Child {
+           constructor() {
+             tokenValue = inject(token);
+           }
+         }
+
+         @Component({template: '<host></host>'})
+         class App {
+         }
+
+         TestBed.configureTestingModule({declarations: [App, Host, Child]});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         expect(tokenValue).toBe('host');
+       });
+
+    it('should not be able to access viewProviders from the host in the host directives', () => {
+      const token = new InjectionToken<string>('token');
+      let tokenValue: string|null = null;
+
+      @Directive({standalone: true})
+      class HostDir {
+        constructor() {
+          tokenValue = inject(token, {optional: true});
+        }
+      }
+
+      @Component({
+        selector: 'host',
+        hostDirectives: [HostDir],
+        viewProviders: [{provide: token, useValue: 'host'}],
+        template: '',
+      } as HostDirectiveAny)
+      class Host {
+      }
+
+      @Component({template: '<host></host>'})
+      class App {
+      }
+
+      TestBed.configureTestingModule({declarations: [App, Host]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
+
+      expect(tokenValue).toBe(null);
+    });
+  });
+});


### PR DESCRIPTION
Expands the runtime to allow for basic host directives to be invoked within a template. This is achieved by making a second pass over the directives that were matched based on their selectors and producing a new array of directives that include host directives. Note that the ordering in the array is important, because it determines which host bindings and DI tokens will be overwritten.