### PR TITLE
fix(animations): fix incorrect handling of camel-case css properties

### DIFF
--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -191,7 +191,7 @@ export class AnimationStateStyles {
           }
           const normalizedProp = this.normalizer.normalizePropertyName(prop, errors);
           val = this.normalizer.normalizeStyleValue(prop, normalizedProp, val, errors);
-          finalStyles.set(normalizedProp, val);
+          finalStyles.set(prop, val);
         });
       }
     });


### PR DESCRIPTION
fix the issue of camel-case properties not being handled correctly in state transition causing them not to be applied to the element

resolves #48246

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

CSS kebab-case properties are not correctly handled in state transitions (whilst camelCase ones are)

for example:
![before](https://user-images.githubusercontent.com/61631103/206872731-6677ab65-4c25-415b-b632-478c730eeceb.gif)


## What is the new behavior?

CSS kebab-case properties are correctly handled, consistently as the camelCase ones

for example:
![after](https://user-images.githubusercontent.com/61631103/206872770-c1e046fd-39ed-4c53-ab27-c4ccce44267d.gif)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
