### PR TITLE
docs: release notes for the v15.0.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+<a name="15.0.4"></a>
+# 15.0.4 (2022-12-14)
+### animations
+| Commit | Type | Description |
+| -- | -- | -- |
+| [6c1064c72f](https://github.com/angular/angular/commit/6c1064c72f7d5b9a455813046939ab0161c143bf) | fix | fix incorrect handling of camel-case css properties ([#48436](https://github.com/angular/angular/pull/48436)) |
+### common
+| Commit | Type | Description |
+| -- | -- | -- |
+| [f30d18a942](https://github.com/angular/angular/commit/f30d18a9424afacbd47d70f91e233e286bb94b0d) | fix | Fix TestBed.overrideProvider type to include multi ([#48424](https://github.com/angular/angular/pull/48424)) |
+| [59c6bfb632](https://github.com/angular/angular/commit/59c6bfb6324c5baf53b907afee9170e1ce81ddbc) | fix | Update `Location` to get a normalized URL valid in case a represented URL starts with the substring equals `APP_BASE_HREF` ([#48394](https://github.com/angular/angular/pull/48394)) |
+### compiler-cli
+| Commit | Type | Description |
+| -- | -- | -- |
+| [b55d2dab5d](https://github.com/angular/angular/commit/b55d2dab5d76ffa809ac1feb78392a75c3081dec) | fix | evaluate const tuple types statically ([#48091](https://github.com/angular/angular/pull/48091)) |
+## Special Thanks
+Alan Agius, Andrew Kushnir, Andrew Scott, Aristeidis Bampakos, Bob Watson, BrowserPerson, Jens, Jessica Janiuk, Joey Perrott, JoostK, Konstantin Kharitonov, Lukas Matta, Piotr Kowalski, Virginia Dooley, Yannick Baron, dario-piotrowicz, lsst25, piyush132000 and why520crazy
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="15.1.0-next.2"></a>
 # 15.1.0-next.2 (2022-12-07)
 ### common

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 | Commit | Type | Description |
 | -- | -- | -- |
 | [f30d18a942](https://github.com/angular/angular/commit/f30d18a9424afacbd47d70f91e233e286bb94b0d) | fix | Fix TestBed.overrideProvider type to include multi ([#48424](https://github.com/angular/angular/pull/48424)) |
-| [59c6bfb632](https://github.com/angular/angular/commit/59c6bfb6324c5baf53b907afee9170e1ce81ddbc) | fix | Update `Location` to get a normalized URL valid in case a represented URL starts with the substring equals `APP_BASE_HREF` ([#48394](https://github.com/angular/angular/pull/48394)) |
 ### compiler-cli
 | Commit | Type | Description |
 | -- | -- | -- |


### PR DESCRIPTION
Cherry-picks the changelog from the "15.0.x" branch to the next branch (main).