### PR TITLE
refactor(router): Add a state manager to manage router URL state

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -26,6 +26,7 @@ import { Provider } from '@angular/core';
 import { ProviderToken } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
+import { RouterState as RouterState_2 } from '@angular/router';
 import { SimpleChanges } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Type } from '@angular/core';
@@ -712,12 +713,13 @@ export class Router {
     resetConfig(config: Routes): void;
     // @deprecated
     routeReuseStrategy: RouteReuseStrategy;
-    readonly routerState: RouterState;
+    get routerState(): RouterState_2;
     serializeUrl(url: UrlTree): string;
     setUpLocationChangeListener(): void;
     get url(): string;
     // @deprecated
-    urlHandlingStrategy: UrlHandlingStrategy;
+    get urlHandlingStrategy(): UrlHandlingStrategy;
+    set urlHandlingStrategy(value: UrlHandlingStrategy);
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<Router, never>;
     // (undocumented)

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -45,7 +45,7 @@
   "platform-server/ngmodule/browser": {
     "uncompressed": {
       "runtime": 2688,
-      "main": 244602,
+      "main": 249925,
       "polyfills": 33778
     }
   },

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -657,6 +657,9 @@
     "name": "StandaloneService"
   },
   {
+    "name": "StateManager"
+  },
+  {
     "name": "Subject"
   },
   {
@@ -1606,9 +1609,6 @@
   },
   {
     "name": "isPromise2"
-  },
-  {
-    "name": "isPublicRouterEvent"
   },
   {
     "name": "isScheduler"

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -22,7 +22,7 @@ import {resolveData} from './operators/resolve_data';
 import {switchTap} from './operators/switch_tap';
 import {TitleStrategy} from './page_title_strategy';
 import {RouteReuseStrategy} from './route_reuse_strategy';
-import {ErrorHandler, ROUTER_CONFIGURATION} from './router_config';
+import {ROUTER_CONFIGURATION} from './router_config';
 import {RouterConfigLoader} from './router_config_loader';
 import {ChildrenOutletContexts} from './router_outlet_context';
 import {ActivatedRoute, ActivatedRouteSnapshot, createEmptyState, RouterState, RouterStateSnapshot} from './router_state';
@@ -213,6 +213,12 @@ export interface Navigation {
    */
   finalUrl?: UrlTree;
   /**
+   * TODO(atscott): If we want to make StateManager public, they will need access to this. Note that
+   * it's already eventually exposed through router.routerState.
+   * @internal
+   */
+  targetRouterState?: RouterState;
+  /**
    * Identifies how this navigation was triggered.
    *
    * * 'imperative'--Triggered by `router.navigateByUrl` or `router.navigate`.
@@ -266,7 +272,7 @@ interface InternalRouterInterface {
   // All of these are public API of router interface and can change during runtime because they are
   // writeable. Ideally, these would be removed and the values retrieved instead from the values
   // available in DI.
-  errorHandler: ErrorHandler;
+  errorHandler: (error: any) => any;
   navigated: boolean;
   urlHandlingStrategy: UrlHandlingStrategy;
   routeReuseStrategy: RouteReuseStrategy;
@@ -470,6 +476,7 @@ export class NavigationTransitions {
                                urlAfterRedirects: extractedUrl,
                                extras: {...extras, skipLocationChange: false, replaceUrl: false},
                              };
+                             this.currentNavigation!.finalUrl = extractedUrl;
                              return of(overallTransitionState);
                            } else {
                              /* When neither the current or previous URL can be processed, do
@@ -607,6 +614,7 @@ export class NavigationTransitions {
                                router.routeReuseStrategy, t.targetSnapshot!, t.currentRouterState);
                            this.currentTransition =
                                overallTransitionState = {...t, targetRouterState};
+                           this.currentNavigation!.targetRouterState = targetRouterState;
                            return overallTransitionState;
                          }),
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -125,7 +125,7 @@ export class Router {
    *   `provideRouter` has the `withNavigationErrorHandler` feature to make this easier.
    * @see {@link withNavigationErrorHandler}
    */
-  errorHandler = this.options.errorHandler || defaultErrorHandler;
+  errorHandler: (error: any) => any = this.options.errorHandler || defaultErrorHandler;
 
   /**
    * A handler for errors thrown by `Router.parseUrl(url)`
@@ -151,7 +151,7 @@ export class Router {
    * @deprecated Configure using `providers` instead:
    *   `{provide: UrlHandlingStrategy, useClass: MyStrategy}`.
    */
-  get urlHandlingStrategy() {
+  get urlHandlingStrategy(): UrlHandlingStrategy {
     return this.stateManager.urlHandlingStrategy;
   }
   /**
@@ -168,7 +168,7 @@ export class Router {
    * @deprecated Configure using `providers` instead:
    *   `{provide: RouteReuseStrategy, useClass: MyStrategy}`.
    */
-  routeReuseStrategy = inject(RouteReuseStrategy);
+  routeReuseStrategy: RouteReuseStrategy = inject(RouteReuseStrategy);
 
   /**
    * How to handle a navigation request to the current URL.
@@ -189,7 +189,7 @@ export class Router {
    * This option is enabled by the `withComponentInputBinding` feature of `provideRouter` or
    * `bindToComponentInputs` in the `ExtraOptions` of `RouterModule.forRoot`.
    */
-  readonly componentInputBindingEnabled = !!inject(INPUT_BINDER, {optional: true});
+  readonly componentInputBindingEnabled: boolean = !!inject(INPUT_BINDER, {optional: true});
 
   constructor() {
     this.isNgZoneEnabled = inject(NgZone) instanceof NgZone && NgZone.isInAngularZone();
@@ -199,7 +199,7 @@ export class Router {
     this.navigationTransitions.setupNavigations(this, this.currentUrlTree, this.routerState)
         .subscribe({
           error: (e) => {
-            this.console.warn(`Unhandled Navigation Error: ${e}`);
+            this.console.warn(ngDevMode ? `Unhandled Navigation Error: ${e}` : e);
           }
         });
     this.subscribeToNavigationEvents();

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -13,14 +13,14 @@ import {Observable, Subject, Subscription, SubscriptionLike} from 'rxjs';
 import {createSegmentGroupFromRoute, createUrlTreeFromSegmentGroup} from './create_url_tree';
 import {INPUT_BINDER} from './directives/router_outlet';
 import {RuntimeErrorCode} from './errors';
-import {BeforeActivateRoutes, Event, IMPERATIVE_NAVIGATION, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped, NavigationStart, NavigationTrigger, PrivateRouterEvents, RedirectRequest, RoutesRecognized} from './events';
+import {BeforeActivateRoutes, Event, IMPERATIVE_NAVIGATION, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationTrigger, PrivateRouterEvents, RedirectRequest} from './events';
 import {NavigationBehaviorOptions, OnSameUrlNavigation, Routes} from './models';
-import {isBrowserTriggeredNavigation, Navigation, NavigationExtras, NavigationTransition, NavigationTransitions, RestoredState, UrlCreationOptions} from './navigation_transition';
+import {isBrowserTriggeredNavigation, Navigation, NavigationExtras, NavigationTransitions, RestoredState, UrlCreationOptions} from './navigation_transition';
 import {RouteReuseStrategy} from './route_reuse_strategy';
 import {ROUTER_CONFIGURATION} from './router_config';
 import {ROUTES} from './router_config_loader';
-import {createEmptyState, RouterState} from './router_state';
 import {Params} from './shared';
+import {StateManager} from './state_manager';
 import {UrlHandlingStrategy} from './url_handling_strategy';
 import {containsTree, IsActiveMatchOptions, isUrlTree, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
 import {standardizeConfig, validateConfig} from './utils/config';
@@ -28,7 +28,7 @@ import {afterNextNavigation} from './utils/navigations';
 
 
 
-function defaultErrorHandler(error: any): any {
+function defaultErrorHandler(error: any): never {
   throw error;
 }
 
@@ -73,92 +73,27 @@ export const subsetMatchOptions: IsActiveMatchOptions = {
  */
 @Injectable({providedIn: 'root'})
 export class Router {
-  /**
-   * Represents the activated `UrlTree` that the `Router` is configured to handle (through
-   * `UrlHandlingStrategy`). That is, after we find the route config tree that we're going to
-   * activate, run guards, and are just about to activate the route, we set the currentUrlTree.
-   *
-   * This should match the `browserUrlTree` when a navigation succeeds. If the
-   * `UrlHandlingStrategy.shouldProcessUrl` is `false`, only the `browserUrlTree` is updated.
-   * @internal
-   */
-  currentUrlTree: UrlTree;
-  /**
-   * Meant to represent the entire browser url after a successful navigation. In the life of a
-   * navigation transition:
-   * 1. The rawUrl represents the full URL that's being navigated to
-   * 2. We apply redirects, which might only apply to _part_ of the URL (due to
-   * `UrlHandlingStrategy`).
-   * 3. Right before activation (because we assume activation will succeed), we update the
-   * rawUrlTree to be a combination of the urlAfterRedirects (again, this might only apply to part
-   * of the initial url) and the rawUrl of the transition (which was the original navigation url in
-   * its full form).
-   * @internal
-   *
-   * Note that this is _only_ here to support `UrlHandlingStrategy.extract` and
-   * `UrlHandlingStrategy.shouldProcessUrl`. If those didn't exist, we could get by with
-   * `currentUrlTree` alone. If a new Router were to be provided (i.e. one that works with the
-   * browser navigation API), we should think about whether this complexity should be carried over.
-   *
-   * - extract: `rawUrlTree` is needed because `extract` may only return part
-   * of the navigation URL. Thus, `currentUrlTree` may only represent _part_ of the browser URL.
-   * When a navigation gets cancelled and we need to reset the URL or a new navigation occurs, we
-   * need to know the _whole_ browser URL, not just the part handled by UrlHandlingStrategy.
-   * - shouldProcessUrl: When this returns `false`, the router just ignores the navigation but still
-   * updates the `rawUrlTree` with the assumption that the navigation was caused by the location
-   * change listener due to a URL update by the AngularJS router. In this case, we still need to
-   * know what the browser's URL is for future navigations.
-   *
-   */
-  rawUrlTree: UrlTree;
-  /**
-   * Meant to represent the part of the browser url that the `Router` is set up to handle (via the
-   * `UrlHandlingStrategy`). This value is updated immediately after the browser url is updated (or
-   * the browser url update is skipped via `skipLocationChange`). With that, note that
-   * `browserUrlTree` _may not_ reflect the actual browser URL for two reasons:
-   *
-   * 1. `UrlHandlingStrategy` only handles part of the URL
-   * 2. `skipLocationChange` does not update the browser url.
-   *
-   * So to reiterate, `browserUrlTree` only represents the Router's internal understanding of the
-   * current route, either before guards with `urlUpdateStrategy === 'eager'` or right before
-   * activation with `'deferred'`.
-   *
-   * This should match the `currentUrlTree` when the navigation succeeds.
-   * @internal
-   */
-  browserUrlTree: UrlTree;
+  private get currentUrlTree() {
+    return this.stateManager.currentUrlTree;
+  }
+  private get rawUrlTree() {
+    return this.stateManager.rawUrlTree;
+  }
+  private get browserUrlTree() {
+    return this.stateManager.browserUrlTree;
+  }
   private disposed = false;
-
   private locationSubscription?: SubscriptionLike;
-  // TODO(b/260747083): This should not exist and navigationId should be private in
-  // `NavigationTransitions`
-  private get navigationId() {
-    return this.navigationTransitions.navigationId;
-  }
+  private isNgZoneEnabled = false;
 
-  /**
-   * The id of the currently active page in the router.
-   * Updated to the transition's target id on a successful navigation.
-   *
-   * This is used to track what page the router last activated. When an attempted navigation fails,
-   * the router can then use this to compute how to restore the state back to the previously active
-   * page.
-   */
-  private currentPageId = 0;
-  /**
-   * The ɵrouterPageId of whatever page is currently active in the browser history. This is
-   * important for computing the target page id for new navigations because we need to ensure each
-   * page id in the browser history is 1 more than the previous entry.
-   */
-  private get browserPageId(): number {
-    if (this.canceledNavigationResolution !== 'computed') {
-      return this.currentPageId;
-    }
-    return (this.location.getState() as RestoredState | null)?.ɵrouterPageId ?? this.currentPageId;
-  }
-  private console = inject(Console);
-  private isNgZoneEnabled: boolean = false;
+  private readonly console = inject(Console);
+  private readonly stateManager = inject(StateManager);
+  private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
+  private readonly pendingTasks = inject(InitialRenderPendingTasks);
+  private readonly urlUpdateStrategy = this.options.urlUpdateStrategy || 'deferred';
+  private readonly navigationTransitions = inject(NavigationTransitions);
+  private readonly urlSerializer = inject(UrlSerializer);
+  private readonly location = inject(Location);
 
   /**
    * The private `Subject` type for the public events exposed in the getter. This is used internally
@@ -179,11 +114,9 @@ export class Router {
   /**
    * The current state of routing in this NgModule.
    */
-  public readonly routerState: RouterState;
-
-  private options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
-
-  private pendingTasks = inject(InitialRenderPendingTasks);
+  get routerState() {
+    return this.stateManager.routerState;
+  }
 
   /**
    * A handler for navigation errors in this NgModule.
@@ -210,7 +143,6 @@ export class Router {
    * false otherwise.
    */
   navigated: boolean = false;
-  private lastSuccessfulId: number = -1;
 
   /**
    * A strategy for extracting and merging URLs.
@@ -219,7 +151,16 @@ export class Router {
    * @deprecated Configure using `providers` instead:
    *   `{provide: UrlHandlingStrategy, useClass: MyStrategy}`.
    */
-  urlHandlingStrategy = inject(UrlHandlingStrategy);
+  get urlHandlingStrategy() {
+    return this.stateManager.urlHandlingStrategy;
+  }
+  /**
+   * @deprecated Configure using `providers` instead:
+   *   `{provide: UrlHandlingStrategy, useClass: MyStrategy}`.
+   */
+  set urlHandlingStrategy(value: UrlHandlingStrategy) {
+    this.stateManager.urlHandlingStrategy = value;
+  }
 
   /**
    * A strategy for re-using routes.
@@ -240,41 +181,7 @@ export class Router {
    */
   onSameUrlNavigation: OnSameUrlNavigation = this.options.onSameUrlNavigation || 'ignore';
 
-  private urlUpdateStrategy: 'deferred'|'eager' = this.options.urlUpdateStrategy || 'deferred';
-
-  /**
-   * Configures how the Router attempts to restore state when a navigation is cancelled.
-   *
-   * 'replace' - Always uses `location.replaceState` to set the browser state to the state of the
-   * router before the navigation started. This means that if the URL of the browser is updated
-   * _before_ the navigation is canceled, the Router will simply replace the item in history rather
-   * than trying to restore to the previous location in the session history. This happens most
-   * frequently with `urlUpdateStrategy: 'eager'` and navigations with the browser back/forward
-   * buttons.
-   *
-   * 'computed' - Will attempt to return to the same index in the session history that corresponds
-   * to the Angular route when the navigation gets cancelled. For example, if the browser back
-   * button is clicked and the navigation is cancelled, the Router will trigger a forward navigation
-   * and vice versa.
-   *
-   * Note: the 'computed' option is incompatible with any `UrlHandlingStrategy` which only
-   * handles a portion of the URL because the history restoration navigates to the previous place in
-   * the browser history rather than simply resetting a portion of the URL.
-   *
-   * The default value is `replace`.
-   *
-   * @see {@link withRouterConfig}
-   * @see {@link provideRouter}
-   * @see {@link RouterModule}
-   */
-  private canceledNavigationResolution: 'replace'|'computed' =
-      this.options.canceledNavigationResolution || 'replace';
-
   config: Routes = inject(ROUTES, {optional: true})?.flat() ?? [];
-
-  private readonly navigationTransitions = inject(NavigationTransitions);
-  private readonly urlSerializer = inject(UrlSerializer);
-  private readonly location = inject(Location);
 
   /**
    * Indicates whether the application has opted in to binding Router data to component inputs.
@@ -288,21 +195,13 @@ export class Router {
     this.isNgZoneEnabled = inject(NgZone) instanceof NgZone && NgZone.isInAngularZone();
 
     this.resetConfig(this.config);
-    this.currentUrlTree = new UrlTree();
-    this.rawUrlTree = this.currentUrlTree;
-    this.browserUrlTree = this.currentUrlTree;
-
-    this.routerState = createEmptyState(this.currentUrlTree, null);
 
     this.navigationTransitions.setupNavigations(this, this.currentUrlTree, this.routerState)
-        .subscribe(
-            t => {
-              this.lastSuccessfulId = t.id;
-              this.currentPageId = this.browserPageId;
-            },
-            e => {
-              this.console.warn(`Unhandled Navigation Error: ${e}`);
-            });
+        .subscribe({
+          error: (e) => {
+            this.console.warn(`Unhandled Navigation Error: ${e}`);
+          }
+        });
     this.subscribeToNavigationEvents();
   }
 
@@ -311,81 +210,38 @@ export class Router {
   private subscribeToNavigationEvents() {
     const subscription = this.navigationTransitions.events.subscribe(e => {
       try {
-        const {currentTransition} = this.navigationTransitions;
-        if (currentTransition === null) {
-          if (isPublicRouterEvent(e)) {
-            this._events.next(e);
-          }
-          return;
-        }
-
-        if (e instanceof NavigationStart) {
-          // If the source of the navigation is from a browser event, the URL is
-          // already updated. We already need to sync the internal state.
-          if (isBrowserTriggeredNavigation(currentTransition.source)) {
-            this.browserUrlTree = currentTransition.extractedUrl;
-          }
-        } else if (e instanceof NavigationSkipped) {
-          this.rawUrlTree = currentTransition.rawUrl;
-        } else if (e instanceof RoutesRecognized) {
-          if (this.urlUpdateStrategy === 'eager') {
-            if (!currentTransition.extras.skipLocationChange) {
-              const rawUrl = this.urlHandlingStrategy.merge(
-                  currentTransition.urlAfterRedirects!, currentTransition.rawUrl);
-              this.setBrowserUrl(rawUrl, currentTransition);
-            }
-            this.browserUrlTree = currentTransition.urlAfterRedirects!;
-          }
-        } else if (e instanceof BeforeActivateRoutes) {
-          this.currentUrlTree = currentTransition.urlAfterRedirects!;
-          this.rawUrlTree = this.urlHandlingStrategy.merge(
-              currentTransition.urlAfterRedirects!, currentTransition.rawUrl);
-          (this as {routerState: RouterState}).routerState = currentTransition.targetRouterState!;
-          if (this.urlUpdateStrategy === 'deferred') {
-            if (!currentTransition.extras.skipLocationChange) {
-              this.setBrowserUrl(this.rawUrlTree, currentTransition);
-            }
-            this.browserUrlTree = currentTransition.urlAfterRedirects!;
-          }
-        } else if (e instanceof NavigationCancel) {
-          if (e.code !== NavigationCancellationCode.Redirect &&
+        const currentTransition = this.navigationTransitions.currentTransition;
+        const currentNavigation = this.navigationTransitions.currentNavigation;
+        if (currentTransition !== null && currentNavigation !== null) {
+          this.stateManager.handleNavigationEvent(e, currentNavigation);
+          if (e instanceof NavigationCancel && e.code !== NavigationCancellationCode.Redirect &&
               e.code !== NavigationCancellationCode.SupersededByNewNavigation) {
             // It seems weird that `navigated` is set to `true` when the navigation is rejected,
             // however it's how things were written initially. Investigation would need to be done
             // to determine if this can be removed.
             this.navigated = true;
+          } else if (e instanceof NavigationEnd) {
+            this.navigated = true;
+          } else if (e instanceof RedirectRequest) {
+            const mergedTree =
+                this.urlHandlingStrategy.merge(e.url, currentTransition.currentRawUrl);
+            const extras = {
+              skipLocationChange: currentTransition.extras.skipLocationChange,
+              // The URL is already updated at this point if we have 'eager' URL
+              // updates or if the navigation was triggered by the browser (back
+              // button, URL bar, etc). We want to replace that item in history
+              // if the navigation is rejected.
+              replaceUrl: this.urlUpdateStrategy === 'eager' ||
+                  isBrowserTriggeredNavigation(currentTransition.source)
+            };
+
+            this.scheduleNavigation(mergedTree, IMPERATIVE_NAVIGATION, null, extras, {
+              resolve: currentTransition.resolve,
+              reject: currentTransition.reject,
+              promise: currentTransition.promise
+            });
           }
-          if (e.code === NavigationCancellationCode.GuardRejected ||
-              e.code === NavigationCancellationCode.NoDataFromResolver) {
-            this.restoreHistory(currentTransition);
-          }
-        } else if (e instanceof RedirectRequest) {
-          const mergedTree = this.urlHandlingStrategy.merge(e.url, currentTransition.currentRawUrl);
-          const extras = {
-            skipLocationChange: currentTransition.extras.skipLocationChange,
-            // The URL is already updated at this point if we have 'eager' URL
-            // updates or if the navigation was triggered by the browser (back
-            // button, URL bar, etc). We want to replace that item in history
-            // if the navigation is rejected.
-            replaceUrl: this.urlUpdateStrategy === 'eager' ||
-                isBrowserTriggeredNavigation(currentTransition.source)
-          };
-
-          this.scheduleNavigation(mergedTree, IMPERATIVE_NAVIGATION, null, extras, {
-            resolve: currentTransition.resolve,
-            reject: currentTransition.reject,
-            promise: currentTransition.promise
-          });
         }
-
-        if (e instanceof NavigationError) {
-          this.restoreHistory(currentTransition, true);
-        }
-
-        if (e instanceof NavigationEnd) {
-          this.navigated = true;
-        }
-
         // Note that it's important to have the Router process the events _before_ the event is
         // pushed through the public observable. This ensures the correct router state is in place
         // before applications observe the events.
@@ -518,7 +374,6 @@ export class Router {
     (typeof ngDevMode === 'undefined' || ngDevMode) && validateConfig(config);
     this.config = config.map(standardizeConfig);
     this.navigated = false;
-    this.lastSuccessfulId = -1;
   }
 
   /** @nodoc */
@@ -766,8 +621,7 @@ export class Router {
     }, {});
   }
 
-  /** @internal */
-  scheduleNavigation(
+  private scheduleNavigation(
       rawUrl: UrlTree, source: NavigationTrigger, restoredState: RestoredState|null,
       extras: NavigationExtras,
       priorPromise?: {resolve: any, reject: any, promise: Promise<boolean>}): Promise<boolean> {
@@ -817,88 +671,6 @@ export class Router {
     return promise.catch((e: any) => {
       return Promise.reject(e);
     });
-  }
-
-  /** @internal */
-  setBrowserUrl(url: UrlTree, transition: NavigationTransition) {
-    const path = this.urlSerializer.serialize(url);
-    if (this.location.isCurrentPathEqualTo(path) || !!transition.extras.replaceUrl) {
-      // replacements do not update the target page
-      const currentBrowserPageId = this.browserPageId;
-      const state = {
-        ...transition.extras.state,
-        ...this.generateNgRouterState(transition.id, currentBrowserPageId)
-      };
-      this.location.replaceState(path, '', state);
-    } else {
-      const state = {
-        ...transition.extras.state,
-        ...this.generateNgRouterState(transition.id, this.browserPageId + 1)
-      };
-      this.location.go(path, '', state);
-    }
-  }
-
-  /**
-   * Performs the necessary rollback action to restore the browser URL to the
-   * state before the transition.
-   * @internal
-   */
-  restoreHistory(transition: NavigationTransition, restoringFromCaughtError = false) {
-    if (this.canceledNavigationResolution === 'computed') {
-      const currentBrowserPageId = this.browserPageId;
-      const targetPagePosition = this.currentPageId - currentBrowserPageId;
-      if (targetPagePosition !== 0) {
-        this.location.historyGo(targetPagePosition);
-      } else if (
-          this.currentUrlTree === this.getCurrentNavigation()?.finalUrl &&
-          targetPagePosition === 0) {
-        // We got to the activation stage (where currentUrlTree is set to the navigation's
-        // finalUrl), but we weren't moving anywhere in history (skipLocationChange or replaceUrl).
-        // We still need to reset the router state back to what it was when the navigation started.
-        this.resetState(transition);
-        // TODO(atscott): resetting the `browserUrlTree` should really be done in `resetState`.
-        // Investigate if this can be done by running TGP.
-        this.browserUrlTree = transition.currentUrlTree;
-        this.resetUrlToCurrentUrlTree();
-      } else {
-        // The browser URL and router state was not updated before the navigation cancelled so
-        // there's no restoration needed.
-      }
-    } else if (this.canceledNavigationResolution === 'replace') {
-      // TODO(atscott): It seems like we should _always_ reset the state here. It would be a no-op
-      // for `deferred` navigations that haven't change the internal state yet because guards
-      // reject. For 'eager' navigations, it seems like we also really should reset the state
-      // because the navigation was cancelled. Investigate if this can be done by running TGP.
-      if (restoringFromCaughtError) {
-        this.resetState(transition);
-      }
-      this.resetUrlToCurrentUrlTree();
-    }
-  }
-
-  private resetState(t: NavigationTransition): void {
-    (this as {routerState: RouterState}).routerState = t.currentRouterState;
-    this.currentUrlTree = t.currentUrlTree;
-    // Note here that we use the urlHandlingStrategy to get the reset `rawUrlTree` because it may be
-    // configured to handle only part of the navigation URL. This means we would only want to reset
-    // the part of the navigation handled by the Angular router rather than the whole URL. In
-    // addition, the URLHandlingStrategy may be configured to specifically preserve parts of the URL
-    // when merging, such as the query params so they are not lost on a refresh.
-    this.rawUrlTree = this.urlHandlingStrategy.merge(this.currentUrlTree, t.rawUrl);
-  }
-
-  private resetUrlToCurrentUrlTree(): void {
-    this.location.replaceState(
-        this.urlSerializer.serialize(this.rawUrlTree), '',
-        this.generateNgRouterState(this.lastSuccessfulId, this.currentPageId));
-  }
-
-  private generateNgRouterState(navigationId: number, routerPageId: number) {
-    if (this.canceledNavigationResolution === 'computed') {
-      return {navigationId, ɵrouterPageId: routerPageId};
-    }
-    return {navigationId};
   }
 }
 

--- a/packages/router/src/state_manager.ts
+++ b/packages/router/src/state_manager.ts
@@ -40,7 +40,7 @@ export class StateManager {
    * `UrlHandlingStrategy.shouldProcessUrl` is `false`, only the `browserUrlTree` is updated.
    * @internal
    */
-  currentUrlTree: UrlTree;
+  currentUrlTree = new UrlTree();
   /**
    * Meant to represent the entire browser url after a successful navigation. In the life of a
    * navigation transition:
@@ -68,7 +68,7 @@ export class StateManager {
    * know what the browser's URL is for future navigations.
    *
    */
-  rawUrlTree: UrlTree;
+  rawUrlTree = this.currentUrlTree;
   /**
    * Meant to represent the part of the browser url that the `Router` is set up to handle (via the
    * `UrlHandlingStrategy`). This value is updated immediately after the browser url is updated (or
@@ -85,7 +85,7 @@ export class StateManager {
    * This should match the `currentUrlTree` when the navigation succeeds.
    * @internal
    */
-  browserUrlTree: UrlTree;
+  browserUrlTree = this.currentUrlTree;
   /**
    * The id of the currently active page in the router.
    * Updated to the transition's target id on a successful navigation.
@@ -107,15 +107,8 @@ export class StateManager {
     }
     return (this.location.getState() as RestoredState | null)?.ɵrouterPageId ?? this.currentPageId;
   }
-  routerState: RouterState;
+  routerState = createEmptyState(this.currentUrlTree, null);
   private stateMemento = this.createStateMemento();
-
-  constructor() {
-    this.currentUrlTree = new UrlTree();
-    this.rawUrlTree = this.currentUrlTree;
-    this.browserUrlTree = this.currentUrlTree;
-    this.routerState = createEmptyState(this.currentUrlTree, null);
-  }
 
   private createStateMemento() {
     return {

--- a/packages/router/src/state_manager.ts
+++ b/packages/router/src/state_manager.ts
@@ -1,0 +1,251 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Location} from '@angular/common';
+import {inject, Injectable} from '@angular/core';
+
+import {BeforeActivateRoutes, Event, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped, NavigationStart, PrivateRouterEvents, RoutesRecognized} from './events';
+import {isBrowserTriggeredNavigation, Navigation, RestoredState} from './navigation_transition';
+import {ROUTER_CONFIGURATION} from './router_config';
+import {createEmptyState, RouterState} from './router_state';
+import {UrlHandlingStrategy} from './url_handling_strategy';
+import {UrlSerializer, UrlTree} from './url_tree';
+
+
+
+@Injectable({providedIn: 'root'})
+export class StateManager {
+  private readonly location = inject(Location);
+  private readonly urlSerializer = inject(UrlSerializer);
+  private readonly options = inject(ROUTER_CONFIGURATION, {optional: true}) || {};
+  private readonly canceledNavigationResolution =
+      this.options.canceledNavigationResolution || 'replace';
+
+  // These are currently writable via the Router public API but are deprecated and should be made
+  // `private readonly` in the future.
+  urlHandlingStrategy = inject(UrlHandlingStrategy);
+  urlUpdateStrategy = this.options.urlUpdateStrategy || 'deferred';
+
+  /**
+   * Represents the activated `UrlTree` that the `Router` is configured to handle (through
+   * `UrlHandlingStrategy`). That is, after we find the route config tree that we're going to
+   * activate, run guards, and are just about to activate the route, we set the currentUrlTree.
+   *
+   * This should match the `browserUrlTree` when a navigation succeeds. If the
+   * `UrlHandlingStrategy.shouldProcessUrl` is `false`, only the `browserUrlTree` is updated.
+   * @internal
+   */
+  currentUrlTree: UrlTree;
+  /**
+   * Meant to represent the entire browser url after a successful navigation. In the life of a
+   * navigation transition:
+   * 1. The rawUrl represents the full URL that's being navigated to
+   * 2. We apply redirects, which might only apply to _part_ of the URL (due to
+   * `UrlHandlingStrategy`).
+   * 3. Right before activation (because we assume activation will succeed), we update the
+   * rawUrlTree to be a combination of the urlAfterRedirects (again, this might only apply to part
+   * of the initial url) and the rawUrl of the transition (which was the original navigation url in
+   * its full form).
+   * @internal
+   *
+   * Note that this is _only_ here to support `UrlHandlingStrategy.extract` and
+   * `UrlHandlingStrategy.shouldProcessUrl`. If those didn't exist, we could get by with
+   * `currentUrlTree` alone. If a new Router were to be provided (i.e. one that works with the
+   * browser navigation API), we should think about whether this complexity should be carried over.
+   *
+   * - extract: `rawUrlTree` is needed because `extract` may only return part
+   * of the navigation URL. Thus, `currentUrlTree` may only represent _part_ of the browser URL.
+   * When a navigation gets cancelled and we need to reset the URL or a new navigation occurs, we
+   * need to know the _whole_ browser URL, not just the part handled by UrlHandlingStrategy.
+   * - shouldProcessUrl: When this returns `false`, the router just ignores the navigation but still
+   * updates the `rawUrlTree` with the assumption that the navigation was caused by the location
+   * change listener due to a URL update by the AngularJS router. In this case, we still need to
+   * know what the browser's URL is for future navigations.
+   *
+   */
+  rawUrlTree: UrlTree;
+  /**
+   * Meant to represent the part of the browser url that the `Router` is set up to handle (via the
+   * `UrlHandlingStrategy`). This value is updated immediately after the browser url is updated (or
+   * the browser url update is skipped via `skipLocationChange`). With that, note that
+   * `browserUrlTree` _may not_ reflect the actual browser URL for two reasons:
+   *
+   * 1. `UrlHandlingStrategy` only handles part of the URL
+   * 2. `skipLocationChange` does not update the browser url.
+   *
+   * So to reiterate, `browserUrlTree` only represents the Router's internal understanding of the
+   * current route, either before guards with `urlUpdateStrategy === 'eager'` or right before
+   * activation with `'deferred'`.
+   *
+   * This should match the `currentUrlTree` when the navigation succeeds.
+   * @internal
+   */
+  browserUrlTree: UrlTree;
+  /**
+   * The id of the currently active page in the router.
+   * Updated to the transition's target id on a successful navigation.
+   *
+   * This is used to track what page the router last activated. When an attempted navigation fails,
+   * the router can then use this to compute how to restore the state back to the previously active
+   * page.
+   */
+  private currentPageId: number = 0;
+  lastSuccessfulId: number = -1;
+  /**
+   * The ɵrouterPageId of whatever page is currently active in the browser history. This is
+   * important for computing the target page id for new navigations because we need to ensure each
+   * page id in the browser history is 1 more than the previous entry.
+   */
+  private get browserPageId(): number {
+    if (this.canceledNavigationResolution !== 'computed') {
+      return this.currentPageId;
+    }
+    return (this.location.getState() as RestoredState | null)?.ɵrouterPageId ?? this.currentPageId;
+  }
+  routerState: RouterState;
+  private stateMemento = this.createStateMemento();
+
+  constructor() {
+    this.currentUrlTree = new UrlTree();
+    this.rawUrlTree = this.currentUrlTree;
+    this.browserUrlTree = this.currentUrlTree;
+    this.routerState = createEmptyState(this.currentUrlTree, null);
+  }
+
+  private createStateMemento() {
+    return {
+      rawUrlTree: this.rawUrlTree,
+      browserUrlTree: this.browserUrlTree,
+      currentUrlTree: this.currentUrlTree,
+      routerState: this.routerState,
+    };
+  }
+
+  handleNavigationEvent(e: Event|PrivateRouterEvents, currentTransition: Navigation) {
+    if (e instanceof NavigationStart) {
+      this.stateMemento = this.createStateMemento();
+      // If the source of the navigation is from a browser event, the URL is
+      // already updated. We already need to sync the internal state.
+      if (isBrowserTriggeredNavigation(currentTransition.trigger)) {
+        this.browserUrlTree = currentTransition.extractedUrl;
+      }
+    } else if (e instanceof NavigationSkipped) {
+      this.rawUrlTree = currentTransition.initialUrl;
+    } else if (e instanceof RoutesRecognized) {
+      if (this.urlUpdateStrategy === 'eager') {
+        if (!currentTransition.extras.skipLocationChange) {
+          const rawUrl = this.urlHandlingStrategy.merge(
+              currentTransition.finalUrl!, currentTransition.initialUrl);
+          this.setBrowserUrl(rawUrl, currentTransition);
+        }
+        this.browserUrlTree = currentTransition.finalUrl!;
+      }
+    } else if (e instanceof BeforeActivateRoutes) {
+      this.currentUrlTree = currentTransition.finalUrl!;
+      this.rawUrlTree =
+          this.urlHandlingStrategy.merge(currentTransition.finalUrl!, currentTransition.initialUrl);
+      this.routerState = currentTransition.targetRouterState!;
+      if (this.urlUpdateStrategy === 'deferred') {
+        if (!currentTransition.extras.skipLocationChange) {
+          this.setBrowserUrl(this.rawUrlTree, currentTransition);
+        }
+        this.browserUrlTree = currentTransition.finalUrl!;
+      }
+    } else if (
+        e instanceof NavigationCancel &&
+        (e.code === NavigationCancellationCode.GuardRejected ||
+         e.code === NavigationCancellationCode.NoDataFromResolver)) {
+      this.restoreHistory(currentTransition);
+    } else if (e instanceof NavigationError) {
+      this.restoreHistory(currentTransition, true);
+    } else if (e instanceof NavigationEnd) {
+      this.lastSuccessfulId = e.id;
+      this.currentPageId = this.browserPageId;
+    }
+  }
+
+  private setBrowserUrl(url: UrlTree, transition: Navigation) {
+    const path = this.urlSerializer.serialize(url);
+    if (this.location.isCurrentPathEqualTo(path) || !!transition.extras.replaceUrl) {
+      // replacements do not update the target page
+      const currentBrowserPageId = this.browserPageId;
+      const state = {
+        ...transition.extras.state,
+        ...this.generateNgRouterState(transition.id, currentBrowserPageId)
+      };
+      this.location.replaceState(path, '', state);
+    } else {
+      const state = {
+        ...transition.extras.state,
+        ...this.generateNgRouterState(transition.id, this.browserPageId + 1)
+      };
+      this.location.go(path, '', state);
+    }
+  }
+
+  /**
+   * Performs the necessary rollback action to restore the browser URL to the
+   * state before the transition.
+   * @internal
+   */
+  restoreHistory(navigation: Navigation, restoringFromCaughtError = false) {
+    if (this.canceledNavigationResolution === 'computed') {
+      const currentBrowserPageId = this.browserPageId;
+      const targetPagePosition = this.currentPageId - currentBrowserPageId;
+      if (targetPagePosition !== 0) {
+        this.location.historyGo(targetPagePosition);
+      } else if (this.currentUrlTree === navigation.finalUrl && targetPagePosition === 0) {
+        // We got to the activation stage (where currentUrlTree is set to the navigation's
+        // finalUrl), but we weren't moving anywhere in history (skipLocationChange or replaceUrl).
+        // We still need to reset the router state back to what it was when the navigation started.
+        this.resetState(navigation);
+        // TODO(atscott): resetting the `browserUrlTree` should really be done in `resetState`.
+        // Investigate if this can be done by running TGP.
+        this.browserUrlTree = this.stateMemento.browserUrlTree;
+        this.resetUrlToCurrentUrlTree();
+      } else {
+        // The browser URL and router state was not updated before the navigation cancelled so
+        // there's no restoration needed.
+      }
+    } else if (this.canceledNavigationResolution === 'replace') {
+      // TODO(atscott): It seems like we should _always_ reset the state here. It would be a no-op
+      // for `deferred` navigations that haven't change the internal state yet because guards
+      // reject. For 'eager' navigations, it seems like we also really should reset the state
+      // because the navigation was cancelled. Investigate if this can be done by running TGP.
+      if (restoringFromCaughtError) {
+        this.resetState(navigation);
+      }
+      this.resetUrlToCurrentUrlTree();
+    }
+  }
+
+  private resetState(navigation: Navigation): void {
+    this.routerState = this.stateMemento.routerState;
+    this.currentUrlTree = this.stateMemento.currentUrlTree;
+    // Note here that we use the urlHandlingStrategy to get the reset `rawUrlTree` because it may be
+    // configured to handle only part of the navigation URL. This means we would only want to reset
+    // the part of the navigation handled by the Angular router rather than the whole URL. In
+    // addition, the URLHandlingStrategy may be configured to specifically preserve parts of the URL
+    // when merging, such as the query params so they are not lost on a refresh.
+    this.rawUrlTree =
+        this.urlHandlingStrategy.merge(this.currentUrlTree, navigation.finalUrl ?? this.rawUrlTree);
+  }
+
+  private resetUrlToCurrentUrlTree(): void {
+    this.location.replaceState(
+        this.urlSerializer.serialize(this.rawUrlTree), '',
+        this.generateNgRouterState(this.lastSuccessfulId, this.currentPageId));
+  }
+
+  private generateNgRouterState(navigationId: number, routerPageId: number) {
+    if (this.canceledNavigationResolution === 'computed') {
+      return {navigationId, ɵrouterPageId: routerPageId};
+    }
+    return {navigationId};
+  }
+}


### PR DESCRIPTION
This commit refactors the router internals to track state inside a separate
`StateManager`. This helps open the door to managing the state in
different, swappable providers. The current interface needed by the
Router is: `currentUrlTree`, `rawUrlTree`, `browserUrlTree`,
`routerState`, and `handleNavigationEvent` (other properties are because
some router properties are writeable when they shouldn't be). This is
a suprisingly small interface and can hopefully be made smaller in the
future (i.e. removing 1 or more of the 3 tracked of `UrlTree`s).

Diffbase: #48427