### PR TITLE
fix(common): Update `Location` to get a normalized URL valid in case a represented URL starts with the substring equals `APP_BASE_HREF`

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -301,7 +301,10 @@ export function createLocation() {
 }
 
 function _stripBasePath(basePath: string, url: string): string {
-  return basePath && url.startsWith(basePath) ? url.substring(basePath.length) : url;
+  if (basePath === url) {
+    return '';
+  }
+  return basePath && url.startsWith(basePath + '/') ? url.substring(basePath.length) : url;
 }
 
 function _stripIndexHtml(url: string): string {

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -266,4 +266,18 @@ describe('Location Class', () => {
       expect(location.normalize(url)).toBe(route);
     });
   });
+
+  describe('location.normalize(url) should return correct route', () => {
+    it('in case url starts with the substring equals APP_BASE_HREF', () => {
+      const baseHref = '/en';
+      const url = '/enigma';
+
+      TestBed.configureTestingModule({providers: [{provide: APP_BASE_HREF, useValue: baseHref}]});
+
+      const location = TestBed.inject(Location);
+
+      expect(location.normalize(url)).toBe(url);
+      expect(location.normalize(baseHref + url)).toBe(url);
+    });
+  });
 });


### PR DESCRIPTION
Update `Location` to get a normalized URL valid in case a represented URL starts with the substring equals `APP_BASE_HREF`

```ts
@NgModule({
  imports: [RouterModule.forRoot([{path: '/enigma', component: EnigmaComponent}])],
  providers: [{provide: APP_BASE_HREF, useValue: '/en'}]
})
export class AppModule {}
```

Navigating to `/enigma` will redirect to `/en/igma` not to `/en/enigma` as it expects

Fixes: #45744

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 45744


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
