### PR TITLE
build(bazel): fix yarn path and workaround issues with AIO deploy script

### DIFF
--- a/aio/scripts/deploy-to-firebase/index.mjs
+++ b/aio/scripts/deploy-to-firebase/index.mjs
@@ -59,7 +59,17 @@ sh.set('-e');
 
 // Constants
 const RUNFILES_ROOT = process.cwd();
-const DIRNAME = path.join(RUNFILES_ROOT, 'aio', 'scripts', 'deploy-to-firebase');
+// TODO: Run this script in the source tree for now (BUILD_WORKSPACE_DIRECTORY) to avoid
+// calls to `yarn` within this script from performing installs inside the runfiles root.
+// The long-term solution is to either not call yarn from this script, or stop running
+// this script under Bazel. The script was originally Bazel-ified in order to run the tests
+// under Bazel, but that may have been short-sighted.
+const DIRNAME = path.join(
+  process.env.BUILD_WORKSPACE_DIRECTORY || RUNFILES_ROOT,
+    'aio',
+    'scripts',
+    'deploy-to-firebase'
+  );
 const ROOT_PKG_PATH = path.join(RUNFILES_ROOT, 'package.json');
 
 // Exports

--- a/aio/scripts/deploy-to-firebase/utils.mjs
+++ b/aio/scripts/deploy-to-firebase/utils.mjs
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import {dirname} from 'path';
+import {dirname, resolve} from 'path';
 import sh from 'shelljs';
 import {fileURLToPath} from 'url';
 
@@ -99,11 +99,12 @@ function nameFunction(name, fn) {
 }
 
 function yarn(cmd) {
+  const YARN_BIN = resolve(process.env.YARN_BIN);
   // Using `--silent` to ensure no secret env variables are printed.
   //
   // NOTE:
   // This is not strictly necessary, since CircleCI will mask secret environment variables in the
   // output (see https://circleci.com/docs/2.0/env-vars/#secrets-masking), but is an extra
   // precaution.
-  return sh.exec(`${process.env.YARN_BIN} --silent ${cmd}`, {cwd: 'aio'});
+  return sh.exec(`${YARN_BIN} --silent ${cmd}`, {cwd: 'aio'});
 }

--- a/aio/scripts/deploy-to-firebase/utils.spec.mjs
+++ b/aio/scripts/deploy-to-firebase/utils.spec.mjs
@@ -282,10 +282,12 @@ describe('deploy-to-firebase/utils:', () => {
   describe('yarn()', () => {
     let execSpy;
 
-    beforeEach(() => execSpy = spyOn(sh, 'exec'));
+    beforeEach(() => {
+      process.env.YARN_BIN = '/foo/yarn';
+      execSpy = spyOn(sh, 'exec');
+    });
 
     it('should execute the yarn binary in process.env.YARN_BIN', () => {
-      process.env.YARN_BIN = '/foo/yarn';
       u.yarn('foo --bar');
       const cmd = execSpy.calls.argsFor(0)[0];
       expect(cmd.startsWith('/foo/yarn')).toEqual(true);


### PR DESCRIPTION
The YARN_BIN env var path was relative to the runfiles root, so cwd in shelljs caused it to not be found.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The AIO deploy script performed a shelljs `cwd`, which made it unable to find the vendored yarn because the path was relative to the runfiles root. There was also a missing dependency on AIO's package.json file.

## What is the new behavior?

Resolved absolute yarn path and added missing dep.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
