### PR TITLE
refactor(core): remove duplicate createRenderer call

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -169,9 +169,7 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
     const elementName = this.componentDef.selectors[0][0] as string || 'div';
     const hostRNode = rootSelectorOrNode ?
         locateHostElement(hostRenderer, rootSelectorOrNode, this.componentDef.encapsulation) :
-        createElementNode(
-            rendererFactory.createRenderer(null, this.componentDef), elementName,
-            getNamespace(elementName));
+        createElementNode(hostRenderer, elementName, getNamespace(elementName));
 
     const rootFlags = this.componentDef.onPush ? LViewFlags.Dirty | LViewFlags.IsRoot :
                                                  LViewFlags.CheckAlways | LViewFlags.IsRoot;


### PR DESCRIPTION
Fixes that we were calling `createRenderer` even though we had one already. This likely wasn't a performance issue since the renderer factory caches the renderer, but it's still better to reuse it to avoid confusion in the future.

Fixes #47980.