### PR TITLE
build(bazel): copy dist folder to aio for firebase deployment

### DIFF
--- a/aio/firebase.json
+++ b/aio/firebase.json
@@ -2,7 +2,7 @@
   // Docs on Firebase hosting configuration: https://firebase.google.com/docs/hosting/full-config
   "hosting": {
     "target": "aio",
-    "public": "../dist/bin/aio/build",
+    "public": "dist",
     "cleanUrls": true,
     //////////////////////////////////////////////////////////////////////////////////////////////
     // ADDING REDIRECTS

--- a/aio/scripts/deploy-to-firebase/index.mjs
+++ b/aio/scripts/deploy-to-firebase/index.mjs
@@ -384,6 +384,10 @@ function deploy(data) {
   u.logSectionHeader('Run pre-deploy actions.');
   preDeployActions.forEach(fn => fn(data));
 
+  // Firebase requires that the distributable be in the same folder as firebase.json.
+  u.logSectionHeader('Copy AIO distributable from Bazel output tree to aio/.');
+  sh.cp('-rf', pre.DIST_DIR, 'dist');
+
   u.logSectionHeader('Deploy AIO to Firebase hosting.');
   const firebase = cmd => u.yarn(`firebase ${cmd} --token "${firebaseToken}"`);
   firebase(`use "${projectId}"`);

--- a/aio/scripts/deploy-to-firebase/pre-deploy-actions.mjs
+++ b/aio/scripts/deploy-to-firebase/pre-deploy-actions.mjs
@@ -14,6 +14,7 @@ const exp = {
   build,
   checkPayloadSize,
   disableServiceWorker,
+  DIST_DIR,
   undo: {
     build: undoBuild,
     checkPayloadSize: undoCheckPayloadSize,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Firebase requires the distributable to be in the same folder as firebase.json. Deployment fails looking a level up in the bazel output tree.

## What is the new behavior?

Copy the distributable under aio for firebase.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
