### PR TITLE
fix(platform-server): call `onSerialize` when state is empty

### DIFF
--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -21,15 +21,20 @@ export const TRANSFER_STATE_SERIALIZATION_PROVIDERS: Provider[] = [{
 
 function serializeTransferStateFactory(doc: Document, appId: string, transferStore: TransferState) {
   return () => {
+    // The `.toJSON` here causes the `onSerialize` callbacks to be called.
+    // These callbacks can be used to provide the value for a given key.
+    const content = transferStore.toJson();
+
     if (transferStore.isEmpty) {
       // The state is empty, nothing to transfer,
       // avoid creating an extra `<script>` tag in this case.
       return;
     }
+
     const script = doc.createElement('script');
     script.id = appId + '-state';
     script.setAttribute('type', 'application/json');
-    script.textContent = escapeHtml(transferStore.toJson());
+    script.textContent = escapeHtml(content);
     doc.body.appendChild(script);
   };
 }

--- a/packages/platform-server/test/transfer_state_spec.ts
+++ b/packages/platform-server/test/transfer_state_spec.ts
@@ -1,0 +1,86 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, NgModule,} from '@angular/core';
+import {BrowserModule, makeStateKey, TransferState} from '@angular/platform-browser';
+import {renderModule, ServerModule} from '@angular/platform-server';
+
+describe('transfer_state', () => {
+  const defaultExpectedOutput =
+      '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other">Works!</app><script id="transfer-state" type="application/json">{&q;test&q;:10}</script></body></html>';
+
+  it('adds transfer script tag when using renderModule', async () => {
+    const STATE_KEY = makeStateKey<number>('test');
+
+    @Component({selector: 'app', template: 'Works!'})
+    class TransferComponent {
+      constructor(private transferStore: TransferState) {
+        this.transferStore.set(STATE_KEY, 10);
+      }
+    }
+
+    @NgModule({
+      bootstrap: [TransferComponent],
+      declarations: [TransferComponent],
+      imports: [BrowserModule.withServerTransition({appId: 'transfer'}), ServerModule],
+    })
+    class TransferStoreModule {
+    }
+
+    const output = await renderModule(TransferStoreModule, {document: '<app></app>'});
+    expect(output).toBe(defaultExpectedOutput);
+  });
+
+  it('cannot break out of <script> tag in serialized output', async () => {
+    const STATE_KEY = makeStateKey<string>('testString');
+
+    @Component({selector: 'esc-app', template: 'Works!'})
+    class EscapedComponent {
+      constructor(private transferStore: TransferState) {
+        this.transferStore.set(STATE_KEY, '</script><script>alert(\'Hello&\' + "World");');
+      }
+    }
+    @NgModule({
+      bootstrap: [EscapedComponent],
+      declarations: [EscapedComponent],
+      imports: [BrowserModule.withServerTransition({appId: 'transfer'}), ServerModule],
+    })
+    class EscapedTransferStoreModule {
+    }
+
+    const output =
+        await renderModule(EscapedTransferStoreModule, {document: '<esc-app></esc-app>'});
+    expect(output).toBe(
+        '<html><head></head><body><esc-app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other">Works!</esc-app>' +
+        '<script id="transfer-state" type="application/json">' +
+        '{&q;testString&q;:&q;&l;/script&g;&l;script&g;' +
+        'alert(&s;Hello&a;&s; + \\&q;World\\&q;);&q;}</script></body></html>');
+  });
+
+  it('adds transfer script tag when setting state during onSerialize', async () => {
+    const STATE_KEY = makeStateKey<number>('test');
+
+    @Component({selector: 'app', template: 'Works!'})
+    class TransferComponent {
+      constructor(private transferStore: TransferState) {
+        this.transferStore.onSerialize(STATE_KEY, () => 10);
+      }
+    }
+
+    @NgModule({
+      bootstrap: [TransferComponent],
+      declarations: [TransferComponent],
+      imports: [BrowserModule.withServerTransition({appId: 'transfer'}), ServerModule],
+    })
+    class TransferStoreModule {
+    }
+
+    const output = await renderModule(TransferStoreModule, {document: '<app></app>'});
+    expect(output).toBe(defaultExpectedOutput);
+  });
+});

--- a/packages/platform-server/testing/src/server.ts
+++ b/packages/platform-server/testing/src/server.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createPlatformFactory, NgModule, PlatformRef, StaticProvider} from '@angular/core';
+import {createPlatformFactory, NgModule} from '@angular/core';
 import {BrowserDynamicTestingModule, ɵplatformCoreDynamicTesting as platformCoreDynamicTesting} from '@angular/platform-browser-dynamic/testing';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 import {ɵINTERNAL_SERVER_PLATFORM_PROVIDERS as INTERNAL_SERVER_PLATFORM_PROVIDERS, ɵSERVER_RENDER_PROVIDERS as SERVER_RENDER_PROVIDERS} from '@angular/platform-server';


### PR DESCRIPTION
Commit https://github.com/angular/angular/commit/a0b2d364156eed0d33831c37b00ea5c58ff4bbec#diff-3975e0ee5aa3e06ecbcd76f5fa5134612f7fd2e6802ca7d370973bd410aab55cR25-R31 changed the serialization phase logic so that when the state is empty the script tag is not added to the document. As a side effect, this caused the `toJson` not called which caused the `onSerialize` callbacks also not to be called. These callbacks are used to provide the value for a key when `toJson` is called. Example: https://github.com/ngrx/platform/issues/101#issuecomment-351998548

Closes #47172
