### PR TITLE
refactor(core): support applying directives to the root component

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -19,7 +19,7 @@ import {createElementRef, ElementRef} from '../linker/element_ref';
 import {NgModuleRef} from '../linker/ng_module_factory';
 import {Renderer2, RendererFactory2} from '../render/api';
 import {Sanitizer} from '../sanitization/sanitizer';
-import {assertDefined, assertIndexInRange} from '../util/assert';
+import {assertDefined, assertGreaterThan, assertIndexInRange} from '../util/assert';
 import {VERSION} from '../version';
 import {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from '../view/provider_flags';
 
@@ -399,6 +399,8 @@ function createRootComponent<T>(
 
   // We're guaranteed for the `componentOffset` to be positive here
   // since a root component always matches a component def.
+  ngDevMode &&
+      assertGreaterThan(rootTNode.componentOffset, -1, 'componentOffset must be great than -1');
   const component = getNodeInjectable(
       rootLView, tView, rootTNode.directiveStart + rootTNode.componentOffset, rootTNode);
   componentView[CONTEXT] = rootLView[CONTEXT] = component;

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -17,32 +17,34 @@ import {ComponentFactory as AbstractComponentFactory, ComponentRef as AbstractCo
 import {ComponentFactoryResolver as AbstractComponentFactoryResolver} from '../linker/component_factory_resolver';
 import {createElementRef, ElementRef} from '../linker/element_ref';
 import {NgModuleRef} from '../linker/ng_module_factory';
-import {RendererFactory2} from '../render/api';
+import {Renderer2, RendererFactory2} from '../render/api';
 import {Sanitizer} from '../sanitization/sanitizer';
-import {assertDefined, assertIndexInRange} from '../util/assert';
+import {assertDefined, assertEqual, assertIndexInRange} from '../util/assert';
 import {VERSION} from '../version';
 import {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from '../view/provider_flags';
 
 import {assertComponentType} from './assert';
+import {attachPatchData} from './context_discovery';
 import {getComponentDef} from './definition';
-import {diPublicInInjector, getOrCreateNodeInjectorForNode, NodeInjector} from './di';
+import {diPublicInInjector, getNodeInjectable, getOrCreateNodeInjectorForNode, NodeInjector} from './di';
 import {throwProviderNotFoundError} from './errors_di';
 import {registerPostOrderHooks} from './hooks';
 import {reportUnknownPropertyError} from './instructions/element_validation';
-import {addToViewTree, createLView, createTView, getOrCreateComponentTView, getOrCreateTNode, initTNodeFlags, instantiateRootComponent, invokeHostBindingsInCreationMode, locateHostElement, markAsComponentHost, markDirtyIfOnPush, registerHostBindingOpCodes, renderView, setInputsForProperty} from './instructions/shared';
-import {ComponentDef, RenderFlags} from './interfaces/definition';
+import {addToViewTree, allocExpando, configureViewWithDirective, createLView, createTView, getOrCreateComponentTView, getOrCreateTNode, initializeInputAndOutputAliases, initTNodeFlags, invokeHostBindingsInCreationMode, locateHostElement, markAsComponentHost, markDirtyIfOnPush, registerHostBindingOpCodes, renderView, setInputsForProperty} from './instructions/shared';
+import {ComponentDef, DirectiveDef, RenderFlags} from './interfaces/definition';
 import {PropertyAliasValue, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType} from './interfaces/node';
 import {Renderer, RendererFactory} from './interfaces/renderer';
 import {RElement, RNode} from './interfaces/renderer_dom';
-import {CONTEXT, HEADER_OFFSET, LView, LViewFlags, TVIEW, TViewType} from './interfaces/view';
+import {CONTEXT, HEADER_OFFSET, LView, LViewFlags, TView, TVIEW, TViewType} from './interfaces/view';
 import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from './namespaces';
 import {createElementNode, writeDirectClass, writeDirectStyle} from './node_manipulation';
 import {extractAttrsAndClassesFromSelector, stringifyCSSSelectorList} from './node_selector_matcher';
 import {enterView, getCurrentTNode, getLView, leaveView, setSelectedIndex} from './state';
 import {computeStaticStyling} from './styling/static_styling';
-import {setUpAttributes} from './util/attrs_utils';
+import {NO_CHANGE} from './tokens';
+import {mergeHostAttrs, setUpAttributes} from './util/attrs_utils';
 import {stringifyForError} from './util/stringify_utils';
-import {getTNode} from './util/view_utils';
+import {getNativeByTNode, getTNode} from './util/view_utils';
 import {RootViewRef, ViewRef} from './view_ref';
 
 export class ComponentFactoryResolver extends AbstractComponentFactoryResolver {
@@ -190,46 +192,30 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
     let tElementNode: TElementNode;
 
     try {
+      const rootDirectives = [this.componentDef];
+      const hostTNode = createRootComponentTNode(rootLView, hostRNode);
       const componentView = createRootComponentView(
-          hostRNode, this.componentDef, rootLView, rendererFactory, hostRenderer);
-      if (hostRNode) {
-        if (rootSelectorOrNode) {
-          setUpAttributes(hostRenderer, hostRNode, ['ng-version', VERSION.full]);
-        } else {
-          // If host element is created as a part of this function call (i.e. `rootSelectorOrNode`
-          // is not defined), also apply attributes and classes extracted from component selector.
-          // Extract attributes and classes from the first selector only to match VE behavior.
-          const {attrs, classes} =
-              extractAttrsAndClassesFromSelector(this.componentDef.selectors[0]);
-          if (attrs) {
-            setUpAttributes(hostRenderer, hostRNode, attrs);
-          }
-          if (classes && classes.length > 0) {
-            writeDirectClass(hostRenderer, hostRNode, classes.join(' '));
-          }
-        }
-      }
+          hostTNode, hostRNode, this.componentDef, rootDirectives, rootLView, rendererFactory,
+          hostRenderer);
 
       tElementNode = getTNode(rootTView, HEADER_OFFSET) as TElementNode;
 
+      // TODO(crisbeto): in practice `hostRNode` should always be defined, but there are some tests
+      // where the renderer is mocked out and `undefined` is returned. We should update the tests so
+      // that this check can be removed.
+      if (hostRNode) {
+        setRootNodeAttributes(hostRenderer, this.componentDef, hostRNode, rootSelectorOrNode);
+      }
+
       if (projectableNodes !== undefined) {
-        const projection: (TNode|RNode[]|null)[] = tElementNode.projection = [];
-        for (let i = 0; i < this.ngContentSelectors.length; i++) {
-          const nodesforSlot = projectableNodes[i];
-          // Projectable nodes can be passed as array of arrays or an array of iterables (ngUpgrade
-          // case). Here we do normalize passed data structure to be an array of arrays to avoid
-          // complex checks down the line.
-          // We also normalize the length of the passed in projectable nodes (to match the number of
-          // <ng-container> slots defined by a component).
-          projection.push(nodesforSlot != null ? Array.from(nodesforSlot) : null);
-        }
+        projectNodes(tElementNode, this.ngContentSelectors, projectableNodes);
       }
 
       // TODO: should LifecycleHooksFeature and other host features be generated by the compiler and
       // executed here?
       // Angular 5 reference: https://stackblitz.com/edit/lifecycle-hooks-vcref
-      component =
-          createRootComponent(componentView, this.componentDef, rootLView, [LifecycleHooksFeature]);
+      component = createRootComponent(
+          componentView, this.componentDef, rootDirectives, rootLView, [LifecycleHooksFeature]);
       renderView(rootTView, rootLView, null);
     } finally {
       leaveView();
@@ -319,11 +305,24 @@ export const NULL_INJECTOR: Injector = {
   }
 };
 
+/** Creates a TNode that can be used to instantiate a root component. */
+function createRootComponentTNode(lView: LView, rNode: RNode): TElementNode {
+  const tView = lView[TVIEW];
+  const index = HEADER_OFFSET;
+  ngDevMode && assertIndexInRange(lView, index);
+  lView[index] = rNode;
+
+  // '#host' is added here as we don't know the real host DOM name (we don't want to read it) and at
+  // the same time we want to communicate the debug `TNode` that this is a special `TNode`
+  // representing a host element.
+  return getOrCreateTNode(tView, index, TNodeType.Element, '#host', null);
+}
+
 /**
  * Creates the root component view and the root component node.
  *
  * @param rNode Render host element.
- * @param def ComponentDef
+ * @param rootComponentDef ComponentDef
  * @param rootView The parent view where the host node is stored
  * @param rendererFactory Factory to be used for creating child renderers.
  * @param hostRenderer The current renderer
@@ -331,22 +330,44 @@ export const NULL_INJECTOR: Injector = {
  *
  * @returns Component view created
  */
-export function createRootComponentView(
-    rNode: RElement|null, def: ComponentDef<any>, rootView: LView, rendererFactory: RendererFactory,
+function createRootComponentView(
+    tNode: TElementNode, rNode: RElement|null, rootComponentDef: ComponentDef<any>,
+    rootDirectives: DirectiveDef<any>[], rootView: LView, rendererFactory: RendererFactory,
     hostRenderer: Renderer, sanitizer?: Sanitizer|null): LView {
   const tView = rootView[TVIEW];
-  const index = HEADER_OFFSET;
-  ngDevMode && assertIndexInRange(rootView, index);
-  rootView[index] = rNode;
-  // '#host' is added here as we don't know the real host DOM name (we don't want to read it) and at
-  // the same time we want to communicate the debug `TNode` that this is a special `TNode`
-  // representing a host element.
-  const tNode: TElementNode = getOrCreateTNode(tView, index, TNodeType.Element, '#host', null);
-  const mergedAttrs = tNode.mergedAttrs = def.hostAttrs;
-  if (mergedAttrs !== null) {
-    computeStaticStyling(tNode, mergedAttrs, true);
+  applyRootComponentStyling(rootDirectives, tNode, rNode, hostRenderer);
+
+  const viewRenderer = rendererFactory.createRenderer(rNode, rootComponentDef);
+  const componentView = createLView(
+      rootView, getOrCreateComponentTView(rootComponentDef), null,
+      rootComponentDef.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, rootView[tNode.index],
+      tNode, rendererFactory, viewRenderer, sanitizer || null, null, null);
+
+  if (tView.firstCreatePass) {
+    diPublicInInjector(
+        getOrCreateNodeInjectorForNode(tNode, rootView), tView, rootComponentDef.type);
+    markAsComponentHost(tView, tNode, 0);
+    initTNodeFlags(tNode, rootView.length, rootDirectives.length);
+  }
+
+  addToViewTree(rootView, componentView);
+
+  // Store component view at node index, with node as the HOST
+  return rootView[tNode.index] = componentView;
+}
+
+/** Sets up the styling information on a root component. */
+function applyRootComponentStyling(
+    rootDirectives: DirectiveDef<any>[], tNode: TElementNode, rNode: RElement|null,
+    hostRenderer: Renderer): void {
+  for (const def of rootDirectives) {
+    tNode.mergedAttrs = mergeHostAttrs(tNode.mergedAttrs, def.hostAttrs);
+  }
+
+  if (tNode.mergedAttrs !== null) {
+    computeStaticStyling(tNode, tNode.mergedAttrs, true);
     if (rNode !== null) {
-      setUpAttributes(hostRenderer, rNode, mergedAttrs);
+      setUpAttributes(hostRenderer, rNode, tNode.mergedAttrs);
       if (tNode.classes !== null) {
         writeDirectClass(hostRenderer, rNode, tNode.classes);
       }
@@ -355,68 +376,133 @@ export function createRootComponentView(
       }
     }
   }
-
-  const viewRenderer = rendererFactory.createRenderer(rNode, def);
-  const componentView = createLView(
-      rootView, getOrCreateComponentTView(def), null,
-      def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, rootView[index], tNode,
-      rendererFactory, viewRenderer, sanitizer || null, null, null);
-
-  if (tView.firstCreatePass) {
-    diPublicInInjector(getOrCreateNodeInjectorForNode(tNode, rootView), tView, def.type);
-    markAsComponentHost(tView, tNode, 0);
-    initTNodeFlags(tNode, rootView.length, 1);
-  }
-
-  addToViewTree(rootView, componentView);
-
-  // Store component view at node index, with node as the HOST
-  return rootView[index] = componentView;
 }
 
 /**
  * Creates a root component and sets it up with features and host bindings.Shared by
  * renderComponent() and ViewContainerRef.createComponent().
  */
-export function createRootComponent<T>(
-    componentView: LView, componentDef: ComponentDef<T>, rootLView: LView,
-    hostFeatures: HostFeature[]|null): any {
+function createRootComponent<T>(
+    componentView: LView, rootComponentDef: ComponentDef<T>, rootDirectives: DirectiveDef<any>[],
+    rootLView: LView, hostFeatures: HostFeature[]|null): any {
   const tView = rootLView[TVIEW];
-  // Create directive instance with factory() and store at next index in viewData
-  const component = instantiateRootComponent(tView, rootLView, componentDef);
+  const rootTNode = getCurrentTNode() as TElementNode;
+  ngDevMode && assertDefined(rootTNode, 'tNode should have been already created');
 
-  // Root view only contains an instance of this component,
-  // so we use a reference to that component instance as a context.
+  instantiateRootDirectives(rootTNode, tView, rootLView, rootDirectives);
+
+  // We're guaranteed for the `componentOffset` to be positive here.
+  const component = getNodeInjectable(
+      rootLView, tView, rootTNode.directiveStart + rootTNode.componentOffset, rootTNode);
   componentView[CONTEXT] = rootLView[CONTEXT] = component;
 
   if (hostFeatures !== null) {
     for (const feature of hostFeatures) {
-      feature(component, componentDef);
+      feature(component, rootComponentDef);
     }
   }
 
   // We want to generate an empty QueryList for root content queries for backwards
   // compatibility with ViewEngine.
-  if (componentDef.contentQueries) {
-    const tNode = getCurrentTNode()!;
-    ngDevMode && assertDefined(tNode, 'TNode expected');
-    componentDef.contentQueries(RenderFlags.Create, component, tNode.directiveStart);
-  }
+  executeContentQueries(rootTNode, rootLView, rootDirectives);
 
-  const rootTNode = getCurrentTNode()!;
-  ngDevMode && assertDefined(rootTNode, 'tNode should have been already created');
-  if (tView.firstCreatePass &&
-      (componentDef.hostBindings !== null || componentDef.hostAttrs !== null)) {
-    setSelectedIndex(rootTNode.index);
-
-    const rootTView = rootLView[TVIEW];
-    registerHostBindingOpCodes(
-        rootTView, rootTNode, rootLView, rootTNode.directiveStart, rootTNode.directiveEnd,
-        componentDef);
-
-    invokeHostBindingsInCreationMode(componentDef, component);
-  }
   return component;
+}
+
+/** Executes the content queries on a root component. */
+function executeContentQueries(
+    rootTNode: TElementNode, rootLView: LView<unknown>, rootDirectives: DirectiveDef<any>[]) {
+  for (let i = 0; i < rootDirectives.length; i++) {
+    const def = rootDirectives[i];
+    if (def.contentQueries) {
+      const directiveIndex = rootTNode.directiveStart + i;
+      const instance = rootLView[directiveIndex];
+      def.contentQueries(RenderFlags.Create, instance, directiveIndex);
+    }
+  }
+}
+
+/** Sets the static attributes on a root component. */
+function setRootNodeAttributes(
+    hostRenderer: Renderer2, componentDef: ComponentDef<unknown>, hostRNode: RElement,
+    rootSelectorOrNode: any) {
+  if (rootSelectorOrNode) {
+    setUpAttributes(hostRenderer, hostRNode, ['ng-version', VERSION.full]);
+  } else {
+    // If host element is created as a part of this function call (i.e. `rootSelectorOrNode`
+    // is not defined), also apply attributes and classes extracted from component selector.
+    // Extract attributes and classes from the first selector only to match VE behavior.
+    const {attrs, classes} = extractAttrsAndClassesFromSelector(componentDef.selectors[0]);
+    if (attrs) {
+      setUpAttributes(hostRenderer, hostRNode, attrs);
+    }
+    if (classes && classes.length > 0) {
+      writeDirectClass(hostRenderer, hostRNode, classes.join(' '));
+    }
+  }
+}
+
+/** Instantiates all of the directives on the root component. */
+function instantiateRootDirectives(
+    rootTNode: TElementNode, tView: TView, lView: LView,
+    rootDirectives: DirectiveDef<any>[]): void {
+  if (!tView.firstCreatePass) {
+    return;
+  }
+
+  // Needs to be run before we allocate the expando or the directive indexes will be wrong.
+  for (const def of rootDirectives) {
+    if (def.providersResolver) def.providersResolver(def);
+  }
+
+  const directiveStart = allocExpando(tView, lView, rootDirectives.length, null);
+  ngDevMode &&
+      assertEqual(
+          directiveStart, rootTNode.directiveStart,
+          'Because this is a root component the allocated expando should match the TNode component.');
+
+  // We need to configure the directive and instantiate it in two passes so that
+  // the host directives and the root component are able to inject each other.
+  for (let i = 0; i < rootDirectives.length; i++) {
+    configureViewWithDirective(tView, rootTNode, lView, directiveStart + i, rootDirectives[i]);
+  }
+
+  for (let i = 0; i < rootDirectives.length; i++) {
+    const def = rootDirectives[i];
+    const directiveIndex = directiveStart + i;
+    const directiveInstance = getNodeInjectable(lView, tView, directiveIndex, rootTNode);
+    attachPatchData(directiveInstance, lView);
+
+    if (def.hostBindings !== null || def.hostAttrs !== null) {
+      setSelectedIndex(directiveIndex);
+      registerHostBindingOpCodes(
+          tView, rootTNode, directiveIndex, allocExpando(tView, lView, def.hostVars, NO_CHANGE),
+          def);
+      invokeHostBindingsInCreationMode(def, directiveInstance);
+    }
+  }
+
+  const native = getNativeByTNode(rootTNode, lView);
+  if (native) {
+    attachPatchData(native, lView);
+  }
+
+  initializeInputAndOutputAliases(tView, rootTNode);
+}
+
+/** Projects the `projectableNodes` that were specified when creating a root component. */
+function projectNodes(
+    tNode: TElementNode, ngContentSelectors: string[], projectableNodes: any[][]) {
+  const projection: (TNode|RNode[]|null)[] = tNode.projection = [];
+  for (let i = 0; i < ngContentSelectors.length; i++) {
+    const nodesforSlot = projectableNodes[i];
+    // Projectable nodes can be passed as array of arrays or an array of iterables (ngUpgrade
+    // case). Here we do normalize passed data structure to be an array of arrays to avoid
+    // complex checks down the line.
+    // We also normalize the length of the passed in projectable nodes (to match the number of
+    // <ng-container> slots defined by a component).
+    projection.push(nodesforSlot != null ? Array.from(nodesforSlot) : null);
+  }
 }
 
 /**

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -15,10 +15,9 @@ import {RElement} from '../interfaces/renderer_dom';
 import {isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
 import {HEADER_OFFSET, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
-import {appendChild, createElementNode, writeDirectClass, writeDirectStyle} from '../node_manipulation';
+import {appendChild, createElementNode, setupStaticAttributes} from '../node_manipulation';
 import {decreaseElementDepthCount, getBindingIndex, getCurrentTNode, getElementDepthCount, getLView, getNamespace, getTView, increaseElementDepthCount, isCurrentTNodeParent, setCurrentTNode, setCurrentTNodeAsNotParent} from '../state';
 import {computeStaticStyling} from '../styling/static_styling';
-import {setUpAttributes} from '../util/attrs_utils';
 import {getConstant} from '../util/view_utils';
 
 import {validateElementIsKnown} from './element_validation';
@@ -92,19 +91,7 @@ export function ɵɵelementStart(
           adjustedIndex, tView, lView, native, name, attrsIndex, localRefsIndex) :
       tView.data[adjustedIndex] as TElementNode;
   setCurrentTNode(tNode, true);
-
-  const mergedAttrs = tNode.mergedAttrs;
-  if (mergedAttrs !== null) {
-    setUpAttributes(renderer, native, mergedAttrs);
-  }
-  const classes = tNode.classes;
-  if (classes !== null) {
-    writeDirectClass(renderer, native, classes);
-  }
-  const styles = tNode.styles;
-  if (styles !== null) {
-    writeDirectStyle(renderer, native, styles);
-  }
+  setupStaticAttributes(renderer, native, tNode);
 
   if ((tNode.flags & TNodeFlags.isDetached) !== TNodeFlags.isDetached) {
     // In the i18n case, the translation may have removed this element, so only add it if it is not

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1028,32 +1028,6 @@ export function setNgReflectProperties(
 }
 
 /**
- * Instantiate a root component.
- */
-export function instantiateRootComponent<T>(tView: TView, lView: LView, def: ComponentDef<T>): T {
-  const rootTNode = getCurrentTNode()!;
-  if (tView.firstCreatePass) {
-    if (def.providersResolver) def.providersResolver(def);
-    const directiveIndex = allocExpando(tView, lView, 1, null);
-    ngDevMode &&
-        assertEqual(
-            directiveIndex, rootTNode.directiveStart,
-            'Because this is a root component the allocated expando should match the TNode component.');
-    configureViewWithDirective(tView, rootTNode, lView, directiveIndex, def);
-    initializeInputAndOutputAliases(tView, rootTNode);
-  }
-  const directive = getNodeInjectable(
-      lView, tView, rootTNode.directiveStart + rootTNode.componentOffset,
-      rootTNode as TElementNode);
-  attachPatchData(directive, lView);
-  const native = getNativeByTNode(rootTNode, lView);
-  if (native) {
-    attachPatchData(native, lView);
-  }
-  return directive;
-}
-
-/**
  * Resolve the matched directives on a node.
  */
 export function resolveDirectives(
@@ -1143,13 +1117,12 @@ export function resolveDirectives(
  *
  * @param tView `TView` to which the `hostBindings` should be added.
  * @param tNode `TNode` the element which contains the directive
- * @param lView `LView` current `LView`
  * @param directiveIdx Directive index in view.
  * @param directiveVarsIdx Where will the directive's vars be stored
  * @param def `ComponentDef`/`DirectiveDef`, which contains the `hostVars`/`hostBindings` to add.
  */
 export function registerHostBindingOpCodes(
-    tView: TView, tNode: TNode, lView: LView, directiveIdx: number, directiveVarsIdx: number,
+    tView: TView, tNode: TNode, directiveIdx: number, directiveVarsIdx: number,
     def: ComponentDef<any>|DirectiveDef<any>): void {
   ngDevMode && assertFirstCreatePass(tView);
 
@@ -1406,7 +1379,7 @@ export function initTNodeFlags(tNode: TNode, index: number, numberOfDirectives: 
  * @param directiveIndex Index where the directive will be stored in the Expando.
  * @param def `DirectiveDef`
  */
-function configureViewWithDirective<T>(
+export function configureViewWithDirective<T>(
     tView: TView, tNode: TNode, lView: LView, directiveIndex: number, def: DirectiveDef<T>): void {
   ngDevMode &&
       assertGreaterThanOrEqual(directiveIndex, HEADER_OFFSET, 'Must be in Expando section');
@@ -1422,8 +1395,7 @@ function configureViewWithDirective<T>(
   lView[directiveIndex] = nodeInjectorFactory;
 
   registerHostBindingOpCodes(
-      tView, tNode, lView, directiveIndex, allocExpando(tView, lView, def.hostVars, NO_CHANGE),
-      def);
+      tView, tNode, directiveIndex, allocExpando(tView, lView, def.hostVars, NO_CHANGE), def);
 }
 
 function addComponentLogic<T>(lView: LView, hostTNode: TElementNode, def: ComponentDef<T>): void {

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -27,6 +27,7 @@ import {isLContainer, isLView} from './interfaces/type_checks';
 import {CHILD_HEAD, CLEANUP, DECLARATION_COMPONENT_VIEW, DECLARATION_LCONTAINER, DestroyHookData, FLAGS, HookData, HookFn, HOST, LView, LViewFlags, NEXT, PARENT, QUERIES, RENDERER, T_HOST, TVIEW, TView, TViewType, unusedValueExportToPlacateAjd as unused5} from './interfaces/view';
 import {assertTNodeType} from './node_assert';
 import {profiler, ProfilerEvent} from './profiler';
+import {setUpAttributes} from './util/attrs_utils';
 import {getLViewParent} from './util/view_traversal_utils';
 import {getNativeByTNode, unwrapRNode, updateTransplantedViewCount} from './util/view_utils';
 
@@ -1090,4 +1091,21 @@ export function writeDirectClass(renderer: Renderer, element: RElement, newValue
     renderer.setAttribute(element, 'class', newValue);
   }
   ngDevMode && ngDevMode.rendererSetClassName++;
+}
+
+/** Sets up the static DOM attributes on an `RNode`. */
+export function setupStaticAttributes(renderer: Renderer, element: RElement, tNode: TNode) {
+  const {mergedAttrs, classes, styles} = tNode;
+
+  if (mergedAttrs !== null) {
+    setUpAttributes(renderer, element, mergedAttrs);
+  }
+
+  if (classes !== null) {
+    writeDirectClass(renderer, element, classes);
+  }
+
+  if (styles !== null) {
+    writeDirectStyle(renderer, element, styles);
+  }
 }

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -732,6 +732,9 @@
     "name": "executeCheckHooks"
   },
   {
+    "name": "executeContentQueries"
+  },
+  {
     "name": "executeInitAndCheckHooks"
   },
   {
@@ -921,10 +924,7 @@
     "name": "incrementInitPhaseFlags"
   },
   {
-    "name": "initTNodeFlags"
-  },
-  {
-    "name": "initializeInputAndOutputAliases"
+    "name": "initializeDirectives"
   },
   {
     "name": "injectArgs"
@@ -958,6 +958,9 @@
   },
   {
     "name": "invertObject"
+  },
+  {
+    "name": "invokeDirectivesHostBindings"
   },
   {
     "name": "invokeHostBindingsInCreationMode"
@@ -1179,9 +1182,6 @@
     "name": "refreshView"
   },
   {
-    "name": "registerHostBindingOpCodes"
-  },
-  {
     "name": "registerPostOrderHooks"
   },
   {
@@ -1287,6 +1287,9 @@
     "name": "setUpAttributes"
   },
   {
+    "name": "setupStaticAttributes"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1342,9 +1345,6 @@
   },
   {
     "name": "writeDirectClass"
-  },
-  {
-    "name": "writeDirectStyle"
   },
   {
     "name": "writeStyleAttribute"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -516,6 +516,9 @@
     "name": "executeCheckHooks"
   },
   {
+    "name": "executeContentQueries"
+  },
+  {
     "name": "executeInitAndCheckHooks"
   },
   {
@@ -687,10 +690,7 @@
     "name": "incrementInitPhaseFlags"
   },
   {
-    "name": "initTNodeFlags"
-  },
-  {
-    "name": "initializeInputAndOutputAliases"
+    "name": "initializeDirectives"
   },
   {
     "name": "injectArgs"
@@ -718,6 +718,9 @@
   },
   {
     "name": "invertObject"
+  },
+  {
+    "name": "invokeDirectivesHostBindings"
   },
   {
     "name": "invokeHostBindingsInCreationMode"
@@ -885,9 +888,6 @@
     "name": "refreshView"
   },
   {
-    "name": "registerHostBindingOpCodes"
-  },
-  {
     "name": "registerPostOrderHooks"
   },
   {
@@ -966,6 +966,9 @@
     "name": "setUpAttributes"
   },
   {
+    "name": "setupStaticAttributes"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1012,9 +1015,6 @@
   },
   {
     "name": "writeDirectClass"
-  },
-  {
-    "name": "writeDirectStyle"
   },
   {
     "name": "ɵɵdefineComponent"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -750,6 +750,9 @@
     "name": "executeCheckHooks"
   },
   {
+    "name": "executeContentQueries"
+  },
+  {
     "name": "executeInitAndCheckHooks"
   },
   {
@@ -1017,10 +1020,7 @@
     "name": "inheritViewQuery"
   },
   {
-    "name": "initTNodeFlags"
-  },
-  {
-    "name": "initializeInputAndOutputAliases"
+    "name": "initializeDirectives"
   },
   {
     "name": "injectArgs"
@@ -1054,6 +1054,9 @@
   },
   {
     "name": "invertObject"
+  },
+  {
+    "name": "invokeDirectivesHostBindings"
   },
   {
     "name": "invokeHostBindingsInCreationMode"
@@ -1326,9 +1329,6 @@
     "name": "registerDestroyHooksIfSupported"
   },
   {
-    "name": "registerHostBindingOpCodes"
-  },
-  {
     "name": "registerOnValidatorChange"
   },
   {
@@ -1443,6 +1443,9 @@
     "name": "setUpValidators"
   },
   {
+    "name": "setupStaticAttributes"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1504,9 +1507,6 @@
   },
   {
     "name": "writeDirectClass"
-  },
-  {
-    "name": "writeDirectStyle"
   },
   {
     "name": "ɵInternalFormsSharedModule"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -720,6 +720,9 @@
     "name": "executeCheckHooks"
   },
   {
+    "name": "executeContentQueries"
+  },
+  {
     "name": "executeInitAndCheckHooks"
   },
   {
@@ -978,10 +981,7 @@
     "name": "inheritViewQuery"
   },
   {
-    "name": "initTNodeFlags"
-  },
-  {
-    "name": "initializeInputAndOutputAliases"
+    "name": "initializeDirectives"
   },
   {
     "name": "injectArgs"
@@ -1018,6 +1018,9 @@
   },
   {
     "name": "invertObject"
+  },
+  {
+    "name": "invokeDirectivesHostBindings"
   },
   {
     "name": "invokeHostBindingsInCreationMode"
@@ -1290,9 +1293,6 @@
     "name": "registerDestroyHooksIfSupported"
   },
   {
-    "name": "registerHostBindingOpCodes"
-  },
-  {
     "name": "registerOnValidatorChange"
   },
   {
@@ -1419,6 +1419,9 @@
     "name": "setUpValidators"
   },
   {
+    "name": "setupStaticAttributes"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1480,9 +1483,6 @@
   },
   {
     "name": "writeDirectClass"
-  },
-  {
-    "name": "writeDirectStyle"
   },
   {
     "name": "ɵInternalFormsSharedModule"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -666,9 +666,6 @@
     "name": "refreshView"
   },
   {
-    "name": "registerHostBindingOpCodes"
-  },
-  {
     "name": "rememberChangeHistoryAndInvokeOnChangesHook"
   },
   {
@@ -693,6 +690,9 @@
     "name": "rxSubscriber"
   },
   {
+    "name": "saveNameToExportMap"
+  },
+  {
     "name": "scheduleArray"
   },
   {
@@ -700,6 +700,9 @@
   },
   {
     "name": "setBindingRootForHostBindings"
+  },
+  {
+    "name": "setCurrentDirectiveIndex"
   },
   {
     "name": "setCurrentInjector"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -321,6 +321,9 @@
     "name": "config"
   },
   {
+    "name": "configureViewWithDirective"
+  },
+  {
     "name": "connectableObservableDescriptor"
   },
   {
@@ -531,6 +534,9 @@
     "name": "internalImportProvidersFrom"
   },
   {
+    "name": "invokeHostBindingsInCreationMode"
+  },
+  {
     "name": "isArray"
   },
   {
@@ -595,6 +601,12 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeHostAttribute"
+  },
+  {
+    "name": "mergeHostAttrs"
   },
   {
     "name": "mergeMap"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -957,6 +957,9 @@
     "name": "executeCheckHooks"
   },
   {
+    "name": "executeContentQueries"
+  },
+  {
     "name": "executeInitAndCheckHooks"
   },
   {
@@ -1245,10 +1248,7 @@
     "name": "inheritedParamsDataResolve"
   },
   {
-    "name": "initTNodeFlags"
-  },
-  {
-    "name": "initializeInputAndOutputAliases"
+    "name": "initializeDirectives"
   },
   {
     "name": "inject"
@@ -1291,6 +1291,9 @@
   },
   {
     "name": "invertObject"
+  },
+  {
+    "name": "invokeDirectivesHostBindings"
   },
   {
     "name": "invokeHostBindingsInCreationMode"
@@ -1581,9 +1584,6 @@
     "name": "refreshView"
   },
   {
-    "name": "registerHostBindingOpCodes"
-  },
-  {
     "name": "registerPostOrderHooks"
   },
   {
@@ -1687,6 +1687,9 @@
   },
   {
     "name": "setUpAttributes"
+  },
+  {
+    "name": "setupStaticAttributes"
   },
   {
     "name": "shallowEqual"
@@ -1810,9 +1813,6 @@
   },
   {
     "name": "writeDirectClass"
-  },
-  {
-    "name": "writeDirectStyle"
   },
   {
     "name": "ɵEmptyOutletComponent"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -753,9 +753,6 @@
     "name": "refreshView"
   },
   {
-    "name": "registerHostBindingOpCodes"
-  },
-  {
     "name": "rememberChangeHistoryAndInvokeOnChangesHook"
   },
   {
@@ -783,6 +780,9 @@
     "name": "rxSubscriber"
   },
   {
+    "name": "saveNameToExportMap"
+  },
+  {
     "name": "scheduleArray"
   },
   {
@@ -790,6 +790,9 @@
   },
   {
     "name": "setBindingRootForHostBindings"
+  },
+  {
+    "name": "setCurrentDirectiveIndex"
   },
   {
     "name": "setCurrentInjector"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -390,6 +390,9 @@
     "name": "config"
   },
   {
+    "name": "configureViewWithDirective"
+  },
+  {
     "name": "connectableObservableDescriptor"
   },
   {
@@ -615,6 +618,9 @@
     "name": "invertObject"
   },
   {
+    "name": "invokeHostBindingsInCreationMode"
+  },
+  {
     "name": "isArray"
   },
   {
@@ -682,6 +688,12 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeHostAttribute"
+  },
+  {
+    "name": "mergeHostAttrs"
   },
   {
     "name": "mergeMap"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -630,6 +630,9 @@
     "name": "executeCheckHooks"
   },
   {
+    "name": "executeContentQueries"
+  },
+  {
     "name": "executeInitAndCheckHooks"
   },
   {
@@ -852,10 +855,7 @@
     "name": "incrementInitPhaseFlags"
   },
   {
-    "name": "initTNodeFlags"
-  },
-  {
-    "name": "initializeInputAndOutputAliases"
+    "name": "initializeDirectives"
   },
   {
     "name": "injectArgs"
@@ -889,6 +889,9 @@
   },
   {
     "name": "invertObject"
+  },
+  {
+    "name": "invokeDirectivesHostBindings"
   },
   {
     "name": "invokeHostBindingsInCreationMode"
@@ -1098,9 +1101,6 @@
     "name": "refreshView"
   },
   {
-    "name": "registerHostBindingOpCodes"
-  },
-  {
     "name": "registerPostOrderHooks"
   },
   {
@@ -1200,6 +1200,9 @@
     "name": "setUpAttributes"
   },
   {
+    "name": "setupStaticAttributes"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1255,9 +1258,6 @@
   },
   {
     "name": "writeDirectClass"
-  },
-  {
-    "name": "writeDirectStyle"
   },
   {
     "name": "ɵɵadvance"


### PR DESCRIPTION
Currently the code that creates a root component assumes that it's always going to deal with a single component definition which won't work with host directives. These changes rework the code so that it's able to apply multiple directives, allowing us to eventually add support for host directives.

I also tried to make the root component creation easier to follow by breaking it up into smaller functions.