### PR TITLE
fix(core): pad error codes up to 4 digits

### DIFF
--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -120,7 +120,7 @@ let thisArg: any;
          getComponent().items = <any>'whaaa';
          expect(() => fixture.detectChanges())
              .toThrowError(
-                 `NG02200: Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables, such as Arrays. Find more at https://angular.io/errors/NG02200`);
+                 `NG2200: Cannot find a differ supporting object 'whaaa' of type 'string'. NgFor only supports binding to Iterables, such as Arrays. Find more at https://angular.io/errors/NG2200`);
        }));
 
     it('should throw on non-iterable ref and suggest using an array ', waitForAsync(() => {
@@ -129,7 +129,7 @@ let thisArg: any;
          getComponent().items = <any>{'stuff': 'whaaa'};
          expect(() => fixture.detectChanges())
              .toThrowError(
-                 `NG02200: Cannot find a differ supporting object '\[object Object\]' of type 'object'. NgFor only supports binding to Iterables, such as Arrays. Did you mean to use the keyvalue pipe? Find more at https://angular.io/errors/NG02200`);
+                 `NG2200: Cannot find a differ supporting object '\[object Object\]' of type 'object'. NgFor only supports binding to Iterables, such as Arrays. Did you mean to use the keyvalue pipe? Find more at https://angular.io/errors/NG2200`);
        }));
 
     it('should throw on ref changing to string', waitForAsync(() => {

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -373,7 +373,7 @@ describe('Image directive', () => {
           fixture.detectChanges();
         })
             .toThrowError(
-                `NG0${
+                `NG${
                     RuntimeErrorCode
                         .INVALID_INPUT}: The NgOptimizedImage directive (activated on an <img> element with the \`ngSrc="img"\`) ` +
                 `has detected that the \`ngSrcset\` contains an unsupported image density:` +
@@ -402,7 +402,7 @@ describe('Image directive', () => {
           fixture.detectChanges();
         })
             .toThrowError(
-                `NG0${
+                `NG${
                     RuntimeErrorCode
                         .INVALID_INPUT}: The NgOptimizedImage directive (activated on an <img> element with the \`ngSrc="img"\`) ` +
                 `has detected that the \`ngSrcset\` contains an unsupported image density:` +

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -113,7 +113,7 @@ export function formatRuntimeError<T extends number = RuntimeErrorCode>(
     code: T, message: null|false|string): string {
   // Error code might be a negative number, which is a special marker that instructs the logic to
   // generate a link to the error details page on angular.io.
-  const fullCode = `NG0${Math.abs(code)}`;
+  const fullCode = `NG${Math.abs(code).toString().padStart(4, '0')}`;
 
   let errorMessage = `${fullCode}${message ? ': ' + message.trim() : ''}`;
 


### PR DESCRIPTION
Add leading 0 in error codes optionally. 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `formatRuntimeError` method adds a leading zero for error codes that already are 4 digits, resulting in an error URL that does not exist such as:

https://angular.io/errors/NG02200

## What is the new behavior?
The `formatRuntimeError` method pads the absolute code with a leading zero only up to a minimum length of 4. In the preceding example, the URL of the error will become:

https://angular.io/errors/NG2200

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I have also updated other tests that refer to the wrong functionality.