### PR TITLE
build(bazel): create AIO example playgrounds for manual testing

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -6,6 +6,7 @@
 node_modules
 dist
 aio/node_modules
+aio/content/example-playground
 aio/tools/examples/shared/node_modules
 aio/tools/examples/shared/example-scaffold
 packages/bazel/node_modules

--- a/aio/.gitignore
+++ b/aio/.gitignore
@@ -42,6 +42,9 @@ testem.log
 # e2e
 protractor-results*.txt
 
+# Example playground
+content/example-playground
+
 # System files
 .DS_Store
 Thumbs.db

--- a/aio/README.md
+++ b/aio/README.md
@@ -30,6 +30,8 @@ Here are the most important tasks you might need to use:
 * `yarn docs-lint` - check that the doc gen code follows our style rules.
 
 * `yarn create-example` - create a new example directory containing initial source files.
+* `yarn example-playground <exampleName>` - set up a playground to manually test an example combined with its boilerplate files
+  - `--local` - link locally build Angular packages as deps
 
 * `yarn example-e2e` - run all e2e tests for examples. Available options:
   - `--local`: run e2e tests against locally built Angular packages.

--- a/aio/content/examples/examples.bzl
+++ b/aio/content/examples/examples.bzl
@@ -182,7 +182,7 @@ def docs_example(name, test = True, test_tags = [], test_exec_properties = {}):
 
         # Local package deps are passed as args to the test script in the form "@package/name#path/to/package"
         # for the script's convenience.
-        LOCAL_PACKAGE_ARGS = ["%s#$(rootpath %s)" % (dep, to_package_label(dep)) for dep in AIO_EXAMPLE_PACKAGES]
+        LOCAL_PACKAGE_ARGS = ["--localPackage=%s#$(rootpath %s)" % (dep, to_package_label(dep)) for dep in AIO_EXAMPLE_PACKAGES]
 
         nodejs_test(
             name = "e2e",
@@ -206,7 +206,7 @@ def docs_example(name, test = True, test_tags = [], test_exec_properties = {}):
                 "//conditions:default": [],
             }),
             configuration_env_vars = ["NG_BUILD_CACHE"],
