### PR TITLE
Introduce `NG_OPTIMIZED_IMAGE_CONFIG` token to configure image directive

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -410,6 +410,9 @@ export class LowerCasePipe implements PipeTransform {
 }
 
 // @public
+export const NG_OPTIMIZED_IMAGE_CONFIG: InjectionToken<NgOptimizedImageConfig>;
+
+// @public
 export class NgClass implements DoCheck {
     constructor(_iterableDiffers: IterableDiffers, _keyValueDiffers: KeyValueDiffers, _ngEl: ElementRef, _renderer: Renderer2);
     // (undocumented)
@@ -559,6 +562,11 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[ngSrc],img[rawSrc]", never, { "rawSrc": "rawSrc"; "ngSrc": "ngSrc"; "ngSrcset": "ngSrcset"; "width": "width"; "height": "height"; "loading": "loading"; "priority": "priority"; "src": "src"; "srcset": "srcset"; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgOptimizedImage, never>;
+}
+
+// @public
+export interface NgOptimizedImageConfig {
+    preconnectCheckBlocklist?: string[];
 }
 
 // @public
@@ -786,9 +794,6 @@ interface PopStateEvent_2 {
     url?: string;
 }
 export { PopStateEvent_2 as PopStateEvent }
-
-// @public
-export const PRECONNECT_CHECK_BLOCKLIST: InjectionToken<(string | string[])[]>;
 
 // @public
 export const provideCloudflareLoader: (path: string, options?: {

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -27,4 +27,4 @@ export {PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID, PLATFORM_SERVER_ID as ɵPL
 export {VERSION} from './version';
 export {ViewportScroller, NullViewportScroller as ɵNullViewportScroller} from './viewport_scroller';
 export {XhrFactory} from './xhr';
-export {IMAGE_LOADER, ImageLoader, ImageLoaderConfig, NgOptimizedImage, PRECONNECT_CHECK_BLOCKLIST, provideCloudflareLoader, provideCloudinaryLoader, provideImageKitLoader, provideImgixLoader} from './directives/ng_optimized_image';
+export {IMAGE_LOADER, ImageLoader, ImageLoaderConfig, NG_OPTIMIZED_IMAGE_CONFIG, NgOptimizedImageConfig, NgOptimizedImage, provideCloudflareLoader, provideCloudinaryLoader, provideImageKitLoader, provideImgixLoader} from './directives/ng_optimized_image';

--- a/packages/common/src/directives/ng_optimized_image/config.ts
+++ b/packages/common/src/directives/ng_optimized_image/config.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectionToken, Injector} from '@angular/core';
+
+/**
+ * Represents the `NgOptimizedImage` configuration that can be provided using the
+ * `NG_OPTIMIZED_IMAGE_CONFIG` DI token.
+ *
+ * @see `NG_OPTIMIZED_IMAGE_CONFIG`
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export interface NgOptimizedImageConfig {
+  /**
+   * Configures a set of origins that should be excluded from the preconnect check
+   * performed by the `NgOptimizedImage` directive for priority images to find
+   * corresponding `<link rel="preconnect">` tags on a page.
+   */
+  preconnectCheckBlocklist?: string[];
+}
+
+/**
+ * A token that can be used to configure `NgOptimizedImage` directives.
+ *
+ * @see `NgOptimizedImageConfig`
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export const NG_OPTIMIZED_IMAGE_CONFIG =
+    new InjectionToken<NgOptimizedImageConfig>(ngDevMode ? 'NG_OPTIMIZED_IMAGE_CONFIG' : '');
+
+export function getDirectiveConfig(injector: Injector) {
+  return injector.get(NG_OPTIMIZED_IMAGE_CONFIG, null) ?? {};
+}

--- a/packages/common/src/directives/ng_optimized_image/index.ts
+++ b/packages/common/src/directives/ng_optimized_image/index.ts
@@ -7,10 +7,10 @@
  */
 
 // These exports represent the set of symbols exposed as a public API.
+export {NG_OPTIMIZED_IMAGE_CONFIG, NgOptimizedImageConfig} from './config';
 export {provideCloudflareLoader} from './image_loaders/cloudflare_loader';
 export {provideCloudinaryLoader} from './image_loaders/cloudinary_loader';
 export {IMAGE_LOADER, ImageLoader, ImageLoaderConfig} from './image_loaders/image_loader';
 export {provideImageKitLoader} from './image_loaders/imagekit_loader';
 export {provideImgixLoader} from './image_loaders/imgix_loader';
 export {NgOptimizedImage} from './ng_optimized_image';
-export {PRECONNECT_CHECK_BLOCKLIST} from './preconnect_link_checker';

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -298,7 +298,7 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
       assertNoImageDistortion(this, this.imgElement, this.renderer);
       if (this.priority) {
         const checker = this.injector.get(PreconnectLinkChecker);
-        checker.assertPreconnect(this.getRewrittenSrc(), this.ngSrc);
+        checker.assertPreconnect(this.getRewrittenSrc(), this.ngSrc, this.injector);
       } else {
         // Monitor whether an image is an LCP element only in case
         // the `priority` attribute is missing. Otherwise, an image

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule, DOCUMENT} from '@angular/common';
+import {CommonModule, DOCUMENT, NG_OPTIMIZED_IMAGE_CONFIG} from '@angular/common';
 import {RuntimeErrorCode} from '@angular/common/src/errors';
 import {Component, Provider, Type} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
@@ -739,11 +739,12 @@ describe('Image directive', () => {
          }));
     });
 
