### PR TITLE
Revert "fix(common): Update `Location` to get a normalized URL valid …

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -301,10 +301,7 @@ export function createLocation() {
 }
 
 function _stripBasePath(basePath: string, url: string): string {
-  if (basePath === url) {
-    return '';
-  }
-  return basePath && url.startsWith(basePath + '/') ? url.substring(basePath.length) : url;
+  return basePath && url.startsWith(basePath) ? url.substring(basePath.length) : url;
 }
 
 function _stripIndexHtml(url: string): string {

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -266,18 +266,4 @@ describe('Location Class', () => {
       expect(location.normalize(url)).toBe(route);
     });
   });
-
-  describe('location.normalize(url) should return correct route', () => {
-    it('in case url starts with the substring equals APP_BASE_HREF', () => {
-      const baseHref = '/en';
-      const url = '/enigma';
-
-      TestBed.configureTestingModule({providers: [{provide: APP_BASE_HREF, useValue: baseHref}]});
-
-      const location = TestBed.inject(Location);
-
-      expect(location.normalize(url)).toBe(url);
-      expect(location.normalize(baseHref + url)).toBe(url);
-    });
-  });
 });


### PR DESCRIPTION
…in case a represented URL starts with the substring equals `APP_BASE_HREF`"

This reverts commit ae0efb6a09af213e069d1fc92061949afca4f5f7.
