### PR TITLE
docs(compiler-cli): fix commands to run compliance unit test

### DIFF
--- a/packages/compiler-cli/test/compliance/README.md
+++ b/packages/compiler-cli/test/compliance/README.md
@@ -208,19 +208,19 @@ yarn test //packages/compiler-cli/test/compliance/linked --config=debug
 To debug generating the partial golden output use the following form of Bazel command:
 
 ```sh
-yarn bazel run //packages/compiler-cli/test/compliance/test_cases:generate_partial_for_<path/to/test_case>.debug
+yarn bazel run //packages/compiler-cli/test/compliance/test_cases:partial_<path/to/test_case>.debug
 ```
 
 The `path/to/test_case` is relative to the `test_cases` directory. So for this `TEST_CASES.json` file at:
 
 ```
-packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_directives/directives/matching/TEST_CASES.json
+packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_directives/matching/TEST_CASES.json
 ```
 
 The command to debug the test-cases would be:
 
 ```
-yarn bazel run //packages/compiler-cli/test/compliance/test_cases:generate_partial_for_r3_view_compiler_directives/directives/matching.debug
+yarn bazel run //packages/compiler-cli/test/compliance/test_cases:partial_r3_view_compiler_directives/matching.debug
 ```
 
 


### PR DESCRIPTION
Quick doc fix following [this commit on `partial_compliance_goldens.bzl`](https://github.com/angular/angular/pull/39661/files#diff-6b0003adb7dc68f268fb70c25781358cf0a04d834c21a9d22cf3dc8e5c85b7f2)