### PR TITLE
Adds canMatch guard to the list of available router guards

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -362,6 +362,7 @@ The following route guards are available in Angular:
 *   [`CanActivate`](api/router/CanActivate)
 *   [`CanActivateChild`](api/router/CanActivateChild)
 *   [`CanDeactivate`](api/router/CanDeactivate)
+*   [`CanMatch`](api/router/CanMatch)
 *   [`Resolve`](api/router/Resolve)
 *   [`CanLoad`](api/router/CanLoad)
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
It looks like that `canMatch` guard is missing in the list of guards on [this page](https://angular.io/guide/router#preventing-unauthorized-access)
Issue Number: N/A


## What is the new behavior?
`canMatch` has been added to the list of available router guards and added the link to the guard

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
