### PR TITLE
fix(http): Set Accept based on responseType

### DIFF
--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -68,11 +68,6 @@ export class HttpXhrBackend implements HttpBackend {
       // Add all the requested headers.
       req.headers.forEach((name, values) => xhr.setRequestHeader(name, values.join(',')));
 
-      // Add an Accept header if one isn't present already.
-      if (!req.headers.has('Accept')) {
-        xhr.setRequestHeader('Accept', 'application/json, text/plain, */*');
-      }
-
       // Auto-detect the Content-Type header if one isn't present already.
       if (!req.headers.has('Content-Type')) {
         const detectedType = req.detectContentTypeHeader();
@@ -92,6 +87,13 @@ export class HttpXhrBackend implements HttpBackend {
         // retrieve the prefixed JSON data in order to strip the prefix. Thus, all JSON
         // is parsed by first requesting text and then applying JSON.parse.
         xhr.responseType = ((responseType !== 'json') ? responseType : 'text') as any;
+      }
+
+      // Add an Accept header if one isn't present already.
+      if (!req.headers.has('Accept')) {
+        xhr.setRequestHeader(
+          (xhr.responseType === 'json') ? 'application/json' : ((xhr.responseType === 'text') ? 'text/plain' : '*/*')
+        );
       }
 
       // Serialize the request body if one is present. If not, this will be set to null.


### PR DESCRIPTION
Fix how the Accept HTTP header is handled.
Set the Accept header based on the response
Type field to ensure HTTP response consistency per RFC
JSON -> `application/json`
Text -> `text/plain`
Other -> `*/*`

Fixes #48505

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #48505


## What is the new behavior?
Set `Accept` HTTP header based on `responseType`

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
