### PR TITLE
feat(compiler): allow self-closing tags on custom elements

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/GOLDEN_PARTIAL.js
@@ -921,3 +921,107 @@ export declare class MyModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: self_closing_tags.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComp {
+}
+MyComp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComp, selector: "my-comp", ngImport: i0, template: 'hello', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComp, decorators: [{
+            type: Component,
+            args: [{ selector: 'my-comp', template: 'hello' }]
+        }] });
+export class App {
+}
+App.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: App, deps: [], target: i0.ɵɵFactoryTarget.Component });
+App.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: App, selector: "ng-component", ngImport: i0, template: `<my-comp/>`, isInline: true, dependencies: [{ kind: "component", type: MyComp, selector: "my-comp" }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: App, decorators: [{
+            type: Component,
+            args: [{ template: `<my-comp/>` }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [App, MyComp] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [App, MyComp] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: self_closing_tags.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComp, "my-comp", never, {}, {}, never, never, false, never>;
+}
+export declare class App {
+    static ɵfac: i0.ɵɵFactoryDeclaration<App, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<App, "ng-component", never, {}, {}, never, never, false, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof App, typeof MyComp], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: self_closing_tags_nested.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyComp {
+}
+MyComp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyComp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyComp, selector: "my-comp", ngImport: i0, template: 'hello', isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyComp, decorators: [{
+            type: Component,
+            args: [{ selector: 'my-comp', template: 'hello' }]
+        }] });
+export class App {
+}
+App.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: App, deps: [], target: i0.ɵɵFactoryTarget.Component });
+App.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: App, selector: "ng-component", ngImport: i0, template: `
+    <my-comp title="a">Before<my-comp title="b"></my-comp>After</my-comp>
+  `, isInline: true, dependencies: [{ kind: "component", type: MyComp, selector: "my-comp" }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: App, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <my-comp title="a">Before<my-comp title="b"></my-comp>After</my-comp>
+  `
+                }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [App, MyComp] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [App, MyComp] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: self_closing_tags_nested.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyComp {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyComp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyComp, "my-comp", never, {}, {}, never, never, false, never>;
+}
+export declare class App {
+    static ɵfac: i0.ɵɵFactoryDeclaration<App, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<App, "ng-component", never, {}, {}, never, never, false, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof App, typeof MyComp], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/TEST_CASES.json
@@ -286,6 +286,40 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should allow self-closing custom elements in templates",
+      "inputFiles": [
+        "self_closing_tags.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "self_closing_tags_template.js",
+              "generated": "self_closing_tags.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
+      "description": "should not confuse self-closing tag for an end tag",
+      "inputFiles": [
+        "self_closing_tags_nested.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "self_closing_tags_nested_template.js",
+              "generated": "self_closing_tags_nested.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/self_closing_tags.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/self_closing_tags.ts
@@ -1,0 +1,13 @@
+import {Component, NgModule} from '@angular/core';
+
+@Component({selector: 'my-comp', template: 'hello'})
+export class MyComp {
+}
+
+@Component({template: `<my-comp/>`})
+export class App {
+}
+
+@NgModule({declarations: [App, MyComp]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/self_closing_tags_nested.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/self_closing_tags_nested.ts
@@ -1,0 +1,17 @@
+import {Component, NgModule} from '@angular/core';
+
+@Component({selector: 'my-comp', template: 'hello'})
+export class MyComp {
+}
+
+@Component({
+  template: `
+    <my-comp title="a">Before<my-comp title="b"></my-comp>After</my-comp>
+  `
+})
+export class App {
+}
+
+@NgModule({declarations: [App, MyComp]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/self_closing_tags_nested_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/self_closing_tags_nested_template.js
@@ -1,0 +1,11 @@
+template: function App_Template(rf, ctx) {
+  if (rf & 1) {
+    …
+    i0.ɵɵelementStart(0, "my-comp", 0);
+    i0.ɵɵtext(1, "Before");
+    i0.ɵɵelement(2, "my-comp", 1);
+    i0.ɵɵtext(3, "After");
+    i0.ɵɵelementEnd();
+    …
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/self_closing_tags_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/self_closing_tags_template.js
@@ -1,0 +1,7 @@
+template: function App_Template(rf, ctx) {
+  if (rf & 1) {
+    …
+    i0.ɵɵelement(0, "my-comp");
+    …
+  }
+}

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -279,7 +279,8 @@ class _TreeBuilder {
       if (!(tagDef.canSelfClose || getNsPrefix(fullName) !== null || tagDef.isVoid)) {
         this.errors.push(TreeError.create(
             fullName, startTagToken.sourceSpan,
-            `Only void and foreign elements can be self closed "${startTagToken.parts[1]}"`));
+            `Only void, custom and foreign elements can be self closed "${
+                startTagToken.parts[1]}"`));
       }
     } else if (this._peek.type === TokenType.TAG_OPEN_END) {
       this._advance();

--- a/packages/compiler/src/selector.ts
+++ b/packages/compiler/src/selector.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {getHtmlTagDefinition} from './ml_parser/html_tags';
-
 const _SELECTOR_REGEXP = new RegExp(
     '(\\:not\\()|' +               // 1: ":not("
         '(([\\.\\#]?)[-\\w]+)|' +  // 2: "tag"; 3: "."/"#";
@@ -170,22 +168,6 @@ export class CssSelector {
 
   setElement(element: string|null = null) {
     this.element = element;
-  }
-
-  /** Gets a template string for an element that matches the selector. */
-  getMatchingElementTemplate(): string {
-    const tagName = this.element || 'div';
-    const classAttr = this.classNames.length > 0 ? ` class="${this.classNames.join(' ')}"` : '';
-
-    let attrs = '';
-    for (let i = 0; i < this.attrs.length; i += 2) {
-      const attrName = this.attrs[i];
-      const attrValue = this.attrs[i + 1] !== '' ? `="${this.attrs[i + 1]}"` : '';
-      attrs += ` ${attrName}${attrValue}`;
-    }
-
-    return getHtmlTagDefinition(tagName).isVoid ? `<${tagName}${classAttr}${attrs}/>` :
-                                                  `<${tagName}${classAttr}${attrs}></${tagName}>`;
   }
 
   getAttrs(): string[] {

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -754,7 +754,7 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
           const p = parser.parse(
               `{messages.length, plural, =0 {<b/>}`, 'TestComp', {tokenizeExpansionForms: true});
           expect(humanizeErrors(p.errors)).toEqual([
-            ['b', 'Only void and foreign elements can be self closed "b"', '0:30']
+            ['b', 'Only void, custom and foreign elements can be self closed "b"', '0:30']
           ]);
         });
       });
