### PR TITLE
[14.2.x] fix(core): hardening rules related to the attribute order on iframe elements

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -89,6 +89,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     UNKNOWN_ELEMENT = 304,
     // (undocumented)
+    UNSAFE_IFRAME_ATTRS = 910,
+    // (undocumented)
     UNSAFE_VALUE_IN_RESOURCE_URL = 904,
     // (undocumented)
     UNSAFE_VALUE_IN_SCRIPT = 905,

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 454655,
+      "main": 455505,
       "polyfills": 33922,
       "styles": 73640,
       "light-theme": 78045,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/security_sensitive_constant_attributes.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/security_sensitive_constant_attributes.js
@@ -6,7 +6,7 @@ consts: [
 ],
 template: function MyComponent_Template(rf, ctx) {
   if (rf & 1) {
-    $r3$.ɵɵelement(0, "embed", 0)(1, "iframe", 1)(2, "object", 2)(3, "embed", 0)(4, "img", 3);
+    $r3$.ɵɵelement(0, "embed", 0)(1, "iframe", 1, null, i0.ɵɵvalidateIframeStaticAttributes)(2, "object", 2)(3, "embed", 0)(4, "img", 3);
   }
   …
 }

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -7137,6 +7137,219 @@ function allTests(os: string) {
       });
     });
 
