### PR TITLE
refactor(router): move internal router properties to transition handl…

### DIFF
--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -358,7 +358,7 @@ export function withEnabledBlockingInitialNavigation(): EnabledBlockingInitialNa
                 resolve(true);
               });
 
-              router.afterPreactivation = () => {
+              injector.get(NavigationTransitions).afterPreactivation = () => {
                 // Unblock APP_INITIALIZER once we get to `afterPreactivation`. At this point, we
                 // assume activation will complete successfully (even though this is not
                 // guaranteed).

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -205,14 +205,6 @@ export class Router {
   private lastSuccessfulId: number = -1;
 
   /**
-   * Hook that enables you to pause navigation after the preactivation phase.
-   * Used by `RouterModule`.
-   *
-   * @internal
-   */
-  afterPreactivation: () => Observable<void> = () => of(void 0);
-
-  /**
    * A strategy for extracting and merging URLs.
    * Used for AngularJS to Angular migrations.
    *
@@ -317,9 +309,6 @@ export class Router {
   private readonly urlSerializer = inject(UrlSerializer);
   private readonly location = inject(Location);
 
-  /** @internal */
-  rootComponentType: Type<any>|null = null;
-
   constructor() {
     this.isNgZoneEnabled = inject(NgZone) instanceof NgZone && NgZone.isInAngularZone();
 
@@ -328,7 +317,7 @@ export class Router {
     this.rawUrlTree = this.currentUrlTree;
     this.browserUrlTree = this.currentUrlTree;
 
-    this.routerState = createEmptyState(this.currentUrlTree, this.rootComponentType);
+    this.routerState = createEmptyState(this.currentUrlTree, null);
 
     this.navigationTransitions.setupNavigations(this).subscribe(
         t => {
@@ -342,10 +331,10 @@ export class Router {
 
   /** @internal */
   resetRootComponentType(rootComponentType: Type<any>): void {
-    this.rootComponentType = rootComponentType;
     // TODO: vsavkin router 4.0 should make the root component set to null
     // this will simplify the lifecycle of the router.
-    this.routerState.root.component = this.rootComponentType;
+    this.routerState.root.component = rootComponentType;
+    this.navigationTransitions.rootComponentType = rootComponentType;
   }
 
   /**


### PR DESCRIPTION
…er where appropriate

Working towards removing the backwards dependency on router from the navigation transition handler, this change moves `rootComponentType` and `afterPreactivation` to the transition handler since that is the only location those properties are used.
