### PR TITLE
refactor(core): remove Renderer3-related cleanup code paths

### DIFF
--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -9,7 +9,7 @@
 
 import {assertIndexInRange} from '../../util/assert';
 import {isObservable} from '../../util/lang';
-import {PropertyAliasValue, TNode, TNodeFlags, TNodeType} from '../interfaces/node';
+import {PropertyAliasValue, TNode, TNodeType} from '../interfaces/node';
 import {GlobalTargetResolver, Renderer} from '../interfaces/renderer';
 import {RElement} from '../interfaces/renderer_dom';
 import {isDirectiveHost} from '../interfaces/type_checks';
@@ -31,7 +31,8 @@ import {getOrCreateLViewCleanup, getOrCreateTViewCleanup, handleError, loadCompo
  *
  * @param eventName Name of the event
  * @param listenerFn The function to be called when event emits
- * @param useCapture Whether or not to use capture in event listener
+ * @param useCapture Whether or not to use capture in event listener - this argument is a reminder
+ *     from the Renderer3 infrastructure and should be removed from the instruction arguments
  * @param eventTargetResolver Function that returns global target information in case this listener
  * should be attached to a global object like window, document or body
  *
@@ -44,8 +45,7 @@ export function ɵɵlistener(
   const tView = getTView();
   const tNode = getCurrentTNode()!;
   listenerInternal(
-      tView, lView, lView[RENDERER], tNode, eventName, listenerFn, !!useCapture,
-      eventTargetResolver);
+      tView, lView, lView[RENDERER], tNode, eventName, listenerFn, eventTargetResolver);
   return ɵɵlistener;
 }
 
@@ -77,7 +77,7 @@ export function ɵɵsyntheticHostListener(
   const tView = getTView();
   const currentDef = getCurrentDirectiveDef(tView.data);
   const renderer = loadComponentRenderer(currentDef, tNode, lView);
-  listenerInternal(tView, lView, renderer, tNode, eventName, listenerFn, false);
+  listenerInternal(tView, lView, renderer, tNode, eventName, listenerFn);
   return ɵɵsyntheticHostListener;
 }
 
@@ -115,8 +115,7 @@ function findExistingListener(
 
 function listenerInternal(
     tView: TView, lView: LView<{}|null>, renderer: Renderer, tNode: TNode, eventName: string,
-    listenerFn: (e?: any) => any, useCapture: boolean,
-    eventTargetResolver?: GlobalTargetResolver): void {
+    listenerFn: (e?: any) => any, eventTargetResolver?: GlobalTargetResolver): void {
   const isTNodeDirectiveHost = isDirectiveHost(tNode);
   const firstCreatePass = tView.firstCreatePass;
   const tCleanup: false|any[] = firstCreatePass && getOrCreateTViewCleanup(tView);

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -9,7 +9,7 @@
 import {ViewEncapsulation} from '../metadata/view';
 import {RendererStyleFlags2} from '../render/api_flags';
 import {addToArray, removeFromArray} from '../util/array_utils';
-import {assertDefined, assertEqual, assertFunction, assertString} from '../util/assert';
+import {assertDefined, assertEqual, assertFunction, assertNumber, assertString} from '../util/assert';
 import {escapeCommentText} from '../util/dom';
 
 import {assertLContainer, assertLView, assertParentView, assertProjectionSlots, assertTNodeForLView} from './assert';
@@ -451,24 +451,16 @@ function processCleanups(tView: TView, lView: LView): void {
   if (tCleanup !== null) {
     for (let i = 0; i < tCleanup.length - 1; i += 2) {
       if (typeof tCleanup[i] === 'string') {
-        // This is a native DOM listener
-        const idxOrTargetGetter = tCleanup[i + 1];
-        const target = typeof idxOrTargetGetter === 'function' ?
-            idxOrTargetGetter(lView) :
-            unwrapRNode(lView[idxOrTargetGetter]);
-        const listener = lCleanup[lastLCleanupIndex = tCleanup[i + 2]];
-        const useCaptureOrSubIdx = tCleanup[i + 3];
-        if (typeof useCaptureOrSubIdx === 'boolean') {
-          // native DOM listener registered with Renderer3
-          target.removeEventListener(tCleanup[i], listener, useCaptureOrSubIdx);
+        // This is a native DOM listener. It will occupy 4 entries in the TCleanup array (hence i +=
+        // 2 at the end of this block).
+        const targetIdx = tCleanup[i + 3];
+        ngDevMode && assertNumber(targetIdx, 'cleanup target must be a number');
+        if (targetIdx >= 0) {
+          // unregister
+          lCleanup[lastLCleanupIndex = targetIdx]();
         } else {
-          if (useCaptureOrSubIdx >= 0) {
-            // unregister
-            lCleanup[lastLCleanupIndex = useCaptureOrSubIdx]();
-          } else {
-            // Subscription
-            lCleanup[lastLCleanupIndex = -useCaptureOrSubIdx].unsubscribe();
-          }
+          // Subscription
+          lCleanup[lastLCleanupIndex = -targetIdx].unsubscribe();
         }
         i += 2;
       } else {


### PR DESCRIPTION
Renderer3 had to store reference to the listener function in order to properly cleanup event listeners. Since the Renderer3 abstraction was removed the corresponding code path is no longer needed (Renderer2 returns a cleanup function that can be called directly).

Please note that we still need to store references to the native listeners function due to the event coalescing. We just don't need to account for special form of the listener cleanup function.