### PR TITLE
build: add `--keep_going` to components tests.

### DIFF
--- a/scripts/ci/run_angular_components_unit_tests.sh
+++ b/scripts/ci/run_angular_components_unit_tests.sh
@@ -23,4 +23,5 @@ bazel test \
   --build_tag_filters=-docs-package,-e2e,-browser:firefox \
   --test_tag_filters=-e2e,-browser:firefox \
   --build_tests_only \
+  --keep_going \
   -- src/...


### PR DESCRIPTION
This configures CI to run all the tests and report all the failures instead of aborting after the first one.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Build related changes

## What is the current behavior?

Components CI test aborts after the first failure, meaning it requires that first failure to be fixed in the components repo and updated in FW before it will reveal other failures.

Example:
* [First run](https://app.circleci.com/pipelines/github/angular/angular/52727/workflows/13afdede-30be-40c3-b876-b8cbb2570321/jobs/1249860)
* [Components fix PR](https://github.com/angular/components/pull/25911)
* [Second run](https://app.circleci.com/pipelines/github/angular/angular/52732/workflows/0e0f6cd3-810f-4446-a7cf-2dd6b0084292/jobs/1249912)

## What is the new behavior?

Components CI test now runs all tests as much as it can and reports all the failures.

## Does this PR introduce a breaking change?

- [X] No

## Other information

[`--keep_going` flag](https://bazel.build/docs/user-manual#keep-going)