### PR TITLE
feat(common): Add fill mode to NgOptimizedImage

### DIFF
--- a/aio/content/guide/image-directive.md
+++ b/aio/content/guide/image-directive.md
@@ -81,6 +81,18 @@ providers: [
 
 </code-example>
 
+### Using `fill` mode
+
+In cases where you want to have an image fill a containing element, you can use the `fill` attribute. This is often useful when you want to achieve a "background image" behavior, or when you don't know the exact width and height of your image.
+
+When you add the `fill` attribute to your image, you do not need and should not include a `width` and `height`, as in this example:
+
+<code-example format="typescript" language="typescript">
+
+&lt;img ngSrc="cat.jpg" fill&gt;
+
+</code-example> 
+
 ### Adjusting image styling
 
 Depending on the image's styling, adding `width` and `height` attributes may cause the image to render differently. `NgOptimizedImage` warns you if your image styling renders the image at a distorted aspect ratio.

--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -549,6 +549,9 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     set disableOptimizedSrcset(value: string | boolean | undefined);
     // (undocumented)
     get disableOptimizedSrcset(): boolean;
+    set fill(value: string | boolean | undefined);
+    // (undocumented)
+    get fill(): boolean;
     set height(value: string | number | undefined);
     // (undocumented)
     get height(): number | undefined;
@@ -571,7 +574,7 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     // (undocumented)
     get width(): number | undefined;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[ngSrc],img[rawSrc]", never, { "rawSrc": "rawSrc"; "ngSrc": "ngSrc"; "ngSrcset": "ngSrcset"; "sizes": "sizes"; "width": "width"; "height": "height"; "loading": "loading"; "priority": "priority"; "disableOptimizedSrcset": "disableOptimizedSrcset"; "src": "src"; "srcset": "srcset"; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[ngSrc],img[rawSrc]", never, { "rawSrc": "rawSrc"; "ngSrc": "ngSrc"; "ngSrcset": "ngSrcset"; "sizes": "sizes"; "width": "width"; "height": "height"; "loading": "loading"; "priority": "priority"; "disableOptimizedSrcset": "disableOptimizedSrcset"; "fill": "fill"; "src": "src"; "srcset": "srcset"; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgOptimizedImage, never>;
 }

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -794,6 +794,123 @@ describe('Image directive', () => {
     });
   });
 
+  describe('fill mode', () => {
+    it('should allow unsized images in fill mode', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+      expect(() => {
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+      }).not.toThrow();
+    });
+    it('should throw if width is provided for fill mode image', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" width="500" fill>';
+      expect(() => {
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+      })
+          .toThrowError(
+              'NG02952: The NgOptimizedImage directive (activated on an <img> element with the ' +
+              '`ngSrc="path/img.png"`) has detected that the attributes `height` and/or `width` ' +
+              'are present along with the `fill` attribute. Because `fill` mode causes an image ' +
+              'to fill its containing element, the size attributes have no effect and should be removed.');
+    });
+    it('should throw if height is provided for fill mode image', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" height="500" fill>';
+      expect(() => {
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+      })
+          .toThrowError(
+              'NG02952: The NgOptimizedImage directive (activated on an <img> element with the ' +
+              '`ngSrc="path/img.png"`) has detected that the attributes `height` and/or `width` ' +
+              'are present along with the `fill` attribute. Because `fill` mode causes an image ' +
+              'to fill its containing element, the size attributes have no effect and should be removed.');
+    });
+    it('should apply appropriate styles in fill mode', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      expect(img.getAttribute('style')?.replace(/\s/g, ''))
+          .toBe('position:absolute;width:100%;height:100%;inset:0px;');
+    });
+    it('should augment existing styles in fill mode', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" style="border-radius: 5px; padding: 10px" fill>';
+
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      expect(img.getAttribute('style')?.replace(/\s/g, ''))
+          .toBe(
+              'border-radius:5px;padding:10px;position:absolute;width:100%;height:100%;inset:0px;');
+    });
+    it('should not add fill styles if not in fill mode', () => {
+      setupTestingModule();
+
+      const template =
+          '<img ngSrc="path/img.png" width="400" height="300" style="position: relative; border-radius: 5px">';
+
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      expect(img.getAttribute('style')?.replace(/\s/g, ''))
+          .toBe('position:relative;border-radius:5px;');
+    });
+    it('should add default sizes value in fill mode', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      expect(img.getAttribute('sizes')).toBe('100vw');
+    });
+    it('should not overwrite sizes value in fill mode', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" sizes="50vw" fill>';
+
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      expect(img.getAttribute('sizes')).toBe('50vw');
+    });
+    it('should cause responsive srcset to be generated in fill mode', () => {
+      setupTestingModule();
+
+      const template = '<img ngSrc="path/img.png" fill>';
+
+      const fixture = createTestComponent(template);
+      fixture.detectChanges();
+      const nativeElement = fixture.nativeElement as HTMLElement;
+      const img = nativeElement.querySelector('img')!;
+      expect(img.getAttribute('srcset'))
+          .toBe(
+              `${IMG_BASE_URL}/path/img.png 640w, ${IMG_BASE_URL}/path/img.png 750w, ${
+                  IMG_BASE_URL}/path/img.png 828w, ` +
+              `${IMG_BASE_URL}/path/img.png 1080w, ${IMG_BASE_URL}/path/img.png 1200w, ${
+                  IMG_BASE_URL}/path/img.png 1920w, ` +
+              `${IMG_BASE_URL}/path/img.png 2048w, ${IMG_BASE_URL}/path/img.png 3840w`);
+    });
+  });
+
   describe('preconnect detector', () => {
     const imageLoader = () => {
       // We need something different from the `localhost` (as we don't want to produce


### PR DESCRIPTION
This PR adds a new boolean attribute to NgOptimizedImage called `fill` which does the following:
* Removes the requirement for height and width
* Adds inline styling to cause the image to fill its containing element
* Adds a default `sizes` value of `100vw` which will cause the image to have a responsive srcset automatically generated

CC: @AndrewKushnir @pkozlowski-opensource @kara 