### PR TITLE
fix(core): distinguish injection tokens based on their value type

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/application-providers/window_provider.ts
+++ b/devtools/projects/ng-devtools/src/lib/application-providers/window_provider.ts
@@ -8,6 +8,6 @@
 
 import {InjectionToken} from '@angular/core';
 
-export const WINDOW = new InjectionToken<Window>('WINDOW', {
+export const WINDOW = new InjectionToken<typeof globalThis>('WINDOW', {
   factory: () => window,
 });

--- a/devtools/projects/ng-devtools/src/lib/shared/split/responsive-split.directive.ts
+++ b/devtools/projects/ng-devtools/src/lib/shared/split/responsive-split.directive.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.dev/license
  */
 
-import {Directive, ElementRef, inject, input, DestroyRef, output} from '@angular/core';
+import {DestroyRef, Directive, ElementRef, inject, input, output} from '@angular/core';
 import {WINDOW} from '../../application-providers/window_provider';
 import {Debouncer} from '../utils/debouncer';
-import {SplitComponent} from './split.component';
 import {Direction} from './interface';
+import {SplitComponent} from './split.component';
 
 export const RESIZE_DEBOUNCE = 50; // in milliseconds
 
@@ -30,7 +30,7 @@ export type ResponsiveSplitConfig = {
 export class ResponsiveSplitDirective {
   private readonly host = inject(SplitComponent);
   private readonly elementRef = inject(ElementRef);
-  private readonly window = inject<typeof globalThis>(WINDOW);
+  private readonly window = inject(WINDOW);
 
   protected readonly config = input.required<ResponsiveSplitConfig>({
     alias: 'ngResponsiveSplit',

--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -928,6 +928,7 @@ export interface InjectDecorator {
 
 // @public
 export class InjectionToken<T> {
+    __brand__: T;
     // @deprecated
     constructor(_desc: string, options: {
         providedIn: Type<any> | 'any';

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -69,6 +69,18 @@ export class InjectionToken<T> {
   readonly ɵprov: unknown;
 
   /**
+   * This property is only used to allow the compiler to distinguish between injection tokens based
+   * on their generic type. If the property didn't exist, the following wouldn't result in an error:
+   *
+   * ```
+   * const foo = new InjectionToken<number>('foo');
+   * const bar: InjectionToken<string> = foo; // Should be an error.
+   * ```
+   */
+  // tslint:disable-next-line:require-internal-with-underscore
+  declare __brand__: T;
+
+  /**
    * @deprecated The `providedIn: NgModule` or `providedIn:'any'` options are deprecated. Please use the other signature.
    */
   constructor(
@@ -120,7 +132,9 @@ export class InjectionToken<T> {
    * @internal
    */
   get multi(): InjectionToken<Array<T>> {
-    return this as InjectionToken<Array<T>>;
+    // TODO(crisbeto): the `as unknown` here shouldn't be necessary,
+    // but it fails internally, likely because g3 is still on TS 4.7.
+    return this as unknown as InjectionToken<Array<T>>;
   }
 
   toString(): string {

--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -24,11 +24,11 @@ import {
   CanActivateChildFn,
   CanActivateFn,
   CanDeactivateFn,
-  GuardResult,
   CanLoadFn,
   CanMatchFn,
-  Route,
+  GuardResult,
   PartialMatchRouteSnapshot,
+  Route,
 } from '../models';
 import {redirectingNavigationError} from '../navigation_canceling_error';
 import type {NavigationTransition} from '../navigation_transition';
@@ -50,8 +50,8 @@ import {
   isCanMatch,
 } from '../utils/type_guards';
 
-import {prioritizedGuardValue} from './prioritized_guard_value';
 import {takeUntilAbort} from '../utils/abort_signal_to_observable';
+import {prioritizedGuardValue} from './prioritized_guard_value';
 
 export function checkGuards(
   forwardEvent?: (evt: Event) => void,
@@ -188,8 +188,8 @@ function runCanActivateChild(
       const guardsMapped = d.guards.map(
         (canActivateChild: CanActivateChildFn | ProviderToken<unknown>) => {
           const closestInjector = d.node._environmentInjector;
-          const guard = getTokenOrFunctionIdentity<{canActivateChild: CanActivateChildFn}>(
-            canActivateChild,
+          const guard = getTokenOrFunctionIdentity(
+            canActivateChild as ProviderToken<CanActivateChildFn>,
             closestInjector,
           );
           const guardVal = isCanActivateChild(guard)


### PR DESCRIPTION
Currently the generic type of `InjectionToken` isn't used anywhere which means that the compiler won't flag the following as an error:

```
const foo = new InjectionToken<number>('foo');
const bar: InjectionToken<string> = foo; // Should be an error, but it's not.
```

These changes add a private property to allow the compiler to distinguish between the two.

Fixes #46815.