### PR TITLE
fix(core): infer correct return type when `inject` is used with generic classes

### DIFF
--- a/goldens/public-api/core/index.api.md
+++ b/goldens/public-api/core/index.api.md
@@ -9,10 +9,7 @@ import { Subject } from 'rxjs';
 import { Subscription } from 'rxjs';
 
 // @public
-export interface AbstractType<T> extends Function {
-    // (undocumented)
-    prototype: T;
-}
+export type AbstractType<T> = abstract new (...args: unknown[]) => T;
 
 // @public
 export interface AfterContentChecked {

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -282,7 +282,7 @@ export class NgOptimizedImage implements OnInit, OnChanges {
   private imageLoader = inject(IMAGE_LOADER);
   private config: ImageConfig = processConfig(inject(IMAGE_CONFIG));
   private renderer = inject(Renderer2);
-  private imgElement: HTMLImageElement = inject(ElementRef).nativeElement;
+  private imgElement = inject(ElementRef<HTMLImageElement>).nativeElement;
   private injector = inject(Injector);
 
   // An LCP image observer should be injected only in development mode.

--- a/packages/core/src/interface/type.ts
+++ b/packages/core/src/interface/type.ts
@@ -30,9 +30,7 @@ export function isType(v: any): v is Type<any> {
  *
  * @publicApi
  */
-export interface AbstractType<T> extends Function {
-  prototype: T;
-}
+export type AbstractType<T> = abstract new (...args: unknown[]) => T;
 
 export interface Type<T> extends Function {
   new (...args: any[]): T;

--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -62,14 +62,14 @@ export function getTokenOrFunctionIdentity<T>(
   injector: Injector,
 ): Function | T {
   const NOT_FOUND = Symbol();
-  const result = injector.get<T | Symbol>(tokenOrFunction, NOT_FOUND);
+  const result = injector.get<T | Symbol>(tokenOrFunction as ProviderToken<T>, NOT_FOUND);
   if (result === NOT_FOUND) {
     if (typeof tokenOrFunction === 'function' && !isInjectable(tokenOrFunction)) {
       // We think the token is just a function so return it as-is
       return tokenOrFunction;
     } else {
       // This will throw the not found error
-      return injector.get<T>(tokenOrFunction);
+      return injector.get(tokenOrFunction as ProviderToken<T>);
     }
   }
   return result as T;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #48126


## What is the new behavior?

The return type of the `inject` function is correctly inferred when a class/abstract class with generics is passed as an input argument.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This commit introduces a breaking change with types when `inject` is used with generic classes/abstract classes.

BEFORE:

The inferred generic type is always `any`:

```ts
class C<T extends number> {}
abstract class AC<T extends string> {}

const c1 = inject(C); // type: C<any>
const c2 = inject(C<1>); // type: C<any>

const ac1 = inject(AC); // type: AC<any>
const ac2 = inject(AC<'ng'>); // type: AC<any>
```

AFTER:

The generic type is properly inferred:

```ts
class C<T extends number> {}
abstract class AC<T extends string> {}

const c1 = inject(C); // type: C<number>
const c2 = inject(C<1>); // type: C<1>

const ac1 = inject(AC); // type: AC<string>
const ac2 = inject(AC<'ng'>); // type: AC<'ng'>
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
