### PR TITLE
feat(core): Make the isStandalone() function available in public API

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -788,6 +788,9 @@ export interface InputDecorator {
 export function isDevMode(): boolean;
 
 // @public
+export function isStandalone(type: Type<unknown>): boolean;
+
+// @public
 export interface IterableChangeRecord<V> {
     readonly currentIndex: number | null;
     readonly item: V;

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -38,6 +38,7 @@ export {SecurityContext} from './sanitization/security';
 export {Sanitizer} from './sanitization/sanitizer';
 export {createNgModule, createNgModuleRef, createEnvironmentInjector} from './render3/ng_module_ref';
 export {createComponent, reflectComponentType, ComponentMirror} from './render3/component';
+export {isStandalone} from './render3/definition';
 
 import {global} from './util/global';
 if (typeof ngDevMode !== 'undefined' && ngDevMode) {

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -248,7 +248,6 @@ export {
 export {
   compilePipe as ɵcompilePipe,
 } from './render3/jit/pipe';
-export { isStandalone as ɵisStandalone} from './render3/definition';
 export { Profiler as ɵProfiler, ProfilerEvent as ɵProfilerEvent } from './render3/profiler';
 export {
   publishDefaultGlobalUtils as ɵpublishDefaultGlobalUtils

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -7,7 +7,6 @@
  */
 
 import {ChangeDetectionStrategy} from '../change_detection/constants';
-import {NG_PROV_DEF} from '../di/interface/defs';
 import {Mutable, Type} from '../interface/type';
 import {NgModuleDef} from '../metadata/ng_module_def';
 import {SchemaMetadata} from '../metadata/schema';
@@ -741,7 +740,15 @@ export function getPipeDef<T>(type: any): PipeDef<T>|null {
   return type[NG_PIPE_DEF] || null;
 }
 
-export function isStandalone<T>(type: Type<T>): boolean {
+/**
+ * Checks whether a given Component, Directive or Pipe is marked as standalone.
+ * This will return false if passed anything other than a Component, Directive, or Pipe class
+ * See this guide for additional information: https://angular.io/guide/standalone-components
+ *
+ * @param type A reference to a Component, Directive or Pipe.
+ * @publicApi
+ */
+export function isStandalone(type: Type<unknown>): boolean {
   const def = getComponentDef(type) || getDirectiveDef(type) || getPipeDef(type);
   return def !== null ? def.standalone : false;
 }

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -173,9 +173,7 @@ export function compileNgModuleDefs(
   Object.defineProperty(moduleType, NG_INJ_DEF, {
     get: () => {
       if (ngInjectorDef === null) {
-        ngDevMode &&
-            verifySemanticsOfNgModuleDef(
-                moduleType as any as NgModuleType, allowDuplicateDeclarationsInRoot);
+        ngDevMode && verifySemanticsOfNgModuleDef(moduleType, allowDuplicateDeclarationsInRoot);
         const meta: R3InjectorMetadataFacade = {
           name: moduleType.name,
           type: moduleType,

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {Component, createEnvironmentInjector, Directive, EnvironmentInjector, forwardRef, Injector, Input, NgModule, NO_ERRORS_SCHEMA, OnInit, Pipe, PipeTransform, ViewChild, ViewContainerRef} from '@angular/core';
+import {Component, createEnvironmentInjector, Directive, EnvironmentInjector, forwardRef, Injector, Input, isStandalone, NgModule, NO_ERRORS_SCHEMA, OnInit, Pipe, PipeTransform, ViewChild, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 describe('standalone components, directives, and pipes', () => {
@@ -845,6 +845,70 @@ describe('standalone components, directives, and pipes', () => {
       // the assumption here is that not providing a template is equivalent to providing an empty
       // one
       expect(fixture.nativeElement.textContent).toBe('');
+    });
+  });
+
+  describe('isStandalone()', () => {
+    it('should return `true` if component is standalone', () => {
+      @Component({selector: 'standalone-cmp', standalone: true})
+      class StandaloneCmp {
+      }
+
+      expect(isStandalone(StandaloneCmp)).toBeTrue();
+    });
+
+    it('should return `false` if component is not standalone', () => {
+      @Component({selector: 'standalone-cmp', standalone: false})
+      class StandaloneCmp {
+      }
+
+      expect(isStandalone(StandaloneCmp)).toBeFalse();
+    });
+
+    it('should return `true` if directive is standalone', () => {
+      @Directive({selector: '[standaloneDir]', standalone: true})
+      class StandAloneDirective {
+      }
+
+      expect(isStandalone(StandAloneDirective)).toBeTrue();
+    });
+
+    it('should return `false` if directive is standalone', () => {
+      @Directive({selector: '[standaloneDir]', standalone: false})
+      class StandAloneDirective {
+      }
+
+      expect(isStandalone(StandAloneDirective)).toBeFalse();
+    });
+
+    it('should return `true` if pipe is standalone', () => {
+      @Pipe({name: 'standalonePipe', standalone: true})
+      class StandAlonePipe {
+      }
+
+      expect(isStandalone(StandAlonePipe)).toBeTrue();
+    });
+
+    it('should return `false` if pipe is standalone', () => {
+      @Pipe({name: 'standalonePipe', standalone: false})
+      class StandAlonePipe {
+      }
+
+      expect(isStandalone(StandAlonePipe)).toBeFalse();
+    });
+
+    it('should return `false` if the class is not annotated', () => {
+      class NonAnnotatedClass {}
+
+      expect(isStandalone(NonAnnotatedClass)).toBeFalse();
+    });
+
+    it('should return `false` if the class is an NgModule', () => {
+      @NgModule({})
+      class Module {
+      }
+
+      expect(isStandalone(Module)).toBeFalse();
     });
   });
 });

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createEnvironmentInjector, EnvironmentInjector, Type, ɵisStandalone as isStandalone, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {createEnvironmentInjector, EnvironmentInjector, isStandalone, Type, ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {EmptyOutletComponent} from '../components/empty_outlet';
 import {RuntimeErrorCode} from '../errors';


### PR DESCRIPTION
Making isStandalone() a public api

fixes #47919

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [x] No (outside of removing `ɵisStandalone`) 

## Other information

It's the first time I'm exposing a previously private API. Feedbacks are welcome ! 
