### PR TITLE
build(devtools): migrate to manifest v3

### DIFF
--- a/devtools/projects/shell-browser/src/BUILD.bazel
+++ b/devtools/projects/shell-browser/src/BUILD.bazel
@@ -133,6 +133,7 @@ pkg_web(
         "//devtools/projects/shell-browser/src/app:backend_bundle",
         "//devtools/projects/shell-browser/src/app:background_bundle",
         "//devtools/projects/shell-browser/src/app:content_script_bundle",
+        "//devtools/projects/shell-browser/src/app:detect_angular_for_extension_icon_bundle",
         "//devtools/projects/shell-browser/src/app:ng_validate_bundle",
         "//devtools/projects/shell-browser/src/assets",
         "//devtools/projects/shell-browser/src/popups",

--- a/devtools/projects/shell-browser/src/app/BUILD.bazel
+++ b/devtools/projects/shell-browser/src/app/BUILD.bazel
@@ -126,7 +126,7 @@ ts_library(
     srcs = [
         "background.ts",
     ],
-    deps = ["//devtools/projects/shell-browser/src/app:ng_validate"],
+    deps = ["//devtools/projects/shell-browser/src/app:detect_angular_for_extension_icon"],
 )
 
 ts_library(
@@ -153,6 +153,30 @@ ts_library(
         ":same_page_message_bus",
         "//devtools/projects/protocol",
         "@npm//@types",
+    ],
+)
+
+ts_library(
+    name = "detect_angular_for_extension_icon",
+    srcs = [
+        "detect-angular-for-extension-icon.ts",
+    ],
+    deps = [
+        "@npm//@types",
+    ],
+)
+
+esbuild(
+    name = "detect_angular_for_extension_icon_bundle",
+    config = "//devtools/tools/esbuild:esbuild_config_iife",
+    entry_point = "detect-angular-for-extension-icon.ts",
+    format = "iife",
+    minify = True,
+    platform = "browser",
+    splitting = False,
+    target = "esnext",
+    deps = [
+        ":detect_angular_for_extension_icon",
     ],
 )
 

--- a/devtools/projects/shell-browser/src/app/detect-angular-for-extension-icon.ts
+++ b/devtools/projects/shell-browser/src/app/detect-angular-for-extension-icon.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export interface AngularDetection {
+  // This is necessary because the runtime
+  // message listener handles messages globally
+  // including from other extensions. We don't
+  // want to set icon and/or popup based on
+  // a message coming from an unrelated extension.
+  isAngularDevTools: true;
+  isIvy: boolean;
+  isAngular: boolean;
+  isDebugMode: boolean;
+  isSupportedAngularVersion: boolean;
+}
+
+function detectAngular(win: Window): void {
+  const isDebugMode = Boolean((win as any).ng);
+  const ngVersionElement = document.querySelector('[ng-version]');
+  let isSupportedAngularVersion = false;
+  let isAngular = false;
+
+  if (ngVersionElement) {
+    isAngular = true;
+    const attr = ngVersionElement.getAttribute('ng-version');
+    const major = attr ? parseInt(attr.split('.')[0], 10) : -1;
+    // In case of g3 apps we support major 0.
+    if (attr && (major >= 12 || major === 0)) {
+      isSupportedAngularVersion = true;
+    }
+  }
+
+  win.postMessage(
+      {
+        isIvy: typeof (ngVersionElement as any)?.__ngContext__ !== 'undefined',
+        isAngular,
+        isDebugMode,
+        isSupportedAngularVersion,
+        isAngularDevTools: true,
+      } as AngularDetection,
+      '*');
+
+  if (!isAngular) {
+    setTimeout(() => detectAngular(win), 1000);
+  }
+}
+
+detectAngular(window);

--- a/devtools/projects/shell-browser/src/app/ng-validate.ts
+++ b/devtools/projects/shell-browser/src/app/ng-validate.ts
@@ -8,68 +8,13 @@
 
 /// <reference types="chrome"/>
 
-export interface AngularDetection {
-  // This is necessary because the runtime
-  // message listener handles messages globally
-  // including from other extensions. We don't
-  // want to set icon and/or popup based on
-  // a message coming from an unrelated extension.
-  isAngularDevTools: true;
-  isIvy: boolean;
-  isAngular: boolean;
-  isDebugMode: boolean;
-  isSupportedAngularVersion: boolean;
-}
-
 window.addEventListener('message', (event: MessageEvent) => {
   if (event.source === window && event.data) {
     chrome.runtime.sendMessage(event.data);
   }
 });
 
-function detectAngular(win: Window): void {
-  const isDebugMode = Boolean((win as any).ng);
-  const ngVersionElement = document.querySelector('[ng-version]');
-  let isSupportedAngularVersion = false;
-  let isAngular = false;
-  if (ngVersionElement) {
-    isAngular = true;
-    const attr = ngVersionElement.getAttribute('ng-version');
-    const major = attr ? parseInt(attr.split('.')[0], 10) : -1;
-    // In case of g3 apps we support major 0.
-    if (attr && (major >= 9 || major === 0)) {
-      isSupportedAngularVersion = true;
-    }
-  }
-
-  win.postMessage(
-      {
-        // Needs to be inline because we're stringifying
-        // this function and executing it with eval.
-        isIvy: typeof (ngVersionElement as any)?.__ngContext__ !== 'undefined',
-        isAngular,
-        isDebugMode,
-        isSupportedAngularVersion,
-        isAngularDevTools: true,
-      } as AngularDetection,
-      '*');
-
-  if (!isAngular) {
-    setTimeout(() => detectAngular(win), 1000);
-  }
-}
-
-function installScript(fn: string): void {
-  const source = `;(${fn})(window)`;
-  const script = document.createElement('script');
-  script.textContent = source;
-  document.documentElement.appendChild(script);
-  const parentElement = script.parentElement;
-  if (parentElement) {
-    parentElement.removeChild(script);
-  }
-}
-
-if (document instanceof Document) {
-  installScript(detectAngular.toString());
-}
+const script = document.createElement('script');
+script.src = chrome.runtime.getURL('app/detect_angular_for_extension_icon_bundle.js');
+document.documentElement.appendChild(script);
+document.documentElement.removeChild(script);

--- a/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
+++ b/devtools/projects/shell-browser/src/manifest/manifest.chrome.json
@@ -1,36 +1,48 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "short_name": "Angular DevTools",
   "name": "Angular DevTools",
   "description": "Angular DevTools extends Chrome DevTools adding Angular specific debugging and profiling capabilities.",
   "version": "1.0.6",
   "version_name": "1.0.6",
-  "minimum_chrome_version": "50",
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "minimum_chrome_version": "102",
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
   "icons": {
     "16": "assets/icon16.png",
     "48": "assets/icon48.png",
     "128": "assets/icon128.png"
   },
-  "browser_action": {
-    "default_popup": "popups/not-angular.html"
+  "action": {
+    "default_popup": "popups/not-angular.html",
+    "default_icon": {
+      "16": "assets/icon-bw16.png",
+      "48": "assets/icon-bw48.png",
+      "128": "assets/icon-bw128.png"
+    }
   },
   "devtools_page": "devtools.html",
   "web_accessible_resources": [
-    "app/backend_bundle.js",
-    "devtools.html"
+    {
+      "resources": [
+        "app/backend_bundle.js",
+        "app/detect_angular_for_extension_icon_bundle.js",
+        "devtools.html"
+      ],
+      "matches": ["<all_urls>"],
+      "extension_ids": []
+    }
   ],
   "background": {
-    "scripts": [
-      "app/background_bundle.js"
-    ],
-    "persistent": false
+    "service_worker": "app/background_bundle.js"
   },
   "permissions": [
-    "activeTab",
-    "http://*/*",
-    "https://*/*",
-    "file:///*"
+    "scripting",
+    "activeTab"
+  ],
+  "host_permissions": [
+    "<all_urls>"
   ],
   "content_scripts": [
     {


### PR DESCRIPTION
Previously we built DevTools for all browsers with version 2 of the manifest file format.

This commit includes a number of refactors and API additions that will enable us to build DevTools with version 3 of the manifest file format.

The manifest v3 build of Angular DevTools has been tested on Chrome, Edge, and Safari.

Notably, the Firefox version of Angular DevTools remains as a manifest v2 build. Firefox does not yet support manifest v3 in it's latest stable release. When Firefox makes this transition, a follow up PR will update the Firefox manifest file to version 3.

Because Firefox still needs v2, we need to keep some old v2 APIs around in our background page (service worker in v3) that will execute conditionally based on if the extension was built for v2 or v3. This is determined with the `chrome.runtime.getManifest().manifest_version` API.

# Changes

> `ng_validate.ts` content script was refactored into `ng_validate.ts` and `detect-angular-for-extension-icon.ts`. Previously this script would execute code on the main page that would detect the existence of Angular and communicate it to the DevTools background page in order to update the Angular icon and popup in the toolbar.
>
> This code would execute on the main page through a script tag that we supply a function to like so, `script.textContent = functionAsString`. 
>
> With v3, this method of executing code in a content script [no longer works](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#code-execution), so we follow the [migration guide](https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/#api-remote-code) to [resolve this](https://github.com/angular/angular/blob/63f158cdf5012d577187dba2a404cec416084eca/devtools/projects/shell-browser/src/app/ng-validate.ts#L18). 
>
> The only notable change here is that our detection code no longer executes synchronously with `ng_validate.ts`. This is not an issue as this content script was always loaded asynchronously in the first place, and we have no such feature in Angular DevTools that requires it to execute synchronously.

> The `chrome.tabs.executeScript` API no longer works in v3. As [per the guide](https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/#api-tabs), we switch to using `chrome.scripting.executeScript`.


> The `chrome.browserAction` API was previously used to set the icon and popup in the browser toolbar. In v3, this API along with the `chrome.pageAction` API was merged into the `chrome.action` API. As [per the guide](https://developer.chrome.com/docs/extensions/mv3/mv3-migration-checklist/#api-browser-action-js), we make this change.

>[This guide](https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#updating-manifest-dot-json) to migrating the manifest.json file was followed.

closes #46287