### PR TITLE
feat(router): add withLocationStrategy for standalone router api

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-
 export {createUrlTreeFromSnapshot} from './create_url_tree';
 export {RouterLink, RouterLinkWithHref} from './directives/router_link';
 export {RouterLinkActive} from './directives/router_link_active';
@@ -14,7 +13,7 @@ export {RouterOutlet, RouterOutletContract} from './directives/router_outlet';
 export {ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, Event, EventType, GuardsCheckEnd, GuardsCheckStart, NavigationCancel, NavigationCancellationCode as NavigationCancellationCode, NavigationEnd, NavigationError, NavigationStart, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RouterEvent, RoutesRecognized, Scroll} from './events';
 export {CanActivate, CanActivateChild, CanActivateChildFn, CanActivateFn, CanDeactivate, CanDeactivateFn, CanLoad, CanLoadFn, CanMatch, CanMatchFn, Data, LoadChildren, LoadChildrenCallback, NavigationBehaviorOptions, QueryParamsHandling, Resolve, ResolveData, ResolveFn, Route, Routes, RunGuardsAndResolvers, UrlMatcher, UrlMatchResult} from './models';
 export {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
-export {DebugTracingFeature, DisabledInitialNavigationFeature, EnabledBlockingInitialNavigationFeature, InitialNavigationFeature, InMemoryScrollingFeature, PreloadingFeature, provideRouter, provideRoutes, RouterConfigurationFeature, RouterFeature, RouterFeatures, withDebugTracing, withDisabledInitialNavigation, withEnabledBlockingInitialNavigation, withInMemoryScrolling, withPreloading, withRouterConfig} from './provide_router';
+export {DebugTracingFeature, DisabledInitialNavigationFeature, EnabledBlockingInitialNavigationFeature, InitialNavigationFeature, InMemoryScrollingFeature, PreloadingFeature, provideRouter, provideRoutes, RouterConfigurationFeature, RouterFeature, RouterFeatures, withDebugTracing, withDisabledInitialNavigation, withEnabledBlockingInitialNavigation, withInMemoryScrolling, withLocationStrategy, withPreloading, withRouterConfig} from './provide_router';
 export {BaseRouteReuseStrategy, DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Navigation, NavigationExtras, Router, UrlCreationOptions} from './router';
 export {ExtraOptions, InitialNavigation, InMemoryScrollingOptions, ROUTER_CONFIGURATION, RouterConfigOptions} from './router_config';

--- a/packages/router/src/private_export.ts
+++ b/packages/router/src/private_export.ts
@@ -6,9 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-
 export {ɵEmptyOutletComponent} from './components/empty_outlet';
-export {withPreloading as ɵwithPreloading} from './provide_router';
+export {withLocationStrategy as ɵwithLocationStrategy, withPreloading as ɵwithPreloading} from './provide_router';
 export {assignExtraOptionsToRouter as ɵassignExtraOptionsToRouter, RestoredState as ɵRestoredState} from './router';
 export {ROUTER_PROVIDERS as ɵROUTER_PROVIDERS} from './router_module';
 export {flatten as ɵflatten} from './utils/collection';

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -164,6 +164,14 @@ export interface InMemoryScrollingOptions {
 }
 
 /**
+ * A set of configuration options for a location strategy,
+ * either enabling HashLocationStrategy or PathlocationStrategy
+ */
+export interface LocationStrategyOptions {
+  useHash: boolean;
+}
+
+/**
  * A set of configuration options for a router module, provided in the
  * `forRoot()` method.
  *

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -166,13 +166,13 @@ export function provideRouterScroller(): Provider {
 
 // Note: For internal use only with `RouterModule`. Standalone setup via `provideRouter` should
 // provide hash location directly via `{provide: LocationStrategy, useClass: HashLocationStrategy}`.
-function provideHashLocationStrategy(): Provider {
+export function provideHashLocationStrategy(): Provider {
   return {provide: LocationStrategy, useClass: HashLocationStrategy};
 }
 
 // Note: For internal use only with `RouterModule`. Standalone setup via `provideRouter` does not
 // need this at all because `PathLocationStrategy` is the default factory for `LocationStrategy`.
-function providePathLocationStrategy(): Provider {
+export function providePathLocationStrategy(): Provider {
   return {provide: LocationStrategy, useClass: PathLocationStrategy};
 }
 

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -17,7 +17,7 @@ import {concat, defer, EMPTY, from, Observable, Observer, of, Subscription} from
 import {delay, filter, first, last, map, mapTo, takeWhile, tap} from 'rxjs/operators';
 
 import {CanActivateChildFn, CanActivateFn, CanMatch, CanMatchFn, ResolveFn} from '../src/models';
-import {withRouterConfig} from '../src/provide_router';
+import {withLocationStrategy, withRouterConfig} from '../src/provide_router';
 import {forEach, wrapIntoObservable} from '../src/utils/collection';
 import {getLoadedRoutes} from '../src/utils/config';
 import {provideRouterForTesting} from '../testing/src/provide_router_for_testing';
@@ -6984,6 +6984,21 @@ describe('Testing router options', () => {
       const router: Router = TestBed.inject(Router);
       expect(router.urlUpdateStrategy).toBe('eager');
     });
+  });
+
+  describe('should use the appropriate location strategy', () => {
+    it('using hash location',
+       () => {fakeAsync(() => {
+         TestBed.configureTestingModule({
+           declarations: [RootCmp],
+           providers: [provideRouterForTesting([], withLocationStrategy({useHash: true}))]
+         });
+         const router: Router = TestBed.inject(Router);
+         const fixture = createRoot(router, RootCmp);
+         router.navigateByUrl('/someUrl');
+         advance(fixture);
+         expect(router.url).toBe('/#/someUrl');
+       })});
   });
 });
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?


<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
With version 14's standalone API `createRouter` now will have a new function config `withLocationStrategy` that we can set whether we want to use hash or not. If not provided the default is Path Location Strategy

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
