### PR TITLE
refactor(common): drop deprecated selector from the NgOptimizedImage directive

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -567,14 +567,12 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     set priority(value: string | boolean | undefined);
     // (undocumented)
     get priority(): boolean;
-    // @deprecated
-    set rawSrc(value: string);
     sizes?: string;
     set width(value: string | number | undefined);
     // (undocumented)
     get width(): number | undefined;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[ngSrc],img[rawSrc]", never, { "rawSrc": "rawSrc"; "ngSrc": "ngSrc"; "ngSrcset": "ngSrcset"; "sizes": "sizes"; "width": "width"; "height": "height"; "loading": "loading"; "priority": "priority"; "disableOptimizedSrcset": "disableOptimizedSrcset"; "fill": "fill"; "src": "src"; "srcset": "srcset"; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[ngSrc]", never, { "ngSrc": "ngSrc"; "ngSrcset": "ngSrcset"; "sizes": "sizes"; "width": "width"; "height": "height"; "loading": "loading"; "priority": "priority"; "disableOptimizedSrcset": "disableOptimizedSrcset"; "fill": "fill"; "src": "src"; "srcset": "srcset"; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgOptimizedImage, never>;
 }

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -201,7 +201,7 @@ export const IMAGE_CONFIG = new InjectionToken<ImageConfig>(
  */
 @Directive({
   standalone: true,
-  selector: 'img[ngSrc],img[rawSrc]',
+  selector: 'img[ngSrc]',
   host: {
     '[style.position]': 'fill ? "absolute" : null',
     '[style.width]': 'fill ? "100%" : null',
@@ -228,29 +228,6 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
    * instance that might be already destroyed).
    */
   private _renderedSrc: string|null = null;
-
-  /**
-   * Previously, the `rawSrc` attribute was used to activate the directive.
-   * The attribute was renamed to `ngSrc` and this input just produces an error,
-   * suggesting to switch to `ngSrc` instead.
-   *
-   * This error should be removed in v15.
-   *
-   * @nodoc
-   * @deprecated Use `ngSrc` instead.
-   */
-  @Input()
-  set rawSrc(value: string) {
-    if (ngDevMode) {
-      throw new RuntimeError(
-          RuntimeErrorCode.INVALID_INPUT,
-          `${imgDirectiveDetails(value, false)} the \`rawSrc\` attribute was used ` +
-              `to activate the directive. Newer version of the directive uses the \`ngSrc\` ` +
-              `attribute instead. Please replace \`rawSrc\` with \`ngSrc\` and ` +
-              `\`rawSrcset\` with \`ngSrcset\` attributes in the template to ` +
-              `enable image optimizations.`);
-    }
-  }
 
   /**
    * Name of the source image.

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -288,21 +288,6 @@ describe('Image directive', () => {
               'attribute.');
     });
 
-    it('should throw if an old `rawSrc` is present', () => {
-      setupTestingModule();
-
-      const template = '<img rawSrc="path/img.png" src="path/img2.png" width="100" height="50">';
-      expect(() => {
-        const fixture = createTestComponent(template);
-        fixture.detectChanges();
-      })
-          .toThrowError(
-              'NG02952: The NgOptimizedImage directive has detected that the `rawSrc` ' +
-              'attribute was used to activate the directive. Newer version of the directive uses ' +
-              'the `ngSrc` attribute instead. Please replace `rawSrc` with `ngSrc` and ' +
-              '`rawSrcset` with `ngSrcset` attributes in the template to enable image optimizations.');
-    });
-
     it('should throw if `ngSrc` contains a Base64-encoded image (that starts with `data:`)', () => {
       setupTestingModule();
 


### PR DESCRIPTION
This commit updates the NgOptimizedImage directive to:
- drop a deprecated selector (the `rawSrc` one)
- drop corresponding input getter

The `rawSrc` was replaced by the `ngSrc` one during the developer preview phase.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No