### PR TITLE
docs: change Style 05-04 lines number from 3 to 30

### DIFF
--- a/aio/content/guide/styleguide.md
+++ b/aio/content/guide/styleguide.md
@@ -1620,7 +1620,7 @@ However, you wouldn't use this technique on a custom element.
 
 <div class="s-rule do">
 
-**Do** extract templates and styles into a separate file, when more than 3 lines.
+**Do** extract templates and styles into a separate file, when there are more than 30 lines.
 
 </div>
 
@@ -1646,14 +1646,6 @@ However, you wouldn't use this technique on a custom element.
 
 **Why**? <br />
 Large, inline templates and styles obscure the component's purpose and implementation, reducing readability and maintainability.
-
-</div>
-
-<div class="s-why">
-
-**Why**? <br />
-In most editors, syntax hints and code snippets aren't available when developing inline templates and styles.
-The Angular TypeScript Language Service \(forthcoming\) promises to overcome this deficiency for HTML templates in those editors that support it; it won't help with CSS styles.
 
 </div>
 


### PR DESCRIPTION
Having to extract templates and styles into a separate file when there are more than 3 lines is not right I'd say. Today IDE-s are powerful enough and have support for multi lines in single file components.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
