### PR TITLE
fix(animations): make sure that the useAnimation function delay is applied

### DIFF
--- a/packages/animations/browser/src/dsl/animation_timeline_builder.ts
+++ b/packages/animations/browser/src/dsl/animation_timeline_builder.ts
@@ -183,32 +183,25 @@ export class AnimationTimelineBuilderVisitor implements AstVisitor {
   visitAnimateRef(ast: AnimateRefAst, context: AnimationTimelineContext): any {
     const innerContext = context.createSubContext(ast.options);
     innerContext.transformIntoNewTimeline();
-    this._applyAnimateRefDelay(ast.animation, context, innerContext);
+    this._applyAnimationRefDelays([ast.options, ast.animation.options], context, innerContext);
     this.visitReference(ast.animation, innerContext);
     context.transformIntoNewTimeline(innerContext.currentTimeline.currentTime);
     context.previousNode = ast;
   }
 
-  private _applyAnimateRefDelay(
-      animation: ReferenceAst, context: AnimationTimelineContext,
+  private _applyAnimationRefDelays(
+      animationsRefsOptions: (AnimationOptions|null)[], context: AnimationTimelineContext,
       innerContext: AnimationTimelineContext) {
-    const animationDelay = animation.options?.delay;
-
-    if (!animationDelay) {
-      return;
+    for (const animationRefOptions of animationsRefsOptions) {
+      const animationDelay = animationRefOptions?.delay;
+      if (animationDelay) {
+        const animationDelayValue = typeof animationDelay === 'number' ?
+            animationDelay :
+            resolveTimingValue(interpolateParams(
+                animationDelay, animationRefOptions?.params ?? {}, context.errors));
+        innerContext.delayNextStep(animationDelayValue);
+      }
     }
-
-    let animationDelayValue: number;
-
-    if (typeof animationDelay === 'string') {
-      const interpolatedDelay =
-          interpolateParams(animationDelay, animation.options?.params ?? {}, context.errors);
-      animationDelayValue = resolveTimingValue(interpolatedDelay);
-    } else {
-      animationDelayValue = animationDelay;
-    }
-
-    innerContext.delayNextStep(animationDelayValue);
   }
 
   private _visitSubInstructions(


### PR DESCRIPTION
make sure that when an animation is used via the `useAnimation` function and a delay has been provided then that delay gets correctly applied

(this PR is a follow up for #47285)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

If the user provides a delay via `useAnimation` such delay is ignored:
![before](https://user-images.githubusercontent.com/61631103/190865052-facc34f9-0c01-4a63-a4fa-81e652f555bb.gif)


## What is the new behavior?

The delay is correctly applied:
![after](https://user-images.githubusercontent.com/61631103/190865065-9ef800af-8bde-48e3-a2b5-2be30b7b675e.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

