### PR TITLE
refactor(core): support host directives on a root component

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 455234,
+      "main": 455738,
       "polyfills": 33922,
       "styles": 73640,
       "light-theme": 78045,

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -366,6 +366,9 @@
     "name": "detectChangesInternal"
   },
   {
+    "name": "diPublicInInjector"
+  },
+  {
     "name": "empty"
   },
   {
@@ -460,6 +463,9 @@
   },
   {
     "name": "getOrCreateInjectable"
+  },
+  {
+    "name": "getOrCreateNodeInjectorForNode"
   },
   {
     "name": "getOrCreateTNode"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -435,6 +435,9 @@
     "name": "detectChangesInternal"
   },
   {
+    "name": "diPublicInInjector"
+  },
+  {
     "name": "empty"
   },
   {
@@ -541,6 +544,9 @@
   },
   {
     "name": "getOrCreateInjectable"
+  },
+  {
+    "name": "getOrCreateNodeInjectorForNode"
   },
   {
     "name": "getOrCreateTNode"


### PR DESCRIPTION
Adds support for host directives on the root component by calling `findHostDirectiveDefs` and passing the results to the relevant functions.