### PR TITLE
build: attempt to avoid nodejs version flakiness in `test_win` job

### DIFF
--- a/.circleci/env.windows.sh
+++ b/.circleci/env.windows.sh
@@ -3,6 +3,9 @@
 ####################################################################################################
 cp "${PROJECT_ROOT}/.circleci/bazel.windows.rc" ".bazelrc.user";
 
+# Override the `PATH` environment variable so that the windows-nvm NodeJS version
+# always has precedence over potential existing NodeJS versions from the image.
+setPublicVar PATH "/c/Program Files/nodejs/:$PATH"
 
 # Expose the Bazelisk version. We need to run Bazelisk globally since Windows has problems launching
 # Bazel from a node modules directoy that might be modified by the Bazel Yarn install then.


### PR DESCRIPTION
The `test_win` job is occasionally failing where a super old NodeJS version is used even though we installed a proper one with `nvm`.

It's unclear how the CircleCI windows VMs differ here, it's coming up rarely and is hard to reproduce when SSH-ing into VMs. Our best guess is that the existing NodeJS version from the container/image is super old and somehow takes precedence over the NVM-managed NodeJS version. This could happen due to bad ordering in the `$PATH` environment variable, or NVM not properly being wired up there.

We attempt to fix this by always setting `$PATH` to the NVM symlink directory manually- with highest priority.