### PR TITLE
fix(core): correctly check for `typeof` of undefined in `ngDevMode` check

### DIFF
--- a/packages/core/src/util/is_dev_mode.ts
+++ b/packages/core/src/util/is_dev_mode.ts
@@ -49,7 +49,7 @@ export function enableProdMode(): void {
 
   // The below check is there so when ngDevMode is set via terser
   // `global['ngDevMode'] = false;` is also dropped.
-  if (typeof ngDevMode === undefined || !!ngDevMode) {
+  if (typeof ngDevMode === 'undefined' || ngDevMode) {
     global['ngDevMode'] = false;
   }
 


### PR DESCRIPTION

Previously, this check was wrong as typeof returns a string.
