### PR TITLE
build: fix AIO jobs not running with RBE and CircleCI Bazel settings

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -71,7 +71,7 @@ build:snapshot-build --stamp
 build --flag_alias=aio_build_config=//aio:flag_aio_build_config
 
 ####################################
-# AIO first party dep substitution # 
+# AIO first party dep substitution #
 # Turn on with                     #
 #  --config=aio_local_deps         #
 ####################################
@@ -173,4 +173,4 @@ build --flag_alias=ng_perf=//packages/compiler-cli:ng_perf
 
 # Load any settings which are specific to the current user. Needs to be *last* statement
 # in this config, as the user configuration should be able to overwrite flags from this file.
-try-import .bazelrc.user
+try-import %workspace%/.bazelrc.user

--- a/.circleci/bazel.common.rc
+++ b/.circleci/bazel.common.rc
@@ -1,8 +1,5 @@
 # Settings in this file should be OS agnostic. Use the bazel.<OS>.rc files for OS specific settings.
 
-# Don't be spammy in the logs
-build --noshow_progress
-
 # Print all the options that apply to the build.
 # This helps us diagnose which options override others
 # (e.g. /etc/bazel.bazelrc vs. tools/bazel.rc)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -25,6 +25,10 @@ http_archive(
 
 http_archive(
     name = "build_bazel_rules_nodejs",
+    patches = [
+        # TODO(devversion): remove when https://github.com/bazelbuild/rules_nodejs/pull/3605 is available.
+        "//tools:bazel-repo-patches/rules_nodejs__#3605.patch",
+    ],
     sha256 = "c29944ba9b0b430aadcaf3bf2570fece6fc5ebfb76df145c6cdad40d65c20811",
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.7.0/rules_nodejs-5.7.0.tar.gz"],
 )

--- a/tools/bazel-repo-patches/rules_nodejs__#3605.patch
+++ b/tools/bazel-repo-patches/rules_nodejs__#3605.patch
@@ -1,0 +1,48 @@
+diff --git internal/node/node.bzl internal/node/node.bzl
+index 18d7ce4..3b8ce74 100755
+--- internal/node/node.bzl
++++ internal/node/node.bzl
+@@ -353,10 +353,22 @@ if (process.cwd() !== __dirname) {
+     else:
+         executable = ctx.outputs.launcher_sh
+
+-    # syntax sugar: allows you to avoid repeating the entry point in data
+-    # entry point is only needed in runfiles if it is a javascript file
+-    if len(ctx.files.entry_point) == 1 and is_javascript_file(ctx.files.entry_point[0]):
+-        runfiles.extend(ctx.files.entry_point)
++    # Note: `to_list()` is expensive and should only be called once.
++    sources_list = sources.to_list()
++    entry_point_input_short_path = _ts_to_js(_get_entry_point_file(ctx).short_path)
++    entry_point_script = None
++
++    for f in sources_list:
++        if f.short_path == entry_point_input_short_path:
++            entry_point_script = f
++            break
++
++    if not entry_point_script and len(ctx.files.entry_point) == 1 and is_javascript_file(ctx.files.entry_point[0]):
++        entry_point_script = ctx.files.entry_point[0]
++
++        # Convenience: We add the entry point to the runfiles. This means that users would not
++        # need to explicitly repeat the entry point in the `data` attribute.
++        runfiles.append(entry_point_script)
+
+     return [
+         DefaultInfo(
+@@ -371,14 +383,14 @@ if (process.cwd() !== __dirname) {
+                         # Calling the .to_list() method may have some perfs hits,
+                         # so we should be running this method only once per rule.
+                         # see: https://docs.bazel.build/versions/main/skylark/depsets.html#performance
+-                        node_modules.to_list() + sources.to_list(),
++                        node_modules.to_list() + sources_list,
+                 collect_data = True,
+             ),
+         ),
+         # TODO(alexeagle): remove sources and node_modules from the runfiles
+         # when downstream usage is ready to rely on linker
+         NodeRuntimeDepsInfo(
+-            deps = depset(ctx.files.entry_point, transitive = [node_modules, sources]),
++            deps = depset([entry_point_script], transitive = [node_modules, sources]),
+             pkgs = data,
+         ),
+         # indicates that the this binary should be instrumented by coverage


### PR DESCRIPTION
See individual commits. This PR fixes that AIO actions were not cached, run remotely if supported. Also fixes some rules NodeJS issue that surfaces now that we run some actions for AIO with RBE.