### PR TITLE
feat(core): Allow typeguards on QueryList.filter

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1189,7 +1189,9 @@ export class QueryList<T> implements Iterable<T> {
     destroy(): void;
     // (undocumented)
     readonly dirty = true;
-    filter(fn: (item: T, index: number, array: T[]) => boolean): T[];
+    filter<S extends T>(predicate: (value: T, index: number, array: readonly T[]) => value is S): S[];
+    // (undocumented)
+    filter(predicate: (value: T, index: number, array: readonly T[]) => unknown): T[];
     find(fn: (item: T, index: number, array: T[]) => boolean): T | undefined;
     // (undocumented)
     readonly first: T;

--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -92,6 +92,8 @@ export class QueryList<T> implements Iterable<T> {
    * See
    * [Array.filter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter)
    */
+  filter<S extends T>(predicate: (value: T, index: number, array: readonly T[]) => value is S): S[];
+  filter(predicate: (value: T, index: number, array: readonly T[]) => unknown): T[];
   filter(fn: (item: T, index: number, array: T[]) => boolean): T[] {
     return this._results.filter(fn);
   }

--- a/packages/core/test/linker/query_list_spec.ts
+++ b/packages/core/test/linker/query_list_spec.ts
@@ -139,6 +139,13 @@ import {fakeAsync, tick} from '@angular/core/testing';
       expect(queryList.some(item => item === 'four')).toEqual(false);
     });
 
+    it('should support guards on filter', () => {
+      const qList = new QueryList<'foo'|'bar'>();
+      qList.reset(['foo']);
+      const foos: Array<'foo'> = queryList.filter((item): item is 'foo' => item === 'foo');
+      expect(qList.length).toEqual(1);
+    });
+
     it('should be iterable', () => {
       const data = ['one', 'two', 'three'];
       queryList.reset([...data]);


### PR DESCRIPTION
To match the behaviour of Array.filter, typeguards can now be used on QueryList.filter to narrow the return type.

Fixes #38446

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No