### PR TITLE
fix(core): update `isDevMode` to rely on `ngDevMode`

### DIFF
--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -12,7 +12,6 @@ import {noUndefined} from './util';
 export class CompilerConfig {
   public defaultEncapsulation: ViewEncapsulation|null;
   public useJit: boolean;
-  public jitDevMode: boolean;
   public missingTranslation: MissingTranslationStrategy|null;
   public preserveWhitespaces: boolean;
   public strictInjectionParameters: boolean;
@@ -20,21 +19,18 @@ export class CompilerConfig {
   constructor({
     defaultEncapsulation = ViewEncapsulation.Emulated,
     useJit = true,
-    jitDevMode = false,
     missingTranslation = null,
     preserveWhitespaces,
     strictInjectionParameters
   }: {
     defaultEncapsulation?: ViewEncapsulation,
     useJit?: boolean,
-    jitDevMode?: boolean,
     missingTranslation?: MissingTranslationStrategy|null,
     preserveWhitespaces?: boolean,
     strictInjectionParameters?: boolean,
   } = {}) {
     this.defaultEncapsulation = defaultEncapsulation;
     this.useJit = !!useJit;
-    this.jitDevMode = !!jitDevMode;
     this.missingTranslation = missingTranslation;
     this.preserveWhitespaces = preserveWhitespacesDefault(noUndefined(preserveWhitespaces));
     this.strictInjectionParameters = strictInjectionParameters === true;

--- a/packages/core/src/util/is_dev_mode.ts
+++ b/packages/core/src/util/is_dev_mode.ts
@@ -9,27 +9,16 @@
 import {global} from './global';
 
 /**
- * This file is used to control if the default rendering pipeline should be `ViewEngine` or `Ivy`.
+ * Returns whether Angular is in development mode.
  *
- * For more information on how to run and debug tests with either Ivy or View Engine (legacy),
- * please see [BAZEL.md](./docs/BAZEL.md).
- */
-
-let _devMode: boolean = true;
-let _runModeLocked: boolean = false;
-
-
-/**
- * Returns whether Angular is in development mode. After called once,
- * the value is locked and won't change any more.
- *
- * By default, this is true, unless a user calls `enableProdMode` before calling this.
+ * By default, this is true, unless `enableProdMode` is invoked prior to calling this method or the
+ * application is built using the Angular CLI with the `optimization` option.
+ * @see {@link cli/build ng build}
  *
  * @publicApi
  */
 export function isDevMode(): boolean {
-  _runModeLocked = true;
-  return _devMode;
+  return typeof ngDevMode === 'undefined' || !!ngDevMode;
 }
 
 /**
@@ -40,18 +29,16 @@ export function isDevMode(): boolean {
  * does not result in additional changes to any bindings (also known as
  * unidirectional data flow).
  *
+ * Using this method is discouraged as the Angular CLI will set production mode when using the
+ * `optimization` option.
+ * @see {@link cli/build ng build}
+ *
  * @publicApi
  */
 export function enableProdMode(): void {
-  if (_runModeLocked) {
-    throw new Error('Cannot enable prod mode after platform setup.');
-  }
-
   // The below check is there so when ngDevMode is set via terser
   // `global['ngDevMode'] = false;` is also dropped.
   if (typeof ngDevMode === undefined || !!ngDevMode) {
     global['ngDevMode'] = false;
   }
-
-  _devMode = false;
 }

--- a/packages/platform-browser-dynamic/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/src/compiler_factory.ts
@@ -7,7 +7,7 @@
  */
 
 import {CompilerConfig} from '@angular/compiler';
-import {Compiler, CompilerFactory, CompilerOptions, InjectionToken, Injector, isDevMode, MissingTranslationStrategy, PACKAGE_ROOT_URL, StaticProvider, ViewEncapsulation} from '@angular/core';
+import {Compiler, CompilerFactory, CompilerOptions, InjectionToken, Injector, MissingTranslationStrategy, PACKAGE_ROOT_URL, StaticProvider, ViewEncapsulation} from '@angular/core';
 
 export const ERROR_COLLECTOR_TOKEN = new InjectionToken('ErrorCollector');
 
@@ -52,7 +52,6 @@ export class JitCompilerFactory implements CompilerFactory {
             // let explicit values from the compiler options overwrite options
             // from the app providers
             useJit: opts.useJit,
-            jitDevMode: isDevMode(),
             // let explicit values from the compiler options overwrite options
             // from the app providers
             defaultEncapsulation: opts.defaultEncapsulation,


### PR DESCRIPTION
This commits update `isDevMode` to rely on the `ngDevMode` which in the CLI is set by the bundler.

We also update `@angular/platform-dynamic-browser` and `@angular/compiler` to remove usage of `jitDevMode`, which was the last internal usages of `isDevMode`.
