### PR TITLE
refactor(router): Remove internal state tracking for browserUrlTree

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1512,9 +1512,6 @@
     "name": "isArrayLike"
   },
   {
-    "name": "isBrowserTriggeredNavigation"
-  },
-  {
     "name": "isCommandWithOutlets"
   },
   {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -79,9 +79,6 @@ export class Router {
   private get rawUrlTree() {
     return this.stateManager.rawUrlTree;
   }
-  private get browserUrlTree() {
-    return this.stateManager.browserUrlTree;
-  }
   private disposed = false;
   private locationSubscription?: SubscriptionLike;
   private isNgZoneEnabled = false;
@@ -639,7 +636,6 @@ export class Router {
       restoredState,
       currentUrlTree: this.currentUrlTree,
       currentRawUrl: this.currentUrlTree,
-      currentBrowserUrl: this.browserUrlTree,
       rawUrl,
       extras,
       resolve,

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -959,31 +959,6 @@ describe('Integration', () => {
            expect(location.path()).toEqual('/login');
          })));
 
-      it('should set browserUrlTree with false `shouldProcessUrl`',
-         fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
-           const fixture = TestBed.createComponent(RootCmp);
-           advance(fixture);
-
-           router.resetConfig([
-             {path: 'team/:id', component: SimpleCmp},
-             {path: 'login', component: AbsoluteSimpleLinkCmp}
-           ]);
-
-           router.navigateByUrl('/team/22');
-           advance(fixture, 1);
-
-           expect((router as any).browserUrlTree.toString()).toBe('/team/22');
-
-           // Force to not process URL changes
-           TestBed.inject(UrlHandlingStrategy).shouldProcessUrl = (url: UrlTree) => false;
-
-           router.navigateByUrl('/login');
-           advance(fixture, 1);
-
-           // Do not change locations
-           expect((router as any).browserUrlTree.toString()).toBe('/team/22');
-         })));
-
       it('should eagerly update URL after redirects are applied',
          fakeAsync(inject([Router, Location], (router: Router, location: Location) => {
            const fixture = TestBed.createComponent(RootCmp);

--- a/packages/router/upgrade/test/upgrade.spec.ts
+++ b/packages/router/upgrade/test/upgrade.spec.ts
@@ -125,9 +125,6 @@ describe('setUpLocationSync', () => {
     const callback = $rootScope.$on.calls.argsFor(0)[1];
     callback({}, url + pathname + query + hash, '');
 
-    expect(location.normalize).toHaveBeenCalledTimes(1);
-    expect(location.normalize).toHaveBeenCalledWith(pathname);
-
     expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
     expect(router.navigateByUrl).toHaveBeenCalledWith(normalizedPathname + query + hash);
   });
@@ -147,9 +144,6 @@ describe('setUpLocationSync', () => {
 
     const callback = $rootScope.$on.calls.argsFor(0)[1];
     callback({}, combinedUrl, '');
-
-    expect(location.normalize).toHaveBeenCalledTimes(1);
-    expect(location.normalize).toHaveBeenCalledWith(pathname);
 
     expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
     expect(router.navigateByUrl).toHaveBeenCalledWith(normalizedPathname + query + hash);


### PR DESCRIPTION
The `browserUrlTree` is _only_ used to support the `onSameUrlNavigation: 'ignore'` logic. We can achieve this functionality without having this state tracked inside the Router. Instead, we can re-examine what `ignore` means: We don't want to rerun the matching logic, guards, or resolvers when we already know that nothing is changing.
Outside of the "navigated", there are two things that constitute a "change":

1. The browser URL might change. Because of `skipLocationChange`, the browser URL might not always match the internal state of the Router (we can navigate to a path but skip updating the browser URL). If we're navigating to a place that would change the browser URL, we should process the navigation. Theoretically, all we need to really do is update the browser URL instead of processing the whole navigation w/ guards, redirects, and resolvers. But this doesn't matter that much because the default value for `runGuardsAndResolvers` will skip all of this anyways.
2. The internal state of the Router might change. That is, we're navigating to a new path and may or may not be updating the updating the browser URL.

If either of the above are true, we process the navigation. If both are false, we aren't changing anything so we can safely ignore the navigation request (as long as `onSameUrlNavigation === 'ignore'`).

Why is this change important?

* Simplification of Router internals. The Router has a lot of special case handling and one-offs to handle a limited set of scenarios. Removing these when possible makes the code easier to follow
