### PR TITLE
build(bazel): fix dist dir in AIO deploy script

### DIFF
--- a/aio/scripts/deploy-to-firebase/pre-deploy-actions.mjs
+++ b/aio/scripts/deploy-to-firebase/pre-deploy-actions.mjs
@@ -4,7 +4,7 @@ import u from './utils.mjs';
 
 
 // Constants
-const DIST_DIR = 'dist/bin/aio/build';
+const DIST_DIR = '../dist/bin/aio/build';
 const FIREBASE_JSON_PATH = 'firebase.json';
 const NGSW_JSON_PATH = `${DIST_DIR}/ngsw.json`;
 const NGSW_JSON_BAK_PATH = `${NGSW_JSON_PATH}.bak`;


### PR DESCRIPTION
The script is run cd'ed into aio so the path to the Bazel dist location is up one folder.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The deploy script tries to access the build AIO app from the aio folder, but the dist dir was set relative to the project root.


## What is the new behavior?

Fix the relative dist dir.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
