### PR TITLE
docs(router): Update ROUTES docs to not point to provideRoutes

### DIFF
--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -24,7 +24,7 @@ const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
  * `ROUTES` is a low level API for router configuration via dependency injection.
  *
  * We recommend that in almost all cases to use higher level APIs such as `RouterModule.forRoot()`,
- * `RouterModule.forChild()`, `provideRoutes`, or `Router.resetConfig()`.
+ * `provideRouter`, or `Router.resetConfig()`.
  *
  * @publicApi
  */


### PR DESCRIPTION
provideRoutes is deprecated in favor of the ROUTES token directly for complex situations where it's necessary.

fixes #48411