### PR TITLE
refactor(router): Add opt-in provider for upcoming router change 

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -111,6 +111,9 @@
     "name": "Console"
   },
   {
+    "name": "CreateUrlTreeStrategy"
+  },
+  {
     "name": "DEFAULT_SERIALIZER"
   },
   {
@@ -250,6 +253,9 @@
   },
   {
     "name": "LQuery_"
+  },
+  {
+    "name": "LegacyCreateUrlTree"
   },
   {
     "name": "LifecycleHooksFeature"

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -74,10 +74,11 @@ export function createUrlTreeFromSnapshot(
   return createUrlTreeFromSegmentGroup(relativeToUrlSegmentGroup, commands, queryParams, fragment);
 }
 
-function createSegmentGroupFromRoute(route: ActivatedRouteSnapshot): UrlSegmentGroup {
+export function createSegmentGroupFromRoute(route: ActivatedRouteSnapshot): UrlSegmentGroup {
   let targetGroup: UrlSegmentGroup|undefined;
 
-  function createSegmentGroupFromRouteRecursive(currentRoute: ActivatedRouteSnapshot) {
+  function createSegmentGroupFromRouteRecursive(currentRoute: ActivatedRouteSnapshot):
+      UrlSegmentGroup {
     const childOutlets: {[outlet: string]: UrlSegmentGroup} = {};
     for (const childSnapshot of currentRoute.children) {
       const root = createSegmentGroupFromRouteRecursive(childSnapshot);

--- a/packages/router/src/create_url_tree_strategy.ts
+++ b/packages/router/src/create_url_tree_strategy.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable} from '@angular/core';
+
+import {createSegmentGroupFromRoute, createUrlTree, createUrlTreeFromSegmentGroup} from './create_url_tree';
+import {ActivatedRoute, RouterState} from './router_state';
+import {Params} from './shared';
+import {UrlSegmentGroup, UrlTree} from './url_tree';
+
+const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
+
+@Injectable()
+export class LegacyCreateUrlTree implements CreateUrlTreeStrategy {
+  createUrlTree(
+      relativeTo: ActivatedRoute|null|undefined, currentState: RouterState, currentUrlTree: UrlTree,
+      commands: any[], queryParams: Params|null, fragment: string|null): UrlTree {
+    const a = relativeTo || currentState.root;
+    return createUrlTree(a, currentUrlTree, commands, queryParams, fragment);
+  }
+}
+
+@Injectable()
+export class CreateUrlTreeUsingSnapshot implements CreateUrlTreeStrategy {
+  createUrlTree(
+      relativeTo: ActivatedRoute|null|undefined, currentState: RouterState, currentUrlTree: UrlTree,
+      commands: any[], queryParams: Params|null, fragment: string|null): UrlTree {
+    let relativeToUrlSegmentGroup: UrlSegmentGroup|undefined;
+    try {
+      const relativeToSnapshot = relativeTo ? relativeTo.snapshot : currentState.snapshot.root;
+      relativeToUrlSegmentGroup = createSegmentGroupFromRoute(relativeToSnapshot);
+    } catch (e: unknown) {
+      // This is strictly for backwards compatibility with tests that create
+      // invalid `ActivatedRoute` mocks.
+      // Note: the difference between having this fallback for invalid `ActivatedRoute` setups and
+      // just throwing is ~500 test failures. Fixing all of those tests by hand is not feasible at
+      // the moment.
+      if (NG_DEV_MODE) {
+        console.warn(
+            `The ActivatedRoute has an invalid structure. This is likely due to an incomplete mock in tests.`);
+      }
+      if (typeof commands[0] !== 'string' || !commands[0].startsWith('/')) {
+        // Navigations that were absolute in the old way of creating UrlTrees
+        // would still work because they wouldn't attempt to match the
+        // segments in the `ActivatedRoute` to the `currentUrlTree` but
+        // instead just replace the root segment with the navigation result.
+        // Non-absolute navigations would fail to apply the commands because
+        // the logic could not find the segment to replace (so they'd act like there were no
+        // commands).
+        commands = [];
+      }
+      relativeToUrlSegmentGroup = currentUrlTree.root;
+    }
+    return createUrlTreeFromSegmentGroup(
+        relativeToUrlSegmentGroup, commands, queryParams, fragment);
+  }
+}
+
+@Injectable({providedIn: 'root', useClass: LegacyCreateUrlTree})
+export abstract class CreateUrlTreeStrategy {
+  abstract createUrlTree(
+      relativeTo: ActivatedRoute|null|undefined, currentState: RouterState, currentUrlTree: UrlTree,
+      commands: any[], queryParams: Params|null, fragment: string|null): UrlTree;
+}


### PR DESCRIPTION
This commit adds a swappable provider for an upcoming change to the
implementation of `Router#createUrlTree`. This will be a breaking change
and is planned to be included in V16.