### PR TITLE
build(bazel): allow tag propagation on host machine

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -118,7 +118,7 @@ build:remote --remote_executor=remotebuildexecution.googleapis.com
 
 # Ensure that tags like "no-remote-exec" get propagated to actions created by rules.
 # https://bazel.build/reference/command-line-reference#flag--experimental_allow_tags_propagation
-build:remote --experimental_allow_tags_propagation
+build --experimental_allow_tags_propagation
 
 # Disable network access in the sandbox by default. To enable network access
 # for a particular target, use:


### PR DESCRIPTION
@devversion @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`tags = ["requires-network"]` doesn't get propagated on the host machine, causing one of the git dgeni filters to misbehave.


## What is the new behavior?

Tags are propagated locally.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
