### PR TITLE
build: allow network access to the sandbox while in debug mode

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 # Enable debugging tests with --config=debug
-test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
+test:debug --sandbox_default_allow_network --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
 
 ###############################
 # Filesystem interactions     #


### PR DESCRIPTION
When running with --config=debug by default the sandbox allows network access, allowing the debugger to be attached to.
