### PR TITLE
wip! remove styles from DOM of destroyed components (test)

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 457045,
+      "main": 457976,
       "polyfills": 33952,
       "styles": 73964,
       "light-theme": 88046,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,7 +2,7 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 1083,
-      "main": 124531,
+      "main": 125644,
       "polyfills": 33824
     }
   },
@@ -19,21 +19,21 @@
   "cli-hello-world-ivy-compat": {
     "uncompressed": {
       "runtime": 1102,
-      "main": 131519,
+      "main": 132632,
       "polyfills": 33957
     }
   },
   "cli-hello-world-ivy-i18n": {
     "uncompressed": {
       "runtime": 926,
-      "main": 124195,
+      "main": 125114,
       "polyfills": 35252
     }
   },
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2835,
-      "main": 225991,
+      "main": 226675,
       "polyfills": 33842,
       "src_app_lazy_lazy_routes_ts": 487
     }
@@ -41,21 +41,21 @@
   "forms": {
     "uncompressed": {
       "runtime": 1060,
-      "main": 156411,
+      "main": 157413,
       "polyfills": 33915
     }
   },
   "animations": {
     "uncompressed": {
       "runtime": 1070,
-      "main": 156355,
+      "main": 157121,
       "polyfills": 33897
     }
   },
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 1090,
-      "main": 83452,
+      "main": 84119,
       "polyfills": 33945
     }
   },

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -333,6 +333,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NoopAnimationDriver"
   },
   {
@@ -1207,9 +1210,6 @@
   },
   {
     "name": "removeNodesAfterAnimationDone"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -237,6 +237,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -907,9 +910,6 @@
   },
   {
     "name": "removeFromArray"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -345,6 +345,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -1351,9 +1354,6 @@
   },
   {
     "name": "removeListItem2"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "removeValidators"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -336,6 +336,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -1315,9 +1318,6 @@
   },
   {
     "name": "removeListItem"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "removeValidators"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -387,6 +387,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -1636,9 +1639,6 @@
   },
   {
     "name": "removeFromArray"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -210,6 +210,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -775,9 +778,6 @@
   },
   {
     "name": "removeFromArray"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "renderComponent"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -252,6 +252,9 @@
     "name": "NodeInjectorFactory"
   },
   {
+    "name": "NoneEncapsulationDomRenderer"
+  },
+  {
     "name": "NullInjector"
   },
   {
@@ -1120,9 +1123,6 @@
   },
   {
     "name": "removeFromArray"
-  },
-  {
-    "name": "removeStyle"
   },
   {
     "name": "renderComponent"

--- a/packages/platform-browser/src/dom/shared_styles_host.ts
+++ b/packages/platform-browser/src/dom/shared_styles_host.ts
@@ -6,75 +6,108 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
+import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable, OnDestroy} from '@angular/core';
 
 @Injectable()
