### PR TITLE
test(docs-infra): add mocks for missing mat-icons

### DIFF
--- a/aio/src/app/custom-elements/search/file-not-found-search.component.spec.ts
+++ b/aio/src/app/custom-elements/search/file-not-found-search.component.spec.ts
@@ -7,7 +7,13 @@ import { SearchResults } from 'app/search/interfaces';
 import { SearchResultsComponent } from 'app/shared/search-results/search-results.component';
 import { SearchService } from 'app/search/search.service';
 import { FileNotFoundSearchComponent } from './file-not-found-search.component';
+import { Component } from '@angular/core';
 
+@Component({
+  selector: 'mat-icon',
+  template: '',
+})
+class MockMatIcon {}
 
 describe('FileNotFoundSearchComponent', () => {
   let fixture: ComponentFixture<FileNotFoundSearchComponent>;
@@ -17,7 +23,7 @@ describe('FileNotFoundSearchComponent', () => {
   beforeEach(() => {
 
     TestBed.configureTestingModule({
-      declarations: [ FileNotFoundSearchComponent, SearchResultsComponent ],
+      declarations: [ FileNotFoundSearchComponent, SearchResultsComponent, MockMatIcon ],
       providers: [
         { provide: LocationService, useValue: new MockLocationService('base/initial-url?some-query') },
         SearchService

--- a/aio/src/app/shared/search-results/search-results.component.spec.ts
+++ b/aio/src/app/shared/search-results/search-results.component.spec.ts
@@ -1,8 +1,14 @@
-import { DebugElement } from '@angular/core';
+import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { SearchResult } from 'app/search/interfaces';
 import { SearchResultsComponent } from './search-results.component';
+
+@Component({
+  selector: 'mat-icon',
+  template: '',
+})
+class MockMatIcon {}
 
 describe('SearchResultsComponent', () => {
 
@@ -76,7 +82,7 @@ describe('SearchResultsComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [ SearchResultsComponent ]
+      declarations: [ SearchResultsComponent, MockMatIcon ]
     });
   });
 


### PR DESCRIPTION
add mocks for missing mat-icons in order to reduce noise when running aio tests

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

When running the aio tests a bunch of messages get displayed regarding an undeclared mat-icon:
![Screenshot at 2022-09-17 22-53-59](https://user-images.githubusercontent.com/61631103/190877738-0732826f-e3c0-45ed-bdec-c8cbc4fd6d3d.png)


## What is the new behavior?

Mocks for the mat-icon component have been added to the tests so that the messages are not being displayed anymore


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
