### PR TITLE
fix(core): allow readonly arrays in NgModule imports and exports

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -1173,9 +1173,9 @@ export type NgIterable<T> = Array<T> | Iterable<T>;
 export interface NgModule {
     bootstrap?: Array<Type<any> | any[]>;
     declarations?: Array<Type<any> | any[]>;
-    exports?: Array<Type<any> | any[]>;
+    exports?: Array<Type<any> | ReadonlyArray<any>>;
     id?: string;
-    imports?: Array<Type<any> | ModuleWithProviders<{}> | any[]>;
+    imports?: Array<Type<any> | ModuleWithProviders<{}> | ReadonlyArray<any>>;
     jit?: true;
     providers?: Array<Provider | EnvironmentProviders>;
     schemas?: Array<SchemaMetadata | any[]>;

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -135,7 +135,7 @@ export interface NgModule {
    * ```
    *
    */
-  imports?: Array<Type<any> | ModuleWithProviders<{}> | any[]>;
+  imports?: Array<Type<any> | ModuleWithProviders<{}> | ReadonlyArray<any>>;
 
   /**
    * The set of components, directives, and pipes declared in this
@@ -167,7 +167,7 @@ export interface NgModule {
    * }
    * ```
    */
-  exports?: Array<Type<any> | any[]>;
+  exports?: Array<Type<any> | ReadonlyArray<any>>;
 
   /**
    * The set of components that are bootstrapped when this module is bootstrapped.

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -537,6 +537,66 @@ describe('standalone components, directives, and pipes', () => {
     expect(fixture.nativeElement.innerHTML).toBe('<div red="true">blue</div>');
   });
 
+  it('should support readonly arrays in @NgModule.imports and @NgModule.exports', () => {
+    @Directive({selector: '[red]', standalone: true, host: {'[attr.red]': 'true'}})
+    class RedIdDirective {}
+
+    @Pipe({name: 'blue', pure: true, standalone: true})
+    class BluePipe implements PipeTransform {
+      transform() {
+        return 'blue';
+      }
+    }
+
+    const DirAndPipe = [RedIdDirective, BluePipe] as const;
+
+    @NgModule({
+      imports: [DirAndPipe],
+      exports: [DirAndPipe],
+    })
+    class TestNgModule {}
+
+    @Component({
+      selector: 'uses-standalone',
+      template: `<div red>{{'' | blue}}</div>`,
+    })
+    class TestComponent {}
+
+    const fixture = TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [TestNgModule],
+    }).createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerHTML).toBe('<div red="true">blue</div>');
+  });
+
+  it('should support readonly arrays in TestBed testing module imports', () => {
+    @Directive({selector: '[red]', standalone: true, host: {'[attr.red]': 'true'}})
+    class RedIdDirective {}
+
+    @Pipe({name: 'blue', pure: true, standalone: true})
+    class BluePipe implements PipeTransform {
+      transform() {
+        return 'blue';
+      }
+    }
+
+    const DirAndPipe = [RedIdDirective, BluePipe] as const;
+
+    @Component({
+      selector: 'uses-standalone',
+      template: `<div red>{{'' | blue}}</div>`,
+    })
+    class TestComponent {}
+
+    const fixture = TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      imports: [DirAndPipe],
+    }).createComponent(TestComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.innerHTML).toBe('<div red="true">blue</div>');
+  });
+
   it('should deduplicate declarations', () => {
     @Component({selector: 'test-red', standalone: true, template: 'red(<ng-content></ng-content>)'})
     class RedComponent {}


### PR DESCRIPTION
NgModule should support readonly arrays in `@NgModule.imports` and `@NgModule.exports`.

Partly fixes #48089 (#48091 is also needed)
