### PR TITLE
fix(docs-infra): initialize events arrays in EventsComponent

### DIFF
--- a/aio/src/app/custom-elements/events/events.component.html
+++ b/aio/src/app/custom-elements/events/events.component.html
@@ -1,5 +1,5 @@
 <h2>Where we'll be presenting:</h2>
-<ng-container [ngSwitch]="!!upcomingEvents?.length">
+<ng-container [ngSwitch]="!!upcomingEvents.length">
   <div *ngSwitchCase="false">
     <p>We don't have any upcoming speaking engagements at the moment.</p>
     <p>

--- a/aio/src/app/custom-elements/events/events.component.spec.ts
+++ b/aio/src/app/custom-elements/events/events.component.spec.ts
@@ -20,11 +20,11 @@ describe('EventsComponent', () => {
   });
 
   it('should have no pastEvents when first created', () => {
-    expect(component.pastEvents).toBeUndefined();
+    expect(component.pastEvents.length).toEqual(0);
   });
 
   it('should have no upcoming when first created', () => {
-    expect(component.upcomingEvents).toBeUndefined();
+    expect(component.upcomingEvents.length).toEqual(0);
   });
 
   describe('ngOnInit()', () => {

--- a/aio/src/app/custom-elements/events/events.component.ts
+++ b/aio/src/app/custom-elements/events/events.component.ts
@@ -18,8 +18,8 @@ export interface AngularEvent {
 })
 export class EventsComponent implements OnInit {
 
-  pastEvents: AngularEvent[];
-  upcomingEvents: AngularEvent[];
+  pastEvents: AngularEvent[] = [];
+  upcomingEvents: AngularEvent[] = [];
 
   constructor(private eventsService: EventsService) { }
 


### PR DESCRIPTION
initialize the events fields of the EventsComponent so that they are always defined

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When running the aio app locally the following warning gets shown in the terminal:

![Screenshot at 2022-09-15 22-54-15](https://user-images.githubusercontent.com/61631103/190516916-252f0421-7102-4095-bf07-1b782768c70f.png)

## What is the new behavior?

The `upcomingEvents` gets initialized to `[]`, so it is always defined and no optional chaining is needed (I could have made the field optional and that would also have solved the issue, but I figured it could be cleaner to initialize the array instead)

I've also initialized the `pastEvents` for consistency, it is also directly accessed without checks so I assume that it should be initialized (strangely, but I removed its assignment and I wasn't getting any runtime error...)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



 