### PR TITLE
fix(docs-infra): fix `Update AIO events` GitHub Action

### DIFF
--- a/.github/workflows/update-events.yml
+++ b/.github/workflows/update-events.yml
@@ -5,7 +5,7 @@ on:
     inputs: {}
   schedule:
     # Run every day at 15:00.
-    - cron: 0 15 * * *
+    - cron: '0 15 * * *'
 
 # Declare default permissions as read only.
 permissions:
@@ -29,7 +29,7 @@ jobs:
       - name: Generate `events.json`
         run: node aio/scripts/generate-events/index.mjs --ignore-invalid-dates
       - name: Create a PR (if necessary)
-        uses: angular/dev-infra/github-actions/create-pr-for-changes@bf4bb09bb2d32015f71943371c7484cb845f8c33
+        uses: angular/dev-infra/github-actions/create-pr-for-changes@3c526cbb36b8517829dbbf02a7833fa3081479bb
         with:
           branch-prefix: docs-update-events
           pr-title: 'docs: update events'
@@ -39,4 +39,4 @@ jobs:
             action: review
             comp: docs
             target: patch
-          angular-robot-key: ${{ secrets.ANGULAR_ROBOT_PRIVATE_KEY }}
+          angular-robot-token: ${{ secrets.ANGULAR_ROBOT_ACCESS_TOKEN }}


### PR DESCRIPTION
Previously, the `Update AIO events` GitHub Action was using a version of the `create-pr-for-changes` GitHub Action that relied on a GitHub App key for Angular Robot. This, however, prevented PRs from being created from the accounts fork.

Switch to a newer version of the `create-pr-for-changes` action that uses a GitHub Personal Access Token instead.

##
This is blocked on:

- [x] Adding a `ANGULAR_ROBOT_ACCESS_TOKEN` GitHub Action secret.