### PR TITLE
docs: improve grammer in CLI command template

### DIFF
--- a/aio/tools/transforms/templates/cli/cli-command.template.html
+++ b/aio/tools/transforms/templates/cli/cli-command.template.html
@@ -20,7 +20,7 @@
     {% endif%}
 
     {% if doc.subcommands.length %}
-    <p>This command has the following <a href="#{$ doc.name $}-commands">commands</a>:<p>
+    <p>This command has the following <a href="#{$ doc.name $}-commands">sub-commands</a>:<p>
     <ul>
       {% for subcommand in doc.subcommands %}
       <li><a class="code-anchor" href="#{$ subcommand.name $}-command">{$ subcommand.name $}</a></li>


### PR DESCRIPTION
Before
```
This command has the following commands:
```

Now
```
This command has the following sub-commands:
```