### PR TITLE
fix(core): add` zone.js` version `0.12.x` as a valid peer dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "rxjs": "^6.5.3 || ^7.4.0",
-    "zone.js": "~0.11.4"
+    "zone.js": "~0.11.4 || ~0.12.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit adds `zone.js` version `0.12.x` as a valid peer dependency


