### PR TITLE
fix(compiler): fix inconsistant decoding of hard coded html entities in interpolated expressions

### DIFF
--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -395,7 +395,7 @@ class _TreeBuilder {
           // expressions. This is arguably a bug, but it could be a considerable breaking change to
           // fix it. It should be addressed in a larger project to refactor the entire parser/lexer
           // chain after View Engine has been removed.
-          value += valueToken.parts.join('').replace(/&([^;]+);/g, decodeEntity);
+          value += valueToken.parts.join('').replace(/&([^&;]+);/g, decodeEntity);
         } else if (valueToken.type === TokenType.ENCODED_ENTITY) {
           value += valueToken.parts[0];
         } else {

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -777,6 +777,16 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
               ]);
         });
 
+        it('should interpolate correctly the nbsp entity', () => {
+          const template = `<div title="{{ (1) ? '=&nbsp;=' : '' }}"></div>
+                            <div title="{{ (1 && 1) ? '=&nbsp;=' : '' }}"></div>`;
+          const parsed = parser.parse(template, 'TestComp');
+
+          expect((parsed.rootNodes[0] as any).attrs[0].value).toBe(`{{ (1) ? '=\xA0=' : '' }}`);
+          expect((parsed.rootNodes[2] as any).attrs[0].value)
+              .toBe(`{{ (1 && 1) ? '=\xA0=' : '' }}`);
+        });
+
         it('should set the start and end source spans', () => {
           const node = <html.Element>parser.parse('<div>a</div>', 'TestComp').rootNodes[0];
 


### PR DESCRIPTION
Handle correctly decoding of hardcoded HTML entities when there is an extra ampersand in the interpolated string

fixes #44827

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] No