### PR TITLE
refactor: remove unnecessary test support check utilities

### DIFF
--- a/packages/animations/browser/test/render/web_animations/web_animations_driver_spec.ts
+++ b/packages/animations/browser/test/render/web_animations/web_animations_driver_spec.ts
@@ -27,20 +27,18 @@ import {WebAnimationsPlayer} from '../../../src/render/web_animations/web_animat
       });
     });
 
-    if (browserDetection.supportsShadowDom) {
-      describe('when animation is inside a shadow DOM', () => {
-        it('should consider an element inside the shadow DOM to be contained by the document body',
-           (() => {
-             const hostElement = createElement();
-             const shadowRoot = hostElement.attachShadow({mode: 'open'});
-             const elementToAnimate = createElement();
-             shadowRoot.appendChild(elementToAnimate);
-             document.body.appendChild(hostElement);
-             const animator = new WebAnimationsDriver();
-             expect(animator.containsElement(document.body, elementToAnimate)).toBeTrue();
-           }));
-      });
-    }
+    describe('when animation is inside a shadow DOM', () => {
+      it('should consider an element inside the shadow DOM to be contained by the document body',
+         (() => {
+           const hostElement = createElement();
+           const shadowRoot = hostElement.attachShadow({mode: 'open'});
+           const elementToAnimate = createElement();
+           shadowRoot.appendChild(elementToAnimate);
+           document.body.appendChild(hostElement);
+           const animator = new WebAnimationsDriver();
+           expect(animator.containsElement(document.body, elementToAnimate)).toBeTrue();
+         }));
+    });
   });
 }
 

