### PR TITLE
fix(compiler-cli): use @ts-ignore.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/host.ts
@@ -68,7 +68,7 @@ export class DelegatingCompilerHost implements
   useCaseSensitiveFileNames = this.delegateMethod('useCaseSensitiveFileNames');
   writeFile = this.delegateMethod('writeFile');
   getModuleResolutionCache = this.delegateMethod('getModuleResolutionCache');
-  // @ts-expect-error 'hasInvalidatedResolutions' is visible (and thus required here) in latest TSC
+  // @ts-ignore 'hasInvalidatedResolutions' is visible (and thus required here) in latest TSC
   // main. It's already present, so the code works at runtime.
   // TODO: remove this comment including the suppression once Angular uses a TSC version that
   // includes this change (github.com/microsoft/TypeScript@a455955).

--- a/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
+++ b/packages/compiler-cli/src/ngtsc/program_driver/src/ts_create_program_driver.ts
@@ -52,7 +52,7 @@ export class DelegatingCompilerHost implements
   trace = this.delegateMethod('trace');
   useCaseSensitiveFileNames = this.delegateMethod('useCaseSensitiveFileNames');
   getModuleResolutionCache = this.delegateMethod('getModuleResolutionCache');
-  // @ts-expect-error 'hasInvalidatedResolutions' is visible (and thus required here) in latest TSC
+  // @ts-ignore 'hasInvalidatedResolutions' is visible (and thus required here) in latest TSC
   // main. It's already present, so the code works at runtime.
   // TODO: remove this comment including the suppression once Angular uses a TSC version that
   // includes this change (github.com/microsoft/TypeScript@a455955).


### PR DESCRIPTION
The previous commit 2e1dddec45 used `@ts-expect-error` to suppress the current error, with the intent of being informed once that's no longer an error, ie. when we updated to an upstream TS version that includes this change.

However this unfortunately means the change is incompatible with the fixed version, which prevents it from working with an updated TS version in google3.

This change reverts back to the original `@ts-ignore` which is forwards and backwards compatible, avoiding that problem (but unfortunately losing the benefit of being notified once fixed).

This is a follow up to PR #47585.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

## PR Type

- [x] Bugfix

## What is the current behavior?

See above.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
