### PR TITLE
docs: Add v15 release blog post link to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 <a name="15.0.0"></a>
 # 15.0.0 (2022-11-16)
+
+[Blog post "Angular v15 is now available"](http://goo.gle/angular-v15).
+
 ## Breaking Changes
 ### compiler
 - Keyframes names are now prefixed with the component's "scope name".


### PR DESCRIPTION
This adds a link to the v15 release blog post to the changelog for people to view.