### PR TITLE
build: use npx for setting firebase deploy targets in AIO preview

### DIFF
--- a/.github/workflows/aio-preview-deploy.yml
+++ b/.github/workflows/aio-preview-deploy.yml
@@ -24,9 +24,11 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3
 
       - name: Configure Firebase deploy target
+        working-directory: aio/
         run: |
-          yarn --cwd aio firebase target:clear hosting aio
-          yarn --cwd aio firebase target:apply hosting aio ng-comp-dev
+          # We can use `npx` as the Firebase deploy actions uses it too.
+          npx -y firebase-tools@latest target:clear hosting aio
+          npx -y firebase-tools@latest target:apply hosting aio ng-comp-dev
 
       - uses: angular/dev-infra/github-actions/deploy-previews/upload-artifacts-to-firebase@3bc93449e11b733260d0294305bf57240d7e0a81
         with:


### PR DESCRIPTION
For the deploy job we still need to use the Firebase CLI to configure the proper hosting deploy targets. See:
011ef66a04d576b33e8828844a94960393fbc8aa.

We don't have node modules installed in this job, and it would also be overkill to install them for just using firebase here.

Since the action uses `npx firebase-tools` down the line anyway, we can use it without any speed downsides.