+    describe('iframe processing', () => {
+      it('should generate attribute and property bindings with a validator fn when on <iframe>',
+         () => {
+           env.write('test.ts', `
+                import {Component} from '@angular/core';
+
+                @Component({
+                  template: \`
+                    <iframe src="http://angular.io"
+                      [sandbox]="''" [attr.allow]="''"
+                      [title]="'Hi!'"
+                    ></iframe>
+                  \`
+                })
+                export class SomeComponent {}
+              `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Only `sandbox` has an extra validation fn (since it's security-sensitive),
+           // the `title` property doesn't have an extra validation fn.
+           expect(jsContents)
+               .toContain(
+                   'ɵɵproperty("sandbox", "", i0.ɵɵvalidateIframeAttribute)("title", "Hi!")');
+
+           // The `allow` property is also security-sensitive, thus an extra validation fn.
+           expect(jsContents).toContain('ɵɵattribute("allow", "", i0.ɵɵvalidateIframeAttribute)');
+
+           // Expect an extra validation function on the `element` instruction for an <iframe>
+           // to validate static attributes.
+           expect(jsContents)
+               .toContain('ɵɵelement(0, "iframe", 0, null, i0.ɵɵvalidateIframeStaticAttributes)');
+         });
+
+      it('should generate attribute and property bindings with a validator fn when on <iframe> ' +
+             'with an *ngIf on it as well',
+         () => {
+           env.write('test.ts', `
+                import {Component} from '@angular/core';
+
+                @Component({
+                  template: \`
+                    <iframe
+                      *ngIf="visible"
+                      src="http://angular.io"
+                      [sandbox]="''"
+                    ></iframe>
+                  \`
+                })
+                export class SomeComponent {
+                  visible = true;
+                }
+              `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Expect an extra validation function on the `element` instruction for an <iframe>
+           // to validate static attributes.
+           expect(jsContents)
+               .toContain('ɵɵelement(0, "iframe", 1, null, i0.ɵɵvalidateIframeStaticAttributes)');
+
+           // The `template` instruction that represents an <iframe> remains as is
+           // (without additional validation fns).
+           expect(jsContents)
+               .toContain('ɵɵtemplate(0, SomeComponent_iframe_0_Template, 1, 1, "iframe", 0)');
+         });
+
+      it('should generate an element instruction with a validator function for <iframe>s ' +
+             '(making sure it\'s case-insensitive, since this is allowed in Angular templates)',
+         () => {
+           env.write('test.ts', `
+              import {Component} from '@angular/core';
+
+              @Component({
+                template: \`
+                  <IFRAME
+                    src="http://angular.io"
+                    [attr.SANDBOX]="''"
+                  ></IFRAME>
+                \`
+              })
+              export class SomeComponent {}
+            `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Make sure that the `sandbox` has an extra validation fn,
+           // and the check is case-insensitive (since the `setAttribute` DOM API
+           // is case-insensitive as well).
+           expect(jsContents).toContain('ɵɵattribute("SANDBOX", "", i0.ɵɵvalidateIframeAttribute)');
+
+           // Expect an extra validation function on the `element` instruction for an <iframe>
+           // to validate static attributes.
+           expect(jsContents)
+               .toContain('ɵɵelement(0, "IFRAME", 0, null, i0.ɵɵvalidateIframeStaticAttributes)');
+         });
+
+      it('should include static attribute validation fn when on <iframe> ' +
+             '(even if there are no static attributes)',
+         () => {
+           env.write('test.ts', `
+                import {Component} from '@angular/core';
+
+                @Component({
+                  template: \`
+                    <iframe [src]="'http://angular.io'"></iframe>
+                  \`
+                })
+                export class SomeComponent {}
+              `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Expect an extra validation function on the `element` instruction for an <iframe>
+           // to validate static attributes even if there are no static attributes present
+           // on an <iframe>. There might be directives with static host attributes mathcing
+           // this <iframe>, the validation function will be used to check the final set of
+           // static attributes (from all directives and an element itself).
+           expect(jsContents)
+               .toContain('ɵɵelement(0, "iframe", 0, null, i0.ɵɵvalidateIframeStaticAttributes)');
+         });
+
+      it('should *not* generate a validator fn for attribute and property bindings ' +
+             'when *not* on <iframe>',
+         () => {
+           env.write('test.ts', `
+                import {Component, Directive} from '@angular/core';
+
+                @Directive({
+                  standalone: true,
+                  selector: '[sandbox]',
+                  inputs: ['sandbox']
+                })
+                class Dir {}
+
+                @Component({
+                  standalone: true,
+                  imports: [Dir],
+                  template: \`
+                    <div [sandbox]="''" [title]="'Hi!'"></div>
+                  \`
+                })
+                export class SomeComponent {}
+              `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Note: no extra validation fn, since a security-sensitive attribute is *not* on an
+           // <iframe>.
+           expect(jsContents).toContain('ɵɵproperty("sandbox", "")("title", "Hi!")');
+
+           // No extra validation fn on an `element` instruction too, since it's
+           // not an <iframe>.
+           expect(jsContents).toContain('ɵɵelement(0, "div", 0)');
+         });
+
+      it('should generate a validator fn for attribute and property host bindings on a directive',
+         () => {
+           env.write('test.ts', `
+              import {Directive} from '@angular/core';
+
+              @Directive({
+                host: {
+                  '[sandbox]': "''",
+                  '[attr.allow]': "''",
+                  'src': 'http://angular.io'
+                }
+              })
+              export class SomeDir {}
+            `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // The `sandbox` is potentially a security-sensitive attribute of an <iframe>.
+           // Generate an extra validation function to invoke at runtime, which would
+           // check if an underlying host element is an <iframe>.
+           expect(jsContents)
+               .toContain('ɵɵhostProperty("sandbox", "", i0.ɵɵvalidateIframeAttribute)');
+
+           // Similar to the above, but for an attribute binding (host attributes are
+           // represented via `ɵɵattribute`).
+           expect(jsContents).toContain('ɵɵattribute("allow", "", i0.ɵɵvalidateIframeAttribute)');
+         });
+
+      it('should generate a validator fn for attribute host bindings on a directive ' +
+             '(making sure the check is case-insensitive)',
+         () => {
+           env.write('test.ts', `
+              import {Directive} from '@angular/core';
+
+              @Directive({
+                host: {
+                  '[attr.SANDBOX]': "''"
+                }
+              })
+              export class SomeDir {}
+            `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Make sure that we generate a validation fn for the `sandbox` attribute,
+           // even when it was declared as `SANDBOX`.
+           expect(jsContents).toContain('ɵɵattribute("SANDBOX", "", i0.ɵɵvalidateIframeAttribute)');
+         });
+    });
+
     describe('undecorated providers', () => {
       it('should error when an undecorated class, with a non-trivial constructor, is provided directly in a module',
          () => {

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -343,4 +343,8 @@ export class Identifiers {
   static trustConstantHtml: o.ExternalReference = {name: 'ɵɵtrustConstantHtml', moduleName: CORE};
   static trustConstantResourceUrl:
       o.ExternalReference = {name: 'ɵɵtrustConstantResourceUrl', moduleName: CORE};
+  static validateIframeAttribute:
+      o.ExternalReference = {name: 'ɵɵvalidateIframeAttribute', moduleName: CORE};
+  static validateIframeStaticAttributes:
+      o.ExternalReference = {name: 'ɵɵvalidateIframeStaticAttributes', moduleName: CORE};
 }

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -12,6 +12,7 @@ import * as core from '../../core';
 import {AST, ParsedEvent, ParsedEventType, ParsedProperty} from '../../expression_parser/ast';
 import * as o from '../../output/output_ast';
 import {ParseError, ParseSourceSpan, sanitizeIdentifier} from '../../parse_util';
+import {isIframeSecuritySensitiveAttr} from '../../schema/dom_security_schema';
 import {CssSelector} from '../../selector';
 import {ShadowCss} from '../../shadow_css';
 import {BindingParser} from '../../template_parser/binding_parser';
@@ -567,6 +568,19 @@ function createHostBindingsFunction(
     const instructionParams = [o.literal(bindingName), bindingExpr.currValExpr];
     if (sanitizerFn) {
       instructionParams.push(sanitizerFn);
+    } else {
+      // If there was no sanitization function found based on the security context
+      // of an attribute/property binding - check whether this attribute/property is
+      // one of the security-sensitive <iframe> attributes.
+      // Note: for host bindings defined on a directive, we do not try to find all
+      // possible places where it can be matched, so we can not determine whether
+      // the host element is an <iframe>. In this case, if an attribute/binding
+      // name is in the `IFRAME_SECURITY_SENSITIVE_ATTRS` set - append a validation
+      // function, which would be invoked at runtime and would have access to the
+      // underlying DOM element, check if it's an <iframe> and if so - runs extra checks.
+      if (isIframeSecuritySensitiveAttr(bindingName)) {
+        instructionParams.push(o.importExpr(R3.validateIframeAttribute));
+      }
     }
 
     updateVariables.push(...bindingExpr.stmts);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -23,6 +23,7 @@ import {mapLiteral} from '../../output/map_util';
 import * as o from '../../output/output_ast';
 import {ParseError, ParseSourceSpan, sanitizeIdentifier} from '../../parse_util';
 import {DomElementSchemaRegistry} from '../../schema/dom_element_schema_registry';
+import {isIframeSecuritySensitiveAttr} from '../../schema/dom_security_schema';
 import {isTrustedTypesSink} from '../../schema/trusted_types_sinks';
 import {CssSelector} from '../../selector';
 import {BindingParser} from '../../template_parser/binding_parser';
@@ -675,6 +676,16 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
     const refs = this.prepareRefsArray(element.references);
     parameters.push(this.addToConsts(refs));
 
+    // If this element is an <iframe>, append an extra validation
+    // function, which would be invoked at runtime to make sure that
+    // all security-sensitive attributes defined statically (both on
+    // the element itself as well as on all matched directives) are
+    // set on the underlying <iframe> *before* setting its `src` or
+    // `srcdoc` (otherwise they'd not be taken into account).
+    if (isIframeElement(element.name)) {
+      parameters.push(o.importExpr(R3.validateIframeStaticAttributes));
+    }
+
     const wasInNamespace = this._namespace;
     const currentNamespace = this.getNamespaceInstruction(namespaceKey);
 
@@ -783,8 +794,19 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
           const params: any[] = [];
           const [attrNamespace, attrName] = splitNsName(input.name);
           const isAttributeBinding = inputType === BindingType.Attribute;
-          const sanitizationRef = resolveSanitizationFn(input.securityContext, isAttributeBinding);
-          if (sanitizationRef) params.push(sanitizationRef);
+          let sanitizationRef = resolveSanitizationFn(input.securityContext, isAttributeBinding);
+          if (!sanitizationRef) {
+            // If there was no sanitization function found based on the security context
+            // of an attribute/property - check whether this attribute/property is
+            // one of the security-sensitive <iframe> attributes (and that the current
+            // element is actually an <iframe>).
+            if (isIframeElement(element.name) && isIframeSecuritySensitiveAttr(input.name)) {
+              sanitizationRef = o.importExpr(R3.validateIframeAttribute);
+            }
+          }
+          if (sanitizationRef) {
+            params.push(sanitizationRef);
+          }
           if (attrNamespace) {
             const namespaceLiteral = o.literal(attrNamespace);
 
@@ -2209,6 +2231,10 @@ function isSingleElementTemplate(children: t.Node[]): children is[t.Element] {
 
 function isTextNode(node: t.Node): boolean {
   return node instanceof t.Text || node instanceof t.BoundText || node instanceof t.Icu;
+}
+
+function isIframeElement(tagName: string): boolean {
+  return tagName.toLowerCase() === 'iframe';
 }
 
 function hasTextChildrenOnly(children: t.Node[]): boolean {

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -76,3 +76,28 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
 function registerContext(ctx: SecurityContext, specs: string[]) {
   for (const spec of specs) _SECURITY_SCHEMA[spec.toLowerCase()] = ctx;
 }
+
+/**
+ * The set of security-sensitive attributes of an `<iframe>` that *must* be
+ * applied before setting the `src` or `srcdoc` attribute value.
+ * This ensures that all security-sensitive attributes are taken into account
+ * while creating an instance of an `<iframe>` at runtime.
+ *
+ * Keep this list in sync with the `IFRAME_SECURITY_SENSITIVE_ATTRS` token
+ * from the `packages/core/src/sanitization/iframe_attrs_validation.ts` script.
+ *
+ * Avoid using this set directly, use the `isIframeSecuritySensitiveAttr` function
+ * in the code instead.
+ */
+export const IFRAME_SECURITY_SENSITIVE_ATTRS = new Set(
+    ['sandbox', 'allow', 'allowfullscreen', 'referrerpolicy', 'loading', 'csp', 'fetchpriority']);
+
+/**
+ * Checks whether a given attribute name might represent a security-sensitive
+ * attribute of an <iframe>.
+ */
+export function isIframeSecuritySensitiveAttr(attrName: string): boolean {
+  // The `setAttribute` DOM API is case-insensitive, so we lowercase the value
+  // before checking it against a known security-sensitive attributes.
+  return IFRAME_SECURITY_SENSITIVE_ATTRS.has(attrName.toLowerCase());
+}

--- a/packages/compiler/test/security_spec.ts
+++ b/packages/compiler/test/security_spec.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {IFRAME_SECURITY_SENSITIVE_ATTRS, SECURITY_SCHEMA} from '../src/schema/dom_security_schema';
+
+
+describe('security-related tests', () => {
+  it('should have no overlap between `IFRAME_SECURITY_SENSITIVE_ATTRS` and `SECURITY_SCHEMA`',
+     () => {
+       // The `IFRAME_SECURITY_SENSITIVE_ATTRS` and `SECURITY_SCHEMA` tokens configure sanitization
+       // and validation rules and used to pick the right sanitizer function.
+       // This test verifies that there is no overlap between two sets of rules to flag
+       // a situation when 2 sanitizer functions may be needed at the same time (in which
+       // case, compiler logic should be extended to support that).
+       const schema = new Set();
+       Object.keys(SECURITY_SCHEMA()).forEach((key: string) => schema.add(key.toLowerCase()));
+       let hasOverlap = false;
+       IFRAME_SECURITY_SENSITIVE_ATTRS.forEach(attr => {
+         if (schema.has('*|' + attr) || schema.has('iframe|' + attr)) {
+           hasOverlap = true;
+         }
+       });
+       expect(hasOverlap).toBeFalse();
+     });
+});

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -272,6 +272,10 @@ export {
   ɵɵtrustConstantResourceUrl,
 } from './sanitization/sanitization';
 export {
+  ɵɵvalidateIframeAttribute,
+  ɵɵvalidateIframeStaticAttributes,
+} from './sanitization/iframe_attrs_validation';
+export {
   noSideEffects as ɵnoSideEffects,
 } from './util/closure';
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -76,6 +76,7 @@ export const enum RuntimeErrorCode {
   TYPE_IS_NOT_STANDALONE = 907,
   MISSING_ZONEJS = 908,
   UNEXPECTED_ZONE_STATE = 909,
+  UNSAFE_IFRAME_ATTRS = 910,
 }
 
 /**

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -12,6 +12,7 @@ import {attachPatchData} from '../context_discovery';
 import {registerPostOrderHooks} from '../hooks';
 import {hasClassInput, hasStyleInput, TAttributes, TElementNode, TNodeFlags, TNodeType} from '../interfaces/node';
 import {RElement} from '../interfaces/renderer_dom';
+import {SanitizerFn} from '../interfaces/sanitization';
 import {isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
 import {HEADER_OFFSET, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
@@ -28,7 +29,8 @@ import {createDirectivesInstances, executeContentQueries, getOrCreateTNode, reso
 
 function elementStartFirstCreatePass(
     index: number, tView: TView, lView: LView, native: RElement, name: string,
-    attrsIndex?: number|null, localRefsIndex?: number): TElementNode {
+    attrsIndex?: number|null, localRefsIndex?: number,
+    staticAttrsSanitizer?: (attrs: TAttributes) => void): TElementNode {
   ngDevMode && assertFirstCreatePass(tView);
   ngDevMode && ngDevMode.firstCreatePass++;
 
@@ -38,6 +40,11 @@ function elementStartFirstCreatePass(
 
   const hasDirectives =
       resolveDirectives(tView, lView, tNode, getConstant<string[]>(tViewConsts, localRefsIndex));
+
+  if (staticAttrsSanitizer && tNode.mergedAttrs !== null) {
+    staticAttrsSanitizer(tNode.mergedAttrs);
+  }
+
   if (ngDevMode) {
     validateElementIsKnown(native, lView, tNode.value, tView.schemas, hasDirectives);
   }
@@ -73,8 +80,8 @@ function elementStartFirstCreatePass(
  * @codeGenApi
  */
 export function ɵɵelementStart(
-    index: number, name: string, attrsIndex?: number|null,
-    localRefsIndex?: number): typeof ɵɵelementStart {
+    index: number, name: string, attrsIndex?: number|null, localRefsIndex?: number,
+    staticAttrsSanitizer?: (attrs: TAttributes) => void): typeof ɵɵelementStart {
   const lView = getLView();
   const tView = getTView();
   const adjustedIndex = HEADER_OFFSET + index;
@@ -87,10 +94,10 @@ export function ɵɵelementStart(
 
   const renderer = lView[RENDERER];
   const native = lView[adjustedIndex] = createElementNode(renderer, name, getNamespace());
-  const tNode = tView.firstCreatePass ?
-      elementStartFirstCreatePass(
-          adjustedIndex, tView, lView, native, name, attrsIndex, localRefsIndex) :
-      tView.data[adjustedIndex] as TElementNode;
+  const tNode = tView.firstCreatePass ? elementStartFirstCreatePass(
+                                            adjustedIndex, tView, lView, native, name, attrsIndex,
+                                            localRefsIndex, staticAttrsSanitizer) :
+                                        tView.data[adjustedIndex] as TElementNode;
   setCurrentTNode(tNode, true);
 
   const mergedAttrs = tNode.mergedAttrs;
@@ -184,9 +191,9 @@ export function ɵɵelementEnd(): typeof ɵɵelementEnd {
  * @codeGenApi
  */
 export function ɵɵelement(
-    index: number, name: string, attrsIndex?: number|null,
-    localRefsIndex?: number): typeof ɵɵelement {
-  ɵɵelementStart(index, name, attrsIndex, localRefsIndex);
+    index: number, name: string, attrsIndex?: number|null, localRefsIndex?: number,
+    staticAttrsSanitizer?: (attrs: TAttributes) => void): typeof ɵɵelement {
+  ɵɵelementStart(index, name, attrsIndex, localRefsIndex, staticAttrsSanitizer);
   ɵɵelementEnd();
   return ɵɵelement;
 }

--- a/packages/core/src/render3/instructions/element_validation.ts
+++ b/packages/core/src/render3/instructions/element_validation.ts
@@ -268,7 +268,7 @@ export function isHostComponentStandalone(lView: LView): boolean {
  *
  * @param lView An `LView` that represents a current component that is being rendered.
  */
-function getTemplateLocationDetails(lView: LView): string {
+export function getTemplateLocationDetails(lView: LView): string {
   !ngDevMode && throwError('Must never be called in production mode');
 
   const hostComponentDef = getDeclarationComponentDef(lView);

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -10,6 +10,7 @@ import {forwardRef, resolveForwardRef} from '../../di/forward_ref';
 import {ɵɵinject, ɵɵinvalidFactoryDep} from '../../di/injector_compatibility';
 import {ɵɵdefineInjectable, ɵɵdefineInjector} from '../../di/interface/defs';
 import {registerNgModuleType} from '../../linker/ng_module_registration';
+import * as iframe_attrs_validation from '../../sanitization/iframe_attrs_validation';
 import * as sanitization from '../../sanitization/sanitization';
 import * as r3 from '../index';
 
@@ -168,6 +169,8 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵsanitizeUrlOrResourceUrl': sanitization.ɵɵsanitizeUrlOrResourceUrl,
        'ɵɵtrustConstantHtml': sanitization.ɵɵtrustConstantHtml,
        'ɵɵtrustConstantResourceUrl': sanitization.ɵɵtrustConstantResourceUrl,
+       'ɵɵvalidateIframeAttribute': iframe_attrs_validation.ɵɵvalidateIframeAttribute,
+       'ɵɵvalidateIframeStaticAttributes': iframe_attrs_validation.ɵɵvalidateIframeStaticAttributes,
 
        'forwardRef': forwardRef,
        'resolveForwardRef': resolveForwardRef,

--- a/packages/core/src/sanitization/iframe_attrs_validation.ts
+++ b/packages/core/src/sanitization/iframe_attrs_validation.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {RuntimeError, RuntimeErrorCode} from '../errors';
+import {getTemplateLocationDetails} from '../render3/instructions/element_validation';
+import {TAttributes, TNodeType} from '../render3/interfaces/node';
+import {RComment, RElement} from '../render3/interfaces/renderer_dom';
+import {LView} from '../render3/interfaces/view';
+import {getCurrentTNode, getLView} from '../render3/state';
+import {getNativeByTNode} from '../render3/util/view_utils';
+
+/*
+ * The set of security-sensitive attributes of an `<iframe>` that *must* be
+ * applied before setting the `src` or `srcdoc` attribute value.
+ * This ensures that all security-sensitive attributes are taken into account
+ * while creating an instance of an `<iframe>` at runtime.
+ *
+ * Keep this list in sync with the `IFRAME_SECURITY_SENSITIVE_ATTRS` token
+ * from the `packages/compiler/src/schema/dom_security_schema.ts` script.
+ */
+export const IFRAME_SECURITY_SENSITIVE_ATTRS = new Set(
+    ['sandbox', 'allow', 'allowfullscreen', 'referrerpolicy', 'loading', 'csp', 'fetchpriority']);
+
+/**
+ * Validation function invoked at runtime for each binding that might potentially
+ * represent a security-sensitive attribute of an <iframe>
+ * (see `IFRAME_SECURITY_SENSITIVE_ATTRS` for the full list of such attributes).
+ *
+ * @codeGenApi
+ */
+export function ɵɵvalidateIframeAttribute(attrValue: any, tagName: string, attrName: string) {
+  const lView = getLView();
+  const tNode = getCurrentTNode()!;
+  const element = getNativeByTNode(tNode, lView) as RElement | RComment;
+
+  if (tNode.type === TNodeType.Element && tNode.value.toLowerCase() === 'iframe' &&
+      // Note: check for all false'y values including an empty string as a value,
+      // since this is a default value for an `<iframe>`'s `src` attribute.
+      ((element as HTMLIFrameElement).src || (element as HTMLIFrameElement).srcdoc)) {
+    throw unsafeIframeAttributeError(lView, attrName);
+  }
+}
+
+/**
+ * Constructs an instance of a `RuntimeError` to indicate that
+ * a security-sensitive attribute of an <iframe> was set after
+ * setting an `src` or `srcdoc`.
+ */
+function unsafeIframeAttributeError(lView: LView, attrName: string) {
+  const errorMessage = ngDevMode &&
+      `For security reasons, setting the \`${attrName}\` attribute on an <iframe> ` +
+          `after the \`src\` or \`srcdoc\` is not allowed${getTemplateLocationDetails(lView)}. ` +
+          `To fix this, reorder the list of attributes (applied to the <iframe> in a template ` +
+          `or via host bindings) to make sure the \`${attrName}\` is set before the ` +
+          `\`src\` or \`srcdoc\``;
+  return new RuntimeError(RuntimeErrorCode.UNSAFE_IFRAME_ATTRS, errorMessage);
+}
+
+/**
+ * Validation function invoked at runtime for each <iframe>, which verifies that
+ * all security-sensitive attributes are located before an `src` or `srcdoc` attributes.
+ * This is needed to make sure that these security-sensitive attributes are taken into
+ * account while creating an <iframe> at runtime. See `IFRAME_SECURITY_SENSITIVE_ATTRS`
+ * for the full list of such attributes.
+ *
+ * @codeGenApi
+ */
+export function ɵɵvalidateIframeStaticAttributes(attrs: TAttributes) {
+  // Static attributes are located in front of the `TAttributes` array in the following format:
+  // `[attr1, value1, attr2, value2, ...]`. Exit when we come across the first marker (represented
+  // by a number) or when we reach the end of an array. See additional information about the
+  // `TAttributes` format in the `setUpAttributes` function docs.
+  let i = 0;
+  let seenSrc = false;
+  while (i < attrs.length) {
+    let attrName = attrs[i];
+
+    // We came across a marker -> exit, since there
+    // are no more static attributes in the array.
+    if (typeof attrName === 'number') return;
+
+    // Lower-case attribute names before checking, since the attribute name
+    // in the native `setAttribute` is case-insensitive.
+    attrName = (attrName as string).toLowerCase();
+    if (attrName === 'src' || attrName === 'srcdoc') {
+      seenSrc = true;
+    } else {
+      if (seenSrc && IFRAME_SECURITY_SENSITIVE_ATTRS.has(attrName)) {
+        throw unsafeIframeAttributeError(getLView(), attrName as string);
+      }
+    }
+    i += 2;
+  }
+}

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -6,9 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
-
+import {NgIf} from '@angular/common';
+import {Component, Directive, inject, Type} from '@angular/core';
+import {RuntimeErrorCode} from '@angular/core/src/errors';
+import {global} from '@angular/core/src/util/global';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {DomSanitizer} from '@angular/platform-browser';
 
 describe('comment node text escaping', () => {
   // see: https://html.spec.whatwg.org/multipage/syntax.html#comments
@@ -39,5 +42,591 @@ describe('comment node text escaping', () => {
          const script = div.querySelector('script');
          expect(script).toBeFalsy();
        });
+  });
+});
+
+describe('iframe processing', () => {
+  function getErrorMessageRegexp() {
+    const errorMessagePart = 'NG0' + RuntimeErrorCode.UNSAFE_IFRAME_ATTRS.toString();
+    return new RegExp(errorMessagePart);
+  }
+
+  function expectIframeCreationToFail<T>(component: Type<T>, attrName: string) {
+    expect(() => {
+      let fixture = TestBed.createComponent(component);
+      fixture.detectChanges();
+    }).toThrowError(getErrorMessageRegexp());
+  }
+
+  function expectIframeToBeCreated<T>(
+      component: Type<T>, srcAttrToCheck?: string, expectedValue?: string): ComponentFixture<T> {
+    let fixture: ComponentFixture<T>;
+    expect(() => {
+      fixture = TestBed.createComponent(component);
+      fixture.detectChanges();
+    }).not.toThrow();
+
+    const iframe = fixture!.nativeElement.querySelector('iframe');
+    if (srcAttrToCheck) {
+      expect(iframe[srcAttrToCheck]).toEqual(expectedValue);
+    }
+
+    return fixture!;
+  }
+
+  // *Must* be in sync with the `SECURITY_SENSITIVE_ATTRS` list
+  // from the `packages/compiler/src/schema/dom_security_schema.ts`.
+  const SECURITY_SENSITIVE_ATTRS =
+      ['sandbox', 'allow', 'allowfullscreen', 'referrerpolicy', 'loading'];
+
+  const TEST_IFRAME_URL = 'https://angular.io/assets/images/logos/angular/angular.png';
+
+  let oldNgDevMode!: typeof ngDevMode;
+
+  beforeAll(() => {
+    oldNgDevMode = ngDevMode;
+  });
+
+  afterAll(() => {
+    global['ngDevMode'] = oldNgDevMode;
+  });
+
+  [true, false].forEach(devModeFlag => {
+    beforeAll(() => {
+      global['ngDevMode'] = devModeFlag;
+
+      // TestBed and JIT compilation have some dependencies on the ngDevMode state, so we need to
+      // reset TestBed to ensure we get a 'clean' JIT compilation under the new rules.
+      TestBed.resetTestingModule();
+    });
+
+    describe(`with ngDevMode = ${devModeFlag}`, () => {
+      SECURITY_SENSITIVE_ATTRS.forEach((securityAttr: string) => {
+        ['src', 'srcdoc'].forEach((srcAttr: string) => {
+          it(`should error when a security-sensitive attribute is located ` +
+                 `*after* the \`${srcAttr}\` (checking \`${securityAttr}\` as a static attribute)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                  <iframe
+                    ${srcAttr}="${TEST_IFRAME_URL}"
+                    ${securityAttr}="">
+                  </iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp, securityAttr);
+             });
+
+          it(`should error when a security-sensitive attribute is located *after* the \`${
+                 srcAttr}\` ` +
+                 `(checking \`${securityAttr}\` as a static attribute, making sure it's ` +
+                 `case-insensitive)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                  <iframe
+                    ${srcAttr.toUpperCase()}="${TEST_IFRAME_URL}"
+                    ${securityAttr.toUpperCase()}="">
+                  </iframe>
+                 `,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp, securityAttr);
+             });
+
+          it(`should error when a security-sensitive attribute is located ` +
+                 `*after* the \`${srcAttr}\` (checking \`${securityAttr}\` as a property binding)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template:
+                     `<iframe ${srcAttr}="${TEST_IFRAME_URL}" [${securityAttr}]="''"></iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp, securityAttr);
+             });
+
+          it(`should error when a security-sensitive attribute is located ` +
+                 `*after* the \`${srcAttr}\` (checking \`${
+                     securityAttr}\` as a property interpolation)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template:
+                     `<iframe ${srcAttr}="${TEST_IFRAME_URL}" ${securityAttr}="{{''}}"></iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp, securityAttr);
+             });
+
+
+          it(`should error when a security-sensitive attribute is located ` +
+                 `*after* the \`${srcAttr}\` (checking \`${
+                     securityAttr}\` as a property binding, ` +
+                 `making sure it's case-insensitive)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                  <iframe
+                    ${srcAttr}="${TEST_IFRAME_URL}"
+                    [${securityAttr.toUpperCase()}]="''"
+                  ></iframe>
+                 `,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp, securityAttr.toUpperCase());
+             });
+
+          it(`should error when a security-sensitive attribute is located ` +
+                 `*after* the \`${srcAttr}\` (checking \`${
+                     securityAttr}\` as an attribute binding)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                    <iframe ${srcAttr}="${TEST_IFRAME_URL}" [attr.${securityAttr}]="''"></iframe>
+                  `,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp, securityAttr);
+             });
+
+          it(`should error when a security-sensitive attribute is located ` +
+                 `*after* the \`${srcAttr}\` (checking \`${
+                     securityAttr}\` as an attribute interpolation)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                <iframe ${srcAttr}="${TEST_IFRAME_URL}" attr.${securityAttr}="{{''}}"></iframe>
+              `,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp, securityAttr);
+             });
+
+          it(`should error when a security-sensitive attribute is located ` +
+                 `*after* the \`${srcAttr}\` (checking \`${
+                     securityAttr}\` as an attribute binding, ` +
+                 `making sure it's case-insensitive)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                    <iframe
+                      ${srcAttr}="${TEST_IFRAME_URL}"
+                      [attr.${securityAttr.toUpperCase()}]="''">
+                    </iframe>
+                  `,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp, securityAttr.toUpperCase());
+             });
+
+          it(`should work when a security-sensitive attribute is set ` +
+                 `before the \`${srcAttr}\` (checking \`${securityAttr}\`)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `<iframe ${securityAttr}="" ${srcAttr}="${TEST_IFRAME_URL}"></iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeToBeCreated(IframeComp, srcAttr, TEST_IFRAME_URL);
+             });
+
+          it(`should error when trying to change a security-sensitive attribute after initial creation ` +
+                 `when the \`${srcAttr}\` is set (checking \`${securityAttr}\`)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                    <iframe
+                      [${securityAttr}]="securityAttr"
+                      [${srcAttr}]="src">
+                    </iframe>
+                  `,
+               })
+               class IframeComp {
+                 private sanitizer = inject(DomSanitizer);
+                 src = this.sanitizeFn(TEST_IFRAME_URL);
+                 securityAttr = 'allow-forms';
+
+                 get sanitizeFn() {
+                   return srcAttr === 'src' ? this.sanitizer.bypassSecurityTrustResourceUrl :
+                                              this.sanitizer.bypassSecurityTrustHtml;
+                 }
+               }
+
+               const fixture = expectIframeToBeCreated(IframeComp, srcAttr, TEST_IFRAME_URL);
+               const component = fixture.componentInstance;
+
+               // Expect to throw if security-sensitive attribute is changed
+               // after the `src` or `srcdoc` is set.
+               component.securityAttr = 'allow-modals';
+               expect(() => fixture.detectChanges()).toThrowError(getErrorMessageRegexp());
+
+               // However, changing the `src` or `srcdoc` is allowed.
+               const newUrl = 'https://angular.io/about?group=Angular';
+               component.src = component.sanitizeFn(newUrl);
+               expect(() => fixture.detectChanges()).not.toThrow();
+               expect(fixture.nativeElement.querySelector('iframe')[srcAttr]).toEqual(newUrl);
+             });
+        });
+      });
+
+      it('should error when a directive sets a security-sensitive attribute after setting `src`',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+               'sandbox': '',
+             },
+           })
+           class IframeDir {
+           }
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: '<iframe dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp, 'sandbox');
+         });
+
+      it('should not error when a directive sets a security-sensitive host attribute on a non-iframe element',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+               'sandbox': '',
+             },
+           })
+           class Dir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [Dir],
+             selector: 'my-comp',
+             template: '<img dir>',
+           })
+           class NonIframeComp {
+           }
+
+           const fixture = TestBed.createComponent(NonIframeComp);
+           fixture.detectChanges();
+
+           expect(fixture.nativeElement.firstChild.src).toEqual(TEST_IFRAME_URL);
+         });
+
+
+      it('should error when a security-sensitive attribute is set after `src` on an <iframe> ' +
+             'which also has a structural directive (*ngIf)',
+         () => {
+           @Component({
+             standalone: true,
+             imports: [NgIf],
+             selector: 'my-comp',
+             template: `<iframe *ngIf="visible" src="${TEST_IFRAME_URL}" sandbox=""></iframe>`,
+           })
+           class IframeComp {
+             visible = true;
+           }
+
+           expectIframeCreationToFail(IframeComp, 'sandbox');
+         });
+
+      it('should error when a security-sensitive attribute is set between `src` and `srcdoc`',
+         () => {
+           @Component({
+             standalone: true,
+             selector: 'my-comp',
+             template: `<iframe src="${TEST_IFRAME_URL}" sandbox srcdoc="Hi!"></iframe>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp, 'sandbox');
+         });
+
+      it('should work when a directive sets a security-sensitive attribute before setting `src`',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'sandbox': '',
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: '<iframe dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, 'src', TEST_IFRAME_URL);
+         });
+
+      it('should error when a directive sets an `src` and ' +
+             'there was a security-sensitive attribute set in a template' +
+             '(directive attribute after `sandbox`)',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: '<iframe sandbox dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp, 'sandbox');
+         });
+
+      it('should error when a directive sets a security-sensitive attribute in uppercase ' +
+             'and it gets applied before an `src` value',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               '[attr.SANDBOX]': '\'\'',
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: `<IFRAME dir src="${TEST_IFRAME_URL}"></IFRAME>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp, 'SANDBOX');
+         });
+
+      it('should error when a directive sets an `src` and ' +
+             'there was a security-sensitive attribute set in a template' +
+             '(directive attribute before `sandbox`)',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: '<iframe dir sandbox></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp, 'sandbox');
+         });
+
+      it('should work when a directive sets a security-sensitive attribute and ' +
+             'there was an `src` attribute set in a template' +
+             '(directive attribute after `src`)',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: `<iframe src="${TEST_IFRAME_URL}" dir></iframe>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, 'src', TEST_IFRAME_URL);
+         });
+
+      it('should work when a directive sets a security-sensitive attribute and ' +
+             'there was an `src` attribute set in a template' +
+             '(directive attribute before `src`)',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: `<iframe dir src="${TEST_IFRAME_URL}"></iframe>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, 'src', TEST_IFRAME_URL);
+         });
+
+      it('should error when a directive that sets a security-sensitive attribute goes ' +
+             'after the directive that sets an `src` attribute value',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[set-src]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class DirThatSetsSrc {
+           }
+
+           @Directive({
+             standalone: true,
+             selector: '[set-sandbox]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class DirThatSetsSandbox {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [DirThatSetsSrc, DirThatSetsSandbox],
+             selector: 'my-comp',
+             template: '<iframe set-src set-sandbox></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp, 'sandbox');
+         });
+
+      it('should work when a directive that sets a security-sensitive attribute goes ' +
+             'before the directive that sets an `src` attribute value',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[set-src]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class DirThatSetsSrc {
+           }
+
+           @Directive({
+             standalone: true,
+             selector: '[set-sandbox]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class DirThatSetsSandbox {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [DirThatSetsSandbox, DirThatSetsSrc],
+             selector: 'my-comp',
+             // Important note: even though the `set-sandbox` goes after the `set-src`,
+             // the directive matching order (thus the order of host attributes) is
+             // based on the imports order, so the `sandbox` gets set first and the `src` second.
+             template: '<iframe set-src set-sandbox></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, 'src', TEST_IFRAME_URL);
+         });
+
+      it(`should error when a security-sensitive attribute is located after the \`src\` ` +
+             `on an <iframe> with the tag name defined in uppercase`,
+         () => {
+           @Component({
+             standalone: true,
+             selector: 'my-comp',
+             template: `<IFRAME src="${TEST_IFRAME_URL}" sandbox=""></IFRAME>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp, 'sandbox');
+         });
+    });
   });
 });


### PR DESCRIPTION
This commit updates the logic related to the attribute order on iframes and makes the rules more strict. There is a set of iframe attributes that may affect the behavior of an iframe, this change enforces that these attributes are applied before an `src` or `srcdoc` attributes are applied to an iframe, so that they are taken into account.

If Angular detects that some of the attributes are set after the `src` or `srcdoc`, it throws an error message, which contains the name of ann attribute that is causing the problem and the name of a Component where an iframe is located. In most cases, it should be enough to change the order of attributes in a template to move the `src` or `srcdoc` ones to the very end.

BREAKING CHANGE:

Existing iframe usages may have `src` or `srcdoc` preceding other attributes. Such usages may need to be updated to ensure compliance with the new stricter rules around iframe bindings.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No