### PR TITLE
fix(language-service): Prevent crashes on unemitable references

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -18,7 +18,8 @@ import {SymbolWithValueDeclaration} from '../../util/src/typescript';
  */
 export interface PotentialImport {
   kind: PotentialImportKind;
-  moduleSpecifier: string;
+  // If no moduleSpecifier is present, the given symbol name is already in scope.
+  moduleSpecifier?: string;
   symbolName: string;
 }
 

--- a/packages/language-service/src/codefixes/fix_missing_import.ts
+++ b/packages/language-service/src/codefixes/fix_missing_import.ts
@@ -93,10 +93,13 @@ function getCodeActions(
       }
 
       // Create a code action for this import.
+      let description = `Import ${importName}`;
+      if (potentialImport.moduleSpecifier !== undefined) {
+        description += ` from '${potentialImport.moduleSpecifier}' on ${importOn.name!.text}`;
+      }
       codeActions.push({
         fixName: FixIdForCodeFixesAll.FIX_MISSING_IMPORT,
-        description: `Import ${importName} from '${potentialImport.moduleSpecifier}' on ${
-            importOn.name!.text}`,
+        description,
         changes: [{
           fileName: importOn.getSourceFile().fileName,
           textChanges: [...fileImportChanges, ...traitImportChanges],
@@ -115,7 +118,10 @@ function getCodeActions(
 function updateImportsForTypescriptFile(
     tsChecker: ts.TypeChecker, file: ts.SourceFile, newImport: PotentialImport,
     tsFileToImport: ts.SourceFile): [ts.TextChange[], string] {
-  const changes = new Array<ts.TextChange>();
+  // If the expression is already imported, we can just return its name.
+  if (newImport.moduleSpecifier === undefined) {
+    return [[], newImport.symbolName];
+  }
 
   // The trait might already be imported, possibly under a different name. If so, determine the
   // local name of the imported trait.


### PR DESCRIPTION
Currently, when generating an import of a selector, the language service might crash if the compiler cannot emit a reference to the new symbol's file from the target component's file. (This might happen because the two are the same file.) We should handle that case by reusing the existing identifier if possible, or otherwise failing gracefully.