### PR TITLE
fix(compiler-cli): support hasInvalidatedResolutions.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/host.ts
@@ -68,6 +68,11 @@ export class DelegatingCompilerHost implements
   useCaseSensitiveFileNames = this.delegateMethod('useCaseSensitiveFileNames');
   writeFile = this.delegateMethod('writeFile');
   getModuleResolutionCache = this.delegateMethod('getModuleResolutionCache');
+  // @ts-expect-error 'hasInvalidatedResolutions' is visible (and thus required here) in latest TSC
+  // main. It's already present, so the code works at runtime.
+  // TODO: remove this comment including the suppression once Angular uses a TSC version that
+  // includes this change (github.com/microsoft/TypeScript@a455955).
+  hasInvalidatedResolutions = this.delegateMethod('hasInvalidatedResolutions');
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
+++ b/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
@@ -52,6 +52,11 @@ export class DelegatingCompilerHost implements
   trace = this.delegateMethod('trace');
   useCaseSensitiveFileNames = this.delegateMethod('useCaseSensitiveFileNames');
   getModuleResolutionCache = this.delegateMethod('getModuleResolutionCache');
+  // @ts-expect-error 'hasInvalidatedResolutions' is visible (and thus required here) in latest TSC
+  // main. It's already present, so the code works at runtime.
+  // TODO: remove this comment including the suppression once Angular uses a TSC version that
+  // includes this change (github.com/microsoft/TypeScript@a455955).
+  hasInvalidatedResolutions = this.delegateMethod('hasInvalidatedResolutions');
 }
 
 /**


### PR DESCRIPTION
The latest TypeScript compiler exposes the previously private field `hasInvalidatedResolutions`. That breaks Angular in the newer TS, because the new field would be required on DelegatingCompilerHost. However we cannot just add the field here, because it's not present in the older compiler.

This change adds the field for delegation, which works at runtime because the field is present. It suppresses the compiler error using a `// @ts-expect-error`, which should be removed once Angular moves to a TSC version that includes this change.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Doesn't compile with the latest tsc.

Issue Number: N/A


## What is the new behavior?

Compiles with the latest tsc.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
