### PR TITLE
refactor(compiler-cli): use mkdirSync recursive option instead of custom implementation

### DIFF
--- a/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
+++ b/packages/compiler-cli/src/ngtsc/file_system/src/node_js_file_system.ts
@@ -123,29 +123,10 @@ export class NodeJSFileSystem extends NodeJSReadonlyFileSystem implements FileSy
     fs.renameSync(from, to);
   }
   ensureDir(path: AbsoluteFsPath): void {
-    const parents: AbsoluteFsPath[] = [];
-    while (!this.isRoot(path) && !this.exists(path)) {
-      parents.push(path);
-      path = this.dirname(path);
-    }
-    while (parents.length) {
-      this.safeMkdir(parents.pop()!);
-    }
+    fs.mkdirSync(path, {recursive: true});
   }
   removeDeep(path: AbsoluteFsPath): void {
     fs.rmdirSync(path, {recursive: true});
-  }
-
-  private safeMkdir(path: AbsoluteFsPath): void {
-    try {
-      fs.mkdirSync(path);
-    } catch (err) {
-      // Ignore the error, if the path already exists and points to a directory.
-      // Re-throw otherwise.
-      if (!this.exists(path) || !this.stat(path).isDirectory()) {
-        throw err;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
The supported Node.js versions for the `@angular/compiler-cli` package (^14.15.0 || >=16.10.0) allow for the use of the `recursive` option of `mkdirSync`.  Using the `recursive` option removes the need to manually create each subdirectory in a given path.