### PR TITLE
build(bazel): fix yarn call in aio deploy script

### DIFF
--- a/aio/scripts/deploy-to-firebase/BUILD.bazel
+++ b/aio/scripts/deploy-to-firebase/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@aio_npm//@bazel/jasmine:index.bzl", "jasmine_node_test")
 load("//tools:defaults.bzl", "nodejs_binary")
 load("@aio_npm//@angular/build-tooling/bazel/remote-execution:index.bzl", "ENABLE_NETWORK")
+load("//:yarn.bzl", "YARN_LABEL")
 
 DEPLOY_TO_FIREBASE_SOURCES = glob(
     ["**/*.mjs"],
@@ -11,12 +12,16 @@ DEPLOY_TO_FIREBASE_DEPS = [
     "@aio_npm//shelljs",
     "//aio:build",
     "//:package.json",
+    YARN_LABEL,
 ]
 
 nodejs_binary(
     name = "deploy-to-firebase",
     data = DEPLOY_TO_FIREBASE_SOURCES + DEPLOY_TO_FIREBASE_DEPS,
     entry_point = "index.mjs",
+    env = {
+        "YARN_BIN": "$(rootpath %s)" % YARN_LABEL,
+    },
 )
 
 jasmine_node_test(

--- a/aio/scripts/deploy-to-firebase/utils.mjs
+++ b/aio/scripts/deploy-to-firebase/utils.mjs
@@ -105,5 +105,5 @@ function yarn(cmd) {
   // This is not strictly necessary, since CircleCI will mask secret environment variables in the
   // output (see https://circleci.com/docs/2.0/env-vars/#secrets-masking), but is an extra
   // precaution.
-  return sh.exec(`yarn --silent ${cmd}`);
+  return sh.exec(`${process.env.YARN_BIN} --silent ${cmd}`, {cwd: 'aio'});
 }

--- a/aio/scripts/deploy-to-firebase/utils.spec.mjs
+++ b/aio/scripts/deploy-to-firebase/utils.spec.mjs
@@ -284,9 +284,25 @@ describe('deploy-to-firebase/utils:', () => {
 
     beforeEach(() => execSpy = spyOn(sh, 'exec'));
 
+    it('should execute the yarn binary in process.env.YARN_BIN', () => {
+      process.env.YARN_BIN = '/foo/yarn';
+      u.yarn('foo --bar');
+      const cmd = execSpy.calls.argsFor(0)[0];
+      expect(cmd.startsWith('/foo/yarn')).toEqual(true);
+    });
+
     it('should execute yarn in silent mode', () => {
       u.yarn('foo --bar');
-      expect(execSpy).toHaveBeenCalledWith('yarn --silent foo --bar');
+
+      const cmd = execSpy.calls.argsFor(0)[0];
+      expect(cmd.endsWith('--silent foo --bar')).toEqual(true);
+    });
+
+    it('should cd into aio', () => {
+      u.yarn('foo --bar');
+
+      const options = execSpy.calls.argsFor(0)[1];
+      expect(options.cwd).toEqual('aio');
     });
 
     it('should return the output from the command\'s execution', () => {


### PR DESCRIPTION
Incorrectly calls yarn scripts from the root package.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

AIO deploy script fails under Bazel.


## What is the new behavior?

Fix yarn calls to cwd into aio.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