-export class SharedStylesHost {
-  /** @internal */
-  protected _stylesSet = new Set<string>();
+export class SharedStylesHost implements OnDestroy {
+  private readonly usedStyles = new Map<string /** Style string */, number /** Usage count */>();
 
   addStyles(styles: string[]): void {
-    const additions = new Set<string>();
-    styles.forEach(style => {
-      if (!this._stylesSet.has(style)) {
-        this._stylesSet.add(style);
-        additions.add(style);
+    for (const style of styles) {
+      let usedCount = this.usedStyles.get(style) ?? 0;
+      usedCount++;
+      this.usedStyles.set(style, usedCount);
+
+      if (usedCount === 1) {
+        this.onStyleAdded(style);
       }
-    });
-    this.onStylesAdded(additions);
+    }
   }
 
-  onStylesAdded(additions: Set<string>): void {}
+  removeStyles(styles: string[]): void {
+    for (const style of styles) {
+      let usedCount = this.usedStyles.get(style) ?? 0;
+      usedCount--;
 
-  getAllStyles(): string[] {
-    return Array.from(this._stylesSet);
+      if (usedCount > 0) {
+        this.usedStyles.set(style, usedCount);
+      } else {
+        this.usedStyles.delete(style);
+        this.onStyleRemoved(style);
+      }
+    }
+  }
+
+  onStyleRemoved(style: string): void {}
+
+  onStyleAdded(style: string): void {}
+
+  getAllStyles(): IterableIterator<string> {
+    return this.usedStyles.keys();
+  }
+
+  ngOnDestroy(): void {
+    for (const style of this.getAllStyles()) {
+      this.onStyleRemoved(style);
+    }
+
+    this.usedStyles.clear();
   }
 }
 
 @Injectable()
 export class DomSharedStylesHost extends SharedStylesHost implements OnDestroy {
   // Maps all registered host nodes to a list of style nodes that have been added to the host node.
-  private _hostNodes = new Map<Node, Node[]>();
+  private readonly styleRef = new Map<string, HTMLStyleElement[]>();
+  private hostNodes = new Set<Node>();
 
-  constructor(@Inject(DOCUMENT) private _doc: any) {
+  constructor(@Inject(DOCUMENT) private readonly doc: any) {
     super();
-    this._hostNodes.set(_doc.head, []);
+    this.hostNodes.add(this.doc.head);
   }
 
-  private _addStylesToHost(styles: Set<string>, host: Node, styleNodes: Node[]): void {
-    styles.forEach((style: string) => {
-      const styleEl = this._doc.createElement('style');
-      styleEl.textContent = style;
-      styleNodes.push(host.appendChild(styleEl));
-    });
+  override onStyleAdded(style: string): void {
+    for (const host of this.hostNodes) {
+      this.addStyleToHost(host, style);
+    }
+  }
+
+  override onStyleRemoved(style: string): void {
+    const styleElements = this.styleRef.get(style);
+    styleElements?.forEach(e => e.remove());
+    this.styleRef.delete(style);
+  }
+
+  override ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this.styleRef.clear();
+    this.hostNodes.clear();
+    this.hostNodes.add(this.doc.head);
   }
 
   addHost(hostNode: Node): void {
-    const styleNodes: Node[] = [];
-    this._addStylesToHost(this._stylesSet, hostNode, styleNodes);
-    this._hostNodes.set(hostNode, styleNodes);
+    this.hostNodes.add(hostNode);
+
+    for (const style of this.getAllStyles()) {
+      this.addStyleToHost(hostNode, style);
+    }
   }
 
   removeHost(hostNode: Node): void {
-    const styleNodes = this._hostNodes.get(hostNode);
-    if (styleNodes) {
-      styleNodes.forEach(removeStyle);
+    this.hostNodes.delete(hostNode);
+  }
+
+  private addStyleToHost(host: Node, style: string): void {
+    const styleEl = this.doc.createElement('style');
+    styleEl.textContent = style;
+    host.appendChild(styleEl);
+
+    const styleRef = this.styleRef.get(style);
+    if (styleRef) {
+      styleRef.push(styleEl);
+    } else {
+      this.styleRef.set(style, [styleEl]);
     }
-    this._hostNodes.delete(hostNode);
   }
-
-  override onStylesAdded(additions: Set<string>): void {
-    this._hostNodes.forEach((styleNodes, hostNode) => {
-      this._addStylesToHost(additions, hostNode, styleNodes);
-    });
-  }
-
-  ngOnDestroy(): void {
-    this._hostNodes.forEach(styleNodes => styleNodes.forEach(removeStyle));
-  }
-}
-
-function removeStyle(styleNode: Node): void {
-  getDOM().remove(styleNode);
 }

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -46,15 +46,6 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       expect(doc.head).toHaveText('a {};b {};');
     });
 
-    it('should remove style nodes when the host is removed', () => {
-      ssh.addStyles(['a {};']);
-      ssh.addHost(someHost);
-      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
-
-      ssh.removeHost(someHost);
-      expect(someHost.innerHTML).toEqual('');
-    });
-
     it('should remove style nodes on destroy', () => {
       ssh.addStyles(['a {};']);
       ssh.addHost(someHost);

--- a/packages/platform-server/src/styles_host.ts
+++ b/packages/platform-server/src/styles_host.ts
@@ -22,8 +22,8 @@ export class ServerStylesHost extends SharedStylesHost {
     this.head = doc.getElementsByTagName('head')[0];
   }
 
-  private _addStyle(style: string): void {
-    let adapter = getDOM();
+  override onStyleAdded(style: string): void {
+    const adapter = getDOM();
     const el = adapter.createElement('style');
     el.textContent = style;
     if (!!this.transitionId) {
@@ -33,11 +33,9 @@ export class ServerStylesHost extends SharedStylesHost {
     this._styleNodes.add(el);
   }
 
-  override onStylesAdded(additions: Set<string>) {
-    additions.forEach(style => this._addStyle(style));
-  }
-
-  ngOnDestroy() {
+  override ngOnDestroy() {
     this._styleNodes.forEach(styleNode => styleNode.remove());
+    this._styleNodes.clear();
+    super.ngOnDestroy();
   }
 }


### PR DESCRIPTION
Currently style of components using `encapsulation`, `None` or `Emulated` will not be removed from the DOM once the component get destroyed.

This commit fixes this by keeping track of the number of times a component is rendered, when the component is destroyed the counter is decreased and once this reaches zero the style element is removed from the DOM.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
