### PR TITLE
feat(service-worker): add service worker script token to public API

### DIFF
--- a/goldens/public-api/service-worker/index.md
+++ b/goldens/public-api/service-worker/index.md
@@ -5,6 +5,7 @@
 ```ts
 
 import * as i0 from '@angular/core';
+import { InjectionToken } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
 import { Observable } from 'rxjs';
 
@@ -29,6 +30,9 @@ export class ServiceWorkerModule {
     // (undocumented)
     static ɵmod: i0.ɵɵNgModuleDeclaration<ServiceWorkerModule, never, never, never>;
 }
+
+// @public
+export const SW_SCRIPT: InjectionToken<string>;
 
 // @public
 export class SwPush {

--- a/packages/examples/service-worker/script/BUILD.bazel
+++ b/packages/examples/service-worker/script/BUILD.bazel
@@ -1,0 +1,58 @@
+load("//tools:defaults.bzl", "ng_module", "protractor_web_test_suite", "ts_devserver", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "sw_script_examples",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["**/*_spec.ts"],
+    ),
+    generate_ve_shims = True,
+    deps = [
+        "//packages/core",
+        "//packages/platform-browser",
+        "//packages/platform-browser-dynamic",
+        "//packages/service-worker",
+    ],
+)
+
+ts_library(
+    name = "sw_script_e2e_tests_lib",
+    testonly = True,
+    srcs = glob(["**/e2e_test/*_spec.ts"]),
+    tsconfig = "//packages/examples:tsconfig-e2e.json",
+    deps = [
+        "//packages/examples/test-utils",
+        "//packages/private/testing",
+        "@npm//@types/jasminewd2",
+        "@npm//protractor",
+    ],
+)
+
+ts_devserver(
+    name = "devserver",
+    additional_root_paths = ["angular/packages/examples"],
+    bootstrap = [
+        "//packages/zone.js/bundles:zone.umd.js",
+        "ngsw-worker.js",
+    ],
+    entry_module = "@angular/examples/service-worker/script/main",
+    port = 4200,
+    scripts = [
+        "//tools/rxjs:rxjs_umd_modules",
+        "@npm//:node_modules/tslib/tslib.js",
+    ],
+    static_files = ["//packages/examples:index.html"],
+    deps = [":sw_script_examples"],
+)
+
+protractor_web_test_suite(
+    name = "protractor_tests",
+    on_prepare = "start-server.js",
+    server = ":devserver",
+    deps = [
+        ":sw_script_e2e_tests_lib",
+        "@npm//selenium-webdriver",
+    ],
+)

--- a/packages/examples/service-worker/script/e2e_test/script_spec.ts
+++ b/packages/examples/service-worker/script/e2e_test/script_spec.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {browser, by, element} from 'protractor';
+
+import {verifyNoBrowserErrors} from '../../../test-utils';
+
+describe('SW `SW_SCRIPT` example', () => {
+  const appElem = element(by.css('example-app'));
+
+  afterEach(verifyNoBrowserErrors);
+
+  it('register the SW by factory', () => {
+    browser.get(browser.baseUrl);
+    expect(appElem.getText()).toBe(`SW script: ${browser.baseUrl}/ngsw-worker.js`);
+  });
+});

--- a/packages/examples/service-worker/script/main.ts
+++ b/packages/examples/service-worker/script/main.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
+
+import {AppModule} from './module';
+
+platformBrowserDynamic().bootstrapModule(AppModule);

--- a/packages/examples/service-worker/script/module.ts
+++ b/packages/examples/service-worker/script/module.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// tslint:disable: no-duplicate-imports
+// clang-format off
+import {Component} from '@angular/core';
+// clang-format on
+// #docregion sw-script
+import {APP_BASE_HREF} from '@angular/common';
+import {NgModule} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {ServiceWorkerModule, SW_SCRIPT} from '@angular/service-worker';
+
+// #enddocregion sw-script
+// tslint:enable: no-duplicate-imports
+
+@Component({
+  selector: 'example-app',
+  template: 'SW script: {{ script }}',
+})
+export class AppComponent {
+  get script(): string|undefined {
+    return navigator.serviceWorker?.controller?.scriptURL;
+  }
+}
+// #docregion sw-script
+
+@NgModule({
+  // #enddocregion sw-script
+  bootstrap: [
+    AppComponent,
+  ],
+  declarations: [
+    AppComponent,
+  ],
+  // #docregion sw-script
+  imports: [
+    BrowserModule,
+    ServiceWorkerModule.register(''),
+  ],
+  providers: [
+    // #enddocregion sw-script
+    {
+      provide: APP_BASE_HREF,
+      useValue: '/',
+    },
+    // #docregion sw-script
+    {
+      provide: SW_SCRIPT,
+      useFactory: (href: string) => (href + 'ngsw-worker.js'),
+      deps: [APP_BASE_HREF],
+    },
+  ],
+})
+export class AppModule {
+}
+// #enddocregion sw-script

--- a/packages/examples/service-worker/script/ngsw-worker.js
+++ b/packages/examples/service-worker/script/ngsw-worker.js
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// Mock `ngsw-worker.js` used for testing the examples.
+// Immediately takes over and unregisters itself.
+self.addEventListener('install', evt => evt.waitUntil(self.skipWaiting()));
+self.addEventListener(
+    'activate',
+    evt => evt.waitUntil(self.clients.claim().then(() => self.registration.unregister())));

--- a/packages/examples/service-worker/script/start-server.js
+++ b/packages/examples/service-worker/script/start-server.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+const protractorUtils = require('@bazel/protractor/protractor-utils');
+const protractor = require('protractor');
+
+module.exports = async function(config) {
+  const {port} = await protractorUtils.runServer(config.workspace, config.server, '-port', []);
+  const serverUrl = `http://localhost:${port}`;
+
+  protractor.browser.baseUrl = serverUrl;
+};

