### PR TITLE
build: check out project before setting AIO preview targets

### DIFF
--- a/.github/workflows/aio-preview-deploy.yml
+++ b/.github/workflows/aio-preview-deploy.yml
@@ -27,6 +27,7 @@ jobs:
         working-directory: aio/
         run: |
           # We can use `npx` as the Firebase deploy actions uses it too.
+          npx -y firebase-tools@latest use ng-comp-dev
           npx -y firebase-tools@latest target:clear hosting aio
           npx -y firebase-tools@latest target:apply hosting aio ng-comp-dev
 


### PR DESCRIPTION
Checks out the Firebase project before setting the AIO preview targets. Surprisingly Firebase requires a project when setting resource identifiers for the targets. This is already done by the Firebase deploy action from @FirebaseExtended, but we need to do it earlier.