### PR TITLE
refactor(core): expose host directives to their host through DI

### DIFF
--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -63,7 +63,7 @@ export function getLContext(target: any): LContext|null {
         if (nodeIndex == -1) {
           throw new Error('The provided directive was not found in the application');
         }
-        directives = getDirectivesAtNodeIndex(nodeIndex, lView, false);
+        directives = getDirectivesAtNodeIndex(nodeIndex, lView);
       } else {
         nodeIndex = findViaNativeElement(lView, target as RElement);
         if (nodeIndex == -1) {
@@ -295,20 +295,18 @@ function findViaDirective(lView: LView, directiveInstance: {}): number {
 
 /**
  * Returns a list of directives extracted from the given view based on the
- * provided list of directive index values.
+ * provided list of directive index values, excluding components.
  *
  * @param nodeIndex The node index
  * @param lView The target view data
- * @param includeComponents Whether or not to include components in returned directives
  */
-export function getDirectivesAtNodeIndex(
-    nodeIndex: number, lView: LView, includeComponents: boolean): any[]|null {
+export function getDirectivesAtNodeIndex(nodeIndex: number, lView: LView): any[]|null {
   const tNode = lView[TVIEW].data[nodeIndex] as TNode;
   if (tNode.directiveStart === 0) return EMPTY_ARRAY;
   const results: any[] = [];
   for (let i = tNode.directiveStart; i < tNode.directiveEnd; i++) {
     const directiveInstance = lView[i];
-    if (!isComponentInstance(directiveInstance) || includeComponents) {
+    if (!isComponentInstance(directiveInstance)) {
       results.push(directiveInstance);
     }
   }

--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -294,8 +294,9 @@ function findViaDirective(lView: LView, directiveInstance: {}): number {
 }
 
 /**
- * Returns a list of directives extracted from the given view based on the
- * provided list of directive index values, excluding components.
+ * Returns a list of directives applied to a node at a specific index. The list includes
+ * directives matched by selector and any host directives, but it excludes components.
+ * Use `getComponentAtNodeIndex` to find the component applied to a node.
  *
  * @param nodeIndex The node index
  * @param lView The target view data

--- a/packages/core/src/render3/features/host_directives_feature.ts
+++ b/packages/core/src/render3/features/host_directives_feature.ts
@@ -64,6 +64,8 @@ function findHostDirectiveDefs(
     for (const hostDirectiveConfig of def.hostDirectives) {
       const hostDirectiveDef = getDirectiveDef(hostDirectiveConfig.directive)!;
 
+      // TODO(crisbeto): assert that the def exists.
+
       // Host directives execute before the host so that its host bindings can be overwritten.
       findHostDirectiveDefs(matches, hostDirectiveDef, tView, lView, tNode);
       matches.push(hostDirectiveDef);

--- a/packages/core/src/render3/features/host_directives_feature.ts
+++ b/packages/core/src/render3/features/host_directives_feature.ts
@@ -61,15 +61,12 @@ function findHostDirectiveDefs(
     matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, lView: LView,
     tNode: TElementNode|TContainerNode|TElementContainerNode): void {
   if (def.hostDirectives !== null) {
-    // Iterate in reverse so the directive that declares
-    // the host directives preserves its original order.
-    for (let i = def.hostDirectives.length - 1; i > -1; i--) {
-      const hostDirectiveConfig = def.hostDirectives[i];
+    for (const hostDirectiveConfig of def.hostDirectives) {
       const hostDirectiveDef = getDirectiveDef(hostDirectiveConfig.directive)!;
 
       // Host directives execute before the host so that its host bindings can be overwritten.
-      matches.unshift(hostDirectiveDef);
       findHostDirectiveDefs(matches, hostDirectiveDef, tView, lView, tNode);
+      matches.push(hostDirectiveDef);
     }
   }
 }

--- a/packages/core/src/render3/features/host_directives_feature.ts
+++ b/packages/core/src/render3/features/host_directives_feature.ts
@@ -61,18 +61,17 @@ function findHostDirectiveDefs(
     matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, lView: LView,
     tNode: TElementNode|TContainerNode|TElementContainerNode): void {
   if (def.hostDirectives !== null) {
-    for (const hostDirectiveConfig of def.hostDirectives) {
+    // Iterate in reverse so the directive that declares
+    // the host directives preserves its original order.
+    for (let i = def.hostDirectives.length - 1; i > -1; i--) {
+      const hostDirectiveConfig = def.hostDirectives[i];
       const hostDirectiveDef = getDirectiveDef(hostDirectiveConfig.directive)!;
 
-      // TODO(crisbeto): assert that the def exists.
-
       // Host directives execute before the host so that its host bindings can be overwritten.
+      matches.unshift(hostDirectiveDef);
       findHostDirectiveDefs(matches, hostDirectiveDef, tView, lView, tNode);
     }
   }
-
-  // Push the def itself at the end since it needs to execute after the host directives.
-  matches.push(def);
 }
 
 /**

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1295,7 +1295,11 @@ function findDirectiveDefMatches(
           // compatibility. This logic doesn't make sense with host directives, because it
           // would allow the host directives to undo any overrides the host may have made.
           // To handle this case, the host directives of components are inserted at the beginning
-          // of the array, followed by the component.
+          // of the array, followed by the component. As such, the insertion order is as follows:
+          // 1. Host directives belonging to the selector-matched component.
+          // 2. Selector-matched component.
+          // 3. Host directives belonging to selector-matched directives.
+          // 4. Selector-matched directives.
           if (def.findHostDirectiveDefs !== null) {
             const hostDirectiveMatches: DirectiveDef<unknown>[] = [];
             // Append any host directives to the matches first.

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1302,12 +1302,17 @@ function findDirectiveDefMatches(
           // 4. Selector-matched directives.
           if (def.findHostDirectiveDefs !== null) {
             const hostDirectiveMatches: DirectiveDef<unknown>[] = [];
-            // Append any host directives to the matches first.
             def.findHostDirectiveDefs(hostDirectiveMatches, def, tView, lView, tNode);
-            hostDirectiveMatches.push(def);
-            matches.unshift(...hostDirectiveMatches);
-            markAsComponentHost(tView, tNode, hostDirectiveMatches.length - 1);
+            // Add all host directives declared on this component, followed by the component itself.
+            // Host directives should execute first so the host has a chance to override changes
+            // to the DOM made by them.
+            matches.unshift(...hostDirectiveMatches, def);
+            // Component is offset starting from the beginning of the host directives array.
+            const componentOffset = hostDirectiveMatches.length;
+            markAsComponentHost(tView, tNode, componentOffset);
           } else {
+            // No host directives on this component, just add the
+            // component def to the beginning of the matches.
             matches.unshift(def);
             markAsComponentHost(tView, tNode, 0);
           }

--- a/packages/core/src/render3/util/discovery_utils.ts
+++ b/packages/core/src/render3/util/discovery_utils.ts
@@ -221,7 +221,7 @@ export function getDirectives(node: Node): {}[] {
     return [];
   }
   if (context.directives === undefined) {
-    context.directives = getDirectivesAtNodeIndex(nodeIndex, lView, false);
+    context.directives = getDirectivesAtNodeIndex(nodeIndex, lView);
   }
 
   // The `directives` in this case are a named array called `LComponentView`. Clone the

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -362,95 +362,95 @@ describe('host directives', () => {
       ]);
     });
 
-    // Note: lifecycle hook order is different when components and
-    // directives are mixed so this test aims to cover it.
-    it('should invoke lifecycle hooks in the correct order when host directives are applied to a component',
-       () => {
-         const logs: string[] = [];
+    // Note: lifecycle hook order is different when components and directives are mixed so this
+    // test aims to cover it. Usually lifecycle hooks are invoked based on the order in which
+    // directives were matched, but components bypass this logic and always execute first.
+    it('should invoke host directive lifecycle hooks before the host component hooks', () => {
+      const logs: string[] = [];
 
-         // Utility so we don't have to repeat the logging code.
-         @Directive({standalone: true})
-         abstract class LogsLifecycles implements OnInit, AfterViewInit {
-           abstract name: string;
+      // Utility so we don't have to repeat the logging code.
+      @Directive({standalone: true})
+      abstract class LogsLifecycles implements OnInit, AfterViewInit {
+        abstract name: string;
 
-           ngOnInit() {
-             logs.push(`${this.name} - ngOnInit`);
-           }
+        ngOnInit() {
+          logs.push(`${this.name} - ngOnInit`);
+        }
 
-           ngAfterViewInit() {
-             logs.push(`${this.name} - ngAfterViewInit`);
-           }
-         }
+        ngAfterViewInit() {
+          logs.push(`${this.name} - ngAfterViewInit`);
+        }
+      }
 
-         @Directive({standalone: true})
-         class ChildHostDir extends LogsLifecycles {
-           override name = 'ChildHostDir';
-         }
+      @Directive({standalone: true})
+      class ChildHostDir extends LogsLifecycles {
+        override name = 'ChildHostDir';
+      }
 
-         @Directive({standalone: true})
-         class OtherChildHostDir extends LogsLifecycles {
-           override name = 'OtherChildHostDir';
-         }
+      @Directive({standalone: true})
+      class OtherChildHostDir extends LogsLifecycles {
+        override name = 'OtherChildHostDir';
+      }
 
-         @Component({
-           selector: 'child',
-           hostDirectives: [ChildHostDir, OtherChildHostDir],
-         } as HostDirectiveAny)
-         class Child extends LogsLifecycles {
-           override name = 'Child';
-         }
+      @Component({
+        selector: 'child',
+        hostDirectives: [ChildHostDir, OtherChildHostDir],
+      } as HostDirectiveAny)
+      class Child extends LogsLifecycles {
+        override name = 'Child';
+      }
 
-         @Directive({standalone: true})
-         class ParentHostDir extends LogsLifecycles {
-           override name = 'ParentHostDir';
-         }
+      @Directive({standalone: true})
+      class ParentHostDir extends LogsLifecycles {
+        override name = 'ParentHostDir';
+      }
 
-         @Directive({standalone: true})
-         class OtherParentHostDir extends LogsLifecycles {
-           override name = 'OtherParentHostDir';
-         }
+      @Directive({standalone: true})
+      class OtherParentHostDir extends LogsLifecycles {
+        override name = 'OtherParentHostDir';
+      }
 
-         @Component({
-           selector: 'parent',
-           hostDirectives: [ParentHostDir, OtherParentHostDir],
-           template: '<child plain-dir="PlainDir on child"></child>',
-         } as HostDirectiveAny)
-         class Parent extends LogsLifecycles {
-           override name = 'Parent';
-         }
+      @Component({
+        selector: 'parent',
+        hostDirectives: [ParentHostDir, OtherParentHostDir],
+        template: '<child plain-dir="PlainDir on child"></child>',
+      } as HostDirectiveAny)
+      class Parent extends LogsLifecycles {
+        override name = 'Parent';
+      }
 
-         @Directive({selector: '[plain-dir]'})
-         class PlainDir extends LogsLifecycles {
-           @Input('plain-dir') override name = '';
-         }
+      @Directive({selector: '[plain-dir]'})
+      class PlainDir extends LogsLifecycles {
+        @Input('plain-dir') override name = '';
+      }
 
-         @Component({template: '<parent plain-dir="PlainDir on parent"></parent>'})
-         class App {
-         }
+      @Component({template: '<parent plain-dir="PlainDir on parent"></parent>'})
+      class App {
+      }
 
-         TestBed.configureTestingModule({declarations: [App, Parent, Child, PlainDir]});
-         const fixture = TestBed.createComponent(App);
-         fixture.detectChanges();
+      TestBed.configureTestingModule({declarations: [App, Parent, Child, PlainDir]});
+      const fixture = TestBed.createComponent(App);
+      fixture.detectChanges();
 
-         expect(logs).toEqual([
-           'ParentHostDir - ngOnInit',
-           'OtherParentHostDir - ngOnInit',
-           'Parent - ngOnInit',
-           'PlainDir on parent - ngOnInit',
-           'ChildHostDir - ngOnInit',
-           'OtherChildHostDir - ngOnInit',
-           'Child - ngOnInit',
-           'PlainDir on child - ngOnInit',
-           'ChildHostDir - ngAfterViewInit',
-           'OtherChildHostDir - ngAfterViewInit',
-           'Child - ngAfterViewInit',
-           'PlainDir on child - ngAfterViewInit',
-           'ParentHostDir - ngAfterViewInit',
-           'OtherParentHostDir - ngAfterViewInit',
-           'Parent - ngAfterViewInit',
-           'PlainDir on parent - ngAfterViewInit',
-         ]);
-       });
+      expect(logs).toEqual([
+        'ParentHostDir - ngOnInit',
+        'OtherParentHostDir - ngOnInit',
+        'Parent - ngOnInit',
+        'PlainDir on parent - ngOnInit',
+        'ChildHostDir - ngOnInit',
+        'OtherChildHostDir - ngOnInit',
+        'Child - ngOnInit',
+        'PlainDir on child - ngOnInit',
+        'ChildHostDir - ngAfterViewInit',
+        'OtherChildHostDir - ngAfterViewInit',
+        'Child - ngAfterViewInit',
+        'PlainDir on child - ngAfterViewInit',
+        'ParentHostDir - ngAfterViewInit',
+        'OtherParentHostDir - ngAfterViewInit',
+        'Parent - ngAfterViewInit',
+        'PlainDir on parent - ngAfterViewInit',
+      ]);
+    });
   });
 
   describe('host bindings', () => {

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -186,20 +186,38 @@ describe('host directives', () => {
     } as HostDirectiveAny)
     class MyComp {
       constructor() {
-        logs.push('host');
+        logs.push('MyComp');
       }
     }
-    @Component({template: '<my-comp></my-comp>'})
+
+    @Directive({standalone: true})
+    class SelectorMatchedHostDir {
+      constructor() {
+        logs.push('SelectorMatchedHostDir');
+      }
+    }
+
+    @Directive({
+      selector: '[selector-matched-dir]',
+      hostDirectives: [SelectorMatchedHostDir],
+    } as HostDirectiveAny)
+    class SelectorMatchedDir {
+      constructor() {
+        logs.push('SelectorMatchedDir');
+      }
+    }
+
+    @Component({template: '<my-comp selector-matched-dir></my-comp>'})
     class App {
     }
 
-    TestBed.configureTestingModule({declarations: [App, MyComp]});
+    TestBed.configureTestingModule({declarations: [App, MyComp, SelectorMatchedDir]});
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
 
     expect(diTokenValue!).toBe('host value');
     expect(fixture.nativeElement.innerHTML)
-        .toBe('<my-comp id="host-id" class="leaf middle host"></my-comp>');
+        .toBe('<my-comp id="host-id" selector-matched-dir="" class="leaf middle host"></my-comp>');
     expect(logs).toEqual([
       'Chain1 - level 3',
       'Chain1 - level 2',
@@ -208,7 +226,9 @@ describe('host directives', () => {
       'Chain2 - level 1',
       'Chain3 - level 2',
       'Chain3 - level 1',
-      'host',
+      'MyComp',
+      'SelectorMatchedHostDir',
+      'SelectorMatchedDir',
     ]);
   });
 


### PR DESCRIPTION
Exposes the host directives to the host and its descendants through DI. This can be useful, because it allows the host to further configure the host directives.