### PR TITLE
feat(core): create getInjectorResolutionPath global debug function

### DIFF
--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -215,7 +215,7 @@ export function isDirectiveInstance(instance: any): boolean {
 /**
  * Locates the element within the given LView and returns the matching index
  */
-function findViaNativeElement(lView: LView, target: RElement): number {
+export function findViaNativeElement(lView: LView, target: RElement): number {
   const tView = lView[TVIEW];
   for (let i = HEADER_OFFSET; i < tView.bindingStartIndex; i++) {
     if (unwrapRNode(lView[i]) === target) {

--- a/packages/core/src/render3/util/global_utils.ts
+++ b/packages/core/src/render3/util/global_utils.ts
@@ -8,8 +8,9 @@
 import {assertDefined} from '../../util/assert';
 import {global} from '../../util/global';
 import {setProfiler} from '../profiler';
+
 import {applyChanges} from './change_detection_utils';
-import {getComponent, getContext, getDirectiveMetadata, getDirectives, getHostElement, getInjector, getListeners, getOwningComponent, getRootComponents} from './discovery_utils';
+import {getComponent, getContext, getDirectiveMetadata, getDirectives, getHostElement, getInjector, getInjectorResolutionPath, getListeners, getOwningComponent, getRootComponents} from './discovery_utils';
 
 
 
@@ -57,6 +58,7 @@ export function publishDefaultGlobalUtils() {
     publishGlobalUtil('getRootComponents', getRootComponents);
     publishGlobalUtil('getDirectives', getDirectives);
     publishGlobalUtil('applyChanges', applyChanges);
+    publishGlobalUtil('getInjectorResolutionPath', getInjectorResolutionPath);
   }
 }
 

--- a/packages/core/test/acceptance/discover_utils_spec.ts
+++ b/packages/core/test/acceptance/discover_utils_spec.ts
@@ -7,6 +7,8 @@
  */
 import {CommonModule} from '@angular/common';
 import {ChangeDetectionStrategy, Component, Directive, HostBinding, InjectionToken, Input, Output, ViewChild, ViewEncapsulation} from '@angular/core';
+import {NullInjector} from '@angular/core/src/di/null_injector';
+import {R3Injector} from '@angular/core/src/di/r3_injector';
 import {EventEmitter} from '@angular/core/src/event_emitter';
 import {isLView} from '@angular/core/src/render3/interfaces/type_checks';
 import {CONTEXT} from '@angular/core/src/render3/interfaces/view';
@@ -15,7 +17,7 @@ import {getElementStyles} from '@angular/core/testing/src/styling';
 
 import {getLContext} from '../../src/render3/context_discovery';
 import {getHostElement} from '../../src/render3/index';
-import {ComponentDebugMetadata, getComponent, getComponentLView, getContext, getDebugNode, getDirectiveMetadata, getDirectives, getInjectionTokens, getInjector, getListeners, getLocalRefs, getOwningComponent, getRootComponents} from '../../src/render3/util/discovery_utils';
+import {ComponentDebugMetadata, getComponent, getComponentLView, getContext, getDebugNode, getDirectiveMetadata, getDirectives, getInjectionTokens, getInjector, getInjectorResolutionPath, getListeners, getLocalRefs, getOwningComponent, getRootComponents} from '../../src/render3/util/discovery_utils';
 
 describe('discovery utils', () => {
   let fixture: ComponentFixture<MyApp>;
@@ -365,6 +367,36 @@ describe('discovery utils', () => {
       expect(metadata!.inputs).toEqual({a: 'b'});
       expect(metadata!.outputs).toEqual({c: 'd'});
     });
+  });
+
+  describe('getInjectorResolutionPath', () => {
+    it('should be able to get the resolution path from the dom element of an element injector',
+       () => {
+         /**
+          * Expected resolution path:
+          *
+          * Element Injector (my-app)
+          *    |
+          *    v
+          * Module Injector (TestBed Module)
+          *    |
+          *    v
+          * Platform Injector
+          *    |
+          *    v
+          * Null Injector
+          */
+         const injectorResolutionPath = getInjectorResolutionPath(fixture.nativeElement);
+         expect(injectorResolutionPath).toBeTruthy();
+         expect(injectorResolutionPath!.length).toEqual(4);
+         expect(injectorResolutionPath![0].type).toBe('Element');
+         expect(injectorResolutionPath![0].owner).toBe(fixture.nativeElement);
+         expect(injectorResolutionPath![1].type).toBe('Module');
+         expect(injectorResolutionPath![2].type).toBe('Platform');
+         expect(injectorResolutionPath![2].owner).toBeInstanceOf(R3Injector);
+         expect(injectorResolutionPath![3].type).toBe('NullInjector');
+         expect(injectorResolutionPath![3].owner).toBeInstanceOf(NullInjector);
+       });
   });
 });
 


### PR DESCRIPTION
This commit creates a new public API for the ng global object called `getInjectorResolutionPath`. This API takes in an element as an argument and returns an array of DebugInjector objects. These objects can be used to reason about the resolution path of element starting from its Node Injector, all the way up to the Null Injector.

See test case for example usage
