### PR TITLE
refactor(compiler): replace `flatten` and `map` with `flatMap`.

### DIFF
--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1393,7 +1393,7 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
       return o.TYPED_NULL_EXPR;
     }
 
-    const refsParam = flatten(references.map(reference => {
+    const refsParam = references.flatMap(reference => {
       const slot = this.allocateDataSlot();
       // Generate the update temporary.
       const variableName = this._bindingScope.freshReferenceName();
@@ -1410,8 +1410,9 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
             const refExpr = lhs.set(o.importExpr(R3.reference).callFn([o.literal(slot)]));
             return nextContextStmt.concat(refExpr.toConstDecl());
           }, true);
+
       return [reference.name, reference.value];
-    }));
+    });
 
     return asLiteral(refsParam);
   }
@@ -2359,11 +2360,4 @@ export interface ParsedTemplate {
    * option is enabled.
    */
   commentNodes?: t.Comment[];
-}
-
-function flatten<T>(list: Array<T|T[]>): T[] {
-  return list.reduce((flat: any[], item: T|T[]): T[] => {
-    const flatItem = Array.isArray(item) ? flatten(item) : item;
-    return (<T[]>flat).concat(flatItem);
-  }, []);
 }


### PR DESCRIPTION
Replace custom `flatten` and `map` with native `flatMap` usage.

Benchmark:
| Test case name 	| Result                                                 	|
|----------------	|--------------------------------------------------------	|
| flatten & map  	| flatten & map x 1,182 ops/sec ±2.18% (63 runs sampled) 	|
| flatMap        	| flatMap x 6,011 ops/sec ±0.91% (35 runs sampled)       	|


The fact that `flatMap` is faster is also highlighted in https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap