### PR TITLE
docs: declare Standalone APIs as stable

### DIFF
--- a/aio/content/guide/standalone-components.md
+++ b/aio/content/guide/standalone-components.md
@@ -1,13 +1,6 @@
 # Getting started with standalone components
 
-<div class="alert is-important">
-
-The standalone component feature is available for [developer preview](https://angular.io/guide/releases#developer-preview).
-It's ready for you to try, but it might change before it is stable.
-
-</div>
-
-In v14 and higher, **standalone components** provide a simplified way to build Angular applications. Standalone components, directives, and pipes aim to streamline the authoring experience by reducing the need for `NgModule`s. Existing applications can optionally and incrementally adopt the new standalone style without any breaking changes.
+**Standalone components** provide a simplified way to build Angular applications. Standalone components, directives, and pipes aim to streamline the authoring experience by reducing the need for `NgModule`s. Existing applications can optionally and incrementally adopt the new standalone style without any breaking changes.
 
 ## Creating standalone components
 

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -315,6 +315,11 @@
           "tooltip": "A list of developer guides for building Angular applications."
         },
         {
+          "url": "guide/standalone-components",
+          "title": "Standalone components",
+          "tooltip": "Standalone components, directives, and pipes"
+        },
+        {
           "title": "Change detection",
           "tooltip": "Learn how Angular updates the view based on data changes and how to keep your application fast",
           "children": [
@@ -852,11 +857,6 @@
       "title": "Feature preview",
       "tooltip": "Angular preview features and APIs",
       "children": [
-        {
-          "url": "guide/standalone-components",
-          "title": "Standalone components",
-          "tooltip": "Standalone components, directives, and pipes"
-        },
         {
           "url": "guide/image-directive",
           "title": "Image Directive",

--- a/packages/common/testing/src/provide_location_mocks.ts
+++ b/packages/common/testing/src/provide_location_mocks.ts
@@ -16,7 +16,6 @@ import {MockLocationStrategy} from './mock_location_strategy';
  * Returns mock providers for the `Location` and `LocationStrategy` classes.
  * The mocks are helpful in tests to fire simulated location events.
  *
- * @developerPreview
  * @publicApi
  */
 export function provideLocationMocks(): Provider[] {

--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -37,7 +37,6 @@ export function makeEnvironmentProviders(providers: Provider[]): EnvironmentProv
 /**
  * A source of providers for the `importProvidersFrom` function.
  *
- * @developerPreview
  * @publicApi
  */
 export type ImportProvidersSource =
@@ -82,7 +81,6 @@ export type ImportProvidersSource =
  *
  * @returns Collected providers from the specified list of types.
  * @publicApi
- * @developerPreview
  */
 export function importProvidersFrom(...sources: ImportProvidersSource[]): EnvironmentProviders {
   return {

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -73,8 +73,6 @@ interface Record<T> {
 /**
  * An `Injector` that's part of the environment injector hierarchy, which exists outside of the
  * component tree.
- *
- * @developerPreview
  */
 export abstract class EnvironmentInjector implements Injector {
   /**

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -328,8 +328,6 @@ export interface Directive {
    *
    * More information about standalone components, directives, and pipes can be found in [this
    * guide](guide/standalone-components).
-   *
-   * @developerPreview
    */
   standalone?: boolean;
 
@@ -617,8 +615,6 @@ export interface Component extends Directive {
    *
    * More information about standalone components, directives, and pipes can be found in [this
    * guide](guide/standalone-components).
-   *
-   * @developerPreview
    */
   standalone?: boolean;
 
@@ -632,8 +628,6 @@ export interface Component extends Directive {
    *
    * More information about standalone components, directives, and pipes can be found in [this
    * guide](guide/standalone-components).
-   *
-   * @developerPreview
    */
   imports?: (Type<any>|any[])[];
 

--- a/packages/core/src/render3/ng_module_ref.ts
+++ b/packages/core/src/render3/ng_module_ref.ts
@@ -154,7 +154,6 @@ class EnvironmentNgModuleRefAdapter extends viewEngine_NgModuleRef<null> {
  *     messages.
  *
  * @publicApi
- * @developerPreview
  */
 export function createEnvironmentInjector(
     providers: Array<Provider|EnvironmentProviders>, parent: EnvironmentInjector,

--- a/packages/platform-browser/animations/src/module.ts
+++ b/packages/platform-browser/animations/src/module.ts
@@ -79,7 +79,6 @@ export class BrowserAnimationsModule {
  * ```
  *
  * @publicApi
- * @developerPreview
  */
 export function provideAnimations(): Provider[] {
   // Return a copy to prevent changes to the original array in case any in-place
@@ -118,7 +117,6 @@ export class NoopAnimationsModule {
  * ```
  *
  * @publicApi
- * @developerPreview
  */
 export function provideNoopAnimations(): Provider[] {
   // Return a copy to prevent changes to the original array in case any in-place

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -24,7 +24,6 @@ const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 /**
  * Set of config options available during the application bootstrap operation.
  *
- * @developerPreview
  * @publicApi
  */
 export interface ApplicationConfig {
@@ -92,7 +91,6 @@ export interface ApplicationConfig {
  * @returns A promise that returns an `ApplicationRef` instance once resolved.
  *
  * @publicApi
- * @developerPreview
  */
 export function bootstrapApplication(
     rootComponent: Type<unknown>, options?: ApplicationConfig): Promise<ApplicationRef> {
@@ -110,7 +108,6 @@ export function bootstrapApplication(
  * @returns A promise that returns an `ApplicationRef` instance once resolved.
  *
  * @publicApi
- * @developerPreview
  */
 export function createApplication(options?: ApplicationConfig) {
   return internalCreateApplication(createProvidersConfig(options));
@@ -135,7 +132,6 @@ function createProvidersConfig(options?: ApplicationConfig) {
  * @returns An array of providers required to setup Testability for an application and make it
  *     available for testing using Protractor.
  *
- * @developerPreview
  * @publicApi
  */
 export function provideProtractorTestingSupport(): Provider[] {

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -54,7 +54,6 @@ const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
  * @see `RouterFeatures`
  *
  * @publicApi
- * @developerPreview
  * @param routes A set of `Route`s to use for the application routing table.
  * @param features Optional features to configure additional router behaviors.
  * @returns A set of providers to setup a Router.
@@ -79,7 +78,6 @@ export function rootRoute(router: Router): ActivatedRoute {
  * Helper type to represent a Router feature.
  *
  * @publicApi
- * @developerPreview
  */
 export interface RouterFeature<FeatureKind extends RouterFeatureKind> {
   ɵkind: FeatureKind;
@@ -122,7 +120,6 @@ export function provideRoutes(routes: Routes): Provider[] {
  * @see `provideRouter`
  *
  * @publicApi
- * @developerPreview
  */
 export type InMemoryScrollingFeature = RouterFeature<RouterFeatureKind.InMemoryScrollingFeature>;
 
@@ -147,7 +144,6 @@ export type InMemoryScrollingFeature = RouterFeature<RouterFeatureKind.InMemoryS
  * @see `ViewportScroller`
  *
  * @publicApi
- * @developerPreview
  * @param options Set of configuration parameters to customize scrolling behavior, see
  *     `InMemoryScrollingOptions` for additional information.
  * @returns A set of providers for use with `provideRouter`.
@@ -236,7 +232,6 @@ const INITIAL_NAVIGATION = new InjectionToken<InitialNavigation>(
  * @see `provideRouter`
  *
  * @publicApi
- * @developerPreview
  */
 export type EnabledBlockingInitialNavigationFeature =
     RouterFeature<RouterFeatureKind.EnabledBlockingInitialNavigationFeature>;
@@ -250,7 +245,6 @@ export type EnabledBlockingInitialNavigationFeature =
  * @see `provideRouter`
  *
  * @publicApi
- * @developerPreview
  */
 export type InitialNavigationFeature =
     EnabledBlockingInitialNavigationFeature|DisabledInitialNavigationFeature;
@@ -278,7 +272,6 @@ export type InitialNavigationFeature =
  * @see `provideRouter`
  *
  * @publicApi
- * @developerPreview
  * @returns A set of providers for use with `provideRouter`.
  */
 export function withEnabledBlockingInitialNavigation(): EnabledBlockingInitialNavigationFeature {
@@ -369,7 +362,6 @@ export function withEnabledBlockingInitialNavigation(): EnabledBlockingInitialNa
  * @see `provideRouter`
  *
  * @publicApi
- * @developerPreview
  */
 export type DisabledInitialNavigationFeature =
     RouterFeature<RouterFeatureKind.DisabledInitialNavigationFeature>;
@@ -399,7 +391,6 @@ export type DisabledInitialNavigationFeature =
  * @returns A set of providers for use with `provideRouter`.
  *
  * @publicApi
- * @developerPreview
  */
 export function withDisabledInitialNavigation(): DisabledInitialNavigationFeature {
   const providers = [
@@ -425,7 +416,6 @@ export function withDisabledInitialNavigation(): DisabledInitialNavigationFeatur
  * @see `provideRouter`
  *
  * @publicApi
- * @developerPreview
  */
 export type DebugTracingFeature = RouterFeature<RouterFeatureKind.DebugTracingFeature>;
 
@@ -452,7 +442,6 @@ export type DebugTracingFeature = RouterFeature<RouterFeatureKind.DebugTracingFe
  * @returns A set of providers for use with `provideRouter`.
  *
  * @publicApi
- * @developerPreview
  */
 export function withDebugTracing(): DebugTracingFeature {
   let providers: Provider[] = [];
@@ -488,7 +477,6 @@ const ROUTER_PRELOADER = new InjectionToken<RouterPreloader>(NG_DEV_MODE ? 'rout
  * @see `provideRouter`
  *
  * @publicApi
- * @developerPreview
  */
 export type PreloadingFeature = RouterFeature<RouterFeatureKind.PreloadingFeature>;
 
@@ -517,7 +505,6 @@ export type PreloadingFeature = RouterFeature<RouterFeatureKind.PreloadingFeatur
  * @returns A set of providers for use with `provideRouter`.
  *
  * @publicApi
- * @developerPreview
  */
 export function withPreloading(preloadingStrategy: Type<PreloadingStrategy>): PreloadingFeature {
   const providers = [
@@ -534,7 +521,6 @@ export function withPreloading(preloadingStrategy: Type<PreloadingStrategy>): Pr
  * @see `provideRouter`
  *
  * @publicApi
- * @developerPreview
  */
 export type RouterConfigurationFeature =
     RouterFeature<RouterFeatureKind.RouterConfigurationFeature>;
@@ -565,7 +551,6 @@ export type RouterConfigurationFeature =
  * @returns A set of providers for use with `provideRouter`.
  *
  * @publicApi
- * @developerPreview
  */
 export function withRouterConfig(options: RouterConfigOptions): RouterConfigurationFeature {
   const providers = [
@@ -583,7 +568,6 @@ export function withRouterConfig(options: RouterConfigOptions): RouterConfigurat
  * @see `provideRouter`
  *
  * @publicApi
- * @developerPreview
  */
 export type RouterFeatures = PreloadingFeature|DebugTracingFeature|InitialNavigationFeature|
     InMemoryScrollingFeature|RouterConfigurationFeature;

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -49,7 +49,6 @@ export type InitialNavigation = 'disabled'|'enabledBlocking'|'enabledNonBlocking
  * Extra configuration options that can be used with the `withRouterConfig` function.
  *
  * @publicApi
- * @developerPreview
  */
 export interface RouterConfigOptions {
   /**
@@ -115,7 +114,6 @@ export interface RouterConfigOptions {
  * function.
  *
  * @publicApi
- * @developerPreview
  */
 export interface InMemoryScrollingOptions {
   /**


### PR DESCRIPTION
In v14, we've introduced core concepts to allow Components, Directives and Pipes to configure their dependencies without the need to use NgModules and without the need to be declared in an NgModule. The concepts and initial set of APIs were marked as "developer preview" to allow developers to use these APIs and share the feedback.

Since v14, we've been reviewing the entire API surface of the framework and either updating existing APIs to support standalone or creating new APIs that allowed to use Router, HttpClient and other abstractions without NgModules.

Based on the mentioned work to review and stabilize APIs and also based on the positive feedback from the community, we are happy to announce that the Standalone APIs are promoted to stable!

This commit updates vast majority of standalone-related APIs to drop the `@developerPreview` label, which effectively documents then as stable.

Two APIs that retained the `@developerPreview` annotations are:
- withRequestsMadeViaParent (from `@angular/common/http`)
- renderApplication (from `@angular/platform-server`)

We plan to collect some additional feedback for the mentioned APIs and drop the `@developerPreview` annotation before the next major release.

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No