-            entry_point = "//aio/tools/examples:run-example-e2e",
+            entry_point = "//aio/tools/examples:run-example-e2e.mjs",
             env = {
                 "CHROME_BIN": "$(CHROMIUM)",
                 "CHROMEDRIVER_BIN": "$(CHROMEDRIVER)",

--- a/aio/package.json
+++ b/aio/package.json
@@ -33,6 +33,7 @@
     "example-e2e": "node --experimental-import-meta-resolve tools/examples/run-filtered-example-e2es.mjs",
     "example-list-overrides": "bazel run //aio/tools/examples:example-boilerplate list-overrides",
     "example-lint": "eslint content/examples",
+    "example-playground": "node ./tools/examples/create-example-playground-wrapper.mjs",
     "deploy-production": "bazel run //aio/scripts/deploy-to-firebase",
     "check-env": "yarn ~~check-env",
     "payload-size": "scripts/payload.sh",

--- a/aio/tools/examples/BUILD.bazel
+++ b/aio/tools/examples/BUILD.bazel
@@ -1,8 +1,14 @@
 load("//tools:defaults.bzl", "nodejs_binary")
 load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
 load("@aio_npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
+load("//aio/content/examples:examples.bzl", "EXAMPLES")
+load("//:packages.bzl", "AIO_EXAMPLE_PACKAGES", "to_package_label")
 
 package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "run-example-e2e.mjs",
+])
 
 EXAMPLE_BOILERPLATE_SRCS = [
     "example-boilerplate.js",
@@ -59,14 +65,24 @@ jasmine_node_test(
 )
 
 js_library(
+    name = "example-sandbox",
+    srcs = ["example-sandbox.mjs"],
+    deps = [
+        "@aio_npm//cjson",
+        "@aio_npm//fs-extra",
+        "@aio_npm//globby",
+    ],
+)
+
+js_library(
     name = "run-example-e2e",
     srcs = [
         "run-example-e2e.mjs",
     ],
     deps = [
+        ":example-sandbox",
         "@aio_npm//@bazel/runfiles",
         "@aio_npm//canonical-path",
-        "@aio_npm//cjson",
         "@aio_npm//cross-spawn",
         "@aio_npm//fs-extra",
         "@aio_npm//get-port",
@@ -75,4 +91,31 @@ js_library(
         "@aio_npm//tree-kill",
         "@aio_npm//yargs",
     ],
+)
+
+EXAMPLES_WITH_BOILERPLATE = ["//aio/content/examples/%s" % example for example in EXAMPLES]
+
+LOCAL_PACKAGE_DEPS = [to_package_label(dep) for dep in AIO_EXAMPLE_PACKAGES]
+
+LOCAL_PACKAGE_ARGS = ["--localPackage=%s#$(rootpath %s)" % (
+    dep,
+    to_package_label(dep),
+) for dep in AIO_EXAMPLE_PACKAGES]
+
+nodejs_binary(
+    name = "create-example-playground",
+    args = select({
+        # Hardcode package names/paths in args
+        "//aio:aio_local_deps": LOCAL_PACKAGE_ARGS,
+        "//conditions:default": [],
+    }),
+    data = [
+        ":example-sandbox",
+        "@aio_example_deps//:node_modules_files",
+        "@aio_npm//yargs",
+    ] + EXAMPLES_WITH_BOILERPLATE + select({
+        "//aio:aio_local_deps": LOCAL_PACKAGE_DEPS,
+        "//conditions:default": [],
+    }),
+    entry_point = "create-example-playground.mjs",
 )

--- a/aio/tools/examples/README.md
+++ b/aio/tools/examples/README.md
@@ -140,6 +140,16 @@ By default the script will place basic scaffold files into the new example (from
 But you can also specify the path to a separate CLI project, from which the script will copy files that would not be considered "boilerplate".
 See the [Boilerplate overview](#boilerplate-overview) for more information.
 
+### `create-example-playground.mjs`
+
+The [create-example-playground.mjs](./create-example-playground.mjs) script combines example sources, boilerplate, and shared node_modules deps into git-ignored playground directory `content/example-playground/{{EXAMPLE}}` that can be used for manual testing. This should be invoked via the yarn script:
+
+```bash
+yarn example-playground <exampleName> [--local]
+```
+
+The `--local` flag links in locally-built angular packages as dependencies.
+
 ### Updating example dependencies
 
 With every major Angular release, we update the examples to be on the latest version.

--- a/aio/tools/examples/create-example-playground-wrapper.mjs
+++ b/aio/tools/examples/create-example-playground-wrapper.mjs
@@ -1,0 +1,43 @@
+import shelljs from 'shelljs';
+import yargs from 'yargs'
+import {hideBin} from 'yargs/helpers';
+import {getNativeBinary as getNativeBazelBinary} from '@bazel/bazelisk';
+
+shelljs.set('-e')
+shelljs.set('-v')
+
+/**
+ * Create an example playground with shared example deps and optionally linked local
+ * angular packages in the source tree under content/examples/example-playground. This
+ * is a wrapper around the equivalent bazel binary but adds the --local option to link
+ * local packages.
+ *   
+ * Usage: node ./tools/examples/create-example-playground-wrapper.mjs <example> [options]
+ *
+ * Args:
+ *  example: name of the example
+ * 
+ * Flags:
+ *  --local: use locally built angular packages
+ */
+
+const options = yargs(hideBin(process.argv))
+  .command('$0 <example>', 'Set up a playground for <example> in the source tree for manual testing')
+  .option('local', {default: false, type: 'boolean'})
+  .version(false)
+  .strict()
+  .argv;
+
+const cmd = [
+  getNativeBazelBinary(),
+  'run',
+  '//aio/tools/examples:create-example-playground',
+  '--',
+  `--example=${options.example}`,
+];
+
+if (options.local) {
+  cmd.splice(2, 0, '--config=aio_local_deps');
+}
+
+shelljs.exec(cmd.join(' '));

--- a/aio/tools/examples/create-example-playground.mjs
+++ b/aio/tools/examples/create-example-playground.mjs
@@ -1,0 +1,66 @@
+import path from 'node:path';
+import yargs from 'yargs';
+import {hideBin} from 'yargs/helpers'
+import {constructExampleSandbox} from './example-sandbox.mjs';
+
+if (!process.env.BUILD_WORKSPACE_DIRECTORY) {
+  console.error(
+    'Not running script as part of `bazel run`.'
+  )
+  process.exit(1);
+}
+const sourceRoot = process.env.BUILD_WORKSPACE_DIRECTORY;
+const runfilesRoot = path.join(process.env.RUNFILES, 'angular');
+const playgroundRoot = path.join(sourceRoot, 'aio', 'content', 'example-playground');
+
+/**
+ * Create an example playground with shared example deps and optionally linked local
+ * angular packages in the source tree under content/examples/example-playground. This
+ * script is intended to only be run under bazel as it has the localPackage arguments
+ * hardcoded into the binary via starlark.
+ *
+ * Usage: bazel run //aio/tools/examples:create-example-playground -- --example=<example>
+ *
+ * Args:
+ *  example: name of the example
+ */
+
+async function main(args) {
+  const options =
+    yargs(args)
+    // Note: localPackage not listed above in usage as it's hardcoded in by the nodejs_binary
+    .option('localPackage', {
+      array: true,
+      type: 'string',
+      default: [],
+      describe: 'Locally built package to substitute, in the form `packageName#packagePath`'
+    })
+    .option('example', {
+      type: 'string',
+      describe: 'Name of the example'
+    })
+    .demandOption('example')
+    .strict()
+    .version(false)
+    .argv;
+
+  const localPackages = options.localPackage.reduce((pkgs, pkgNameAndPath) => {
+    const [pkgName, pkgPath] = pkgNameAndPath.split('#');
+    pkgs[pkgName] = path.resolve(pkgPath);
+    return pkgs;
+  }, {});
+
+  const exampleName = options.example;
+
+  // Note: the example sources plus boilerplate are merged into a target named after the example
+  const fullExamplePath = path.join(runfilesRoot, 'aio', 'content', 'examples', exampleName, exampleName);
+
+  const destPath = path.join(playgroundRoot, exampleName);
+  const nodeModules = path.join(runfilesRoot, '..', 'aio_example_deps', 'node_modules');
+
+  await constructExampleSandbox(fullExamplePath, destPath, nodeModules, localPackages);
+
+  console.log(`A playground folder for ${exampleName} has been set up at\n\n  ${destPath}\n`);
+}
+
+(async () => await main(hideBin(process.argv)))();

--- a/aio/tools/examples/example-sandbox.mjs
+++ b/aio/tools/examples/example-sandbox.mjs
@@ -1,0 +1,172 @@
+import jsonc from 'cjson';
+import fs from 'fs-extra';
+import {globbySync} from 'globby';
+import path from 'node:path';
+import os from 'node:os';
+
+// Construct a sandbox environment for an example, linking in shared example node_modules
+// and optionally linking in locally-built angular packages.
+export async function constructExampleSandbox(examplePath, destPath, nodeModulesPath, localPackages) {
+  fs.rmSync(destPath, {
+    recursive: true,
+    force: true
+  });
+  fs.copySync(examplePath, destPath);
+
+  // Remove write protection as the example was copied from bazel output tree
+  chmodSyncRec(destPath);
+
+  // Symlink shared example node_modules, substituting for locally built deps if requested
+  await constructSymlinkedNodeModules(destPath, nodeModulesPath, localPackages);
+
+  // Add preserveSymlinks fixups to various files --- needed when linkin in local deps
+  preserveSymlinksWhenUsingLocalPackages(localPackages, destPath);
+}
+
+async function constructSymlinkedNodeModules(examplePath, exampleDepsNodeModules, localPackages) {
+  const linkedNodeModules = path.resolve(examplePath, 'node_modules');
+  fs.ensureDirSync(linkedNodeModules);
+
+  await Promise.all([
+    linkExampleDeps(exampleDepsNodeModules, linkedNodeModules, localPackages),
+    linkLocalDeps(exampleDepsNodeModules, linkedNodeModules, localPackages)
+  ]);
+
+  fs.copySync(path.join(exampleDepsNodeModules, '.bin'), path.join(linkedNodeModules, '.bin'));
+  pointBinSymlinksToLocalPackages(linkedNodeModules, exampleDepsNodeModules, localPackages);
+}
+
+function linkExampleDeps(exampleDepsNodeModules, linkedNodeModules, localPackages) {
+  const exampleDepsPackages = getPackageNamesFromNodeModules(exampleDepsNodeModules);
+
+  return Promise.all(exampleDepsPackages
+    .filter(pkgName => !(pkgName in localPackages))
+    .map(pkgName => fs.ensureSymlink(
+      path.join(exampleDepsNodeModules, pkgName),
+      path.join(linkedNodeModules, pkgName), 'dir'))
+  );
+}
+
+function getPackageNamesFromNodeModules(nodeModulesPath) {
+  return globbySync([
+    '@*/*',
+    '!@*$', // Exclude a namespace folder itself
+    '(?!@)*',
+    '!.bin',
+    '!.yarn-integrity',
+    '!_*'
+  ], {
+    cwd: nodeModulesPath,
+    onlyDirectories: true,
+    dot: true
+  });
+}
+
+async function linkLocalDeps(exampleDepsNodeModules, linkedNodeModules, localPackages) {
+  const hasNpmDepForPkg = await Promise.all(Object.keys(localPackages)
+    .map(pkgName => fs.pathExists(path.join(exampleDepsNodeModules, pkgName))));
+
+  return Promise.all(Object.keys(localPackages).filter((pkgName, i) => hasNpmDepForPkg[i])
+    .map(pkgName => fs.ensureSymlinkSync(localPackages[pkgName], path.join(linkedNodeModules, pkgName), 'dir')));
+}
+
+// The .bin folder is copied over from the original yarn_install repository, so the
+// bin symlinks point there. When we link local packages in place of their npm equivalent,
+// we need to alter those symlinks to point into the local package.
+function pointBinSymlinksToLocalPackages(linkedNodeModules, exampleDepsNodeModules, localPackages) {
+  if (os.platform() === 'win32') {
+    // Bins on Windows are not symlinks; they are scripts that will invoke the bin
+    // relative to their location. The relative path will already point to the symlinked
+    // local package, so no further action is required.
+    return;
+  }
+  const allNodeModuleBins = globbySync(['**'], {
+    cwd: path.join(linkedNodeModules, '.bin'),
+    onlyFiles: true
+  });
+  allNodeModuleBins.forEach(bin => {
+    // TODO: Swapping the symlink to ngc with the local package equivalent
+    // doesn't seem to work. When ngc runs in upgrade-phonecat-2-hybrid via
+    // the build:aot yarn script, node cannot resolve @angular/compiler.
+    if (bin === 'ngc') {
+      return;
+    }
+    const symlinkTarget = fs.readlinkSync(path.join(linkedNodeModules, '.bin', bin));
+    for (const pkgName of Object.keys(localPackages)) {
+      const binMightBeInLocalPackage = symlinkTarget.includes(path.join(exampleDepsNodeModules, pkgName) + path
+      .sep);
+      if (binMightBeInLocalPackage) {
+        const pathToBinWithinPackage = symlinkTarget.substring(symlinkTarget.indexOf(pkgName) +
+          pkgName.length + path.sep.length);
+        const binExistsInLocalPackage = fs.existsSync(path.join(linkedNodeModules, pkgName,
+        pathToBinWithinPackage));
+        if (binExistsInLocalPackage) {
+          // Replace the copied bin symlink with one that points to the symlinked local package.
+          fs.rmSync(path.join(linkedNodeModules, '.bin', bin));
+          fs.ensureSymlinkSync(path.join(
+              '..',
+              pkgName,
+              pathToBinWithinPackage),
+            path.join(linkedNodeModules, '.bin', bin)
+          );
+        }
+        break;
+      }
+    }
+  });
+}
+
+// When local packages are symlinked in, node has trouble resolving some peer deps. Setting
+// preserveSymlinks in relevant files fixes this. This isn't required without local packages
+// because in the worst case we would leak into the original Bazel repository and it would
+// still find a node_modules folder for resolution. Add the preserveSymlinks options to various
+// files that are used by the cli and systemjs tests (and sometimes both).
+function preserveSymlinksWhenUsingLocalPackages(LOCAL_PACKAGES, appDir) {
+  if (Object.keys(LOCAL_PACKAGES).length === 0) {
+    return;
+  }
+
+  // Set preserveSymlinks in angular.json
+  const angularJsonPath = path.join(appDir, 'angular.json');
+  if (fs.existsSync(angularJsonPath)) {
+    const angularJson = jsonc.load(angularJsonPath, {
+      encoding: 'utf-8'
+    });
+    angularJson.projects['angular.io-example'].architect.build.options.preserveSymlinks = true;
+    fs.writeFileSync(angularJsonPath, JSON.stringify(angularJson, undefined, 2));
+  }
+
+  // Set preserveSymlinks in any tsconfig.json files
+  const tsConfigPaths = globbySync([path.join(appDir, 'tsconfig*.json')]);
+  for (const tsConfigPath of tsConfigPaths) {
+    const tsConfig = jsonc.load(tsConfigPath, {
+      encoding: 'utf-8'
+    });
+    const isRootConfig = !tsConfig.extends;
+    if (isRootConfig) {
+      tsConfig.compilerOptions.preserveSymlinks = true;
+      fs.writeFileSync(tsConfigPath, JSON.stringify(tsConfig, undefined, 2));
+    }
+  }
+
+  // Call rollup with --preserveSymlinks
+  const packageJsonPath = path.join(appDir, 'package.json');
+  const packageJson = jsonc.load(packageJsonPath, {
+    encoding: 'utf-8'
+  });
+  if ('rollup' in packageJson.dependencies || 'rollup' in packageJson.devDependencies) {
+    packageJson.scripts.rollup = 'rollup --preserveSymlinks';
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, undefined, 2));
+  }
+}
+
+function chmodSyncRec(dest) {
+  // Glob patterns always use unix-style paths
+  const allFilesPattern = path.join(dest, '**').replace(/\\/g, '/');
+
+  globbySync(allFilesPattern, {
+    dot: true,
+    onlyFiles: false
+  }).forEach(file => fs.chmodSync(file, '755'));
+  fs.chmodSync(dest, '755');
+}

--- a/packages/animations/BUILD.bazel
+++ b/packages/animations/BUILD.bazel
@@ -29,6 +29,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",
         "//packages/compiler/test:__pkg__",
@@ -66,6 +67,5 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
-        "PACKAGE.md",
-    ]),
+    ]) + ["PACKAGE.md"],
 )

