### PR TITLE
build: hide `--loader` warning when ESM import patch is installed

### DIFF
--- a/tools/defaults.bzl
+++ b/tools/defaults.bzl
@@ -413,6 +413,7 @@ def _apply_esm_import_patch(env, templated_args, data):
     env = dict(env, **{"NODE_MODULES_WORKSPACE_NAME": _node_modules_workspace_name()})
     templated_args = templated_args + [
         "--node_options=--loader=file:///$$(rlocation $(rootpath //tools/esm-loader:esm-loader.mjs))",
+        "--node_options=--no-warnings",  # `--loader` is an experimental feature with warnings.
     ]
     data = data + [
         "//tools/esm-loader",


### PR DESCRIPTION
Similar to the Rules NodeJS require patch, we have an ESM import patch as of the AIO Bazel migration (to support ESM scripts better).

This script uses `--loader`, an experimental NodeJS flag. This is similar to how `ts-node` uses it. We should disable the warnings as it results in a lot of unreadable Bazel output and the warnings are okay to be ignored. Note that we cannot fine-grain disable the specific warning so all others would be disabled too.

Realistically we haven't seen any in the past and long-term we will be not relying on patched resolution anyway (looking at `rules_js`).

Avoids spam like:

```
INFO: From NpmPackageBin aio/content/examples/toh-pt6/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/toh-pt0/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/inputs-outputs/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/two-way-binding/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/i18n/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/ngmodules/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/routing-with-urlmatcher/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/lifecycle-hooks/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/docs-style-guide/second.stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/template-reference-variables/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/providers-viewproviders/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/router/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/reactive-forms/stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
INFO: From NpmPackageBin aio/content/examples/http/specs.stackblitz.html:
(node:23) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
```