### PR TITLE
refactor(forms): make FormBuilder classes provided in root

### DIFF
--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -9,7 +9,6 @@
 import {inject, Injectable} from '@angular/core';
 
 import {AsyncValidatorFn, ValidatorFn} from './directives/validators';
-import {ReactiveFormsModule} from './form_providers';
 import {AbstractControl, AbstractControlOptions, FormHooks} from './model/abstract_model';
 import {FormArray, UntypedFormArray} from './model/form_array';
 import {FormControl, FormControlOptions, FormControlState, UntypedFormControl} from './model/form_control';
@@ -107,7 +106,7 @@ export type ɵElement<T, N extends null> =
  *
  * @publicApi
  */
-@Injectable({providedIn: ReactiveFormsModule})
+@Injectable({providedIn: 'root'})
 export class FormBuilder {
   private useNonNullable: boolean = false;
 
@@ -370,7 +369,7 @@ export class FormBuilder {
  * @publicApi
  */
 @Injectable({
-  providedIn: ReactiveFormsModule,
+  providedIn: 'root',
   useFactory: () => inject(FormBuilder).nonNullable,
 })
 export abstract class NonNullableFormBuilder {
@@ -416,7 +415,7 @@ export abstract class NonNullableFormBuilder {
 /**
  * UntypedFormBuilder is the same as @see FormBuilder, but it provides untyped controls.
  */
-@Injectable({providedIn: ReactiveFormsModule})
+@Injectable({providedIn: 'root'})
 export class UntypedFormBuilder extends FormBuilder {
   /**
    * Like `FormBuilder#group`, except the resulting group is untyped.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: https://github.com/angular/angular/issues/48237


## What is the new behavior?
formBuilder is provided in root now.
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
