### PR TITLE
docs(docs-infra): update strongbrew resource to new website

### DIFF
--- a/aio/content/marketing/resources.json
+++ b/aio/content/marketing/resources.json
@@ -939,10 +939,10 @@
             "title": "Angular.Schule (German)",
             "url": "https://angular.schule/"
           },
-          "strbrw": {
+          "simplified": {
             "desc": "Angular and RxJS trainings, Code Reviews and consultancy. We help software engineers all over the world to create better web-applications...",
-            "title": "StrongBrew",
-            "url": "https://strongbrew.io/"
+            "title": "Simplified Courses",
+            "url": "https://simplified.courses/"
           },
           "angular.de": {
             "desc": "Onsite Angular Training delivered by the greatest community in the german speaking area in Germany, Austria and Switzerland. We also regularly post articles and tutorials on our blog.",


### PR DESCRIPTION
StrongBrew has stopped a few years back. 
We are taking over at https://simplified.courses where we have an Angular blog, do on-site training and create content.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The resource still point to a company that has stopped.
I should point to the new website where we same services are provided

## What is the new behavior?
The docs are updated to point to the new website, since the old one will get taken down in a few weeks/months.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
