### PR TITLE
docs: fixed typo in example of AsyncValidatorFn

### DIFF
--- a/aio/content/errors/NG1003.md
+++ b/aio/content/errors/NG1003.md
@@ -7,7 +7,7 @@ Async validators must return a promise or an observable, and emit/resolve them w
 
 ```typescript
 export function isTenAsync(control: AbstractControl): 
-  Observable<ValidationErrors> | null {
+  Observable<ValidationErrors | null> {
     const v: number = control.value;
     if (v !== 10) {
     // Emit an object with a validation error.


### PR DESCRIPTION
the return type must be 
Observable<ValidationErrors | null>
instead of 
Observable<ValidationErrors> | null

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
