### PR TITLE
docs: visualize keyboard shortcut for search

### DIFF
--- a/aio/src/app/search/search-box/search-box.component.ts
+++ b/aio/src/app/search/search-box/search-box.component.ts
@@ -24,6 +24,7 @@ import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
     (keyup)="doSearch()"
     (focus)="doFocus()"
     (click)="doSearch()">
+  <div class="search-box-shortcut">/</div>
   <mat-icon
     *ngIf="searchBox.value"
     (click)="searchBox.value = ''; searchBox.focus()">

--- a/aio/src/styles/1-layouts/top-menu/_top-menu-theme.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu-theme.scss
@@ -88,6 +88,11 @@
           color: constants.$mediumgray;
         }
       }
+
+      .search-box-shortcut {
+        border-color: constants.$mediumgray;
+        color: constants.$mediumgray;
+      }
     }
 
     aio-theme-toggle {

--- a/aio/src/styles/1-layouts/top-menu/_top-menu.scss
+++ b/aio/src/styles/1-layouts/top-menu/_top-menu.scss
@@ -208,6 +208,24 @@ mat-toolbar.app-toolbar {
       }
     }
 
+    .search-box-shortcut {
+      display: none;
+      position: absolute;
+      right: 16px;
+      font-size: 1.2rem;
+      line-height: 2.2rem;
+      padding: 0 0.8rem;
+      pointer-events: none;
+      font-weight: bold;
+      text-align: center;
+      border-radius: 4px;
+      border: 1px solid;
+    }
+
+    input:not(:focus):placeholder-shown + .search-box-shortcut {
+      display: block;
+    }
+
     mat-icon {
       position: absolute;
       color: constants.$blue;


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current/new behavior?

Currently, there is no visual guidance on how to jump straight to the search box via keyboard shortcut.
Presenting the keyboard shortcut right in the search bar is pretty common these days:
- Storybook <img width="186" alt="image" src="https://user-images.githubusercontent.com/5166666/191561359-55318d9a-7ca1-48fb-be3f-7732c72d0a8d.png">
- Tailwindcss <img width="267" alt="image" src="https://user-images.githubusercontent.com/5166666/191561479-18b98168-4945-483a-8cac-73783cbe1679.png">
- Vue.js <img width="233" alt="image" src="https://user-images.githubusercontent.com/5166666/191562022-32f54f65-f559-40ca-9574-5465ce08fba8.png">
- Github <img width="337" alt="image" src="https://user-images.githubusercontent.com/5166666/191560646-4b114a24-0b78-427b-8aaa-01c49f650d84.png">
- Docusaurus <img width="367" alt="image" src="https://user-images.githubusercontent.com/5166666/191561102-d34fa397-14c0-43bc-8dd3-ad074d5f5cff.png">
- the list goes on...

I didn't even know that Angular docs supports `/` shortcut for this already.
Would be a nice touch to show this the same way Github does.

Feel free to make any changes or reject, this is just a proposal.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