-    describe('PRECONNECT_CHECK_BLOCKLIST token', () => {
-      it(`should allow passing host names`, withHead('', () => {
-           const providers = [
-             {provide: PRECONNECT_CHECK_BLOCKLIST, useValue: 'angular.io', multi: true},
-           ];
+    describe('NG_OPTIMIZED_IMAGE_CONFIG token', () => {
+      it(`should allow passing host names in preconnect check blocklist`, withHead('', () => {
+           const providers = [{
+             provide: NG_OPTIMIZED_IMAGE_CONFIG,
+             useValue: {preconnectCheckBlocklist: ['angular.io']}
+           }];
            setupTestingModule({imageLoader, extraProviders: providers});
 
            const consoleWarnSpy = spyOn(console, 'warn');
@@ -755,10 +756,11 @@ describe('Image directive', () => {
            expect(consoleWarnSpy.calls.count()).toBe(0);
          }));
 
-      it(`should allow passing origins`, withHead('', () => {
-           const providers = [
-             {provide: PRECONNECT_CHECK_BLOCKLIST, useValue: 'https://angular.io', multi: true},
-           ];
+      it(`should allow passing origins in preconnect check blocklist`, withHead('', () => {
+           const providers = [{
+             provide: NG_OPTIMIZED_IMAGE_CONFIG,
+             useValue: {preconnectCheckBlocklist: ['https://angular.io']}
+           }];
            setupTestingModule({imageLoader, extraProviders: providers});
 
            const consoleWarnSpy = spyOn(console, 'warn');
@@ -770,41 +772,11 @@ describe('Image directive', () => {
            expect(consoleWarnSpy.calls.count()).toBe(0);
          }));
 
-      it(`should allow passing arrays of host names`, withHead('', () => {
-           const providers = [
-             {provide: PRECONNECT_CHECK_BLOCKLIST, useValue: ['https://angular.io'], multi: true},
-           ];
-           setupTestingModule({imageLoader, extraProviders: providers});
-
-           const consoleWarnSpy = spyOn(console, 'warn');
-           const template = '<img ngSrc="a.png" width="100" height="50" priority>';
-           const fixture = createTestComponent(template);
-           fixture.detectChanges();
-
-           // Expect no warnings in the console.
-           expect(consoleWarnSpy.calls.count()).toBe(0);
-         }));
-
-      it(`should allow passing nested arrays of host names`, withHead('', () => {
-           const providers = [
-             {provide: PRECONNECT_CHECK_BLOCKLIST, useValue: [['https://angular.io']], multi: true},
-           ];
-           setupTestingModule({imageLoader, extraProviders: providers});
-
-           const consoleWarnSpy = spyOn(console, 'warn');
-           const template = '<img ngSrc="a.png" width="100" height="50" priority>';
-           const fixture = createTestComponent(template);
-           fixture.detectChanges();
-
-           // Expect no warnings in the console.
-           expect(consoleWarnSpy.calls.count()).toBe(0);
-         }));
-
-      it(`should throw when PRECONNECT_CHECK_BLOCKLIST is not a multi provider`,
-         withHead('', () => {
-           const providers = [
-             {provide: PRECONNECT_CHECK_BLOCKLIST, useValue: 'https://angular.io'},
-           ];
+      it(`should throw when preconnect check blocklist is not an array`, withHead('', () => {
+           const providers = [{
+             provide: NG_OPTIMIZED_IMAGE_CONFIG,
+             useValue: {preconnectCheckBlocklist: 'https://angular.io'}
+           }];
            setupTestingModule({imageLoader, extraProviders: providers});
 
            const template = '<img ngSrc="a.png" width="100" height="50" priority>';
@@ -813,9 +785,9 @@ describe('Image directive', () => {
              fixture.detectChanges();
            })
                .toThrowError(
-                   'NG02957: The blocklist for the preconnect check was not ' +
-                   'provided as an array. Check that the `PRECONNECT_CHECK_BLOCKLIST` token ' +
-                   'is configured as a `multi: true` provider.');
+                   'NG02957: The blocklist for the preconnect check was not provided ' +
+                   'as an array. Check that the `NG_OPTIMIZED_IMAGE_CONFIG` token value ' +
+                   'has correct shape.');
          }));
     });
   });

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -8,12 +8,12 @@
 
 import {CommonModule, DOCUMENT} from '@angular/common';
 import {RuntimeErrorCode} from '@angular/common/src/errors';
-import {Component, Provider} from '@angular/core';
+import {Component, Provider, Type} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {withHead} from '@angular/private/testing';
 
-import {IMAGE_LOADER, ImageLoader, ImageLoaderConfig} from '../../src/directives/ng_optimized_image/image_loaders/image_loader';
+import {createImageLoader, IMAGE_LOADER, ImageLoader, ImageLoaderConfig} from '../../src/directives/ng_optimized_image/image_loaders/image_loader';
 import {ABSOLUTE_SRCSET_DENSITY_CAP, assertValidNgSrcset, NgOptimizedImage, RECOMMENDED_SRCSET_DENSITY_CAP} from '../../src/directives/ng_optimized_image/ng_optimized_image';
 import {PRECONNECT_CHECK_BLOCKLIST} from '../../src/directives/ng_optimized_image/preconnect_link_checker';
 
@@ -883,6 +883,66 @@ describe('Image directive', () => {
       expect(img.src).toBe(`${IMG_BASE_URL}/img.png`);
     });
 
+    it(`should allow providing image loaders via Component providers`, withHead('', () => {
+         const createImgUrl = (path: string, config: ImageLoaderConfig) => `${path}/${config.src}`;
+         const provideCustomLoader = createImageLoader(createImgUrl);
+
+         @Component({
+           selector: 'test-cmp',
+           template: '<img ngSrc="a.png" width="100" height="50" priority>',
+           providers: [provideCustomLoader('https://angular.io')]
+         })
+         class TestComponent {
+         }
+
+         setupTestingModule({component: TestComponent});
+
+         const consoleWarnSpy = spyOn(console, 'warn');
+         const fixture = TestBed.createComponent(TestComponent);
+         fixture.detectChanges();
+
+         const nativeElement = fixture.nativeElement as HTMLElement;
+         const img = nativeElement.querySelector('img')!;
+         expect(img.src).toBe('https://angular.io/a.png');
+
+         // Verify that there is a warning in a console related to a missing preconnect.
+         const warning = consoleWarnSpy.calls.argsFor(0)[0];
+         expect(warning).toContain(
+             'NG02956: The NgOptimizedImage directive ' +
+             '(activated on an <img> element with the `ngSrc="a.png"`) ' +
+             'has detected that there is no preconnect tag present for this image.');
+       }));
+
+    it(`should allow disabling preconnect check for image loaders configured using Component providers`,
+       withHead('', () => {
+         const createImgUrl = (path: string, config: ImageLoaderConfig) => `${path}/${config.src}`;
+         const provideCustomLoader = createImageLoader(createImgUrl);
+
+         @Component({
+           selector: 'test-cmp',
+           template: '<img ngSrc="a.png" width="100" height="50" priority>',
+           providers: [
+             provideCustomLoader('https://angular.io', {ensurePreconnect: false}),
+           ]
+         })
+         class TestComponent {
+         }
+
+         setupTestingModule({component: TestComponent});
+
+         const consoleWarnSpy = spyOn(console, 'warn');
+         const fixture = TestBed.createComponent(TestComponent);
+         fixture.detectChanges();
+
+         const nativeElement = fixture.nativeElement as HTMLElement;
+         const img = nativeElement.querySelector('img')!;
+         expect(img.src).toBe('https://angular.io/a.png');
+
+         // The `ensurePreconnect: false` was specified in a loader config,
+         // so we expect no warnings in the console.
+         expect(consoleWarnSpy.calls.count()).toBe(0);
+       }));
+
     describe('`ngSrcset` values', () => {
       let imageLoader!: ImageLoader;
 
@@ -1051,7 +1111,8 @@ class TestComponent {
   priority = false;
 }
 
-function setupTestingModule(config?: {imageLoader?: ImageLoader, extraProviders?: any[]}) {
+function setupTestingModule(
+    config?: {imageLoader?: ImageLoader, extraProviders?: Provider[], component?: Type<unknown>}) {
   const defaultLoader = (config: ImageLoaderConfig) => {
     const isAbsolute = /^https?:\/\//.test(config.src);
     return isAbsolute ? config.src : window.location.origin + '/' + config.src;
@@ -1065,7 +1126,7 @@ function setupTestingModule(config?: {imageLoader?: ImageLoader, extraProviders?
   ];
 
   TestBed.configureTestingModule({
-    declarations: [TestComponent],
+    declarations: [config?.component ?? TestComponent],
     // Note: the `NgOptimizedImage` directive is experimental and is not a part of the
     // `CommonModule` yet, so it's imported separately.
     imports: [CommonModule, NgOptimizedImage],

--- a/packages/common/test/image_loaders/image_loader_spec.ts
+++ b/packages/common/test/image_loaders/image_loader_spec.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {IMAGE_LOADER, ImageLoader, PRECONNECT_CHECK_BLOCKLIST} from '@angular/common/src/directives/ng_optimized_image';
+import {IMAGE_LOADER, ImageLoader} from '@angular/common/src/directives/ng_optimized_image';
 import {provideCloudflareLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/cloudflare_loader';
 import {provideCloudinaryLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader';
 import {provideImageKitLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader';
 import {provideImgixLoader} from '@angular/common/src/directives/ng_optimized_image/image_loaders/imgix_loader';
+import {PRECONNECT_CHECK_BLOCKLIST} from '@angular/common/src/directives/ng_optimized_image/preconnect_link_checker';
 import {isValidPath} from '@angular/common/src/directives/ng_optimized_image/url';
 import {createEnvironmentInjector, EnvironmentInjector, ValueProvider} from '@angular/core';
 import {TestBed} from '@angular/core/testing';


### PR DESCRIPTION
NOTES:
- this PR is created on top of #47498 and will need a rebase once PR #47498 lands.
- more tests are needed to verify `NG_OPTIMIZED_IMAGE_CONFIG` token behavior

This commit replaces the `PRECONNECT_CHECK_BLOCKLIST` (used to configure a list of origins to skip preconnect check) with the `NG_OPTIMIZED_IMAGE_CONFIG` token that represents a consolidated config for `NgOptimizedImage` directives.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

NOTE: marking it as a refactoring to land the change in the patch branch. The `NgOptimizedImage` directive is in the Developer Preview mode which allows us to update public APIs in patch releases.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No