### PR TITLE
fix(router): Router.createUrlTree should work with any ActivatedRoute

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -138,6 +138,9 @@
     "name": "CreateUrlTreeStrategy"
   },
   {
+    "name": "CreateUrlTreeUsingSnapshot"
+  },
+  {
     "name": "DEFAULT_LOCALE_ID"
   },
   {
@@ -298,9 +301,6 @@
   },
   {
     "name": "LQuery_"
-  },
-  {
-    "name": "LegacyCreateUrlTree"
   },
   {
     "name": "LifecycleHooksFeature"
@@ -1006,9 +1006,6 @@
   },
   {
     "name": "createTemplateRef"
-  },
-  {
-    "name": "createUrlTree"
   },
   {
     "name": "deactivateRouteAndItsChildren"

--- a/packages/router/src/create_url_tree_strategy.ts
+++ b/packages/router/src/create_url_tree_strategy.ts
@@ -74,7 +74,7 @@ export class CreateUrlTreeUsingSnapshot implements CreateUrlTreeStrategy {
   }
 }
 
-@Injectable({providedIn: 'root', useClass: LegacyCreateUrlTree})
+@Injectable({providedIn: 'root', useClass: CreateUrlTreeUsingSnapshot})
 export abstract class CreateUrlTreeStrategy {
   abstract createUrlTree(
       relativeTo: ActivatedRoute|null|undefined, currentState: RouterState, currentUrlTree: UrlTree,


### PR DESCRIPTION
This change makes the `createUrlTreeFromSnapshot` added in https://github.com/angular/angular/pull/45877 the
default and only behavior in the Router. This now addreses https://github.com/angular/angular/issues/42191, https://github.com/angular/angular/issues/38276, https://github.com/angular/angular/issues/22763,
and https://github.com/angular/angular/issues/48472 without needing to create custom handling to
call `createUrlTreeFromSnapshot` (since it's now called by `Router.createUrlTree`).

BREAKING CHANGE: Tests which mock `ActivatedRoute` instances may need to be adjusted
because Router.createUrlTree now does the right thing in more
scenarios. This means that tests with invalid/incomplete ActivatedRoute mocks
may behave differently than before. Additionally, tests may now navigate
to a real URL where before they would navigate to the root. Ensure that
tests provide expected routes to match.
There is rarely production impact, but it has been found that relative
navigations when using an `ActivatedRoute` that does not appear in the
current router state were effectively ignored in the past. By creating
the correct URLs, this sometimes resulted in different navigation
behavior in the application. Most often, this happens when attempting to
create a navigation that only updates query params using an empty
command array, for example `router.navigate([], {relativeTo: route,
queryParams: newQueryParams})`. In this case, the `relativeTo` property
should be removed.