### PR TITLE
test(router): run change detection before accessing DOM in tests

### DIFF
--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -349,6 +349,7 @@ describe('standalone in Router API', () => {
       });
 
       const root = TestBed.createComponent(RootCmp);
+      root.detectChanges();
       await TestBed.inject(Router).navigateByUrl('/home');
 
       expect(root.nativeElement.innerHTML).toContain('default exported');
@@ -363,6 +364,7 @@ describe('standalone in Router API', () => {
       });
 
       const root = TestBed.createComponent(RootCmp);
+      root.detectChanges();
       await TestBed.inject(Router).navigateByUrl('/home');
 
       expect(root.nativeElement.innerHTML).toContain('default exported');


### PR DESCRIPTION
This commit updates a couple tests that started to fail as a result of merging changes in the `RouterOutlet` and adding auto-unwrapping of default imports. The `RouterOutlet` activation happens during the change detection, so we invoke `detectChanges` to trigger that and fully initialize Router outlet.

## PR Type
What kind of change does this PR introduce?

- [x] Other... Please describe: testing-related changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No