### PR TITLE
build: fix rxjs 7 build failure

### DIFF
--- a/integration/typings_test_rxjs7/package.json
+++ b/integration/typings_test_rxjs7/package.json
@@ -18,6 +18,7 @@
     "@angular/service-worker": "file:../../dist/packages-dist/service-worker",
     "@angular/upgrade": "file:../../dist/packages-dist/upgrade",
     "@types/jasmine": "file:../../node_modules/@types/jasmine",
+    "@types/node": "file:../../node_modules/@types/node",
     "rxjs": "^7.4.0",
     "typescript": "file:../../node_modules/typescript",
     "zone.js": "file:../../dist/zone.js-dist/archive/zone.js.tgz"


### PR DESCRIPTION
Fixes that the `node` typings weren't included in the rxjs 7 typings test.