### PR TITLE
build(bazel): mark an AIO sjs e2e test as flakey

### DIFF
--- a/aio/content/examples/upgrade-module/BUILD.bazel
+++ b/aio/content/examples/upgrade-module/BUILD.bazel
@@ -5,6 +5,7 @@ package(default_visibility = ["//visibility:public"])
 
 docs_example(
     name = "upgrade-module",
+    flaky = True,  # TODO: figure out why this is flaky or times out
     # This example downloads and inlines resources
     test_exec_properties = ENABLE_NETWORK,
     test_tags = ["requires-network"],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

`upgrade-module` test is occasionally flaky on CI.

## What is the new behavior?

Like a couple of the the other systemjs e2e tests, mark this one as flaky as it always seems to pass the second time..

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
