### PR TITLE
feat(core): Add `TestBed.runInContext` to help test functions which use `inject`

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -160,6 +160,7 @@ export interface TestBed {
     resetTestEnvironment(): void;
     // (undocumented)
     resetTestingModule(): TestBed;
+    runInInjectionContext<T>(fn: () => T): T;
 }
 
 // @public

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_INITIALIZER, ChangeDetectorRef, Compiler, Component, Directive, ElementRef, ErrorHandler, getNgModuleById, Inject, Injectable, InjectFlags, InjectionToken, InjectOptions, Injector, Input, LOCALE_ID, ModuleWithProviders, NgModule, Optional, Pipe, Type, ViewChild, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineInjector as defineInjector, ɵɵdefineNgModule as defineNgModule, ɵɵelementEnd as elementEnd, ɵɵelementStart as elementStart, ɵɵsetNgModuleScope as setNgModuleScope, ɵɵtext as text} from '@angular/core';
+import {APP_INITIALIZER, ChangeDetectorRef, Compiler, Component, Directive, ElementRef, ErrorHandler, getNgModuleById, inject, Inject, Injectable, InjectFlags, InjectionToken, InjectOptions, Injector, Input, LOCALE_ID, ModuleWithProviders, NgModule, Optional, Pipe, Type, ViewChild, ɵsetClassMetadata as setClassMetadata, ɵɵdefineComponent as defineComponent, ɵɵdefineInjector as defineInjector, ɵɵdefineNgModule as defineNgModule, ɵɵelementEnd as elementEnd, ɵɵelementStart as elementStart, ɵɵsetNgModuleScope as setNgModuleScope, ɵɵtext as text} from '@angular/core';
 import {TestBed, TestBedImpl} from '@angular/core/testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -1892,6 +1892,20 @@ describe('TestBed', () => {
             .toBeNull();
       });
     });
+  });
+
+  it('should be able to call Testbed.runInInjectionContext in tests', () => {
+    const expectedValue = 'testValue';
+    @Injectable({providedIn: 'root'})
+    class SomeInjectable {
+      readonly instanceValue = expectedValue;
+    }
+
+    function functionThatUsesInject(): string {
+      return inject(SomeInjectable).instanceValue;
+    }
+
+    expect(TestBed.runInInjectionContext(functionThatUsesInject)).toEqual(expectedValue);
   });
 });
 

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -14,6 +14,7 @@
 import {
   Component,
   Directive,
+  EnvironmentInjector,
   InjectFlags,
   InjectionToken,
   InjectOptions,
@@ -103,6 +104,13 @@ export interface TestBed {
   get<T>(token: ProviderToken<T>, notFoundValue?: T, flags?: InjectFlags): any;
   /** @deprecated from v9.0.0 use TestBed.inject */
   get(token: any, notFoundValue?: any): any;
+
+  /**
+   * Runs the given function in the `EnvironmentInjector` context of `TestBed`.
+   *
+   * @see EnvironmentInjector#runInContext
+   */
+  runInInjectionContext<T>(fn: () => T): T;
 
   execute(tokens: any[], fn: Function, context?: any): any;
 
@@ -325,6 +333,15 @@ export class TestBedImpl implements TestBed {
     return TestBedImpl.INSTANCE.inject(token, notFoundValue, flags);
   }
 
+  /**
+   * Runs the given function in the `EnvironmentInjector` context of `TestBed`.
+   *
+   * @see EnvironmentInjector#runInContext
+   */
+  static runInInjectionContext<T>(fn: () => T): T {
+    return TestBedImpl.INSTANCE.runInInjectionContext(fn);
+  }
+
   static createComponent<T>(component: Type<T>): ComponentFixture<T> {
     return TestBedImpl.INSTANCE.createComponent(component);
   }
@@ -514,6 +531,10 @@ export class TestBedImpl implements TestBed {
   get(token: any, notFoundValue: any = Injector.THROW_IF_NOT_FOUND,
       flags: InjectFlags = InjectFlags.Default): any {
     return this.inject(token, notFoundValue, flags);
+  }
+
+  runInInjectionContext<T>(fn: () => T): T {
+    return this.inject(EnvironmentInjector).runInContext(fn);
   }
 
   execute(tokens: any[], fn: Function, context?: any): any {


### PR DESCRIPTION
This commit adds `TestBed.runInContext` which is equivalent to `TestBed.inject(EnvironmentInjector).runInContext`. This function will help make tests for functions which call `inject` from `@angular/core` a little bit less verbose.
