### PR TITLE
fix(core): hardening attribute and property binding rules for <iframe> elements

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -101,6 +101,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     UNKNOWN_ELEMENT = 304,
     // (undocumented)
+    UNSAFE_IFRAME_ATTRS = 910,
+    // (undocumented)
     UNSAFE_VALUE_IN_RESOURCE_URL = 904,
     // (undocumented)
     UNSAFE_VALUE_IN_SCRIPT = 905,

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -346,4 +346,6 @@ export class Identifiers {
   static trustConstantHtml: o.ExternalReference = {name: 'ɵɵtrustConstantHtml', moduleName: CORE};
   static trustConstantResourceUrl:
       o.ExternalReference = {name: 'ɵɵtrustConstantResourceUrl', moduleName: CORE};
+  static validateIframeAttribute:
+      o.ExternalReference = {name: 'ɵɵvalidateIframeAttribute', moduleName: CORE};
 }

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -12,6 +12,7 @@ import * as core from '../../core';
 import {AST, ParsedEvent, ParsedEventType, ParsedProperty} from '../../expression_parser/ast';
 import * as o from '../../output/output_ast';
 import {ParseError, ParseSourceSpan, sanitizeIdentifier} from '../../parse_util';
+import {isIframeSecuritySensitiveAttr} from '../../schema/dom_security_schema';
 import {CssSelector} from '../../selector';
 import {ShadowCss} from '../../shadow_css';
 import {BindingParser} from '../../template_parser/binding_parser';
