### PR TITLE
build(docs-infra): upgrade cli command docs sources to 22d1977c5

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 23b229e89",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 22d1977c5",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint && yarn security-lint",
     "test": "yarn check-env && ng test",
     "test:bazel": "bazelisk test //aio:test",


### PR DESCRIPTION
Updating [angular#main](https://github.com/angular/angular/tree/main) from [cli-builds#main](https://github.com/angular/cli-builds/tree/main).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/23b229e89...22d1977c5):

**Modified**
- help/generate.json