### PR TITLE
docs: correct section header and text

### DIFF
--- a/aio/content/tutorial/toh-pt4.md
+++ b/aio/content/tutorial/toh-pt4.md
@@ -329,7 +329,7 @@ This template binds directly to the component's `messageService`.
 
 The messages look better after you add the private CSS styles to `messages.component.css` as listed in one of the ["final code review"](#final-code-review) tabs below.
 
-## Add messages to hero service
+## Add messages to hero component
 
 The following example shows how to display a history of each time the user clicks on a hero.
 This helps when you get to the next section on [Routing](tutorial/toh-pt5).
@@ -337,7 +337,7 @@ This helps when you get to the next section on [Routing](tutorial/toh-pt5).
 <code-example header="src/app/heroes/heroes.component.ts" path="toh-pt4/src/app/heroes/heroes.component.ts"></code-example>
 
 Refresh the browser to see the list of heroes, and scroll to the bottom to see the messages from the HeroService.
-Each time you click a hero, a new message appears to record the selection.
+Each time you click a hero, a new message from the HeroComponent appears to record the selection.
 Use the **Clear messages** button to clear the message history.
 
 <a id="final-code-review"></a>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On Section 4 of Tour of Heroes tutorial, the [last section](https://angular.io/tutorial/toh-pt4#add-messages-to-hero-service) reads "Add messages to hero service" while the code extract demonstrates adding messages to the hero _component_. This PR updates the section header and text to reflect the code.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
