### PR TITLE
fix(devtools): fix positioning of property explorer expansion icon

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.scss
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/directive-explorer/property-tab/property-view/property-view-tree.component.scss
@@ -18,6 +18,8 @@
         font-size: 11px;
         width: 8px;
         height: 16px;
+        position: relative;
+        top: 6px;
       }
     }
   }


### PR DESCRIPTION
At some point this went out of sync with the rest of the styling around it. This commit fixes the positioning.

before
![76091b52b3ec7191cb203effa11622ce](https://user-images.githubusercontent.com/39253660/190303326-ca649079-ec43-4222-8f65-3db8cd4d2c7d.png)

after
![bf0ac68ce30ddd4a345b4f7c2e3484c1 (1)](https://user-images.githubusercontent.com/39253660/190303236-bc100c7c-baf8-4410-9be3-6a283fac73c3.png)

