### PR TITLE
feat(forms): FormArray.at can return undefined

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -228,7 +228,7 @@ export interface Form {
 // @public
 export class FormArray<TControl extends AbstractControl<any> = any> extends AbstractControl<ɵTypedOrUntyped<TControl, ɵFormArrayValue<TControl>, any>, ɵTypedOrUntyped<TControl, ɵFormArrayRawValue<TControl>, any>> {
     constructor(controls: Array<TControl>, validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null, asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null);
-    at(index: number): ɵTypedOrUntyped<TControl, TControl, AbstractControl<any>>;
+    at(index: number): ɵTypedOrUntyped<TControl, TControl, AbstractControl<any>> | undefined;
     clear(options?: {
         emitEvent?: boolean;
     }): void;

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -18,6 +18,7 @@ pkg_npm(
     visibility = ["//packages/core:__pkg__"],
     deps = [
         "//packages/core/schematics/migrations/block-template-entities:bundle",
+        "//packages/core/schematics/migrations/form-array-at:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration:bundle",
     ],
 )

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -4,6 +4,11 @@
       "version": "17.0.0",
       "description": "Angular v17 introduces a new control flow syntax that uses the @ and } characters. This migration replaces the existing usages with their corresponding HTML entities.",
       "factory": "./migrations/block-template-entities/bundle"
+    },
+    "migration-formArray-at": {
+      "version": "18.0.0",
+      "description": "As of Angular v18, the type of `FormArray.at` can return undefined. This migration automatically identifies usages and adds non-null assertions.",
+      "factory": "./migrations/form-array-at/bundle"
     }
   }
 }

--- a/packages/core/schematics/migrations/form-array-at/BUILD.bazel
+++ b/packages/core/schematics/migrations/form-array-at/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//tools:defaults.bzl", "esbuild", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "form-array-at",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    entry_point = ":index.ts",
+    external = [
+        "@angular-devkit/*",
+        "typescript",
+    ],
+    format = "cjs",
+    platform = "node",
+    deps = [":form-array-at"],
+)

--- a/packages/core/schematics/migrations/form-array-at/README.md
+++ b/packages/core/schematics/migrations/form-array-at/README.md
@@ -1,0 +1,32 @@
+## Typed Forms migration
+
+As of Angular v16, the type of `FormArray.at` can return undefined. This migration automatically
+identifies usages and adds non-null assertions.
+
+#### Before
+
+```ts
+import {Component} from '@angular/core';
+import {FormArray} from '@angular/forms';
+@Component()
+export class MyComponent {
+  private _formArray = new FormArray();
+  getFirstValue() {
+    return this._formArray.at(0).value; // <- Compilation error in v16.
+  }
+}
+```
+
+#### After
+
+```ts
+import {Component} from '@angular/core';
+import {FormControl} from '@angular/forms';
+@Component()
+export class MyComponent {
+  private _formArray = new FormArray();
+  getFirstValue() {
+    return this._formArray.at(0)!.value; // <- Non-null assertion added during the migration.
+  }
+}
+```

--- a/packages/core/schematics/migrations/form-array-at/index.ts
+++ b/packages/core/schematics/migrations/form-array-at/index.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {relative} from 'path';
+import ts from 'typescript';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {createMigrationProgram} from '../../utils/typescript/compiler_host';
+
+import {migrateFile} from './util';
+
+/** Migration that marks accesses of `FormArray.at` as potentially undefined. */
+export default function(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot migrate FormArray.at accesses.');
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runNativeFormArrayAtMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+function runNativeFormArrayAtMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const program = createMigrationProgram(tree, tsconfigPath, basePath);
+  const typeChecker = program.getTypeChecker();
+  const sourceFiles = program.getSourceFiles().filter(
+      (f) => !f.isDeclarationFile && !program.isSourceFileFromExternalLibrary(f));
+
+  const updateFn =
+      (sourceFile: ts.SourceFile, start: number, length: number, content: string,
+       basePath?: string) => {
+        const update = tree.beginUpdate(relative(basePath!, sourceFile.fileName));
+        update.insertRight(start + length, content);
+        tree.commitUpdate(update);
+      };
+
+  sourceFiles.forEach((sourceFile) => migrateFile(sourceFile, basePath, typeChecker, updateFn));
+}

