### PR TITLE
docs: move Image Directive guide link to the Feature Preview section

### DIFF
--- a/aio/content/guide/image-directive-setup.md
+++ b/aio/content/guide/image-directive-setup.md
@@ -1,5 +1,12 @@
 # Setting up `NgOptimizedImage`
 
+<div class="alert is-important">
+
+The `NgOptimizedImage` directive is available for [developer preview](https://angular.io/guide/releases#developer-preview).
+It's ready for you to try, but it might change before it is stable.
+
+</div>
+
 This tutorial explains how to set up the `NgOptimizedImage`. For information on using `NgOptimizedImage`, see [Getting Started with NgOptimizedImage](/guide/image-directive).
 
 ## Import `NgOptimizedImage`

--- a/aio/content/guide/image-directive.md
+++ b/aio/content/guide/image-directive.md
@@ -1,6 +1,11 @@
 # Getting started with NgOptimizedImage
 
-Note: the `NgOptimizedImage` directive is currently in the ["Developer Preview" mode](https://angular.io/guide/releases#developer-preview). The Angular team will stabilize the APIs based on the feedback and will make an announcement once the APIs are fully stable.
+<div class="alert is-important">
+
+The `NgOptimizedImage` directive is available for [developer preview](https://angular.io/guide/releases#developer-preview).
+It's ready for you to try, but it might change before it is stable.
+
+</div>
 
 The `NgOptimizedImage` directive makes it easy to adopt performance best practices for loading images.
 

--- a/aio/content/guide/standalone-components.md
+++ b/aio/content/guide/standalone-components.md
@@ -1,13 +1,13 @@
 # Getting started with standalone components
 
-In v14 and higher, **standalone components** provide a simplified way to build Angular applications. Standalone components, directives, and pipes aim to streamline the authoring experience by reducing the need for `NgModule`s. Existing applications can optionally and incrementally adopt the new standalone style without any breaking changes.
-
 <div class="alert is-important">
 
-The standalone component feature is available for developer preview. 
-It's ready for you to try; but it might change before it is stable.
+The standalone component feature is available for [developer preview](https://angular.io/guide/releases#developer-preview).
+It's ready for you to try, but it might change before it is stable.
 
 </div>
+
+In v14 and higher, **standalone components** provide a simplified way to build Angular applications. Standalone components, directives, and pipes aim to streamline the authoring experience by reducing the need for `NgModule`s. Existing applications can optionally and incrementally adopt the new standalone style without any breaking changes.
 
 ## Creating standalone components
 

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -637,11 +637,6 @@
           "url": "guide/prerendering",
           "title": "Prerendering",
           "tooltip": "Prerender HTML server-side with Angular Universal."
-        },
-        {
-          "url": "guide/image-directive",
-          "title": "Image Directive",
-          "tooltip": "Performant images with the Angular image directive."
         }
       ]
     },
@@ -861,6 +856,11 @@
           "url": "guide/standalone-components",
           "title": "Standalone components",
           "tooltip": "Standalone components, directives and pipes"
+        },
+        {
+          "url": "guide/image-directive",
+          "title": "Image Directive",
+          "tooltip": "Performant images with the Angular image directive."
         }
       ]
     },


### PR DESCRIPTION
This commit updates the location of the Image Directive guide link in the left navigation menu. Now the link is located under the Feature Preview section.

Also, this commit updates the Image Directive guides to add a highlighted message that the directive is in the developer preview mode.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No