### PR TITLE
build: add more debug information for occasional windows flakiness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -674,6 +674,16 @@ jobs:
             - *cache_key_win
             - *cache_key_win_fallback
 
+      - run:
+          name: Debug information for flakiness of Windows job
+          command: |
+            node -v
+            yarn -v
+            which node
+            which yarn
+            echo "Path: $PATH"
+            yarn node -v
+
       # Install project dependencies, and install Bazelisk globally. This is necessary as
       # Windows might error when `bazel` is invoked from the project node modules. The Bazel
       # invocation might modify the symlinked project `node_modules` again, causing failures.


### PR DESCRIPTION
Ocassionally the NodeJS version is not correct after NVM on Windows. This adds some debug information that should help improve stability here. A recent attempt to update the `$PATH` did not seem to help.