### PR TITLE
fix(http): better handle unexpected `undefined` XSRF tokens

### DIFF
--- a/packages/common/http/src/xsrf.ts
+++ b/packages/common/http/src/xsrf.ts
@@ -90,7 +90,7 @@ export function xsrfInterceptorFn(
   const headerName = inject(XSRF_HEADER_NAME);
 
   // Be careful not to overwrite an existing header of the same name.
-  if (token !== null && !req.headers.has(headerName)) {
+  if (token != null && !req.headers.has(headerName)) {
     req = req.clone({headers: req.headers.set(headerName, token)});
   }
   return next(req);


### PR DESCRIPTION
`HttpXsrfTokenExtractor` allows returning `string|null` for an XSRF token, and the interceptor checked if the returned token is `null`. However, some implementations return `undefined` instead (behind an `any`) type, which caused the interceptor to crash when trying to set an `undefined` value for the header.

This commit makes the XSRF interceptor a little more resilient against such broken implementations of the `HttpXsrfTokenExtractor` interface.