### PR TITLE
docs: removing http-server section in Service worker tour

### DIFF
--- a/aio/content/guide/service-worker-getting-started.md
+++ b/aio/content/guide/service-worker-getting-started.md
@@ -45,21 +45,6 @@ The CLI project is now set up to use the Angular service worker.
 This section demonstrates a service worker in action,
 using an example application.
 
-### Serving with `http-server`
-
-Because `ng serve` does not work with service workers, you must use a separate HTTP server to test your project locally.
-Use any HTTP server.
-The following example uses the [http-server](https://www.npmjs.com/package/http-server) package from npm.
-To reduce the possibility of conflicts and avoid serving stale content, test on a dedicated port and disable caching.
-
-To serve the directory containing your web files with `http-server`, run the following command:
-
-<code-example format="shell" language="shell">
-
-http-server -p 8080 -c-1 dist/&lt;project-name&gt;
-
-</code-example>
-
 ### Initial load
 
 With the server running, point your browser at `http://localhost:8080`.


### PR DESCRIPTION
- Based on issue #47583
- Updated docs for Service workers by removing the section which used http-server to use service workers with ng serve
- By changelog of v14.2.0, service workers become compatible with ng serve using [feature](https://github.com/angular/angular-cli/pull/23679)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Docs are outdated

Closes: #47583


## What is the new behavior?
Removed http-server section for service workers


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


