### PR TITLE
fix(compiler): auto-close multiple elements at once if needed

### DIFF
--- a/packages/compiler/src/ml_parser/html_tags.ts
+++ b/packages/compiler/src/ml_parser/html_tags.ts
@@ -89,7 +89,7 @@ export function getHtmlTagDefinition(tagName: string): HtmlTagDefinition {
           'address', 'article', 'aside',   'blockquote', 'div',  'dl',  'fieldset',
           'footer',  'form',    'h1',      'h2',         'h3',   'h4',  'h5',
           'h6',      'header',  'hgroup',  'hr',         'main', 'nav', 'ol',
-          'p',       'pre',     'section', 'table',      'ul'
+          'p',       'pre',     'section', 'table',      'ul',   'li'
         ],
         closedByParent: true
       }),

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -307,10 +307,11 @@ class _TreeBuilder {
   }
 
   private _pushElement(el: html.Element) {
-    const parentEl = this._getParentElement();
+    let parentEl = this._getParentElement();
 
-    if (parentEl && this.getTagDefinition(parentEl.name).isClosedByChild(el.name)) {
+    while (parentEl && this.getTagDefinition(parentEl.name).isClosedByChild(el.name)) {
       this._elementStack.pop();
+      parentEl = this._getParentElement();
     }
 
     this._addToParent(el);

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -257,6 +257,20 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
           ]);
           expect(errors).toEqual([]);
         });
+
+        // https://github.com/angular/angular/issues/47473
+        it('should auto-close multiple elements at once', () => {
+          // The second <li> element should close both the <p> and the first <li> element.
+          expect(humanizeDom(parser.parse('<ul><li>bbb<p>ccc<li>ddd</ul>', 'TestComp'))).toEqual([
+            [html.Element, 'ul', 0],
+            [html.Element, 'li', 1],
+            [html.Text, 'bbb', 2, ['bbb']],
+            [html.Element, 'p', 2],
+            [html.Text, 'ccc', 3, ['ccc']],
+            [html.Element, 'li', 1],
+            [html.Text, 'ddd', 2, ['ddd']],
+          ]);
+        });
       });
 
       describe('attributes', () => {


### PR DESCRIPTION
The `<ul><li>bbb<p>ccc<li>ddd</ul>` HTML fragment should be parsed as if it were `<ul><li>bbb<p>ccc</p></li><li>ddd</li></ul>`, i.e. the second <li> should cause two elements to be auto-closed.

Fixes #47473