### PR TITLE
refactor(compiler-cli): avoid using `getMutableClone` API if targeting ES2015 and later

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -33,7 +33,7 @@ import {TemplateTypeCheckerImpl} from '../../typecheck';
 import {OptimizeFor, TemplateTypeChecker, TypeCheckingConfig} from '../../typecheck/api';
 import {ALL_DIAGNOSTIC_FACTORIES, ExtendedTemplateCheckerImpl} from '../../typecheck/extended';
 import {ExtendedTemplateChecker} from '../../typecheck/extended/api';
-import {getSourceFileOrNull, isDtsPath, toUnredirectedSourceFile} from '../../util/src/typescript';
+import {getEmitModuleKind, getSourceFileOrNull, isDtsPath, toUnredirectedSourceFile} from '../../util/src/typescript';
 import {Xi18nContext} from '../../xi18n';
 import {DiagnosticCategoryLabel, NgCompilerAdapter, NgCompilerOptions} from '../api';
 
@@ -617,7 +617,9 @@ export class NgCompiler {
       importRewriter = new NoopImportRewriter();
     }
 
-    const defaultImportTracker = new DefaultImportTracker();
+    const isCommonJsEmit =
+        getEmitModuleKind(this.currentProgram.getCompilerOptions()) < ts.ModuleKind.ES2015;
+    const defaultImportTracker = new DefaultImportTracker(isCommonJsEmit);
 
     const before = [
       ivyTransformFactory(

--- a/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/test/default_spec.ts
@@ -42,7 +42,7 @@ runInEachFileSystem(() => {
       const fooClause = getDeclaration(program, _('/test.ts'), 'Foo', ts.isImportClause);
       const fooDecl = fooClause.parent;
 
-      const tracker = new DefaultImportTracker();
+      const tracker = new DefaultImportTracker(false);
       tracker.recordUsedImport(fooDecl);
       program.emit(undefined, undefined, undefined, undefined, {
         before: [tracker.importPreservingTransformer()],
@@ -71,7 +71,7 @@ runInEachFileSystem(() => {
       const fooId = fooClause.name!;
       const fooDecl = fooClause.parent;
 
-      const tracker = new DefaultImportTracker();
+      const tracker = new DefaultImportTracker(true);
       tracker.recordUsedImport(fooDecl);
       program.emit(undefined, undefined, undefined, undefined, {
         before: [

--- a/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/typescript.ts
@@ -204,3 +204,21 @@ export function toUnredirectedSourceFile(sf: ts.SourceFile): ts.SourceFile {
   }
   return redirectInfo.unredirected;
 }
+
+/**
+ * Determines the effective module kind from the compiler options.
+ *
+ * Derived from
+ * https://github.com/microsoft/TypeScript/blob/release-4.8/src/compiler/utilities.ts#L6354-L6365
+ */
+export function getEmitModuleKind(options: ts.CompilerOptions): ts.ModuleKind {
+  if (options.module !== undefined) {
+    return options.module;
+  }
+
+  if (options.target === undefined || options.target < ts.ScriptTarget.ES2015) {
+    return ts.ModuleKind.CommonJS;
+  }
+
+  return ts.ModuleKind.ES2015;
+}


### PR DESCRIPTION
Using default imports for DI types currently results in a printed deprecation message when using TypeScript 4.8 and later, as the compiler uses the deprecated `ts.getMutableClone` API to cause TypeScript to retain a default important that is only used in type-only locations. Using alternative API introduces problems when producing CommonJS outputs, as any references to the default import would no longer be converted into a property access for the `default` symbol.

This commit avoids the deprecation warning by switching over to API to derive a synthetic import declaration, which will be retained by TypeScript without generating the deprecation warning. Only when CommonJS output is requested will the `getMutableClone` API still be used.
