### PR TITLE
[draft] Add 'fill mode' to NgOptimizedImage

### DIFF
--- a/aio/content/guide/image-directive.md
+++ b/aio/content/guide/image-directive.md
@@ -89,7 +89,40 @@ You can typically fix this by adding `height: auto` or `width: auto` to your ima
 
 ### Handling `srcset` attributes
 
-If your `<img>` tag defines a `srcset` attribute, replace it with `ngSrcset`.
+Defining a [`srcset` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset) ensures that the browser requests an image at the right size for your user's viewport, so it doesn't waste time downloading an image that's too large. 'NgOptimizedImage' generates an appropriate `srcset` for the image, based on the presence and value of the [`sizes` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes) on the image tag.
+
+#### Fixed-size images
+
+If your image should be "fixed" in size  (i.e. the same size across devices, except for [pixel density](https://web.dev/codelab-density-descriptors/)), there is no need to set a `sizes` attribute. A `srcset` can be generated automatically from the image's width and height attributes with no further input required. 
+
+Example srcset generated: `<img ... srcset="image-400w.jpg 1x, image-800w.jpg 2x">`
+
+#### Responsive images
+
+If your image should be responsive (i.e. grow and shrink according to viewport size), then you will need to define a [`sizes` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes) to generate the `srcset`.
+
+If you haven't used `sizes` before, a good place to start is to set it based on viewport width. For example, if your CSS causes the image to fill 100% of viewport width, set `sizes` to `100vw` and the browser will select the image in the `srcset` that is closest to the viewport width (after accounting for pixel density). If your image is only likely to take up half the screen (ex: in a sidebar), set `sizes` to `50vw` to ensure the browser selects a smaller image. And so on.
+
+If you find that the above does not cover your desired image behavior, see the documentation on [advanced sizes values](#advanced-sizes-values).
+
+By default, the responsive breakpoints are:
+
+`[16, 32, 48, 64, 96, 128, 256, 384, 640, 750, 828, 1080, 1200, 1920, 2048, 3840]`
+
+If you would like to customize these breakpoints, you can do so using the `IMAGE_CONFIG` provider:
+
+<code-example format="typescript" language="typescript">
+providers: [
+  {
+    provide: IMAGE_CONFIG,
+    useValue: {
+      breakpoints: [16, 48, 96, 128, 384, 640, 750, 828, 1080, 1200, 1920]
+    }
+  },
+],
+</code-example>
+
+If you would like to manually define a `srcset` attribute, you can provide your own directly, or use the `ngSrcset` attribute:
 
 <code-example format="html" language="html">
 
@@ -97,13 +130,21 @@ If your `<img>` tag defines a `srcset` attribute, replace it with `ngSrcset`.
 
 </code-example>
 
-If the `ngSrcset` attribute is present, `NgOptimizedImage` generates and sets the [`srcset` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/srcset) using the configured image loader. Do not include image file names in `ngSrcset` - the directive infers this information from `ngSrc`. The directive supports both width descriptors (e.g. `100w`) and density descriptors (e.g. `1x`) are supported.
-
-You can also use `ngSrcset` with the standard image [`sizes` attribute](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes).
+If the `ngSrcset` attribute is present, `NgOptimizedImage` generates and sets the `srcset` using the configured image loader. Do not include image file names in `ngSrcset` - the directive infers this information from `ngSrc`. The directive supports both width descriptors (e.g. `100w`) and density descriptors (e.g. `1x`) are supported.
 
 <code-example format="html" language="html">
 
 &lt;img ngSrc="hero.jpg" ngSrcset="100w, 200w, 300w" sizes="50vw"&gt;
+
+</code-example>
+
+### Disabling automatic srcset generation
+
+To disable srcset generation for a single image, you can add the `disableOptimizedSrcset` attribute on the image:
+
+<code-example format="html" language="html">
+
+&lt;img ngSrc="about.jpg" disableOptimizedSrcset&gt;
 
 </code-example>
 
@@ -116,6 +157,20 @@ By default, `NgOptimizedImage` sets `loading=lazy` for all images that are not m
 &lt;img ngSrc="cat.jpg" width="400" height="200" loading="eager"&gt;
 
 </code-example>
+
+### Advanced 'sizes' values
+
+You may want to have images displayed at varying widths on differently-sized screens. A common example of this pattern is a grid- or column-based layout that renders a single column on mobile devices, and two columns on larger devices. You can capture this behavior in the `sizes` attribute, using a "media query" syntax, such as the following:
+
+<code-example format="html" language="html">
+
+&lt;img ngSrc="cat.jpg" width="400" height="200" sizes="(max-width: 768px) 100vw, 50vw"&gt;
+
+</code-example>
+
+The `sizes` attribute in the above example says "I expect this image to be 100 percent of the screen width on devices under 768px wide. Otherwise, I expect it to be 50 percent of the screen width.
+
+For additional information about the `sizes` attribute, see [web.dev](https://web.dev/learn/design/responsive-images/#sizes) or [mdn](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/sizes).
 
 <!-- links -->
 

--- a/aio/content/guide/image-directive.md
+++ b/aio/content/guide/image-directive.md
@@ -81,6 +81,18 @@ providers: [
 
 </code-example>
 
+### Using `fill` mode
+
+In cases where you want to have an image fill a containing element, you can use the `fill` attribute. This is often useful when you want to achieve a "background image" behavior, or when you don't know the exact width and height of your image.
+
+When you add the `fill` attribute to your image, you do not need and should not include a `width` and `height`, as in this example:
+
+<code-example format="typescript" language="typescript">
+
+&lt;img ngSrc="cat.jpg" fill&gt;
+
+</code-example> 
+
 ### Adjusting image styling
 
 Depending on the image's styling, adding `width` and `height` attributes may cause the image to render differently. `NgOptimizedImage` warns you if your image styling renders the image at a distorted aspect ratio.

--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -546,6 +546,9 @@ export abstract class NgLocalization {
 
 // @public
 export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
+    set disableOptimizedSrcset(value: string | boolean | undefined);
+    // (undocumented)
+    get disableOptimizedSrcset(): boolean;
     set height(value: string | number | undefined);
     // (undocumented)
     get height(): number | undefined;
@@ -563,11 +566,12 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     get priority(): boolean;
     // @deprecated
     set rawSrc(value: string);
+    sizes?: string;
     set width(value: string | number | undefined);
     // (undocumented)
     get width(): number | undefined;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[ngSrc],img[rawSrc]", never, { "rawSrc": "rawSrc"; "ngSrc": "ngSrc"; "ngSrcset": "ngSrcset"; "width": "width"; "height": "height"; "loading": "loading"; "priority": "priority"; "src": "src"; "srcset": "srcset"; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[ngSrc],img[rawSrc]", never, { "rawSrc": "rawSrc"; "ngSrc": "ngSrc"; "ngSrcset": "ngSrcset"; "sizes": "sizes"; "width": "width"; "height": "height"; "loading": "loading"; "priority": "priority"; "disableOptimizedSrcset": "disableOptimizedSrcset"; "src": "src"; "srcset": "srcset"; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgOptimizedImage, never>;
 }

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -1192,6 +1192,58 @@ describe('Image directive', () => {
            expect(img.getAttribute('srcset')).toBeNull();
          });
     });
+    describe('fill mode', () => {
+      it('should allow unsized images in fill mode', () => {
+        setupTestingModule();
+
+        const template = '<img ngSrc="path/img.png" fill>';
+        expect(() => {
+          const fixture = createTestComponent(template);
+          fixture.detectChanges();
+        }).not.toThrow();
+      });
+      it('should throw if width is provided for fill mode image', () => {
+        setupTestingModule();
+
+        const template = '<img ngSrc="path/img.png" width="500" fill>';
+        expect(() => {
+          const fixture = createTestComponent(template);
+          fixture.detectChanges();
+        })
+            .toThrowError(
+                'NG02952: The NgOptimizedImage directive (activated on an <img> element with the ' +
+                '`ngSrc="path/img.png"`) has detected that the attributes `height` and/or `width` ' +
+                'are present along with the `fill` attribute. Because `fill` mode causes an image ' +
+                'to fill its containing element, the size attributes have no effect and should be removed.');
+      });
+      it('should apply appropriate styles in fill mode', () => {
+        setupTestingModule();
+
+        const template = '<img ngSrc="path/img.png" fill>';
+
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+        const nativeElement = fixture.nativeElement as HTMLElement;
+        const img = nativeElement.querySelector('img')!;
+        expect(img.getAttribute('style'))
+            .toBe(
+                'position: absolute; width: 100%; height: 100%; left: 0; top: 0; right: 0; bottom: 0')
+      });
+      it('should augment existing styles in fill mode', () => {
+        setupTestingModule();
+
+        const template =
+            '<img ngSrc="path/img.png" style="border-radius: 5px; padding: 10px" fill>';
+
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+        const nativeElement = fixture.nativeElement as HTMLElement;
+        const img = nativeElement.querySelector('img')!;
+        expect(img.getAttribute('style'))
+            .toBe(
+                'border-radius: 5px; padding: 10px; position: absolute; width: 100%; height: 100%; left: 0; top: 0; right: 0; bottom: 0')
+      });
+    });
   });
 });
 

