### PR TITLE
refactor(compiler): Add `getPotentialImportsFor` method on template type checker

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -14,7 +14,7 @@ import {ErrorCode} from '../../diagnostics';
 
 import {FullTemplateMapping, NgTemplateDiagnostic, TypeCheckableDirectiveMeta} from './api';
 import {GlobalCompletion} from './completion';
-import {PotentialDirective, PotentialPipe} from './scope';
+import {PotentialDirective, PotentialImport, PotentialPipe} from './scope';
 import {ElementSymbol, Symbol, TcbLocation, TemplateSymbol} from './symbols';
 
 /**
@@ -145,6 +145,12 @@ export interface TemplateTypeChecker {
    * the DOM schema.
    */
   getPotentialElementTags(component: ts.ClassDeclaration): Map<string, PotentialDirective|null>;
+
+  /**
+   * In the context of an Angular trait, generate potential imports for a directive.
+   */
+  getPotentialImportsFor(directive: PotentialDirective, inComponent: ts.ClassDeclaration):
+      ReadonlyArray<PotentialImport>;
 
   /**
    * Get the primary decorator for an Angular class (such as @Component). This does not work for

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -13,6 +13,24 @@ import {ClassDeclaration} from '../../reflection';
 import {SymbolWithValueDeclaration} from '../../util/src/typescript';
 
 /**
+ * A PotentialImport for some Angular trait has a TypeScript module specifier, which can be
+ * relative, as well as an identifier name.
+ */
+export interface PotentialImport {
+  kind: PotentialImportKind;
+  moduleSpecifier: string;
+  symbolName: string;
+}
+
+/**
+ * Which kind of Angular Trait the import targets.
+ */
+export enum PotentialImportKind {
+  NgModule,
+  Standalone,
+}
+
+/**
  * Metadata on a directive which is available in a template.
  */
 export interface PotentialDirective {


### PR DESCRIPTION
`getPotentialImportsFor` returns an array of possible imports, including TypeScript module specifier and identifier name, for a requested trait in the context of a given component.

Previous PRs in this sequence: https://github.com/angular/angular/pull/47181, https://github.com/angular/angular/pull/47180, https://github.com/angular/angular/pull/47166, https://github.com/angular/angular/pull/47561