--- a/packages/common/test/viewport_scroller_spec.ts
+++ b/packages/common/test/viewport_scroller_spec.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
-
 import {BrowserViewportScroller, ViewportScroller} from '../src/viewport_scroller';
 
 describe('BrowserViewportScroller', () => {
@@ -81,11 +79,6 @@ describe('BrowserViewportScroller', () => {
     });
 
     it('should scroll when element with matching id is found inside the shadow DOM', () => {
-      // This test is only relevant for browsers that support shadow DOM.
-      if (!browserDetection.supportsShadowDom) {
-        return;
-      }
-
       const {anchorNode, cleanup} = createTallElementWithShadowRoot();
       anchorNode.id = anchor;
       scroller.scrollToAnchor(anchor);
@@ -94,11 +87,6 @@ describe('BrowserViewportScroller', () => {
     });
 
     it('should scroll when anchor with matching name is found inside the shadow DOM', () => {
-      // This test is only relevant for browsers that support shadow DOM.
-      if (!browserDetection.supportsShadowDom) {
-        return;
-      }
-
       const {anchorNode, cleanup} = createTallElementWithShadowRoot();
       anchorNode.name = anchor;
       scroller.scrollToAnchor(anchor);

--- a/packages/elements/test/create-custom-element-env_spec.ts
+++ b/packages/elements/test/create-custom-element-env_spec.ts
@@ -8,45 +8,42 @@
 
 import {Component} from '@angular/core';
 import {createApplication} from '@angular/platform-browser';
-import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 
 import {createCustomElement} from '../public_api';
 
-if (browserDetection.supportsCustomElements) {
-  describe('createCustomElement with env injector', () => {
-    let testContainer: HTMLDivElement;
+describe('createCustomElement with env injector', () => {
+  let testContainer: HTMLDivElement;
 
-    beforeEach(() => {
-      testContainer = document.createElement('div');
-      document.body.appendChild(testContainer);
-    });
-
-    afterEach(() => {
-      document.body.removeChild(testContainer);
-      (testContainer as any) = null;
-    });
-
-    it('should use provided EnvironmentInjector to create a custom element', async () => {
-      @Component({
-        standalone: true,
-        template: `Hello, standalone element!`,
-      })
-      class TestStandaloneCmp {
-      }
-
-      const appRef = await createApplication();
-
-      try {
-        const NgElementCtor = createCustomElement(TestStandaloneCmp, {injector: appRef.injector});
-
-        customElements.define('test-standalone-cmp', NgElementCtor);
-        const customEl = document.createElement('test-standalone-cmp');
-        testContainer.appendChild(customEl);
-
-        expect(testContainer.innerText).toBe('Hello, standalone element!');
-      } finally {
-        appRef.destroy();
-      }
-    });
+  beforeEach(() => {
+    testContainer = document.createElement('div');
+    document.body.appendChild(testContainer);
   });
-}
+
+  afterEach(() => {
+    document.body.removeChild(testContainer);
+    (testContainer as any) = null;
+  });
+
+  it('should use provided EnvironmentInjector to create a custom element', async () => {
+    @Component({
+      standalone: true,
+      template: `Hello, standalone element!`,
+    })
+    class TestStandaloneCmp {
+    }
+
+    const appRef = await createApplication();
+
+    try {
+      const NgElementCtor = createCustomElement(TestStandaloneCmp, {injector: appRef.injector});
+
+      customElements.define('test-standalone-cmp', NgElementCtor);
+      const customEl = document.createElement('test-standalone-cmp');
+      testContainer.appendChild(customEl);
+
+      expect(testContainer.innerText).toBe('Hello, standalone element!');
+    } finally {
+      appRef.destroy();
+    }
+  });
+});

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -9,7 +9,6 @@
 import {Component, destroyPlatform, DoBootstrap, EventEmitter, Injector, Input, NgModule, Output} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
-import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 import {Subject} from 'rxjs';
 
 import {createCustomElement, NgElementConstructor} from '../src/create-custom-element';
@@ -20,322 +19,320 @@ type WithFooBar = {
   barBar: string
 };
 
-if (browserDetection.supportsCustomElements) {
-  describe('createCustomElement', () => {
-    let selectorUid = 0;
-    let testContainer: HTMLDivElement;
-    let NgElementCtor: NgElementConstructor<WithFooBar>;
-    let strategy: TestStrategy;
-    let strategyFactory: TestStrategyFactory;
-    let injector: Injector;
+describe('createCustomElement', () => {
+  let selectorUid = 0;
+  let testContainer: HTMLDivElement;
+  let NgElementCtor: NgElementConstructor<WithFooBar>;
+  let strategy: TestStrategy;
+  let strategyFactory: TestStrategyFactory;
+  let injector: Injector;
 
-    beforeAll(done => {
-      testContainer = document.createElement('div');
-      document.body.appendChild(testContainer);
-      destroyPlatform();
-      platformBrowserDynamic()
-          .bootstrapModule(TestModule)
-          .then(ref => {
-            injector = ref.injector;
-            strategyFactory = new TestStrategyFactory();
-            strategy = strategyFactory.testStrategy;
+  beforeAll(done => {
+    testContainer = document.createElement('div');
+    document.body.appendChild(testContainer);
+    destroyPlatform();
+    platformBrowserDynamic()
+        .bootstrapModule(TestModule)
+        .then(ref => {
+          injector = ref.injector;
+          strategyFactory = new TestStrategyFactory();
+          strategy = strategyFactory.testStrategy;
 
-            NgElementCtor = createAndRegisterTestCustomElement(strategyFactory);
-          })
-          .then(done, done.fail);
-    });
-
-    afterEach(() => strategy.reset());
-
-    afterAll(() => {
-      destroyPlatform();
-      document.body.removeChild(testContainer);
-      (testContainer as any) = null;
-    });
-
-    it('should use a default strategy for converting component inputs', () => {
-      expect(NgElementCtor.observedAttributes).toEqual(['foo-foo', 'barbar']);
-    });
-
-    it('should send input values from attributes when connected', () => {
-      const element = new NgElementCtor(injector);
-      element.setAttribute('foo-foo', 'value-foo-foo');
-      element.setAttribute('barbar', 'value-barbar');
-      element.connectedCallback();
-      expect(strategy.connectedElement).toBe(element);
-
-      expect(strategy.getInputValue('fooFoo')).toBe('value-foo-foo');
-      expect(strategy.getInputValue('barBar')).toBe('value-barbar');
-    });
-
-    it('should work even if the constructor is not called (due to polyfill)', () => {
-      // Some polyfills (e.g. `document-register-element`) do not call the constructor of custom
-      // elements. Currently, all the constructor does is initialize the `injector` property. This
-      // test simulates not having called the constructor by "unsetting" the property.
-      //
-      // NOTE:
-      // If the constructor implementation changes in the future, this test needs to be adjusted
-      // accordingly.
-      const element = new NgElementCtor(injector);
-      delete (element as any).injector;
-
-      element.setAttribute('foo-foo', 'value-foo-foo');
-      element.setAttribute('barbar', 'value-barbar');
-      element.connectedCallback();
-
-      expect(strategy.connectedElement).toBe(element);
-      expect(strategy.getInputValue('fooFoo')).toBe('value-foo-foo');
-      expect(strategy.getInputValue('barBar')).toBe('value-barbar');
-    });
-
-    it('should listen to output events after connected', () => {
-      const element = new NgElementCtor(injector);
-      element.connectedCallback();
-
-      let eventValue: any = null;
-      element.addEventListener('some-event', (e: Event) => eventValue = (e as CustomEvent).detail);
-      strategy.events.next({name: 'some-event', value: 'event-value'});
-
-      expect(eventValue).toEqual('event-value');
-    });
-
-    it('should not listen to output events after disconnected', () => {
-      const element = new NgElementCtor(injector);
-      element.connectedCallback();
-      element.disconnectedCallback();
-      expect(strategy.disconnectCalled).toBe(true);
-
-      let eventValue: any = null;
-      element.addEventListener('some-event', (e: Event) => eventValue = (e as CustomEvent).detail);
-      strategy.events.next({name: 'some-event', value: 'event-value'});
-
-      expect(eventValue).toEqual(null);
-    });
-
-    it('should listen to output events during initialization', () => {
-      const events: string[] = [];
-
-      const element = new NgElementCtor(injector);
-      element.addEventListener('strategy-event', evt => events.push((evt as CustomEvent).detail));
-      element.connectedCallback();
-
-      expect(events).toEqual(['connect']);
-    });
-
-    it('should not break if `NgElementStrategy#events` is not available before calling `NgElementStrategy#connect()`',
-       () => {
-         class TestStrategyWithLateEvents extends TestStrategy {
-           override events: Subject<NgElementStrategyEvent> = undefined!;
-
-           override connect(element: HTMLElement): void {
-             this.connectedElement = element;
-             this.events = new Subject<NgElementStrategyEvent>();
-             this.events.next({name: 'strategy-event', value: 'connect'});
-           }
-         }
-
-         const strategyWithLateEvents = new TestStrategyWithLateEvents();
-         const capturedEvents: string[] = [];
-
-         const NgElementCtorWithLateEventsStrategy =
-             createAndRegisterTestCustomElement({create: () => strategyWithLateEvents});
-
-         const element = new NgElementCtorWithLateEventsStrategy(injector);
-         element.addEventListener(
-             'strategy-event', evt => capturedEvents.push((evt as CustomEvent).detail));
-         element.connectedCallback();
-
-         // The "connect" event (emitted during initialization) was missed, but things didn't break.
-         expect(capturedEvents).toEqual([]);
-
-         // Subsequent events are still captured.
-         strategyWithLateEvents.events.next({name: 'strategy-event', value: 'after-connect'});
-         expect(capturedEvents).toEqual(['after-connect']);
-       });
-
-    it('should properly set getters/setters on the element', () => {
-      const element = new NgElementCtor(injector);
-      element.fooFoo = 'foo-foo-value';
-      element.barBar = 'barBar-value';
-
-      expect(strategy.inputs.get('fooFoo')).toBe('foo-foo-value');
-      expect(strategy.inputs.get('barBar')).toBe('barBar-value');
-    });
-
-    it('should properly handle getting/setting properties on the element even if the constructor is not called',
-       () => {
-         // Create a custom element while ensuring that the `NgElementStrategy` is not created
-         // inside the constructor. This is done to emulate the behavior of some polyfills that do
-         // not call the constructor.
-         strategyFactory.create = () => undefined as unknown as NgElementStrategy;
-         const element = new NgElementCtor(injector);
-         strategyFactory.create = TestStrategyFactory.prototype.create;
-
-         element.fooFoo = 'foo-foo-value';
-         element.barBar = 'barBar-value';
-
-         expect(strategy.inputs.get('fooFoo')).toBe('foo-foo-value');
-         expect(strategy.inputs.get('barBar')).toBe('barBar-value');
-       });
-
-    it('should capture properties set before upgrading the element', () => {
-      // Create a regular element and set properties on it.
-      const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
-      const element = Object.assign(document.createElement(selector), {
-        fooFoo: 'foo-prop-value',
-        barBar: 'bar-prop-value',
-      });
-      expect(element.fooFoo).toBe('foo-prop-value');
-      expect(element.barBar).toBe('bar-prop-value');
-
-      // Upgrade the element to a Custom Element and insert it into the DOM.
-      customElements.define(selector, ElementCtor);
-      testContainer.appendChild(element);
-      expect(element.fooFoo).toBe('foo-prop-value');
-      expect(element.barBar).toBe('bar-prop-value');
-
-      expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
-      expect(strategy.inputs.get('barBar')).toBe('bar-prop-value');
-    });
-
-    it('should capture properties set after upgrading the element but before inserting it into the DOM',
-       () => {
-         // Create a regular element and set properties on it.
-         const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
-         const element = Object.assign(document.createElement(selector), {
-           fooFoo: 'foo-prop-value',
-           barBar: 'bar-prop-value',
-         });
-         expect(element.fooFoo).toBe('foo-prop-value');
-         expect(element.barBar).toBe('bar-prop-value');
-
-         // Upgrade the element to a Custom Element (without inserting it into the DOM) and update a
-         // property.
-         customElements.define(selector, ElementCtor);
-         customElements.upgrade(element);
-         element.barBar = 'bar-prop-value-2';
-         expect(element.fooFoo).toBe('foo-prop-value');
-         expect(element.barBar).toBe('bar-prop-value-2');
-
-         // Insert the element into the DOM.
-         testContainer.appendChild(element);
-         expect(element.fooFoo).toBe('foo-prop-value');
-         expect(element.barBar).toBe('bar-prop-value-2');
-
-         expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
-         expect(strategy.inputs.get('barBar')).toBe('bar-prop-value-2');
-       });
-
-    it('should allow overwriting properties with attributes after upgrading the element but before inserting it into the DOM',
-       () => {
-         // Create a regular element and set properties on it.
-         const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
-         const element = Object.assign(document.createElement(selector), {
-           fooFoo: 'foo-prop-value',
-           barBar: 'bar-prop-value',
-         });
-         expect(element.fooFoo).toBe('foo-prop-value');
-         expect(element.barBar).toBe('bar-prop-value');
-
-         // Upgrade the element to a Custom Element (without inserting it into the DOM) and set an
-         // attribute.
-         customElements.define(selector, ElementCtor);
-         customElements.upgrade(element);
-         element.setAttribute('barbar', 'bar-attr-value');
-         expect(element.fooFoo).toBe('foo-prop-value');
-         expect(element.barBar).toBe('bar-attr-value');
-
-         // Insert the element into the DOM.
-         testContainer.appendChild(element);
-         expect(element.fooFoo).toBe('foo-prop-value');
-         expect(element.barBar).toBe('bar-attr-value');
-
-         expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
-         expect(strategy.inputs.get('barBar')).toBe('bar-attr-value');
-       });
-
-    // Helpers
-    function createAndRegisterTestCustomElement(strategyFactory: NgElementStrategyFactory) {
-      const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
-
-      // The `@webcomponents/custom-elements/src/native-shim.js` polyfill allows us to create
-      // new instances of the NgElement which extends HTMLElement, as long as we define it.
-      customElements.define(selector, ElementCtor);
-
-      return ElementCtor;
-    }
-
-    function createTestCustomElement(strategyFactory: NgElementStrategyFactory) {
-      return {
-        selector: `test-element-${++selectorUid}`,
-        ElementCtor: createCustomElement<WithFooBar>(TestComponent, {injector, strategyFactory}),
-      };
-    }
-
-    @Component({
-      selector: 'test-component',
-      template: 'TestComponent|foo({{ fooFoo }})|bar({{ barBar }})',
-    })
-    class TestComponent {
-      @Input() fooFoo: string = 'foo';
-      // TODO(issue/24571): remove '!'.
-      @Input('barbar') barBar!: string;
-
-      @Output() bazBaz = new EventEmitter<boolean>();
-      @Output('quxqux') quxQux = new EventEmitter<Object>();
-    }
-    @NgModule({
-      imports: [BrowserModule],
-      declarations: [TestComponent],
-    })
-    class TestModule implements DoBootstrap {
-      ngDoBootstrap() {}
-    }
-
-    class TestStrategy implements NgElementStrategy {
-      connectedElement: HTMLElement|null = null;
-      disconnectCalled = false;
-      inputs = new Map<string, any>();
-
-      events = new Subject<NgElementStrategyEvent>();
-
-      connect(element: HTMLElement): void {
-        this.events.next({name: 'strategy-event', value: 'connect'});
-        this.connectedElement = element;
-      }
-
-      disconnect(): void {
-        this.disconnectCalled = true;
-      }
-
-      getInputValue(propName: string): any {
-        return this.inputs.get(propName);
-      }
-
-      setInputValue(propName: string, value: string): void {
-        this.inputs.set(propName, value);
-      }
-
-      reset(): void {
-        this.connectedElement = null;
-        this.disconnectCalled = false;
-        this.inputs.clear();
-      }
-    }
-
-    class TestStrategyFactory implements NgElementStrategyFactory {
-      testStrategy = new TestStrategy();
-
-      create(injector: Injector): NgElementStrategy {
-        // Although not used by the `TestStrategy`, verify that the injector is provided.
-        if (!injector) {
-          throw new Error(
-              'Expected injector to be passed to `TestStrategyFactory#create()`, but received ' +
-              `value of type ${typeof injector}: ${injector}`);
-        }
-
-        return this.testStrategy;
-      }
-    }
+          NgElementCtor = createAndRegisterTestCustomElement(strategyFactory);
+        })
+        .then(done, done.fail);
   });
-}
+
+  afterEach(() => strategy.reset());
+
+  afterAll(() => {
+    destroyPlatform();
+    document.body.removeChild(testContainer);
+    (testContainer as any) = null;
+  });
+
+  it('should use a default strategy for converting component inputs', () => {
+    expect(NgElementCtor.observedAttributes).toEqual(['foo-foo', 'barbar']);
+  });
+
+  it('should send input values from attributes when connected', () => {
+    const element = new NgElementCtor(injector);
+    element.setAttribute('foo-foo', 'value-foo-foo');
+    element.setAttribute('barbar', 'value-barbar');
+    element.connectedCallback();
+    expect(strategy.connectedElement).toBe(element);
+
+    expect(strategy.getInputValue('fooFoo')).toBe('value-foo-foo');
+    expect(strategy.getInputValue('barBar')).toBe('value-barbar');
+  });
+
+  it('should work even if the constructor is not called (due to polyfill)', () => {
+    // Some polyfills (e.g. `document-register-element`) do not call the constructor of custom
+    // elements. Currently, all the constructor does is initialize the `injector` property. This
+    // test simulates not having called the constructor by "unsetting" the property.
+    //
+    // NOTE:
+    // If the constructor implementation changes in the future, this test needs to be adjusted
+    // accordingly.
+    const element = new NgElementCtor(injector);
+    delete (element as any).injector;
+
+    element.setAttribute('foo-foo', 'value-foo-foo');
+    element.setAttribute('barbar', 'value-barbar');
+    element.connectedCallback();
+
+    expect(strategy.connectedElement).toBe(element);
+    expect(strategy.getInputValue('fooFoo')).toBe('value-foo-foo');
+    expect(strategy.getInputValue('barBar')).toBe('value-barbar');
+  });
+
+  it('should listen to output events after connected', () => {
+    const element = new NgElementCtor(injector);
+    element.connectedCallback();
+
+    let eventValue: any = null;
+    element.addEventListener('some-event', (e: Event) => eventValue = (e as CustomEvent).detail);
+    strategy.events.next({name: 'some-event', value: 'event-value'});
+
+    expect(eventValue).toEqual('event-value');
+  });
+
+  it('should not listen to output events after disconnected', () => {
+    const element = new NgElementCtor(injector);
+    element.connectedCallback();
+    element.disconnectedCallback();
+    expect(strategy.disconnectCalled).toBe(true);
+
+    let eventValue: any = null;
+    element.addEventListener('some-event', (e: Event) => eventValue = (e as CustomEvent).detail);
+    strategy.events.next({name: 'some-event', value: 'event-value'});
+
+    expect(eventValue).toEqual(null);
+  });
+
+  it('should listen to output events during initialization', () => {
+    const events: string[] = [];
+
+    const element = new NgElementCtor(injector);
+    element.addEventListener('strategy-event', evt => events.push((evt as CustomEvent).detail));
+    element.connectedCallback();
+
+    expect(events).toEqual(['connect']);
+  });
+
+  it('should not break if `NgElementStrategy#events` is not available before calling `NgElementStrategy#connect()`',
+     () => {
+       class TestStrategyWithLateEvents extends TestStrategy {
+         override events: Subject<NgElementStrategyEvent> = undefined!;
+
+         override connect(element: HTMLElement): void {
+           this.connectedElement = element;
+           this.events = new Subject<NgElementStrategyEvent>();
+           this.events.next({name: 'strategy-event', value: 'connect'});
+         }
+       }
+
+       const strategyWithLateEvents = new TestStrategyWithLateEvents();
+       const capturedEvents: string[] = [];
+
+       const NgElementCtorWithLateEventsStrategy =
+           createAndRegisterTestCustomElement({create: () => strategyWithLateEvents});
+
+       const element = new NgElementCtorWithLateEventsStrategy(injector);
+       element.addEventListener(
+           'strategy-event', evt => capturedEvents.push((evt as CustomEvent).detail));
+       element.connectedCallback();
+
+       // The "connect" event (emitted during initialization) was missed, but things didn't break.
+       expect(capturedEvents).toEqual([]);
+
+       // Subsequent events are still captured.
+       strategyWithLateEvents.events.next({name: 'strategy-event', value: 'after-connect'});
+       expect(capturedEvents).toEqual(['after-connect']);
+     });
+
+  it('should properly set getters/setters on the element', () => {
+    const element = new NgElementCtor(injector);
+    element.fooFoo = 'foo-foo-value';
+    element.barBar = 'barBar-value';
+
+    expect(strategy.inputs.get('fooFoo')).toBe('foo-foo-value');
+    expect(strategy.inputs.get('barBar')).toBe('barBar-value');
+  });
+
+  it('should properly handle getting/setting properties on the element even if the constructor is not called',
+     () => {
+       // Create a custom element while ensuring that the `NgElementStrategy` is not created
+       // inside the constructor. This is done to emulate the behavior of some polyfills that do
+       // not call the constructor.
+       strategyFactory.create = () => undefined as unknown as NgElementStrategy;
+       const element = new NgElementCtor(injector);
+       strategyFactory.create = TestStrategyFactory.prototype.create;
+
+       element.fooFoo = 'foo-foo-value';
+       element.barBar = 'barBar-value';
+
+       expect(strategy.inputs.get('fooFoo')).toBe('foo-foo-value');
+       expect(strategy.inputs.get('barBar')).toBe('barBar-value');
+     });
+
+  it('should capture properties set before upgrading the element', () => {
+    // Create a regular element and set properties on it.
+    const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
+    const element = Object.assign(document.createElement(selector), {
+      fooFoo: 'foo-prop-value',
+      barBar: 'bar-prop-value',
+    });
+    expect(element.fooFoo).toBe('foo-prop-value');
+    expect(element.barBar).toBe('bar-prop-value');
+
+    // Upgrade the element to a Custom Element and insert it into the DOM.
+    customElements.define(selector, ElementCtor);
+    testContainer.appendChild(element);
+    expect(element.fooFoo).toBe('foo-prop-value');
+    expect(element.barBar).toBe('bar-prop-value');
+
+    expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
+    expect(strategy.inputs.get('barBar')).toBe('bar-prop-value');
+  });
+
+  it('should capture properties set after upgrading the element but before inserting it into the DOM',
+     () => {
+       // Create a regular element and set properties on it.
+       const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
+       const element = Object.assign(document.createElement(selector), {
+         fooFoo: 'foo-prop-value',
+         barBar: 'bar-prop-value',
+       });
+       expect(element.fooFoo).toBe('foo-prop-value');
+       expect(element.barBar).toBe('bar-prop-value');
+
+       // Upgrade the element to a Custom Element (without inserting it into the DOM) and update a
+       // property.
+       customElements.define(selector, ElementCtor);
+       customElements.upgrade(element);
+       element.barBar = 'bar-prop-value-2';
+       expect(element.fooFoo).toBe('foo-prop-value');
+       expect(element.barBar).toBe('bar-prop-value-2');
+
+       // Insert the element into the DOM.
+       testContainer.appendChild(element);
+       expect(element.fooFoo).toBe('foo-prop-value');
+       expect(element.barBar).toBe('bar-prop-value-2');
+
+       expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
+       expect(strategy.inputs.get('barBar')).toBe('bar-prop-value-2');
+     });
+
+  it('should allow overwriting properties with attributes after upgrading the element but before inserting it into the DOM',
+     () => {
+       // Create a regular element and set properties on it.
+       const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
+       const element = Object.assign(document.createElement(selector), {
+         fooFoo: 'foo-prop-value',
+         barBar: 'bar-prop-value',
+       });
+       expect(element.fooFoo).toBe('foo-prop-value');
+       expect(element.barBar).toBe('bar-prop-value');
+
+       // Upgrade the element to a Custom Element (without inserting it into the DOM) and set an
+       // attribute.
+       customElements.define(selector, ElementCtor);
+       customElements.upgrade(element);
+       element.setAttribute('barbar', 'bar-attr-value');
+       expect(element.fooFoo).toBe('foo-prop-value');
+       expect(element.barBar).toBe('bar-attr-value');
+
+       // Insert the element into the DOM.
+       testContainer.appendChild(element);
+       expect(element.fooFoo).toBe('foo-prop-value');
+       expect(element.barBar).toBe('bar-attr-value');
+
+       expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
+       expect(strategy.inputs.get('barBar')).toBe('bar-attr-value');
+     });
+
+  // Helpers
+  function createAndRegisterTestCustomElement(strategyFactory: NgElementStrategyFactory) {
+    const {selector, ElementCtor} = createTestCustomElement(strategyFactory);
+
+    // The `@webcomponents/custom-elements/src/native-shim.js` polyfill allows us to create
+    // new instances of the NgElement which extends HTMLElement, as long as we define it.
+    customElements.define(selector, ElementCtor);
+
+    return ElementCtor;
+  }
+
+  function createTestCustomElement(strategyFactory: NgElementStrategyFactory) {
+    return {
+      selector: `test-element-${++selectorUid}`,
+      ElementCtor: createCustomElement<WithFooBar>(TestComponent, {injector, strategyFactory}),
+    };
+  }
+
+  @Component({
+    selector: 'test-component',
+    template: 'TestComponent|foo({{ fooFoo }})|bar({{ barBar }})',
+  })
+  class TestComponent {
+    @Input() fooFoo: string = 'foo';
+    // TODO(issue/24571): remove '!'.
+    @Input('barbar') barBar!: string;
+
+    @Output() bazBaz = new EventEmitter<boolean>();
+    @Output('quxqux') quxQux = new EventEmitter<Object>();
+  }
+  @NgModule({
+    imports: [BrowserModule],
+    declarations: [TestComponent],
+  })
+  class TestModule implements DoBootstrap {
+    ngDoBootstrap() {}
+  }
+
+  class TestStrategy implements NgElementStrategy {
+    connectedElement: HTMLElement|null = null;
+    disconnectCalled = false;
+    inputs = new Map<string, any>();
+
+    events = new Subject<NgElementStrategyEvent>();
+
+    connect(element: HTMLElement): void {
+      this.events.next({name: 'strategy-event', value: 'connect'});
+      this.connectedElement = element;
+    }
+
+    disconnect(): void {
+      this.disconnectCalled = true;
+    }
+
+    getInputValue(propName: string): any {
+      return this.inputs.get(propName);
+    }
+
+    setInputValue(propName: string, value: string): void {
+      this.inputs.set(propName, value);
+    }
+
+    reset(): void {
+      this.connectedElement = null;
+      this.disconnectCalled = false;
+      this.inputs.clear();
+    }
+  }
+
+  class TestStrategyFactory implements NgElementStrategyFactory {
+    testStrategy = new TestStrategy();
+
+    create(injector: Injector): NgElementStrategy {
+      // Although not used by the `TestStrategy`, verify that the injector is provided.
+      if (!injector) {
+        throw new Error(
+            'Expected injector to be passed to `TestStrategyFactory#create()`, but received ' +
+            `value of type ${typeof injector}: ${injector}`);
+      }
+
+      return this.testStrategy;
+    }
+  }
+});

--- a/packages/elements/test/slots_spec.ts
+++ b/packages/elements/test/slots_spec.ts
@@ -9,95 +9,91 @@
 import {Component, ComponentFactoryResolver, destroyPlatform, EventEmitter, Input, NgModule, Output, ViewEncapsulation} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
-import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 
 import {createCustomElement, NgElement} from '../src/create-custom-element';
 
 
-// we only run these tests in browsers that support Shadom DOM slots natively
-if (browserDetection.supportsCustomElements && browserDetection.supportsShadowDom) {
-  describe('slots', () => {
-    let testContainer: HTMLDivElement;
+describe('slots', () => {
+  let testContainer: HTMLDivElement;
 
-    beforeAll(done => {
-      testContainer = document.createElement('div');
-      document.body.appendChild(testContainer);
-      destroyPlatform();
-      platformBrowserDynamic()
-          .bootstrapModule(TestModule)
-          .then(ref => {
-            const injector = ref.injector;
-            const cfr: ComponentFactoryResolver = injector.get(ComponentFactoryResolver);
+  beforeAll(done => {
+    testContainer = document.createElement('div');
+    document.body.appendChild(testContainer);
+    destroyPlatform();
+    platformBrowserDynamic()
+        .bootstrapModule(TestModule)
+        .then(ref => {
+          const injector = ref.injector;
+          const cfr: ComponentFactoryResolver = injector.get(ComponentFactoryResolver);
 
-            testElements.forEach(comp => {
-              const compFactory = cfr.resolveComponentFactory(comp);
-              customElements.define(compFactory.selector, createCustomElement(comp, {injector}));
-            });
-          })
-          .then(done, done.fail);
-    });
-
-    afterAll(() => {
-      destroyPlatform();
-      testContainer.remove();
-      (testContainer as any) = null;
-    });
-
-    it('should use slots to project content', () => {
-      const tpl = `<default-slot-el><span class="projected"></span></default-slot-el>`;
-      testContainer.innerHTML = tpl;
-      const testEl = testContainer.querySelector('default-slot-el')!;
-      const content = testContainer.querySelector('span.projected')!;
-      const slot = testEl.shadowRoot!.querySelector('slot')!;
-      const assignedNodes = slot.assignedNodes();
-      expect(assignedNodes[0]).toBe(content);
-    });
-
-    it('should use a named slot to project content', () => {
-      const tpl = `<named-slot-el><span class="projected" slot="header"></span></named-slot-el>`;
-      testContainer.innerHTML = tpl;
-      const testEl = testContainer.querySelector('named-slot-el')!;
-      const content = testContainer.querySelector('span.projected')!;
-      const slot = testEl.shadowRoot!.querySelector('slot[name=header]') as HTMLSlotElement;
-      const assignedNodes = slot.assignedNodes();
-      expect(assignedNodes[0]).toBe(content);
-    });
-
-    it('should use named slots to project content', () => {
-      const tpl = `
-      <named-slots-el>
-        <span class="projected-header" slot="header"></span>
-        <span class="projected-body" slot="body"></span>
-      </named-slots-el>`;
-      testContainer.innerHTML = tpl;
-      const testEl = testContainer.querySelector('named-slots-el')!;
-      const headerContent = testContainer.querySelector('span.projected-header')!;
-      const bodyContent = testContainer.querySelector('span.projected-body')!;
-      const headerSlot = testEl.shadowRoot!.querySelector('slot[name=header]') as HTMLSlotElement;
-      const bodySlot = testEl.shadowRoot!.querySelector('slot[name=body]') as HTMLSlotElement;
-
-      expect(headerContent.assignedSlot).toBe(headerSlot);
-      expect(bodyContent.assignedSlot).toBe(bodySlot);
-    });
-
-    it('should listen to slotchange events', (done) => {
-      const templateEl = document.createElement('template');
-      const tpl = `
-      <slot-events-el>
-        <span class="projected">Content</span>
-      </slot-events-el>`;
-      templateEl.innerHTML = tpl;
-      const template = templateEl.content.cloneNode(true) as DocumentFragment;
-      const testEl = template.querySelector('slot-events-el')! as NgElement & SlotEventsComponent;
-      testEl.addEventListener('slotEventsChange', e => {
-        expect(testEl.slotEvents.length).toEqual(1);
-        done();
-      });
-      testContainer.appendChild(template);
-      expect(testEl.slotEvents.length).toEqual(0);
-    });
+          testElements.forEach(comp => {
+            const compFactory = cfr.resolveComponentFactory(comp);
+            customElements.define(compFactory.selector, createCustomElement(comp, {injector}));
+          });
+        })
+        .then(done, done.fail);
   });
-}
+
+  afterAll(() => {
+    destroyPlatform();
+    testContainer.remove();
+    (testContainer as any) = null;
+  });
+
+  it('should use slots to project content', () => {
+    const tpl = `<default-slot-el><span class="projected"></span></default-slot-el>`;
+    testContainer.innerHTML = tpl;
+    const testEl = testContainer.querySelector('default-slot-el')!;
+    const content = testContainer.querySelector('span.projected')!;
+    const slot = testEl.shadowRoot!.querySelector('slot')!;
+    const assignedNodes = slot.assignedNodes();
+    expect(assignedNodes[0]).toBe(content);
+  });
+
+  it('should use a named slot to project content', () => {
+    const tpl = `<named-slot-el><span class="projected" slot="header"></span></named-slot-el>`;
+    testContainer.innerHTML = tpl;
+    const testEl = testContainer.querySelector('named-slot-el')!;
+    const content = testContainer.querySelector('span.projected')!;
+    const slot = testEl.shadowRoot!.querySelector('slot[name=header]') as HTMLSlotElement;
+    const assignedNodes = slot.assignedNodes();
+    expect(assignedNodes[0]).toBe(content);
+  });
+
+  it('should use named slots to project content', () => {
+    const tpl = `
+    <named-slots-el>
+      <span class="projected-header" slot="header"></span>
+      <span class="projected-body" slot="body"></span>
+    </named-slots-el>`;
+    testContainer.innerHTML = tpl;
+    const testEl = testContainer.querySelector('named-slots-el')!;
+    const headerContent = testContainer.querySelector('span.projected-header')!;
+    const bodyContent = testContainer.querySelector('span.projected-body')!;
+    const headerSlot = testEl.shadowRoot!.querySelector('slot[name=header]') as HTMLSlotElement;
+    const bodySlot = testEl.shadowRoot!.querySelector('slot[name=body]') as HTMLSlotElement;
+
+    expect(headerContent.assignedSlot).toBe(headerSlot);
+    expect(bodyContent.assignedSlot).toBe(bodySlot);
+  });
+
+  it('should listen to slotchange events', (done) => {
+    const templateEl = document.createElement('template');
+    const tpl = `
+    <slot-events-el>
+      <span class="projected">Content</span>
+    </slot-events-el>`;
+    templateEl.innerHTML = tpl;
+    const template = templateEl.content.cloneNode(true) as DocumentFragment;
+    const testEl = template.querySelector('slot-events-el')! as NgElement & SlotEventsComponent;
+    testEl.addEventListener('slotEventsChange', e => {
+      expect(testEl.slotEvents.length).toEqual(1);
+      done();
+    });
+    testContainer.appendChild(template);
+    expect(testEl.slotEvents.length).toEqual(0);
+  });
+});
 
 // Helpers
 @Component({

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -9,7 +9,6 @@ import {Component, Renderer2, ViewEncapsulation} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {NAMESPACE_URIS} from '@angular/platform-browser/src/dom/dom_renderer';
-import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 {
@@ -103,44 +102,40 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       });
     });
 
-    if (browserDetection.supportsShadowDom) {
-      it('should allow to style components with emulated encapsulation and no encapsulation inside of components with shadow DOM',
-         () => {
-           const fixture = TestBed.createComponent(SomeApp);
-           const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
-           const shadow = cmp.shadowRoot.querySelector('.shadow');
+    it('should allow to style components with emulated encapsulation and no encapsulation inside of components with shadow DOM',
+       () => {
+         const fixture = TestBed.createComponent(SomeApp);
+         const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
+         const shadow = cmp.shadowRoot.querySelector('.shadow');
 
-           expect(window.getComputedStyle(shadow).color).toEqual('rgb(255, 0, 0)');
+         expect(window.getComputedStyle(shadow).color).toEqual('rgb(255, 0, 0)');
 
-           const emulated = cmp.shadowRoot.querySelector('.emulated');
-           expect(window.getComputedStyle(emulated).color).toEqual('rgb(0, 0, 255)');
+         const emulated = cmp.shadowRoot.querySelector('.emulated');
+         expect(window.getComputedStyle(emulated).color).toEqual('rgb(0, 0, 255)');
 
-           const none = cmp.shadowRoot.querySelector('.none');
-           expect(window.getComputedStyle(none).color).toEqual('rgb(0, 255, 0)');
-         });
-    }
+         const none = cmp.shadowRoot.querySelector('.none');
+         expect(window.getComputedStyle(none).color).toEqual('rgb(0, 255, 0)');
+       });
 
-    if (browserDetection.supportsTemplateElement) {
-      it('should be able to append children to a <template> element', () => {
-        const template = document.createElement('template');
-        const child = document.createElement('div');
+    it('should be able to append children to a <template> element', () => {
+      const template = document.createElement('template');
+      const child = document.createElement('div');
 
-        renderer.appendChild(template, child);
+      renderer.appendChild(template, child);
 
-        expect(child.parentNode).toBe(template.content);
-      });
+      expect(child.parentNode).toBe(template.content);
+    });
 
-      it('should be able to insert children before others in a <template> element', () => {
-        const template = document.createElement('template');
-        const child = document.createElement('div');
-        const otherChild = document.createElement('div');
-        template.content.appendChild(child);
+    it('should be able to insert children before others in a <template> element', () => {
+      const template = document.createElement('template');
+      const child = document.createElement('div');
+      const otherChild = document.createElement('div');
+      template.content.appendChild(child);
 
-        renderer.insertBefore(template, otherChild, child);
+      renderer.insertBefore(template, otherChild, child);
 
-        expect(otherChild.parentNode).toBe(template.content);
-      });
-    }
+      expect(otherChild.parentNode).toBe(template.content);
+    });
   });
 }
 

--- a/packages/platform-browser/testing/src/browser_util.ts
+++ b/packages/platform-browser/testing/src/browser_util.ts
@@ -67,31 +67,9 @@ export class BrowserDetection {
         this._ua.indexOf('Edge') == -1;
   }
 
-  get supportsCustomElements() {
-    return (typeof (<any>global).customElements !== 'undefined');
-  }
-
-  get supportsDeprecatedCustomCustomElementsV0() {
-    return (typeof (document as any).registerElement !== 'undefined');
-  }
-
-  get supportsRegExUnicodeFlag(): boolean {
-    return RegExp.prototype.hasOwnProperty('unicode');
-  }
-
   get supportsShadowDom() {
     const testEl = document.createElement('div');
     return (typeof testEl.attachShadow !== 'undefined');
-  }
-
-  get supportsDeprecatedShadowDomV0() {
-    const testEl = document.createElement('div') as any;
-    return (typeof testEl.createShadowRoot !== 'undefined');
-  }
-
-  get supportsTemplateElement() {
-    const testEl = document.createElement('template') as any;
-    return (typeof testEl.content !== 'undefined');
   }
 }
 
@@ -210,10 +188,6 @@ export function setCookie(name: string, value: string) {
   // document.cookie is magical, assigning into it assigns/overrides one cookie value, but does
   // not clear other cookies.
   document.cookie = encodeURIComponent(name) + '=' + encodeURIComponent(value);
-}
-
-export function supportsWebAnimation(): boolean {
-  return typeof (<any>Element).prototype['animate'] === 'function';
 }
 
 export function hasStyle(element: any, styleName: string, styleValue?: string|null): boolean {


### PR DESCRIPTION
remove the following utilities used in unit tests which check for features that are supported by all supported browsers:
 - supportsCustomElements
 - supportsWebAnimation
 - supportsRegExUnicodeFlag
 - supportsTemplateElement

also remove the following utilities which check for features that are not supported (and aren't going to be) by any of the supported browsers:
 - supportsDeprecatedCustomCustomElementsV0
 - supportsDeprecatedShadowDomV0

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 I just noticed the `supportsWebAnimation` function in the `packages/platform-browser/testing/src/browser_util.ts` file not being imported anywhere but also not being too useful since all supported browsers do implement the web animations api, so I figured it could be nice to clean that up. I also checked for other support checks in the same file and removed others that also seem not to be of much use.
 
So I thought that some clean up could be nice :slightly_smiling_face: 
 
I also wanted to remove the `supportsShadowDom` function but that would cause some tests to fail for some reason (I suspect it could be some domino related issue?)
