### PR TITLE
refactor(compiler): reduce complexity for legacy i18n digest string output

### DIFF
--- a/packages/compiler/src/i18n/digest.ts
+++ b/packages/compiler/src/i18n/digest.ts
@@ -152,7 +152,18 @@ export function sha1(str: string): string {
     e = add32(e, h4);
   }
 
-  return bytesToHexString(words32ToByteString([a, b, c, d, e]));
+  // Convert the output parts to a 160-bit hexadecimal string
+  return toHexU32(a) + toHexU32(b) + toHexU32(c) + toHexU32(d) + toHexU32(e);
+}
+
+/**
+ * Convert and format a number as a string representing a 32-bit unsigned hexadecimal number.
+ * @param value The value to format as a string.
+ * @returns A hexadecimal string representing the value.
+ */
+function toHexU32(value: number): string {
+  // unsigned right shift of zero ensures an unsigned 32-bit number
+  return (value >>> 0).toString(16).padStart(8, '0');
 }
 
 function fk(index: number, b: number, c: number, d: number): [number, number] {
@@ -355,27 +366,6 @@ function wordAt(bytes: Byte[], index: number, endian: Endian): number {
     }
   }
   return word;
-}
-
-function words32ToByteString(words32: number[]): Byte[] {
-  return words32.reduce((bytes, word) => bytes.concat(word32ToByteString(word)), [] as Byte[]);
-}
-
-function word32ToByteString(word: number): Byte[] {
-  let bytes: Byte[] = [];
-  for (let i = 0; i < 4; i++) {
-    bytes.push((word >>> 8 * (3 - i)) & 0xff);
-  }
-  return bytes;
-}
-
-function bytesToHexString(bytes: Byte[]): string {
-  let hex: string = '';
-  for (let i = 0; i < bytes.length; i++) {
-    const b = byteAt(bytes, i);
-    hex += (b >>> 4).toString(16) + (b & 0x0f).toString(16);
-  }
-  return hex.toLowerCase();
 }
 
 /**


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

When using the legacy digest algorithm for i18n messages, the output hexadecimal string now leverages a number's `toString()` function in addition to the `padStart` string function to generate the result. This removes the need for several helper functions which involved a series of iteration and bitwise operations to previously generate the same output.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
