### PR TITLE
fix(devtools): prevent devTools to load when not text/html document 

### DIFF
--- a/devtools/projects/shell-browser/src/app/ng-validate.ts
+++ b/devtools/projects/shell-browser/src/app/ng-validate.ts
@@ -14,7 +14,9 @@ window.addEventListener('message', (event: MessageEvent) => {
   }
 });
 
-const script = document.createElement('script');
-script.src = chrome.runtime.getURL('app/detect_angular_for_extension_icon_bundle.js');
-document.documentElement.appendChild(script);
-document.documentElement.removeChild(script);
+if (document.contentType === 'text/html') {
+  const script = document.createElement('script');
+  script.src = chrome.runtime.getURL('app/detect_angular_for_extension_icon_bundle.js');
+  document.documentElement.appendChild(script);
+  document.documentElement.removeChild(script);
+}


### PR DESCRIPTION
The Angular DevTools extension breaks the XML formatting on Firefox. 
This happens because a script tag is injected into the DOM even if it's a XML Document. 

React DevTools had the [same issue](https://github.com/facebook/react/issues/17620).  They fixed it by checking the `content-type` before injecting the script. 

Fixes #48017 


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:




## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
