### PR TITLE
fix(common): `Location` does not support base href containing `origin`

### DIFF
--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule, Location, LocationStrategy, PathLocationStrategy, PlatformLocation} from '@angular/common';
+import {APP_BASE_HREF, CommonModule, Location, LocationStrategy, PathLocationStrategy, PlatformLocation} from '@angular/common';
 import {MockLocationStrategy, MockPlatformLocation} from '@angular/common/testing';
 import {TestBed} from '@angular/core/testing';
 
@@ -55,7 +55,7 @@ describe('Location Class', () => {
               return new MockPlatformLocation();
             }
           },
-          {provide: Location, useClass: Location, deps: [LocationStrategy, PlatformLocation]},
+          {provide: Location, useClass: Location, deps: [LocationStrategy]},
         ]
       });
 
@@ -147,7 +147,7 @@ describe('Location Class', () => {
               return new MockPlatformLocation();
             }
           },
-          {provide: Location, useClass: Location, deps: [LocationStrategy, PlatformLocation]},
+          {provide: Location, useClass: Location, deps: [LocationStrategy]},
         ]
       });
 
@@ -213,6 +213,57 @@ describe('Location Class', () => {
       locationStrategy.simulatePopState('/test');
 
       expect(notificationCount).toBe(1);
+    });
+  });
+
+  describe('location.normalize(url) should return only route', () => {
+    const basePath = '/en';
+    const route = '/go/to/there';
+    const url = basePath + route;
+    const getBaseHref = (origin: string) => origin + basePath + '/';
+
+    it('in case APP_BASE_HREF starts with http:', () => {
+      const origin = 'http://example.com';
+      const baseHref = getBaseHref(origin);
+
+      TestBed.configureTestingModule({providers: [{provide: APP_BASE_HREF, useValue: baseHref}]});
+
+      const location = TestBed.inject(Location);
+
+      expect(location.normalize(url)).toBe(route);
+    });
+
+    it('in case APP_BASE_HREF starts with https:', () => {
+      const origin = 'https://example.com';
+      const baseHref = getBaseHref(origin);
+
+      TestBed.configureTestingModule({providers: [{provide: APP_BASE_HREF, useValue: baseHref}]});
+
+      const location = TestBed.inject(Location);
+
+      expect(location.normalize(url)).toBe(route);
+    });
+
+    it('in case APP_BASE_HREF starts with no protocol', () => {
+      const origin = '//example.com';
+      const baseHref = getBaseHref(origin);
+
+      TestBed.configureTestingModule({providers: [{provide: APP_BASE_HREF, useValue: baseHref}]});
+
+      const location = TestBed.inject(Location);
+
+      expect(location.normalize(url)).toBe(route);
+    });
+
+    it('in case APP_BASE_HREF starts with no origin', () => {
+      const origin = '';
+      const baseHref = getBaseHref(origin);
+
+      TestBed.configureTestingModule({providers: [{provide: APP_BASE_HREF, useValue: baseHref}]});
+
+      const location = TestBed.inject(Location);
+
+      expect(location.normalize(url)).toBe(route);
     });
   });
 });

--- a/packages/common/testing/src/location_mock.ts
+++ b/packages/common/testing/src/location_mock.ts
@@ -25,7 +25,7 @@ export class SpyLocation implements Location {
   /** @internal */
   _subject: EventEmitter<any> = new EventEmitter();
   /** @internal */
-  _baseHref: string = '';
+  _basePath: string = '';
   /** @internal */
   _locationStrategy: LocationStrategy = null!;
   /** @internal */
@@ -43,7 +43,7 @@ export class SpyLocation implements Location {
   }
 
   setBaseHref(url: string) {
-    this._baseHref = url;
+    this._basePath = url;
   }
 
   path(): string {
@@ -81,7 +81,7 @@ export class SpyLocation implements Location {
     if (url.length > 0 && !url.startsWith('/')) {
       url = '/' + url;
     }
-    return this._baseHref + url;
+    return this._basePath + url;
   }
 
   go(path: string, query: string = '', state: any = null) {


### PR DESCRIPTION
In case `APP_BASE_HREF` is set including `origin` the further usage of it might cause failure 

e.g.
If an app is placed on `https://example.com` and bundles are on `https://cdn-example.com` you have to set `APP_BASE_HREF` up as `https://example.com/` and build the app with `--base-href` as `https://cdn-example.com/` but it does not work because of the bug

Fixes #48175

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`Location` does not support base href containing `origin` (only base hrefs with just the path are supported)
Issue Number: 48175

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

