### PR TITLE
docs: remove empty onInit() & constructors

### DIFF
--- a/aio/content/examples/property-binding/src/app/item-detail/item-detail.component.ts
+++ b/aio/content/examples/property-binding/src/app/item-detail/item-detail.component.ts
@@ -7,7 +7,7 @@ import { Component, OnInit, Input } from '@angular/core';
   templateUrl: './item-detail.component.html',
   styleUrls: ['./item-detail.component.css']
 })
-export class ItemDetailComponent implements OnInit {
+export class ItemDetailComponent {
 
   // #docregion input-type
   @Input() childItem = '';
@@ -17,10 +17,5 @@ export class ItemDetailComponent implements OnInit {
 
 
   currentItem = 'bananas in boxes';
-
-  constructor() { }
-
-  ngOnInit() {
-  }
 
 }

--- a/aio/content/examples/property-binding/src/app/item-list/item-list.component.ts
+++ b/aio/content/examples/property-binding/src/app/item-list/item-list.component.ts
@@ -12,6 +12,5 @@ export class ItemListComponent {
   // #docregion item-input
   @Input() items: Item[] = [];
   // #enddocregion item-input
-  constructor() { }
 
 }

--- a/aio/content/examples/toh-pt1/src/app/heroes/heroes.component.ts
+++ b/aio/content/examples/toh-pt1/src/app/heroes/heroes.component.ts
@@ -1,6 +1,6 @@
 // #docplaster
 // #docregion, v1
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 // #enddocregion v1
 import { Hero } from '../hero';
 // #docregion v1
@@ -10,7 +10,7 @@ import { Hero } from '../hero';
   templateUrl: './heroes.component.html',
   styleUrls: ['./heroes.component.css']
 })
