### PR TITLE
docs: add searchKeywords in testing guide

### DIFF
--- a/aio/content/guide/testing.md
+++ b/aio/content/guide/testing.md
@@ -1,5 +1,7 @@
 <a id="top"></a>
 
+{@searchKeywords test testing karma jasmine coverage}
+
 # Testing
 
 Testing your Angular application helps you check that your app is working as you expect.


### PR DESCRIPTION
This is to push up the page in search results when searching for these terms.

Ex: currently when searching using the term `test` this page is displayed at the middle of the results.
