### PR TITLE
fix(router): fix redirectTo on named outlets - resolves #33783

### DIFF
--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -84,8 +84,8 @@ function validateNode(route: Route, fullPath: string, requireStandaloneComponent
           RuntimeErrorCode.INVALID_ROUTE_CONFIG,
           `Invalid configuration of route '${fullPath}': Array cannot be specified`);
     }
-    if (!route.component && !route.loadComponent && !route.children && !route.loadChildren &&
-        (route.outlet && route.outlet !== PRIMARY_OUTLET)) {
+    if (!route.redirectTo && !route.component && !route.loadComponent && !route.children &&
+        !route.loadChildren && (route.outlet && route.outlet !== PRIMARY_OUTLET)) {
       throw new RuntimeError(
           RuntimeErrorCode.INVALID_ROUTE_CONFIG,
           `Invalid configuration of route '${

--- a/packages/router/test/config.spec.ts
+++ b/packages/router/test/config.spec.ts
@@ -157,6 +157,12 @@ describe('config', () => {
         validateConfig([{path: 'a', outlet: 'aux', loadChildren: jasmine.createSpy('child')}]);
       }).not.toThrow();
     });
+
+    it('should not throw when outlet has redirectTo', () => {
+      expect(() => {
+        validateConfig([{path: '', pathMatch: 'prefix', outlet: 'aux', redirectTo: 'main'}]);
+      }).not.toThrow();
+    });
   });
 });
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2983,6 +2983,22 @@ describe('Integration', () => {
         expect(history[history.length - 1].state)
             .toEqual({foo: 'bar', navigationId: history.length});
       })));
+
+
+      it('can redirect from componentless named outlets', fakeAsync(() => {
+           const router = TestBed.inject(Router);
+           const fixture = createRoot(router, RootCmp);
+
+           router.resetConfig([
+             {path: 'main', outlet: 'aux', component: BlankCmp},
+             {path: '', pathMatch: 'full', outlet: 'aux', redirectTo: 'main'},
+           ]);
+
+           router.navigateByUrl('');
+           advance(fixture);
+
+           expect(TestBed.inject(Location).path()).toEqual('/(aux:main)');
+         }));
     });
 
     it('should set href on area elements', fakeAsync(() => {


### PR DESCRIPTION
fix(router): fix redirectTo on named outlets

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #33783 


## What is the new behavior?
You can now redirect your named outlets. Useful when creating sub navigations like sub page tabs and such.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
