### PR TITLE
build(bazel): fix a bug where the esm loader did not point to node_modules in runfiles

### DIFF
--- a/tools/esm-loader/esm-loader.mjs
+++ b/tools/esm-loader/esm-loader.mjs
@@ -25,7 +25,7 @@ export async function resolve(specifier, context, defaultResolve) {
       return defaultResolve(specifier, context, defaultResolve);
     }
 
-    const runfilesRoot = path.resolve(process.env.RUNFILES, 'angular');
+    const runfilesRoot = path.resolve(process.env.RUNFILES);
     const nodeModules = path.join(runfilesRoot, process.env.NODE_MODULES_WORKSPACE_NAME, 'node_modules');
     const packageImport = parsePackageImport(specifier);
     const pathToNodeModule = path.join(nodeModules, packageImport.packageName);


### PR DESCRIPTION
@devversion @josephperrott @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

AIO targets started failing on CI due to not being able to resolve node_modules.


## What is the new behavior?

Fixed node_modules resolution in the esm patch. I didn't catch this earlier as it was passing locally (probably escaping up to node_modules in the source tree).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->