### PR TITLE
ci: mark //aio:e2e tests as flaky

### DIFF
--- a/aio/BUILD.bazel
+++ b/aio/BUILD.bazel
@@ -319,6 +319,9 @@ architect_test(
         "CHROME_BIN": "../$(CHROMIUM)",
         "CHROMEDRIVER_BIN": "../$(CHROMEDRIVER)",
     },
+    # TODO: investigate why those tests became more flaky
+    #       (presumably after AIO migration to Bazel)
+    flaky = True,
     toolchains = [
         "@aio_npm//@angular/build-tooling/bazel/browsers/chromium:toolchain_alias",
     ],


### PR DESCRIPTION
AIO e2e tests became more flaky recently. More investigation is needed to identify why, but we mark the `//aio:e2e` as flaky for now to rerun those tests on CI if they fail.


## PR Type
What kind of change does this PR introduce?

- [ ] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No