### PR TITLE
fix(platform-browser): take serialization into account for empty check of transfer state

### DIFF
--- a/packages/platform-browser/src/browser/transfer_state.ts
+++ b/packages/platform-browser/src/browser/transfer_state.ts
@@ -129,7 +129,8 @@ export class TransferState {
    * Indicates whether the state is empty.
    */
   get isEmpty(): boolean {
-    return Object.keys(this.store).length === 0;
+    return Object.keys(this.store).length === 0 &&
+        Object.keys(this.onSerializeCallbacks).length === 0;
   }
 
   /**

--- a/packages/platform-browser/test/browser/transfer_state_spec.ts
+++ b/packages/platform-browser/test/browser/transfer_state_spec.ts
@@ -8,7 +8,7 @@
 
 import {DOCUMENT} from '@angular/common';
 import {TestBed} from '@angular/core/testing';
-import {BrowserModule, BrowserTransferStateModule, TransferState} from '@angular/platform-browser';
+import {BrowserModule, TransferState} from '@angular/platform-browser';
 import {escapeHtml, makeStateKey, unescapeHtml} from '@angular/platform-browser/src/browser/transfer_state';
 
 (function() {
@@ -128,6 +128,9 @@ describe('TransferState', () => {
 
     transferState.remove(TEST_KEY);
     expect(transferState.isEmpty).toBeTrue();
+
+    transferState.onSerialize(TEST_KEY, () => 10);
+    expect(transferState.isEmpty).toBeFalse();
   });
 });
 


### PR DESCRIPTION
Transfer states with no keys and only serialization callbacks were previously treated as empty which lead to no script getting embedded to transfer the state from the server to the client.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

I am not sure if there is anything in the docs that needs to be updated.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When no key is present in the transfer state and serialization callbacks are registered, these callbacks are never called as the state is treated as empty and toJson is therefore not called on the server side.

Issue Number: N/A


## What is the new behavior?
Transfer states without keys and serialization callbacks are now treated as non empty which allows them to be send from the server to the client.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
Considering the current behaviour being not very logical and probably not intended I would not consider this change a breaking change.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
