### PR TITLE
fix(bazel): remove duplicate license banners from FESM bundles

### DIFF
--- a/packages/bazel/package.json
+++ b/packages/bazel/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@microsoft/api-extractor": "^7.24.2",
+    "magic-string": "^0.27.0",
     "tsickle": "^0.46.3",
     "tslib": "^2.3.0"
   },

--- a/packages/bazel/src/ng_package/rollup/BUILD.bazel
+++ b/packages/bazel/src/ng_package/rollup/BUILD.bazel
@@ -13,6 +13,7 @@ nodejs_binary(
     data = [
         "@npm//@rollup/plugin-commonjs",
         "@npm//@rollup/plugin-node-resolve",
+        "@npm//magic-string",
         "@npm//rollup",
         "@npm//rollup-plugin-sourcemaps",
         "@npm//typescript",

--- a/packages/bazel/test/ng_package/example_package.golden
+++ b/packages/bazel/test/ng_package/example_package.golden
@@ -321,13 +321,6 @@ export const a = 1;
 import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class A11yModule {
 }
 A11yModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: A11yModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -337,14 +330,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             type: NgModule,
             args: [{}]
         }] });
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 /**
  * Generated bundle index. Do not edit.
@@ -365,13 +350,6 @@ export { A11yModule };
 import * as i0 from '@angular/core';
 import { Injectable } from '@angular/core';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class MySecondService {
 }
 MySecondService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MySecondService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
@@ -381,13 +359,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             args: [{ providedIn: 'root' }]
         }] });
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class MyService {
     constructor(secondService) {
         this.secondService = secondService;
@@ -399,14 +370,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             type: Injectable,
             args: [{ providedIn: 'root' }]
         }], ctorParameters: function () { return [{ type: MySecondService }]; } });
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 /**
  * Generated bundle index. Do not edit.
@@ -427,13 +390,6 @@ export { MyService };
 import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class SecondaryModule {
 }
 SecondaryModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -444,14 +400,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             args: [{}]
         }] });
 const a = 1;
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 /**
  * Generated bundle index. Do not edit.
@@ -472,13 +420,6 @@ export { SecondaryModule, a };
 import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class MyModule {
 }
 MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -488,14 +429,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             type: NgModule,
             args: [{}]
         }] });
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 /**
  * Generated bundle index. Do not edit.
@@ -516,13 +449,6 @@ export { MyModule };
 import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class A11yModule {
 }
 A11yModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: A11yModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -532,14 +458,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             type: NgModule,
             args: [{}]
         }] });
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 /**
  * Generated bundle index. Do not edit.
@@ -560,13 +478,6 @@ export { A11yModule };
 import * as i0 from '@angular/core';
 import { Injectable } from '@angular/core';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class MySecondService {
 }
 MySecondService.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MySecondService, deps: [], target: i0.ɵɵFactoryTarget.Injectable });
@@ -576,13 +487,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             args: [{ providedIn: 'root' }]
         }] });
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class MyService {
     constructor(secondService) {
         this.secondService = secondService;
@@ -594,14 +498,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             type: Injectable,
             args: [{ providedIn: 'root' }]
         }], ctorParameters: function () { return [{ type: MySecondService }]; } });
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 /**
  * Generated bundle index. Do not edit.
@@ -622,13 +518,6 @@ export { MyService };
 import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class SecondaryModule {
 }
 SecondaryModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: SecondaryModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -639,14 +528,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             args: [{}]
         }] });
 const a = 1;
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 /**
  * Generated bundle index. Do not edit.
@@ -667,13 +548,6 @@ export { SecondaryModule, a };
 import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class MyModule {
 }
 MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -683,14 +557,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             type: NgModule,
             args: [{}]
         }] });
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 /**
  * Generated bundle index. Do not edit.

--- a/packages/bazel/test/ng_package/example_with_ts_library_package.golden
+++ b/packages/bazel/test/ng_package/example_with_ts_library_package.golden
@@ -129,13 +129,6 @@ export function dispatchFakeEvent(el, ev) {
  * License: MIT
  */
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 const VERSION = '0.0.0';
 
 export { VERSION };
