### PR TITLE
refactor(common): make `provideHttpClient` return `EnvironmentProviders`

### DIFF
--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { EnvironmentInjector } from '@angular/core';
+import { EnvironmentProviders } from '@angular/core';
 import * as i0 from '@angular/core';
 import { InjectionToken } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
@@ -2162,7 +2163,7 @@ export class JsonpInterceptor {
 }
 
 // @public (undocumented)
-export function provideHttpClient(...features: HttpFeature<HttpFeatureKind>[]): Provider[];
+export function provideHttpClient(...features: HttpFeature<HttpFeatureKind>[]): EnvironmentProviders;
 
 // @public (undocumented)
 export function withInterceptors(interceptorFns: HttpInterceptorFn[]): HttpFeature<HttpFeatureKind.Interceptors>;

--- a/packages/common/http/src/provider.ts
+++ b/packages/common/http/src/provider.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {inject, InjectionToken, Provider} from '@angular/core';
+import {EnvironmentProviders, inject, InjectionToken, makeEnvironmentProviders, Provider} from '@angular/core';
 
 import {HttpBackend, HttpHandler} from './backend';
 import {HttpClient} from './client';
@@ -38,7 +38,8 @@ function makeHttpFeature<KindT extends HttpFeatureKind>(
 }
 
 
-export function provideHttpClient(...features: HttpFeature<HttpFeatureKind>[]): Provider[] {
+export function provideHttpClient(...features: HttpFeature<HttpFeatureKind>[]):
+    EnvironmentProviders {
   if (ngDevMode) {
     const featureKinds = new Set(features.map(f => f.ɵkind));
     if (featureKinds.has(HttpFeatureKind.NoXsrfProtection) &&
@@ -69,7 +70,7 @@ export function provideHttpClient(...features: HttpFeature<HttpFeatureKind>[]): 
     providers.push(...feature.ɵproviders);
   }
 
-  return providers;
+  return makeEnvironmentProviders(providers);
 }
 
 export function withInterceptors(interceptorFns: HttpInterceptorFn[]):


### PR DESCRIPTION
This commit updates the `provideHttpClient` function to return the `EnvironmentProviders` instead of a regular `Provider[]`, to make sure that the `provideHttpClient` can only be used where an environment is being setup.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No