### PR TITLE
refactor(router): Remove unnecessary logic in enabledBlocking option 

### DIFF
--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -314,7 +314,6 @@ export function withEnabledBlockingInitialNavigation(): EnabledBlockingInitialNa
       useFactory: (injector: Injector) => {
         const locationInitialized: Promise<any> =
             injector.get(LOCATION_INITIALIZED, Promise.resolve());
-        let initNavigation = false;
 
         /**
          * Performs the given action once the router finishes its next/current navigation.
@@ -358,7 +357,6 @@ export function withEnabledBlockingInitialNavigation(): EnabledBlockingInitialNa
                 // Unblock APP_INITIALIZER in case the initial navigation was canceled or errored
                 // without a redirect.
                 resolve(true);
-                initNavigation = true;
               });
 
               router.afterPreactivation = () => {
@@ -366,13 +364,7 @@ export function withEnabledBlockingInitialNavigation(): EnabledBlockingInitialNa
                 // assume activation will complete successfully (even though this is not
                 // guaranteed).
                 resolve(true);
-                // only the initial navigation should be delayed until bootstrapping is done.
-                if (!initNavigation) {
-                  return bootstrapDone.closed ? of(void 0) : bootstrapDone;
-                  // subsequent navigations should not be delayed
-                } else {
-                  return of(void 0);
-                }
+                return bootstrapDone.closed ? of(void 0) : bootstrapDone;
               };
               router.initialNavigation();
             });

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -157,8 +157,9 @@ describe('bootstrap', () => {
          }
        }
 
-       await Promise.all(
-           [platformBrowserDynamic([]).bootstrapModule(TestModule), navigationEndPromise]);
+       await expectAsync(Promise.all([
+         platformBrowserDynamic([]).bootstrapModule(TestModule), navigationEndPromise
+       ])).toBeResolved();
      });
 
   it('should wait for redirect when initialNavigation = enabledBlocking', async () => {


### PR DESCRIPTION
The `initNavigated` flag is not necessary. The way `enabledBlocking`
works is by blocking any navigations from finishing until the
application has bootstrapped. The bootstrap is unblocked as soon as we
hit the `afterPreactivation` step. After that point,
`afterPreactivation` is always unblocked because the `bootstrapDone`
Subject is completed/stopped. There is no need for an additional
variable to track this information.