### PR TITLE
docs: fix dates in release guide

### DIFF
--- a/aio/content/guide/releases.md
+++ b/aio/content/guide/releases.md
@@ -129,8 +129,8 @@ The following table provides the status for Angular versions under support.
 
 | Version | Status | Released   | Active ends | LTS ends   |
 |:---     |:---    |:---        |:---         |:---        |
-| ^15.0.0 | Active | 2022-11-18 | 2022-05-18  | 2023-05-18 |
-| ^14.0.0 | LTS    | 2022-06-02 | 2022-12-02  | 2023-11-18 |
+| ^15.0.0 | Active | 2022-11-18 | 2023-05-18  | 2024-05-18 |
+| ^14.0.0 | LTS    | 2022-06-02 | 2022-11-18  | 2023-11-18 |
 | ^13.0.0 | LTS    | 2021-11-04 | 2022-06-02  | 2023-05-04 |
 
 Angular versions v2 to v12 are no longer under support.


### PR DESCRIPTION
A version always stays for about a year in LTS.
