### PR TITLE
docs(common): Add note to location about investigating base href hand…

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -68,6 +68,12 @@ export class Location implements OnDestroy {
   constructor(locationStrategy: LocationStrategy) {
     this._locationStrategy = locationStrategy;
     const baseHref = this._locationStrategy.getBaseHref();
+    // Note: This class's interaction with base HREF does not fully follow the rules
+    // outlined in the spec https://www.freesoft.org/CIE/RFC/1808/18.htm.
+    // Instead of trying to fix individual bugs with more and more code, we should
+    // investigate using the URL constructor and providing the base as a second
+    // argument.
+    // https://developer.mozilla.org/en-US/docs/Web/API/URL/URL#parameters
     this._basePath = _stripOrigin(stripTrailingSlash(_stripIndexHtml(baseHref)));
     this._locationStrategy.onPopState((ev) => {
       this._subject.emit({


### PR DESCRIPTION
…ling

There have been/are several bugs related to base href handling in Angular (#45744, #48175, #19296).
These all stem from the attempted custom handling of base href in the `Location` class. This logic does not really make an attempt to be fully compliant with the spec.