--- a/packages/service-worker/src/index.ts
+++ b/packages/service-worker/src/index.ts
@@ -15,6 +15,6 @@
  */
 
 export {NoNewVersionDetectedEvent, UnrecoverableStateEvent, UpdateActivatedEvent, UpdateAvailableEvent, VersionDetectedEvent, VersionEvent, VersionInstallationFailedEvent, VersionReadyEvent} from './low_level';
-export {ServiceWorkerModule, SwRegistrationOptions} from './module';
+export {ServiceWorkerModule, SW_SCRIPT, SwRegistrationOptions} from './module';
 export {SwPush} from './push';
 export {SwUpdate} from './update';

--- a/packages/service-worker/src/module.ts
+++ b/packages/service-worker/src/module.ts
@@ -75,7 +75,19 @@ export abstract class SwRegistrationOptions {
   registrationStrategy?: string|(() => Observable<unknown>);
 }
 
-export const SCRIPT = new InjectionToken<string>('NGSW_REGISTER_SCRIPT');
+/**
+ * Token that can be used to provide script for `ServiceWorkerModule` outside of
+ * `ServiceWorkerModule.register()`.
+ *
+ * You can use this token to define a provider that generates the script at runtime,
+ * for example via a function call:
+ *
+ * {@example service-worker/script/module.ts region="sw-script"
+ *     header="app.module.ts"}
+ *
+ * @publicApi
+ */
+export const SW_SCRIPT = new InjectionToken<string>('NGSW_REGISTER_SCRIPT');
 
 export function ngswAppInitializer(
     injector: Injector, script: string, options: SwRegistrationOptions,
@@ -168,7 +180,7 @@ export class ServiceWorkerModule {
     return {
       ngModule: ServiceWorkerModule,
       providers: [
-        {provide: SCRIPT, useValue: script},
+        {provide: SW_SCRIPT, useValue: script},
         {provide: SwRegistrationOptions, useValue: opts},
         {
           provide: NgswCommChannel,
@@ -178,7 +190,7 @@ export class ServiceWorkerModule {
         {
           provide: APP_INITIALIZER,
           useFactory: ngswAppInitializer,
-          deps: [Injector, SCRIPT, SwRegistrationOptions, PLATFORM_ID],
+          deps: [Injector, SW_SCRIPT, SwRegistrationOptions, PLATFORM_ID],
           multi: true,
         },
       ],

--- a/packages/service-worker/test/module_spec.ts
+++ b/packages/service-worker/test/module_spec.ts
@@ -11,7 +11,7 @@ import {fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 import {Subject} from 'rxjs';
 import {filter, take} from 'rxjs/operators';
 
-import {ServiceWorkerModule, SwRegistrationOptions} from '../src/module';
+import {ServiceWorkerModule, SW_SCRIPT, SwRegistrationOptions} from '../src/module';
 import {SwUpdate} from '../src/update';
 
 
@@ -79,6 +79,26 @@ describe('ServiceWorkerModule', () => {
       await configTestBed({enabled: true, scope: 'foo'});
       expect(consoleErrorSpy)
           .toHaveBeenCalledWith('Service worker registration failed with:', 'no reason');
+    });
+  });
+
+  describe('SW_SCRIPT', () => {
+    const configTestBed = async (providerScript: string) => {
+      TestBed.configureTestingModule({
+        imports: [ServiceWorkerModule.register('sw.js')],
+        providers: [
+          {provide: PLATFORM_ID, useValue: 'browser'},
+          {provide: SW_SCRIPT, useFactory: () => providerScript},
+        ],
+      });
+
+      await untilStable();
+    };
+
+    it('sets the script (and overwrites this set via `.register()`', async () => {
+      await configTestBed('provider-sw.js');
+
+      expect(swRegisterSpy).toHaveBeenCalledWith('provider-sw.js', {scope: undefined});
     });
   });
 


### PR DESCRIPTION
Applications can provide their own `SW_SCRIPT`, which depends on, for instance: `APP_BASE_HREF`. 

Since the `deployUrl` was deprecated you need to use for CDN the `appBaseHref` and for the routing the `APP_BASE_HREF`. The service worker can't be initialized in a browser from a different url; therefore you need to hardcode the current origin: `ServiceWorkerModule.register('https://example.com/ngsw-worker.js')`. Another problem if a site works on two different domains.

Related links:
* https://github.com/w3c/ServiceWorker/issues/940

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