@@ -153,13 +146,6 @@ export { VERSION };
 import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class PortalModule {
 }
 PortalModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: PortalModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -170,14 +156,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             args: [{}]
         }] });
 const a = 1;
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 /**
  * Generated bundle index. Do not edit.
@@ -195,24 +173,9 @@ export { PortalModule, a };
  * License: MIT
  */
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 function dispatchFakeEvent(el, ev) {
     el.dispatchEvent(ev);
 }
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 export { dispatchFakeEvent };
 //# sourceMappingURL=utils.mjs.map
@@ -226,13 +189,6 @@ export { dispatchFakeEvent };
  * License: MIT
  */
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 const VERSION = '0.0.0';
 
 export { VERSION };
@@ -250,13 +206,6 @@ export { VERSION };
 import * as i0 from '@angular/core';
 import { NgModule } from '@angular/core';
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 class PortalModule {
 }
 PortalModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0", ngImport: i0, type: PortalModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
@@ -267,14 +216,6 @@ i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0", ngImport
             args: [{}]
         }] });
 const a = 1;
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 /**
  * Generated bundle index. Do not edit.
@@ -292,24 +233,9 @@ export { PortalModule, a };
  * License: MIT
  */
 
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 function dispatchFakeEvent(el, ev) {
     el.dispatchEvent(ev);
 }
-
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
 
 export { dispatchFakeEvent };
 //# sourceMappingURL=utils.mjs.map

--- a/packages/zone.js/rollup.config.js
+++ b/packages/zone.js/rollup.config.js
@@ -1,5 +1,6 @@
 const node = require('@rollup/plugin-node-resolve').default;
 const commonjs = require('@rollup/plugin-commonjs');
+const MagicString = require('magic-string');
 
 // Parse the stamp file produced by Bazel from the version control system
 let version = '<unknown>';
@@ -35,6 +36,7 @@ module.exports = {
       mainFields: ['es2015', 'module', 'jsnext:main', 'main'],
     }),
     commonjs(),
+    stripBannerPlugin,
   ],
   external: (id) => {
     if (/zone\.js[\\/]lib/.test(id)) {
@@ -55,5 +57,28 @@ module.exports = {
       'rxjs/symbol/rxSubscriber': 'Rx.Symbol',
     },
     banner,
+  },
+};
+
+/** Removed license banners from input files. */
+const stripBannerPlugin = {
+  name: 'strip-license-banner',
+  transform(code, _filePath) {
+    const banner = /(\/\**\s+\*\s@license.*?\*\/)/s.exec(code);
+    if (!banner) {
+      return;
+    }
+
+    const [bannerContent] = banner;
+    const magicString = new MagicString(code);
+    const pos = code.indexOf(bannerContent);
+    magicString.remove(pos, pos + bannerContent.length).trimStart();
+
+    return {
+      code: magicString.toString(),
+      map: magicString.generateMap({
+        hires: true,
+      }),
+    };
   },
 };

--- a/packages/zone.js/rollup.config.js
+++ b/packages/zone.js/rollup.config.js
@@ -15,6 +15,29 @@ if (bazel_version_file) {
   }
 }
 
+/** Removed license banners from input files. */
+const stripBannerPlugin = {
+  name: 'strip-license-banner',
+  transform(code, _filePath) {
+    const banner = /(\/\**\s+\*\s@license.*?\*\/)/s.exec(code);
+    if (!banner) {
+      return;
+    }
+
+    const [bannerContent] = banner;
+    const magicString = new MagicString(code);
+    const pos = code.indexOf(bannerContent);
+    magicString.remove(pos, pos + bannerContent.length).trimStart();
+
+    return {
+      code: magicString.toString(),
+      map: magicString.generateMap({
+        hires: true,
+      }),
+    };
+  },
+};
+
 // Add 'use strict' to the bundle, https://github.com/angular/angular/pull/40456
 // When rollup build esm bundle of zone.js, there will be no 'use strict'
 // since all esm bundles are `strict`, but when webpack load the esm bundle,
