### PR TITLE
fix(router): Ensure renavigating in component init works with enabled…

### DIFF
--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -184,8 +184,10 @@ export function getBootstrapListener() {
     injector.get(ROUTER_PRELOADER, null, InjectFlags.Optional)?.setUpPreloading();
     injector.get(ROUTER_SCROLLER, null, InjectFlags.Optional)?.init();
     router.resetRootComponentType(ref.componentTypes[0]);
-    bootstrapDone.next();
-    bootstrapDone.complete();
+    if (!bootstrapDone.closed) {
+      bootstrapDone.next();
+      bootstrapDone.unsubscribe();
+    }
   };
 }
 


### PR DESCRIPTION
…Blocking

The way to complete the `Subject` in a way that is able to be read on the subject properties itself is to call `unsubscribe`: https://github.com/ReactiveX/rxjs/blob/afac3d574323333572987e043adcd0f8d4cff546/src/internal/Subject.ts#L101-L104 This sets the `closed` property to `true` whereas `complete` does not.

fixes #48052
