### PR TITLE
docs(docs-infra): fix errors page hover styles

### DIFF
--- a/aio/src/styles/2-modules/errors/_errors-theme.scss
+++ b/aio/src/styles/2-modules/errors/_errors-theme.scss
@@ -1,6 +1,9 @@
+@use 'sass:map';
 @use '../../constants';
 
 @mixin theme($theme) {
+  $is-dark-theme: map.get($theme, is-dark);
+
   .error-list {
     li {
       .symbol {
@@ -17,7 +20,7 @@
         color: constants.$blue-grey-600;
 
         &:hover {
-          background: constants.$blue-grey-50;
+          background: if($is-dark-theme, constants.$darkgray, constants.$blue-grey-50);
           color: constants.$blue-500;
         }
       }


### PR DESCRIPTION
fix hover styles for error messages to be consistent for dark theme

Fixes #47723

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
There is an issue with the theming for the Angular errors page.   This will fix #47723

Issue Number: #47723


## What is the new behavior?

This changes the color on hover for the listed errors

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information


### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/4327754/195849210-6293b045-b384-4716-88e6-b0014d19ecbb.png)

#### After
![image](https://user-images.githubusercontent.com/4327754/195848716-61e493ec-bba7-4750-8eed-414374973590.png)
