### PR TITLE
[12.2.x] fix(core): hardening attribute and property binding rules for <iframe> elements

### DIFF
--- a/aio/content/errors/NG0910.md
+++ b/aio/content/errors/NG0910.md
@@ -1,0 +1,71 @@
+@name Unsafe bindings on an iframe element
+@category runtime
+@shortDescription Unsafe bindings on an iframe element
+
+@description
+You see this error when Angular detects an attribute binding or a property binding on an `<iframe>` element using the following property names:
+
+* sandbox
+* allow
+* allowFullscreen
+* referrerPolicy
+* csp
+* fetchPriority
+
+The mentioned attributes affect the security model setup for `<iframe>`s
+and it's important to apply them before setting the `src` or `srcdoc` attributes.
+To enforce that, Angular requires these attributes to be set on `<iframe>`s as
+static attributes, so the values are set at the element creation time and they
+remain the same throughout the lifetime of an `<iframe>` instance.
+
+The error is thrown when a property binding with one of the mentioned attribute names is used:
+```html
+<iframe [sandbox]="'allow-scripts'" src="..."></iframe>
+```
+
+or when it's an attribute bindings:
+
+```html
+<iframe [attr.sandbox]="'allow-scripts'" src="..."></iframe>
+```
+
+Also, the error is thrown when a similar pattern is used in Directive's host bindings:
+
+```typescript
+@Directive({
+  selector: 'iframe',
+  host: {
+    '[sandbox]': `'allow-scripts'`,
+    '[attr.sandbox]': `'allow-scripts'`,
+  }
+})
+class IframeDirective {}
+```
+
+@debugging
+
+The error message includes the name of the component with the template where
+an `<iframe>` element with unsafe bindings is located.
+
+The recommended solution is to use the mentioned attributes as static ones, for example:
+
+```html
+<iframe sandbox="allow-scripts" src="..."></iframe>
+```
+
+If you need to have different values for these attributes (depending on various conditions),
+you can use an `*ngIf` or an `*ngSwitch` on an `<iframe>` element:
+
+```html
+<iframe *ngIf="someConditionA" sandbox="allow-scripts" src="..."></iframe>
+<iframe *ngIf="someConditionB" sandbox="allow-forms" src="..."></iframe>
+<iframe *ngIf="someConditionC" sandbox="allow-popups" src="..."></iframe>
+```
+
+<!-- links -->
+
+<!-- external links -->
+
+<!-- end links -->
+
+@reviewed 2022-05-27

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -7548,6 +7548,158 @@ export const Foo = Foo__PRE_R3__;
       });
     });
 
