### PR TITLE
docs: release notes for the v14.2.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+<a name="14.2.8"></a>
+# 14.2.8 (2022-10-26)
+## Special Thanks
+Andrew Scott, Balaji, Paul Gschwendtner, WD Snoeijer, onrails and vyom1611
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="15.0.0-rc.0"></a>
 # 15.0.0-rc.0 (2022-10-19)
 ### common


### PR DESCRIPTION
Cherry-picks the changelog from the "14.2.x" branch to the next branch (main).