--- a/packages/core/schematics/migrations/form-array-at/util.ts
+++ b/packages/core/schematics/migrations/form-array-at/util.ts
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {normalize} from 'path';
+import ts from 'typescript';
+
+import {hasOneOfTypes, isNullableType} from '../../utils/typescript/symbol';
+
+type UpdateFn =
+    (sourceFile: ts.SourceFile, start: number, length: number, content: string,
+     basePath?: string) => void;
+
+export function migrateFile(
+    sourceFile: ts.SourceFile, basePath: string, typeChecker: ts.TypeChecker, updateFn: UpdateFn) {
+  // We sort the nodes based on their position in the file and we offset the positions by one
+  // for each non-null assertion that we've added. We have to do it this way, rather than
+  // creating and printing a new AST node like in other migrations, because property access
+  // expressions can be nested (e.g. `control.parent.parent.value`), but the node positions
+  // aren't being updated as we're inserting new code. If we were to go through the AST,
+  // we'd have to update the `SourceFile` and start over after each operation.
+  findAtCalls(typeChecker, sourceFile)
+      .sort((a, b) => a.getStart() - b.getStart())
+      .forEach(
+          (node, index) =>
+              updateFn(sourceFile, node.getStart(), node.getWidth() + index, '!', basePath));
+}
+
+/**
+ * Finds the `PropertyAccessExpression`-s that are accessing the `parent` property in
+ * such a way that may result in a compilation error after the v11 type changes.
+ */
+export function findAtCalls(typeChecker: ts.TypeChecker, sourceFile: ts.SourceFile): ts.Node[] {
+  const results: ts.Node[] = [];
+
+  sourceFile.forEachChild(function walk(node: ts.Node) {
+    const parent = node.parent;
+    if (ts.isPropertyAccessExpression(node) && node.name.text === 'at' &&
+        ts.isCallExpression(node.parent) && !isNullCheck(node) && !isSafeAccess(node.parent) &&
+        results.indexOf(node) === -1 && isFormArrayReference(typeChecker, node) &&
+        isNullableType(typeChecker, node)) {
+      const lastToken = node.parent.expression.getLastToken();
+      if (lastToken) {
+        results.unshift(parent);
+      }
+    }
+    node.forEachChild(walk);
+  });
+
+  return results;
+}
+
+/**
+ * Checks whether a particular node is part of a null check. E.g. given:
+ * `control.parent ? control.parent.value : null` the null check would be `control.parent`.
+ */
+function isNullCheck(node: ts.Node): boolean {
+  if (!node.parent) {
+    return false;
+  }
+
+  // `control.parent && control.parent.value` where `node` is `control.parent`.
+  if (ts.isBinaryExpression(node.parent) && node.parent.left === node) {
+    return true;
+  }
+
+  // `control.parent && control.parent.parent && control.parent.parent.value`
+  // where `node` is `control.parent`.
+  if (node.parent.parent && ts.isBinaryExpression(node.parent.parent) &&
+      node.parent.parent.left === node.parent) {
+    return true;
+  }
+
+  // `if (control.parent) {...}` where `node` is `control.parent`.
+  if (ts.isIfStatement(node.parent) && node.parent.expression === node) {
+    return true;
+  }
+
+  // `control.parent ? control.parent.value : null` where `node` is `control.parent`.
+  if (ts.isConditionalExpression(node.parent) && node.parent.condition === node) {
+    return true;
+  }
+
+  return false;
+}
+
+/** Checks whether a property access is safe (e.g. `foo.parent?.value`). */
+function isSafeAccess(node: ts.Node): boolean {
+  return (
+      node.parent != null && ts.isPropertyAccessExpression(node.parent) &&
+      node.parent.expression === node && node.parent.questionDotToken != null);
+}
+
+/** Checks whether a property access is on an `FormArray` coming from `@angular/forms`. */
+function isFormArrayReference(
+    typeChecker: ts.TypeChecker, node: ts.PropertyAccessExpression): boolean {
+  let current: ts.Expression = node;
+  const formsPattern = /node_modules\/?.*\/@angular\/forms/;
+  // Walks up the property access chain and tries to find a symbol tied to a `SourceFile`.
+  // If such a node is found, we check whether the type is one of the `FormArray` symbols
+  // and whether it comes from the `@angular/forms` directory in the `node_modules`.
+  while (ts.isPropertyAccessExpression(current)) {
+    const symbol = typeChecker.getTypeAtLocation(current.expression)?.getSymbol();
+
+    if (symbol) {
+      const sourceFile = symbol.valueDeclaration?.getSourceFile();
+      return (
+          sourceFile != null &&
+          formsPattern.test(normalize(sourceFile.fileName).replace(/\\/g, '/')) &&
+          hasOneOfTypes(typeChecker, current.expression, ['FormArray']));
+    }
+    current = current.expression;
+  }
+  return false;
+}

