### PR TITLE
refactor(router): Remove DeprecatedLoadChildren

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -361,7 +361,7 @@ export interface IsActiveMatchOptions {
 }
 
 // @public
-export type LoadChildren = LoadChildrenCallback | ɵDeprecatedLoadChildren;
+export type LoadChildren = LoadChildrenCallback;
 
 // @public
 export type LoadChildrenCallback = () => Type<any> | NgModuleFactory<any> | Routes | Observable<Type<any> | Routes | DefaultExport<Type<any>> | DefaultExport<Routes>> | Promise<NgModuleFactory<any> | Type<any> | Routes | DefaultExport<Type<any>> | DefaultExport<Routes>>;

--- a/packages/router/src/deprecated_load_children.ts
+++ b/packages/router/src/deprecated_load_children.ts
@@ -12,14 +12,6 @@ import {Observable} from 'rxjs';
 // This file exists to support the legacy `loadChildren: string` behavior being patched back into
 // Angular.
 
-/**
- * Deprecated `loadChildren` value types.
- *
- * @publicApi
- * @deprecated represents the deprecated type side of `LoadChildren`.
- */
-export type DeprecatedLoadChildren = never;
-
 export function deprecatedLoadChildrenString(
     injector: Injector, loadChildren: unknown): Observable<NgModuleFactory<any>>|null {
   return null;

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -9,7 +9,6 @@
 import {EnvironmentInjector, EnvironmentProviders, InjectionToken, NgModuleFactory, Provider, Type} from '@angular/core';
 import {Observable} from 'rxjs';
 
-import {DeprecatedLoadChildren} from './deprecated_load_children';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
 import {UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
 
@@ -175,7 +174,7 @@ export type LoadChildrenCallback = () => Type<any>|NgModuleFactory<any>|Routes|
  * @see `LoadChildrenCallback`
  * @publicApi
  */
-export type LoadChildren = LoadChildrenCallback|DeprecatedLoadChildren;
+export type LoadChildren = LoadChildrenCallback;
 
 /**
  *

--- a/packages/router/src/private_export.ts
+++ b/packages/router/src/private_export.ts
@@ -8,7 +8,6 @@
 
 
 export {ɵEmptyOutletComponent} from './components/empty_outlet';
-export {DeprecatedLoadChildren as ɵDeprecatedLoadChildren} from './deprecated_load_children';
 export {RestoredState as ɵRestoredState} from './navigation_transition';
 export {withPreloading as ɵwithPreloading} from './provide_router';
 export {assignExtraOptionsToRouter as ɵassignExtraOptionsToRouter} from './router';


### PR DESCRIPTION
This option has already been removed from availability externally. Internally, the last use has been removed for the type on Route.loadChildren. More testing will be necessary to verify nothing relies on the other code paths.
