### PR TITLE
build: update ng-dev configuration to account for caretaker note label change

### DIFF
--- a/.ng-dev/caretaker.mts
+++ b/.ng-dev/caretaker.mts
@@ -10,7 +10,7 @@ export const caretaker: CaretakerConfig = {
     },
     {
       name: 'Merge Assistance Queue',
-      query: `is:pr is:open label:"action: caretaker note"`,
+      query: `is:pr is:open label:"merge: caretaker note" label:"action: merge"`,
     },
     {
       name: 'Initial Triage Queue',


### PR DESCRIPTION
The caretaker note label has been renamed to the new standardized label name. This commit updates the ng-dev caretaker check configuration to account for this.

Also the merge assistance queue query is updated to only show PRs marked as ready for merge. Other PRs with just a caretaker note should not be of interest for the caretaker yet.