--- a/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
@@ -60,18 +60,18 @@ export class ImageDistortionPassingComponent {
      <!-- These images should throw -->
      <!-- Supplied aspect ratio differs from intrinsic aspect ratio by > .1 -->
      <!-- Aspect-ratio: 0.86666666666 -->
-     <img ngSrc="/e2e/b.png" width="26" height="30">
+     <img ngSrc="/e2e/b.png" width="26" height="30" disableOptimizedSrcset>
      <!-- Aspect-ratio: 0.1 -->
-     <img ngSrc="/e2e/b.png" width="24" height="240">
+     <img ngSrc="/e2e/b.png" width="24" height="240" disableOptimizedSrcset>
      <!-- Supplied aspect ratio is incorrect & image has 0x0 rendered size -->
-     <img ngSrc="/e2e/a.png" width="222" height="25" style="display: none">
+     <img ngSrc="/e2e/a.png" width="222" height="25" style="display: none" disableOptimizedSrcset>
      <br>
      <!-- Image styling is causing distortion -->
      <div style="width: 300px; height: 300px">
-       <img ngSrc="/e2e/b.png" width="250" height="250" style="width: 10%">
-       <img ngSrc="/e2e/b.png" width="250" height="250" style="max-height: 10%">
+       <img ngSrc="/e2e/b.png" width="250" height="250" style="width: 10%" disableOptimizedSrcset>
+       <img ngSrc="/e2e/b.png" width="250" height="250" style="max-height: 10%" disableOptimizedSrcset>
        <!-- Images dimensions are incorrect AND image styling is incorrect -->
-       <img ngSrc="/e2e/b.png" width="150" height="250" style="max-height: 10%">
+       <img ngSrc="/e2e/b.png" width="150" height="250" style="max-height: 10%" disableOptimizedSrcset>
      </div>
      `,
 })

--- a/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.ts
+++ b/packages/core/test/bundling/image-directive/e2e/oversized-image/oversized-image.ts
@@ -36,7 +36,7 @@ export class OversizedImageComponentPassing {
   template: `
       <!-- Image is rendered too small  -->
       <div style="width: 300px; height: 300px">
-         <img ngSrc="/e2e/logo-1500w.jpg" width="100" height="100" priority>
+         <img ngSrc="/e2e/logo-1500w.jpg" width="100" height="100" priority disableOptimizedSrcset>
        </div>
       `,
 })


### PR DESCRIPTION
This PR creates a new boolean attribute on the ngOptimizedImage directive called `fill`, which allows the directive to be used without height and width, and which automatically styles the image to fill it's containing element.

This PR still requires some additional test cases before merging. Posting now for feedback from @AndrewKushnir and @pkozlowski-opensource. CC: @kara 
