### PR TITLE
feat(common): add IANA time zone support for date pipe

### DIFF
--- a/packages/common/src/pipes/date_pipe.ts
+++ b/packages/common/src/pipes/date_pipe.ts
@@ -233,7 +233,8 @@ export class DatePipe implements PipeTransform {
    * custom format string.  When not provided, the `DatePipe` looks for the value using the
    * `DATE_PIPE_DEFAULT_OPTIONS` injection token (and reads the `dateFormat` property).
    * If the token is not configured, the `mediumDate` is used as a value.
-   * @param timezone A timezone offset (such as `'+0430'`), or a standard UTC/GMT, or continental US
+   * @param timezone An IANA time zone name (such as `'Europe/Vilnius'`),
+   * or a timezone offset (such as `'+0430'`), or a standard UTC/GMT, or continental US
    * timezone abbreviation. When not provided, the `DatePipe` looks for the value using the
    * `DATE_PIPE_DEFAULT_OPTIONS` injection token (and reads the `timezone` property). If the token
    * is not configured, the end-user's local system timezone is used as a value.

--- a/packages/common/test/i18n/format_date_spec.ts
+++ b/packages/common/test/i18n/format_date_spec.ts
@@ -390,6 +390,29 @@ describe('Format date', () => {
              .toEqual(formatDate(localDate, `MMM d, y, h:mm:ss a ZZZZZ`, ɵDEFAULT_LOCALE_ID));
        });
 
+    it('should support IANA timezone name', () => {
+      // In America/Chicago timezone:
+      // UTC-6 offset at 2022-11-07
+      expect(formatDate('2022-11-07T14:00:00.000Z', 'short', ɵDEFAULT_LOCALE_ID, 'America/Chicago'))
+          .toEqual('11/7/22, 8:00 AM');
+      // UTC-5 offset at 2023-03-14 (because of DST)
+      expect(formatDate('2023-03-14T13:00:00.000Z', 'short', ɵDEFAULT_LOCALE_ID, 'America/Chicago'))
+          .toEqual('3/14/23, 8:00 AM');
+
+      // In Europe/Vilnius timezone:
+      // UTC+2 offset at 2022-10-31
+      expect(formatDate('2022-10-31T06:00:00.000Z', 'short', ɵDEFAULT_LOCALE_ID, 'Europe/Vilnius'))
+          .toEqual('10/31/22, 8:00 AM');
+      // UTC+3 offset at 2023-03-27 (because of DST)
+      expect(formatDate('2023-03-27T05:00:00.000Z', 'short', ɵDEFAULT_LOCALE_ID, 'Europe/Vilnius'))
+          .toEqual('3/27/23, 8:00 AM');
+
+      // In Africa/Freetown timezone:
+      // UTC (no offset) all the time
+      expect(formatDate('2022-10-31T08:00:00.000Z', 'short', ɵDEFAULT_LOCALE_ID, 'Africa/Freetown'))
+          .toEqual('10/31/22, 8:00 AM');
+    });
+
     it('should remove bidi control characters',
        () => expect(formatDate(date, 'MM/dd/yyyy', ɵDEFAULT_LOCALE_ID)!.length).toEqual(10));
 

--- a/packages/common/test/pipes/date_pipe_spec.ts
+++ b/packages/common/test/pipes/date_pipe_spec.ts
@@ -200,6 +200,29 @@ import {TestBed} from '@angular/core/testing';
            const content = fixture.nativeElement.textContent;
            expect(content).toBe('Jan 10, 2017');
          });
+
+      it('should support IANA timezone name', () => {
+        // In America/Chicago timezone:
+        // UTC-6 offset at 2022-11-07
+        expect(pipe.transform('2022-11-07T14:00:00.000Z', 'short', 'America/Chicago'))
+            .toEqual('11/7/22, 8:00 AM');
+        // UTC-5 offset at 2023-03-14 (because of DST)
+        expect(pipe.transform('2023-03-14T13:00:00.000Z', 'short', 'America/Chicago'))
+            .toEqual('3/14/23, 8:00 AM');
+
+        // In Europe/Vilnius timezone:
+        // UTC+2 offset at 2022-10-31
+        expect(pipe.transform('2022-10-31T06:00:00.000Z', 'short', 'Europe/Vilnius'))
+            .toEqual('10/31/22, 8:00 AM');
+        // UTC+3 offset at 2023-03-27 (because of DST)
+        expect(pipe.transform('2023-03-27T05:00:00.000Z', 'short', 'Europe/Vilnius'))
+            .toEqual('3/27/23, 8:00 AM');
+
+        // In Africa/Freetown timezone:
+        // UTC (no offset) all the time
+        expect(pipe.transform('2022-10-31T08:00:00.000Z', 'short', 'Africa/Freetown'))
+            .toEqual('10/31/22, 8:00 AM');
+      });
     });
 
     it('should be available as a standalone pipe', () => {


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Feature

## What is the new behavior?

Adds an IANA time zone name (e.g., "Europe/Vilnius") support for the date pipe, which is considered to be more reliable than the UTC offset, mainly because of daylight saving time (DST) respect. 

Closes #48279 

In that issue Jessica also mentions about possibility to fully switch to `Intl` API, which to me looks way out of scope with lots of challenges just for the sake of adding IANA tz support.

The current solution might seem a bit hacky - read the comments in the code on why.
Because of that, I did some manual testing to be sure that `fr` locale uses `UTC` offset (and not some kind of abbreviation like `EET`) for all the time zones in all the platforms (latest Chrome, latest Firefox, latest Safari, and Node.js `14.19.3`) by basically running this and inspecting every value for any weirdness:
```ts
Intl.supportedValuesOf('timeZone')
  .map((timeZone) => 
     Intl.DateTimeFormat('fr', { timeZone, timeZoneName: 'short' })
       .formatToParts(new Date(Date.UTC(2022, 9, 31, 0, 0, 0))).pop()
  );
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No