### PR TITLE
fix(common): Update `Location` to get a normalized URL valid in case a represented URL starts with the substring equals `APP_BASE_HREF`

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -301,7 +301,9 @@ export function createLocation() {
 }
 
 function _stripBasePath(basePath: string, url: string): string {
-  return basePath && url.startsWith(basePath) ? url.substring(basePath.length) : url;
+  return basePath && new RegExp(`^${basePath}([/;?#]|$)`).test(url) ?
+      url.substring(basePath.length) :
+      url;
 }
 
 function _stripIndexHtml(url: string): string {

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -266,4 +266,25 @@ describe('Location Class', () => {
       expect(location.normalize(url)).toBe(route);
     });
   });
+
+  describe('location.normalize(url) should return properly normalized url', () => {
+    it('in case url starts with the substring equals APP_BASE_HREF', () => {
+      const baseHref = '/en';
+      const path = '/enigma';
+      const queryParams = '?param1=123';
+      const matrixParams = ';param1=123';
+      const fragment = '#anchor1';
+
+      TestBed.configureTestingModule({providers: [{provide: APP_BASE_HREF, useValue: baseHref}]});
+
+      const location = TestBed.inject(Location);
+
+      expect(location.normalize(path)).toBe(path);
+      expect(location.normalize(baseHref)).toBe('');
+      expect(location.normalize(baseHref + path)).toBe(path);
+      expect(location.normalize(baseHref + queryParams)).toBe(queryParams);
+      expect(location.normalize(baseHref + matrixParams)).toBe(matrixParams);
+      expect(location.normalize(baseHref + fragment)).toBe(fragment);
+    });
+  });
 });


### PR DESCRIPTION
fix(common): Update `Location` to get a normalized URL valid in case a represented URL starts with the substring equals `APP_BASE_HREF`

```ts
@NgModule({
  imports: [RouterModule.forRoot([{path: '/enigma', component: EnigmaComponent}])],
  providers: [{provide: APP_BASE_HREF, useValue: '/en'}]
})
export class AppModule {}
```

Navigating to `/enigma` will redirect to `/en/igma` not to `/en/enigma` as it expects

Fixes: #45744

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 45744

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