-export class HeroesComponent implements OnInit {
+export class HeroesComponent {
   // #enddocregion, v1
   /*
   // #docregion add-hero
@@ -23,11 +23,5 @@ export class HeroesComponent implements OnInit {
     name: 'Windstorm'
   };
   // #docregion v1
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
 }
 // #enddocregion, v1

--- a/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.ts
+++ b/aio/content/examples/toh-pt2/src/app/heroes/heroes.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { Hero } from '../hero';
 // #docregion import-heroes
 import { HEROES } from '../mock-heroes';
@@ -14,18 +14,13 @@ import { HEROES } from '../mock-heroes';
 // #enddocregion metadata
 
 // #docregion component
-export class HeroesComponent implements OnInit {
+export class HeroesComponent {
 
   heroes = HEROES;
   // #enddocregion component
   // #docregion on-select
   selectedHero?: Hero;
  // #enddocregion on-select
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
 
   // #docregion on-select
   onSelect(hero: Hero): void {

--- a/aio/content/examples/toh-pt3/src/app/hero-detail/hero-detail.component.ts
+++ b/aio/content/examples/toh-pt3/src/app/hero-detail/hero-detail.component.ts
@@ -1,6 +1,6 @@
 // #docregion
 // #docregion import-input
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 // #enddocregion import-input
 // #docregion import-hero
 import { Hero } from '../hero';
@@ -11,14 +11,8 @@ import { Hero } from '../hero';
   templateUrl: './hero-detail.component.html',
   styleUrls: ['./hero-detail.component.css']
 })
-export class HeroDetailComponent implements OnInit {
+export class HeroDetailComponent {
   // #docregion input-hero
   @Input() hero?: Hero;
   // #enddocregion input-hero
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
 }

--- a/aio/content/examples/toh-pt4/src/app/messages/messages.component.ts
+++ b/aio/content/examples/toh-pt4/src/app/messages/messages.component.ts
@@ -1,5 +1,5 @@
 // #docregion
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 // #docregion import-message-service
 import { MessageService } from '../message.service';
 // #enddocregion import-message-service
@@ -9,13 +9,10 @@ import { MessageService } from '../message.service';
   templateUrl: './messages.component.html',
   styleUrls: ['./messages.component.css']
 })
-export class MessagesComponent implements OnInit {
+export class MessagesComponent {
 
   // #docregion ctor
   constructor(public messageService: MessageService) {}
   // #enddocregion ctor
-
-  ngOnInit() {
-  }
 
 }

--- a/aio/content/examples/toh-pt5/src/app/messages/messages.component.ts
+++ b/aio/content/examples/toh-pt5/src/app/messages/messages.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { MessageService } from '../message.service';
 
 @Component({
@@ -6,11 +6,8 @@ import { MessageService } from '../message.service';
   templateUrl: './messages.component.html',
   styleUrls: ['./messages.component.css']
 })
-export class MessagesComponent implements OnInit {
+export class MessagesComponent {
 
   constructor(public messageService: MessageService) {}
-
-  ngOnInit() {
-  }
 
 }

--- a/aio/content/examples/toh-pt6/src/app/messages/messages.component.ts
+++ b/aio/content/examples/toh-pt6/src/app/messages/messages.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { MessageService } from '../message.service';
 
 @Component({
@@ -6,11 +6,8 @@ import { MessageService } from '../message.service';
   templateUrl: './messages.component.html',
   styleUrls: ['./messages.component.css']
 })
-export class MessagesComponent implements OnInit {
+export class MessagesComponent {
 
   constructor(public messageService: MessageService) {}
-
-  ngOnInit() {
-  }
 
 }

--- a/aio/content/examples/two-way-binding/src/app/app.component.ts
+++ b/aio/content/examples/two-way-binding/src/app/app.component.ts
@@ -6,7 +6,6 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
-  constructor() { }
   // #docregion font-size
   fontSizePx = 16;
   // #enddocregion font-size

--- a/aio/content/examples/upgrade-lazy-load-ajs/src/app/home/home.component.ts
+++ b/aio/content/examples/upgrade-lazy-load-ajs/src/app/home/home.component.ts
@@ -1,15 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.css']
 })
-export class HomeComponent implements OnInit {
-
-  constructor() { }
-
-  ngOnInit() {
-  }
+export class HomeComponent {
 
 }

--- a/aio/content/start/start-data.md
+++ b/aio/content/start/start-data.md
@@ -115,9 +115,6 @@ For customers to see their cart, you can create the cart view in two steps:
 
     <code-example header="src/app/cart/cart.component.ts" path="getting-started/src/app/cart/cart.component.1.ts"></code-example>
 
-    StackBlitz also generates an `ngOnInit()` by default in components.
-    You can ignore the `CartComponent` `ngOnInit()` for this tutorial.
-
 1.  Notice that the newly created `CartComponent` is added to the module's `declarations` in `app.module.ts`.
 
     <code-example header="src/app/app.module.ts" path="getting-started/src/app/app.module.ts" region="declare-cart"></code-example>

--- a/aio/content/tutorial/tour-of-heroes/toh-pt1.md
+++ b/aio/content/tutorial/tour-of-heroes/toh-pt1.md
@@ -41,10 +41,6 @@ You always import the `Component` symbol from the Angular core library and annot
 
 The [CSS element selector](https://developer.mozilla.org/docs/Web/CSS/Type_selectors), `'app-heroes'`, matches the name of the HTML element that identifies this component within a parent component's template.
 
-The `ngOnInit()` is a [lifecycle hook](guide/lifecycle-hooks#oninit).
-Angular calls `ngOnInit()` shortly after creating a component.
-It's a good place to put initialization logic.
-
 Always `export` the component class so you can `import` it elsewhere &hellip; like in the `AppModule`.
 
 ### Add a `hero` property


### PR DESCRIPTION
Following  angular/angular-cli#24008, the schematics don't produce ngOnInit and the constructor anymore. Let's reflect that in the Tour of Heroes tutorial.

Edit: I also removed it from other parts of the documentation. 

Fixes #48575

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes