### PR TITLE
build(bazel): fix pwa test metrics

### DIFF
--- a/aio/package.json
+++ b/aio/package.json
@@ -24,7 +24,7 @@
     "smoke-tests": "protractor tests/deployment/e2e/protractor.conf.js --suite smoke --baseUrl",
     "test-a11y-score": "bazel run //aio/scripts:test-aio-a11y",
     "test-a11y-score-localhost": "bazel test //aio:test-a11y-score-localhost",
-    "test-pwa-score": "sh -c 'bazel run //aio/scripts:audit-web-app ${0} ${1}'",
+    "test-pwa-score": "sh -c 'bazel run //aio/scripts:audit-web-app ${0} all:0,pwa:${1}'",
     "test-pwa-score-localhost": "bazel test //aio:test-pwa-score-localhost",
     "example-e2e": "node --experimental-import-meta-resolve tools/examples/run-filtered-example-e2es.mjs",
     "example-list-overrides": "bazel run //aio/tools/examples:example-boilerplate list-overrides",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Prior to the AIO bazel migration, the pwa test script only tested the pwa metric. A bug was introduced where the score target was used for all metrics, causing the AIO deploy test to fail.

## What is the new behavior?

Fixed regression in the pwa yarn script. See old version: https://github.com/angular/angular/blob/4f03a9c327102567b869a47810244fa43667ddab/aio/package.json#L42 for comparison.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No