### PR TITLE
build(bazel): remove write protection on aio dist folder for deployment

### DIFF
--- a/aio/scripts/deploy-to-firebase/pre-deploy-actions.mjs
+++ b/aio/scripts/deploy-to-firebase/pre-deploy-actions.mjs
@@ -36,6 +36,9 @@ function build({deployedUrl, deployEnv}) {
   u.logSectionHeader('Build the AIO app.');
   u.yarn(`build --aio_build_config=${deployEnv}`);
 
+  u.logSectionHeader('Remove write protection on the Bazel AIO distribution.');
+  sh.chmod('-R', 'u+w', DIST_DIR);
+
   u.logSectionHeader('Add any mode-specific files into the AIO distribution.');
   sh.cp('-rf', `src/extra-files/${deployEnv}/.`, DIST_DIR);
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Deploy script adds extra files to AIO dist and needs write access to Bazel output folder.

## What is the new behavior?

Grants write access.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

