### PR TITLE
refactor(router): Update RouterOutlet to not read internal route prop…

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -321,7 +321,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     }
     this._activatedRoute = activatedRoute;
     const location = this.location;
-    const snapshot = activatedRoute._futureSnapshot;
+    const snapshot = activatedRoute.snapshot;
     const component = snapshot.component!;
     const childContexts = this.parentContexts.getOrCreateContext(this.name).children;
     const injector = new OutletInjector(activatedRoute, childContexts, location.injector);


### PR DESCRIPTION
…erty

The `RouterOutlet` currently reads the `_futureSnapshot` of the Route. However, by the time `activateWith` is called, this value is the same as `snapshot` (https://github.com/angular/angular/blob/414b1b2d5ffe8eac33749bf472af7eafcf248dba/packages/router/src/operators/activate_routes.ts#L163-L205).

This change will make it easier for developers to fork the `RouterOutlet` implementation if necessary without needing to modify any code.