--- a/packages/core/schematics/migrations/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/google3/BUILD.bazel
@@ -5,11 +5,21 @@ ts_library(
     srcs = glob(["**/*.ts"]),
     tsconfig = "//packages/core/schematics:tsconfig.json",
     deps = [
+        "//packages/core/schematics/migrations/form-array-at",
         "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tslint",
         "@npm//tslint",
         "@npm//typescript",
     ],
+)
+
+esbuild(
+    name = "form_array_at_cjs",
+    entry_point = ":formArrayAtRule.ts",
+    format = "cjs",
+    output = "formArrayAtCjsRule.js",
+    platform = "node",
+    deps = [":google3"],
 )
 
 esbuild(
@@ -24,6 +34,7 @@ esbuild(
 filegroup(
     name = "google3_cjs",
     srcs = [
+        ":form_array_at_cjs",
         ":wait_for_async_rule_cjs",
     ],
     visibility = ["//packages/core/schematics/test/google3:__pkg__"],

--- a/packages/core/schematics/migrations/google3/formArrayAtRule.ts
+++ b/packages/core/schematics/migrations/google3/formArrayAtRule.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Replacement, RuleFailure, Rules} from 'tslint';
+import ts from 'typescript';
+
+import {migrateFile} from '../form-array-at/util';
+
+/** TSLint rule for Typed Forms migration. */
+export class Rule extends Rules.TypedRule {
+  override applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[] {
+    const typeChecker = program.getTypeChecker();
+
+    const failures: RuleFailure[] = [];
+
+    const rewriter =
+        (sourceFile: ts.SourceFile, startPos: number, origLength: number, text: string) => {
+          const failure = new RuleFailure(
+              sourceFile, startPos, startPos + origLength,
+              `FormArray's at can return undefined so it need to be accessed safely`, this.ruleName,
+              new Replacement(startPos, origLength, text));
+          failures.push(failure);
+        };
+
+    migrateFile(sourceFile, '', typeChecker, rewriter);
+
+    return failures;
+  }
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -19,6 +19,8 @@ jasmine_node_test(
     data = [
         "//packages/core/schematics:collection.json",
         "//packages/core/schematics:migrations.json",
+        "//packages/core/schematics/migrations/form-array-at",
+        "//packages/core/schematics/migrations/form-array-at:bundle",
         "//packages/core/schematics/migrations/block-template-entities",
         "//packages/core/schematics/migrations/block-template-entities:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration",

--- a/packages/core/schematics/test/form-array-at_spec.ts
+++ b/packages/core/schematics/test/form-array-at_spec.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('FormArray.at migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {lib: ['es2015'], strictNullChecks: true},
+    }));
+    writeFile('/angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+
+
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('/node_modules/@angular/forms/index.d.ts', `
+       export declare class FormArray extends AbstractControl {
+         getRawValue(): any[];
+         at(index: number): {} | undefined
+       }
+     `);
+
+    // Fake non-Angular package to make sure that we don't migrate packages we don't own.
+    writeFile('/node_modules/@not-angular/forms/index.d.ts', `
+        export declare class FormArray extends AbstractControl {
+          getRawValue(): any[];
+          at(index: number): {} | undefined
+        }
+     `);
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  it('should add non-null assertions to accesses of FormArray.at', async () => {
+    writeFile('/index.ts', `
+       import {FormArray} from '@angular/forms';
+       class App {
+         private _formArray: FormArray;
+         getValueAt(index:number) {
+           return this._formArray.at(index).value;
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toContain(`return this._formArray.at(index)!.value;`);
+  });
+
+  it('should not add non-null assertions to accesses of FormArray.at', async () => {
+    writeFile('/index.ts', `
+       import {FormArray} from '@angular/forms';
+       class App {
+         private _formArray: FormArray;
+         getValueAt(index:number) {
+           return this._formArray.at(index)?.value;
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toContain(`return this._formArray.at(index)?.value;`);
+  });
+
+  it('should add non-null assertions to accesses of FormArray.at', async () => {
+    writeFile('/index.ts', `
+       import {FormArray} from '@angular/forms';
+       class App {
+         getValueAt(index:number) {
+          return this._getFormArray().at(index).value;
+         }
+         private _getFormArray() {
+           return new FormArray();
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`return this._getFormArray().at(index)!.value;`);
+  });
+
+  it('should add non-null assertions to accesses of FormArray.at', async () => {
+    writeFile('/index.ts', `
+       import {FormArray} from '@angular/forms';
+       class App {
+         getValueAt(index:number) {
+           const ctrl = (window.foo as FormArray).at(index);
+           return ctrl.value;
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`const ctrl = (window.foo as FormArray).at(index)!;`);
+  });
+
+  it('should not add non-null assertions if the symbol does not come from @angular/forms',
+     async () => {
+       writeFile('/index.ts', `
+        import {FormArray} from '@not-angular/forms';
+        getValueAt(index:number) {
+          return new FormArray([]).at(index).value;
+        }
+      `);
+
+       await runMigration();
+       expect(tree.readContent('/index.ts')).toContain(`return new FormArray([]).at(index).value;`);
+     });
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('migration-v17-formArray-at', {}, tree);
+  }
+});

--- a/packages/core/schematics/test/google3/form-array-at_spec.ts
+++ b/packages/core/schematics/test/google3/form-array-at_spec.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {runfiles} from '@bazel/runfiles';
+import {writeFileSync} from 'fs';
+import {dirname, join} from 'path';
+import shx from 'shelljs';
+import {Configuration, Linter} from 'tslint';
+
+describe('FormArray at access migration', () => {
+  const rulesDirectory =
+      dirname(runfiles.resolvePackageRelative('../../migrations/google3/formArrayAtCjsRule.js'));
+  let tmpDir: string;
+  let previousWorkingDir: string;
+
+
+  beforeEach(() => {
+    tmpDir = join(process.env['TEST_TMPDIR']!, 'google3-test');
+    shx.mkdir('-p', tmpDir);
+    shx.cd(tmpDir);
+
+    writeFile('tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+        strictNullChecks: true,
+      },
+    }));
+    writeFile('angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+    }));
+
+    shx.mkdir('-p', 'node_modules/@angular/forms');
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('node_modules/@angular/forms/index.d.ts', `
+       export declare class FormArray<T> {
+         at(index: number): {} | undefined
+       }
+     `);
+
+    previousWorkingDir = shx.pwd();
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDir);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDir);
+  });
+
+  const testFileLinting = (fileContent: string, numOfFailures: number) => {
+    writeFile('/index.ts', fileContent);
+    const linter = runTSLint(false);
+    const failures = linter.getResult().failures.map((failure) => failure.getFailure());
+
+    expect(failures.length).toBe(numOfFailures);
+    failures.forEach(
+        (failure) => expect(failure).toMatch(
+            /FormArray's at can return undefined so it need to be accessed safely/));
+  };
+
+  it('should add ! to accesses to a FormArray\'s at() return', () => {
+    const fileContent = `
+    import { FormArray } from '@angular/forms';
+       export class Foo implements OnInit {
+        formArray = new FormArray()
+
+         ngOnInit() {
+           console.log(this.formArray.at(0).value);
+         }
+       }
+     `;
+    const expectedFailures = 1;
+    testFileLinting(fileContent, expectedFailures);
+  });
+
+  function writeFile(fileName: string, content: string) {
+    writeFileSync(join(tmpDir, fileName), content);
+  }
+
+  function runTSLint(fix: boolean) {
+    const program = Linter.createProgram(join(tmpDir, 'tsconfig.json'));
+    const linter = new Linter({fix, rulesDirectory: [rulesDirectory]}, program);
+    const config = Configuration.parseConfigFile({rules: {'form-array-at-cjs': true}});
+
+    program.getRootFileNames().forEach((fileName) => {
+      linter.lint(fileName, program.getSourceFile(fileName)!.getFullText(), config);
+    });
+
+    return linter;
+  }
+});

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -142,7 +142,7 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
    *     around from the back, and if index is greatly negative (less than `-length`), the result is
    * undefined. This behavior is the same as `Array.at(index)`.
    */
-  at(index: number): ɵTypedOrUntyped<TControl, TControl, AbstractControl<any>> {
+  at(index: number): ɵTypedOrUntyped<TControl, TControl, AbstractControl<any>>|undefined {
     return (this.controls as any)[this._adjustIndex(index)];
   }
 
@@ -286,7 +286,7 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     assertAllValuesPresent(this, false, value);
     value.forEach((newValue: any, index: number) => {
       assertControlPresent(this, false, index);
-      this.at(index).setValue(newValue, {onlySelf: true, emitEvent: options.emitEvent});
+      this.at(index)?.setValue(newValue, {onlySelf: true, emitEvent: options.emitEvent});
     });
     this.updateValueAndValidity(options);
   }
@@ -334,9 +334,7 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
     if (value == null /* both `null` and `undefined` */) return;
 
     value.forEach((newValue, index) => {
-      if (this.at(index)) {
-        this.at(index).patchValue(newValue, {onlySelf: true, emitEvent: options.emitEvent});
-      }
+      this.at(index)?.patchValue(newValue, {onlySelf: true, emitEvent: options.emitEvent});
     });
     this.updateValueAndValidity(options);
   }

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -183,8 +183,8 @@ describe('FormArray', () => {
             {'c2': new FormControl('v2') as AbstractControl, 'c3': new FormControl('v3')}) as any,
         new FormArray([new FormControl('v4'), new FormControl('v5')])
       ]);
-      a.at(0).get('c3')!.disable();
-      (a.at(1) as FormArray).at(1).disable();
+      a.at(0)!.get('c3')!.disable();
+      (a.at(1)! as FormArray).at(1)!.disable();
 
       expect(a.getRawValue()).toEqual([{'c2': 'v2', 'c3': 'v3'}, ['v4', 'v5']]);
     });

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -57,7 +57,7 @@ describe('FormGroup', () => {
         'array': new FormArray([new FormControl('v4'), new FormControl('v5')])
       });
       fg.get('group')!.get('c3')!.disable();
-      (fg.get('array') as FormArray).at(1).disable();
+      (fg.get('array') as FormArray).at(1)!.disable();
 
       expect(fg.getRawValue())
           .toEqual({'c1': 'v1', 'group': {'c2': 'v2', 'c3': 'v3'}, 'array': ['v4', 'v5']});

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -744,7 +744,7 @@ describe('Typed Class', () => {
         t1 = null as unknown as ValueType;
       }
       c.at(0);
-      c.at(0).valueChanges.subscribe(v => {});
+      c.at(0)!.valueChanges.subscribe(v => {});
       c.push(new FormControl('', {nonNullable: true}));
       c.insert(0, new FormControl('', {nonNullable: true}));
       c.removeAt(0);


### PR DESCRIPTION
FormArray.at may return undefined as arrays do return undefined with an out-of-bound index.

fixes #16933

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [x] Yes, migration schematics provided. 
- [ ] No


This is my 1st PR for a feature with a migration schematic, I'm open for every constructive comments about it. 

Per @dylhunn, on #16933, I helped myself with [aeec223](https://github.com/angular/angular/commit/aeec223db1236db236ab56a4a283cf2ca410cae3) to create the schematic. 
