### PR TITLE
refactor(compiler): Add `getPotentialTemplateDirectives` API method.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -17,7 +17,7 @@ import {AbsoluteModuleStrategy, AliasingHost, AliasStrategy, DefaultImportTracke
 import {IncrementalBuildStrategy, IncrementalCompilation, IncrementalState} from '../../incremental';
 import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {generateAnalysis, IndexedComponent, IndexingContext} from '../../indexer';
-import {ComponentResources, CompoundMetadataReader, CompoundMetadataRegistry, DirectiveMeta, DtsMetadataReader, HostDirectivesResolver, InjectableClassRegistry, LocalMetadataRegistry, MetadataReader, PipeMeta, ResourceRegistry} from '../../metadata';
+import {ComponentResources, CompoundMetadataReader, CompoundMetadataRegistry, DirectiveMeta, DtsMetadataReader, HostDirectivesResolver, InjectableClassRegistry, LocalMetadataRegistry, MetadataReader, MetadataReaderWithIndex, PipeMeta, ResourceRegistry} from '../../metadata';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {ActivePerfRecorder, DelegatingPerfRecorder, PerfCheckpoint, PerfEvent, PerfPhase} from '../../perf';
 import {FileUpdate, ProgramDriver, UpdateMode} from '../../program_driver';
@@ -966,7 +966,7 @@ export class NgCompiler {
         new PartialEvaluator(reflector, checker, this.incrementalCompilation.depGraph);
     const dtsReader = new DtsMetadataReader(checker, reflector);
     const localMetaRegistry = new LocalMetadataRegistry();
-    const localMetaReader: MetadataReader = localMetaRegistry;
+    const localMetaReader: MetadataReaderWithIndex = localMetaRegistry;
     const depScopeReader = new MetadataDtsModuleScopeResolver(dtsReader, aliasingHost);
     const metaReader = new CompoundMetadataReader([localMetaReader, dtsReader]);
     const ngModuleScopeRegistry = new LocalModuleScopeRegistry(
@@ -1069,8 +1069,8 @@ export class NgCompiler {
 
     const templateTypeChecker = new TemplateTypeCheckerImpl(
         this.inputProgram, notifyingDriver, traitCompiler, this.getTypeCheckingConfig(), refEmitter,
-        reflector, this.adapter, this.incrementalCompilation, metaReader, scopeReader,
-        typeCheckScopeRegistry, this.delegatingPerfRecorder);
+        reflector, this.adapter, this.incrementalCompilation, metaReader, localMetaReader,
+        scopeReader, typeCheckScopeRegistry, this.delegatingPerfRecorder);
 
     // Only construct the extended template checker if the configuration is valid and usable.
     const extendedTemplateChecker = this.constructionDiagnostics.length === 0 ?

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -251,6 +251,13 @@ export interface MetadataReader {
 }
 
 /**
+ * A MetadataReader which also allows access to the set of all known directive classes.
+ */
+export interface MetadataReaderWithIndex extends MetadataReader {
+  getKnownDirectives(): Iterable<ClassDeclaration>;
+}
+
+/**
  * Registers new metadata for directives, pipes, and modules.
  */
 export interface MetadataRegistry {

--- a/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
@@ -9,14 +9,14 @@
 import {Reference} from '../../imports';
 import {ClassDeclaration, ReflectionHost} from '../../reflection';
 
-import {DirectiveMeta, MetadataReader, MetadataRegistry, NgModuleMeta, PipeMeta} from './api';
+import {DirectiveMeta, MetadataReaderWithIndex, MetadataRegistry, NgModuleMeta, PipeMeta} from './api';
 import {hasInjectableFields} from './util';
 
 /**
  * A registry of directive, pipe, and module metadata for types defined in the current compilation
  * unit, which supports both reading and registering.
  */
-export class LocalMetadataRegistry implements MetadataRegistry, MetadataReader {
+export class LocalMetadataRegistry implements MetadataRegistry, MetadataReaderWithIndex {
   private directives = new Map<ClassDeclaration, DirectiveMeta>();
   private ngModules = new Map<ClassDeclaration, NgModuleMeta>();
   private pipes = new Map<ClassDeclaration, PipeMeta>();
@@ -39,6 +39,10 @@ export class LocalMetadataRegistry implements MetadataRegistry, MetadataReader {
   }
   registerPipeMetadata(meta: PipeMeta): void {
     this.pipes.set(meta.ref.node, meta);
+  }
+
+  getKnownDirectives(): Iterable<ClassDeclaration> {
+    return this.directives.keys();
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -14,7 +14,7 @@ import {ErrorCode} from '../../diagnostics';
 
 import {FullTemplateMapping, NgTemplateDiagnostic, TypeCheckableDirectiveMeta} from './api';
 import {GlobalCompletion} from './completion';
-import {DirectiveInScope, PipeInScope} from './scope';
+import {PipeInScope, PotentialDirective} from './scope';
 import {ElementSymbol, Symbol, TcbLocation, TemplateSymbol} from './symbols';
 
 /**
@@ -131,7 +131,7 @@ export interface TemplateTypeChecker {
   /**
    * Get basic metadata on the directives which are in scope for the given component.
    */
-  getDirectivesInScope(component: ts.ClassDeclaration): DirectiveInScope[]|null;
+  getDirectivesInScope(component: ts.ClassDeclaration): PotentialDirective[]|null;
 
   /**
    * Get basic metadata on the pipes which are in scope for the given component.
@@ -139,11 +139,11 @@ export interface TemplateTypeChecker {
   getPipesInScope(component: ts.ClassDeclaration): PipeInScope[]|null;
 
   /**
-   * Retrieve a `Map` of potential template element tags, to either the `DirectiveInScope` that
+   * Retrieve a `Map` of potential template element tags, to either the `PotentialDirective` that
    * declares them (if the tag is from a directive/component), or `null` if the tag originates from
    * the DOM schema.
    */
-  getPotentialElementTags(component: ts.ClassDeclaration): Map<string, DirectiveInScope|null>;
+  getPotentialElementTags(component: ts.ClassDeclaration): Map<string, PotentialDirective|null>;
 
   /**
    * Get the primary decorator for an Angular class (such as @Component). This does not work for

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -14,7 +14,7 @@ import {ErrorCode} from '../../diagnostics';
 
 import {FullTemplateMapping, NgTemplateDiagnostic, TypeCheckableDirectiveMeta} from './api';
 import {GlobalCompletion} from './completion';
-import {PipeInScope, PotentialDirective} from './scope';
+import {PotentialDirective, PotentialPipe} from './scope';
 import {ElementSymbol, Symbol, TcbLocation, TemplateSymbol} from './symbols';
 
 /**
@@ -137,7 +137,7 @@ export interface TemplateTypeChecker {
   /**
    * Get basic metadata on the pipes which are in scope for the given component.
    */
-  getPipesInScope(component: ts.ClassDeclaration): PipeInScope[]|null;
+  getPipesInScope(component: ts.ClassDeclaration): PotentialPipe[]|null;
 
   /**
    * Retrieve a `Map` of potential template element tags, to either the `PotentialDirective` that

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -129,9 +129,10 @@ export interface TemplateTypeChecker {
       |null;
 
   /**
-   * Get basic metadata on the directives which are in scope for the given component.
+   * Get basic metadata on the directives which are in scope or can be imported for the given
+   * component.
    */
-  getDirectivesInScope(component: ts.ClassDeclaration): PotentialDirective[]|null;
+  getPotentialTemplateDirectives(component: ts.ClassDeclaration): PotentialDirective[];
 
   /**
    * Get basic metadata on the pipes which are in scope for the given component.

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -13,7 +13,7 @@ import {ClassDeclaration} from '../../reflection';
 import {SymbolWithValueDeclaration} from '../../util/src/typescript';
 
 /**
- * Metadata on a directive which is available in the scope of a template.
+ * Metadata on a directive which is available in a template.
  */
 export interface PotentialDirective {
   ref: Reference<ClassDeclaration>;
@@ -50,9 +50,9 @@ export interface PotentialDirective {
 }
 
 /**
- * Metadata for a pipe which is available in the scope of a template.
+ * Metadata for a pipe which is available in a template.
  */
-export interface PipeInScope {
+export interface PotentialPipe {
   /**
    * The `ts.Symbol` for the pipe class.
    */

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -8,6 +8,7 @@
 
 import ts from 'typescript';
 
+import {EmittedReference, Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
 import {SymbolWithValueDeclaration} from '../../util/src/typescript';
 
@@ -15,6 +16,8 @@ import {SymbolWithValueDeclaration} from '../../util/src/typescript';
  * Metadata on a directive which is available in the scope of a template.
  */
 export interface PotentialDirective {
+  ref: Reference<ClassDeclaration>;
+
   /**
    * The `ts.Symbol` for the directive class.
    */
@@ -39,6 +42,11 @@ export interface PotentialDirective {
    * `true` if this directive is a structural directive.
    */
   isStructural: boolean;
+
+  /**
+   * Whether or not this directive is in scope.
+   */
+  isInScope: boolean;
 }
 
 /**
@@ -54,4 +62,9 @@ export interface PipeInScope {
    * Name of the pipe.
    */
   name: string;
+
+  /**
+   * Whether or not this pipe is in scope.
+   */
+  isInScope: boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -14,7 +14,7 @@ import {SymbolWithValueDeclaration} from '../../util/src/typescript';
 /**
  * Metadata on a directive which is available in the scope of a template.
  */
-export interface DirectiveInScope {
+export interface PotentialDirective {
   /**
    * The `ts.Symbol` for the directive class.
    */

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/symbols.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/symbols.ts
@@ -12,7 +12,7 @@ import ts from 'typescript';
 import {AbsoluteFsPath} from '../../file_system';
 import {SymbolWithValueDeclaration} from '../../util/src/typescript';
 
-import {DirectiveInScope} from './scope';
+import {PotentialDirective} from './scope';
 
 export enum SymbolKind {
   Input,
@@ -262,7 +262,7 @@ export interface TemplateSymbol {
  * A representation of a directive/component whose selector matches a node in a component
  * template.
  */
-export interface DirectiveSymbol extends DirectiveInScope {
+export interface DirectiveSymbol extends PotentialDirective {
   kind: SymbolKind.Directive;
 
   /** The `ts.Type` for the class declaration. */

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -20,7 +20,7 @@ import {ClassDeclaration, isNamedClassDeclaration, ReflectionHost} from '../../r
 import {ComponentScopeKind, ComponentScopeReader, TypeCheckScopeRegistry} from '../../scope';
 import {isShim} from '../../shims';
 import {getSourceFileOrNull, isSymbolWithValueDeclaration} from '../../util/src/typescript';
-import {DirectiveInScope, ElementSymbol, FullTemplateMapping, GlobalCompletion, NgTemplateDiagnostic, OptimizeFor, PipeInScope, ProgramTypeCheckAdapter, Symbol, TcbLocation, TemplateDiagnostic, TemplateId, TemplateSymbol, TemplateTypeChecker, TypeCheckableDirectiveMeta, TypeCheckingConfig} from '../api';
+import {ElementSymbol, FullTemplateMapping, GlobalCompletion, NgTemplateDiagnostic, OptimizeFor, PipeInScope, PotentialDirective, ProgramTypeCheckAdapter, Symbol, TcbLocation, TemplateDiagnostic, TemplateId, TemplateSymbol, TemplateTypeChecker, TypeCheckableDirectiveMeta, TypeCheckingConfig} from '../api';
 import {makeTemplateDiagnostic} from '../diagnostics';
 
 import {CompletionEngine} from './completion';
@@ -75,7 +75,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
    * destroyed when the `ts.Program` changes and the `TemplateTypeCheckerImpl` as a whole is
    * destroyed and replaced.
    */
-  private elementTagCache = new Map<ts.ClassDeclaration, Map<string, DirectiveInScope|null>>();
+  private elementTagCache = new Map<ts.ClassDeclaration, Map<string, PotentialDirective|null>>();
 
   private isComplete = false;
 
@@ -549,7 +549,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     return builder;
   }
 
-  getDirectivesInScope(component: ts.ClassDeclaration): DirectiveInScope[]|null {
+  getDirectivesInScope(component: ts.ClassDeclaration): PotentialDirective[]|null {
     const data = this.getScopeData(component);
     if (data === null) {
       return null;
@@ -572,12 +572,12 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     return this.typeCheckScopeRegistry.getTypeCheckDirectiveMetadata(new Reference(dir));
   }
 
-  getPotentialElementTags(component: ts.ClassDeclaration): Map<string, DirectiveInScope|null> {
+  getPotentialElementTags(component: ts.ClassDeclaration): Map<string, PotentialDirective|null> {
     if (this.elementTagCache.has(component)) {
       return this.elementTagCache.get(component)!;
     }
 
-    const tagMap = new Map<string, DirectiveInScope|null>();
+    const tagMap = new Map<string, PotentialDirective|null>();
 
     for (const tag of REGISTRY.allKnownElementNames()) {
       tagMap.set(tag, null);
@@ -886,7 +886,7 @@ class SingleShimTypeCheckingHost extends SingleFileTypeCheckingHost {
  * Cached scope information for a component.
  */
 interface ScopeData {
-  directives: DirectiveInScope[];
+  directives: PotentialDirective[];
   pipes: PipeInScope[];
   isPoisoned: boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -20,7 +20,7 @@ import {ClassDeclaration, DeclarationNode, isNamedClassDeclaration, ReflectionHo
 import {ComponentScopeKind, ComponentScopeReader, TypeCheckScopeRegistry} from '../../scope';
 import {isShim} from '../../shims';
 import {getSourceFileOrNull, isSymbolWithValueDeclaration} from '../../util/src/typescript';
-import {ElementSymbol, FullTemplateMapping, GlobalCompletion, NgTemplateDiagnostic, OptimizeFor, PipeInScope, PotentialDirective, ProgramTypeCheckAdapter, Symbol, TcbLocation, TemplateDiagnostic, TemplateId, TemplateSymbol, TemplateTypeChecker, TypeCheckableDirectiveMeta, TypeCheckingConfig} from '../api';
+import {ElementSymbol, FullTemplateMapping, GlobalCompletion, NgTemplateDiagnostic, OptimizeFor, PotentialDirective, PotentialPipe, ProgramTypeCheckAdapter, Symbol, TcbLocation, TemplateDiagnostic, TemplateId, TemplateSymbol, TemplateTypeChecker, TypeCheckableDirectiveMeta, TypeCheckingConfig} from '../api';
 import {makeTemplateDiagnostic} from '../diagnostics';
 
 import {CompletionEngine} from './completion';
@@ -572,7 +572,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     return Array.from(resultingDirectives.values());
   }
 
-  getPipesInScope(component: ts.ClassDeclaration): PipeInScope[]|null {
+  getPipesInScope(component: ts.ClassDeclaration): PotentialPipe[]|null {
     const data = this.getScopeData(component);
     if (data === null) {
       return null;
@@ -910,6 +910,6 @@ class SingleShimTypeCheckingHost extends SingleFileTypeCheckingHost {
  */
 interface ScopeData {
   directives: PotentialDirective[];
-  pipes: PipeInScope[];
+  pipes: PotentialPipe[];
   isPoisoned: boolean;
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -13,10 +13,10 @@ import {ErrorCode, ngErrorCode} from '../../diagnostics';
 import {absoluteFrom, absoluteFromSourceFile, AbsoluteFsPath, getSourceFileOrError} from '../../file_system';
 import {Reference, ReferenceEmitter} from '../../imports';
 import {IncrementalBuild} from '../../incremental/api';
-import {MetadataReader, MetaKind} from '../../metadata';
+import {DirectiveMeta, MetadataReader, MetadataReaderWithIndex, MetaKind} from '../../metadata';
 import {PerfCheckpoint, PerfEvent, PerfPhase, PerfRecorder} from '../../perf';
 import {ProgramDriver, UpdateMode} from '../../program_driver';
-import {ClassDeclaration, isNamedClassDeclaration, ReflectionHost} from '../../reflection';
+import {ClassDeclaration, DeclarationNode, isNamedClassDeclaration, ReflectionHost} from '../../reflection';
 import {ComponentScopeKind, ComponentScopeReader, TypeCheckScopeRegistry} from '../../scope';
 import {isShim} from '../../shims';
 import {getSourceFileOrNull, isSymbolWithValueDeclaration} from '../../util/src/typescript';
@@ -86,6 +86,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
       private compilerHost: Pick<ts.CompilerHost, 'getCanonicalFileName'>,
       private priorBuild: IncrementalBuild<unknown, FileTypeCheckingData>,
       private readonly metaReader: MetadataReader,
+      private readonly localMetaReader: MetadataReaderWithIndex,
       private readonly componentScopeReader: ComponentScopeReader,
       private readonly typeCheckScopeRegistry: TypeCheckScopeRegistry,
       private readonly perf: PerfRecorder) {}
@@ -549,12 +550,26 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     return builder;
   }
 
-  getDirectivesInScope(component: ts.ClassDeclaration): PotentialDirective[]|null {
-    const data = this.getScopeData(component);
-    if (data === null) {
-      return null;
+  getPotentialTemplateDirectives(component: ts.ClassDeclaration): PotentialDirective[] {
+    const typeChecker = this.programDriver.getProgram().getTypeChecker();
+    const inScopeDirectives = this.getScopeData(component)?.directives ?? [];
+    const resultingDirectives = new Map<ClassDeclaration<DeclarationNode>, PotentialDirective>();
+    // First, all in scope directives can be used.
+    for (const d of inScopeDirectives) {
+      resultingDirectives.set(d.ref.node, d);
     }
-    return data.directives;
+    // Any additional directives found from the global registry can be used, but are not in scope.
+    // In the future, we can also walk other registries for .d.ts files, or traverse the
+    // import/export graph.
+    for (const directiveClass of this.localMetaReader.getKnownDirectives()) {
+      const directiveMeta = this.metaReader.getDirectiveMetadata(new Reference(directiveClass));
+      if (directiveMeta === null) continue;
+      if (resultingDirectives.has(directiveClass)) continue;
+      const withScope = this.scopeDataOfDirectiveMeta(typeChecker, directiveMeta);
+      if (withScope === null) continue;
+      resultingDirectives.set(directiveClass, {...withScope, isInScope: false});
+    }
+    return Array.from(resultingDirectives.values());
   }
 
   getPipesInScope(component: ts.ClassDeclaration): PipeInScope[]|null {
@@ -686,28 +701,9 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     const typeChecker = this.programDriver.getProgram().getTypeChecker();
     for (const dep of dependencies) {
       if (dep.kind === MetaKind.Directive) {
-        if (dep.selector === null) {
-          // Skip this directive, it can't be added to a template anyway.
-          continue;
-        }
-        const tsSymbol = typeChecker.getSymbolAtLocation(dep.ref.node.name);
-        if (!isSymbolWithValueDeclaration(tsSymbol)) {
-          continue;
-        }
-
-        let ngModule: ClassDeclaration|null = null;
-        const moduleScopeOfDir = this.componentScopeReader.getScopeForComponent(dep.ref.node);
-        if (moduleScopeOfDir !== null && moduleScopeOfDir.kind === ComponentScopeKind.NgModule) {
-          ngModule = moduleScopeOfDir.ngModule;
-        }
-
-        data.directives.push({
-          isComponent: dep.isComponent,
-          isStructural: dep.isStructural,
-          selector: dep.selector,
-          tsSymbol,
-          ngModule,
-        });
+        const dirScope = this.scopeDataOfDirectiveMeta(typeChecker, dep);
+        if (dirScope === null) continue;
+        data.directives.push({...dirScope, isInScope: true});
       } else if (dep.kind === MetaKind.Pipe) {
         const tsSymbol = typeChecker.getSymbolAtLocation(dep.ref.node.name);
         if (tsSymbol === undefined) {
@@ -716,13 +712,40 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
         data.pipes.push({
           name: dep.name,
           tsSymbol,
+          isInScope: true,
         });
       }
     }
 
-
     this.scopeCache.set(component, data);
     return data;
+  }
+
+  private scopeDataOfDirectiveMeta(typeChecker: ts.TypeChecker, dep: DirectiveMeta):
+      Omit<PotentialDirective, 'isInScope'>|null {
+    if (dep.selector === null) {
+      // Skip this directive, it can't be added to a template anyway.
+      return null;
+    }
+    const tsSymbol = typeChecker.getSymbolAtLocation(dep.ref.node.name);
+    if (!isSymbolWithValueDeclaration(tsSymbol)) {
+      return null;
+    }
+
+    let ngModule: ClassDeclaration|null = null;
+    const moduleScopeOfDir = this.componentScopeReader.getScopeForComponent(dep.ref.node);
+    if (moduleScopeOfDir !== null && moduleScopeOfDir.kind === ComponentScopeKind.NgModule) {
+      ngModule = moduleScopeOfDir.ngModule;
+    }
+
+    return {
+      ref: dep.ref,
+      isComponent: dep.isComponent,
+      isStructural: dep.isStructural,
+      selector: dep.selector,
+      tsSymbol,
+      ngModule,
+    };
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/template_symbol_builder.ts
@@ -135,14 +135,17 @@ export class SymbolBuilder {
             return null;
           }
           const isComponent = meta.isComponent ?? null;
+          const ref = new Reference<ClassDeclaration>(symbol.tsSymbol.valueDeclaration as any);
           const directiveSymbol: DirectiveSymbol = {
             ...symbol,
+            ref,
             tsSymbol: symbol.tsSymbol,
             selector: meta.selector,
             isComponent,
             ngModule,
             kind: SymbolKind.Directive,
             isStructural: meta.isStructural,
+            isInScope: true,
           };
           return directiveSymbol;
         })
@@ -361,8 +364,10 @@ export class SymbolBuilder {
       return null;
     }
 
+    const ref: Reference<ClassDeclaration> = new Reference(symbol.tsSymbol.valueDeclaration as any);
     const ngModule = this.getDirectiveModule(symbol.tsSymbol.valueDeclaration);
     return {
+      ref,
       kind: SymbolKind.Directive,
       tsSymbol: symbol.tsSymbol,
       tsType: symbol.tsType,
@@ -371,6 +376,7 @@ export class SymbolBuilder {
       isStructural,
       selector,
       ngModule,
+      isInScope: true,  // TODO: this should always be in scope in this context, right?
     };
   }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
@@ -104,7 +104,8 @@ runInEachFileSystem(() => {
       const sf = getSourceFileOrError(program, MAIN_TS);
       const SomeCmp = getClass(sf, 'SomeCmp');
 
-      const directives = templateTypeChecker.getDirectivesInScope(SomeCmp) ?? [];
+      let directives = templateTypeChecker.getPotentialTemplateDirectives(SomeCmp) ?? [];
+      directives = directives.filter(d => d.isInScope);
       const pipes = templateTypeChecker.getPipesInScope(SomeCmp) ?? [];
       expect(directives.map(dir => dir.selector)).toEqual(['other-dir']);
       expect(pipes.map(pipe => pipe.name)).toEqual(['otherPipe']);

--- a/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
@@ -170,5 +170,36 @@ runInEachFileSystem(() => {
         expect(ngModuleRetrievedClass).toEqual(ngModuleKnownClass);
       });
     });
+
+    describe('can retrieve candidate directives` ', () => {
+      it('which are out of scope', () => {
+        env.write('one.ts', `
+		   import {Component} from '@angular/core';
+   
+		   @Component({
+			   standalone: true,
+			   selector: 'one-cmp',
+			   template: '<div></div>',
+		   })
+		   export class OneCmp {}
+		   `);
+
+        env.write('two.ts', `
+		   import {Component} from '@angular/core';
+   
+		   @Component({
+			   standalone: true,
+			   selector: 'two-cmp',
+			   template: '<div></div>',
+		   })
+		   export class TwoCmp {}
+		   `);
+        const {program, checker} = env.driveTemplateTypeChecker();
+        const sf = program.getSourceFile(_('/one.ts'));
+        expect(sf).not.toBeNull();
+        const directives = checker.getPotentialTemplateDirectives(getClass(sf!, 'OneCmp'));
+        expect(directives.map(d => d.selector)).toContain('two-cmp');
+      });
+    });
   });
 });

--- a/packages/language-service/src/attribute_completions.ts
+++ b/packages/language-service/src/attribute_completions.ts
@@ -7,7 +7,7 @@
  */
 
 import {CssSelector, SelectorMatcher, TmplAstElement, TmplAstTemplate} from '@angular/compiler';
-import {DirectiveInScope, ElementSymbol, TemplateSymbol, TemplateTypeChecker, TypeCheckableDirectiveMeta} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
+import {ElementSymbol, PotentialDirective, TemplateSymbol, TemplateTypeChecker, TypeCheckableDirectiveMeta} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import ts from 'typescript';
 
 import {DisplayInfoKind, unsafeCastDisplayInfoKindToScriptElementKind} from './display_parts';
@@ -116,7 +116,7 @@ export interface DirectiveAttributeCompletion {
   /**
    * The directive whose selector gave rise to this completion.
    */
-  directive: DirectiveInScope;
+  directive: PotentialDirective;
 }
 
 /**
@@ -135,7 +135,7 @@ export interface DirectiveInputCompletion {
   /**
    * The directive which has this input.
    */
-  directive: DirectiveInScope;
+  directive: PotentialDirective;
 
   /**
    * The field name on the directive class which corresponds to this input.
@@ -164,7 +164,7 @@ export interface DirectiveOutputCompletion {
   /**
    *The directive which has this output.
    */
-  directive: DirectiveInScope;
+  directive: PotentialDirective;
 
   /**
    * The field name on the directive class which corresponds to this output.
@@ -251,7 +251,8 @@ export function buildAttributeCompletionTable(
 
   // Next, explore hypothetical directives and determine if the addition of any single attributes
   // can cause the directive to match the element.
-  const directivesInScope = checker.getDirectivesInScope(component);
+  const directivesInScope =
+      checker.getPotentialTemplateDirectives(component).filter(d => d.isInScope);
   if (directivesInScope !== null) {
     const elementSelector = makeElementSelector(element);
 

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -8,7 +8,7 @@
 
 import {AST, ASTWithSource, BindingPipe, BindingType, Call, EmptyExpr, ImplicitReceiver, LiteralPrimitive, ParsedEventType, ParseSourceSpan, PropertyRead, PropertyWrite, SafePropertyRead, TmplAstBoundAttribute, TmplAstBoundEvent, TmplAstElement, TmplAstNode, TmplAstReference, TmplAstTemplate, TmplAstText, TmplAstTextAttribute, TmplAstVariable} from '@angular/compiler';
 import {NgCompiler} from '@angular/compiler-cli/src/ngtsc/core';
-import {CompletionKind, DirectiveInScope, SymbolKind, TemplateDeclarationSymbol} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
+import {CompletionKind, PotentialDirective, SymbolKind, TemplateDeclarationSymbol} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import {BoundEvent, TextAttribute} from '@angular/compiler/src/render3/r3_ast';
 import ts from 'typescript';
 
@@ -905,7 +905,7 @@ function makeReplacementSpanFromAst(node: PropertyRead|PropertyWrite|SafePropert
   };
 }
 
-function tagCompletionKind(directive: DirectiveInScope|null): ts.ScriptElementKind {
+function tagCompletionKind(directive: PotentialDirective|null): ts.ScriptElementKind {
   let kind: DisplayInfoKind;
   if (directive === null) {
     kind = DisplayInfoKind.ELEMENT;

--- a/packages/language-service/src/display_parts.ts
+++ b/packages/language-service/src/display_parts.ts
@@ -7,7 +7,7 @@
  */
 
 import {isNamedClassDeclaration} from '@angular/compiler-cli/src/ngtsc/reflection';
-import {DirectiveInScope, ReferenceSymbol, Symbol, SymbolKind, TcbLocation, VariableSymbol} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
+import {PotentialDirective, ReferenceSymbol, Symbol, SymbolKind, TcbLocation, VariableSymbol} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
 import ts from 'typescript';
 
 
@@ -130,7 +130,7 @@ function getDocumentationFromTypeDefAtLocation(
 }
 
 export function getDirectiveDisplayInfo(
-    tsLS: ts.LanguageService, dir: DirectiveInScope): DisplayInfo {
+    tsLS: ts.LanguageService, dir: PotentialDirective): DisplayInfo {
   const kind = dir.isComponent ? DisplayInfoKind.COMPONENT : DisplayInfoKind.DIRECTIVE;
   const decl = dir.tsSymbol.declarations.find(ts.isClassDeclaration);
   if (decl === undefined || decl.name === undefined) {


### PR DESCRIPTION
`getPotentialTemplateDirectives` returns possible directives which can be used in the provided context, whether already in scope or requiring an import.

This is necessary to implement auto-import support for standalone components in the language service.

This is fourth in an ongoing sequence of PRs, including #47181, #47180, and #47166.