--- a/packages/bazel/BUILD.bazel
+++ b/packages/bazel/BUILD.bazel
@@ -33,6 +33,7 @@ pkg_npm(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
     ],
     deps = [

--- a/packages/common/BUILD.bazel
+++ b/packages/common/BUILD.bazel
@@ -48,6 +48,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
         "//packages/bazel/test/ng_package:__pkg__",
         "//packages/compiler-cli/integrationtest:__pkg__",
@@ -92,6 +93,5 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
-        "PACKAGE.md",
-    ]),
+    ]) + ["PACKAGE.md"],
 )

--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -133,6 +133,7 @@ pkg_npm(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",
     ],

--- a/packages/compiler/BUILD.bazel
+++ b/packages/compiler/BUILD.bazel
@@ -31,6 +31,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",
         "//packages/language-service/test:__pkg__",

--- a/packages/core/BUILD.bazel
+++ b/packages/core/BUILD.bazel
@@ -62,6 +62,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
         "//packages/bazel/test/ng_package:__pkg__",
         "//packages/compiler-cli/integrationtest:__pkg__",
@@ -121,8 +122,9 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
+    ]) + [
         "PACKAGE.md",
         "global/index.ts",
         "global/PACKAGE.md",
-    ]),
+    ],
 )

--- a/packages/elements/BUILD.bazel
+++ b/packages/elements/BUILD.bazel
@@ -29,6 +29,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
     ],
     deps = [
@@ -51,6 +52,5 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
-        "PACKAGE.md",
-    ]),
+    ]) + ["PACKAGE.md"],
 )

