### PR TITLE
refactor(core): replace usages of removeChild

### DIFF
--- a/packages/animations/browser/test/dsl/animation_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_spec.ts
@@ -40,7 +40,7 @@ function createDiv() {
     });
 
     afterEach(() => {
-      document.body.removeChild(rootElement);
+      rootElement.remove();
     });
 
     describe('validation', () => {

--- a/packages/animations/browser/test/dsl/animation_trigger_spec.ts
+++ b/packages/animations/browser/test/dsl/animation_trigger_spec.ts
@@ -30,7 +30,7 @@ import {makeTrigger} from '../shared';
     });
 
     afterEach(() => {
-      document.body.removeChild(element);
+      element.remove();
     });
 
     describe('trigger validation', () => {

--- a/packages/animations/browser/test/render/timeline_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/timeline_animation_engine_spec.ts
@@ -33,7 +33,7 @@ describe('TimelineAnimationEngine', () => {
     document.body.appendChild(element);
   });
 
-  afterEach(() => document.body.removeChild(element));
+  afterEach(() => element.remove());
 
   it('should animate a timeline', () => {
     const engine = makeEngine(getBodyNode());

--- a/packages/animations/browser/test/render/transition_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/transition_animation_engine_spec.ts
@@ -33,7 +33,7 @@ describe('TransitionAnimationEngine', () => {
   });
 
   afterEach(() => {
-    document.body.removeChild(element);
+    element.remove();
   });
 
   function makeEngine(normalizer?: AnimationStyleNormalizer) {

--- a/packages/common/test/viewport_scroller_spec.ts
+++ b/packages/common/test/viewport_scroller_spec.ts
@@ -116,8 +116,8 @@ describe('BrowserViewportScroller', () => {
       return {
         anchorNode,
         cleanup: () => {
-          document.body.removeChild(tallItem);
-          document.body.removeChild(anchorNode);
+          tallItem.remove();
+          anchorNode.remove();
         }
       };
     }
@@ -136,8 +136,8 @@ describe('BrowserViewportScroller', () => {
       return {
         anchorNode,
         cleanup: () => {
-          document.body.removeChild(tallItem);
-          document.body.removeChild(elementWithShadowRoot);
+          tallItem.remove();
+          elementWithShadowRoot.remove();
         }
       };
     }

--- a/packages/core/src/render3/interfaces/renderer.ts
+++ b/packages/core/src/render3/interfaces/renderer.ts
@@ -43,7 +43,7 @@ export interface Renderer {
   destroyNode?: ((node: RNode) => void)|null;
   appendChild(parent: RElement, newChild: RNode): void;
   insertBefore(parent: RNode, newChild: RNode, refChild: RNode|null, isMove?: boolean): void;
-  removeChild(parent: RElement, oldChild: RNode, isHostElement?: boolean): void;
+  removeChild(parent: RElement|null, oldChild: RNode, isHostElement?: boolean): void;
   selectRootElement(selectorOrNode: string|any, preserveContent?: boolean): RElement;
 
   parentNode(node: RNode): RElement|null;

--- a/packages/core/src/render3/interfaces/renderer_dom.ts
+++ b/packages/core/src/render3/interfaces/renderer_dom.ts
@@ -36,12 +36,6 @@ export interface RNode {
   nextSibling: RNode|null;
 
   /**
-   * Removes a child from the current node and returns the removed node
-   * @param oldChild the child node to remove
-   */
-  removeChild(oldChild: RNode): RNode;
-
-  /**
    * Insert a child node.
    *
    * Used exclusively for adding View root nodes into ViewAnchor location.
@@ -73,7 +67,7 @@ export interface RElement extends RNode {
       value: string|TrustedHTML|TrustedScript|TrustedScriptURL): void;
   addEventListener(type: string, listener: EventListener, useCapture?: boolean): void;
   removeEventListener(type: string, listener?: EventListener, options?: boolean): void;
-
+  remove(): void;
   setProperty?(name: string, value: any): void;
 }
 

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -624,17 +624,6 @@ function nativeAppendOrInsertBefore(
   }
 }
 
-/** Removes a node from the DOM given its native parent. */
-function nativeRemoveChild(
-    renderer: Renderer, parent: RElement, child: RNode, isHostElement?: boolean): void {
-  renderer.removeChild(parent, child, isHostElement);
-}
-
-/** Checks if an element is a `<template>` node. */
-function isTemplateNode(node: RElement): node is RTemplate {
-  return node.tagName === 'TEMPLATE' && (node as RTemplate).content !== undefined;
-}
-
 /**
  * Returns a native parent of a given native node.
  */
@@ -827,10 +816,7 @@ export function getBeforeNodeForView(viewIndexInContainer: number, lContainer: L
  */
 export function nativeRemoveNode(renderer: Renderer, rNode: RNode, isHostElement?: boolean): void {
   ngDevMode && ngDevMode.rendererRemoveNode++;
-  const nativeParent = nativeParentNode(renderer, rNode);
-  if (nativeParent) {
-    nativeRemoveChild(renderer, nativeParent, rNode, isHostElement);
-  }
+  renderer.removeChild(null, rNode, isHostElement);
 }
 
 

--- a/packages/core/src/sanitization/html_sanitizer.ts
+++ b/packages/core/src/sanitization/html_sanitizer.ts
@@ -278,7 +278,7 @@ export function _sanitizeHtml(defaultDoc: any, unsafeHtmlInput: string): Trusted
     if (inertBodyElement) {
       const parent = getTemplateContent(inertBodyElement) || inertBodyElement;
       while (parent.firstChild) {
-        parent.removeChild(parent.firstChild);
+        parent.firstChild.remove();
       }
     }
   }

--- a/packages/core/src/sanitization/inert_body.ts
+++ b/packages/core/src/sanitization/inert_body.ts
@@ -50,7 +50,7 @@ class DOMParserHelper implements InertBodyHelper {
         // the `inertDocumentHelper` instead.
         return this.inertDocumentHelper.getInertBodyElement(html);
       }
-      body.removeChild(body.firstChild!);
+      body.firstChild!.remove();
       return body;
     } catch {
       return null;

--- a/packages/core/test/acceptance/renderer_factory_spec.ts
+++ b/packages/core/test/acceptance/renderer_factory_spec.ts
@@ -505,8 +505,8 @@ class MockRenderer implements Renderer2 {
   insertBefore(parent: Node, newChild: Node, refChild: Node|null): void {
     parent.insertBefore(newChild, refChild);
   }
-  removeChild(parent: RElement, oldChild: Node): void {
-    parent.removeChild(oldChild);
+  removeChild(parent: RElement, oldChild: Element): void {
+    oldChild.remove();
   }
   selectRootElement(selectorOrNode: string|any): RElement {
     return typeof selectorOrNode === 'string' ? document.querySelector(selectorOrNode) :

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -2461,9 +2461,7 @@ describe('ViewContainerRef', () => {
           containerEl!.appendChild(rootEl);
         },
         removeAllRootElements() {
-          if (containerEl) {
-            containerEl.parentNode?.removeChild(containerEl);
-          }
+          containerEl?.remove();
         }
       };
     }

--- a/packages/core/test/dom/dom_adapter_spec.ts
+++ b/packages/core/test/dom/dom_adapter_spec.ts
@@ -50,7 +50,7 @@ import {isTextNode} from '@angular/platform-browser/testing/src/browser_util';
           headEl.appendChild(baseEl);
 
           const baseHref = getDOM().getBaseHref(defaultDoc);
-          headEl.removeChild(baseEl);
+          baseEl.remove();
           getDOM().resetBaseElement();
 
           expect(baseHref).toEqual('/drop/bass/connon/');
@@ -63,7 +63,7 @@ import {isTextNode} from '@angular/platform-browser/testing/src/browser_util';
           headEl.appendChild(baseEl);
 
           const baseHref = getDOM().getBaseHref(defaultDoc)!;
-          headEl.removeChild(baseEl);
+          baseEl.remove();
           getDOM().resetBaseElement();
 
           expect(baseHref.endsWith('/base')).toBe(true);

--- a/packages/core/test/render3/instructions/mock_renderer_factory.ts
+++ b/packages/core/test/render3/instructions/mock_renderer_factory.ts
@@ -40,8 +40,8 @@ class MockRenderer implements Renderer {
   insertBefore(parent: Node, newChild: Node, refChild: Node|null): void {
     parent.insertBefore(newChild, refChild);
   }
-  removeChild(parent: RElement, oldChild: Node): void {
-    parent.removeChild(oldChild);
+  removeChild(_parent: RElement|null, oldChild: RElement): void {
+    oldChild.remove();
   }
   selectRootElement(selectorOrNode: string|any): RElement {
     return typeof selectorOrNode === 'string' ? document.querySelector(selectorOrNode) :

--- a/packages/core/test/render3/perf/noop_renderer.ts
+++ b/packages/core/test/render3/perf/noop_renderer.ts
@@ -16,9 +16,7 @@ export class MicroBenchmarkRenderNode implements RNode, RComment, RText {
   parentNode: RNode|null = null;
   parentElement: RElement|null = null;
   nextSibling: RNode|null = null;
-  removeChild(oldChild: RNode): RNode {
-    return oldChild;
-  }
+  remove(): void {}
   insertBefore(newChild: RNode, refChild: RNode|null, isViewRoot: boolean): void {}
   appendChild(newChild: RNode): RNode {
     return newChild;
@@ -121,9 +119,7 @@ class MicroBenchmarkDomRenderer implements Renderer {
   }
 
   removeChild(parent: any, oldChild: any): void {
-    if (parent) {
-      parent.removeChild(oldChild);
-    }
+    oldChild.remove();
   }
 
   selectRootElement(selectorOrNode: string|any, preserveContent?: boolean): any {

--- a/packages/elements/test/create-custom-element-env_spec.ts
+++ b/packages/elements/test/create-custom-element-env_spec.ts
@@ -22,7 +22,7 @@ if (browserDetection.supportsCustomElements) {
     });
 
     afterEach(() => {
-      document.body.removeChild(testContainer);
+      testContainer.remove();
       (testContainer as any) = null;
     });
 

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -49,7 +49,7 @@ if (browserDetection.supportsCustomElements) {
 
     afterAll(() => {
       destroyPlatform();
-      document.body.removeChild(testContainer);
+      testContainer.remove();
       (testContainer as any) = null;
     });
 

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -30,14 +30,7 @@ export class AnimationRendererFactory implements RendererFactory2 {
   constructor(
       private delegate: RendererFactory2, private engine: AnimationEngine, private _zone: NgZone) {
     engine.onRemovalComplete = (element: any, delegate: Renderer2) => {
-      // Note: if a component element has a leave animation, and a host leave animation,
-      // the view engine will call `removeChild` for the parent
-      // component renderer as well as for the child component renderer.
-      // Therefore, we need to check if we already removed the element.
-      const parentNode = delegate?.parentNode(element);
-      if (parentNode) {
-        delegate.removeChild(parentNode, element);
-      }
+      delegate?.removeChild(null, element);
     };
   }
 

--- a/packages/platform-browser/animations/test/animation_renderer_spec.ts
+++ b/packages/platform-browser/animations/test/animation_renderer_spec.ts
@@ -65,9 +65,8 @@ describe('AnimationRenderer', () => {
   it('should hook into the engine\'s insert operations when removing children', () => {
     const renderer = makeRenderer();
     const engine = TestBed.inject(AnimationEngine) as MockAnimationEngine;
-    const container = el('<div></div>');
 
-    renderer.removeChild(container, element);
+    renderer.removeChild(null, element);
     expect(engine.captures['onRemove'].pop()).toEqual([element]);
   });
 

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -34,9 +34,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     el.dispatchEvent(evt);
   }
   remove(node: Node): void {
-    if (node.parentNode) {
-      node.parentNode.removeChild(node);
-    }
+    (node as Element | Text | Comment).remove();
   }
   createElement(tagName: string, doc?: Document): HTMLElement {
     doc = doc || this.getDefaultDocument();

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -180,10 +180,8 @@ class DefaultDomRenderer2 implements Renderer2 {
     }
   }
 
-  removeChild(parent: any, oldChild: any): void {
-    if (parent) {
-      parent.removeChild(oldChild);
-    }
+  removeChild(_parent: any, oldChild: any): void {
+    oldChild.remove();
   }
 
   selectRootElement(selectorOrNode: string|any, preserveContent?: boolean): any {
@@ -351,8 +349,8 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
   override insertBefore(parent: any, newChild: any, refChild: any): void {
     return super.insertBefore(this.nodeOrShadowRoot(parent), newChild, refChild);
   }
-  override removeChild(parent: any, oldChild: any): void {
-    return super.removeChild(this.nodeOrShadowRoot(parent), oldChild);
+  override removeChild(_parent: any, oldChild: any): void {
+    return super.removeChild(null, oldChild);
   }
   override parentNode(node: any): any {
     return this.nodeOrShadowRoot(super.parentNode(this.nodeOrShadowRoot(node)));

--- a/packages/platform-browser/test/browser/transfer_state_spec.ts
+++ b/packages/platform-browser/test/browser/transfer_state_spec.ts
@@ -13,10 +13,7 @@ import {escapeHtml, makeStateKey, unescapeHtml} from '@angular/platform-browser/
 
 (function() {
 function removeScriptTag(doc: Document, id: string) {
-  const existing = doc.getElementById(id);
-  if (existing) {
-    doc.body.removeChild(existing);
-  }
+  doc.getElementById(id)?.remove();
 }
 
 function addScriptTag(doc: Document, appId: string, data: {}) {

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -338,7 +338,7 @@ describe('EventManager', () => {
     expect(timeoutId).not.toBe(null);
 
     // cleanup the DOM by removing the test element we attached earlier.
-    doc.body.removeChild(element);
+    element.remove();
     timeoutId && clearTimeout(timeoutId);
   });
 

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -99,10 +99,8 @@ class DefaultServerRenderer2 implements Renderer2 {
     }
   }
 
-  removeChild(parent: any, oldChild: any): void {
-    if (parent) {
-      parent.removeChild(oldChild);
-    }
+  removeChild(_parent: any, oldChild: any): void {
+    oldChild.remove();
   }
 
   selectRootElement(selectorOrNode: string|any, preserveContent?: boolean): any {
@@ -113,7 +111,7 @@ class DefaultServerRenderer2 implements Renderer2 {
     }
     if (!preserveContent) {
       while (el.firstChild) {
-        el.removeChild(el.firstChild);
+        el.firstChild.remove();
       }
     }
     return el;

--- a/packages/upgrade/src/common/test/helpers/common_test_helpers.ts
+++ b/packages/upgrade/src/common/test/helpers/common_test_helpers.ts
@@ -71,8 +71,7 @@ export function createWithEachNg1VersionFn(setNg1: typeof setAngularJSGlobal) {
             const delay = 5000;
             win.console.warn(
                 `\n[${new Date().toISOString()}] Retrying to load "${scriptUrl}" in ${delay}ms...`);
-
-            document.body.removeChild(script);
+            script.remove();
             setTimeout(() => loadScript(scriptUrl, --retry).then(resolve, reject), delay);
           } : () => {
             // Whenever the script failed loading, browsers will just pass an "ErrorEvent" which
@@ -84,7 +83,7 @@ export function createWithEachNg1VersionFn(setNg1: typeof setAngularJSGlobal) {
             reject(`An error occurred while loading "${scriptUrl}".`);
           };
           script.onload = () => {
-            document.body.removeChild(script);
+            script.remove();
             resolve();
           };
           script.src = `base/npm/node_modules/${scriptUrl}`;


### PR DESCRIPTION
These changes replace most usages of `removeChild` with `remove`. The latter has the advantage of not having to look up the `parentNode` and ensure that the child being removed actually belongs to the specific parent.

The refactor should be fairly safe since all the browsers we cover support `remove`. [Something similar was done in Components](https://github.com/angular/components/pull/23592) a year ago and there haven't been any bug reports as a result.