+    describe('iframe processing', () => {
+      it('should generate attribute and property bindings with a validator fn when on <iframe>',
+         () => {
+           env.write('test.ts', `
+                import {Component, Directive, NgModule} from '@angular/core';
+
+                @Directive({
+                  selector: 'iframe',
+                  inputs: ['sandbox']
+                })
+                class SomeDirective {}
+
+                @Component({
+                  template: \`
+                    <iframe src="http://angular.io"
+                      [sandbox]="''" [attr.allow]="''"
+                      [title]="'Hi!'"
+                    ></iframe>
+                  \`
+                })
+                class SomeComponent {}
+
+                @NgModule({
+                  declarations: [SomeDirective, SomeComponent]
+                })
+                class SomeNgModule {}
+              `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Only `sandbox` has an extra validation fn (since it's security-sensitive),
+           // the `title` property doesn't have an extra validation fn.
+           expect(jsContents)
+               .toContain(
+                   'ɵɵproperty("sandbox", "", i0.ɵɵvalidateIframeAttribute)("title", "Hi!")');
+
+           // The `allow` property is also security-sensitive, thus an extra validation fn.
+           expect(jsContents).toContain('ɵɵattribute("allow", "", i0.ɵɵvalidateIframeAttribute)');
+         });
+
+      it('should generate an attribute binding instruction with a validator function ' +
+             '(making sure it\'s case-insensitive, since this is allowed in Angular templates)',
+         () => {
+           env.write('test.ts', `
+              import {Component} from '@angular/core';
+
+              @Component({
+                template: \`
+                  <IFRAME
+                    src="http://angular.io"
+                    [attr.SANDBOX]="''"
+                  ></IFRAME>
+                \`
+              })
+              export class SomeComponent {}
+            `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Make sure that the `sandbox` has an extra validation fn,
+           // and the check is case-insensitive (since the `setAttribute` DOM API
+           // is case-insensitive as well).
+           expect(jsContents).toContain('ɵɵattribute("SANDBOX", "", i0.ɵɵvalidateIframeAttribute)');
+         });
+
+      it('should *not* generate a validator fn for attribute and property bindings when *not* on <iframe>',
+         () => {
+           env.write('test.ts', `
+                import {Component, Directive, NgModule} from '@angular/core';
+
+                @Directive({
+                  selector: '[sandbox]',
+                  inputs: ['sandbox']
+                })
+                class Dir {}
+
+                @Component({
+                  imports: [Dir],
+                  template: \`
+                    <div [sandbox]="''" [title]="'Hi!'"></div>
+                  \`
+                })
+                export class SomeComponent {}
+
+                @NgModule({
+                  declarations: [Dir, SomeComponent]
+                })
+                class SomeNgModule {}
+              `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Note: no extra validation fn, since a security-sensitive attribute is *not* on an
+           // <iframe>.
+           expect(jsContents).toContain('ɵɵproperty("sandbox", "")("title", "Hi!")');
+         });
+
+      it('should generate a validator fn for attribute and property host bindings on a directive',
+         () => {
+           env.write('test.ts', `
+              import {Directive} from '@angular/core';
+
+              @Directive({
+                host: {
+                  '[sandbox]': "''",
+                  '[attr.allow]': "''",
+                  'src': 'http://angular.io'
+                }
+              })
+              export class SomeDir {}
+            `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // The `sandbox` is potentially a security-sensitive attribute of an <iframe>.
+           // Generate an extra validation function to invoke at runtime, which would
+           // check if an underlying host element is an <iframe>.
+           expect(jsContents)
+               .toContain('ɵɵhostProperty("sandbox", "", i0.ɵɵvalidateIframeAttribute)');
+
+           // Similar to the above, but for an attribute binding (host attributes are
+           // represented via `ɵɵattribute`).
+           expect(jsContents).toContain('ɵɵattribute("allow", "", i0.ɵɵvalidateIframeAttribute)');
+         });
+
+      it('should generate a validator fn for attribute host bindings on a directive ' +
+             '(making sure the check is case-insensitive)',
+         () => {
+           env.write('test.ts', `
+              import {Directive} from '@angular/core';
+
+              @Directive({
+                host: {
+                  '[attr.SANDBOX]': "''"
+                }
+              })
+              export class SomeDir {}
+            `);
+
+           env.driveMain();
+           const jsContents = env.getContents('test.js');
+
+           // Make sure that we generate a validation fn for the `sandbox` attribute,
+           // even when it was declared as `SANDBOX`.
+           expect(jsContents).toContain('ɵɵattribute("SANDBOX", "", i0.ɵɵvalidateIframeAttribute)');
+         });
+    });
+
     describe('undecorated providers', () => {
       it('should error when an undecorated class, with a non-trivial constructor, is provided directly in a module',
          () => {

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -336,4 +336,6 @@ export class Identifiers {
   static trustConstantHtml: o.ExternalReference = {name: 'ɵɵtrustConstantHtml', moduleName: CORE};
   static trustConstantResourceUrl:
       o.ExternalReference = {name: 'ɵɵtrustConstantResourceUrl', moduleName: CORE};
+  static validateIframeAttribute:
+      o.ExternalReference = {name: 'ɵɵvalidateIframeAttribute', moduleName: CORE};
 }

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -13,6 +13,7 @@ import * as core from '../../core';
 import {AST, ParsedEvent, ParsedEventType, ParsedProperty} from '../../expression_parser/ast';
 import * as o from '../../output/output_ast';
 import {ParseError, ParseSourceSpan, sanitizeIdentifier} from '../../parse_util';
+import {isIframeSecuritySensitiveAttr} from '../../schema/dom_security_schema';
 import {CssSelector, SelectorMatcher} from '../../selector';
 import {ShadowCss} from '../../shadow_css';
 import {CONTENT_ATTR, HOST_ATTR} from '../../style_compiler';
@@ -561,6 +562,19 @@ function createHostBindingsFunction(
     const instructionParams = [o.literal(bindingName), bindingExpr.currValExpr];
     if (sanitizerFn) {
       instructionParams.push(sanitizerFn);
+    } else {
+      // If there was no sanitization function found based on the security context
+      // of an attribute/property binding - check whether this attribute/property is
+      // one of the security-sensitive <iframe> attributes.
+      // Note: for host bindings defined on a directive, we do not try to find all
+      // possible places where it can be matched, so we can not determine whether
+      // the host element is an <iframe>. In this case, if an attribute/binding
+      // name is in the `IFRAME_SECURITY_SENSITIVE_ATTRS` set - append a validation
+      // function, which would be invoked at runtime and would have access to the
+      // underlying DOM element, check if it's an <iframe> and if so - runs extra checks.
+      if (isIframeSecuritySensitiveAttr(bindingName)) {
+        instructionParams.push(o.importExpr(R3.validateIframeAttribute));
+      }
     }
 
     updateStatements.push(...bindingExpr.stmts);

--- a/packages/compiler/src/schema/dom_security_schema.ts
+++ b/packages/compiler/src/schema/dom_security_schema.ts
@@ -62,3 +62,25 @@ export function SECURITY_SCHEMA(): {[k: string]: SecurityContext} {
 function registerContext(ctx: SecurityContext, specs: string[]) {
   for (const spec of specs) _SECURITY_SCHEMA[spec.toLowerCase()] = ctx;
 }
+
+/**
+ * The set of security-sensitive attributes of an `<iframe>` that *must* be
+ * applied as a static attribute only. This ensures that all security-sensitive
+ * attributes are taken into account while creating an instance of an `<iframe>`
+ * at runtime.
+ *
+ * Note: avoid using this set directly, use the `isIframeSecuritySensitiveAttr` function
+ * in the code instead.
+ */
+export const IFRAME_SECURITY_SENSITIVE_ATTRS =
+    new Set(['sandbox', 'allow', 'allowfullscreen', 'referrerpolicy', 'csp', 'fetchpriority']);
+
+/**
+ * Checks whether a given attribute name might represent a security-sensitive
+ * attribute of an <iframe>.
+ */
+export function isIframeSecuritySensitiveAttr(attrName: string): boolean {
+  // The `setAttribute` DOM API is case-insensitive, so we lowercase the value
+  // before checking it against a known security-sensitive attributes.
+  return IFRAME_SECURITY_SENSITIVE_ATTRS.has(attrName.toLowerCase());
+}

--- a/packages/compiler/test/security_spec.ts
+++ b/packages/compiler/test/security_spec.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {IFRAME_SECURITY_SENSITIVE_ATTRS, SECURITY_SCHEMA} from '../src/schema/dom_security_schema';
+
+
+describe('security-related tests', () => {
+  it('should have no overlap between `IFRAME_SECURITY_SENSITIVE_ATTRS` and `SECURITY_SCHEMA`',
+     () => {
+       // The `IFRAME_SECURITY_SENSITIVE_ATTRS` and `SECURITY_SCHEMA` tokens configure sanitization
+       // and validation rules and used to pick the right sanitizer function.
+       // This test verifies that there is no overlap between two sets of rules to flag
+       // a situation when 2 sanitizer functions may be needed at the same time (in which
+       // case, compiler logic should be extended to support that).
+       const schema = new Set();
+       Object.keys(SECURITY_SCHEMA()).forEach((key: string) => schema.add(key.toLowerCase()));
+       let hasOverlap = false;
+       IFRAME_SECURITY_SENSITIVE_ATTRS.forEach(attr => {
+         if (schema.has('*|' + attr) || schema.has('iframe|' + attr)) {
+           hasOverlap = true;
+         }
+       });
+       expect(hasOverlap).toBeFalse();
+     });
+});

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -294,6 +294,9 @@ export {
   bypassSanitizationTrustUrl as ɵbypassSanitizationTrustUrl,
 } from './sanitization/bypass';
 export {
+  ɵɵvalidateIframeAttribute,
+} from './sanitization/iframe_attrs_validation';
+export {
   ɵɵsanitizeHtml,
   ɵɵsanitizeResourceUrl,
   ɵɵsanitizeScript,
@@ -303,9 +306,6 @@ export {
   ɵɵtrustConstantHtml,
   ɵɵtrustConstantResourceUrl,
 } from './sanitization/sanitization';
-export {
-  ɵɵvalidateIframeAttribute,
-} from './sanitization/iframe_attrs_validation';
 export {
   noSideEffects as ɵnoSideEffects,
 } from './util/closure';

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -304,6 +304,9 @@ export {
   ɵɵtrustConstantResourceUrl,
 } from './sanitization/sanitization';
 export {
+  ɵɵvalidateIframeAttribute,
+} from './sanitization/iframe_attrs_validation';
+export {
   noSideEffects as ɵnoSideEffects,
 } from './util/closure';
 

--- a/packages/core/src/render3/error_code.ts
+++ b/packages/core/src/render3/error_code.ts
@@ -54,6 +54,7 @@ export const RUNTIME_ERRORS_WITH_GUIDES = new Set([
   RuntimeErrorCode.MULTIPLE_COMPONENTS_MATCH,
   RuntimeErrorCode.EXPORT_NOT_FOUND,
   RuntimeErrorCode.PIPE_NOT_FOUND,
+  RuntimeErrorCode.UNSAFE_IFRAME_ATTRS,
 ]);
 /* tslint:enable:no-toplevel-property-access */
 

--- a/packages/core/src/render3/error_code.ts
+++ b/packages/core/src/render3/error_code.ts
@@ -24,7 +24,7 @@ export const enum RuntimeErrorCode {
   PIPE_NOT_FOUND = '302',
   UNKNOWN_BINDING = '303',
   UNKNOWN_ELEMENT = '304',
-  TEMPLATE_STRUCTURE_ERROR = '305'
+  TEMPLATE_STRUCTURE_ERROR = '305',
 
   // Styling Errors
 
@@ -33,6 +33,9 @@ export const enum RuntimeErrorCode {
   // i18n Errors
 
   // Compilation Errors
+
+  // Other
+  UNSAFE_IFRAME_ATTRS = '910',
 }
 
 export class RuntimeError extends Error {

--- a/packages/core/src/render3/instructions/element_validation.ts
+++ b/packages/core/src/render3/instructions/element_validation.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {throwError} from '../../util/assert';
+import {getComponentDef} from '../definition';
+import {ComponentDef} from '../interfaces/definition';
+import {CONTEXT, DECLARATION_COMPONENT_VIEW, LView} from '../interfaces/view';
+
+/**
+ * WARNING: this is a **dev-mode only** function (thus should always be guarded by the `ngDevMode`)
+ * and must **not** be used in production bundles. The function makes megamorphic reads, which might
+ * be too slow for production mode and also it relies on the constructor function being available.
+ *
+ * Gets a reference to the host component def (where a current component is declared).
+ *
+ * @param lView An `LView` that represents a current component that is being rendered.
+ */
+function getDeclarationComponentDef(lView: LView): ComponentDef<unknown>|null {
+  !ngDevMode && throwError('Must never be called in production mode');
+
+  const declarationLView = lView[DECLARATION_COMPONENT_VIEW] as LView;
+  const context = declarationLView[CONTEXT];
+
+  // Unable to obtain a context.
+  if (!context) return null;
+
+  return context.constructor ? getComponentDef(context.constructor) : null;
+}
+
+/**
+ * WARNING: this is a **dev-mode only** function (thus should always be guarded by the `ngDevMode`)
+ * and must **not** be used in production bundles. The function makes megamorphic reads, which might
+ * be too slow for production mode.
+ *
+ * Constructs a string describing the location of the host component template. The function is used
+ * in dev mode to produce error messages.
+ *
+ * @param lView An `LView` that represents a current component that is being rendered.
+ */
+export function getTemplateLocationDetails(lView: LView): string {
+  !ngDevMode && throwError('Must never be called in production mode');
+
+  const hostComponentDef = getDeclarationComponentDef(lView);
+  const componentClassName = hostComponentDef?.type?.name;
+  return componentClassName ? ` (used in the '${componentClassName}' component template)` : '';
+}

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -9,6 +9,7 @@
 import {forwardRef, resolveForwardRef} from '../../di/forward_ref';
 import {ɵɵinject, ɵɵinvalidFactoryDep} from '../../di/injector_compatibility';
 import {ɵɵdefineInjectable, ɵɵdefineInjector} from '../../di/interface/defs';
+import * as iframe_attrs_validation from '../../sanitization/iframe_attrs_validation';
 import * as sanitization from '../../sanitization/sanitization';
 import * as r3 from '../index';
 
@@ -164,6 +165,7 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵsanitizeUrlOrResourceUrl': sanitization.ɵɵsanitizeUrlOrResourceUrl,
        'ɵɵtrustConstantHtml': sanitization.ɵɵtrustConstantHtml,
        'ɵɵtrustConstantResourceUrl': sanitization.ɵɵtrustConstantResourceUrl,
+       'ɵɵvalidateIframeAttribute': iframe_attrs_validation.ɵɵvalidateIframeAttribute,
 
        'forwardRef': forwardRef,
        'resolveForwardRef': resolveForwardRef,

--- a/packages/core/src/sanitization/iframe_attrs_validation.ts
+++ b/packages/core/src/sanitization/iframe_attrs_validation.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {RuntimeError, RuntimeErrorCode} from '../render3/error_code';
+import {getTemplateLocationDetails} from '../render3/instructions/element_validation';
+import {TNodeType} from '../render3/interfaces/node';
+import {RComment, RElement} from '../render3/interfaces/renderer_dom';
+import {RENDERER} from '../render3/interfaces/view';
+import {nativeRemoveNode} from '../render3/node_manipulation';
+import {getLView, getSelectedTNode} from '../render3/state';
+import {getNativeByTNode} from '../render3/util/view_utils';
+import {trustedHTMLFromString} from '../util/security/trusted_types';
+
+
+/**
+ * Validation function invoked at runtime for each binding that might potentially
+ * represent a security-sensitive attribute of an <iframe>.
+ * See `IFRAME_SECURITY_SENSITIVE_ATTRS` in the
+ * `packages/compiler/src/schema/dom_security_schema.ts` script for the full list
+ * of such attributes.
+ *
+ * @codeGenApi
+ */
+export function ɵɵvalidateIframeAttribute(attrValue: any, tagName: string, attrName: string) {
+  const lView = getLView();
+  const tNode = getSelectedTNode()!;
+  const element = getNativeByTNode(tNode, lView) as RElement | RComment;
+
+  // Restrict any dynamic bindings of security-sensitive attributes/properties
+  // on an <iframe> for security reasons.
+  if (tNode.type === TNodeType.Element && tagName.toLowerCase() === 'iframe') {
+    const iframe = element as HTMLIFrameElement;
+
+    // Unset previously applied `src` and `srcdoc` if we come across a situation when
+    // a security-sensitive attribute is set later via an attribute/property binding.
+    iframe.src = '';
+    iframe.srcdoc = trustedHTMLFromString('') as unknown as string;
+
+    // Also remove the <iframe> from the document.
+    nativeRemoveNode(lView[RENDERER], iframe);
+
+    const errorMessage = ngDevMode ?  //
+        `Angular has detected that the \`${attrName}\` was applied ` +
+            `as a binding to an <iframe>${getTemplateLocationDetails(lView)}. ` +
+            `For security reasons, the \`${attrName}\` can be set on an <iframe> ` +
+            `as a static attribute only. \n` +
+            `To fix this, switch the \`${attrName}\` binding to a static attribute ` +
+            `in a template or in host bindings section.` :
+        '';
+    throw new RuntimeError(RuntimeErrorCode.UNSAFE_IFRAME_ATTRS, errorMessage);
+  }
+  return attrValue;
+}

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -48,7 +48,7 @@ describe('comment node text escaping', () => {
 
 onlyInIvy('Ivy-specific handling of bindings').describe('iframe processing', () => {
   function getErrorMessageRegexp() {
-    const errorMessagePart = 'NG0' + RuntimeErrorCode.UNSAFE_IFRAME_ATTRS.toString();
+    const errorMessagePart = 'NG0' + RuntimeErrorCode.UNSAFE_IFRAME_ATTRS;
     return new RegExp(errorMessagePart);
   }
 

--- a/packages/core/test/acceptance/security_spec.ts
+++ b/packages/core/test/acceptance/security_spec.ts
@@ -6,9 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
-
+import {CommonModule, NgIf} from '@angular/common';
+import {Component, Directive, TemplateRef, Type, ViewChild, ViewContainerRef} from '@angular/core';
+import {RuntimeErrorCode} from '@angular/core/src/render3/error_code';
+import {global} from '@angular/core/src/util/global';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {DomSanitizer} from '@angular/platform-browser';
+import {onlyInIvy} from '@angular/private/testing/src/ivy_test_selectors';
 
 describe('comment node text escaping', () => {
   // see: https://html.spec.whatwg.org/multipage/syntax.html#comments
@@ -39,5 +43,556 @@ describe('comment node text escaping', () => {
          const script = div.querySelector('script');
          expect(script).toBeFalsy();
        });
+  });
+});
+
+onlyInIvy('Ivy-specific handling of bindings').describe('iframe processing', () => {
+  function getErrorMessageRegexp() {
+    const errorMessagePart = 'NG0' + RuntimeErrorCode.UNSAFE_IFRAME_ATTRS.toString();
+    return new RegExp(errorMessagePart);
+  }
+
+  function ensureNoIframePresent(fixture?: ComponentFixture<unknown>) {
+    // Note: a `fixture` may not exist in case an error was thrown at creation time.
+    const iframe = fixture?.nativeElement.querySelector('iframe');
+    expect(!!iframe).toBeFalse();
+  }
+
+  function expectIframeCreationToFail<T>(
+      component: Type<T>, declarations?: Array<Type<unknown>>): ComponentFixture<T> {
+    TestBed.configureTestingModule({
+      imports: [CommonModule],
+      declarations: [component, ...(declarations ?? [])],
+    });
+
+    let fixture: ComponentFixture<T>|undefined;
+    expect(() => {
+      fixture = TestBed.createComponent(component);
+      fixture.detectChanges();
+    }).toThrowError(getErrorMessageRegexp());
+
+    ensureNoIframePresent(fixture);
+    return fixture!;
+  }
+
+  function expectIframeToBeCreated<T>(
+      component: Type<T>, attrsToCheck: {[key: string]: string},
+      declarations?: Array<Type<unknown>>): ComponentFixture<T> {
+    TestBed.configureTestingModule({
+      imports: [CommonModule],
+      declarations: [component, ...(declarations ?? [])],
+    });
+
+    let fixture: ComponentFixture<T>;
+    expect(() => {
+      fixture = TestBed.createComponent(component);
+      fixture.detectChanges();
+    }).not.toThrow();
+
+    const iframe = fixture!.nativeElement.querySelector('iframe');
+    for (const [attrName, attrValue] of Object.entries(attrsToCheck)) {
+      expect(iframe[attrName]).toEqual(attrValue);
+    }
+
+    return fixture!;
+  }
+
+  // *Must* be in sync with the `SECURITY_SENSITIVE_ATTRS` list
+  // from the `packages/compiler/src/schema/dom_security_schema.ts`.
+  const SECURITY_SENSITIVE_ATTRS = ['sandbox', 'allow', 'allowFullscreen', 'referrerPolicy'];
+  if (!isBrowser) {
+    // Browsers used during the CI may not have support for the 'csp'
+    // and 'fetchPriority' properties, so the Angular logs an "unknown
+    // property" error and exits. As a result, we can only check this
+    // behavior while running tests in Node.
+    SECURITY_SENSITIVE_ATTRS.push('csp', 'fetchPriority');
+  }
+
+  const TEST_IFRAME_URL = 'https://angular.io/assets/images/logos/angular/angular.png';
+
+  let oldNgDevMode!: typeof ngDevMode;
+
+  beforeAll(() => {
+    oldNgDevMode = ngDevMode;
+  });
+
+  afterAll(() => {
+    global['ngDevMode'] = oldNgDevMode;
+  });
+
+  [true, false].forEach(devModeFlag => {
+    beforeAll(() => {
+      global['ngDevMode'] = devModeFlag;
+
+      // TestBed and JIT compilation have some dependencies on the ngDevMode state, so we need to
+      // reset TestBed to ensure we get a 'clean' JIT compilation under the new rules.
+      TestBed.resetTestingModule();
+    });
+
+    describe(`with ngDevMode = ${devModeFlag}`, () => {
+      SECURITY_SENSITIVE_ATTRS.forEach((securityAttr: string) => {
+        ['src', 'srcdoc'].forEach((srcAttr: string) => {
+          it(`should work when a security-sensitive attribute is set ` +
+                 `as a static attribute (checking \`${securityAttr}\`)`,
+             () => {
+               @Component({
+                 selector: 'my-comp',
+                 template: `
+                  <iframe
+                    ${srcAttr}="${TEST_IFRAME_URL}"
+                    ${securityAttr}="">
+                  </iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeToBeCreated(IframeComp, {[srcAttr]: TEST_IFRAME_URL});
+             });
+
+          it(`should error when a security-sensitive attribute is applied ` +
+                 `using a property binding (checking \`${securityAttr}\`)`,
+             () => {
+               @Component({
+                 selector: 'my-comp',
+                 template:
+                     `<iframe ${srcAttr}="${TEST_IFRAME_URL}" [${securityAttr}]="''"></iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp);
+             });
+
+          it(`should error when a security-sensitive attribute is applied ` +
+                 `using a property interpolation (checking \`${securityAttr}\`)`,
+             () => {
+               @Component({
+                 selector: 'my-comp',
+                 template:
+                     `<iframe ${srcAttr}="${TEST_IFRAME_URL}" ${securityAttr}="{{''}}"></iframe>`,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp);
+             });
+
+          it(`should error when a security-sensitive attribute is applied ` +
+                 `using a property binding (checking \`${securityAttr}\`)`,
+             () => {
+               @Component({
+                 selector: 'my-comp',
+                 template: `
+                    <iframe
+                      ${srcAttr}="${TEST_IFRAME_URL}"
+                      [attr.${securityAttr}]="''"
+                    ></iframe>
+                  `,
+               })
+               class IframeComp {
+               }
+
+               expectIframeCreationToFail(IframeComp);
+             });
+
+          it(`should allow changing \`${srcAttr}\` after initial render`, () => {
+            @Component({
+              selector: 'my-comp',
+              template: `
+                    <iframe
+                      ${securityAttr}="allow-forms"
+                      [${srcAttr}]="src">
+                    </iframe>
+                  `,
+            })
+            class IframeComp {
+              src = this.sanitizeFn(TEST_IFRAME_URL);
+
+              constructor(private sanitizer: DomSanitizer) {}
+
+              get sanitizeFn() {
+                return srcAttr === 'src' ? this.sanitizer.bypassSecurityTrustResourceUrl :
+                                           this.sanitizer.bypassSecurityTrustHtml;
+              }
+            }
+
+            const fixture = expectIframeToBeCreated(IframeComp, {[srcAttr]: TEST_IFRAME_URL});
+            const component = fixture.componentInstance;
+
+            // Changing `src` or `srcdoc` is allowed.
+            const newUrl = 'https://angular.io/about?group=Angular';
+            component.src = component.sanitizeFn(newUrl);
+            fixture.detectChanges();
+            // expect(() => fixture.detectChanges()).not.toThrow();
+            expect(fixture.nativeElement.querySelector('iframe')[srcAttr]).toEqual(newUrl);
+          });
+        });
+      });
+
+      it('should work when a directive sets a security-sensitive attribute as a static attribute',
+         () => {
+           @Directive({
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+               'sandbox': '',
+             },
+           })
+           class IframeDir {
+           }
+           @Component({
+             selector: 'my-comp',
+             template: '<iframe dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL}, [IframeDir]);
+         });
+
+      it('should work when a directive sets a security-sensitive host attribute on a non-iframe element',
+         () => {
+           @Directive({
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+               'sandbox': '',
+             },
+           })
+           class Dir {
+           }
+
+           @Component({
+             selector: 'my-comp',
+             template: '<img dir>',
+           })
+           class NonIframeComp {
+           }
+
+           TestBed.configureTestingModule({
+             declarations: [NonIframeComp, Dir],
+           });
+
+           const fixture = TestBed.createComponent(NonIframeComp);
+           fixture.detectChanges();
+
+           expect(fixture.nativeElement.firstChild.src).toEqual(TEST_IFRAME_URL);
+         });
+
+
+      it('should work when a security-sensitive attribute on an <iframe> ' +
+             'which also has a structural directive (*ngIf)',
+         () => {
+           @Component({
+             selector: 'my-comp',
+             template: `<iframe *ngIf="visible" src="${TEST_IFRAME_URL}" sandbox=""></iframe>`,
+           })
+           class IframeComp {
+             visible = true;
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL}, [NgIf]);
+         });
+
+      it('should work when a security-sensitive attribute is set between `src` and `srcdoc`',
+         () => {
+           @Component({
+             selector: 'my-comp',
+             template: `<iframe src="${TEST_IFRAME_URL}" sandbox srcdoc="Hi!"></iframe>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+         });
+
+      it('should work when a directive sets a security-sensitive attribute before setting `src`',
+         () => {
+           @Directive({
+             selector: '[dir]',
+             host: {
+               'sandbox': '',
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             selector: 'my-comp',
+             template: '<iframe dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL}, [IframeDir]);
+         });
+
+      it('should work when a directive sets an `src` and ' +
+             'there was a security-sensitive attribute set in a template' +
+             '(directive attribute after `sandbox`)',
+         () => {
+           @Directive({
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             selector: 'my-comp',
+             template: '<iframe sandbox dir></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL}, [IframeDir]);
+         });
+
+      it('should error when a directive sets a security-sensitive attribute ' +
+             'as an attribute binding (checking that it\'s case-insensitive)',
+         () => {
+           @Directive({
+             selector: '[dir]',
+             host: {
+               '[attr.SANDBOX]': '\'\'',
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             selector: 'my-comp',
+             template: `<IFRAME dir src="${TEST_IFRAME_URL}"></IFRAME>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp, [IframeDir]);
+         });
+
+      it('should work when a directive sets an `src` and ' +
+             'there was a security-sensitive attribute set in a template' +
+             '(directive attribute before `sandbox`)',
+         () => {
+           @Directive({
+             selector: '[dir]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             selector: 'my-comp',
+             template: '<iframe dir sandbox></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL}, [IframeDir]);
+         });
+
+      it('should work when a directive sets a security-sensitive attribute and ' +
+             'there was an `src` attribute set in a template' +
+             '(directive attribute after `src`)',
+         () => {
+           @Directive({
+             selector: '[dir]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             selector: 'my-comp',
+             template: `<iframe src="${TEST_IFRAME_URL}" dir></iframe>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL}, [IframeDir]);
+         });
+
+      it('should work when a security-sensitive attribute is set as a static attribute', () => {
+        @Component({
+          selector: 'my-comp',
+          template: `
+            <iframe referrerPolicy="no-referrer" src="${TEST_IFRAME_URL}"></iframe>
+          `,
+        })
+        class IframeComp {
+        }
+
+        expectIframeToBeCreated(IframeComp, {
+          src: TEST_IFRAME_URL,
+          referrerPolicy: 'no-referrer',
+        });
+      });
+
+      it('should error when a security-sensitive attribute is set ' +
+             'as a property binding and an <iframe> is wrapped into another element',
+         () => {
+           @Component({
+             selector: 'my-comp',
+             template: `
+                <section>
+                  <iframe
+                    src="${TEST_IFRAME_URL}"
+                    [referrerPolicy]="'no-referrer'"
+                  ></iframe>
+                </section>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeCreationToFail(IframeComp);
+         });
+
+      it('should work when a directive sets a security-sensitive attribute and ' +
+             'there was an `src` attribute set in a template' +
+             '(directive attribute before `src`)',
+         () => {
+           @Directive({
+             selector: '[dir]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class IframeDir {
+           }
+
+           @Component({
+             selector: 'my-comp',
+             template: `<iframe dir src="${TEST_IFRAME_URL}"></iframe>`,
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL}, [IframeDir]);
+         });
+
+      it('should work when a directive that sets a security-sensitive attribute goes ' +
+             'before the directive that sets an `src` attribute value',
+         () => {
+           @Directive({
+             selector: '[set-src]',
+             host: {
+               'src': TEST_IFRAME_URL,
+             },
+           })
+           class DirThatSetsSrc {
+           }
+
+           @Directive({
+             selector: '[set-sandbox]',
+             host: {
+               'sandbox': '',
+             },
+           })
+           class DirThatSetsSandbox {
+           }
+
+           @Component({
+             selector: 'my-comp',
+             // Important note: even though the `set-sandbox` goes after the `set-src`,
+             // the directive matching order (thus the order of host attributes) is
+             // based on the imports order, so the `sandbox` gets set first and the `src` second.
+             template: '<iframe set-src set-sandbox></iframe>',
+           })
+           class IframeComp {
+           }
+
+           expectIframeToBeCreated(
+               IframeComp, {src: TEST_IFRAME_URL}, [DirThatSetsSandbox, DirThatSetsSrc]);
+         });
+
+      it('should error when creating a view that contains an <iframe> ' +
+             'with security-sensitive attributes set via property bindings',
+         () => {
+           @Component({
+             selector: 'my-comp',
+             template: `
+                <ng-container #container></ng-container>
+                <ng-template #template>
+                  <iframe src="${TEST_IFRAME_URL}" [sandbox]="''"></iframe>
+                </ng-template>
+              `,
+           })
+           class IframeComp {
+             @ViewChild('container', {read: ViewContainerRef}) container!: ViewContainerRef;
+             @ViewChild('template') template !: TemplateRef<unknown>;
+
+             createEmbeddedView() {
+               this.container.createEmbeddedView(this.template);
+             }
+           }
+
+           const fixture = TestBed.createComponent(IframeComp);
+           fixture.detectChanges();
+
+           expect(() => {
+             fixture.componentInstance.createEmbeddedView();
+             fixture.detectChanges();
+           }).toThrowError(getErrorMessageRegexp());
+
+           ensureNoIframePresent(fixture);
+         });
+
+      describe('i18n', () => {
+        it('should error when a security-sensitive attribute is set as ' +
+               'a property binding on an <iframe> inside i18n block',
+           () => {
+             @Component({
+               selector: 'my-comp',
+               template: `
+                  <section i18n>
+                    <iframe src="${TEST_IFRAME_URL}" [sandbox]="''">
+                    </iframe>
+                  </section>
+                `,
+             })
+             class IframeComp {
+             }
+
+             expectIframeCreationToFail(IframeComp);
+           });
+
+        it('should error when a security-sensitive attribute is set as ' +
+               'a property binding on an <iframe> annotated with i18n attribute',
+           () => {
+             @Component({
+               selector: 'my-comp',
+               template: `
+                  <iframe i18n src="${TEST_IFRAME_URL}" [sandbox]="''">
+                  </iframe>
+                `,
+             })
+             class IframeComp {
+             }
+
+             expectIframeCreationToFail(IframeComp);
+           });
+
+        it('should work when a security-sensitive attributes are marked for translation', () => {
+          @Component({
+            selector: 'my-comp',
+            template: `
+              <iframe src="${TEST_IFRAME_URL}" i18n-sandbox sandbox="">
+              </iframe>
+            `,
+          })
+          class IframeComp {
+          }
+
+          expectIframeToBeCreated(IframeComp, {src: TEST_IFRAME_URL});
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This commit updates the logic related to the attribute and property binding rules for <iframe> elements. There is a set of <iframe> attributes that may affect the behavior of an iframe and this change enforces that these attributes are only applied as static attributes, making sure that they are taken into account while creating an <iframe>.

If Angular detects that some of the security-sensitive attributes are applied as an attribute or property binding, it throws an error message, which contains the name of an attribute that is causing the problem and the name of a Component where an iframe is located.

BREAKING CHANGE:

Existing iframe usages may have security-sensitive attributes applied as an attribute or property binding in a template or via host bindings in a directive. Such usages would require an update to ensure compliance with the new stricter rules around iframe bindings.