### PR TITLE
fix(localize): add all TypeScript types to the root level tsconfig

### DIFF
--- a/packages/localize/schematics/ng-add/index.ts
+++ b/packages/localize/schematics/ng-add/index.ts
@@ -18,6 +18,8 @@ import {Builders} from '@schematics/angular/utility/workspace-models';
 import {Schema} from './schema';
 
 const localizeType = `@angular/localize`;
+const localizeTypeInit = '@angular/localize/init';
+const typesJsonPath: JSONPath = ['compilerOptions', 'types'];
 
 function addTypeScriptConfigTypes(projectName: string): Rule {
   return async (host: Tree) => {
@@ -28,7 +30,7 @@ function addTypeScriptConfigTypes(projectName: string): Rule {
     }
 
     // We add the root workspace tsconfig for better IDE support.
-    const tsConfigFiles = new Set<string>(['tsconfig.json']);
+    const tsConfigFiles = new Set<string>();
     for (const target of project.targets.values()) {
       switch (target.builder) {
         case Builders.Karma:
@@ -43,27 +45,37 @@ function addTypeScriptConfigTypes(projectName: string): Rule {
       }
     }
 
-    const typesJsonPath: JSONPath = ['compilerOptions', 'types'];
+    const allTypes: string[] = [];
+    // All builder target tsconfigs
     for (const path of tsConfigFiles) {
       if (!host.exists(path)) {
         continue;
       }
-
-      const json = new JSONFile(host, path);
-      const types = json.get(typesJsonPath) ?? [];
-      if (!Array.isArray(types)) {
-        throw new SchematicsException(`TypeScript configuration file '${
-            path}' has an invalid 'types' property. It must be an array.`);
+      const builderTsConfig = getJsonFileAndTypes(host, path);
+      if (!builderTsConfig) {
+        continue;
       }
 
-      const hasLocalizeType =
-          types.some((t) => t === localizeType || t === '@angular/localize/init');
+      const {json, types} = builderTsConfig;
+      allTypes.push(...types);
+
+      const hasLocalizeType = types.some((t) => t === localizeType || t === localizeTypeInit);
       if (hasLocalizeType) {
         // Skip has already localize type.
         continue;
       }
 
       json.modify(typesJsonPath, [...types, localizeType]);
+    }
+
+    // Update workspace tsconfig
+    const rootTsConfigFile = getJsonFileAndTypes(host, './tsconfig.json');
+    if (rootTsConfigFile) {
+      const {json, types} = rootTsConfigFile;
+
+      const allTypesForRoot =
+          [...allTypes, ...types, localizeType].filter(t => t !== localizeTypeInit);
+      json.modify(typesJsonPath, Array.from(allTypesForRoot));
     }
   };
 }
@@ -84,6 +96,25 @@ function moveToDependencies(host: Tree, context: SchematicContext): void {
   // Add a task to run the package manager. This is necessary because we updated
   // "package.json" and we want lock files to reflect this.
   context.addTask(new NodePackageInstallTask());
+}
+
+function getJsonFileAndTypes(host: Tree, path: string): {json: JSONFile, types: string[]}|
+    undefined {
+  if (!host.exists(path)) {
+    return undefined;
+  }
+
+  const json = new JSONFile(host, path);
+  const types = json.get(typesJsonPath) ?? [];
+  if (!Array.isArray(types)) {
+    throw new SchematicsException(`TypeScript configuration file '${
+        path}' has an invalid 'types' property. It must be an array.`);
+  }
+
+  return {
+    json,
+    types,
+  };
 }
 
 export default function(options: Schema): Rule {

--- a/packages/localize/schematics/ng-add/index_spec.ts
+++ b/packages/localize/schematics/ng-add/index_spec.ts
@@ -66,9 +66,17 @@ describe('ng-add schematic', () => {
         },
       },
     }));
+
+    const tsConfig = JSON.stringify({
+      compilerOptions: {
+        types: ['jasmine'],
+      },
+    });
+
+    host.create('tsconfig.spec.json', tsConfig);
   });
 
-  it(`should add '@angular/localize' in 'types' in the root level 'tsconfig.json'`, async () => {
+  it(`should add all 'types' in the root level 'tsconfig.json'`, async () => {
     host.create('tsconfig.json', JSON.stringify({
       compilerOptions: {
         types: ['node'],
@@ -78,8 +86,7 @@ describe('ng-add schematic', () => {
     host = await schematicRunner.runSchematicAsync('ng-add', defaultOptions, host).toPromise();
     const {compilerOptions} = host.readJson('tsconfig.json') as TsConfig;
     const types = compilerOptions?.types;
-    expect(types).toContain(localizeType);
-    expect(types).toHaveSize(2);
+    expect(types).toEqual(['jasmine', 'node', '@angular/localize']);
   });
 
   it(`should not add '@angular/localize' in 'types' tsconfig when '@angular/localize/init' is present`,
@@ -93,8 +100,7 @@ describe('ng-add schematic', () => {
        host = await schematicRunner.runSchematicAsync('ng-add', defaultOptions, host).toPromise();
        const {compilerOptions} = host.readJson('tsconfig.json') as TsConfig;
        const types = compilerOptions?.types;
-       expect(types).not.toContain(localizeType);
-       expect(types).toHaveSize(2);
+       expect(types).toEqual(['jasmine', 'node', '@angular/localize']);
      });
 
 
@@ -135,14 +141,6 @@ describe('ng-add schematic', () => {
 
   it(`should add '@angular/localize' in 'types' tsconfigs referenced in karma builder`,
      async () => {
-       const tsConfig = JSON.stringify({
-         compilerOptions: {
-           types: ['node'],
-         },
-       });
-
-       host.create('tsconfig.spec.json', tsConfig);
-
        host = await schematicRunner.runSchematicAsync('ng-add', defaultOptions, host).toPromise();
        const {compilerOptions} = host.readJson('tsconfig.spec.json') as TsConfig;
        const types = compilerOptions?.types;


### PR DESCRIPTION
With this change we add all types from the builders tsconfig file to the root level tsconfig when running `ng add @angular/localize`. This is needed as by adding `@angular/localize` type to the root level tsconfig we exclude all other types in `@types` from being included in the IDE tsconfig which results in bad DX.

More information on how the `types` option works can be found here: https://www.typescriptlang.org/tsconfig#types

Closes #48434
