### PR TITLE
docs: declare NgOptimizedImage APIs as stable

### DIFF
--- a/aio/content/guide/image-directive-setup.md
+++ b/aio/content/guide/image-directive-setup.md
@@ -1,15 +1,6 @@
 # Configuring an image loader for `NgOptimizedImage`
 
-<div class="alert is-important">
-
-The `NgOptimizedImage` directive is available for [developer preview](https://angular.io/guide/releases#developer-preview).
-It's ready for you to try, but it might change before it is stable.
-
-For information on using `NgOptimizedImage`, see [Getting Started with NgOptimizedImage](/guide/image-directive).
-
-</div>
-
-These instructions explain how to set up an image loader for use with the `NgOptimizedImage`. 
+These instructions explain how to set up an image loader for use with the `NgOptimizedImage`.
 
 A "loader" is a function that generates an [image transformation URL](https://web.dev/image-cdns/#how-image-cdns-use-urls-to-indicate-optimization-options) for a given image file. When appropriate, `NgOptimizedImage` sets the size, format, and image quality transformations for an image.
 

--- a/aio/content/guide/image-directive.md
+++ b/aio/content/guide/image-directive.md
@@ -1,12 +1,5 @@
 # Getting started with NgOptimizedImage
 
-<div class="alert is-important">
-
-The `NgOptimizedImage` directive is available for [developer preview](https://angular.io/guide/releases#developer-preview).
-It's ready for you to try, but it might change before it is stable.
-
-</div>
-
 The `NgOptimizedImage` directive makes it easy to adopt performance best practices for loading images.
 
 The directive ensures that the loading of the [Largest Contentful Paint](http://web.dev/lcp) image is prioritized by:

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -418,6 +418,11 @@
           "tooltip": "Use HTTP to talk to a remote server."
         },
         {
+          "url": "guide/image-directive",
+          "title": "Image optimization",
+          "tooltip": "Performant images with the Angular image directive."
+        },
+        {
           "title": "Testing",
           "tooltip": "Testing your Angular apps.",
           "children": [
@@ -850,17 +855,6 @@
               "tooltip": "Information about the Angular Package Format."
             }
           ]
-        }
-      ]
-    },
-    {
-      "title": "Feature preview",
-      "tooltip": "Angular preview features and APIs",
-      "children": [
-        {
-          "url": "guide/image-directive",
-          "title": "Image Directive",
-          "tooltip": "Performant images with the Angular image directive."
         }
       ]
     },

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/cloudflare_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/cloudflare_loader.ts
@@ -18,7 +18,6 @@ import {createImageLoader, ImageLoaderConfig} from './image_loader';
  * @returns Provider that provides an ImageLoader function
  *
  * @publicApi
- * @developerPreview
  */
 export const provideCloudflareLoader = createImageLoader(
     createCloudflareUrl,

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts
@@ -35,7 +35,6 @@ function isCloudinaryUrl(url: string): boolean {
  * @returns Set of providers to configure the Cloudinary loader.
  *
  * @publicApi
- * @developerPreview
  */
 export const provideCloudinaryLoader = createImageLoader(
     createCloudinaryUrl,

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/image_loader.ts
@@ -17,7 +17,6 @@ import {isAbsoluteUrl, isValidPath, normalizePath, normalizeSrc} from '../url';
  * @see `ImageLoader`
  * @see `NgOptimizedImage`
  * @publicApi
- * @developerPreview
  */
 export interface ImageLoaderConfig {
   /**
@@ -35,7 +34,6 @@ export interface ImageLoaderConfig {
  * NgOptimizedImage directive to produce full image URL based on the image name and its width.
  *
  * @publicApi
- * @developerPreview
  */
 export type ImageLoader = (config: ImageLoaderConfig) => string;
 
@@ -62,7 +60,6 @@ export type ImageLoaderInfo = {
  * @see `ImageLoader`
  * @see `NgOptimizedImage`
  * @publicApi
- * @developerPreview
  */
 export const IMAGE_LOADER = new InjectionToken<ImageLoader>('ImageLoader', {
   providedIn: 'root',

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
@@ -34,7 +34,6 @@ function isImageKitUrl(url: string): boolean {
  * @returns Set of providers to configure the ImageKit loader.
  *
  * @publicApi
- * @developerPreview
  */
 export const provideImageKitLoader = createImageLoader(
     createImagekitUrl,

--- a/packages/common/src/directives/ng_optimized_image/image_loaders/imgix_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/imgix_loader.ts
@@ -32,7 +32,6 @@ function isImgixUrl(url: string): boolean {
  * @returns Set of providers to configure the Imgix loader.
  *
  * @publicApi
- * @developerPreview
  */
 export const provideImgixLoader =
     createImageLoader(createImgixUrl, ngDevMode ? ['https://somepath.imgix.net/'] : undefined);

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -203,7 +203,6 @@ export const IMAGE_CONFIG = new InjectionToken<ImageConfig>(
  * ```
  *
  * @publicApi
- * @developerPreview
  */
 @Directive({
   standalone: true,
@@ -325,6 +324,8 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
   /**
    * Sets the image to "fill mode," which eliminates the height/width requirement and adds
    * styles such that the image fills its containing element.
+   *
+   * @developerPreview
    */
   @Input()
   set fill(value: string|boolean|undefined) {

--- a/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
+++ b/packages/common/src/directives/ng_optimized_image/preconnect_link_checker.ts
@@ -35,7 +35,6 @@ const INTERNAL_PRECONNECT_CHECK_BLOCKLIST = new Set(['localhost', '127.0.0.1', '
  * ```
  *
  * @publicApi
- * @developerPreview
  */
 export const PRECONNECT_CHECK_BLOCKLIST =
     new InjectionToken<Array<string|string[]>>('PRECONNECT_CHECK_BLOCKLIST');


### PR DESCRIPTION
In v14.2, we've introduced a new directive to help developers to configure images for better performance. The directive was initially released in the "developer preview" mode. We've collected the feedback, made several improvements and we are happy to announce that the NgOptimizedImage APIs are promoted to stable!

This commit updates vast majority of APIs to drop the `@developerPreview` label, which effectively documents them as stable.

There are few APIs though that retained the `@developerPreview` annotations:
- the `IMAGE_CONFIG` token
- the `ImageConfig` type
- the `fill` @Input of the directive

We plan to collect some additional feedback for the mentioned APIs and drop the `@developerPreview` annotation after that.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No