### PR TITLE
test(router): Move test for redirect under correct describe block

### DIFF
--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2983,22 +2983,6 @@ describe('Integration', () => {
         expect(history[history.length - 1].state)
             .toEqual({foo: 'bar', navigationId: history.length});
       })));
-
-
-      it('can redirect from componentless named outlets', fakeAsync(() => {
-           const router = TestBed.inject(Router);
-           const fixture = createRoot(router, RootCmp);
-
-           router.resetConfig([
-             {path: 'main', outlet: 'aux', component: BlankCmp},
-             {path: '', pathMatch: 'full', outlet: 'aux', redirectTo: 'main'},
-           ]);
-
-           router.navigateByUrl('');
-           advance(fixture);
-
-           expect(TestBed.inject(Location).path()).toEqual('/(aux:main)');
-         }));
     });
 
     it('should set href on area elements', fakeAsync(() => {
@@ -3034,6 +3018,21 @@ describe('Integration', () => {
 
          expect(location.path()).toEqual('/team/22');
        })));
+
+    it('can redirect from componentless named outlets', fakeAsync(() => {
+         const router = TestBed.inject(Router);
+         const fixture = createRoot(router, RootCmp);
+
+         router.resetConfig([
+           {path: 'main', outlet: 'aux', component: BlankCmp},
+           {path: '', pathMatch: 'full', outlet: 'aux', redirectTo: 'main'},
+         ]);
+
+         router.navigateByUrl('');
+         advance(fixture);
+
+         expect(TestBed.inject(Location).path()).toEqual('/(aux:main)');
+       }));
 
     it('should update Navigation object after redirects are applied',
        fakeAsync(inject([Router, Location], (router: Router, location: Location) => {


### PR DESCRIPTION
This moves a redirect test to be grouped with other redirect tests.
