### PR TITLE
docs: update CLI sources ref

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,7 +59,7 @@ http_archive(
 # Download cli source from angular/cli-builds for doc generation at a specific tag or commit.
 # If the ref is a commit sha, use the full sha instead of the abbreviated form. Tags, which
 # hold an abbreviated sha by convention in cli-builds, can continue to use the short form.
-CLI_SRC_REF = "6ccbc6b4cba4fde7898b67d2e195a1ea3bf4553e"
+CLI_SRC_REF = "f0163d17d581f7ea59ada47420599264060db77a"
 
 http_archive(
     name = "angular_cli_src",
@@ -77,7 +77,7 @@ filegroup(
     # Run the following command to calculate the sha256, substituting the CLI_SRC_REF
     # wget -O- -q https://github.com/angular/cli-builds/archive/{CLI_SRC_REF}.tar.gz | sha256sum
     # Alternatively, just remove the parameter and bazel debug will output the sha as a suggestion.
-    sha256 = "6558e1774904719d0615f01b88368d7fe3a927ea1e54cb0436e7957bc8f6d0a6",
+    sha256 = "952a62ce2b040af74fe3ae4d0bef5eaca505b7986df3bcf776e4ce84628cd3ed",
     strip_prefix = "cli-builds-%s" % CLI_SRC_REF,
     url = "https://github.com/angular/cli-builds/archive/%s.tar.gz" % CLI_SRC_REF,
 )


### PR DESCRIPTION
This is needed to update AIO documentation as currently the CLI docs are out of date.
