### PR TITLE
build(docs-infra): upgrade cli command docs sources to aa7d3b377

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -19,7 +19,7 @@
     "build-local": "yarn ~~build",
     "prebuild-local-ci": "yarn setup-local-ci",
     "build-local-ci": "yarn ~~build --progress=false",
-    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js 50d813140",
+    "extract-cli-command-docs": "node tools/transforms/cli-docs-package/extract-cli-commands.js aa7d3b377",
     "lint": "yarn check-env && yarn docs-lint && ng lint && yarn example-lint && yarn tools-lint && yarn security-lint",
     "test": "yarn check-env && ng test",
     "test:bazel": "bazelisk test //aio:test",


### PR DESCRIPTION
Updating [angular#15.0.x](https://github.com/angular/angular/tree/15.0.x) from [cli-builds#15.0.x](https://github.com/angular/cli-builds/tree/15.0.x).

##
Relevant changes in [commit range](https://github.com/angular/cli-builds/compare/50d813140...aa7d3b377):

**Modified**
- help/build.json