### PR TITLE
build: set firebase deploy target when deploying AIO preview

### DIFF
--- a/.github/workflows/aio-preview-deploy.yml
+++ b/.github/workflows/aio-preview-deploy.yml
@@ -22,6 +22,12 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
+
+      - name: Configure Firebase deploy target
+        run: |
+          yarn --cwd aio firebase target:clear hosting aio
+          yarn --cwd aio firebase target:apply hosting aio ng-comp-dev
+
       - uses: angular/dev-infra/github-actions/deploy-previews/upload-artifacts-to-firebase@3bc93449e11b733260d0294305bf57240d7e0a81
         with:
           github-token: '${{secrets.GITHUB_TOKEN}}'


### PR DESCRIPTION
The AIO firebase project specifies `aio` as deploy target. This means that we need to configure this target before being able to deploy AIO previews.

We use the default project target as target since the preview Firebase project does not use multi site targets. See:
https://firebase.google.com/docs/hosting/multisites