@@ -57,28 +80,5 @@ module.exports = {
       'rxjs/symbol/rxSubscriber': 'Rx.Symbol',
     },
     banner,
-  },
-};
-
-/** Removed license banners from input files. */
-const stripBannerPlugin = {
-  name: 'strip-license-banner',
-  transform(code, _filePath) {
-    const banner = /(\/\**\s+\*\s@license.*?\*\/)/s.exec(code);
-    if (!banner) {
-      return;
-    }
-
-    const [bannerContent] = banner;
-    const magicString = new MagicString(code);
-    const pos = code.indexOf(bannerContent);
-    magicString.remove(pos, pos + bannerContent.length).trimStart();
-
-    return {
-      code: magicString.toString(),
-      map: magicString.generateMap({
-        hires: true,
-      }),
-    };
   },
 };

--- a/packages/zone.js/test/karma_test.bzl
+++ b/packages/zone.js/test/karma_test.bzl
@@ -18,6 +18,7 @@ def karma_test_prepare(name, env_srcs, env_deps, env_entry_point, test_srcs, tes
             ":" + name + "_env",
             "@npm//@rollup/plugin-commonjs",
             "@npm//@rollup/plugin-node-resolve",
+            "@npm//magic-string",
         ],
     )
     ts_library(
@@ -37,6 +38,7 @@ def karma_test_prepare(name, env_srcs, env_deps, env_entry_point, test_srcs, tes
             ":" + name + "_test",
             "@npm//@rollup/plugin-commonjs",
             "@npm//@rollup/plugin-node-resolve",
+            "@npm//magic-string",
         ],
     )
 

--- a/packages/zone.js/tools.bzl
+++ b/packages/zone.js/tools.bzl
@@ -14,6 +14,7 @@ def zone_rollup_bundle(module_name, entry_point, rollup_config):
             "//packages/zone.js/lib",
             "@npm//@rollup/plugin-commonjs",
             "@npm//@rollup/plugin-node-resolve",
+            "@npm//magic-string",
         ],
     )
 

--- a/packages/zone.js/tools.bzl
+++ b/packages/zone.js/tools.bzl
@@ -45,23 +45,19 @@ def generate_rollup_bundle(bundles):
             entry_point = rollup_config.get("entrypoint")
             zone_rollup_bundle(
                 module_name = module_name + "-es5",
-                rollup_config = rollup_config,
                 entry_point = entry_point,
             )
             zone_rollup_bundle(
                 module_name = module_name + "-es2015",
-                rollup_config = rollup_config,
                 entry_point = entry_point,
             )
         else:
             zone_rollup_bundle(
                 module_name = module_name + "-es5",
-                rollup_config = rollup_config,
                 entry_point = rollup_config.get("es5"),
             )
             zone_rollup_bundle(
                 module_name = module_name + "-es2015",
-                rollup_config = rollup_config,
                 entry_point = rollup_config.get("es2015"),
             )
 

--- a/packages/zone.js/tools.bzl
+++ b/packages/zone.js/tools.bzl
@@ -2,7 +2,7 @@
 
 load("//tools:defaults.bzl", "rollup_bundle")
 
-def zone_rollup_bundle(module_name, entry_point, rollup_config):
+def zone_rollup_bundle(module_name, entry_point):
     config_file = "//packages/zone.js:rollup.config.js"
     rollup_bundle(
         name = module_name + "-rollup",


### PR DESCRIPTION
Prior to this change the FESM bundles for the FW packages have the license banner duplicated hundreds of times in each published file.

With this change we remove all the banners from the individual input files. A new banner will be appended at the top of the FESM using rollup's banner option.

While there is a rollup plugin on NPM to strip these banners (https://github.com/mjeanroy/rollup-plugin-strip-banner) we could not use this as it does not support `.mjs`.
