### PR TITLE
fix(forms): Form provider FormsModule.withConfig return a FormsModule

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -553,7 +553,7 @@ export interface FormRecord<TControl> {
 export class FormsModule {
     static withConfig(opts: {
         callSetDisabledState?: SetDisabledStateOption;
-    }): ModuleWithProviders<ReactiveFormsModule>;
+    }): ModuleWithProviders<FormsModule>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FormsModule, never>;
     // (undocumented)

--- a/packages/forms/src/form_providers.ts
+++ b/packages/forms/src/form_providers.ts
@@ -38,7 +38,7 @@ export class FormsModule {
    */
   static withConfig(opts: {
     callSetDisabledState?: SetDisabledStateOption,
-  }): ModuleWithProviders<ReactiveFormsModule> {
+  }): ModuleWithProviders<FormsModule> {
     return {
       ngModule: FormsModule,
       providers: [{


### PR DESCRIPTION
Because of a transitive dependency, FormsModule.withConfig wasn't providing FormModule.

fixes: #48519

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [x] No


