### PR TITLE
ci: update payload size for cli-hello-world-lazy test

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -33,7 +33,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2835,
-      "main": 226893,
+      "main": 226360,
       "polyfills": 33842,
       "src_app_lazy_lazy_routes_ts": 487
     }


### PR DESCRIPTION
The size for the mentioned tests decreased causing CI build to fail. Updating sizes to the current ones.
