### PR TITLE
fix(common): Don't generate srcsets with very large sources

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -75,6 +75,14 @@ const ASPECT_RATIO_TOLERANCE = .1;
  */
 const OVERSIZED_IMAGE_TOLERANCE = 1000;
 
+/**
+ * Used to limit automatic srcset generation of very large sources for
+ * fixed-size images. In pixels.
+ */
+const FIXED_SRCSET_WIDTH_LIMIT = 1920;
+const FIXED_SRCSET_HEIGHT_LIMIT = 1080;
+
+
 /** Info about built-in loaders we can test for. */
 export const BUILT_IN_LOADERS = [imgixLoaderInfo, imageKitLoaderInfo, cloudinaryLoaderInfo];
 
@@ -421,8 +429,7 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
 
     if (this.ngSrcset) {
       rewrittenSrcset = this.getRewrittenSrcset();
-    } else if (
-        !this._disableOptimizedSrcset && !this.srcset && this.imageLoader !== noopImageLoader) {
+    } else if (this.shouldGenerateAutomaticSrcset()) {
       rewrittenSrcset = this.getAutomaticSrcset();
     }
 
@@ -514,6 +521,11 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
         multiplier => `${this.imageLoader({src: this.ngSrc, width: this.width! * multiplier})} ${
             multiplier}x`);
     return finalSrcs.join(', ');
+  }
+
+  private shouldGenerateAutomaticSrcset(): boolean {
+    return !this._disableOptimizedSrcset && !this.srcset && this.imageLoader !== noopImageLoader &&
+        !(this.width! > FIXED_SRCSET_WIDTH_LIMIT || this.height! > FIXED_SRCSET_HEIGHT_LIMIT);
   }
 
   /** @nodoc */

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -1495,6 +1495,30 @@ describe('Image directive', () => {
             .toBe(`${IMG_BASE_URL}/img?w=100 1x, ${IMG_BASE_URL}/img?w=200 2x`);
       });
 
+      it('should not add a fixed srcset to the img element if height is too large', () => {
+        setupTestingModule({imageLoader});
+
+        const template = `<img ngSrc="img" width="1100" height="2400">`;
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+
+        const nativeElement = fixture.nativeElement as HTMLElement;
+        const img = nativeElement.querySelector('img')!;
+        expect(img.getAttribute('srcset')).toBeNull();
+      });
+
+      it('should not add a fixed srcset to the img element if width is too large', () => {
+        setupTestingModule({imageLoader});
+
+        const template = `<img ngSrc="img" width="3000" height="400">`;
+        const fixture = createTestComponent(template);
+        fixture.detectChanges();
+
+        const nativeElement = fixture.nativeElement as HTMLElement;
+        const img = nativeElement.querySelector('img')!;
+        expect(img.getAttribute('srcset')).toBeNull();
+      });
+
       it('should use a custom breakpoint set if one is provided', () => {
         const imageConfig = {
           breakpoints: [16, 32, 48, 64, 96, 128, 256, 384, 640, 1280, 3840],


### PR DESCRIPTION
This PR makes a small change to NgOptimizedImage automatic `srcset` generation to prevent users from inadvertently generating srcsets that download enormous images. After this change, if the image's fixed `height` value is above `1080` or the `width` value is above `1920`, no automatic srcset will be generated. We want to prevent this, because the srcset would include a 2x DPI version of the image which is almost certainly larger than what the user wanted for an image of that size.

If the user really does want a 2x version of such a large image, that can still be accomplished by manually adding a ngSrcset attribute. CC: @AndrewKushnir @pkozlowski-opensource 
