### PR TITLE
docs(docs-infra): add missing decorator in tutorial step

### DIFF
--- a/aio/content/examples/getting-started/src/app/cart.service.ts
+++ b/aio/content/examples/getting-started/src/app/cart.service.ts
@@ -1,14 +1,14 @@
 // #docregion import-http
-import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 // #docregion props
 import { Product } from './products';
+import { Injectable } from '@angular/core';
 // #enddocregion props, import-http
 
+// #docregion props, methods, inject-http, get-shipping
 @Injectable({
   providedIn: 'root'
 })
-// #docregion props, methods, inject-http, get-shipping
 export class CartService {
 // #enddocregion get-shipping
   items: Product[] = [];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The `@Injectable` decorator is missing in tutorial step

Issue Number: #47425


## What is the new behavior?

The decorator is being shown in the step, which can help devs not to forget to import it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

