### PR TITLE
docs: add lifecycle-hooks-example topic

### DIFF
--- a/aio/content/guide/lifecycle-hook/lifecycle-hook-example.md
+++ b/aio/content/guide/lifecycle-hook/lifecycle-hook-example.md
@@ -1,9 +1,365 @@
-#
+
+# Example: lifecycle hook methods
+
+## Lifecycle example set
+
+<div class="alert is-helpful">
+
+<!-- To view or download the example code used in the following sections, see [Example Angular component applications][AioGuideComponentExample]. -->
+
+</div>
+
+The following table lists the exercises with brief descriptions.
+The sample code is also used to illustrate specific tasks in the following sections.
+
+| Component                                                                                | Details |
+|:---                                                                                      |:---     |
+| [Peek-a-boo][AioGuideComponentExampleLifecycleSequenceAndFrequencyOfAllLifecycleEvents] | Demonstrates every lifecycle hook. Each hook method writes to the on-screen log.                                                                                                                                                              |
+| [Spy][AioGuideComponentExampleLifecycleUseDirectivesToWatchTheDom]                      | Shows how to use lifecycle hook methods with a custom directive. The `SpyDirective` directive implements the `ngOnInit` and `ngOnDestroy` lifecycle hook methods. The lifecycle hook methods watch and report when an element goes in or out of the current view. |
+| [OnChanges][AioGuideComponentExampleLifecycleUseChangeDetectionHooks]                   | Demonstrates how the Angular framework runs the `ngOnChanges` lifecycle hook method every time one of the component input properties changes, and shows how to interpret the `changes` object passed to the lifecycle hook method.                                         |
+| [DoCheck][AioGuideComponentExampleLifecycleDefineCustomChangeDetection]                 | Implements the `ngDoCheck` lifecycle hook method with custom change detection. Watch the hook post changes to a log to see how often the Angular framework runs this hook.                                                                                       |
+| [AfterView][AioGuideComponentExampleLifecycleRespondToViewChanges]                      | Shows what the Angular framework means by a [view][AioGuideGlossaryView]. Demonstrates the `ngAfterViewInit` and `ngAfterViewChecked` lifecycle hook methods.                                                                                                  |
+| [AfterContent][AioGuideComponentExampleLifecycleRespondToProjectedContentChanges]       | Shows how to project external content into a component and how to distinguish projected content from a component's view children. Demonstrates the `ngAfterContentInit` and `ngAfterContentChecked` lifecycle hook methods.                      |
+| [Counter][AioGuideComponentExampleLifecycleUseComponentAndDirectiveHooksTogether]       | Demonstrates a combination of a component and a directive, each with an associated set of lifecycle hook methods.                                                                                                                                    |
+
+## General examples
+
+The following examples show the request sequence.
+The examples also show the following information.
+
+*   The relative frequency of the various lifecycle events
+*   Usage patterns for the lifecycle hook methods separately in combination with components and directives.
+
+### Sequence and frequency of all lifecycle events
+
+To show how Angular runs the hooks in the expected order, the `PeekABooComponent` component demonstrates all lifecycle hook methods in one component.
+
+In practice, you rarely create and use all interfaces to described in the Lifecycle Hook methods demo.
+
+The following screen capture shows the state of the log after the user selects the buttons that start with `Create` and `Destroy`.
+
+<div class="lightbox">
+
+<img alt="Peek-a-boo" src="generated/images/guide/lifecycle-hooks/peek-a-boo.png">
+
+</div>
+
+The sequence of log messages for the interfaces follows the prescribed lifecycle hook method run order.
+
+<code-example format="none" header="Lifecycle hook method sequence: Detect changes when data-bound input is used" hideCopy language="none">
+
+OnChanges &rarr; OnInit &rarr; DoCheck &rarr; AfterContentInit
+  &rarr; AfterContentChecked &rarr; AfterViewInit &rarr; AfterViewChecked
+
+  &rarr; OnChanges &rarr; DoCheck &rarr; AfterContentChecked &rarr; AfterViewChecked
+
+  &rarr; OnChanges &rarr; DoCheck &rarr; AfterContentChecked &rarr; AfterViewChecked
+
+  &rarr; &hellip;
+
+  &rarr; OnDestroy
+
+</code-example>
+
+<code-tabs>
+    <code-pane header="peek-a-boo-parent.component.ts">import { Component } from '&commat;angular/core'; &NewLine; &NewLine;import { LoggerService } from './logger.service'; &NewLine; &NewLine;&commat;Component({ &NewLine; &nbsp;selector: 'peek-a-boo-parent', &NewLine; &nbsp;template: &grave; &NewLine; &nbsp;&lt;hr /&gt; &NewLine; &nbsp;&lt;div class="parent"&gt; &NewLine; &nbsp; &nbsp;&lt;h2&gt;Peek-A-Boo&lt;/h2&gt; &NewLine; &NewLine; &nbsp; &nbsp;&lt;button type="button" (click)="toggleChild()"&gt; &NewLine; &nbsp; &nbsp; &nbsp;{{hasChild ? 'Destroy' : 'Create'}} PeekABooComponent &NewLine; &nbsp; &nbsp;&lt;/button&gt; &NewLine; &nbsp; &nbsp;&lt;button type="button" (click)="updateHero()" [hidden]="!hasChild"&gt;Update Hero&lt;/button&gt; &NewLine; &NewLine; &nbsp; &nbsp;&lt;div class="info"&gt; &NewLine; &nbsp; &nbsp; &nbsp;&lt;peek-a-boo *ngIf="hasChild" [name]="heroName"&gt;&lt;/peek-a-boo&gt; &NewLine; &NewLine; &nbsp; &nbsp; &nbsp;&lt;h3&gt;Lifecycle Hook Log&lt;/h3&gt; &NewLine; &nbsp; &nbsp; &nbsp;&lt;div *ngFor="let msg of hookLog" class="log"&gt;{{msg}}&lt;/div&gt; &NewLine; &nbsp; &nbsp;&lt;/div&gt; &NewLine; &nbsp;&lt;/div&gt; &NewLine; &nbsp;&grave;, &NewLine; &nbsp;providers:  [ LoggerService ] &NewLine;}) &NewLine;export class PeekABooParentComponent { &NewLine; &NewLine; &nbsp;hasChild = false; &NewLine; &nbsp;hookLog: string[] = []; &NewLine; &NewLine; &nbsp;heroName = 'Windstorm'; &NewLine; &nbsp;private logger: LoggerService; &NewLine; &NewLine; &nbsp;constructor(logger: LoggerService) { &NewLine; &nbsp; &nbsp;this.logger = logger; &NewLine; &nbsp; &nbsp;this.hookLog = logger.logs; &NewLine; &nbsp;} &NewLine; &NewLine; &nbsp;toggleChild() { &NewLine; &nbsp; &nbsp;this.hasChild = !this.hasChild; &NewLine; &nbsp; &nbsp;if (this.hasChild) { &NewLine; &nbsp; &nbsp; &nbsp;this.heroName = 'Windstorm'; &NewLine; &nbsp; &nbsp; &nbsp;this.logger.clear(); // clear log on create &NewLine; &nbsp; &nbsp;} &NewLine; &nbsp; &nbsp;this.hookLog = this.logger.logs; &NewLine; &nbsp; &nbsp;this.logger.tick(); &NewLine; &nbsp;} &NewLine; &NewLine; &nbsp;updateHero() { &NewLine; &nbsp; &nbsp;this.heroName += '!'; &NewLine; &nbsp; &nbsp;this.logger.tick(); &NewLine; &nbsp;} &NewLine;} </code-pane>
+    <code-pane header="peek-a-boo.component.ts">import { &NewLine; &nbsp;AfterContentChecked, &NewLine; &nbsp;AfterContentInit, &NewLine; &nbsp;AfterViewChecked, &NewLine; &nbsp;AfterViewInit, &NewLine; &nbsp;Component, &NewLine; &nbsp;DoCheck, &NewLine; &nbsp;Input, &NewLine; &nbsp;OnChanges, &NewLine; &nbsp;OnDestroy, &NewLine; &nbsp;OnInit, &NewLine; &nbsp;SimpleChanges &NewLine;} from '&commat;angular/core'; &NewLine; &NewLine;import { LoggerService } from './logger.service'; &NewLine;import { PeekABooDirective } from './peek-a-boo.directive'; &NewLine; &NewLine;&commat;Component({ &NewLine; &nbsp;selector: 'peek-a-boo', &NewLine; &nbsp;template: '&lt;p&gt;Now you see my hero, {{name}}&lt;/p&gt;' &NewLine;}) &NewLine;// Don't have to mention the interfaces for Lifecycle Hook methods &NewLine;// unless you want to type and tool support. &NewLine;export class PeekABooComponent extends PeekABooDirective implements &NewLine; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; OnChanges, OnInit, DoCheck, &NewLine; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; AfterContentInit, AfterContentChecked, &NewLine; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; AfterViewInit, AfterViewChecked, &NewLine; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; OnDestroy { &NewLine; &nbsp;&commat;Input() name = ''; &NewLine; &NewLine; &nbsp;private verb = 'initialized'; &NewLine; &NewLine; &nbsp;constructor(logger: LoggerService) { &NewLine; &nbsp; &nbsp;super(logger); &NewLine; &NewLine; &nbsp; &nbsp;const is = this.name ? 'is' : 'is not'; &NewLine; &nbsp; &nbsp;this.logIt(&grave;name &dollar;{is} known at construction&grave;); &NewLine; &nbsp;} &NewLine; &NewLine; &nbsp;// only run when there an &grave;&commat;input&grave; variable is set by parent. &NewLine; &nbsp;ngOnChanges(changes: SimpleChanges) { &NewLine; &nbsp; &nbsp;const changesMsgs: string[] = []; &NewLine; &nbsp; &nbsp;for (const propName in changes) { &NewLine; &nbsp; &nbsp; &nbsp;if (propName === 'name') { &NewLine; &nbsp; &nbsp; &nbsp; &nbsp;const name = changes['name'].currentValue; &NewLine; &nbsp; &nbsp; &nbsp; &nbsp;changesMsgs.push(&grave;name &dollar;{this.verb} to "&dollar;{name}"&grave;); &NewLine; &nbsp; &nbsp; &nbsp;} else { &NewLine; &nbsp; &nbsp; &nbsp; &nbsp;changesMsgs.push(propName + ' ' + this.verb); &NewLine; &nbsp; &nbsp; &nbsp;} &NewLine; &nbsp; &nbsp;} &NewLine; &nbsp; &nbsp;this.logIt(&grave;OnChanges: &dollar;{changesMsgs.join('; ')}&grave;); &NewLine; &nbsp; &nbsp;this.verb = 'changed'; // next time it is a change &NewLine; &nbsp;} &NewLine; &NewLine; &nbsp;// **WARNING**: Frequently run. &NewLine; &nbsp;// Run in every change detection cycle to the rendered DOM structure &NewLine; &nbsp;ngDoCheck() { this.logIt('DoCheck'); } &NewLine; &NewLine; &nbsp;ngAfterContentInit() { this.logIt('AfterContentInit'); } &NewLine; &NewLine; &nbsp;// **WARNING**: Frequently run. &NewLine; &nbsp;// Run in every change detection cycle to the rendered DOM structure &NewLine; &nbsp;ngAfterContentChecked() { this.logIt('AfterContentChecked'); } &NewLine; &NewLine; &nbsp;ngAfterViewInit() { this.logIt('AfterViewInit'); } &NewLine; &NewLine; &nbsp;// **WARNING**: Frequently run. &NewLine; &nbsp;// Run in every change detection cycle to the rendered DOM structure &NewLine; &nbsp;ngAfterViewChecked() { this.logIt('AfterViewChecked'); } &NewLine; &NewLine; &nbsp;ngOnDestroy() { this.logIt('OnDestroy'); } &NewLine;} </code-pane>
+    <code-pane header="peek-a-boo.directive.ts">import { Directive, OnInit } from '&commat;angular/core';&NewLine;import { LoggerService } from './logger.service';&NewLine; &NewLine;let nextId = 1;&NewLine; &NewLine;&commat;Directive({ &NewLine; &nbsp;selector: '[appPeekABoo]' &NewLine;}) &NewLine;export class PeekABooDirective implements OnInit { &NewLine; &nbsp;constructor(private logger: LoggerService) { } &NewLine; &NewLine; &nbsp;// implement OnInit's &grave;ngOnInit&grave; method &NewLine; &nbsp;ngOnInit() { &NewLine; &nbsp; &nbsp;this.logIt('OnInit'); &NewLine; &nbsp;} &NewLine; &NewLine; &nbsp;logIt(msg: string) { &NewLine; &nbsp; &nbsp;this.logger.log(&grave;#&dollar;{nextId++} &dollar;{msg}&grave;); &NewLine; &nbsp;} &NewLine;} </code-pane>
+</code-tabs>
+
+<div class="alert is-helpful">
+
+**NOTE**: <br />
+The log confirms that input properties \(the `name` property in this case\) have no assigned values at construction.
+The input properties are available to the `onInit` lifecycle hook method for further initialization.
+
+</div>
+
+Had the user selected the **Update Hero** button, the log would show another `OnChanges` interface and two more triplets of the `DoCheck`, `AfterContentChecked`, and `AfterViewChecked` interfaces.
+
+<div class="alert is-important">
+
+**IMPORTANT**: <br />
+The three lifecycle hook methods run often, so keep your logic as lean.
+
+</div>
+
+### Use directives to watch the DOM
+
+The `Spy` example demonstrates how to use the lifecycle hook method for directives as well as components.
+The `SpyDirective`  directive discovers when a watched element is in the current view.
+It implements the `ngOnInit` and `ngOnDestroy` lifecycle hook methods.
+
+This HTML template applies the `SpyDirective` to a `div` element in the `ngFor` repeater managed by the parent `SpyComponent`.
+
+The example does not perform any initialization or clean-up.
+It just tracks the appearance and disappearance of an element in the view by recording when the directive is instantiated and destroyed.
+
+A spy directive like this can provide insight into a DOM object that you are not able to change directly.
+You are not able to change the implementation of a built-in `div` element, or change a third-party component.
+You are able to watch the elements with a directive.
+
+The directive defines the `ngOnInit` and `ngOnDestroy` lifecycle hook methods that log messages to the parent using an injected `LoggerService` service.
+
+<code-example header="src/app/spy.directive.ts" path="lifecycle-hooks/src/app/spy.directive.ts" region="spy-directive"></code-example>
+
+Apply the spy to any built-in or component element.
+Verify that the spy is initialized and destroyed at the same time as that element.
+The following code example shows the spy is attached to the repeated hero `div` element.
+
+<code-example header="src/app/spy.component.html" path="lifecycle-hooks/src/app/spy.component.html" region="template"></code-example>
+
+The creation and destruction of each spy marks the appearance and disappearance of the attached hero `div` element with an entry in the *Hook Log*.
+Adding a hero results in a new hero `div` element.
+The `ngOnInit` lifecycle hook method of the spy logs that event.
+
+The **Reset** button clears the `heroes` list.
+Angular removes all hero `div` elements from the DOM and destroys the associated spy directives at the same time.
+The `ngOnDestroy` lifecycle hook method of the spy reports any last moments.
+
+### Use component and directive hooks together
+
+In this example, a `CounterComponent` component uses the `ngOnChanges` lifecycle hook method to log a change every time the parent component increments the associated `counter` input property.
+
+This example applies the `SpyDirective` directive from the previous example to the `CounterComponent` component log, to watch the creation and destruction of log entries.
+
+## Use change detection hooks
+
+Angular runs the `ngOnChanges` lifecycle hook method of a component or directive whenever it detects changes to the  **input properties**.
+The example for the `onChanges` interface demonstrates this by monitoring the `OnChanges` lifecycle hook method.
+
+<code-example header="on-changes.component.ts (excerpt)" path="lifecycle-hooks/src/app/on-changes.component.ts" region="ng-on-changes"></code-example>
+
+The `ngOnChanges` lifecycle hook method takes an object that maps each changed property name to a [SimpleChange][AioApiCoreSimplechange] object holding the current and previous property values.
+This hook iterates over the changed properties and logs them.
+
+In the following code example, the `OnChangesComponent` component has the `hero` and `power` input properties.
+
+<code-example header="src/app/on-changes.component.ts" path="lifecycle-hooks/src/app/on-changes.component.ts" region="inputs"></code-example>
+
+In the following code example, the `OnChangesParentComponent` host component binds to the input properties.
+
+<code-example header="src/app/on-changes-parent.component.html" path="lifecycle-hooks/src/app/on-changes-parent.component.html" region="on-changes"></code-example>
+
+The following image shows the user changes in action.
+
+<div class="lightbox">
+
+<img alt="OnChanges" src="generated/images/guide/lifecycle-hooks/on-changes-anim.gif">
+
+</div>
+
+The log entries appear as the string value of the *power* property changes.
+
+<div class="alert is-helpful">
+
+**IMPORTANT**: <br />
+The `ngOnChanges` lifecycle hook method does not catch changes to `hero.name`.
+
+</div>
+
+This is because Angular only runs the lifecycle hook method when the value of the input property changes.
+In this case, `hero` is the input property, and the value of the `hero` property is the *reference to the hero object*.
+The object reference did not change when the value changed for the associated `name` property.
+
+### Respond to view changes
+
+The Angular framework traverses the [view hierarchy][AioGuideGlossaryViewHierarchy] during change detection.
+The Angular framework must verify that a change in a child component does not cause a change in the associated parent component.
+A change caused by a child component is not properly rendered due to the nature of [unidirectional data flow][AioGuideGlossaryUnidirectionalDataFlow].
+
+To make a change that inverts the expected data flow, you must trigger a new change detection cycle.
+The new change detection cycle allows a change in a child component to render in DOM structure of the associated parent component.
+
+The examples illustrate how to make such changes safely.
+
+The "AfterView" sample explores the `ngAfterViewInit` and `ngAfterViewChecked` lifecycle hook methods that Angular runs *after* it creates a component's child views.
+
+The following code example shows a child view that displays the name of a hero in an `input` element.
+
+<code-example header="ChildViewComponent" path="lifecycle-hooks/src/app/child-view.component.ts" region="child-view"></code-example>
+
+The following code example shows the `AfterViewComponent` component displays the child view within the associated template.
+
+<code-example header="AfterViewComponent (template)" path="lifecycle-hooks/src/app/after-view.component.ts" region="template"></code-example>
+
+The following lifecycle hook methods take action based on changes to values in the HTML template and rendered DOM structure of the child component.
+Access the values in the HTML template and rendered DOM structure of the child component using the property decorated with [@ViewChild][AioApiCoreViewchild].
+
+<code-example header="AfterViewComponent (class excerpts)" path="lifecycle-hooks/src/app/after-view.component.ts" region="hooks"></code-example>
+
+#### Wait before updating the view
+
+In this example, the `doSomething` method updates the screen when the hero name exceeds 10 characters, but waits a tick before updating `comment`.
+
+<code-example header="AfterViewComponent (doSomething)" path="lifecycle-hooks/src/app/after-view.component.ts" region="do-something"></code-example>
+
+Both the `ngAfterViewInit` and `ngAfterViewChecked` lifecycle hook methods fire after the view of the component is composed.
+If you change the lifecycle hook method to immediately update the data-bound `comment` property of the component, Angular throws an error.
+
+The `LoggerService.tick_then()` statement postpones the log update for one turn of the JavaScript cycle of the browser, which triggers a new change-detection cycle.
+
+#### Write lean lifecycle hook methods to avoid performance problems
+
+When you run the *AfterView* sample, notice how frequently Angular runs the `ngAfterViewChecked` lifecycle hook method.
+Often when there are no changes of interest.
+Be careful about how much logic or computation you put into one of these methods.
+
+<div class="lightbox">
+
+<img alt="AfterView" src="generated/images/guide/lifecycle-hooks/after-view-anim.gif">
+
+</div>
+
+### Respond to projected content changes
+
+Content projection is a way to complete the following actions.
+
+1.  Import HTML content from outside the component.
+1.  Insert the imported content into a designated spot in the HTML template of the component.
+
+Identify content projection in a template by looking for the following constructs.
+
+*   HTML between component elements
+*   The presence of instance of the `ng-content` element in the HTML template of the component
+
+<div class="alert is-helpful">
+
+**NOTE**: <br />
+For AngularJS only.
+Content projection was formerly referenced as *transclusion*.
+
+</div>
+
+The example for the `AfterContent` interface explores the `AfterContentInit` and `AfterContentChecked` lifecycle hook methods.
+The Angular framework runs the `AfterContentInit` and `AfterContentChecked` lifecycle hook methods after it projects external content into the component.
+
+Consider this variation on the ["AfterView"][AioGuideComponentExampleLifecycleRespondToViewChanges] example.
+This time, instead of including the child view within the template, it imports the content from the parent of the `AfterContentComponent` component.
+The following is the template of the parent.
+
+<code-example header="AfterContentParentComponent (template excerpt)" path="lifecycle-hooks/src/app/after-content-parent.component.ts" region="parent-template"></code-example>
+
+<div class="alert is-helpful">
+
+**NOTE**: <br />
+The `app-child` element is tucked between the `after-content` elements.
+
+</div>
+
+Only place content that you intend to project content into the component between the element tags of a component.
+
+In the following code example, review the template of the component.
+
+<code-example header="AfterContentComponent (template)" path="lifecycle-hooks/src/app/after-content.component.ts" region="template"></code-example>
+
+The `ng-content` element is a placeholder for the external content.
+
+It tells Angular where to insert that content.
+
+In this case, the projected content is the `app-child` element from the parent.
+
+<div class="lightbox">
+
+<img alt="Projected Content" src="generated/images/guide/lifecycle-hooks/projected-child-view.png">
+
+</div>
+
+#### Use `AfterContent` hooks
+
+The following lifecycle hook methods are similar.
+
+*   The lifecycle hook methods that start with `AfterContent`
+*   The lifecycle hook methods that start with `AfterView`
+
+The key difference is which child component that is targeted.
+
+*   The lifecycle hook methods that start with `AfterContent` concern `ContentChildren`.
+    The `ContentChildren` are the child components projected into the component.
+
+*   The lifecycle hook methods that start with `AfterView` concern `ViewChildren`.
+    The `ViewChildren` are the child components associated with the elements located in the HTML template of the component
+
+In the following code example, the Angular framework uses the `ngAfterContentInit` and `ngAfterContentChecked` lifecycle hook methods to take action based on changes to values in a child component.
+The Angular framework only accesses the child component using the property decorated with [@ContentChild][AioApiCoreContentchild].
+
+<code-example header="AfterContentComponent (class excerpts)" path="lifecycle-hooks/src/app/after-content.component.ts" region="hooks"></code-example>
+
+<div class="alert is-helpful">
+
+<header>No need to wait for content updates</header>
+
+The `doSomething` method immediately updates the `comment` data-bound property.
+The `doSomething` method is specified in the `AfterContentComponent` component.
+You do not need to [delay the update to ensure proper rendering][AioGuideComponentExampleLifecycleWaitBeforeUpdatingTheView].
+
+Angular runs both `AfterContent` lifecycle hook methods before running either of the `AfterView` lifecycle hook methods.
+Angular completes composition of the projected content *before* finishing the composition of the view of this component.
+A small window exists between the lifecycle hook methods that begin with `AfterContent` and `AfterView` that allows you change the rendered DOM structure of the host.
+
+</div>
+
+## Define custom change detection
+
+To show the changes that occur where `ngOnChanges` lifecycle hook method does not check, create and use your change checker, as shown in the "DoCheck" example.
+This example shows how to use the `ngDoCheck` lifecycle hook method to detect and act upon changes that Angular does not otherwise catch.
+
+The following code example shows the "DoCheck" sample extends the "OnChanges" sample with the `ngDoCheck` lifecycle hook method.
+
+<code-example header="DoCheckComponent (ngDoCheck)" path="lifecycle-hooks/src/app/do-check.component.ts" region="ng-do-check"></code-example>
+
+The code completes the following actions.
+
+1.  Inspects specific values of interest.
+1.  Captures the associated current state.
+1.  Compares the associated current state against previous values.
+
+The Angular framework writes a special message to the log when there are no substantive changes to the `hero` or the `power`, so you are able to see how often your application runs the `ngDoCheck` lifecycle hook method.
+The results are illuminating.
+
+<div class="lightbox">
+
+<img alt="DoCheck" src="generated/images/guide/lifecycle-hooks/do-check-anim.gif">
+
+</div>
+
+While the `ngDoCheck` lifecycle hook method is able to detect when the `name` of the hero has changed, the lifecycle hook method is resource intensive.
+The lifecycle hook method is run frequently after every change detection cycle regardless of where the change occurred.
+The lifecycle hook method is run over twenty times in the example before the user is able to do anything.
+
+The first rendering in Angular of unrelated data on the page triggers most of the initial checks.
+If you move the cursor into another `input` element, a request is triggered.
+Relatively few requests reveal actual changes to pertinent data.
+If you use this hook, your implementation must be extremely lightweight or the user experience suffers.
 
 <!-- links -->
+
+[AioApiCoreContentchild]: api/core/ContentChild "ContentChild | @angular/core - API | Angular"
+
+[AioApiCoreSimplechange]: api/core/SimpleChange "SimpleChange | @angular/core - API | Angular"
+
+[AioApiCoreViewchild]: api/core/ViewChild "ViewChild | @angular/core - API | Angular"
+
+<!-- [AioGuideComponentExample]: guide/component/component-example "Example Angular component applications | Angular" -->
+
+[AioGuideComponentExampleLifecycleDefineCustomChangeDetection]: #define-custom-change-detection "Define custom change detection - Example: lifecycle hook methods | Angular"
+
+[AioGuideComponentExampleLifecycleRespondToViewChanges]: #respond-to-view-changes "Respond to view changes - Example: lifecycle hook methods | Angular"
+[AioGuideComponentExampleLifecycleRespondToProjectedContentChanges]: #respond-to-projected-content-changes "Respond to projected content changes - Example: lifecycle hook methods | Angular"
+[AioGuideComponentExampleLifecycleSequenceAndFrequencyOfAllLifecycleEvents]: #sequence-and-frequency-of-all-lifecycle-events "Sequence and frequency of all lifecycle events - Example: lifecycle hook methods | Angular"
+[AioGuideComponentExampleLifecycleUseComponentAndDirectiveHooksTogether]: #use-component-and-directive-hooks-together "Use component and directive hooks together - Example: lifecycle hook methods | Angular"
+[AioGuideComponentExampleLifecycleUseDirectivesToWatchTheDom]: #use-directives-to-watch-the-dom "Use directives to watch the DOM - Example: lifecycle hook methods | Angular"
+[AioGuideComponentExampleLifecycleUseChangeDetectionHooks]: #use-change-detection-hooks "Use change detection hooks - Example: lifecycle hook methods | Angular"
+[AioGuideComponentExampleLifecycleWaitBeforeUpdatingTheView]: #wait-before-updating-the-view "Wait before updating the view - Example: lifecycle hook methods | Angular"
+
+[AioGuideGlossaryUnidirectionalDataFlow]: guide/glossary#unidirectional-data-flow "unidirectional data flow - Glossary | Angular"
+
+[AioGuideGlossaryView]: guide/glossary#view "view - Glossary | Angular"
+
+[AioGuideGlossaryViewHierarchy]: guide/glossary#view-hierarchy "view hierarchy - Glossary | Angular"
 
 <!-- external links -->
 
 <!-- end links -->
 
-@reviewed 2022-08-22
+@reviewed 2022-09-02


### PR DESCRIPTION
Add content to lifecycle-hooks-example topic.

This PR represents the one of many PRs to reorganize the component content.
The interim PRs will add content that is not visible in the left-nav TOC.
The final PR will add the topics to the left-nav TOC and retire the old, existing topics.

The following branches each focus on a set of changes to follow this PR.

| Branch                                         | changes |
|:---                                            |:---     |
| ~~componentUpdateLifecycleHooksBreakOut2022aug22~~ | Empty files for lifecycle-hook directory |
| componentUpdateLifecycleHooksMoveOne2022sep02      | Add lifecycle-hook-use |
| componentUpdateLifecycleHooksMoveTwo2022sep02      | Add lifecycle-hook-example |
