### PR TITLE
docs: call interval methods explicitly from window

### DIFF
--- a/aio/content/examples/component-interaction/src/app/countdown-timer.component.ts
+++ b/aio/content/examples/component-interaction/src/app/countdown-timer.component.ts
@@ -19,7 +19,7 @@ export class CountdownTimerComponent implements OnDestroy {
     this.message = `Holding at T-${this.seconds} seconds`;
   }
 
-  private clearTimer() { clearInterval(this.intervalId); }
+  private clearTimer() { window.clearInterval(this.intervalId); }
 
   private countDown() {
     this.clearTimer();

--- a/aio/content/examples/dynamic-component-loader/src/app/ad-banner.component.ts
+++ b/aio/content/examples/dynamic-component-loader/src/app/ad-banner.component.ts
@@ -31,7 +31,7 @@ export class AdBannerComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    clearInterval(this.interval);
+    window.clearInterval(this.interval);
   }
 
   loadComponent() {
@@ -46,7 +46,7 @@ export class AdBannerComponent implements OnInit, OnDestroy {
   }
 
   getAds() {
-    this.interval = setInterval(() => {
+    this.interval = window.setInterval(() => {
       this.loadComponent();
     }, 3000);
   }

--- a/aio/content/examples/observables-in-angular/src/main.ts
+++ b/aio/content/examples/observables-in-angular/src/main.ts
@@ -44,7 +44,7 @@ export class ZippyComponent {
 })
 export class AsyncObservablePipeComponent {
   time = new Observable<string>(observer => {
-    setInterval(() => observer.next(new Date().toString()), 1000);
+    window.setInterval(() => observer.next(new Date().toString()), 1000);
   });
 }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When running code examples on StackBlitz the TS compiler is not able to identify that the methods **setTimeout** and **clearTimeout** come  from *lib.dom.ts* and not from *@types/node*, and when you try to assign the return value from **setTimeout** to a number variable it complains with the message: Type 'Timer' is not assignable to type 'number'.

Issue Number: N/A

## What is the new behavior?

The TS Compiler on StackBlitz stop complaining.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
