### PR TITLE
docs: wrap json property in double quotes

### DIFF
--- a/aio/content/guide/build.md
+++ b/aio/content/guide/build.md
@@ -234,7 +234,7 @@ Define your size boundaries in the CLI configuration file, `angular.json`, in a 
   "configurations": {
     "production": {
       &hellip;
-      budgets: []
+      "budgets": []
     }
   }
 }


### PR DESCRIPTION
Previously, the `budgets` was not wrapped in quotes which caused the JSON to be invalid.
