### PR TITLE
build(docs-infra): upgrade cli command docs sources to 6b533b661

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 14d4d528c",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 6b533b661",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint && yarn security-lint",
     "test": "yarn check-env && ng test",
     "test:bazel": "bazelisk test //aio:test",


### PR DESCRIPTION
Updating [angular#14.2.x](https://github.com/angular/angular/tree/14.2.x) from [cli-builds#14.2.x](https://github.com/angular/cli-builds/tree/14.2.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/14d4d528c...6b533b661):

**Modified**
- help/completion.json