### PR TITLE
refactor(compiler): Add `getPotentialPipes` API method.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -254,7 +254,7 @@ export interface MetadataReader {
  * A MetadataReader which also allows access to the set of all known directive classes.
  */
 export interface MetadataReaderWithIndex extends MetadataReader {
-  getKnownDirectives(): Iterable<ClassDeclaration>;
+  getKnown(kind: MetaKind): Iterable<ClassDeclaration>;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
@@ -9,7 +9,7 @@
 import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
 
-import {DirectiveMeta, MetadataReaderWithIndex, MetadataRegistry, NgModuleMeta, PipeMeta} from './api';
+import {DirectiveMeta, MetadataReaderWithIndex, MetadataRegistry, MetaKind, NgModuleMeta, PipeMeta} from './api';
 
 /**
  * A registry of directive, pipe, and module metadata for types defined in the current compilation
@@ -40,8 +40,15 @@ export class LocalMetadataRegistry implements MetadataRegistry, MetadataReaderWi
     this.pipes.set(meta.ref.node, meta);
   }
 
-  getKnownDirectives(): Iterable<ClassDeclaration> {
-    return this.directives.keys();
+  getKnown(kind: MetaKind): Iterable<ClassDeclaration> {
+    switch (kind) {
+      case MetaKind.Directive:
+        return this.directives.keys();
+      case MetaKind.Pipe:
+        return this.pipes.keys();
+      case MetaKind.NgModule:
+        return this.ngModules.keys();
+    }
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -135,9 +135,9 @@ export interface TemplateTypeChecker {
   getPotentialTemplateDirectives(component: ts.ClassDeclaration): PotentialDirective[];
 
   /**
-   * Get basic metadata on the pipes which are in scope for the given component.
+   * Get basic metadata on the pipes which are in scope or can be imported for the given component.
    */
-  getPipesInScope(component: ts.ClassDeclaration): PotentialPipe[]|null;
+  getPotentialPipes(component: ts.ClassDeclaration): PotentialPipe[];
 
   /**
    * Retrieve a `Map` of potential template element tags, to either the `PotentialDirective` that

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -72,6 +72,8 @@ export interface PotentialDirective {
  * Metadata for a pipe which is available in a template.
  */
 export interface PotentialPipe {
+  ref: Reference<ClassDeclaration>;
+
   /**
    * The `ts.Symbol` for the pipe class.
    */

--- a/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/test/type_checker__completion_spec.ts
@@ -106,7 +106,7 @@ runInEachFileSystem(() => {
 
       let directives = templateTypeChecker.getPotentialTemplateDirectives(SomeCmp) ?? [];
       directives = directives.filter(d => d.isInScope);
-      const pipes = templateTypeChecker.getPipesInScope(SomeCmp) ?? [];
+      const pipes = templateTypeChecker.getPotentialPipes(SomeCmp) ?? [];
       expect(directives.map(dir => dir.selector)).toEqual(['other-dir']);
       expect(pipes.map(pipe => pipe.name)).toEqual(['otherPipe']);
     });

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -577,8 +577,13 @@ function getFakeMetadataReader(fakeMetadataRegistry: Map<any, DirectiveMeta|null
         null {
           return fakeMetadataRegistry.get(node.debugName) ?? null;
         },
-    getKnownDirectives(): Iterable<ClassDeclaration> {
-      return fakeMetadataRegistry.keys();
+    getKnown(kind: MetaKind): Iterable<ClassDeclaration> {
+      switch (kind) {
+        case MetaKind.Directive:
+          return fakeMetadataRegistry.keys();
+        default:
+          return [];
+      }
     }
   } as MetadataReaderWithIndex;
 }

--- a/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ls_typecheck_helpers_spec.ts
@@ -202,6 +202,37 @@ runInEachFileSystem(() => {
       });
     });
 
+    describe('can retrieve candidate pipes` ', () => {
+      it('which are out of scope', () => {
+        env.write('one.ts', `
+			 import {Pipe} from '@angular/core';
+	 
+			 @Pipe({
+				name: 'foo-pipe',
+				standalone: true,
+			  })
+			  export class OnePipe {
+			  }
+			 `);
+
+        env.write('two.ts', `
+			 import {Component} from '@angular/core';
+	 
+			 @Component({
+				 standalone: true,
+				 selector: 'two-cmp',
+				 template: '<div></div>',
+			 })
+			 export class TwoCmp {}
+			 `);
+        const {program, checker} = env.driveTemplateTypeChecker();
+        const sf = program.getSourceFile(_('/one.ts'));
+        expect(sf).not.toBeNull();
+        const pipes = checker.getPotentialPipes(getClass(sf!, 'OnePipe'));
+        expect(pipes.map(p => p.name)).toContain('foo-pipe');
+      });
+    });
+
     describe('can generate imports` ', () => {
       it('for out of scope standalone components', () => {
         env.write('one.ts', `

--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -842,7 +842,8 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
 
   private getPipeCompletions(this: PipeCompletionBuilder):
       ts.WithMetadata<ts.CompletionInfo>|undefined {
-    const pipes = this.templateTypeChecker.getPipesInScope(this.component);
+    const pipes =
+        this.templateTypeChecker.getPotentialPipes(this.component).filter(p => p.isInScope);
     if (pipes === null) {
       return undefined;
     }


### PR DESCRIPTION
`getPotentialPipes` returns possible pipes which can be used in the provided context, whether already in scope or requiring an import.

This is necessary to implement auto-import support for pipes in the language service.