### PR TITLE
docs: release notes for the v14.2.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="14.2.5"></a>
+# 14.2.5 (2022-10-05)
+## Special Thanks
+Alexander Wiebe, Ciprian Sauliuc, Dmytro Mezhenskyi, George Kalpakas, Joe Martin (Crowdstaffing), Jordan, Ole M, Paul Gschwendtner, Pawel Kozlowski and mgechev
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="15.0.0-next.4"></a>
 # 15.0.0-next.4 (2022-09-28)
 ## Breaking Changes


### PR DESCRIPTION
Cherry-picks the changelog from the "14.2.x" branch to the next branch (main).