### PR TITLE
fix(common): Don't warn about image distortion if fill mode is enabled

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -367,9 +367,11 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
         assertEmptyWidthAndHeight(this);
       } else {
         assertNonEmptyWidthAndHeight(this);
+        // Only check for distorted images when not in fill mode, where
+        // images may be intentionally stretched, cropped or letterboxed.
+        assertNoImageDistortion(this, this.imgElement, this.renderer);
       }
       assertValidLoadingInput(this);
-      assertNoImageDistortion(this, this.imgElement, this.renderer);
       if (!this.ngSrcset) {
         assertNoComplexSizes(this);
       }

--- a/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
+++ b/packages/core/test/bundling/image-directive/e2e/image-distortion/image-distortion.ts
@@ -36,6 +36,10 @@ import {Component} from '@angular/core';
      <!-- Aspect-ratio: 1.0652173913 -->
      <img ngSrc="/e2e/b.png" width="245" height="230">
      <br>
+     <!-- Fill mode disables aspect ratio warning -->
+     <!-- Aspect-ratio: 0.1 -->
+     <img ngSrc="/e2e/b.png" width="24" height="240" disableOptimizedSrcset fill>
+     <br>
      <!-- Supplied aspect ratio is correct & image has 0x0 rendered size -->
      <img ngSrc="/e2e/a.png" width="25" height="25" style="display: none">
      <br>


### PR DESCRIPTION
This PR disables the image distortion warning (when rendered aspect ratio is noticeably different than intrinsic) when in fill mode. The warning doesn't make sense with fill mode, where the user may want the image to stretch, crop or letterbox, depending on their styling. Test is e2e only because this warning only fires after the image is loaded.