### PR TITLE
fix(forms): validate standalone NgModel with the correct initial value

### DIFF
--- a/packages/forms/src/directives/ng_model.ts
+++ b/packages/forms/src/directives/ng_model.ts
@@ -298,7 +298,12 @@ export class NgModel extends NgControl implements OnChanges, OnDestroy {
 
   private _setUpStandalone(): void {
     setUpControl(this.control, this, this.callSetDisabledState);
-    this.control.updateValueAndValidity({emitEvent: false});
+    // Wait to emit value and status changes.
+    this.control.setValue(this.model, {
+      emitEvent: false,
+      emitModelToViewChange: false,
+      onlySelf: true,
+    });
   }
 
   private _checkForErrors(): void {

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -1409,6 +1409,15 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
     });
 
     describe('validation directives', () => {
+      it('should validate with correct initial value', () => {
+        const fixture = initTest(NgModelRequiredValidator);
+        fixture.detectChanges();
+
+        const element = fixture.debugElement.query(By.directive(NgModel));
+        const control = element.injector.get(NgModel).control;
+        expect(control.hasError('required')).toBe(false);
+      });
+
       it('required validator should validate checkbox', fakeAsync(() => {
            const fixture = initTest(NgModelCheckboxRequiredValidator);
            fixture.detectChanges();
@@ -2832,6 +2841,12 @@ class NgModelMultipleValidators {
   minLen!: number;
   // TODO(issue/24571): remove '!'.
   pattern!: string|RegExp;
+}
+
+@Component(
+    {selector: 'ng-model-checkbox-validator', template: `<input [(ngModel)]="value" required>`})
+class NgModelRequiredValidator {
+  value = 'value';
 }
 
 @Component({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

[StackBlitz Example](https://stackblitz.com/edit/angular-ivy-jknx34?file=src%2Fapp%2Fapp.component.ts)

A standalone NgModel's control always initially validates with `null` even if the NgModel has a different value. With a valid value, the control is invalid and then valid. This causes a change detection error, ExpressionChangedAfterItHasBeenCheckedError, when a directive's `NgModel.valid` or `invalid` properties are bound to a property or used in interpolation. This does not affect directives used with forms.

Issue Number: #18748

## What is the new behavior?

Set and validate the correct directive value on the control, but don't emit value or status changes. The value and status changes continue to be emitted later [at the correct time](https://github.com/angular/angular/pull/9559). In addition to automated tests, I validated that fix by linking it with the following repository.
https://github.com/TrevorKarjanis/angular-issue-18747

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

:poop: