### PR TITLE
refactor(docs-infra): add new Input for better description of close button in notification component

### DIFF
--- a/aio/src/app/layout/notification/notification.component.html
+++ b/aio/src/app/layout/notification/notification.component.html
@@ -2,6 +2,6 @@
   <ng-content></ng-content>
 </span>
 
-<button mat-icon-button class="close-button" aria-label="Dismiss notification" (click)="dismiss()">
+<button mat-icon-button class="close-button" [attr.aria-label]="'Close' + bannerNotficationDescription" (click)="dismiss()">
   <mat-icon svgIcon="close"></mat-icon>
 </button>

--- a/aio/src/app/layout/notification/notification.component.ts
+++ b/aio/src/app/layout/notification/notification.component.ts
@@ -21,6 +21,7 @@ const LOCAL_STORAGE_NAMESPACE = 'aio-notification/';
   host: { role: 'group', 'aria-label': 'Notification' }
 })
 export class NotificationComponent implements OnInit {
+  @Input() bannerNotficationDescription = 'notification banner.';
   @Input() dismissOnContentClick: boolean;
   @Input() notificationId: string;
   @Input() expirationDate: string;

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -2,11 +2,11 @@
   "aio": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 454820,
-      "polyfills": 33814,
-      "styles": 73640,
-      "light-theme": 78276,
-      "dark-theme": 78381
+      "main": 455373,
+      "polyfills": 33922,
+      "styles": 73964,
+      "light-theme": 78157,
+      "dark-theme": 78289
     }
   },
   "aio-local": {


### PR DESCRIPTION
Problem: 
The close icon on the announcement should read "Close {description of banner}", this is a reusable component.

Solution proposal:
Add a new input for banner description with default value, allowing the insertion of other descriptions and if nothing is passed, it assumes a default value.
