### PR TITLE
docs: added `missingNgForOfLet` extended diagnostics details page

### DIFF
--- a/aio/content/extended-diagnostics/NG8105.md
+++ b/aio/content/extended-diagnostics/NG8105.md
@@ -1,0 +1,48 @@
+@name Missing `let` keyword in an *ngFor expression
+
+@description
+
+This diagnostic is emitted when an expression used in `*ngFor` is missing the `let` keyword.
+
+<code-example format="typescript" language="typescript">
+
+import {Component} from '&commat;angular/core';
+
+&commat;Component({
+  // The `let` keyword is missing in the `*ngFor` expression.
+  template: `&lt;div *ngFor="item of items"&gt;{{ item }}&lt;/div&gt;`,
+  // &hellip;
+})
+class MyComponent {
+  items = [1, 2, 3];
+}
+
+</code-example>
+
+## How to resolve the problem
+
+Add the missing `let` keyword.
+
+<code-example format="typescript" language="typescript">
+
+import {Component} from '&commat;angular/core';
+
+&commat;Component({
+  // The `let` keyword is now present in the `*ngFor` expression,
+  // no diagnostic messages are emitted in this case.
+  template: `&lt;div *ngFor="let item of items"&gt;{{ item }}&lt;/div&gt;`,
+  // &hellip;
+})
+class MyComponent {
+  items = [1, 2, 3];
+}
+
+</code-example>
+
+<!-- links -->
+
+<!-- external links -->
+
+<!-- end links -->
+
+@reviewed 2022-12-01

--- a/aio/content/extended-diagnostics/index.md
+++ b/aio/content/extended-diagnostics/index.md
@@ -11,6 +11,7 @@ Currently, Angular supports the following extended diagnostics:
 *   [NG8101 - `invalidBananaInBox`](extended-diagnostics/NG8101)
 *   [NG8102 - `nullishCoalescingNotNullable`](extended-diagnostics/NG8102)
 *   [NG8103 - `missingControlFlowDirective`](extended-diagnostics/NG8103)
+*   [NG8105 - `missingNgForOfLet`](extended-diagnostics/NG8105)
 *   [NG8106 - `suffixNotSupported`](extended-diagnostics/NG8106)
 
 ## Configuration


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No