### PR TITLE
feat: allow specifying NgZone options for `createApplication()`

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -191,8 +191,9 @@ export function internalCreateApplication(config: {
   rootComponent?: Type<unknown>,
   appProviders?: Array<Provider|EnvironmentProviders>,
   platformProviders?: Provider[],
+  ngZoneConfig?: BootstrapOptions,
 }): Promise<ApplicationRef> {
-  const {rootComponent, appProviders, platformProviders} = config;
+  const {rootComponent, appProviders, platformProviders, ngZoneConfig} = config;
 
   if (NG_DEV_MODE && rootComponent !== undefined) {
     assertStandaloneComponentType(rootComponent);
@@ -200,7 +201,7 @@ export function internalCreateApplication(config: {
 
   const platformInjector = createOrReusePlatformInjector(platformProviders as StaticProvider[]);
 
-  const ngZone = getNgZone('zone.js', getNgZoneOptions());
+  const ngZone = getNgZone(ngZoneConfig?.ngZone ?? 'zone.js', getNgZoneOptions(ngZoneConfig));
 
   return ngZone.run(() => {
     // Create root application injector based on a set of providers configured at the platform

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, DOCUMENT, XhrFactory, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {APP_ID, ApplicationModule, ApplicationRef, createPlatformFactory, EnvironmentProviders, ErrorHandler, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalCreateApplication as internalCreateApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
+import {APP_ID, ApplicationModule, ApplicationRef, BootstrapOptions, createPlatformFactory, EnvironmentProviders, ErrorHandler, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalCreateApplication as internalCreateApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
 import {SERVER_TRANSITION_PROVIDERS, TRANSITION_ID} from './browser/server-transition';
@@ -26,7 +26,7 @@ const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
  *
  * @publicApi
  */
-export interface ApplicationConfig {
+export interface ApplicationConfig extends BootstrapOptions {
   /**
    * List of providers that should be available to the root component and all its children.
    */
@@ -110,7 +110,14 @@ export function bootstrapApplication(
  * @publicApi
  */
 export function createApplication(options?: ApplicationConfig) {
-  return internalCreateApplication(createProvidersConfig(options));
+  return internalCreateApplication({
+    ...createProvidersConfig(options),
+    ngZoneConfig: {
+      ngZone: options?.ngZone,
+      ngZoneRunCoalescing: options?.ngZoneRunCoalescing,
+      ngZoneEventCoalescing: options?.ngZoneEventCoalescing,
+    },
+  });
 }
 
 function createProvidersConfig(options?: ApplicationConfig) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #47886 


## What is the new behavior?

This adds the `ngZone`, `ngZoneRunCoalescing`, and `ngZoneEventCoalescing` options to the `createApplication()` options.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Closes #47886