### PR TITLE
build(bazel): set aio_preview executor to 2xlarge+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,9 @@ jobs:
       - run: yarn --cwd aio payload-size
 
   deploy_aio:
-    executor: test-browser-executor
+    executor:
+      name: test-browser-executor
+      resource_class: 2xlarge+
     steps:
       - custom_attach_workspace
       - init_environment
@@ -363,7 +365,9 @@ jobs:
 
   # This job should only be run on PR builds, where `CI_PULL_REQUEST` is not `false`.
   aio_preview:
-    executor: default-executor
+    executor:
+      name: default-executor
+      resource_class: 2xlarge+
     environment:
       AIO_SNAPSHOT_ARTIFACT_PATH: &aio_preview_artifact_path 'aio/tmp/snapshot.tgz'
     steps:


### PR DESCRIPTION
This step builds AIO which is memory intensive. Running out of memory may be the cause of some ci flakiness. Change the executor size to test this theory.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

`aio_preview` is flaky. Script seems to unexpectedly fail.

## What is the new behavior?

See if a larger executor helps.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
