### PR TITLE
build(bazel): point to correct dist folder in firebase config

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -2,7 +2,7 @@
   // Docs on Firebase hosting configuration: https://firebase.google.com/docs/hosting/full-config
   "hosting": {
     "target": "aio",
-    "public": "dist",
+    "public": "../dist/bin/aio/build",
     "cleanUrls": true,
     //////////////////////////////////////////////////////////////////////////////////////////////
     // ADDING REDIRECTS


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Firebase config points to old aio dist folder.


## What is the new behavior?

Point to the AIO dist folder in the Bazel output tree.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
