### PR TITLE
release: cut the zone.js-0.11.9 release

### DIFF
--- a/packages/zone.js/CHANGELOG.md
+++ b/packages/zone.js/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [0.11.9](https://github.com/angular/angular/compare/zone.js-0.11.8...zone.js-0.11.9) (2022-10-27)
+
+
+### Bug Fixes
+
+* **zone.js:** cancel tasks only when they are scheduled or running ([#46435](https://github.com/angular/angular/issues/46435)) ([b618b5a](https://github.com/angular/angular/commit/b618b5aa86138c900055c5496967e3348a7b98fc)), closes [#45711](https://github.com/angular/angular/issues/45711)
+* **zone.js:** Fix ConsoleTask interface typo ([#47090](https://github.com/angular/angular/issues/47090)) ([91954cf](https://github.com/angular/angular/commit/91954cf20e17a386d71cc8ea25d1d17b9ae1e31c))
+
+
+
 ## [0.11.8](https://github.com/angular/angular/compare/zone.js-0.11.7...zone.js-0.11.8) (2022-08-08)
 
 

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zone.js",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "Zones for JavaScript",
   "main": "./bundles/zone.umd.js",
   "module": "./fesm2015/zone.js",


### PR DESCRIPTION
Cut the `zone.js-0.11.9` release, to remove the `zone-async-tagging` bundle from the release, since the `AsyncTaggingZoneSpec` has been moved the `packages/core` bundle.