@@ -1117,16 +1117,12 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
           const errors = parser.parse('<p />', 'TestComp').errors;
           expect(errors.length).toEqual(1);
           expect(humanizeErrors(errors)).toEqual([
-            ['p', 'Only void and foreign elements can be self closed "p"', '0:0']
+            ['p', 'Only void, custom and foreign elements can be self closed "p"', '0:0']
           ]);
         });
 
-        it('should report self closing custom element', () => {
-          const errors = parser.parse('<my-cmp />', 'TestComp').errors;
-          expect(errors.length).toEqual(1);
-          expect(humanizeErrors(errors)).toEqual([
-            ['my-cmp', 'Only void and foreign elements can be self closed "my-cmp"', '0:0']
-          ]);
+        it('should not report self closing custom element', () => {
+          expect(parser.parse('<my-cmp />', 'TestComp').errors).toEqual([]);
         });
 
         it('should also report lexer errors', () => {

--- a/packages/compiler/test/selector/selector_spec.ts
+++ b/packages/compiler/test/selector/selector_spec.ts
@@ -512,36 +512,6 @@ import {el} from '@angular/platform-browser/testing/src/browser_util';
       expect(cssSelectors[2].notSelectors[0].classNames).toEqual(['special']);
     });
   });
-
-  describe('CssSelector.getMatchingElementTemplate', () => {
-    it('should create an element with a tagName, classes, and attributes with the correct casing',
-       () => {
-         const selector = CssSelector.parse('Blink.neon.hotpink[Sweet][Dismissable=false]')[0];
-         const template = selector.getMatchingElementTemplate();
-
-         expect(template).toEqual('<Blink class="neon hotpink" Sweet Dismissable="false"></Blink>');
-       });
-
-    it('should create an element without a tag name', () => {
-      const selector = CssSelector.parse('[fancy]')[0];
-      const template = selector.getMatchingElementTemplate();
-
-      expect(template).toEqual('<div fancy></div>');
-    });
-
-    it('should ignore :not selectors', () => {
-      const selector = CssSelector.parse('grape:not(.red)')[0];
-      const template = selector.getMatchingElementTemplate();
-
-      expect(template).toEqual('<grape></grape>');
-    });
-
-    it('should support void tags', () => {
-      const selector = CssSelector.parse('input[fancy]')[0];
-      const template = selector.getMatchingElementTemplate();
-      expect(template).toEqual('<input fancy/>');
-    });
-  });
 }
 
 function getSelectorFor(

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -1530,6 +1530,39 @@ describe('acceptance integration tests', () => {
        });
   });
 
+  describe('self-closing tags', () => {
+    it('should allow a self-closing tag for a custom tag name', () => {
+      @Component({selector: 'my-comp', template: 'hello'})
+      class MyComp {
+      }
+
+      @Component({template: '<my-comp/>'})
+      class App {
+      }
+
+      TestBed.configureTestingModule({declarations: [App, MyComp]});
+      const fixture = TestBed.createComponent(App);
+
+      expect(fixture.nativeElement.innerHTML).toEqual('<my-comp>hello</my-comp>');
+    });
+
+    it('should not confuse self-closing tag for an end tag', () => {
+      @Component({selector: 'my-comp', template: '<ng-content/>'})
+      class MyComp {
+      }
+
+      @Component({template: '<my-comp title="a">Before<my-comp title="b"/>After</my-comp>'})
+      class App {
+      }
+
+      TestBed.configureTestingModule({declarations: [App, MyComp]});
+      const fixture = TestBed.createComponent(App);
+
+      expect(fixture.nativeElement.innerHTML)
+          .toEqual('<my-comp title="a">Before<my-comp title="b"></my-comp>After</my-comp>');
+    });
+  });
+
   it('should only call inherited host listeners once', () => {
     let clicks = 0;
 


### PR DESCRIPTION
Allows for self-closing tags to be used for non-native tag names, e.g. `<foo [input]="bar"></foo>` can now be written as `<foo [input]="bar"/>`. Native tag names still have to have closing tags.

Fixes #39525.