### PR TITLE
fix(platform-browser): remove styles from DOM of destroyed components

### DIFF
--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -184,6 +184,9 @@ export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef
 export function provideProtractorTestingSupport(): Provider[];
 
 // @public
+export const REMOVE_STYLES_ON_COMPONENT_DESTROY: InjectionToken<boolean>;
+
+// @public
 export interface SafeHtml extends SafeValue {
 }
 

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 466290,
+      "main": 467355,
       "polyfills": 33836,
       "styles": 74561,
       "light-theme": 92890,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,7 +2,7 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 908,
-      "main": 125165,
+      "main": 126185,
       "polyfills": 33824
     }
   },
@@ -19,21 +19,21 @@
   "cli-hello-world-ivy-compat": {
     "uncompressed": {
       "runtime": 930,
-      "main": 132182,
+      "main": 133202,
       "polyfills": 33957
     }
   },
   "cli-hello-world-ivy-i18n": {
     "uncompressed": {
       "runtime": 926,
-      "main": 123543,
+      "main": 125026,
       "polyfills": 34628
     }
   },
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2734,
-      "main": 228122,
+      "main": 229111,
       "polyfills": 33842,
       "src_app_lazy_lazy_routes_ts": 487
     }
@@ -41,21 +41,21 @@
   "forms": {
     "uncompressed": {
       "runtime": 888,
-      "main": 157604,
+      "main": 158624,
       "polyfills": 33915
     }
   },
   "animations": {
     "uncompressed": {
       "runtime": 898,
-      "main": 156355,
+      "main": 157699,
       "polyfills": 33897
     }
   },
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 918,
-      "main": 84527,
+      "main": 85547,
       "polyfills": 33945
     }
   },

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -402,6 +402,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NoopAnimationDriver"
   },
   {
@@ -439,6 +442,9 @@
   },
   {
     "name": "REMOVAL_FLAG"
+  },
+  {
+    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
     "name": "RefCountOperator"
@@ -1309,9 +1315,6 @@
   },
   {
     "name": "removeNodesAfterAnimationDone"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -297,6 +297,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -319,6 +322,9 @@
   },
   {
     "name": "R3Injector"
+  },
+  {
+    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
     "name": "RefCountOperator"
@@ -997,9 +1003,6 @@
   },
   {
     "name": "removeFromArray"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -408,6 +408,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -442,6 +445,9 @@
   },
   {
     "name": "R3ViewContainerRef"
+  },
+  {
+    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
     "name": "RadioControlRegistryModule"
@@ -1450,9 +1456,6 @@
   },
   {
     "name": "removeListItem2"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "removeValidators"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -399,6 +399,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -433,6 +436,9 @@
   },
   {
     "name": "R3ViewContainerRef"
+  },
+  {
+    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
     "name": "REQUIRED_VALIDATOR"
@@ -1414,9 +1420,6 @@
   },
   {
     "name": "removeListItem"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "removeValidators"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -477,6 +477,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -532,6 +535,9 @@
   },
   {
     "name": "R3ViewContainerRef"
+  },
+  {
+    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
     "name": "ROUTER_CONFIGURATION"
@@ -1762,9 +1768,6 @@
   },
   {
     "name": "removeFromArray"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -270,6 +270,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -289,6 +292,9 @@
   },
   {
     "name": "R3Injector"
+  },
+  {
+    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
     "name": "RefCountOperator"
@@ -868,9 +874,6 @@
   },
   {
     "name": "removeFromArray"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -312,6 +312,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -346,6 +349,9 @@
   },
   {
     "name": "R3ViewContainerRef"
+  },
+  {
+    "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
     "name": "RefCountOperator"
@@ -1210,9 +1216,6 @@
   },
   {
     "name": "removeFromArray"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/render3/imported_renderer2.ts
+++ b/packages/core/test/render3/imported_renderer2.ts
@@ -8,7 +8,6 @@
 
 import {ɵAnimationEngine, ɵNoopAnimationStyleNormalizer} from '@angular/animations/browser';
 import {MockAnimationDriver} from '@angular/animations/browser/testing';
-import {ɵgetDOM as getDOM} from '@angular/common';
 import {NgZone, RendererFactory2, RendererType2} from '@angular/core';
 import {NoopNgZone} from '@angular/core/src/zone/ng_zone';
 import {EventManager, ɵDomRendererFactory2, ɵDomSharedStylesHost} from '@angular/platform-browser';
@@ -39,8 +38,8 @@ export class SimpleDomEventsPlugin extends EventManagerPlugin {
 export function getRendererFactory2(document: any): RendererFactory2 {
   const fakeNgZone: NgZone = new NoopNgZone();
   const eventManager = new EventManager([new SimpleDomEventsPlugin(document)], fakeNgZone);
-  const rendererFactory =
-      new ɵDomRendererFactory2(eventManager, new ɵDomSharedStylesHost(document), 'dummyappid');
+  const rendererFactory = new ɵDomRendererFactory2(
+      eventManager, new ɵDomSharedStylesHost(document), 'dummyappid', true);
   const origCreateRenderer = rendererFactory.createRenderer;
   rendererFactory.createRenderer = function(element: any, type: RendererType2|null) {
     const renderer = origCreateRenderer.call(this, element, type);

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -13,7 +13,7 @@ import {BrowserDomAdapter} from './browser/browser_adapter';
 import {SERVER_TRANSITION_PROVIDERS, TRANSITION_ID} from './browser/server-transition';
 import {BrowserGetTestability} from './browser/testability';
 import {BrowserXhr} from './browser/xhr';
-import {DomRendererFactory2} from './dom/dom_renderer';
+import {DomRendererFactory2, REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
 import {DomEventsPlugin} from './dom/events/dom_events';
 import {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 import {KeyEventsPlugin} from './dom/events/key_events';
@@ -207,7 +207,7 @@ const BROWSER_MODULE_PROVIDERS: Provider[] = [
   {provide: EVENT_MANAGER_PLUGINS, useClass: KeyEventsPlugin, multi: true, deps: [DOCUMENT]}, {
     provide: DomRendererFactory2,
     useClass: DomRendererFactory2,
-    deps: [EventManager, DomSharedStylesHost, APP_ID]
+    deps: [EventManager, DomSharedStylesHost, APP_ID, REMOVE_STYLES_ON_COMPONENT_DESTROY]
   },
   {provide: RendererFactory2, useExisting: DomRendererFactory2},
   {provide: SharedStylesHost, useExisting: DomSharedStylesHost},

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -28,8 +28,7 @@ export const HOST_ATTR = `_nghost-${COMPONENT_VARIABLE}`;
 export const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
 
 /**
- * The value for `REMOVE_STYLES_ON_COMPONENT_DESTROY` DI token.
- * @defaultvalue false
+ * The default value for the `REMOVE_STYLES_ON_COMPONENT_DESTROY` DI token.
  */
 const REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT = false;
 
@@ -38,7 +37,6 @@ const REMOVE_STYLES_ON_COMPONENT_DESTROY_DEFAULT = false;
  * of destroyed components should be removed from DOM.
  *
  * By default, the value is set to `false`. This will be changed in the next major version.
-
  * @publicApi
  */
 export const REMOVE_STYLES_ON_COMPONENT_DESTROY =

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_ID, Inject, Injectable, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2, ViewEncapsulation} from '@angular/core';
+import {APP_ID, Inject, Injectable, InjectionToken, OnDestroy, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2, ViewEncapsulation} from '@angular/core';
 
 import {EventManager} from './events/event_manager';
 import {DomSharedStylesHost} from './shared_styles_host';
@@ -26,6 +26,21 @@ const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 export const COMPONENT_VARIABLE = '%COMP%';
 export const HOST_ATTR = `_nghost-${COMPONENT_VARIABLE}`;
 export const CONTENT_ATTR = `_ngcontent-${COMPONENT_VARIABLE}`;
+
+
+/**
+ * A [DI token](guide/glossary#di-token "DI token definition") that indicates whether styles
+ * of destroyed components should be removed from DOM.
+ *
+ * By default, the value is set to `false`. This will be changed in the next major version.
+
+ * @publicApi
+ */
+export const REMOVE_STYLES_ON_COMPONENT_DESTROY =
+    new InjectionToken<boolean>('RemoveStylesOnCompDestory', {
+      providedIn: 'root',
+      factory: () => false,
+    });
 
 export function shimContentAttribute(componentShortId: string): string {
   return CONTENT_ATTR.replace(COMPONENT_REGEX, componentShortId);
@@ -67,13 +82,15 @@ function decoratePreventDefault(eventHandler: Function): Function {
 }
 
 @Injectable()
-export class DomRendererFactory2 implements RendererFactory2 {
-  private rendererByCompId = new Map<string, Renderer2>();
+export class DomRendererFactory2 implements RendererFactory2, OnDestroy {
+  private rendererByCompId =
+      new Map<string, EmulatedEncapsulationDomRenderer2|NoneEncapsulationDomRenderer>();
   private defaultRenderer: Renderer2;
 
   constructor(
       private eventManager: EventManager, private sharedStylesHost: DomSharedStylesHost,
-      @Inject(APP_ID) private appId: string) {
+      @Inject(APP_ID) private appId: string,
+      @Inject(REMOVE_STYLES_ON_COMPONENT_DESTROY) private removeStylesOnCompDestory: boolean) {
     this.defaultRenderer = new DefaultDomRenderer2(eventManager);
   }
 
@@ -81,28 +98,43 @@ export class DomRendererFactory2 implements RendererFactory2 {
     if (!element || !type) {
       return this.defaultRenderer;
     }
-    switch (type.encapsulation) {
-      case ViewEncapsulation.Emulated: {
-        let renderer = this.rendererByCompId.get(type.id);
-        if (!renderer) {
-          renderer = new EmulatedEncapsulationDomRenderer2(
-              this.eventManager, this.sharedStylesHost, type, this.appId);
-          this.rendererByCompId.set(type.id, renderer);
-        }
-        (<EmulatedEncapsulationDomRenderer2>renderer).applyToHost(element);
-        return renderer;
-      }
-      case ViewEncapsulation.ShadowDom:
-        return new ShadowDomRenderer(this.eventManager, this.sharedStylesHost, element, type);
-      default: {
-        if (!this.rendererByCompId.has(type.id)) {
-          const styles = flattenStyles(type.id, type.styles);
-          this.sharedStylesHost.addStyles(styles);
-          this.rendererByCompId.set(type.id, this.defaultRenderer);
-        }
-        return this.defaultRenderer;
-      }
+
+    const renderer = this.getOrCreateRenderer(element, type);
+    if (renderer instanceof EmulatedEncapsulationDomRenderer2) {
+      renderer.applyToHost(element);
+    } else if (renderer instanceof NoneEncapsulationDomRenderer) {
+      renderer.applyStyles();
     }
+
+    return renderer;
+  }
+
+  private getOrCreateRenderer(element: any, type: RendererType2): Renderer2 {
+    let renderer = this.rendererByCompId.get(type.id);
+    if (!renderer) {
+      switch (type.encapsulation) {
+        case ViewEncapsulation.Emulated:
+          renderer = new EmulatedEncapsulationDomRenderer2(
+              this.eventManager, this.sharedStylesHost, type, this.appId,
+              this.removeStylesOnCompDestory);
+          break;
+        case ViewEncapsulation.ShadowDom:
+          return new ShadowDomRenderer(this.eventManager, this.sharedStylesHost, element, type);
+        default:
+          renderer = new NoneEncapsulationDomRenderer(
+              this.eventManager, this.sharedStylesHost, type, this.removeStylesOnCompDestory);
+          break;
+      }
+
+      renderer.onDestroy = () => this.rendererByCompId.delete(type.id);
+      this.rendererByCompId.set(type.id, renderer);
+    }
+
+    return renderer;
+  }
+
+  ngOnDestroy() {
+    this.rendererByCompId.clear();
   }
 
   begin() {}
@@ -269,32 +301,6 @@ function isTemplateNode(node: any): node is HTMLTemplateElement {
   return node.tagName === 'TEMPLATE' && node.content !== undefined;
 }
 
-class EmulatedEncapsulationDomRenderer2 extends DefaultDomRenderer2 {
-  private contentAttr: string;
-  private hostAttr: string;
-
-  constructor(
-      eventManager: EventManager, sharedStylesHost: DomSharedStylesHost,
-      private component: RendererType2, appId: string) {
-    super(eventManager);
-    const styles = flattenStyles(appId + '-' + component.id, component.styles);
-    sharedStylesHost.addStyles(styles);
-
-    this.contentAttr = shimContentAttribute(appId + '-' + component.id);
-    this.hostAttr = shimHostAttribute(appId + '-' + component.id);
-  }
-
-  applyToHost(element: any) {
-    super.setAttribute(element, this.hostAttr, '');
-  }
-
-  override createElement(parent: any, name: string): Element {
-    const el = super.createElement(parent, name);
-    super.setAttribute(el, this.contentAttr, '');
-    return el;
-  }
-}
-
 class ShadowDomRenderer extends DefaultDomRenderer2 {
   private shadowRoot: any;
 
@@ -303,21 +309,19 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
       private hostEl: any, component: RendererType2) {
     super(eventManager);
     this.shadowRoot = (hostEl as any).attachShadow({mode: 'open'});
+
     this.sharedStylesHost.addHost(this.shadowRoot);
     const styles = flattenStyles(component.id, component.styles);
-    for (let i = 0; i < styles.length; i++) {
+
+    for (const style of styles) {
       const styleEl = document.createElement('style');
-      styleEl.textContent = styles[i];
+      styleEl.textContent = style;
       this.shadowRoot.appendChild(styleEl);
     }
   }
 
   private nodeOrShadowRoot(node: any): any {
     return node === this.hostEl ? this.shadowRoot : node;
-  }
-
-  override destroy() {
-    this.sharedStylesHost.removeHost(this.shadowRoot);
   }
 
   override appendChild(parent: any, newChild: any): void {
@@ -331,5 +335,68 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
   }
   override parentNode(node: any): any {
     return this.nodeOrShadowRoot(super.parentNode(this.nodeOrShadowRoot(node)));
+  }
+
+  override destroy() {
+    this.sharedStylesHost.removeHost(this.shadowRoot);
+  }
+}
+
+class NoneEncapsulationDomRenderer extends DefaultDomRenderer2 {
+  private readonly styles: string[];
+  private rendererUsageCount = 0;
+  onDestroy: VoidFunction|undefined;
+
+  constructor(
+      eventManager: EventManager,
+      private readonly sharedStylesHost: DomSharedStylesHost,
+      component: RendererType2,
+      private removeStylesOnCompDestory: boolean,
+      compId = component.id,
+  ) {
+    super(eventManager);
+    this.styles = flattenStyles(compId, component.styles);
+  }
+
+  applyStyles(): void {
+    this.sharedStylesHost.addStyles(this.styles);
+    this.rendererUsageCount++;
+  }
+
+  override destroy(): void {
+    if (!this.removeStylesOnCompDestory) {
+      return;
+    }
+
+    this.sharedStylesHost.removeStyles(this.styles);
+    this.rendererUsageCount--;
+    if (this.rendererUsageCount === 0) {
+      this.onDestroy?.();
+    }
+  }
+}
+
+class EmulatedEncapsulationDomRenderer2 extends NoneEncapsulationDomRenderer {
+  private contentAttr: string;
+  private hostAttr: string;
+
+  constructor(
+      eventManager: EventManager, sharedStylesHost: DomSharedStylesHost, component: RendererType2,
+      appId: string, removeStylesOnCompDestory: boolean) {
+    const compId = appId + '-' + component.id;
+    super(eventManager, sharedStylesHost, component, removeStylesOnCompDestory, compId);
+    this.contentAttr = shimContentAttribute(compId);
+    this.hostAttr = shimHostAttribute(compId);
+  }
+
+  applyToHost(element: any): void {
+    this.applyStyles();
+    this.setAttribute(element, this.hostAttr, '');
+  }
+
+  override createElement(parent: any, name: string): Element {
+    const el = super.createElement(parent, name);
+    super.setAttribute(el, this.contentAttr, '');
+    return el;
   }
 }

--- a/packages/platform-browser/src/dom/shared_styles_host.ts
+++ b/packages/platform-browser/src/dom/shared_styles_host.ts
@@ -6,75 +6,108 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
+import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable, OnDestroy} from '@angular/core';
 
 @Injectable()
-export class SharedStylesHost {
-  /** @internal */
-  protected _stylesSet = new Set<string>();
+export class SharedStylesHost implements OnDestroy {
+  private readonly usedStyles = new Map<string /** Style string */, number /** Usage count */>();
 
   addStyles(styles: string[]): void {
-    const additions = new Set<string>();
-    styles.forEach(style => {
-      if (!this._stylesSet.has(style)) {
-        this._stylesSet.add(style);
-        additions.add(style);
+    for (const style of styles) {
+      let usedCount = this.usedStyles.get(style) ?? 0;
+      usedCount++;
+      this.usedStyles.set(style, usedCount);
+
+      if (usedCount === 1) {
+        this.onStyleAdded(style);
       }
-    });
-    this.onStylesAdded(additions);
+    }
   }
 
-  onStylesAdded(additions: Set<string>): void {}
+  removeStyles(styles: string[]): void {
+    for (const style of styles) {
+      let usedCount = this.usedStyles.get(style) ?? 0;
+      usedCount--;
 
-  getAllStyles(): string[] {
-    return Array.from(this._stylesSet);
+      if (usedCount > 0) {
+        this.usedStyles.set(style, usedCount);
+      } else {
+        this.usedStyles.delete(style);
+        this.onStyleRemoved(style);
+      }
+    }
+  }
+
+  onStyleRemoved(style: string): void {}
+
+  onStyleAdded(style: string): void {}
+
+  getAllStyles(): IterableIterator<string> {
+    return this.usedStyles.keys();
+  }
+
+  ngOnDestroy(): void {
+    for (const style of this.getAllStyles()) {
+      this.onStyleRemoved(style);
+    }
+
+    this.usedStyles.clear();
   }
 }
 
 @Injectable()
 export class DomSharedStylesHost extends SharedStylesHost implements OnDestroy {
   // Maps all registered host nodes to a list of style nodes that have been added to the host node.
-  private _hostNodes = new Map<Node, Node[]>();
+  private readonly styleRef = new Map<string, HTMLStyleElement[]>();
+  private hostNodes = new Set<Node>();
 
-  constructor(@Inject(DOCUMENT) private _doc: any) {
+  constructor(@Inject(DOCUMENT) private readonly doc: any) {
     super();
-    this._hostNodes.set(_doc.head, []);
+    this.hostNodes.add(this.doc.head);
   }
 
-  private _addStylesToHost(styles: Set<string>, host: Node, styleNodes: Node[]): void {
-    styles.forEach((style: string) => {
-      const styleEl = this._doc.createElement('style');
-      styleEl.textContent = style;
-      styleNodes.push(host.appendChild(styleEl));
-    });
+  override onStyleAdded(style: string): void {
+    for (const host of this.hostNodes) {
+      this.addStyleToHost(host, style);
+    }
+  }
+
+  override onStyleRemoved(style: string): void {
+    const styleElements = this.styleRef.get(style);
+    styleElements?.forEach(e => e.remove());
+    this.styleRef.delete(style);
+  }
+
+  override ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this.styleRef.clear();
+    this.hostNodes.clear();
+    this.hostNodes.add(this.doc.head);
   }
 
   addHost(hostNode: Node): void {
-    const styleNodes: Node[] = [];
-    this._addStylesToHost(this._stylesSet, hostNode, styleNodes);
-    this._hostNodes.set(hostNode, styleNodes);
+    this.hostNodes.add(hostNode);
+
+    for (const style of this.getAllStyles()) {
+      this.addStyleToHost(hostNode, style);
+    }
   }
 
   removeHost(hostNode: Node): void {
-    const styleNodes = this._hostNodes.get(hostNode);
-    if (styleNodes) {
-      styleNodes.forEach(removeStyle);
+    this.hostNodes.delete(hostNode);
+  }
+
+  private addStyleToHost(host: Node, style: string): void {
+    const styleEl = this.doc.createElement('style');
+    styleEl.textContent = style;
+    host.appendChild(styleEl);
+
+    const styleRef = this.styleRef.get(style);
+    if (styleRef) {
+      styleRef.push(styleEl);
+    } else {
+      this.styleRef.set(style, [styleEl]);
     }
-    this._hostNodes.delete(hostNode);
   }
-
-  override onStylesAdded(additions: Set<string>): void {
-    this._hostNodes.forEach((styleNodes, hostNode) => {
-      this._addStylesToHost(additions, hostNode, styleNodes);
-    });
-  }
-
-  ngOnDestroy(): void {
-    this._hostNodes.forEach(styleNodes => styleNodes.forEach(removeStyle));
-  }
-}
-
-function removeStyle(styleNode: Node): void {
-  getDOM().remove(styleNode);
 }

--- a/packages/platform-browser/src/dom/shared_styles_host.ts
+++ b/packages/platform-browser/src/dom/shared_styles_host.ts
@@ -72,7 +72,7 @@ export class DomSharedStylesHost extends SharedStylesHost implements OnDestroy {
 
   constructor(@Inject(DOCUMENT) private readonly doc: any) {
     super();
-    this.hostNodes.add(this.doc.head);
+    this.resetHostNodes();
   }
 
   override onStyleAdded(style: string): void {
@@ -91,11 +91,7 @@ export class DomSharedStylesHost extends SharedStylesHost implements OnDestroy {
   override ngOnDestroy(): void {
     super.ngOnDestroy();
     this.styleRef.clear();
-
-    const hostNodes = this.hostNodes;
-    hostNodes.clear();
-    // Re-add the head element back since thi sis the default host.
-    hostNodes.add(this.doc.head);
+    this.resetHostNodes();
   }
 
   addHost(hostNode: Node): void {
@@ -121,5 +117,12 @@ export class DomSharedStylesHost extends SharedStylesHost implements OnDestroy {
     } else {
       this.styleRef.set(style, [styleEl]);
     }
+  }
+
+  private resetHostNodes(): void {
+    const hostNodes = this.hostNodes;
+    hostNodes.clear();
+    // Re-add the head element back since this is the default host.
+    hostNodes.add(this.doc.head);
   }
 }

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -12,6 +12,7 @@ export {Title} from './browser/title';
 export {disableDebugTools, enableDebugTools} from './browser/tools/tools';
 export {BrowserTransferStateModule, makeStateKey, StateKey, TransferState} from './browser/transfer_state';
 export {By} from './dom/debug/by';
+export {REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
 export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerLoader, HammerModule} from './dom/events/hammer_gestures';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {Component, Renderer2, ViewEncapsulation} from '@angular/core';
-import {TestBed} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
-import {NAMESPACE_URIS} from '@angular/platform-browser/src/dom/dom_renderer';
+import {NAMESPACE_URIS, REMOVE_STYLES_ON_COMPONENT_DESTROY} from '@angular/platform-browser/src/dom/dom_renderer';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 {
@@ -24,9 +24,13 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
     beforeEach(() => {
       TestBed.configureTestingModule({
         declarations: [
-          TestCmp, SomeApp, CmpEncapsulationEmulated, CmpEncapsulationShadow, CmpEncapsulationNone,
-          CmpEncapsulationShadow
-        ]
+          TestCmp,
+          SomeApp,
+          SomeAppForCleanUp,
+          CmpEncapsulationEmulated,
+          CmpEncapsulationNone,
+          CmpEncapsulationShadow,
+        ],
       });
       renderer = TestBed.createComponent(TestCmp).componentInstance.renderer;
     });
@@ -105,6 +109,8 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
     it('should allow to style components with emulated encapsulation and no encapsulation inside of components with shadow DOM',
        () => {
          const fixture = TestBed.createComponent(SomeApp);
+         fixture.detectChanges();
+
          const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
          const shadow = cmp.shadowRoot.querySelector('.shadow');
 
@@ -136,8 +142,138 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
       expect(otherChild.parentNode).toBe(template.content);
     });
+
+    describe('should not cleanup styles of destroyed components by default', () => {
+      it('works for components without encapsulation emulated', () => {
+        const fixture = TestBed.createComponent(SomeAppForCleanUp);
+        const compInstance = fixture.componentInstance;
+        compInstance.showEmulatedComponents = true;
+
+        fixture.detectChanges();
+        // verify style is in DOM
+        expect(styleCount(fixture, '.emulated')).toBe(1);
+
+        // Remove a single instance of the component.
+        compInstance.componentOneInstanceHidden = true;
+        fixture.detectChanges();
+        // Verify style is still in DOM
+        expect(styleCount(fixture, '.emulated')).toBe(1);
+
+        // Hide all instances of the component
+        compInstance.componentTwoInstanceHidden = true;
+        fixture.detectChanges();
+
+        // Verify style is still in DOM
+        expect(styleCount(fixture, '.emulated')).toBe(1);
+      });
+
+      it('works for components without encapsulation none', () => {
+        const fixture = TestBed.createComponent(SomeAppForCleanUp);
+        const compInstance = fixture.componentInstance;
+        compInstance.showEmulatedComponents = false;
+
+        fixture.detectChanges();
+        // verify style is in DOM
+        expect(styleCount(fixture, '.none')).toBe(1);
+
+        // Remove a single instance of the component.
+        compInstance.componentOneInstanceHidden = true;
+        fixture.detectChanges();
+        // Verify style is still in DOM
+        expect(styleCount(fixture, '.none')).toBe(1);
+
+        // Hide all instances of the component
+        compInstance.componentTwoInstanceHidden = true;
+        fixture.detectChanges();
+
+        // Verify style is still in DOM
+        expect(styleCount(fixture, '.none')).toBe(1);
+      });
+    });
+
+    describe(
+        'should cleanup styles of destroyed components when `REMOVE_STYLES_ON_COMPONENT_DESTROY` is `true`',
+        () => {
+          beforeEach(() => {
+            TestBed.resetTestingModule();
+
+            TestBed.configureTestingModule({
+              declarations: [
+                SomeAppForCleanUp,
+                CmpEncapsulationEmulated,
+                CmpEncapsulationNone,
+              ],
+              providers: [
+                {
+                  provide: REMOVE_STYLES_ON_COMPONENT_DESTROY,
+                  useValue: true,
+                },
+              ],
+            });
+          });
+
+          it('works for components without encapsulation emulated', () => {
+            const fixture = TestBed.createComponent(SomeAppForCleanUp);
+            const compInstance = fixture.componentInstance;
+            compInstance.showEmulatedComponents = true;
+
+            fixture.detectChanges();
+            // verify style is in DOM
+            expect(styleCount(fixture, '.emulated')).toBe(1);
+
+            // Remove a single instance of the component.
+            compInstance.componentOneInstanceHidden = true;
+            fixture.detectChanges();
+            // Verify style is still in DOM
+            expect(styleCount(fixture, '.emulated')).toBe(1);
+
+            // Hide all instances of the component
+            compInstance.componentTwoInstanceHidden = true;
+            fixture.detectChanges();
+
+            // Verify style is not in DOM
+            expect(styleCount(fixture, '.emulated')).toBe(0);
+          });
+
+          it('works for components without encapsulation none', () => {
+            const fixture = TestBed.createComponent(SomeAppForCleanUp);
+            const compInstance = fixture.componentInstance;
+            compInstance.showEmulatedComponents = false;
+
+            fixture.detectChanges();
+            // verify style is in DOM
+            expect(styleCount(fixture, '.none')).toBe(1);
+
+            // Remove a single instance of the component.
+            compInstance.componentOneInstanceHidden = true;
+            fixture.detectChanges();
+            // Verify style is still in DOM
+            expect(styleCount(fixture, '.none')).toBe(1);
+
+            // Hide all instances of the component
+            compInstance.componentTwoInstanceHidden = true;
+            fixture.detectChanges();
+
+            // Verify style is not in DOM
+            expect(styleCount(fixture, '.emulated')).toBe(0);
+          });
+        });
   });
 }
+
+function styleCount(fixture: ComponentFixture<unknown>, cssContentMatcher: string): number {
+  const html = fixture.debugElement.parent?.parent;
+  const debugElements = html?.queryAll(By.css('style'));
+
+  if (!debugElements) {
+    return 0;
+  }
+
+  return debugElements
+      .filter(({nativeElement}) => nativeElement.textContent.includes(cssContentMatcher))
+      .length;
+}
+
 
 @Component({
   selector: 'cmp-emulated',
@@ -169,9 +305,9 @@ class CmpEncapsulationShadow {
 @Component({
   selector: 'some-app',
   template: `
-	  <cmp-shadow></cmp-shadow>
-	  <cmp-emulated></cmp-emulated>
-	  <cmp-none></cmp-none>
+    <cmp-shadow></cmp-shadow>
+    <cmp-emulated></cmp-emulated>
+    <cmp-none></cmp-none>
   `,
 })
 export class SomeApp {
@@ -180,4 +316,20 @@ export class SomeApp {
 @Component({selector: 'test-cmp', template: ''})
 class TestCmp {
   constructor(public renderer: Renderer2) {}
+}
+
+@Component({
+  selector: 'some-app',
+  template: `
+    <cmp-emulated *ngIf="!componentOneInstanceHidden && showEmulatedComponents"></cmp-emulated>
+    <cmp-emulated *ngIf="!componentTwoInstanceHidden && showEmulatedComponents"></cmp-emulated>
+
+    <cmp-none *ngIf="!componentOneInstanceHidden && !showEmulatedComponents"></cmp-none>
+    <cmp-none *ngIf="!componentTwoInstanceHidden && !showEmulatedComponents"></cmp-none>
+  `,
+})
+export class SomeAppForCleanUp {
+  componentOneInstanceHidden = false;
+  componentTwoInstanceHidden = false;
+  showEmulatedComponents = true;
 }

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -46,15 +46,6 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       expect(doc.head).toHaveText('a {};b {};');
     });
 
-    it('should remove style nodes when the host is removed', () => {
-      ssh.addStyles(['a {};']);
-      ssh.addHost(someHost);
-      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
-
-      ssh.removeHost(someHost);
-      expect(someHost.innerHTML).toEqual('');
-    });
-
     it('should remove style nodes on destroy', () => {
       ssh.addStyles(['a {};']);
       ssh.addHost(someHost);

--- a/packages/platform-server/src/styles_host.ts
+++ b/packages/platform-server/src/styles_host.ts
@@ -22,8 +22,8 @@ export class ServerStylesHost extends SharedStylesHost {
     this.head = doc.getElementsByTagName('head')[0];
   }
 
-  private _addStyle(style: string): void {
-    let adapter = getDOM();
+  override onStyleAdded(style: string): void {
+    const adapter = getDOM();
     const el = adapter.createElement('style');
     el.textContent = style;
     if (!!this.transitionId) {
@@ -33,11 +33,9 @@ export class ServerStylesHost extends SharedStylesHost {
     this._styleNodes.add(el);
   }
 
-  override onStylesAdded(additions: Set<string>) {
-    additions.forEach(style => this._addStyle(style));
-  }
-
-  ngOnDestroy() {
+  override ngOnDestroy() {
     this._styleNodes.forEach(styleNode => styleNode.remove());
+    this._styleNodes.clear();
+    super.ngOnDestroy();
   }
 }


### PR DESCRIPTION

Currently style of components using `encapsulation`, `None` or `Emulated` will not be removed from the DOM once the component get destroyed.

This change addresses this by keeping track of the number of times a component is rendered, when the component is destroyed the counter is decreased and once this reaches zero the style element is removed from the DOM.

Currently, this new behaviour is on opt-in bases, but it will be changed in the next major version.

To opt-in, set the `REMOVE_STYLES_ON_COMPONENT_DESTROY` DI token to `true`.

Example 
```ts
@NgModule({
 declarations: [
   AppComponent,
 ],
 imports: [
   BrowserModule
 ],
 providers: [
   { provide: REMOVE_STYLES_ON_COMPONENT_DESTROY, useValue: true }
 ],
 bootstrap: [AppComponent]
})
export class AppModule { }
```

Closes #16670
