### PR TITLE
refactor(platform-browser): simplify `flattenStyles` method

### DIFF
--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -36,7 +36,7 @@ export function shimHostAttribute(componentShortId: string): string {
 }
 
 export function flattenStyles(compId: string, styles: Array<string|string[]>): string[] {
-  // Cannot use iInfinity` as depth as `infinity` is not a number literal in TypeScript.
+  // Cannot use `Infinity` as depth as `infinity` is not a number literal in TypeScript.
   // See: https://github.com/microsoft/TypeScript/issues/32277
   return styles.flat(100).map(s => s.replace(COMPONENT_REGEX, compId));
 }

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -36,7 +36,9 @@ export function shimHostAttribute(componentShortId: string): string {
 }
 
 export function flattenStyles(compId: string, styles: Array<string|string[]>): string[] {
-  return styles.flat().map(s => s.replace(COMPONENT_REGEX, compId));
+  // Cannot use iInfinity` as depth as `infinity` is not a number literal in TypeScript.
+  // See: https://github.com/microsoft/TypeScript/issues/32277
+  return styles.flat(100).map(s => s.replace(COMPONENT_REGEX, compId));
 }
 
 function decoratePreventDefault(eventHandler: Function): Function {

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -45,7 +45,7 @@ export class ServerRendererFactory2 implements RendererFactory2 {
       }
       default: {
         if (!this.rendererByCompId.has(type.id)) {
-          const styles = flattenStyles(type.id, type.styles, []);
+          const styles = flattenStyles(type.id, type.styles);
           this.sharedStylesHost.addStyles(styles);
           this.rendererByCompId.set(type.id, this.defaultRenderer);
         }
@@ -257,7 +257,7 @@ class EmulatedEncapsulationServerRenderer2 extends DefaultServerRenderer2 {
     super(eventManager, document, ngZone, schema);
     // Add a 's' prefix to style attributes to indicate server.
     const componentId = 's' + component.id;
-    const styles = flattenStyles(componentId, component.styles, []);
+    const styles = flattenStyles(componentId, component.styles);
     sharedStylesHost.addStyles(styles);
 
     this.contentAttr = shimContentAttribute(componentId);


### PR DESCRIPTION
With this change we simplify the `flattenStyles` logic using modern JavaScript.
