### PR TITLE
feat(language-service): Allow auto-imports of a pipe via quick fix when its selector is used.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -19,6 +19,7 @@ import {IncrementalBuildStrategy, IncrementalCompilation, IncrementalState} from
 import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {generateAnalysis, IndexedComponent, IndexingContext} from '../../indexer';
 import {ComponentResources, CompoundMetadataReader, CompoundMetadataRegistry, DirectiveMeta, DtsMetadataReader, HostDirectivesResolver, LocalMetadataRegistry, MetadataReader, MetadataReaderWithIndex, PipeMeta, ResourceRegistry} from '../../metadata';
+import {NgModuleIndexImpl} from '../../metadata/src/ng_module_index';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {ActivePerfRecorder, DelegatingPerfRecorder, PerfCheckpoint, PerfEvent, PerfPhase} from '../../perf';
 import {FileUpdate, ProgramDriver, UpdateMode} from '../../program_driver';
@@ -971,6 +972,7 @@ export class NgCompiler {
     const localMetaReader: MetadataReaderWithIndex = localMetaRegistry;
     const depScopeReader = new MetadataDtsModuleScopeResolver(dtsReader, aliasingHost);
     const metaReader = new CompoundMetadataReader([localMetaReader, dtsReader]);
+    const ngModuleIndex = new NgModuleIndexImpl(metaReader, localMetaReader);
     const ngModuleScopeRegistry = new LocalModuleScopeRegistry(
         localMetaReader, metaReader, depScopeReader, refEmitter, aliasingHost);
     const standaloneScopeReader =
@@ -1072,7 +1074,7 @@ export class NgCompiler {
     const templateTypeChecker = new TemplateTypeCheckerImpl(
         this.inputProgram, notifyingDriver, traitCompiler, this.getTypeCheckingConfig(), refEmitter,
         reflector, this.adapter, this.incrementalCompilation, metaReader, localMetaReader,
-        scopeReader, typeCheckScopeRegistry, this.delegatingPerfRecorder);
+        ngModuleIndex, scopeReader, typeCheckScopeRegistry, this.delegatingPerfRecorder);
 
     // Only construct the extended template checker if the configuration is valid and usable.
     const extendedTemplateChecker = this.constructionDiagnostics.length === 0 ?

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -251,10 +251,17 @@ export interface MetadataReader {
 }
 
 /**
- * A MetadataReader which also allows access to the set of all known directive classes.
+ * A MetadataReader which also allows access to the set of all known trait classes.
  */
 export interface MetadataReaderWithIndex extends MetadataReader {
-  getKnown(kind: MetaKind): Iterable<ClassDeclaration>;
+  getKnown(kind: MetaKind): Array<ClassDeclaration>;
+}
+
+/**
+ * An NgModuleIndex allows access to information about traits exported by NgModules.
+ */
+export interface NgModuleIndex {
+  getNgModulesExporting(directiveOrPipe: ClassDeclaration): Array<Reference<ClassDeclaration>>;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/metadata/src/ng_module_index.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/ng_module_index.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Reference} from '../../imports';
+import {ClassDeclaration} from '../../reflection';
+
+import {MetadataReader, MetadataReaderWithIndex, MetaKind, NgModuleIndex} from './api';
+
+/**
+ * An index of all NgModules that export or re-export a given trait.
+ */
+export class NgModuleIndexImpl implements NgModuleIndex {
+  constructor(private metaReader: MetadataReader, private localReader: MetadataReaderWithIndex) {}
+
+  // A map from an NgModule's Class Declaration to the "main" reference to that module, aka the one
+  // present in the reader metadata object
+  private ngModuleAuthoritativeReference = new Map<ClassDeclaration, Reference<ClassDeclaration>>();
+  // A map from a Directive/Pipe's class declaration to the class declarations of all re-exporting
+  // NgModules
+  private typeToExportingModules = new Map<ClassDeclaration, Set<ClassDeclaration>>();
+
+  private indexed = false;
+
+  private updateWith<K, V>(cache: Map<K, Set<V>>, key: K, elem: V) {
+    if (cache.has(key)) {
+      cache.get(key)!.add(elem);
+    } else {
+      const set = new Set<V>();
+      set.add(elem);
+      cache.set(key, set);
+    }
+  }
+
+  private index(): void {
+    const seenTypesWithReexports = new Map<ClassDeclaration, Set<ClassDeclaration>>();
+    const locallyDeclaredDirsAndNgModules = [
+      ...this.localReader.getKnown(MetaKind.NgModule),
+      ...this.localReader.getKnown(MetaKind.Directive),
+    ];
+    for (const decl of locallyDeclaredDirsAndNgModules) {
+      // Here it's safe to create a new Reference because these are known local types.
+      this.indexTrait(new Reference(decl), seenTypesWithReexports);
+    }
+    this.indexed = true;
+  }
+
+  private indexTrait(
+      ref: Reference<ClassDeclaration>,
+      seenTypesWithReexports: Map<ClassDeclaration, Set<ClassDeclaration>>): void {
+    if (seenTypesWithReexports.has(ref.node)) {
+      // We've processed this type before.
+      return;
+    }
+    seenTypesWithReexports.set(ref.node, new Set());
+
+    const meta =
+        this.metaReader.getDirectiveMetadata(ref) ?? this.metaReader.getNgModuleMetadata(ref);
+    if (meta === null) {
+      return;
+    }
+
+    // Component + NgModule: recurse into imports
+    if (meta.imports !== null) {
+      for (const childRef of meta.imports) {
+        this.indexTrait(childRef, seenTypesWithReexports);
+      }
+    }
+
+    if (meta.kind === MetaKind.NgModule) {
+      if (!this.ngModuleAuthoritativeReference.has(ref.node)) {
+        this.ngModuleAuthoritativeReference.set(ref.node, ref);
+      }
+
+      for (const childRef of meta.exports) {
+        this.indexTrait(childRef, seenTypesWithReexports);
+
+        const childMeta = this.metaReader.getDirectiveMetadata(childRef) ??
+            this.metaReader.getPipeMetadata(childRef) ??
+            this.metaReader.getNgModuleMetadata(childRef);
+        if (childMeta === null) {
+          continue;
+        }
+
+        switch (childMeta.kind) {
+          case MetaKind.Directive:
+          case MetaKind.Pipe:
+            this.updateWith(this.typeToExportingModules, childRef.node, ref.node);
+            this.updateWith(seenTypesWithReexports, ref.node, childRef.node);
+            break;
+          case MetaKind.NgModule:
+            if (seenTypesWithReexports.has(childRef.node)) {
+              for (const reexported of seenTypesWithReexports.get(childRef.node)!) {
+                this.updateWith(this.typeToExportingModules, reexported, ref.node);
+                this.updateWith(seenTypesWithReexports, ref.node, reexported);
+              }
+            }
+            break;
+        }
+      }
+    }
+  }
+
+  getNgModulesExporting(directiveOrPipe: ClassDeclaration): Array<Reference<ClassDeclaration>> {
+    if (!this.indexed) {
+      this.index();
+    }
+
+    if (!this.typeToExportingModules.has(directiveOrPipe)) {
+      return [];
+    }
+
+    const refs: Array<Reference<ClassDeclaration>> = [];
+    for (const ngModule of this.typeToExportingModules.get(directiveOrPipe)!) {
+      if (this.ngModuleAuthoritativeReference.has(ngModule)) {
+        refs.push(this.ngModuleAuthoritativeReference.get(ngModule)!);
+      }
+    }
+    return refs;
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/registry.ts
@@ -40,14 +40,14 @@ export class LocalMetadataRegistry implements MetadataRegistry, MetadataReaderWi
     this.pipes.set(meta.ref.node, meta);
   }
 
-  getKnown(kind: MetaKind): Iterable<ClassDeclaration> {
+  getKnown(kind: MetaKind): Array<ClassDeclaration> {
     switch (kind) {
       case MetaKind.Directive:
-        return this.directives.keys();
+        return Array.from(this.directives.values()).map(v => v.ref.node);
       case MetaKind.Pipe:
-        return this.pipes.keys();
+        return Array.from(this.pipes.values()).map(v => v.ref.node);
       case MetaKind.NgModule:
-        return this.ngModules.keys();
+        return Array.from(this.ngModules.values()).map(v => v.ref.node);
     }
   }
 }

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -149,8 +149,9 @@ export interface TemplateTypeChecker {
   /**
    * In the context of an Angular trait, generate potential imports for a directive.
    */
-  getPotentialImportsFor(directive: PotentialDirective, inComponent: ts.ClassDeclaration):
-      ReadonlyArray<PotentialImport>;
+  getPotentialImportsFor(
+      toImport: PotentialDirective|PotentialPipe,
+      inComponent: ts.ClassDeclaration): ReadonlyArray<PotentialImport>;
 
   /**
    * Get the primary decorator for an Angular class (such as @Component). This does not work for

--- a/packages/language-service/test/code_fixes_spec.ts
+++ b/packages/language-service/test/code_fixes_spec.ts
@@ -7,6 +7,8 @@
  */
 
 import {initMockFileSystem} from '@angular/compiler-cli/src/ngtsc/file_system/testing';
+import {spawn} from 'child_process';
+import {CodeAction} from 'typescript';
 
 import {FixIdForCodeFixesAll} from '../src/codefixes/utils';
 import {createModuleAndProjectWithDeclarations, LanguageServiceTestEnv} from '../testing';
@@ -21,15 +23,15 @@ describe('code fixes', () => {
   it('should fix error when property does not exist on type', () => {
     const files = {
       'app.ts': `
-      import {Component, NgModule} from '@angular/core';
-
-      @Component({
-        templateUrl: './app.html'
-      })
-      export class AppComponent {
-        title1 = '';
-      }
-    `,
+       import {Component, NgModule} from '@angular/core';
+ 
+       @Component({
+         templateUrl: './app.html'
+       })
+       export class AppComponent {
+         title1 = '';
+       }
+     `,
       'app.html': `{{title}}`
     };
 
@@ -56,14 +58,14 @@ describe('code fixes', () => {
   it('should fix a missing method when property does not exist on type', () => {
     const files = {
       'app.ts': `
-      import {Component, NgModule} from '@angular/core';
-
-      @Component({
-        templateUrl: './app.html'
-      })
-      export class AppComponent {
-      }
-    `,
+       import {Component, NgModule} from '@angular/core';
+ 
+       @Component({
+         templateUrl: './app.html'
+       })
+       export class AppComponent {
+       }
+     `,
       'app.html': `{{title('Angular')}}`
     };
 
@@ -88,15 +90,15 @@ describe('code fixes', () => {
      () => {
        const files = {
          'app.ts': `
-        import {Component, NgModule} from '@angular/core';
-  
-        @Component({
-          templateUrl: './app.html'
-        })
-        export class AppComponent {
-          title1 = '';
-        }
-      `,
+         import {Component, NgModule} from '@angular/core';
+   
+         @Component({
+           templateUrl: './app.html'
+         })
+         export class AppComponent {
+           title1 = '';
+         }
+       `,
          'app.html': `<div *ngIf="title" />`
        };
 
@@ -112,16 +114,16 @@ describe('code fixes', () => {
   it('should fix all errors when property does not exist on type', () => {
     const files = {
       'app.ts': `
-      import {Component, NgModule} from '@angular/core';
-
-      @Component({
-        template: '{{tite}}{{bannr}}',
-      })
-      export class AppComponent {
-        title = '';
-        banner = '';
-      }
-    `,
+       import {Component, NgModule} from '@angular/core';
+ 
+       @Component({
+         template: '{{tite}}{{bannr}}',
+       })
+       export class AppComponent {
+         title = '';
+         banner = '';
+       }
+     `,
     };
 
     const project = createModuleAndProjectWithDeclarations(env, 'test', files);
@@ -162,15 +164,15 @@ describe('code fixes', () => {
   it('should fix invalid banana-in-box error', () => {
     const files = {
       'app.ts': `
-      import {Component, NgModule} from '@angular/core';
-
-      @Component({
-        templateUrl: './app.html'
-      })
-      export class AppComponent {
-        title = '';
-      }
-    `,
+       import {Component, NgModule} from '@angular/core';
+ 
+       @Component({
+         templateUrl: './app.html'
+       })
+       export class AppComponent {
+         title = '';
+       }
+     `,
       'app.html': `<input ([ngModel])="title">`,
     };
 
@@ -194,16 +196,16 @@ describe('code fixes', () => {
   it('should fix all invalid banana-in-box errors', () => {
     const files = {
       'app.ts': `
-      import {Component, NgModule} from '@angular/core';
-
-      @Component({
-        template: '<input ([ngModel])="title"><input ([value])="title">',
-      })
-      export class AppComponent {
-        title = '';
-        banner = '';
-      }
-    `,
+       import {Component, NgModule} from '@angular/core';
+ 
+       @Component({
+         template: '<input ([ngModel])="title"><input ([value])="title">',
+       })
+       export class AppComponent {
+         title = '';
+         banner = '';
+       }
+     `,
     };
 
     const project = createModuleAndProjectWithDeclarations(env, 'test', files);
@@ -228,61 +230,177 @@ describe('code fixes', () => {
   });
 
   describe('should fix missing selector imports', () => {
-    const files = {};
-    const standaloneFiles = {
-      'foo.ts': ` import {CommonModule} from '@angular/common';
-      import {Component} from '@angular/core';
-
-      @Component({
-        selector: 'foo',
-        template: '<bar></bar>',
-        standalone: true
-      })
-      export class FooComponent {}`,
-      'bar.ts': `
-      import {CommonModule} from '@angular/common';
-      import {Component} from '@angular/core';
-
-      @Component({
-        selector: 'bar',
-        template: '<div>bar</div>',
-        standalone: true
-      })
-      export class BarComponent {}`,
-    };
-
     it('for a new standalone component import', () => {
-      const project =
-          createModuleAndProjectWithDeclarations(env, 'test', files, {}, standaloneFiles);
+      const standaloneFiles = {
+        'foo.ts': `
+         import {Component} from '@angular/core';
+         @Component({
+           selector: 'foo',
+           template: '<bar></bar>',
+           standalone: true
+         })
+         export class FooComponent {}
+         `,
+        'bar.ts': `
+         import {Component} from '@angular/core';
+         @Component({
+           selector: 'bar',
+           template: '<div>bar</div>',
+           standalone: true
+         })
+         export class BarComponent {}
+         `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', {}, {}, standaloneFiles);
       const diags = project.getDiagnosticsForFile('foo.ts');
       const fixFile = project.openFile('foo.ts');
       fixFile.moveCursorToText('<¦bar>');
 
       const codeActions =
           project.getCodeFixesAtPosition('foo.ts', fixFile.cursor, fixFile.cursor, [diags[0].code]);
-      // TODO(dylhunn): These integration test helpers are hard to debug, and somewhat brittle
-      // against formatting. They can be refactored more thoroughly to simplify multiline tests
-      // like these, using Jasime expects all the way down.
-      expectIncludeReplacementText({
-        codeActions,
-        content: fixFile.contents,
-        text: null,
-        newText:
-            `{\n    selector: 'foo',\n    template: '<bar></bar>',\n    standalone: true,\n    imports: [BarComponent]\n}`,
-        fileName: 'foo.ts',
-        description: `Import BarComponent from './bar' on FooComponent`,
-        removeWhitespace: false,  // Include whitespace to check multiline formatting
-      });
-      expectIncludeAddText({
-        codeActions,
-        position: null,
-        text: `import{BarComponent}from"./bar";`,
-        fileName: 'foo.ts',
-        removeWhitespace: true,
-      });
+      const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
+      actionChangesMatch(actionChanges, `Import BarComponent from './bar' on FooComponent`, [
+        [
+          ``,
+          `import { BarComponent } from "./bar";`,
+        ],
+        [
+          `{`,
+          `{ selector: 'foo', template: '<bar></bar>', standalone: true, imports: [BarComponent] }`,
+        ]
+      ]);
+    });
+
+    it('for a new NgModule-based component import', () => {
+      const standaloneFiles = {
+        'foo.ts': `
+         import {Component} from '@angular/core';
+         @Component({
+           selector: 'foo',
+           template: '<bar></bar>',
+           standalone: true
+         })
+         export class FooComponent {}
+         `,
+        'bar.ts': `
+         import {Component, NgModule} from '@angular/core';
+         @Component({
+           selector: 'bar',
+           template: '<div>bar</div>',
+         })
+         export class BarComponent {}
+         @NgModule({
+           declarations: [BarComponent],
+           exports: [BarComponent],
+           imports: []
+         })
+         export class BarModule {}
+         `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', {}, {}, standaloneFiles);
+      const diags = project.getDiagnosticsForFile('foo.ts');
+      const fixFile = project.openFile('foo.ts');
+      fixFile.moveCursorToText('<¦bar>');
+
+      const codeActions =
+          project.getCodeFixesAtPosition('foo.ts', fixFile.cursor, fixFile.cursor, [diags[0].code]);
+      const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
+      actionChangesMatch(actionChanges, `Import BarModule from './bar' on FooComponent`, [
+        [
+          ``,
+          `import { BarModule } from "./bar";`,
+        ],
+        [
+          `{`,
+          `{ selector: 'foo', template: '<bar></bar>', standalone: true, imports: [BarModule] }`,
+        ]
+      ]);
+    });
+
+    it('for an import of a component onto an ngModule', () => {
+      const standaloneFiles = {
+        'foo.ts': `
+         import {Component, NgModule} from '@angular/core';
+         @Component({
+           selector: 'foo',
+           template: '<bar></bar>',
+         })
+         export class FooComponent {}
+         @NgModule({
+           declarations: [FooComponent],
+           exports: [],
+           imports: []
+         })
+         export class FooModule {}
+         `,
+        'bar.ts': `
+         import {Component} from '@angular/core';
+         @Component({
+           selector: 'bar',
+           template: '<div>bar</div>',
+           standalone: true,
+         })
+         export class BarComponent {}
+         `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', {}, {}, standaloneFiles);
+      const diags = project.getDiagnosticsForFile('foo.ts');
+      const fixFile = project.openFile('foo.ts');
+      fixFile.moveCursorToText('<¦bar>');
+
+      const codeActions =
+          project.getCodeFixesAtPosition('foo.ts', fixFile.cursor, fixFile.cursor, [diags[0].code]);
+      const actionChanges = allChangesForCodeActions(fixFile.contents, codeActions);
+      actionChangesMatch(actionChanges, `Import BarComponent from './bar' on FooModule`, [
+        [
+          ``,
+          `import { BarComponent } from "./bar";`,
+        ],
+        [
+          `{`,
+          `{ declarations: [FooComponent], exports: [], imports: [BarComponent] }`,
+        ]
+      ]);
     });
   });
 });
+
+type ActionChanges = {
+  [description: string]: Array<readonly[string, string]>
+};
+
+function actionChangesMatch(
+    actionChanges: ActionChanges, description: string,
+    substitutions: Array<readonly[string, string]>) {
+  expect(Object.keys(actionChanges)).toContain(description);
+  for (const substitution of substitutions) {
+    expect(actionChanges[description]).toContain([substitution[0], substitution[1]]);
+  }
+}
+
+// Returns the ActionChanges for all changes in the given code actions, collapsing whitespace into a
+// single space and trimming at the ends.
+function allChangesForCodeActions(
+    fileContents: string, codeActions: readonly CodeAction[]): ActionChanges {
+  // Replace all whitespace characters with a single space, then deduplicate spaces and trim.
+  const collapse = (s: string) => s.replace(/\s/g, ' ').replace(/\s{2,}/g, ' ').trim();
+  let allActionChanges: ActionChanges = {};
+  // For all code actions, construct a map from descriptions to [oldText, newText] pairs.
+  for (const action of codeActions) {
+    const actionChanges = action.changes.flatMap(change => {
+      return change.textChanges.map(tc => {
+        const oldText = collapse(fileContents.slice(tc.span.start, tc.span.start + spawn.length));
+        const newText = collapse(tc.newText);
+        return [oldText, newText] as const;
+      });
+    });
+    allActionChanges[collapse(action.description)] = actionChanges;
+  }
+  return allActionChanges;
+}
 
 function expectNotIncludeFixAllInfo(codeActions: readonly ts.CodeFixAction[]) {
   for (const codeAction of codeActions) {
@@ -296,22 +414,16 @@ function expectNotIncludeFixAllInfo(codeActions: readonly ts.CodeFixAction[]) {
  * check it.
  */
 function expectIncludeReplacementText(
-    {codeActions, content, text, newText, fileName, description, removeWhitespace = false}: {
+    {codeActions, content, text, newText, fileName, description}: {
       codeActions: readonly ts.CodeAction[]; content: string; text: string | null; newText: string;
       fileName: string;
       description?: string;
-      removeWhitespace?: boolean;
     }) {
   let includeReplacementText = false;
   for (const codeAction of codeActions) {
-    includeReplacementText = includeReplacementTextInChanges({
-                               fileTextChanges: codeAction.changes,
-                               content,
-                               text,
-                               newText,
-                               fileName,
-                               removeWhitespace
-                             }) &&
+    includeReplacementText =
+        includeReplacementTextInChanges(
+            {fileTextChanges: codeAction.changes, content, text, newText, fileName}) &&
         (description === undefined ? true : (description === codeAction.description));
     if (includeReplacementText) {
       return;
@@ -320,14 +432,13 @@ function expectIncludeReplacementText(
   expect(includeReplacementText).toBeTruthy();
 }
 
-function expectIncludeAddText({codeActions, position, text, fileName, removeWhitespace = false}: {
+function expectIncludeAddText({codeActions, position, text, fileName}: {
   codeActions: readonly ts.CodeAction[]; position: number | null; text: string; fileName: string;
-  removeWhitespace?: boolean;
 }) {
   let includeAddText = false;
   for (const codeAction of codeActions) {
-    includeAddText = includeAddTextInChanges(
-        {fileTextChanges: codeAction.changes, position, text, fileName, removeWhitespace});
+    includeAddText =
+        includeAddTextInChanges({fileTextChanges: codeAction.changes, position, text, fileName});
     if (includeAddText) {
       return;
     }
@@ -336,34 +447,26 @@ function expectIncludeAddText({codeActions, position, text, fileName, removeWhit
 }
 
 function expectIncludeReplacementTextForFileTextChange(
-    {fileTextChanges, content, text, newText, fileName, removeWhitespace = false}: {
+    {fileTextChanges, content, text, newText, fileName}: {
       fileTextChanges: readonly ts.FileTextChanges[]; content: string; text: string;
       newText: string;
       fileName: string;
-      removeWhitespace?: boolean;
     }) {
-  expect(includeReplacementTextInChanges(
-             {fileTextChanges, content, text, newText, fileName, removeWhitespace}))
+  expect(includeReplacementTextInChanges({fileTextChanges, content, text, newText, fileName}))
       .toBeTruthy();
 }
 
-function expectIncludeAddTextForFileTextChange(
-    {fileTextChanges, position, text, fileName, removeWhitespace = false}: {
-      fileTextChanges: readonly ts.FileTextChanges[]; position: number; text: string;
-      fileName: string;
-      removeWhitespace?: boolean;
-    }) {
-  expect(includeAddTextInChanges({fileTextChanges, position, text, fileName, removeWhitespace}))
-      .toBeTruthy();
+function expectIncludeAddTextForFileTextChange({fileTextChanges, position, text, fileName}: {
+  fileTextChanges: readonly ts.FileTextChanges[]; position: number; text: string; fileName: string;
+}) {
+  expect(includeAddTextInChanges({fileTextChanges, position, text, fileName})).toBeTruthy();
 }
 
-function includeReplacementTextInChanges(
-    {fileTextChanges, content, text, newText, fileName, removeWhitespace = false}: {
-      fileTextChanges: readonly ts.FileTextChanges[]; content: string; text: string | null;
-      newText: string;
-      fileName: string;
-      removeWhitespace?: boolean;
-    }) {
+function includeReplacementTextInChanges({fileTextChanges, content, text, newText, fileName}: {
+  fileTextChanges: readonly ts.FileTextChanges[]; content: string; text: string | null;
+  newText: string;
+  fileName: string;
+}) {
   for (const change of fileTextChanges) {
     if (!change.fileName.endsWith(fileName)) {
       continue;
@@ -374,9 +477,8 @@ function includeReplacementTextInChanges(
       }
       const textChangeOldText =
           content.slice(textChange.span.start, textChange.span.start + textChange.span.length);
-      let preprocess = removeWhitespace ? deleteWhitespace : (s: string) => s;
-      const oldTextMatches = text === null || (preprocess(textChangeOldText) === preprocess(text));
-      const newTextMatches = preprocess(newText) === preprocess(textChange.newText);
+      const oldTextMatches = text === null || textChangeOldText === text;
+      const newTextMatches = newText === textChange.newText;
       if (oldTextMatches && newTextMatches) {
         return true;
       }
@@ -385,12 +487,10 @@ function includeReplacementTextInChanges(
   return false;
 }
 
-function includeAddTextInChanges(
-    {fileTextChanges, position, text, fileName, removeWhitespace = false}: {
-      fileTextChanges: readonly ts.FileTextChanges[]; position: number | null; text: string;
-      fileName: string;
-      removeWhitespace?: boolean;
-    }) {
+function includeAddTextInChanges({fileTextChanges, position, text, fileName}: {
+  fileTextChanges: readonly ts.FileTextChanges[]; position: number | null; text: string;
+  fileName: string;
+}) {
   for (const change of fileTextChanges) {
     if (!change.fileName.endsWith(fileName)) {
       continue;
@@ -399,21 +499,12 @@ function includeAddTextInChanges(
       if (textChange.span.length > 0) {
         continue;
       }
-      let preprocess = removeWhitespace ? deleteWhitespace : (s: string) => s;
-      const includeAddText = (position === null || position === textChange.span.start) &&
-          preprocess(text) === preprocess(textChange.newText);
+      const includeAddText =
+          (position === null || position === textChange.span.start) && text === textChange.newText;
       if (includeAddText) {
         return true;
       }
     }
   }
   return false;
-}
-
-/**
- * For many test input files, there will be extra whitespace from the file formatting,
- * which causes unnecessarily fragile tests.
- */
-function deleteWhitespace(str: string) {
-  return str.replace(/\s/g, '');
 }


### PR DESCRIPTION
Four commits, as below:

### refactor(language-service): Improve the quick fix auto-import tests.

Currently, the auto-import tests are very difficult to debug, because the `expect`ations are buried several function calls deep, and also because the multi-line replacements are hard to deal with. The auto-import tests now use a different approach, which can be easily debugged from the failure message. In addition, several new tests have been added to cover more cases.

### refactor(compiler-cli): Make `getKnown` return an array of nodes.

`MetadataReaderWithIndex.getKnown` currently returns an iterator. It will be easier to work with for upcoming usages if it returns an array instead.

### feat(language-service): Introduce a new NgModuleIndex, and use it to suggest re-exports.

NgModules can re-export other NgModules, which transitively includes all traits exported by the re-exported NgModule. We want to be able to suggest *all* re-exports of a component when trying to auto-import it.

Previously, we used an approximation when importing from NgModules: we looked at a Component's metadata, and just imported the declaring NgModule. However, this is not technically correct -- the declaring NgModule it is not necessarily the same one that exports it for the current scope. (Indeed, there could be multiple re-exports!) As a replacement, I have implemented a more general solution.

This PR introduces a new class on the template type checker, called `NgModuleIndex`. When queried, it conducts a depth-first-search over the NgModule import/export graph, in order to find all NgModules anywhere in the current dependency graph, as well as all exports of those NgModules. This allows the language service to suggest all of the re-exports, in addition to the original export.

### feat(language-service): Allow auto-imports of a pipe via quick fix when its selector is used, both directly and via reexports.

A previous PR introduced a new compiler abstraction that tracks *all* known exports and re-exports of Angular traits. This PR harnesses that abstraction in the language service, in order to allow automatic imports of pipes.
