### PR TITLE
docs: Added protected modifier info for data-bound properties

### DIFF
--- a/aio/content/guide/aot-compiler.md
+++ b/aio/content/guide/aot-compiler.md
@@ -83,7 +83,8 @@ You write metadata in a *subset* of TypeScript that must conform to the followin
 *   Limit [expression syntax](#expression-syntax) to the supported subset of JavaScript
 *   Only reference exported symbols after [code folding](#code-folding)
 *   Only call [functions supported](#supported-functions) by the compiler
-*   Decorated and data-bound class members must be public
+*   Decorated class members must be public
+*   Data-bound lass members must be public or protected
 
 For additional guidelines and instructions on preparing an application for AOT compilation, see [Angular: Writing AOT-friendly applications](https://medium.com/sparkles-blog/angular-writing-aot-friendly-applications-7b64c8afbe3f).
 
@@ -317,7 +318,7 @@ The compiler can only reference *exported symbols*.
 *   Decorated component class members must be public.
     You cannot make an `@Input()` property private or protected.
 
-*   Data bound properties must also be public
+*   Data bound properties can be public or protected.
 
 <!--<code-example format="typescript" language="typescript">
 


### PR DESCRIPTION
This changed in Angular 14+ and the documentation here wasn't up-to-date anymore.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Out-dated documentation where new behavior wasn't mentioned.



## What is the new behavior?
Fixed docs accordingly.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

