### PR TITLE
docs: temporarily hide banner to improve survey visibility

### DIFF
--- a/aio/src/app/app.component.html
+++ b/aio/src/app/app.component.html
@@ -11,7 +11,7 @@
 <header>
   <mat-toolbar #appToolbar color="primary" class="app-toolbar no-print" [class.transitioning]="isTransitioning">
     <mat-toolbar-row class="notification-container">
-      <aio-notification notificationId="war-ukraine" expirationDate="null" [dismissOnContentClick]="false" (dismissed)="notificationDismissed()">
+      <aio-notification notificationId="war-ukraine" expirationDate="2022-09-26" [dismissOnContentClick]="false" (dismissed)="notificationDismissed()">
         <a class="link" target="_blank" rel="noopener" href="https://www.google.org/ukraine-relief/">
           <span class="title">Support Ukraine</span>
         <mat-icon class="icon" aria-label="Ukraine flag">


### PR DESCRIPTION
Temporarily hiding the "Support Ukraine" banner to provide higher visibility of the Angular developer survey that we will run in a few weeks.

Once the survey us over (sometime in Q4), we'll add the "Support Ukraine" banner back if the situation has not changed.