### PR TITLE
docs: missing closing parenthesis in withHashLocation() example

### DIFF
--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -601,7 +601,7 @@ export type RouterHashLocationFeature = RouterFeature<RouterFeatureKind.RouterHa
  * bootstrapApplication(AppComponent,
  *   {
  *     providers: [
- *       provideRouter(appRoutes, withHashLocation()
+ *       provideRouter(appRoutes, withHashLocation())
  *     ]
  *   }
  * );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The example of `withHashLocation()` is missing a closing parenthesis

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
