### PR TITLE
fix(compiler-cli): Produce diagnostic rather than crash when using in…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/metadata/src/host_directives_resolver.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/host_directives_resolver.ts
@@ -43,12 +43,9 @@ export class HostDirectivesResolver {
     for (const current of directives) {
       const hostMeta = flattenInheritedDirectiveMetadata(this.metaReader, current.directive);
 
-      // This case has been checked for already, but we keep the assertion here so that the
-      // user gets a better error message than "Cannot read property foo of null" in case
-      // something slipped through.
+      // This case has been checked for already and produces a diagnostic
       if (hostMeta === null) {
-        throw new Error(
-            `Could not resolve host directive metadata of ${current.directive.debugName}`);
+        continue;
       }
 
       if (hostMeta.hostDirectives) {

--- a/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
@@ -21,10 +21,10 @@ import {ClassPropertyMapping, ClassPropertyName} from './property_mapping';
  * followed.
  */
 export function flattenInheritedDirectiveMetadata(
-    reader: MetadataReader, dir: Reference<ClassDeclaration>): DirectiveMeta {
+    reader: MetadataReader, dir: Reference<ClassDeclaration>): DirectiveMeta|null {
   const topMeta = reader.getDirectiveMetadata(dir);
   if (topMeta === null) {
-    throw new Error(`Metadata not found for directive: ${dir.debugName}`);
+    return null;
   }
   if (topMeta.baseClass === null) {
     return topMeta;

--- a/packages/compiler-cli/src/ngtsc/scope/src/typecheck.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/src/typecheck.ts
@@ -99,6 +99,9 @@ export class TypeCheckScopeRegistry {
     for (const meta of dependencies) {
       if (meta.kind === MetaKind.Directive && meta.selector !== null) {
         const extMeta = this.getTypeCheckDirectiveMetadata(meta.ref);
+        if (extMeta === null) {
+          continue;
+        }
         matcher.addSelectables(
             CssSelector.parse(meta.selector),
             [...this.hostDirectivesResolver.resolve(extMeta), extMeta]);
@@ -125,13 +128,16 @@ export class TypeCheckScopeRegistry {
     return typeCheckScope;
   }
 
-  getTypeCheckDirectiveMetadata(ref: Reference<ClassDeclaration>): DirectiveMeta {
+  getTypeCheckDirectiveMetadata(ref: Reference<ClassDeclaration>): DirectiveMeta|null {
     const clazz = ref.node;
     if (this.flattenedDirectiveMetaCache.has(clazz)) {
       return this.flattenedDirectiveMetaCache.get(clazz)!;
     }
 
     const meta = flattenInheritedDirectiveMetadata(this.metaReader, ref);
+    if (meta === null) {
+      return null;
+    }
     this.flattenedDirectiveMetaCache.set(clazz, meta);
     return meta;
   }

--- a/packages/compiler-cli/test/ngtsc/host_directives_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/host_directives_spec.ts
@@ -451,6 +451,24 @@ runInEachFileSystem(() => {
         expect(messages).toEqual(['Host directive HostDir must be standalone']);
       });
 
+      it('should produce a diagnostic if a host directive is not a directive', () => {
+        env.write('test.ts', `
+          import {Directive, Pipe, Component, NgModule} from '@angular/core';
+
+          @Pipe({name: 'hostDir'})
+          export class HostDir {}
+
+          @Directive({
+            hostDirectives: [HostDir],
+          })
+          export class Dir {}
+        `);
+
+        const messages = env.driveDiagnostics().map(extractMessage);
+        expect(messages).toEqual(
+            ['HostDir must be a standalone directive to be used as a host directive']);
+      });
+
       it('should produce a diagnostic if a host directive is a component', () => {
         env.write('test.ts', `
           import {Directive, Component, NgModule} from '@angular/core';


### PR DESCRIPTION
…valid hostDirective

Because the language service uses the compiler, we try to produce as much useful information as possible rather than throwing hard errors. Hard errors cause the compiler to crash. While this can be acceptable when compiling a program as part of a regular build, this is undesirable for the language service.
