### PR TITLE
docs: add a link to hierarchical-dependency-injection

### DIFF
--- a/aio/content/guide/dependency-injection.md
+++ b/aio/content/guide/dependency-injection.md
@@ -44,7 +44,7 @@ When you register a provider at the component level, you get a new instance of t
 class HeroListModule {}
 </code-example>
 
-When you register a provider with a specific NgModule, the same instance of a service is available to all components in that NgModule.
+When you register a provider with a specific NgModule, the same instance of a service is available to all components in that NgModule (to understand all edge-cases, see [Hierarchical injectors](guide/hierarchical-dependency-injection)).
 
 * At the application root level, which allows injecting it into other classes in the application. This can be done by adding the `providedIn: 'root'` field to the `@Injectable` decorator:
 

--- a/aio/content/guide/dependency-injection.md
+++ b/aio/content/guide/dependency-injection.md
@@ -44,7 +44,8 @@ When you register a provider at the component level, you get a new instance of t
 class HeroListModule {}
 </code-example>
 
-When you register a provider with a specific NgModule, the same instance of a service is available to all components in that NgModule (to understand all edge-cases, see [Hierarchical injectors](guide/hierarchical-dependency-injection)).
+When you register a provider with a specific NgModule, the same instance of a service is available to all components in that NgModule.
+To understand all edge-cases, see [Hierarchical injectors](guide/hierarchical-dependency-injection).
 
 * At the application root level, which allows injecting it into other classes in the application. This can be done by adding the `providedIn: 'root'` field to the `@Injectable` decorator:
 


### PR DESCRIPTION
It is not clear that when we provide a service to some eagerly loaded module of an application, then that service is available for components of all eagerly loaded modules of that application. It would be better to give a link for more information at least.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
