### PR TITLE
ci: adjust workflow permissions for OpenSSF Scorecard results publishing

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,6 +18,8 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
+      # Needed to publish results
+      id-token: write
       actions: read
       contents: read
 


### PR DESCRIPTION
Version 2 of the `openssf/scorecard-action` GitHub action requires the
`id-token: write` permission to publish results.
