### PR TITLE
refactor(bazel): disables the Tsickle decorator transform

### DIFF
--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -226,9 +226,8 @@ export function compile({
     return delegate(fileName.replace(/\.(ngfactory|ngsummary)\.ts$/, '.ts'));
   };
 
-  // By default, disable tsickle decorator transforming in the tsickle compiler host.
-  // The Angular compilers have their own logic for decorator processing and we wouldn't
-  // want tsickle to interfere with that.
+  // Never run the tsickle decorator transform.
+  // TODO(b/254054103): Remove the transform and this flag.
   bazelHost.transformDecorators = false;
 
   // By default in the `prodmode` output, we do not add annotations for closure compiler.
@@ -238,11 +237,6 @@ export function compile({
   if (!bazelOpts.es5Mode && !bazelOpts.devmode) {
     if (bazelOpts.workspaceName === 'google3') {
       compilerOpts.annotateForClosureCompiler = true;
-      // Enable the tsickle decorator transform in google3 with Ivy mode enabled. The tsickle
-      // decorator transformation is still needed. This might be because of custom decorators
-      // with the `@Annotation` JSDoc that will be processed by the tsickle decorator transform.
-      // TODO: Figure out why this is needed in g3 and how we can improve this. FW-2225
-      bazelHost.transformDecorators = true;
     } else {
       compilerOpts.annotateForClosureCompiler = false;
     }


### PR DESCRIPTION
This is no longer needed in google3 and actively impedes prodmode tests. See http://b/254054103#comment7 for deeper analysis.

This just turns off the transform for now, if it lands successfully I'll follow up with deleting the flag and dead code altogether.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [X] Refactoring (no functional changes, no api changes)

## What is the current behavior?

`ngc_wrapped` in prodmode and runs a transform forked from tsickle which transforms decorators to a different syntax.

Issue Number: http://b/254054103

## What is the new behavior?

This transform is no longer run in any situation in `ngc_wrapped`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

[Global presubmit](http://test/OCL:484372894:BASE:485393496:1667332325896:a3e054ef)