@@ -574,6 +575,19 @@ function createHostBindingsFunction(
     const instructionParams = [o.literal(bindingName), bindingExpr.currValExpr];
     if (sanitizerFn) {
       instructionParams.push(sanitizerFn);
+    } else {
+      // If there was no sanitization function found based on the security context
+      // of an attribute/property binding - check whether this attribute/property is
+      // one of the security-sensitive <iframe> attributes.
+      // Note: for host bindings defined on a directive, we do not try to find all
+      // possible places where it can be matched, so we can not determine whether
+      // the host element is an <iframe>. In this case, if an attribute/binding
+      // name is in the `IFRAME_SECURITY_SENSITIVE_ATTRS` set - append a validation
+      // function, which would be invoked at runtime and would have access to the
+      // underlying DOM element, check if it's an <iframe> and if so - runs extra checks.
+      if (isIframeSecuritySensitiveAttr(bindingName)) {
+        instructionParams.push(o.importExpr(R3.validateIframeAttribute));
+      }
     }
 
     updateVariables.push(...bindingExpr.stmts);

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -23,6 +23,7 @@ import {mapLiteral} from '../../output/map_util';
 import * as o from '../../output/output_ast';
 import {ParseError, ParseSourceSpan, sanitizeIdentifier} from '../../parse_util';
 import {DomElementSchemaRegistry} from '../../schema/dom_element_schema_registry';
+import {isIframeSecuritySensitiveAttr} from '../../schema/dom_security_schema';
 import {isTrustedTypesSink} from '../../schema/trusted_types_sinks';
 import {CssSelector} from '../../selector';
 import {BindingParser} from '../../template_parser/binding_parser';
@@ -783,8 +784,19 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
           const params: any[] = [];
           const [attrNamespace, attrName] = splitNsName(input.name);
           const isAttributeBinding = inputType === BindingType.Attribute;
-          const sanitizationRef = resolveSanitizationFn(input.securityContext, isAttributeBinding);
-          if (sanitizationRef) params.push(sanitizationRef);
+          let sanitizationRef = resolveSanitizationFn(input.securityContext, isAttributeBinding);
+          if (!sanitizationRef) {
+            // If there was no sanitization function found based on the security context
+            // of an attribute/property - check whether this attribute/property is
+            // one of the security-sensitive <iframe> attributes (and that the current
+            // element is actually an <iframe>).
+            if (isIframeElement(element.name) && isIframeSecuritySensitiveAttr(input.name)) {
+              sanitizationRef = o.importExpr(R3.validateIframeAttribute);
+            }
+          }
+          if (sanitizationRef) {
+            params.push(sanitizationRef);
+          }
           if (attrNamespace) {
             const namespaceLiteral = o.literal(attrNamespace);
 
@@ -2209,6 +2221,10 @@ function isSingleElementTemplate(children: t.Node[]): children is[t.Element] {
 
 function isTextNode(node: t.Node): boolean {
   return node instanceof t.Text || node instanceof t.BoundText || node instanceof t.Icu;
+}
+
+function isIframeElement(tagName: string): boolean {
+  return tagName.toLowerCase() === 'iframe';
 }
 
 function hasTextChildrenOnly(children: t.Node[]): boolean {

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -76,3 +76,25 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
 function registerContext(ctx: SecurityContext, specs: string[]) {
   for (const spec of specs) _SECURITY_SCHEMA[spec.toLowerCase()] = ctx;
 }
+
+/**
+ * The set of security-sensitive attributes of an `<iframe>` that *must* be
+ * applied as a static attribute only. This ensures that all security-sensitive
+ * attributes are taken into account while creating an instance of an `<iframe>`
+ * at runtime.
+ *
+ * Note: avoid using this set directly, use the `isIframeSecuritySensitiveAttr` function
+ * in the code instead.
+ */
+export const IFRAME_SECURITY_SENSITIVE_ATTRS =
+    new Set(['sandbox', 'allow', 'allowfullscreen', 'referrerpolicy', 'csp', 'fetchpriority']);
+
+/**
+ * Checks whether a given attribute name might represent a security-sensitive
+ * attribute of an <iframe>.
+ */
+export function isIframeSecuritySensitiveAttr(attrName: string): boolean {
+  // The `setAttribute` DOM API is case-insensitive, so we lowercase the value
+  // before checking it against a known security-sensitive attributes.
+  return IFRAME_SECURITY_SENSITIVE_ATTRS.has(attrName.toLowerCase());
+}

--- a/packages/compiler/test/security_spec.ts
+++ b/packages/compiler/test/security_spec.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {IFRAME_SECURITY_SENSITIVE_ATTRS, SECURITY_SCHEMA} from '../src/schema/dom_security_schema';
+
+
+describe('security-related tests', () => {
+  it('should have no overlap between `IFRAME_SECURITY_SENSITIVE_ATTRS` and `SECURITY_SCHEMA`',
+     () => {
+       // The `IFRAME_SECURITY_SENSITIVE_ATTRS` and `SECURITY_SCHEMA` tokens configure sanitization
+       // and validation rules and used to pick the right sanitizer function.
+       // This test verifies that there is no overlap between two sets of rules to flag
+       // a situation when 2 sanitizer functions may be needed at the same time (in which
+       // case, compiler logic should be extended to support that).
+       const schema = new Set();
+       Object.keys(SECURITY_SCHEMA()).forEach((key: string) => schema.add(key.toLowerCase()));
+       let hasOverlap = false;
+       IFRAME_SECURITY_SENSITIVE_ATTRS.forEach(attr => {
+         if (schema.has('*|' + attr) || schema.has('iframe|' + attr)) {
+           hasOverlap = true;
+         }
+       });
+       expect(hasOverlap).toBeFalse();
+     });
+});

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -273,6 +273,9 @@ export {
   ɵɵtrustConstantResourceUrl,
 } from './sanitization/sanitization';
 export {
+  ɵɵvalidateIframeAttribute,
+} from './sanitization/iframe_attrs_validation';
+export {
   noSideEffects as ɵnoSideEffects,
 } from './util/closure';
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -82,6 +82,7 @@ export const enum RuntimeErrorCode {
   TYPE_IS_NOT_STANDALONE = 907,
   MISSING_ZONEJS = 908,
   UNEXPECTED_ZONE_STATE = 909,
+  UNSAFE_IFRAME_ATTRS = 910,
 }
 
 /**

--- a/packages/core/src/render3/instructions/element_validation.ts
+++ b/packages/core/src/render3/instructions/element_validation.ts
@@ -268,7 +268,7 @@ export function isHostComponentStandalone(lView: LView): boolean {
  *
  * @param lView An `LView` that represents a current component that is being rendered.
  */
-function getTemplateLocationDetails(lView: LView): string {
+export function getTemplateLocationDetails(lView: LView): string {
   !ngDevMode && throwError('Must never be called in production mode');
 
   const hostComponentDef = getDeclarationComponentDef(lView);

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -10,6 +10,7 @@ import {forwardRef, resolveForwardRef} from '../../di/forward_ref';
 import {ɵɵinject, ɵɵinvalidFactoryDep} from '../../di/injector_compatibility';
 import {ɵɵdefineInjectable, ɵɵdefineInjector} from '../../di/interface/defs';
 import {registerNgModuleType} from '../../linker/ng_module_registration';
+import * as iframe_attrs_validation from '../../sanitization/iframe_attrs_validation';
 import * as sanitization from '../../sanitization/sanitization';
 import * as r3 from '../index';
 
@@ -169,6 +170,7 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵsanitizeUrlOrResourceUrl': sanitization.ɵɵsanitizeUrlOrResourceUrl,
        'ɵɵtrustConstantHtml': sanitization.ɵɵtrustConstantHtml,
        'ɵɵtrustConstantResourceUrl': sanitization.ɵɵtrustConstantResourceUrl,
+       'ɵɵvalidateIframeAttribute': iframe_attrs_validation.ɵɵvalidateIframeAttribute,
 
        'forwardRef': forwardRef,
        'resolveForwardRef': resolveForwardRef,

--- a/packages/core/src/sanitization/iframe_attrs_validation.ts
+++ b/packages/core/src/sanitization/iframe_attrs_validation.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {RuntimeError, RuntimeErrorCode} from '../errors';
+import {getTemplateLocationDetails} from '../render3/instructions/element_validation';
+import {TNodeType} from '../render3/interfaces/node';
+import {RComment, RElement} from '../render3/interfaces/renderer_dom';
+import {RENDERER} from '../render3/interfaces/view';
+import {nativeRemoveNode} from '../render3/node_manipulation';
+import {getLView, getSelectedTNode} from '../render3/state';
+import {getNativeByTNode} from '../render3/util/view_utils';
+import {trustedHTMLFromString} from '../util/security/trusted_types';
+
+
+/**
+ * Validation function invoked at runtime for each binding that might potentially
+ * represent a security-sensitive attribute of an <iframe>.
+ * See `IFRAME_SECURITY_SENSITIVE_ATTRS` in the
+ * `packages/compiler/src/schema/dom_security_schema.ts` script for the full list
+ * of such attributes.
+ *
+ * @codeGenApi
+ */
+export function ɵɵvalidateIframeAttribute(attrValue: any, tagName: string, attrName: string) {
+  const lView = getLView();
+  const tNode = getSelectedTNode()!;
+  const element = getNativeByTNode(tNode, lView) as RElement | RComment;
+
+  // Restrict any dynamic bindings of security-sensitive attributes/properties
+  // on an <iframe> for security reasons.
+  if (tNode.type === TNodeType.Element && tagName.toLowerCase() === 'iframe') {
+    const iframe = element as HTMLIFrameElement;
+
+    // Unset previously applied `src` and `srcdoc` if we come across a situation when
+    // a security-sensitive attribute is set later via an attribute/property binding.
+    iframe.src = '';
+    iframe.srcdoc = trustedHTMLFromString('') as unknown as string;
+
+    // Also remove the <iframe> from the document.
+    nativeRemoveNode(lView[RENDERER], iframe);
+
+    const errorMessage = ngDevMode &&
+        `Angular has detected that the \`${attrName}\` was applied ` +
+            `as a binding to an <iframe>${getTemplateLocationDetails(lView)}. ` +
+            `For security reasons, the \`${attrName}\` can be set on an <iframe> ` +
+            `as a static attribute only. \n` +
+            `To fix this, switch the \`${attrName}\` binding to a static attribute ` +
+            `in a template or in host bindings section.`;
+    throw new RuntimeError(RuntimeErrorCode.UNSAFE_IFRAME_ATTRS, errorMessage);
+  }
+  return attrValue;
+}

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -6,9 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
-
+import {NgIf} from '@angular/common';
+import {Component, Directive, inject, TemplateRef, Type, ViewChild, ViewContainerRef} from '@angular/core';
+import {RuntimeErrorCode} from '@angular/core/src/errors';
+import {global} from '@angular/core/src/util/global';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {DomSanitizer} from '@angular/platform-browser';
 
 describe('comment node text escaping', () => {
   // see: https://html.spec.whatwg.org/multipage/syntax.html#comments
@@ -39,5 +42,705 @@ describe('comment node text escaping', () => {
          const script = div.querySelector('script');
          expect(script).toBeFalsy();
        });
+  });
+});
+
+describe('iframe processing', () => {
+  function getErrorMessageRegexp() {
+    const errorMessagePart = 'NG0' + RuntimeErrorCode.UNSAFE_IFRAME_ATTRS.toString();
+    return new RegExp(errorMessagePart);
+  }
+
+  function ensureNoIframePresent(fixture?: ComponentFixture<unknown>) {
+    // Note: a `fixture` may not exist in case an error was thrown at creation time.
+    const iframe = fixture?.nativeElement.querySelector('iframe');
+    expect(!!iframe).toBeFalse();
+  }
+
+  function expectIframeCreationToFail<T>(component: Type<T>): ComponentFixture<T> {
+    let fixture: ComponentFixture<T>|undefined;
+    expect(() => {
+      fixture = TestBed.createComponent(component);
+      fixture.detectChanges();
+    }).toThrowError(getErrorMessageRegexp());
+
+    ensureNoIframePresent(fixture);
+    return fixture!;
+  }
+
+  function expectIframeToBeCreated<T>(
+      component: Type<T>, attrsToCheck: {[key: string]: string}): ComponentFixture<T> {
+    let fixture: ComponentFixture<T>;
+    expect(() => {
+      fixture = TestBed.createComponent(component);
+      fixture.detectChanges();
+    }).not.toThrow();
+
+    const iframe = fixture!.nativeElement.querySelector('iframe');
+    for (const [attrName, attrValue] of Object.entries(attrsToCheck)) {
+      expect(iframe[attrName]).toEqual(attrValue);
+    }
+
+    return fixture!;
+  }
+
+  // *Must* be in sync with the `SECURITY_SENSITIVE_ATTRS` list
+  // from the `packages/compiler/src/schema/dom_security_schema.ts`.
+  const SECURITY_SENSITIVE_ATTRS =
+      ['sandbox', 'allow', 'allowFullscreen', 'referrerPolicy', 'csp', 'fetchPriority'];
+
+  const TEST_IFRAME_URL = 'https://angular.io/assets/images/logos/angular/angular.png';
+
+  let oldNgDevMode!: typeof ngDevMode;
+
+  beforeAll(() => {
+    oldNgDevMode = ngDevMode;
+  });
+
+  afterAll(() => {
+    global['ngDevMode'] = oldNgDevMode;
+  });
+
+  [true, false].forEach(devModeFlag => {
+    beforeAll(() => {
+      global['ngDevMode'] = devModeFlag;
+
+      // TestBed and JIT compilation have some dependencies on the ngDevMode state, so we need to
+      // reset TestBed to ensure we get a 'clean' JIT compilation under the new rules.
+      TestBed.resetTestingModule();
+    });
+
+    describe(`with ngDevMode = ${devModeFlag}`, () => {
+      SECURITY_SENSITIVE_ATTRS.forEach((securityAttr: string) => {
+        ['src', 'srcdoc'].forEach((srcAttr: string) => {
+          it(`should work when a security-sensitive attribute is set ` +
+                 `as a static attribute (checking \`${securityAttr}\`)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                  <iframe
+                    ${srcAttr}="${TEST_IFRAME_URL}"
+                    ${securityAttr}="">
+                  </iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeToBeCreated(IframeComp, {[srcAttr]: TEST_IFRAME_URL});
+             });
+
+          it(`should work when a security-sensitive attribute is set ` +
+                 `as a static attribute (checking \`${securityAttr}\` and ` +
+                 `making sure it's case-insensitive)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                  <iframe
+                    ${srcAttr}="${TEST_IFRAME_URL}"
+                    ${securityAttr.toUpperCase()}="">
+                  </iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeToBeCreated(IframeComp, {[srcAttr]: TEST_IFRAME_URL});
+             });
+
+          it(`should error when a security-sensitive attribute is applied ` +
+                 `using a property binding (checking \`${securityAttr}\`)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template:
+                     `<iframe ${srcAttr}="${TEST_IFRAME_URL}" [${securityAttr}]="''"></iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp);
+             });
+
+          it(`should error when a security-sensitive attribute is applied ` +
+                 `using a property interpolation (checking \`${securityAttr}\`)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template:
+                     `<iframe ${srcAttr}="${TEST_IFRAME_URL}" ${securityAttr}="{{''}}"></iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp);
+             });
+
+          it(`should error when a security-sensitive attribute is applied ` +
+                 `using a property binding (checking \`${securityAttr}\`, making ` +
+                 `sure it's case-insensitive)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                    <iframe
+                      ${srcAttr}="${TEST_IFRAME_URL}"
+                      [${securityAttr.toUpperCase()}]="''"
+                    ></iframe>
+                  `,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp);
+             });
+
+          it(`should error when a security-sensitive attribute is applied ` +
+                 `using a property binding (checking \`${securityAttr}\`)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                    <iframe
+                      ${srcAttr}="${TEST_IFRAME_URL}"
+                      [attr.${securityAttr}]="''"
+                    ></iframe>
+                  `,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp);
+             });
+
+          it(`should error when a security-sensitive attribute is applied ` +
+                 `using a property binding (checking \`${securityAttr}\`, making ` +
+                 `sure it's case-insensitive)`,
+             () => {
+               @Component({
+                 standalone: true,
+                 selector: 'my-comp',
+                 template: `
+                    <iframe
+                      ${srcAttr}="${TEST_IFRAME_URL}"
+                      [attr.${securityAttr.toUpperCase()}]="''"
+                    ></iframe>
+                  `,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp);
+             });
+
+          it(`should allow changing \`${srcAttr}\` after initial render`, () => {
+            @Component({
+              standalone: true,
+              selector: 'my-comp',
+              template: `
+                    <iframe
+                      ${securityAttr}="allow-forms"
+                      [${srcAttr}]="src">
+                    </iframe>
+                  `,
+            })
+            class IframeComp {
+              private sanitizer = inject(DomSanitizer);
+              src = this.sanitizeFn(TEST_IFRAME_URL);
+
+              get sanitizeFn() {
+                return srcAttr === 'src' ? this.sanitizer.bypassSecurityTrustResourceUrl :
+                                           this.sanitizer.bypassSecurityTrustHtml;
+              }
+            }
+
+            const fixture = expectIframeToBeCreated(IframeComp, {[srcAttr]: TEST_IFRAME_URL});
+            const component = fixture.componentInstance;
+
+            // Changing `src` or `srcdoc` is allowed.
+            const newUrl = 'https://angular.io/about?group=Angular';
+            component.src = component.sanitizeFn(newUrl);
+            expect(() => fixture.detectChanges()).not.toThrow();
+            expect(fixture.nativeElement.querySelector('iframe')[srcAttr]).toEqual(newUrl);
+          });
+        });
+      });
+
+      it('should work when a directive sets a security-sensitive attribute as a static attribute',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+               'sandbox': '',
+             },
+           })
+           class IframeDir {
+           }
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: '<iframe dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should work when a directive sets a security-sensitive host attribute on a non-iframe element',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+               'sandbox': '',
+             },
+           })
+           class Dir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [Dir],
+             selector: 'my-comp',
+             template: '<img dir>',
+           })
+           class NonIframeComp {
+           }
+
+           const fixture = TestBed.createComponent(NonIframeComp);
+           fixture.detectChanges();
+
+           expect(fixture.nativeElement.firstChild.src).toEqual(TEST_IFRAME_URL);
+         });
+
+
+      it('should work when a security-sensitive attribute on an <iframe> ' +
+             'which also has a structural directive (*ngIf)',
+         () => {
+           @Component({
+             standalone: true,
+             imports: [NgIf],
+             selector: 'my-comp',
+             template: `<iframe *ngIf="visible" src="${TEST_IFRAME_URL}" sandbox=""></iframe>`,
+           })
+           class IframeComp {
+             visible = true;
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should work when a security-sensitive attribute is set between `src` and `srcdoc`',
+         () => {
+           @Component({
+             standalone: true,
+             selector: 'my-comp',
+             template: `<iframe src="${TEST_IFRAME_URL}" sandbox srcdoc="Hi!"></iframe>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should work when a directive sets a security-sensitive attribute before setting `src`',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'sandbox': '',
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: '<iframe dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should work when a directive sets an `src` and ' +
+             'there was a security-sensitive attribute set in a template' +
+             '(directive attribute after `sandbox`)',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: '<iframe sandbox dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should error when a directive sets a security-sensitive attribute ' +
+             'as an attribute binding (checking that it\'s case-insensitive)',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               '[attr.SANDBOX]': '\'\'',
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: `<IFRAME dir src="${TEST_IFRAME_URL}"></IFRAME>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp);
+         });
+
+      it('should work when a directive sets an `src` and ' +
+             'there was a security-sensitive attribute set in a template' +
+             '(directive attribute before `sandbox`)',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: '<iframe dir sandbox></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should work when a directive sets a security-sensitive attribute and ' +
+             'there was an `src` attribute set in a template' +
+             '(directive attribute after `src`)',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: `<iframe src="${TEST_IFRAME_URL}" dir></iframe>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should work when a security-sensitive attribute is set as a static attribute', () => {
+        @Component({
+          standalone: true,
+          selector: 'my-comp',
+          template: `
+            <iframe referrerPolicy="no-referrer" src="${TEST_IFRAME_URL}"></iframe>
+          `,
+        })
+        class IframeComp {
+        }
+
+        expectIframeToBeCreated(IframeComp, {
+          src: TEST_IFRAME_URL,
+          referrerPolicy: 'no-referrer',
+        });
+      });
+
+      it('should error when a security-sensitive attribute is set ' +
+             'as a property binding and an <iframe> is wrapped into another element',
+         () => {
+           @Component({
+             standalone: true,
+             selector: 'my-comp',
+             template: `
+                <section>
+                  <iframe
+                    src="${TEST_IFRAME_URL}"
+                    [referrerPolicy]="'no-referrer'"
+                  ></iframe>
+                </section>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp);
+         });
+
+      it('should work when a directive sets a security-sensitive attribute and ' +
+             'there was an `src` attribute set in a template' +
+             '(directive attribute before `src`)',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [IframeDir],
+             selector: 'my-comp',
+             template: `<iframe dir src="${TEST_IFRAME_URL}"></iframe>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should work when a directive that sets a security-sensitive attribute goes ' +
+             'before the directive that sets an `src` attribute value',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[set-src]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class DirThatSetsSrc {
+           }
+
+           @Directive({
+             standalone: true,
+             selector: '[set-sandbox]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class DirThatSetsSandbox {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [DirThatSetsSandbox, DirThatSetsSrc],
+             selector: 'my-comp',
+             // Important note: even though the `set-sandbox` goes after the `set-src`,
+             // the directive matching order (thus the order of host attributes) is
+             // based on the imports order, so the `sandbox` gets set first and the `src` second.
+             template: '<iframe set-src set-sandbox></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should work when a directive that sets a security-sensitive attribute has ' +
+             'a host directive that sets an `src` attribute value',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[set-src-dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class DirThatSetsSrc {
+           }
+
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             hostDirectives: [DirThatSetsSrc],
+             host: {
+               'sandbox': '',
+             },
+           })
+           class DirThatSetsSandbox {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [DirThatSetsSandbox],
+             selector: 'my-comp',
+             template: '<iframe dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should work when a directive that sets an `src` has ' +
+             'a host directive that sets a security-sensitive attribute value',
+         () => {
+           @Directive({
+             standalone: true,
+             selector: '[set-sandbox-dir]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class DirThatSetsSandbox {
+           }
+
+           @Directive({
+             standalone: true,
+             selector: '[dir]',
+             hostDirectives: [DirThatSetsSandbox],
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class DirThatSetsSrc {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [DirThatSetsSrc],
+             selector: 'my-comp',
+             template: '<iframe dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+
+      it('should error when creating a view that contains an <iframe> ' +
+             'with security-sensitive attributes set via property bindings',
+         () => {
+           @Component({
+             standalone: true,
+             selector: 'my-comp',
+             template: `
+                <ng-container #container></ng-container>
+                <ng-template #template>
+                  <iframe src="${TEST_IFRAME_URL}" [sandbox]="''"></iframe>
+                </ng-template>
+              `,
+           })
+           class IframeComp {
+             @ViewChild('container', {read: ViewContainerRef}) container!: ViewContainerRef;
+             @ViewChild('template') template!: TemplateRef<unknown>;
+
+             createEmbeddedView() {
+               this.container.createEmbeddedView(this.template);
+             }
+           }
+
+           const fixture = TestBed.createComponent(IframeComp);
+           fixture.detectChanges();
+
+           expect(() => {
+             fixture.componentInstance.createEmbeddedView();
+             fixture.detectChanges();
+           }).toThrowError(getErrorMessageRegexp());
+
+           ensureNoIframePresent(fixture);
+         });
+
+      describe('i18n', () => {
+        it('should error when a security-sensitive attribute is set as ' +
+               'a property binding on an <iframe> inside i18n block',
+           () => {
+             @Component({
+               standalone: true,
+               selector: 'my-comp',
+               template: `
+                  <section i18n>
+                    <iframe src="${TEST_IFRAME_URL}" [sandbox]="''">
+                    </iframe>
+                  </section>
+                `,
+             })
+             class IframeComp {
+             }
+
+             expectIframeCreationToFail(IframeComp);
+           });
+
+        it('should error when a security-sensitive attribute is set as ' +
+               'a property binding on an <iframe> annotated with i18n attribute',
+           () => {
+             @Component({
+               standalone: true,
+               selector: 'my-comp',
+               template: `
+                  <iframe i18n src="${TEST_IFRAME_URL}" [sandbox]="''">
+                  </iframe>
+                `,
+             })
+             class IframeComp {
+             }
+
+             expectIframeCreationToFail(IframeComp);
+           });
+
+        it('should work when a security-sensitive attributes are marked for translation', () => {
+          @Component({
+            standalone: true,
+            selector: 'my-comp',
+            template: `
+              <iframe src="${TEST_IFRAME_URL}" i18n-sandbox sandbox="">
+              </iframe>
+            `,
+          })
+          class IframeComp {
+          }
+
+          expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+        });
+      });
+    });
   });
 });

--- a/packages/tsec-exemption.json
+++ b/packages/tsec-exemption.json
@@ -31,5 +31,8 @@
   ],
   "ban-window-stringfunctiondef": [
     "core/src/render3/util/misc_utils.ts"
+  ],
+  "ban-iframe-srcdoc-assignments": [
+    "core/src/sanitization/iframe_attrs_validation.ts"
   ]
 }


### PR DESCRIPTION
This commit updates the logic related to the attribute and property binding rules for <iframe> elements. There is a set of <iframe> attributes that may affect the behavior of an iframe and this change enforces that these attributes are only applied as static attributes, making sure that they are taken into account while creating an <iframe>.

If Angular detects that some of the security-sensitive attributes are applied as an attribute or property binding, it throws an error message, which contains the name of an attribute that is causing the problem and the name of a Component where an iframe is located.

BREAKING CHANGE:

Existing iframe usages may have security-sensitive attributes applied as an attribute or property binding in a template or via host bindings in a directive. Such usages would require an update to ensure compliance with the new stricter rules around iframe bindings.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No