### PR TITLE
docs(router): deprecate setupTestingRouter

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -85,6 +85,7 @@ v15 - v18
 | `@angular/router`                     | [`resolver` field of the `OutletContext` class](#router)                                                                        | <!-- v14 --> v16         |
 | `@angular/router`                     | [`RouterLinkWithHref` directive](#router)                                                                        | <!-- v15 --> v17         |
 | `@angular/router`                     | [`provideRoutes` function](#router)                                                                        | <!-- v15 --> v17         |
+| `@angular/router`                     | [setupTestingRouter](#router)                                                                        | <!-- v15.1 --> v17         |
 | `@angular/service-worker`           | [`SwUpdate#activated`](api/service-worker/SwUpdate#activated)                                              | <!-- v13 --> v16         |
 | `@angular/service-worker`           | [`SwUpdate#available`](api/service-worker/SwUpdate#available)                                              | <!-- v13 --> v16         |
 | template syntax                     | [`/deep/`, `>>>`, and `::ng-deep`](#deep-component-style-selector)                                         | <!--  v7 --> unspecified |
@@ -169,6 +170,7 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 | [`resolver` field of the `OutletContext` class](api/router/OutletContext#resolver) | No replacement needed | v14                   | Component factories are not required to create an instance of a component dynamically. Passing a factory resolver via `resolver` class field is no longer needed. |
 | [`RouterLinkWithHref` directive](api/router/RouterLinkWithHref) | Use `RouterLink` instead. | v15                   | The `RouterLinkWithHref` directive code was merged into `RouterLink`. Now the `RouterLink` directive can be used for all elements that have `routerLink` attribute. |
 | [`provideRoutes` function](api/router/provideRoutes) | Use `ROUTES` `InjectionToken` instead. | v15                   | The `provideRoutes` helper function is minimally useful and can be unintentionally used instead of `provideRouter` due to similar spelling. |
+| [`setupTestingRouter` function](api/router/testing/setupTestingRouter) | Use `provideRouter` or `RouterTestingModule` instead. | v15.1                   | The `setupTestingRouter` function is not necessary. The `Router` is initialized based on the DI configuration in tests as it would be in production. |
 
 
 <a id="platform-browser"></a>

--- a/goldens/public-api/router/testing/index.md
+++ b/goldens/public-api/router/testing/index.md
@@ -32,11 +32,8 @@ export class RouterTestingModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<RouterTestingModule, never, never, [typeof i1.RouterModule]>;
 }
 
-// @public
+// @public @deprecated
 export function setupTestingRouter(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], opts?: ExtraOptions | UrlHandlingStrategy | null, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy, titleStrategy?: TitleStrategy): Router;
-
-// @public
-export function setupTestingRouterInternal(urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location_2, compiler: Compiler, injector: Injector, routes: Route[][], titleStrategy: TitleStrategy, opts?: ExtraOptions | UrlHandlingStrategy, urlHandlingStrategy?: UrlHandlingStrategy, routeReuseStrategy?: RouteReuseStrategy): Router;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -21,30 +21,10 @@ function isUrlHandlingStrategy(opts: ExtraOptions|
 }
 
 /**
- * Router setup factory function used for testing. Only used internally to keep the factory that's
- * marked as publicApi cleaner (i.e. not having _both_ `TitleStrategy` and `DefaultTitleStrategy`).
- */
-export function setupTestingRouterInternal(
-    urlSerializer: UrlSerializer,
-    contexts: ChildrenOutletContexts,
-    location: Location,
-    compiler: Compiler,
-    injector: Injector,
-    routes: Route[][],
-    titleStrategy: TitleStrategy,
-    opts?: ExtraOptions|UrlHandlingStrategy,
-    urlHandlingStrategy?: UrlHandlingStrategy,
-    routeReuseStrategy?: RouteReuseStrategy,
-) {
-  return setupTestingRouter(
-      urlSerializer, contexts, location, compiler, injector, routes, opts, urlHandlingStrategy,
-      routeReuseStrategy, titleStrategy);
-}
-
-/**
  * Router setup factory function used for testing.
  *
  * @publicApi
+ * @deprecated Use `provideRouter` or `RouterTestingModule` instead.
  */
 export function setupTestingRouter(
     urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
@@ -107,22 +87,6 @@ export function setupTestingRouter(
     ROUTER_PROVIDERS,
     EXTRA_ROUTER_TESTING_PROVIDERS,
     provideLocationMocks(),
-    {
-      provide: Router,
-      useFactory: setupTestingRouterInternal,
-      deps: [
-        UrlSerializer,
-        ChildrenOutletContexts,
-        Location,
-        Compiler,
-        Injector,
-        ROUTES,
-        TitleStrategy,
-        ROUTER_CONFIGURATION,
-        [UrlHandlingStrategy, new Optional()],
-        [RouteReuseStrategy, new Optional()],
-      ]
-    },
     withPreloading(NoPreloading).ɵproviders,
     {provide: ROUTES, multi: true, useValue: []},
   ]


### PR DESCRIPTION
The `setupTestingRouter` function is not necessary. The `Router` can be fully initialized through the DI configuration in the same way as it is in production. Tests should use `provideRouter` or `RouterTestingModule`.