--- a/packages/forms/BUILD.bazel
+++ b/packages/forms/BUILD.bazel
@@ -29,6 +29,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",
         "//packages/compiler-cli/test/diagnostics:__pkg__",
@@ -64,6 +65,5 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
-        "PACKAGE.md",
-    ]),
+    ]) + ["PACKAGE.md"],
 )

--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -28,6 +28,7 @@ pkg_npm(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
     ],
     deps = [

--- a/packages/platform-browser-dynamic/BUILD.bazel
+++ b/packages/platform-browser-dynamic/BUILD.bazel
@@ -33,6 +33,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",
     ],
@@ -57,6 +58,5 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
-        "PACKAGE.md",
-    ]),
+    ]) + ["PACKAGE.md"],
 )

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -39,6 +39,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",
         "//packages/compiler-cli/test:__pkg__",
@@ -65,6 +66,5 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
-        "PACKAGE.md",
-    ]),
+    ]) + ["PACKAGE.md"],
 )

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -50,6 +50,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",
     ],
@@ -75,6 +76,5 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
-        "PACKAGE.md",
-    ]),
+    ]) + ["PACKAGE.md"],
 )

--- a/packages/router/BUILD.bazel
+++ b/packages/router/BUILD.bazel
@@ -32,6 +32,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
         "//packages/compiler-cli/integrationtest:__pkg__",
         "//packages/compiler-cli/test:__pkg__",
