### PR TITLE
refactor(router): use `RegExp` to check if a URL is absolute

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -303,7 +303,13 @@ function _stripIndexHtml(url: string): string {
 }
 
 function _stripOrigin(baseHref: string): string {
-  if (/^(https?:)?\/\//.test(baseHref)) {
+  // DO NOT REFACTOR! Previously, this check looked like this:
+  // `/^(https?:)?\/\//.test(baseHref)`, but that resulted in
+  // syntactically incorrect code after Closure Compiler minification.
+  // This was likely caused by a bug in Closure Compiler, but
+  // for now, the check is rewritten to use `new RegExp` instead.
+  const isAbsoluteUrl = (new RegExp('^(https?:)?//')).test(baseHref);
+  if (isAbsoluteUrl) {
     const [, pathname] = baseHref.split(/\/\/[^\/]+/);
     return pathname;
   }


### PR DESCRIPTION
Previously, this check looked like this: `/^(https?:)?\/\//.test(baseHref)`, but that resulted in syntactically incorrect code after Closure Compiler minification. This was likely caused by a bug in Closure Compiler, but for now, the check is rewritten to use `new RegExp` instead.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No