### PR TITLE
refactor(router): drop own constructor from the `RouterLinkWithHref` class

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -778,7 +778,6 @@ export class RouterLinkActive implements OnChanges, OnDestroy, AfterContentInit 
 
 // @public
 export class RouterLinkWithHref extends RouterLink {
-    constructor(router: Router, route: ActivatedRoute, locationStrategy: LocationStrategy);
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<RouterLinkWithHref, "a[routerLink],area[routerLink]", never, {}, {}, never, never, true, never>;
     // (undocumented)

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1092,6 +1092,9 @@
     "name": "getFactoryDef"
   },
   {
+    "name": "getFactoryOf"
+  },
+  {
     "name": "getFirstLContainer"
   },
   {
@@ -1356,6 +1359,9 @@
     "name": "isEmptyError"
   },
   {
+    "name": "isForwardRef"
+  },
+  {
     "name": "isFunction"
   },
   {
@@ -1537,6 +1543,9 @@
   },
   {
     "name": "noMatch2"
+  },
+  {
+    "name": "noSideEffects"
   },
   {
     "name": "nodeChildrenAsMap"

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -7,7 +7,7 @@
  */
 
 import {LocationStrategy} from '@angular/common';
-import {Attribute, Directive, ElementRef, HostBinding, HostListener, inject, Input, OnChanges, OnDestroy, Renderer2, SimpleChanges, ɵcoerceToBoolean as coerceToBoolean, ɵɵsanitizeUrlOrResourceUrl} from '@angular/core';
+import {Attribute, Directive, ElementRef, HostBinding, HostListener, Input, OnChanges, OnDestroy, Renderer2, SimpleChanges, ɵcoerceToBoolean as coerceToBoolean, ɵɵsanitizeUrlOrResourceUrl} from '@angular/core';
 import {Subject, Subscription} from 'rxjs';
 
 import {Event, NavigationEnd} from '../events';
@@ -389,10 +389,4 @@ export class RouterLink implements OnChanges, OnDestroy {
   standalone: true,
 })
 export class RouterLinkWithHref extends RouterLink {
-  // For backwards compatibility, constructor arguments retained an old shape.
-  constructor(router: Router, route: ActivatedRoute, locationStrategy: LocationStrategy) {
-    super(
-        router, route, undefined /* tabIndexAttribute */, inject(Renderer2), inject(ElementRef),
-        locationStrategy);
-  }
 }


### PR DESCRIPTION
This commit updates the `RouterLinkWithHref` class to further align with the `RouterLink` class by removing own constructor from the `RouterLinkWithHref` class.

## PR Type
What kind of change does this PR introduce?
- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No, we do not officially support extending built-in directives