### PR TITLE
Router:  Remove promise catch and re-reject & unused property in NavigationTransition

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -1382,11 +1382,7 @@ export class Router {
       currentRouterState: this.routerState
     });
 
-    // Make sure that the error is propagated even though `processNavigations` catch
-    // handler does not rethrow
-    return promise.catch((e: any) => {
-      return Promise.reject(e);
-    });
+    return promise;
   }
 
   private setBrowserUrl(url: UrlTree, t: NavigationTransition) {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -252,7 +252,6 @@ export interface NavigationTransition {
   id: number;
   targetPageId: number;
   currentUrlTree: UrlTree;
-  currentRawUrl: UrlTree;
   extractedUrl: UrlTree;
   urlAfterRedirects?: UrlTree;
   rawUrl: UrlTree;
@@ -577,7 +576,6 @@ export class Router {
       id: 0,
       targetPageId: 0,
       currentUrlTree: this.currentUrlTree,
-      currentRawUrl: this.currentUrlTree,
       extractedUrl: this.urlHandlingStrategy.extract(this.currentUrlTree),
       urlAfterRedirects: this.urlHandlingStrategy.extract(this.currentUrlTree),
       rawUrl: this.currentUrlTree,
@@ -1332,7 +1330,6 @@ export class Router {
       resolve = priorPromise.resolve;
       reject = priorPromise.reject;
       promise = priorPromise.promise;
-
     } else {
       promise = new Promise<boolean>((res, rej) => {
         resolve = res;
@@ -1372,7 +1369,6 @@ export class Router {
       source,
       restoredState,
       currentUrlTree: this.currentUrlTree,
-      currentRawUrl: this.rawUrlTree,
       rawUrl,
       extras,
       resolve,


### PR DESCRIPTION
commit 1:

refactor(router): Remove promise catch and re-reject
It is not clear what the intention of the promise catch and reject is. Potentially this is
legacy code built around some ZoneJs bug that doesn't exist anymore.

commit 2:

refactor(router): remove unused currentRawUrl property from transition

The currentRawUrl property of the transition is no longer used after various refactorings in the code over
the past couple years