### PR TITLE
ci: remove redundant aio dependencies installation step

### DIFF
--- a/.github/workflows/update-events.yml
+++ b/.github/workflows/update-events.yml
@@ -30,8 +30,6 @@ jobs:
           # account that is attempted to be used for authentication, instead the remote is set to
           # an authenticated URL.
           persist-credentials: false
-      - name: Install AIO dependencies
-        run: yarn --cwd=aio install
       - name: Generate `events.json`
         run: node aio/scripts/generate-events/index.mjs --ignore-invalid-dates
       - name: Create a PR (if necessary)


### PR DESCRIPTION
Remove redundant aio dependencies installation step from update-events action as this action only uses built-in node.js APIs