### PR TITLE
fix(forms): Runtime error pages must begin with leading zero

### DIFF
--- a/aio/content/errors/NG01203.md
+++ b/aio/content/errors/NG01203.md
@@ -1,5 +1,5 @@
 @name Missing value accessor
-@category forms
+@category runtime
 @shortDescription You must register an `NgValueAccessor` with a custom form control
 
 @description

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -113,6 +113,7 @@ export function formatRuntimeError<T extends number = RuntimeErrorCode>(
     code: T, message: null|false|string): string {
   // Error code might be a negative number, which is a special marker that instructs the logic to
   // generate a link to the error details page on angular.io.
+  // We also prepend `0` to non-compile-time errors.
   const fullCode = `NG0${Math.abs(code)}`;
 
   let errorMessage = `${fullCode}${message ? ': ' + message.trim() : ''}`;


### PR DESCRIPTION
I recently checked in a new error guide. The corresponding page must have a leading zero because it is a runtime error. Otherwise links to this error guide will be invalid.