### PR TITLE
feat(common): add initial value support for async pipe

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -39,11 +39,15 @@ export class AsyncPipe implements OnDestroy, PipeTransform {
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
-    transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T>): T | null;
+    transform<T, K>(obj: Observable<T> | Subscribable<T> | Promise<T>, initialValue: K): T | K;
     // (undocumented)
-    transform<T>(obj: null | undefined): null;
+    transform<T>(obj: null | undefined, initialValue: T): T;
+    // (undocumented)
+    transform(obj: null | undefined): null;
     // (undocumented)
     transform<T>(obj: Observable<T> | Subscribable<T> | Promise<T> | null | undefined): T | null;
+    // (undocumented)
+    transform<T, K>(obj: Observable<T> | Subscribable<T> | Promise<T> | null | undefined, initialValue?: K): T | K | null;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<AsyncPipe, never>;
     // (undocumented)

--- a/packages/common/test/pipes/async_pipe_spec.ts
+++ b/packages/common/test/pipes/async_pipe_spec.ts
@@ -49,6 +49,11 @@ import {of, Subscribable, Unsubscribable} from 'rxjs';
           expect(pipe.transform(subscribable)).toBe(null);
         });
 
+        it('should return "initial" when subscribing to an observable and initial value passed',
+           () => {
+             expect(pipe.transform(subscribable, 'initial')).toBe('initial');
+           });
+
         it('should return the latest available value', done => {
           pipe.transform(subscribable);
           emitter.emit(message);
@@ -158,6 +163,10 @@ import {of, Subscribable, Unsubscribable} from 'rxjs';
       describe('transform', () => {
         it('should return null when subscribing to a promise', () => {
           expect(pipe.transform(promise)).toBe(null);
+        });
+
+        it('should return "initial" when subscribing to a promise and initial value passed', () => {
+          expect(pipe.transform(promise, 'initial')).toBe('initial');
         });
 
         it('should return the latest available value', done => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
        I didn't find the page about AsyncPipe in the repository. Some pages like [this](https://github.com/angular/angular/blob/6952a0a3e68481564b2bc4955afb3ac186df6e34/aio/content/guide/observables-in-angular.md) lead to a [broken page](https://github.com/angular/angular/blob/6952a0a3e68481564b2bc4955afb3ac186df6e34/aio/content/guide/api/common/AsyncPipe).


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Now AsyncPipe always return null value by types and that forces additional checks. 

For example:

1. We should add optional chaining, when we want access object property.
`<div> {{ (someData | async)?.property }}</div>`
2. We should add some checks for Input params.
`@Input() someObject?: SomeObject | null;`

3. That is not Angular way.
`<div> {{ (someData | async) ?? 'initial' }}</div>`
4. And quite a lot of other cases

Issue Number: #43727 

## What is the new behavior?

I am introduce option to pass initial value to AsyncPipe and it's should resolve some painful problem:

1. No more "Object is possibly 'null'". When we pass initial value, we can access to properties and data without additional check.
`<div> {{ (someData | async: {property: 'initial'}).property }}</div>`
2. We can declare inputs without additional checks and without 'null' type
`@Input() someObject: SomeObject;`
3. Angular way. Use standard pipe functional.
`<div> {{ (someData | async: 'initial') }}</div>`
4. Fix some other often cases

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
