### PR TITLE
build: update recommended launch vscode config to use proper bazel dist path

### DIFF
--- a/.vscode/recommended-launch.json
+++ b/.vscode/recommended-launch.json
@@ -16,7 +16,7 @@
       "remoteRoot": "${workspaceRoot}",
       "stopOnEntry": false,
       "timeout": 600000,
-      "outFiles": ["${workspaceFolder}/bazel-out/**/angular/**/*.js"],
+      "outFiles": ["${workspaceFolder}/dist/out/**/packages/**/*.js"]
     },
     {
       "name": "Attach to bazel test ... --config=debug (no source maps)",
@@ -30,58 +30,46 @@
       "remoteRoot": "${workspaceRoot}",
       "stopOnEntry": false,
       "timeout": 600000,
-      "outFiles": ["${workspaceFolder}/bazel-out/**/angular/**/*.js"],
+      "outFiles": ["${workspaceFolder}/dist/out/**/packages/**/*.js"]
     },
     {
       "name": "IVY:packages/core/test/acceptance",
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/.bin/bazelisk",
-      "args": [
-        "test",
-        "packages/core/test/acceptance",
-        "--config=debug"
-      ],
+      "args": ["test", "packages/core/test/acceptance", "--config=debug"],
       "port": 9229,
       "address": "localhost",
       "restart": true,
       "sourceMaps": true,
       "timeout": 600000,
-      "outFiles": ["${workspaceFolder}/bazel-out/**/angular/**/*.js"],
+      "outFiles": ["${workspaceFolder}/dist/out/**/packages/**/*.js"]
     },
     {
       "name": "IVY:packages/core/test/render3",
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/.bin/bazelisk",
-      "args": [
-        "test",
-        "packages/core/test/render3",
-        "--config=debug"
-      ],
+      "args": ["test", "packages/core/test/render3", "--config=debug"],
       "port": 9229,
       "address": "localhost",
       "restart": true,
       "sourceMaps": true,
       "timeout": 600000,
-      "outFiles": ["${workspaceFolder}/bazel-out/**/angular/**/*.js"],
+      "outFiles": ["${workspaceFolder}/dist/out/**/packages/**/*.js"]
     },
     {
       "name": "IVY:packages/core/test",
       "type": "node",
       "request": "launch",
       "program": "${workspaceFolder}/node_modules/.bin/bazelisk",
-      "args": [
-        "test",
-        "packages/core/test",
-        "--config=debug"
-      ],
+      "args": ["test", "packages/core/test", "--config=debug"],
       "port": 9229,
       "address": "localhost",
       "restart": true,
       "sourceMaps": true,
       "timeout": 600000,
-      "outFiles": ["${workspaceFolder}/bazel-out/**/angular/**/*.js"],
-    },
+      "outFiles": ["${workspaceFolder}/dist/out/**/packages/**/*.js"]
+    }
   ]
 }


### PR DESCRIPTION
As of Bazel v5, the `bazel-out` symlink no longer exists. This commit corrects the path in the VSCode recommended launch configuration. This helps speed up this launch configuration given less files having to be explored.