### PR TITLE
fix(compiler): make sure selectors inside container queries are correctly scoped

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -571,7 +571,8 @@ export class ShadowCss {
             this._scopeSelector(rule.selector, scopeSelector, hostSelector, this.strictStyling);
       } else if (
           rule.selector.startsWith('@media') || rule.selector.startsWith('@supports') ||
-          rule.selector.startsWith('@document') || rule.selector.startsWith('@layer')) {
+          rule.selector.startsWith('@document') || rule.selector.startsWith('@layer') ||
+          rule.selector.startsWith('@container')) {
         content = this._scopeSelectors(rule.content, scopeSelector, hostSelector);
       } else if (rule.selector.startsWith('@font-face') || rule.selector.startsWith('@page')) {
         content = this._stripScopingSelectors(rule.content);

--- a/packages/compiler/test/shadow_css/container_queries_spec.ts
+++ b/packages/compiler/test/shadow_css/container_queries_spec.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ShadowCss} from '@angular/compiler/src/shadow_css';
+
+describe('ShadowCss, container queries', () => {
+  function s(css: string, contentAttr: string, hostAttr: string = '') {
+    const shadowCss = new ShadowCss();
+    return shadowCss.shimCssText(css, contentAttr, hostAttr);
+  }
+
+  it('should scope normal selectors inside an unnamed container rules', () => {
+    const css = `@container max(max-width: 500px) {
+             .item {
+               color: red;
+             }
+           }`;
+    const result = s(css, 'host-a');
+    expect(noIndentation(result)).toEqual(noIndentation(`@container max(max-width: 500px) {
+         .item[host-a] {
+           color: red;
+         }
+       }`));
+  });
+
+  it('should scope normal selectors inside a named container rules', () => {
+    const css = `@container container max(max-width: 500px) {
+             .item {
+               color: red;
+             }
+           }`;
+    const result = s(css, 'host-a');
+    // Note that for the time being we are not scoping the container name itself,
+    // this is something that may or may not be done in the future depending
+    // on how the css specs evolve. Currently as of Chrome 107 it looks like shadowDom
+    // boundaries don't effect container queries (thus the scoping wouldn't be needed)
+    // and this aspect of container queries seems to be still under active discussion:
+    // https://github.com/w3c/csswg-drafts/issues/5984
+    expect(noIndentation(result))
+        .toEqual(noIndentation(`@container container max(max-width: 500px) {
+       .item[host-a] {
+         color: red;
+       }
+     }`));
+  });
+});
+
+function noIndentation(str: string): string {
+  return str.replace(/\n\s+/g, '\n');
+}


### PR DESCRIPTION
resolves #48264

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #48264


## What is the new behavior?
Container queries get correctly shimmed by the emulated view encapsulation

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
 - This PR only allows the container queries to be correctly handled and does not provide any scoping for the container names, I am not sure if that is wanted/needed, I've put a comment on it in the issue regarding this