### PR TITLE
docs: nginx.conf file doesn't work if copied directly

### DIFF
--- a/aio/content/examples/i18n/doc-files/nginx.conf
+++ b/aio/content/examples/i18n/doc-files/nginx.conf
@@ -8,25 +8,26 @@ http {
         ~*^en en;
     }
     # ...
-}
 
-server {
-    listen 80;
-    server_name localhost;
-    root /www/data;
 
-    # Fallback to default language if no preference defined by browser
-    if ($accept_language ~ "^$") {
-        set $accept_language "fr";
+    server {
+        listen 80;
+        server_name localhost;
+        root /www/data;
+
+        # Fallback to default language if no preference defined by browser
+        if ($accept_language ~ "^$") {
+            set $accept_language "fr";
+        }
+
+        # Redirect "/" to Angular application in the preferred language of the browser
+        rewrite ^/$ /$accept_language permanent;
+
+        # Everything under the Angular application is always redirected to Angular in the
+        # correct language
+        location ~ ^/(fr|de|en) {
+            try_files $uri /$1/index.html?$args;
+        }
+        # ...
     }
-
-    # Redirect "/" to Angular application in the preferred language of the browser
-    rewrite ^/$ /$accept_language permanent;
-
-    # Everything under the Angular application is always redirected to Angular in the
-    # correct language
-    location ~ ^/(fr|de|en) {
-        try_files $uri /$1/index.html?$args;
-    }
-    # ...
 }


### PR DESCRIPTION
docs: nginx.conf file doesn't work if copied directly

there was an error when I tried to start nginx if I copy this file directly as an nginx.conf

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
nginx.conf file doesn't work if I copy it from the docs
Issue Number: N/A


## What is the new behavior?
Alligned with the nginx.conf file structure

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
