### PR TITLE
feat(forms): export forms utility functions: isFormArray, isFormGroup…

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -560,6 +560,18 @@ export class FormsModule {
 }
 
 // @public
+export const isFormArray: (control: unknown) => control is FormArray<any>;
+
+// @public
+export const isFormControl: (control: unknown) => control is FormControl<any>;
+
+// @public
+export const isFormGroup: (control: unknown) => control is FormGroup<any>;
+
+// @public
+export const isFormRecord: (control: unknown) => control is FormRecord<AbstractControl<any, any>>;
+
+// @public
 export class MaxLengthValidator extends AbstractValidatorDirective {
     maxlength: string | number | null;
     // (undocumented)

--- a/packages/forms/src/forms.ts
+++ b/packages/forms/src/forms.ts
@@ -43,9 +43,9 @@ export {SelectMultipleControlValueAccessor, ɵNgSelectMultipleOption} from './di
 export {AsyncValidator, AsyncValidatorFn, CheckboxRequiredValidator, EmailValidator, MaxLengthValidator, MaxValidator, MinLengthValidator, MinValidator, PatternValidator, RequiredValidator, ValidationErrors, Validator, ValidatorFn} from './directives/validators';
 export {ControlConfig, FormBuilder, NonNullableFormBuilder, UntypedFormBuilder, ɵElement} from './form_builder';
 export {AbstractControl, AbstractControlOptions, FormControlStatus, ɵCoerceStrArrToNumArr, ɵGetProperty, ɵNavigate, ɵRawValue, ɵTokenize, ɵTypedOrUntyped, ɵValue, ɵWriteable} from './model/abstract_model';
-export {FormArray, UntypedFormArray, ɵFormArrayRawValue, ɵFormArrayValue} from './model/form_array';
-export {FormControl, FormControlOptions, FormControlState, UntypedFormControl, ɵFormControlCtor} from './model/form_control';
-export {FormGroup, FormRecord, UntypedFormGroup, ɵFormGroupRawValue, ɵFormGroupValue, ɵOptionalKeys} from './model/form_group';
+export {FormArray, isFormArray, UntypedFormArray, ɵFormArrayRawValue, ɵFormArrayValue} from './model/form_array';
+export {FormControl, FormControlOptions, FormControlState, isFormControl, UntypedFormControl, ɵFormControlCtor} from './model/form_control';
+export {FormGroup, FormRecord, isFormGroup, isFormRecord, UntypedFormGroup, ɵFormGroupRawValue, ɵFormGroupValue, ɵOptionalKeys} from './model/form_group';
 export {NG_ASYNC_VALIDATORS, NG_VALIDATORS, Validators} from './validators';
 export {VERSION} from './version';
 

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -530,4 +530,10 @@ export type UntypedFormArray = FormArray<any>;
 
 export const UntypedFormArray: UntypedFormArrayCtor = FormArray;
 
+/**
+ * @description
+ * Asserts that the given control is an instance of `FormArray`
+ *
+ * @publicApi
+ */
 export const isFormArray = (control: unknown): control is FormArray => control instanceof FormArray;

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -561,5 +561,11 @@ export type UntypedFormControl = FormControl<any>;
 
 export const UntypedFormControl: UntypedFormControlCtor = FormControl;
 
+/**
+ * @description
+ * Asserts that the given control is an instance of `FormControl`
+ *
+ * @publicApi
+ */
 export const isFormControl = (control: unknown): control is FormControl =>
     control instanceof FormControl;

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -604,6 +604,12 @@ export type UntypedFormGroup = FormGroup<any>;
 
 export const UntypedFormGroup: UntypedFormGroupCtor = FormGroup;
 
+/**
+ * @description
+ * Asserts that the given control is an instance of `FormGroup`
+ *
+ * @publicApi
+ */
 export const isFormGroup = (control: unknown): control is FormGroup => control instanceof FormGroup;
 
 /**
@@ -706,5 +712,11 @@ export interface FormRecord<TControl> {
   getRawValue(): {[key: string]: ɵRawValue<TControl>};
 }
 
+/**
+ * @description
+ * Asserts that the given control is an instance of `FormRecord`
+ *
+ * @publicApi
+ */
 export const isFormRecord = (control: unknown): control is FormRecord =>
     control instanceof FormRecord;


### PR DESCRIPTION
This commit exports existing utility functions to check for control instances: isFormControl, isFormGroup, isFormRecord, isFormArray Those are useful when implementing validators that use the specifics of one of those control types. To narrow down the type to what it actually is, we can now use the util functions in validators:

```ts
export const myArrayValidator: ValidatorFn = (control) => {
  if (!isFormArray(control)) { return null; }

  // now you can use FormArray-specific members, e.g.:
  if (control.controls.every(c => !!c.value) {
    return { myerror: true }
  } else { return null; }
}
```

Before, this had to be done manually:

```ts
export const myArrayValidator: ValidatorFn = (control) => {
  if (!(control instanceof FormArray)) { return null; }
  // ... 
}
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
