### PR TITLE
refactor(router): Have router subscribe to transition events to updat…

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -51,6 +51,9 @@
     "name": "BaseRouteReuseStrategy"
   },
   {
+    "name": "BeforeActivateRoutes"
+  },
+  {
     "name": "BehaviorSubject"
   },
   {
@@ -549,6 +552,9 @@
     "name": "ReactiveNode"
   },
   {
+    "name": "RedirectRequest"
+  },
+  {
     "name": "RefCountOperator"
   },
   {
@@ -700,6 +706,9 @@
   },
   {
     "name": "TakeSubscriber"
+  },
+  {
+    "name": "TakeUntilSubscriber"
   },
   {
     "name": "TapSubscriber"
@@ -1575,7 +1584,7 @@
     "name": "isPromise2"
   },
   {
-    "name": "isRedirectingNavigationCancelingError"
+    "name": "isPublicRouterEvent"
   },
   {
     "name": "isScheduler"

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -8,6 +8,7 @@
 
 import {Route} from './models';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from './router_state';
+import {UrlTree} from './url_tree';
 
 /**
  * Identifies the call or event that triggered a navigation.
@@ -595,6 +596,12 @@ export class Scroll {
     return `Scroll(anchor: '${this.anchor}', position: '${pos}')`;
   }
 }
+
+export class BeforeActivateRoutes {}
+export class RedirectRequest {
+  constructor(readonly url: UrlTree) {}
+}
+export type PrivateRouterEvents = BeforeActivateRoutes|RedirectRequest;
 
 /**
  * Router events that allow you to track the lifecycle of the router.

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -262,8 +262,10 @@ export interface NavigationTransition {
  * directly.
  */
 interface InternalRouterInterface {
-  // All of these are public API of router interface and can change during runtime
-  // Ideally, these are removed
+  config: Routes;
+  // All of these are public API of router interface and can change during runtime because they are
+  // writeable. Ideally, these would be removed and the values retrieved instead from the values
+  // available in DI.
   errorHandler: ErrorHandler;
   titleStrategy?: TitleStrategy;
   navigated: boolean;
@@ -271,7 +273,6 @@ interface InternalRouterInterface {
   routeReuseStrategy: RouteReuseStrategy;
   onSameUrlNavigation: 'reload'|'ignore';
   paramsInheritanceStrategy: 'emptyOnly'|'always';
-  config: Routes;
 }
 
 @Injectable({providedIn: 'root'})
@@ -279,6 +280,11 @@ export class NavigationTransitions {
   currentNavigation: Navigation|null = null;
   currentTransition: NavigationTransition|null = null;
   lastSuccessfulNavigation: Navigation|null = null;
+  /**
+   * These events are used to communicate back to the Router about the state of the transition. The
+   * Router wants to respond to these events in various ways. Because the `NavigationTransition`
+   * class is not public, this event subject is not publicly exposed.
+   */
   readonly events = new Subject<Event|BeforeActivateRoutes|RedirectRequest>();
   /**
    * Used to abort the current transition with an error.

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -8,11 +8,11 @@
 
 import {EnvironmentInjector, inject, Injectable, Type} from '@angular/core';
 import {BehaviorSubject, combineLatest, EMPTY, Observable, of, Subject} from 'rxjs';
-import {catchError, defaultIfEmpty, filter, finalize, map, switchMap, take, tap} from 'rxjs/operators';
+import {catchError, defaultIfEmpty, filter, finalize, map, switchMap, take, takeUntil, tap} from 'rxjs/operators';
 
 import {createRouterState} from './create_router_state';
 import {INPUT_BINDER} from './directives/router_outlet';
-import {Event, GuardsCheckEnd, GuardsCheckStart, IMPERATIVE_NAVIGATION, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped, NavigationSkippedCode, NavigationStart, NavigationTrigger, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RoutesRecognized} from './events';
+import {BeforeActivateRoutes, Event, GuardsCheckEnd, GuardsCheckStart, IMPERATIVE_NAVIGATION, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped, NavigationSkippedCode, NavigationStart, NavigationTrigger, RedirectRequest, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RoutesRecognized} from './events';
 import {NavigationBehaviorOptions, QueryParamsHandling, Route, Routes} from './models';
 import {isNavigationCancelingError, isRedirectingNavigationCancelingError, redirectingNavigationError} from './navigation_canceling_error';
 import {activateRoutes} from './operators/activate_routes';
@@ -238,6 +238,7 @@ export interface NavigationTransition {
   currentUrlTree: UrlTree;
   extractedUrl: UrlTree;
   currentRawUrl: UrlTree;
+  currentBrowserUrl: UrlTree;
   urlAfterRedirects?: UrlTree;
   rawUrl: UrlTree;
   extras: NavigationExtras;
@@ -261,10 +262,8 @@ export interface NavigationTransition {
  * directly.
  */
 interface InternalRouterInterface {
-  browserUrlTree: UrlTree;
-  currentUrlTree: UrlTree;
-  rawUrlTree: UrlTree;
-  readonly routerState: RouterState;
+  // All of these are public API of router interface and can change during runtime
+  // Ideally, these are removed
   errorHandler: ErrorHandler;
   titleStrategy?: TitleStrategy;
   navigated: boolean;
@@ -272,22 +271,19 @@ interface InternalRouterInterface {
   routeReuseStrategy: RouteReuseStrategy;
   onSameUrlNavigation: 'reload'|'ignore';
   paramsInheritanceStrategy: 'emptyOnly'|'always';
-  urlUpdateStrategy: 'deferred'|'eager';
-  serializeUrl(url: UrlTree): string;
   config: Routes;
-  setBrowserUrl(url: UrlTree, t: NavigationTransition): void;
-  restoreHistory(t: NavigationTransition, restoringFromCaughtError?: boolean): void;
-  scheduleNavigation(
-      rawUrl: UrlTree, source: NavigationTrigger, restoredState: RestoredState|null,
-      extras: NavigationExtras,
-      priorPromise?: {resolve: any, reject: any, promise: Promise<boolean>}): Promise<boolean>;
 }
 
 @Injectable({providedIn: 'root'})
 export class NavigationTransitions {
   currentNavigation: Navigation|null = null;
+  currentTransition: NavigationTransition|null = null;
   lastSuccessfulNavigation: Navigation|null = null;
-  readonly events = new Subject<Event>();
+  readonly events = new Subject<Event|BeforeActivateRoutes|RedirectRequest>();
+  /**
+   * Used to abort the current transition with an error.
+   */
+  readonly transitionAbortSubject = new Subject<Error>();
   private readonly configLoader = inject(RouterConfigLoader);
   private readonly environmentInjector = inject(EnvironmentInjector);
   private readonly urlSerializer = inject(UrlSerializer);
@@ -322,29 +318,32 @@ export class NavigationTransitions {
   handleNavigationRequest(
       request: Pick<
           NavigationTransition,
-          'source'|'restoredState'|'currentUrlTree'|'currentRawUrl'|'rawUrl'|'extras'|'resolve'|
-          'reject'|'promise'|'currentSnapshot'|'currentRouterState'>) {
+          'source'|'restoredState'|'currentUrlTree'|'currentRawUrl'|'currentBrowserUrl'|'rawUrl'|
+          'extras'|'resolve'|'reject'|'promise'|'currentSnapshot'|'currentRouterState'>) {
     const id = ++this.navigationId;
     this.transitions?.next({...this.transitions.value, ...request, id});
   }
 
-  setupNavigations(router: InternalRouterInterface): Observable<NavigationTransition> {
+  setupNavigations(
+      router: InternalRouterInterface, initialUrlTree: UrlTree,
+      initialRouterState: RouterState): Observable<NavigationTransition> {
     this.transitions = new BehaviorSubject<NavigationTransition>({
       id: 0,
-      currentUrlTree: router.currentUrlTree,
-      currentRawUrl: router.currentUrlTree,
-      extractedUrl: router.urlHandlingStrategy.extract(router.currentUrlTree),
-      urlAfterRedirects: router.urlHandlingStrategy.extract(router.currentUrlTree),
-      rawUrl: router.currentUrlTree,
+      currentUrlTree: initialUrlTree,
+      currentRawUrl: initialUrlTree,
+      currentBrowserUrl: initialUrlTree,
+      extractedUrl: router.urlHandlingStrategy.extract(initialUrlTree),
+      urlAfterRedirects: router.urlHandlingStrategy.extract(initialUrlTree),
+      rawUrl: initialUrlTree,
       extras: {},
       resolve: null,
       reject: null,
       promise: Promise.resolve(true),
       source: IMPERATIVE_NAVIGATION,
       restoredState: null,
-      currentSnapshot: router.routerState.snapshot,
+      currentSnapshot: initialRouterState.snapshot,
       targetSnapshot: null,
-      currentRouterState: router.routerState,
+      currentRouterState: initialRouterState,
       targetRouterState: null,
       guards: {canActivateChecks: [], canDeactivateChecks: []},
       guardsResult: null,
@@ -359,6 +358,7 @@ export class NavigationTransitions {
 
                // Using switchMap so we cancel executing navigations when a new one comes in
                switchMap(overallTransitionState => {
+                 this.currentTransition = overallTransitionState;
                  let completed = false;
                  let errored = false;
                  return of(overallTransitionState)
@@ -378,14 +378,14 @@ export class NavigationTransitions {
                            };
                          }),
                          switchMap(t => {
-                           const browserUrlTree = router.browserUrlTree.toString();
+                           const browserUrlTree = t.currentBrowserUrl.toString();
                            const urlTransition = !router.navigated ||
                                t.extractedUrl.toString() !== browserUrlTree ||
                                // Navigations which succeed or ones which fail and are cleaned up
                                // correctly should result in `browserUrlTree` and `currentUrlTree`
                                // matching. If this is not the case, assume something went wrong and
                                // try processing the URL again.
-                               browserUrlTree !== router.currentUrlTree.toString();
+                               browserUrlTree !== t.currentUrlTree.toString();
 
 
                            const onSameUrlNavigation =
@@ -396,19 +396,13 @@ export class NavigationTransitions {
                                      t.rawUrl} was ignored because it is the same as the current Router URL.` :
                                  '';
                              this.events.next(new NavigationSkipped(
-                                 t.id, router.serializeUrl(overallTransitionState.rawUrl), reason,
+                                 t.id, this.urlSerializer.serialize(t.rawUrl), reason,
                                  NavigationSkippedCode.IgnoredSameUrlNavigation));
-                             router.rawUrlTree = t.rawUrl;
                              t.resolve(null);
                              return EMPTY;
                            }
 
                            if (router.urlHandlingStrategy.shouldProcessUrl(t.rawUrl)) {
-                             // If the source of the navigation is from a browser event, the URL is
-                             // already updated. We already need to sync the internal state.
-                             if (isBrowserTriggeredNavigation(t.source)) {
-                               router.browserUrlTree = t.extractedUrl;
-                             }
                              return of(t).pipe(
                                  // Fire NavigationStart event
                                  switchMap(t => {
@@ -440,15 +434,6 @@ export class NavigationTransitions {
                                      finalUrl: t.urlAfterRedirects
                                    };
 
-                                   if (router.urlUpdateStrategy === 'eager') {
-                                     if (!t.extras.skipLocationChange) {
-                                       const rawUrl = router.urlHandlingStrategy.merge(
-                                           t.urlAfterRedirects!, t.rawUrl);
-                                       router.setBrowserUrl(rawUrl, t);
-                                     }
-                                     router.browserUrlTree = t.urlAfterRedirects!;
-                                   }
-
                                    // Fire RoutesRecognized
                                    const routesRecognized = new RoutesRecognized(
                                        t.id, this.urlSerializer.serialize(t.extractedUrl),
@@ -458,7 +443,7 @@ export class NavigationTransitions {
                                  }));
                            } else if (
                                urlTransition &&
-                               router.urlHandlingStrategy.shouldProcessUrl(router.rawUrlTree)) {
+                               router.urlHandlingStrategy.shouldProcessUrl(t.currentRawUrl)) {
                              /* When the current URL shouldn't be processed, but the previous one
                               * was, we handle this "error condition" by navigating to the
                               * previously successful URL, but leaving the URL intact.*/
@@ -470,7 +455,7 @@ export class NavigationTransitions {
                              const targetSnapshot =
                                  createEmptyState(extractedUrl, this.rootComponentType).snapshot;
 
-                             overallTransitionState = {
+                             this.currentTransition = overallTransitionState = {
                                ...t,
                                targetSnapshot,
                                urlAfterRedirects: extractedUrl,
@@ -486,13 +471,12 @@ export class NavigationTransitions {
                              const reason = (typeof ngDevMode === 'undefined' || ngDevMode) ?
                                  `Navigation was ignored because the UrlHandlingStrategy` +
                                      ` indicated neither the current URL ${
-                                         router.rawUrlTree} nor target URL ${
+                                         t.currentRawUrl} nor target URL ${
                                          t.rawUrl} should be processed.` :
                                  '';
                              this.events.next(new NavigationSkipped(
-                                 t.id, router.serializeUrl(overallTransitionState.extractedUrl),
-                                 reason, NavigationSkippedCode.IgnoredByUrlHandlingStrategy));
-                             router.rawUrlTree = t.rawUrl;
+                                 t.id, this.urlSerializer.serialize(t.extractedUrl), reason,
+                                 NavigationSkippedCode.IgnoredByUrlHandlingStrategy));
                              t.resolve(null);
                              return EMPTY;
                            }
@@ -508,7 +492,7 @@ export class NavigationTransitions {
                          }),
 
                          map(t => {
-                           overallTransitionState = {
+                           this.currentTransition = overallTransitionState = {
                              ...t,
                              guards: getAllRouteGuards(
                                  t.targetSnapshot!, t.currentSnapshot, this.rootContexts)
@@ -533,7 +517,6 @@ export class NavigationTransitions {
 
                          filter(t => {
                            if (!t.guardsResult) {
-                             router.restoreHistory(t);
                              this.cancelNavigationTransition(
                                  t, '', NavigationCancellationCode.GuardRejected);
                              return false;
@@ -562,7 +545,6 @@ export class NavigationTransitions {
                                          next: () => dataResolved = true,
                                          complete: () => {
                                            if (!dataResolved) {
-                                             router.restoreHistory(t);
                                              this.cancelNavigationTransition(
                                                  t,
                                                  (typeof ngDevMode === 'undefined' || ngDevMode) ?
@@ -614,29 +596,13 @@ export class NavigationTransitions {
                          map((t: NavigationTransition) => {
                            const targetRouterState = createRouterState(
                                router.routeReuseStrategy, t.targetSnapshot!, t.currentRouterState);
-                           overallTransitionState = {...t, targetRouterState};
-                           return (overallTransitionState);
+                           this.currentTransition =
+                               overallTransitionState = {...t, targetRouterState};
+                           return overallTransitionState;
                          }),
 
-                         /* Once here, we are about to activate synchronously. The assumption is
-                            this will succeed, and user code may read from the Router service.
-                            Therefore before activation, we need to update router properties storing
-                            the current URL and the RouterState, as well as updated the browser URL.
-                            All this should happen *before* activating. */
-                         tap((t: NavigationTransition) => {
-                           router.currentUrlTree = t.urlAfterRedirects!;
-                           router.rawUrlTree =
-                               router.urlHandlingStrategy.merge(t.urlAfterRedirects!, t.rawUrl);
-
-                           (router as {routerState: RouterState}).routerState =
-                               t.targetRouterState!;
-
-                           if (router.urlUpdateStrategy === 'deferred') {
-                             if (!t.extras.skipLocationChange) {
-                               router.setBrowserUrl(router.rawUrlTree, t);
-                             }
-                             router.browserUrlTree = t.urlAfterRedirects!;
-                           }
+                         tap(() => {
+                           this.events.next(new BeforeActivateRoutes());
                          }),
 
                          activateRoutes(
@@ -652,10 +618,9 @@ export class NavigationTransitions {
                            next: (t: NavigationTransition) => {
                              completed = true;
                              this.lastSuccessfulNavigation = this.currentNavigation;
-                             router.navigated = true;
                              this.events.next(new NavigationEnd(
                                  t.id, this.urlSerializer.serialize(t.extractedUrl),
-                                 this.urlSerializer.serialize(router.currentUrlTree)));
+                                 this.urlSerializer.serialize(t.urlAfterRedirects!)));
                              router.titleStrategy?.updateTitle(t.targetRouterState!.snapshot);
                              t.resolve(true);
                            },
@@ -663,6 +628,18 @@ export class NavigationTransitions {
                              completed = true;
                            }
                          }),
+
+                         // There used to be a lot more logic happening directly within the
+                         // transition Observable. Some of this logic has been refactored out to
+                         // other places but there may still be errors that happen there. This gives
+                         // us a way to cancel the transition from the outside. This may also be
+                         // required in the future to support something like the abort signal of the
+                         // Navigation API where the navigation gets aborted from outside the
+                         // transition.
+                         takeUntil(this.transitionAbortSubject.pipe(tap(err => {
+                           throw err;
+                         }))),
+
                          finalize(() => {
                            /* When the navigation stream finishes either through error or success,
                             * we set the `completed` or `errored` flag. However, there are some
@@ -693,57 +670,26 @@ export class NavigationTransitions {
                            /* This error type is issued during Redirect, and is handled as a
                             * cancellation rather than an error. */
                            if (isNavigationCancelingError(e)) {
-                             if (!isRedirectingNavigationCancelingError(e)) {
-                               // Set property only if we're not redirecting. If we landed on a page
-                               // and redirect to `/` route, the new navigation is going to see the
-                               // `/` isn't a change from the default currentUrlTree and won't
-                               // navigate. This is only applicable with initial navigation, so
-                               // setting `navigated` only when not redirecting resolves this
-                               // scenario.
-                               router.navigated = true;
-                               router.restoreHistory(overallTransitionState, true);
-                             }
-                             const navCancel = new NavigationCancel(
+                             this.events.next(new NavigationCancel(
                                  overallTransitionState.id,
                                  this.urlSerializer.serialize(overallTransitionState.extractedUrl),
-                                 e.message, e.cancellationCode);
-                             this.events.next(navCancel);
+                                 e.message, e.cancellationCode));
 
                              // When redirecting, we need to delay resolving the navigation
                              // promise and push it to the redirect navigation
                              if (!isRedirectingNavigationCancelingError(e)) {
                                overallTransitionState.resolve(false);
                              } else {
-                               const mergedTree =
-                                   router.urlHandlingStrategy.merge(e.url, router.rawUrlTree);
-                               const extras = {
-                                 skipLocationChange:
-                                     overallTransitionState.extras.skipLocationChange,
-                                 // The URL is already updated at this point if we have 'eager' URL
-                                 // updates or if the navigation was triggered by the browser (back
-                                 // button, URL bar, etc). We want to replace that item in history
-                                 // if the navigation is rejected.
-                                 replaceUrl: router.urlUpdateStrategy === 'eager' ||
-                                     isBrowserTriggeredNavigation(overallTransitionState.source)
-                               };
-
-                               router.scheduleNavigation(
-                                   mergedTree, IMPERATIVE_NAVIGATION, null, extras, {
-                                     resolve: overallTransitionState.resolve,
-                                     reject: overallTransitionState.reject,
-                                     promise: overallTransitionState.promise
-                                   });
+                               this.events.next(new RedirectRequest(e.url));
                              }
 
                              /* All other errors should reset to the router's internal URL reference
                               * to the pre-error state. */
                            } else {
-                             router.restoreHistory(overallTransitionState, true);
-                             const navError = new NavigationError(
+                             this.events.next(new NavigationError(
                                  overallTransitionState.id,
                                  this.urlSerializer.serialize(overallTransitionState.extractedUrl),
-                                 e, overallTransitionState.targetSnapshot ?? undefined);
-                             this.events.next(navError);
+                                 e, overallTransitionState.targetSnapshot ?? undefined));
                              try {
                                overallTransitionState.resolve(router.errorHandler(e));
                              } catch (ee) {

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -8,14 +8,14 @@
 
 import {Location} from '@angular/common';
 import {inject, Injectable, NgZone, Type, ɵConsole as Console, ɵInitialRenderPendingTasks as InitialRenderPendingTasks, ɵRuntimeError as RuntimeError} from '@angular/core';
-import {Observable, of, SubscriptionLike} from 'rxjs';
+import {Observable, Subject, Subscription, SubscriptionLike} from 'rxjs';
 
 import {createSegmentGroupFromRoute, createUrlTreeFromSegmentGroup} from './create_url_tree';
 import {INPUT_BINDER} from './directives/router_outlet';
 import {RuntimeErrorCode} from './errors';
-import {Event, IMPERATIVE_NAVIGATION, NavigationTrigger} from './events';
+import {BeforeActivateRoutes, Event, IMPERATIVE_NAVIGATION, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped, NavigationStart, NavigationTrigger, PrivateRouterEvents, RedirectRequest, RoutesRecognized} from './events';
 import {NavigationBehaviorOptions, OnSameUrlNavigation, Routes} from './models';
-import {Navigation, NavigationExtras, NavigationTransition, NavigationTransitions, RestoredState, UrlCreationOptions} from './navigation_transition';
+import {isBrowserTriggeredNavigation, Navigation, NavigationExtras, NavigationTransition, NavigationTransitions, RestoredState, UrlCreationOptions} from './navigation_transition';
 import {TitleStrategy} from './page_title_strategy';
 import {RouteReuseStrategy} from './route_reuse_strategy';
 import {ROUTER_CONFIGURATION} from './router_config';
@@ -161,6 +161,7 @@ export class Router {
   private console = inject(Console);
   private isNgZoneEnabled: boolean = false;
 
+  private _events = new Subject<Event>();
   /**
    * An event stream for routing events.
    */
@@ -169,7 +170,7 @@ export class Router {
     // cleanup: tests are doing `(route.events as Subject<Event>).next(...)`. This isn't
     // allowed/supported but we still have to fix these or file bugs against the teams before making
     // the change.
-    return this.navigationTransitions.events;
+    return this._events;
   }
   /**
    * The current state of routing in this NgModule.
@@ -329,14 +330,119 @@ export class Router {
 
     this.routerState = createEmptyState(this.currentUrlTree, null);
 
-    this.navigationTransitions.setupNavigations(this).subscribe(
-        t => {
-          this.lastSuccessfulId = t.id;
-          this.currentPageId = this.browserPageId;
-        },
-        e => {
-          this.console.warn(`Unhandled Navigation Error: ${e}`);
-        });
+    this.navigationTransitions.setupNavigations(this, this.currentUrlTree, this.routerState)
+        .subscribe(
+            t => {
+              this.lastSuccessfulId = t.id;
+              this.currentPageId = this.browserPageId;
+            },
+            e => {
+              this.console.warn(`Unhandled Navigation Error: ${e}`);
+            });
+    this.subscribeToNavigationEvents();
+  }
+
+
+  private eventsSubscription = new Subscription();
+  private subscribeToNavigationEvents() {
+    const subscription = this.navigationTransitions.events.subscribe(e => {
+      try {
+        const currentTransition = this.navigationTransitions.currentTransition;
+        if (currentTransition === null) {
+          if (isPublicRouterEvent(e)) {
+            this._events.next(e);
+          }
+          return;
+        }
+
+        if (e instanceof NavigationStart) {
+          // If the source of the navigation is from a browser event, the URL is
+          // already updated. We already need to sync the internal state.
+          if (isBrowserTriggeredNavigation(currentTransition!.source)) {
+            this.browserUrlTree = currentTransition.extractedUrl;
+          }
+        }
+
+        if (e instanceof NavigationSkipped) {
+          this.rawUrlTree = currentTransition.rawUrl;
+        }
+
+        if (e instanceof RoutesRecognized) {
+          if (this.urlUpdateStrategy === 'eager') {
+            if (!currentTransition.extras.skipLocationChange) {
+              const rawUrl = this.urlHandlingStrategy.merge(
+                  currentTransition.urlAfterRedirects!, currentTransition.rawUrl);
+              this.setBrowserUrl(rawUrl, currentTransition);
+            }
+            this.browserUrlTree = currentTransition.urlAfterRedirects!;
+          }
+        }
+
+        if (e instanceof BeforeActivateRoutes) {
+          this.currentUrlTree = currentTransition.urlAfterRedirects!;
+          this.rawUrlTree = this.urlHandlingStrategy.merge(
+              currentTransition.urlAfterRedirects!, currentTransition.rawUrl);
+          (this as {routerState: RouterState}).routerState = currentTransition.targetRouterState!;
+          if (this.urlUpdateStrategy === 'deferred') {
+            if (!currentTransition.extras.skipLocationChange) {
+              this.setBrowserUrl(this.rawUrlTree, currentTransition);
+            }
+            this.browserUrlTree = currentTransition.urlAfterRedirects!;
+          }
+        }
+
+        if (e instanceof NavigationCancel) {
+          if (e.code !== NavigationCancellationCode.Redirect &&
+              e.code !== NavigationCancellationCode.SupersededByNewNavigation) {
+            // It seems weird that `navigated` is set to `true` when the navigation is rejected,
+            // however it's how things were written initially. Investigation would need to be done
+            // to determine if this can be removed.
+            this.navigated = true;
+          }
+          if (e.code === NavigationCancellationCode.GuardRejected ||
+              e.code === NavigationCancellationCode.NoDataFromResolver) {
+            this.restoreHistory(currentTransition);
+          }
+        }
+
+        if (e instanceof RedirectRequest) {
+          const mergedTree = this.urlHandlingStrategy.merge(e.url, currentTransition.currentRawUrl);
+          const extras = {
+            skipLocationChange: currentTransition.extras.skipLocationChange,
+            // The URL is already updated at this point if we have 'eager' URL
+            // updates or if the navigation was triggered by the browser (back
+            // button, URL bar, etc). We want to replace that item in history
+            // if the navigation is rejected.
+            replaceUrl: this.urlUpdateStrategy === 'eager' ||
+                isBrowserTriggeredNavigation(currentTransition.source)
+          };
+
+          this.scheduleNavigation(mergedTree, IMPERATIVE_NAVIGATION, null, extras, {
+            resolve: currentTransition.resolve,
+            reject: currentTransition.reject,
+            promise: currentTransition.promise
+          });
+        }
+
+        if (e instanceof NavigationError) {
+          this.restoreHistory(currentTransition, true);
+        }
+
+        if (e instanceof NavigationEnd) {
+          this.navigated = true;
+        }
+
+        // Note that it's important to have the Router process the events _before_ the event is
+        // pushed through the public observable. This ensures the correct router state is in place
+        // before applications observe the events.
+        if (isPublicRouterEvent(e)) {
+          this._events.next(e);
+        }
+      } catch (e: unknown) {
+        this.navigationTransitions.transitionAbortSubject.next(e as Error);
+      }
+    });
+    this.eventsSubscription.add(subscription);
   }
 
   /** @internal */
@@ -474,6 +580,7 @@ export class Router {
       this.locationSubscription = undefined;
     }
     this.disposed = true;
+    this.eventsSubscription.unsubscribe();
   }
 
   /**
@@ -741,6 +848,7 @@ export class Router {
       restoredState,
       currentUrlTree: this.currentUrlTree,
       currentRawUrl: this.currentUrlTree,
+      currentBrowserUrl: this.browserUrlTree,
       rawUrl,
       extras,
       resolve,
@@ -850,4 +958,8 @@ function validateCommands(commands: string[]): void {
               `The requested path contains ${cmd} segment at index ${i}`);
     }
   }
+}
+
+function isPublicRouterEvent(e: Event|PrivateRouterEvents): e is Event {
+  return (!(e instanceof BeforeActivateRoutes) && !(e instanceof RedirectRequest));
 }


### PR DESCRIPTION
…e state

Rather than the navigation transitions managing Router state, this commit updates the Router to manage its own state based on ongoing transition events. In the future, this can be abstracted even further to have a totally separate class that manages the Router state. This would allow the potential for swapping state manager implementations rather than having to implement all types of state management in a single place.