### PR TITLE
test(router): Must run change detection to render components

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -33,7 +33,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2835,
-      "main": 225808,
+      "main": 226404,
       "polyfills": 33842,
       "src_app_lazy_lazy_routes_ts": 487
     }

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -350,6 +350,7 @@ describe('standalone in Router API', () => {
 
       const root = TestBed.createComponent(RootCmp);
       await TestBed.inject(Router).navigateByUrl('/home');
+      root.detectChanges();
 
       expect(root.nativeElement.innerHTML).toContain('default exported');
     });
@@ -364,6 +365,7 @@ describe('standalone in Router API', () => {
 
       const root = TestBed.createComponent(RootCmp);
       await TestBed.inject(Router).navigateByUrl('/home');
+      root.detectChanges();
 
       expect(root.nativeElement.innerHTML).toContain('default exported');
     });


### PR DESCRIPTION
Due to
https://github.com/angular/angular/commit/c3f857975d56cac6ad3939d64f76a51455159c23, the create block of routed components will not execute until change detection runs if the outlet is not yet initiailized.
