### PR TITLE
fix(docs-infra): display "developer preview" label on class members

### DIFF
--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -89,6 +89,11 @@
         {%- else %}{$ method.name $}()
         {%- endif -%}
       </h3>
+      {%- if method.developerPreview %}
+      <label class="api-status-label dev-preview" title="This API is in Developer Preview">
+        <a href="guide/releases#developer-preview">developer preview</a>
+      </label>
+      {% endif %}
       {$ github.githubLinks(method, versionInfo) $}
     </div>
   </th></tr></thead>
@@ -221,6 +226,12 @@
           <code class="{% if property.deprecated %} deprecated-api-item{% endif %}">{$ renderMemberSyntax(property) $}</code>
         </td>
         <td>
+          {%- if property.developerPreview %}
+          <label class="api-status-label dev-preview" title="This API is in Developer Preview">
+            <a href="guide/releases#developer-preview">developer preview</a>
+          </label>
+          {% endif %}
+
           {%- if (property.isGetAccessor or property.isReadonly) and not property.isSetAccessor %}
           <span class='read-only-property'>Read-Only</span>{% endif %}
 

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -322,7 +322,7 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
   private _disableOptimizedSrcset = false;
 
   /**
-   * Sets the image to "fill mode," which eliminates the height/width requirement and adds
+   * Sets the image to "fill mode", which eliminates the height/width requirement and adds
    * styles such that the image fills its containing element.
    *
    * @developerPreview

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -352,6 +352,7 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
    */
   @Input() srcset?: string;
 
+  /** @nodoc */
   ngOnInit() {
     if (ngDevMode) {
       assertNonEmptyInput(this, 'ngSrc', this.ngSrc);
@@ -432,6 +433,7 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     }
   }
 
+  /** @nodoc */
   ngOnChanges(changes: SimpleChanges) {
     if (ngDevMode) {
       assertNoPostInitInputChange(
@@ -502,6 +504,7 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     return finalSrcs.join(', ');
   }
 
+  /** @nodoc */
   ngOnDestroy() {
     if (ngDevMode) {
       if (!this.priority && this._renderedSrc !== null && this.lcpObserver !== null) {


### PR DESCRIPTION
This commit adds the "developer preview" label for class properties and methods.

See an example at https://pr47814-10a887d.ngbuilds.io/ (the "fill" input). 

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No