### PR TITLE
docs(router): Deprecate writing to router.navigated property

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -379,8 +379,7 @@ The injector no longer requires the Reflect polyfill, reducing application size 
 <a id="router-writable-properties"></a>
 
 None of the public properties of the `Router` are meant to be writeable.
-They should all be configured using other methods, all of which have been
-documented.
+They should all be configured using other methods.
 
 The following strategies are meant to be configured by registering the
 application strategy in DI via the `providers` in the root `NgModule` or
@@ -402,6 +401,9 @@ available in `provideRouter`:
   There are currently no plans to make this available in `provideRouter`.
 * `errorHandler` - Developers should instead subscribe to `Router.events`
   and filter for `NavigationError`.
+
+The following properties are meant to be read-only:
+* navigated - This has been found to be used as a way to force the router to reprocess a URL when `onSameUrlNavigation` is set to `'ignore'`. Instead, set `onSameUrlNavigation: 'reload'` in the extra options of the `Router.navigate` method.
 
 <a id="relativeLinkResolution"></a>
 

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -669,7 +669,8 @@ export class Router {
     malformedUriErrorHandler: (error: URIError, urlSerializer: UrlSerializer, url: string) => UrlTree;
     navigate(commands: any[], extras?: NavigationExtras): Promise<boolean>;
     navigateByUrl(url: string | UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean>;
-    navigated: boolean;
+    get navigated(): boolean;
+    set navigated(value: boolean);
     // (undocumented)
     ngOnDestroy(): void;
     // @deprecated

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -463,11 +463,23 @@ export class Router {
       (error: URIError, urlSerializer: UrlSerializer,
        url: string) => UrlTree = defaultMalformedUriErrorHandler;
 
+  private _navigated = false;
   /**
-   * True if at least one navigation event has occurred,
-   * false otherwise.
+   * True if at least one navigation has occurred, false otherwise.
    */
-  navigated: boolean = false;
+  get navigated() {
+    return this._navigated;
+  }
+  /**
+   * @deprecated The navigated property is not meant to be writable. If you want to force the
+   *     router to reprocess a URL during navigation, set `onSameUrlNavigation: 'reload'` in the
+   *     extra options of `Router.navigate`.
+   *
+   * @see NavigationBehaviorOptions
+   */
+  set navigated(value: boolean) {
+    this._navigated = value;
+  }
   private lastSuccessfulId: number = -1;
 
   /**


### PR DESCRIPTION
The router.navigated property is meant to be read-only externally. Writing to it is simply a workaround for APIs that had previously been missing in the Router

DEPRECATED:
The router.navigated property is meant to be read-only externally. Writing to it is simply a workaround for APIs that had previously been missing in the Router. To force reloads, pass `onSameUrlNavigation: 'reload'` in the options of `Router.navigate`.