### PR TITLE
fix(common): Fix TestBed.overrideProvider type to include multi

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -140,16 +140,19 @@ export interface TestBed {
     overrideProvider(token: any, provider: {
         useFactory: Function;
         deps: any[];
+        multi?: boolean;
     }): TestBed;
     // (undocumented)
     overrideProvider(token: any, provider: {
         useValue: any;
+        multi?: boolean;
     }): TestBed;
     // (undocumented)
     overrideProvider(token: any, provider: {
         useFactory?: Function;
         useValue?: any;
         deps?: any[];
+        multi?: boolean;
     }): TestBed;
     // (undocumented)
     overrideTemplate(component: Type<any>, template: string): TestBed;

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -1020,7 +1020,7 @@ describe('TestBed', () => {
 
     it('overridden with an array', () => {
       const overrideValue = ['override'];
-      TestBed.overrideProvider(multiToken, {useValue: overrideValue, multi: true} as any);
+      TestBed.overrideProvider(multiToken, {useValue: overrideValue, multi: true});
 
       const value = TestBed.inject(multiToken);
       expect(value.length).toEqual(overrideValue.length);
@@ -1031,7 +1031,7 @@ describe('TestBed', () => {
       // This is actually invalid because multi providers return arrays. We have this here so we can
       // ensure Ivy behaves the same as VE does currently.
       const overrideValue = 'override';
-      TestBed.overrideProvider(multiToken, {useValue: overrideValue, multi: true} as any);
+      TestBed.overrideProvider(multiToken, {useValue: overrideValue, multi: true});
 
       const value = TestBed.inject(multiToken);
       expect(value.length).toEqual(overrideValue.length);
@@ -1248,7 +1248,7 @@ describe('TestBed', () => {
     });
 
     const multiOverride = {useValue: [{value: 'new provider'}], multi: true};
-    TestBed.overrideProvider(MY_TOKEN, multiOverride as any);
+    TestBed.overrideProvider(MY_TOKEN, multiOverride);
 
     const fixture = TestBed.createComponent(MyComp);
     expect(fixture.componentInstance.myProviders).toEqual([{value: 'new provider'}]);

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -127,13 +127,12 @@ export interface TestBed {
   /**
    * Overwrites all providers for the given token with the given provider definition.
    */
-  overrideProvider(token: any, provider: {
-    useFactory: Function,
-    deps: any[],
-  }): TestBed;
-  overrideProvider(token: any, provider: {useValue: any;}): TestBed;
-  overrideProvider(token: any, provider: {useFactory?: Function, useValue?: any, deps?: any[]}):
+  overrideProvider(token: any, provider: {useFactory: Function, deps: any[], multi?: boolean}):
       TestBed;
+  overrideProvider(token: any, provider: {useValue: any, multi?: boolean}): TestBed;
+  overrideProvider(
+      token: any,
+      provider: {useFactory?: Function, useValue?: any, deps?: any[], multi?: boolean}): TestBed;
 
   overrideTemplateUsingTestingModule(component: Type<any>, template: string): TestBed;
 


### PR DESCRIPTION
TestBed.overrideProvider should include `multi` support in its type. The underlying implementation already supports it, as documented by the tests which are currently casting the override to `any` to get around the bad type.
