### PR TITLE
refactor(core): add input and output filtering for host directives

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -385,7 +385,7 @@ function createRootComponent<T>(
   const tView = rootLView[TVIEW];
   const native = getNativeByTNode(rootTNode, rootLView);
 
-  initializeDirectives(tView, rootLView, rootTNode, rootDirectives, null);
+  initializeDirectives(tView, rootLView, rootTNode, rootDirectives, null, null);
 
   for (let i = 0; i < rootDirectives.length; i++) {
     const directiveIndex = rootTNode.directiveStart + i;

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -209,10 +209,15 @@ export interface DirectiveDef<T> {
   /**
    * Function that will add the host directives to the list of matches during directive matching.
    * Patched onto the definition by the `HostDirectivesFeature`.
+   * @param currentDef Definition that has been matched.
+   * @param matchedDefs List of all matches for a specified node. Will be mutated to include the
+   * host directives.
+   * @param hostDirectiveDefs Mapping of directive definitions to their host directive
+   * configuration. Host directives will be added to the map as they're being matched to the node.
    */
   findHostDirectiveDefs:
-      ((matches: DirectiveDef<unknown>[], def: DirectiveDef<unknown>, tView: TView, lView: LView,
-        tNode: TElementNode|TContainerNode|TElementContainerNode) => void)|null;
+      ((currentDef: DirectiveDef<unknown>, matchedDefs: DirectiveDef<unknown>[],
+        hostDirectiveDefs: HostDirectiveDefs) => void)|null;
 
   /** Additional directives to be applied whenever the directive has been matched. */
   hostDirectives: HostDirectiveDef[]|null;
@@ -412,11 +417,26 @@ export interface HostDirectiveDef<T = unknown> {
   directive: Type<T>;
 
   /** Directive inputs that have been exposed. */
-  inputs: {[publicName: string]: string};
+  inputs: HostDirectiveBindingMap;
 
   /** Directive outputs that have been exposed. */
-  outputs: {[publicName: string]: string};
+  outputs: HostDirectiveBindingMap;
 }
+
+/**
+ * Mapping between the public aliases of directive bindings and the underlying inputs/outputs that
+ * they represent. Also serves as an allowlist of the inputs/outputs from the host directive that
+ * the author has decided to expose.
+ */
+export type HostDirectiveBindingMap = {
+  [publicName: string]: string
+};
+
+/**
+ * Mapping between a directive that was used as a host directive
+ * and the configuration that was used to define it as such.
+ */
+export type HostDirectiveDefs = Map<DirectiveDef<unknown>, HostDirectiveDef>;
 
 export interface ComponentDefFeature {
   <T>(componentDef: ComponentDef<T>): void;

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -552,6 +552,9 @@
     "name": "addComponentLogic"
   },
   {
+    "name": "addPropertyAlias"
+  },
+  {
     "name": "addToViewTree"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -390,6 +390,9 @@
     "name": "addComponentLogic"
   },
   {
+    "name": "addPropertyAlias"
+  },
+  {
     "name": "addToViewTree"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -552,6 +552,9 @@
     "name": "addComponentLogic"
   },
   {
+    "name": "addPropertyAlias"
+  },
+  {
     "name": "addToArray"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -540,6 +540,9 @@
     "name": "addComponentLogic"
   },
   {
+    "name": "addPropertyAlias"
+  },
+  {
     "name": "addToArray"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -273,6 +273,9 @@
     "name": "_wrapInTimeout"
   },
   {
+    "name": "addPropertyAlias"
+  },
+  {
     "name": "allocExpando"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -699,6 +699,9 @@
     "name": "addComponentLogic"
   },
   {
+    "name": "addPropertyAlias"
+  },
+  {
     "name": "addToArray"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -336,6 +336,9 @@
     "name": "_wrapInTimeout"
   },
   {
+    "name": "addPropertyAlias"
+  },
+  {
     "name": "allocExpando"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -468,6 +468,9 @@
     "name": "addComponentLogic"
   },
   {
+    "name": "addPropertyAlias"
+  },
+  {
     "name": "addToArray"
   },
   {


### PR DESCRIPTION
Adds the logic that will filter out unexposed inputs/outputs and apply the aliases that the author specified when writing the host directives.