### PR TITLE
refactor(forms): change access modifier of _calculateStatus to protected

### DIFF
--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -1288,7 +1288,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   }
 
 
-  private _calculateStatus(): FormControlStatus {
+  protected _calculateStatus(): FormControlStatus {
     if (this._allControlsDisabled()) return DISABLED;
     if (this.errors) return INVALID;
     if (this._hasOwnPendingAsyncValidator || this._anyControlsHaveStatus(PENDING)) return PENDING;


### PR DESCRIPTION
Change the access modifier of the _calculateStatus method in AbstractControl to protected, so the forms systems extending the Angular Forms can override the way validity is calculated. Example use case: A form group is valid, even if some of its controls are invalid, but all nested values are empty ({}, [], '', undefined, null). Currently, it can be done by suppressing typescript warnings with @ts-ignore.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently the validity calculation cannot be overriden by classes extending AbstractControl.

## What is the new behavior?

Validity calculation can be overriden by classes extending AbstractControl to cover non-standard validation use cases, for example disregarding validation in nested forms, as long as the value is empty (containing only {}, [], '', undefined, null or more empty values).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
