### PR TITLE
fix(docs-infra): apply `text-top` instead of `top` for table alignment

### DIFF
--- a/aio/src/styles/2-modules/table/_table.scss
+++ b/aio/src/styles/2-modules/table/_table.scss
@@ -37,7 +37,7 @@ table {
       padding: 16px;
       text-align: left;
       @include mixins.line-height(24);
-      vertical-align: text-top;
+      vertical-align: baseline;
 
       @media (max-width: 480px) {
         &:before {

--- a/aio/src/styles/2-modules/table/_table.scss
+++ b/aio/src/styles/2-modules/table/_table.scss
@@ -37,7 +37,7 @@ table {
       padding: 16px;
       text-align: left;
       @include mixins.line-height(24);
-      vertical-align: top;
+      vertical-align: text-top;
 
       @media (max-width: 480px) {
         &:before {


### PR DESCRIPTION
use `text-top` instead of `top` for table cells verical alignment so that the texts are correctly vertially aligned regardless on the dom structure

resolves #47423

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #47423

Before:
![Screenshot at 2022-09-15 22-41-13](https://user-images.githubusercontent.com/61631103/190513907-6814cb8e-bbe7-4243-ae7d-4a718fe17eb2.png)

(it's pretty subtle but you can see that the code on the left placed lightly higher)

## What is the new behavior?

After:

![Screenshot at 2022-09-15 22-41-23](https://user-images.githubusercontent.com/61631103/190514108-6eac0189-7a5d-46aa-9574-334e2e6de121.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