@@ -69,6 +70,5 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
-        "PACKAGE.md",
-    ]),
+    ]) + ["PACKAGE.md"],
 )

--- a/packages/service-worker/BUILD.bazel
+++ b/packages/service-worker/BUILD.bazel
@@ -51,6 +51,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
     ],
     deps = [
@@ -74,6 +75,5 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
-        "PACKAGE.md",
-    ]),
+    ]) + ["PACKAGE.md"],
 )

--- a/packages/upgrade/BUILD.bazel
+++ b/packages/upgrade/BUILD.bazel
@@ -32,6 +32,7 @@ ng_package(
     visibility = [
         "//aio:__pkg__",
         "//aio/content/examples:__subpackages__",
+        "//aio/tools/examples:__pkg__",
         "//integration:__subpackages__",
     ],
     deps = [
@@ -56,6 +57,5 @@ filegroup(
     srcs = glob([
         "*.ts",
         "src/**/*.ts",
-        "PACKAGE.md",
-    ]),
+    ]) + ["PACKAGE.md"],
 )


### PR DESCRIPTION
@devversion @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

After the bazel migration, AIO examples are no longer fully formed in the source tree, making it hard to manually test out or run an example as you build it out.

## What is the new behavior?

The PR creates a mechanism to set up a folder in the source tree with the example, boilerplate, and linked deps for manual testing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
