### PR TITLE
build(bazel): add missing dependency to deploy script

### DIFF
--- a/aio/scripts/deploy-to-firebase/BUILD.bazel
+++ b/aio/scripts/deploy-to-firebase/BUILD.bazel
@@ -10,6 +10,7 @@ DEPLOY_TO_FIREBASE_SOURCES = glob(
 DEPLOY_TO_FIREBASE_DEPS = [
     "@aio_npm//shelljs",
     "//aio:build",
+    "//:package.json",
 ]
 
 nodejs_binary(


### PR DESCRIPTION
fyi: @gregmagolan 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Firebase deploy script missing a dep on root package.json. Surfaced on ci after trying to merge to main, because ci otherwise shortcircuits this logic on a feature branch.

## What is the new behavior?

Properly included dep.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
