### PR TITLE
ci: add Angular CLI help pages action

### DIFF
--- a/.github/workflows/update-cli-help.yml
+++ b/.github/workflows/update-cli-help.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate CLI help
         run: node aio/scripts/update-cli-help/index.mjs
       - name: Create a PR (if necessary)
-        uses: angular/dev-infra/github-actions/create-pr-for-changes@96fdaaa056f1cfa7ffbc4c69b7e9007279f76c94
+        uses: angular/dev-infra/github-actions/create-pr-for-changes@ad1374e8222825244b36a91d0f085f8fc3c7126d
         with:
           branch-prefix: update-cli-help
           pr-title: 'docs: update Angular CLI help'

--- a/.github/workflows/update-cli-help.yml
+++ b/.github/workflows/update-cli-help.yml
@@ -1,0 +1,40 @@
+name: Update AIO Angular CLI help
+
+on:
+  workflow_dispatch:
+    inputs: {}
+  push:
+    branches:
+      - 'main'
+      - '[0-9]+.[0-9]+.x'
+
+# Declare default permissions as read only.
+permissions:
+  contents: read
+
+jobs:
+  update_cli_help:
+    name: Update Angular CLI help (if necessary)
+    if: github.repository == 'angular/angular'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+        with:
+          # Setting `persist-credentials: false` prevents the github-action account from being the
+          # account that is attempted to be used for authentication, instead the remote is set to
+          # an authenticated URL.
+          persist-credentials: false
+      - name: Generate CLI help
+        run: node aio/scripts/update-cli-help/index.mjs
+      - name: Create a PR (if necessary)
+        uses: angular/dev-infra/github-actions/create-pr-for-changes@96fdaaa056f1cfa7ffbc4c69b7e9007279f76c94
+        with:
+          branch-prefix: update-cli-help
+          pr-title: 'docs: update Angular CLI help'
+          pr-description: |
+            Updated Angular CLI help contents.
+          pr-labels: |
+            action: review
+            area: docs
+          angular-robot-token: ${{ secrets.ANGULAR_ROBOT_ACCESS_TOKEN }}

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,32 +57,6 @@ http_archive(
     url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.19.0.tar.gz",
 )
 
-# Download cli source from angular/cli-builds for doc generation at a specific tag or commit.
-# If the ref is a commit sha, use the full sha instead of the abbreviated form. Tags, which
-# hold an abbreviated sha by convention in cli-builds, can continue to use the short form.
-CLI_SRC_REF = "f0163d17d581f7ea59ada47420599264060db77a"
-
-http_archive(
-    name = "angular_cli_src",
-    build_file_content = """
-# Include files used in doc generation
-filegroup(
-    name = "files_for_docgen",
-    srcs = glob([
-        "help/**/*.json",
-        "package.json",
-    ]),
-    visibility = ["//visibility:public"],
-)
-""",
-    # Run the following command to calculate the sha256, substituting the CLI_SRC_REF
-    # wget -O- -q https://github.com/angular/cli-builds/archive/{CLI_SRC_REF}.tar.gz | sha256sum
-    # Alternatively, just remove the parameter and bazel debug will output the sha as a suggestion.
-    sha256 = "952a62ce2b040af74fe3ae4d0bef5eaca505b7986df3bcf776e4ce84628cd3ed",
-    strip_prefix = "cli-builds-%s" % CLI_SRC_REF,
-    url = "https://github.com/angular/cli-builds/archive/%s.tar.gz" % CLI_SRC_REF,
-)
-
 # Setup the Node.js toolchain.
 load("@rules_nodejs//nodejs:repositories.bzl", "nodejs_register_toolchains")
 

--- a/aio/content/BUILD.bazel
+++ b/aio/content/BUILD.bazel
@@ -6,7 +6,6 @@ filegroup(
         ["**"],
         exclude = [
             "BUILD.bazel",
-            "cli/**",
         ],
     ),
 )

--- a/aio/content/cli/BUILD.bazel
+++ b/aio/content/cli/BUILD.bazel
@@ -1,12 +1,11 @@
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
-    name = "content",
+    name = "cli",
     srcs = glob(
         ["**"],
         exclude = [
             "BUILD.bazel",
-            "cli/**",
         ],
     ),
 )

--- a/aio/content/cli/help/add.json
+++ b/aio/content/cli/help/add.json
@@ -1,0 +1,63 @@
+{
+  "name": "add",
+  "command": "ng add <collection>",
+  "shortDescription": "Adds support for an external library to your project.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/add/long-description.md",
+  "longDescription": "Adds the npm package for a published library to your workspace, and configures\nthe project in the current working directory to use that library, as specified by the library's schematic.\nFor example, adding `@angular/pwa` configures your project for PWA support:\n\n```bash\nng add @angular/pwa\n```\n",
+  "aliases": [],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "collection",
+      "type": "string",
+      "description": "The package to be added.",
+      "positional": 0
+    },
+    {
+      "name": "defaults",
+      "type": "boolean",
+      "default": false,
+      "description": "Disable interactive input prompts for options with a default."
+    },
+    {
+      "name": "dry-run",
+      "type": "boolean",
+      "default": false,
+      "description": "Run through and reports activity without writing out results."
+    },
+    {
+      "name": "force",
+      "type": "boolean",
+      "default": false,
+      "description": "Force overwriting of existing files."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "interactive",
+      "type": "boolean",
+      "default": true,
+      "description": "Enable interactive input prompts."
+    },
+    {
+      "name": "registry",
+      "type": "string",
+      "description": "The NPM registry to use."
+    },
+    {
+      "name": "skip-confirmation",
+      "type": "boolean",
+      "default": false,
+      "description": "Skip asking a confirmation prompt before installing and executing the package. Ensure package name is correct prior to using this option."
+    },
+    {
+      "name": "verbose",
+      "type": "boolean",
+      "default": false,
+      "description": "Display additional details about internal operations during execution."
+    }
+  ]
+}

--- a/aio/content/cli/help/analytics.json
+++ b/aio/content/cli/help/analytics.json
@@ -1,0 +1,84 @@
+{
+  "name": "analytics",
+  "command": "ng analytics",
+  "shortDescription": "Configures the gathering of Angular CLI usage metrics.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/analytics/long-description.md",
+  "longDescription": "You can help the Angular Team to prioritize features and improvements by permitting the Angular team to send command-line command usage statistics to Google.\nThe Angular Team does not collect usage statistics unless you explicitly opt in. When installing the Angular CLI you are prompted to allow global collection of usage statistics.\nIf you say no or skip the prompt, no data is collected.\n\n### What is collected?\n\nUsage analytics include the commands and selected flags for each execution.\nUsage analytics may include the following information:\n\n- Your operating system \\(macOS, Linux distribution, Windows\\) and its version.\n- Package manager name and version \\(local version only\\).\n- Node.js version \\(local version only\\).\n- Angular CLI version \\(local version only\\).\n- Command name that was run.\n- Workspace information, the number of application and library projects.\n- For schematics commands \\(add, generate and new\\), the schematic collection and name and a list of selected flags.\n- For build commands \\(build, serve\\), the builder name, the number and size of bundles \\(initial and lazy\\), compilation units, the time it took to build and rebuild, and basic Angular-specific API usage.\n\nOnly Angular owned and developed schematics and builders are reported.\nThird-party schematics and builders do not send data to the Angular Team.\n",
+  "aliases": [],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    }
+  ],
+  "subcommands": [
+    {
+      "name": "disable",
+      "command": "disable",
+      "shortDescription": "Disables analytics gathering and reporting for the user.",
+      "options": [
+        {
+          "name": "global",
+          "type": "boolean",
+          "aliases": [
+            "g"
+          ],
+          "default": false,
+          "description": "Configure analytics gathering and reporting globally in the caller's home directory."
+        }
+      ],
+      "aliases": [
+        "off"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "enable",
+      "command": "enable",
+      "shortDescription": "Enables analytics gathering and reporting for the user.",
+      "options": [
+        {
+          "name": "global",
+          "type": "boolean",
+          "aliases": [
+            "g"
+          ],
+          "default": false,
+          "description": "Configure analytics gathering and reporting globally in the caller's home directory."
+        }
+      ],
+      "aliases": [
+        "on"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "info",
+      "command": "info",
+      "shortDescription": "Prints analytics gathering and reporting configuration in the console.",
+      "options": [],
+      "aliases": [],
+      "deprecated": false
+    },
+    {
+      "name": "prompt",
+      "command": "prompt",
+      "shortDescription": "Prompts the user to set the analytics gathering status interactively.",
+      "options": [
+        {
+          "name": "global",
+          "type": "boolean",
+          "aliases": [
+            "g"
+          ],
+          "default": false,
+          "description": "Configure analytics gathering and reporting globally in the caller's home directory."
+        }
+      ],
+      "aliases": [],
+      "deprecated": false
+    }
+  ]
+}

--- a/aio/content/cli/help/build-info.json
+++ b/aio/content/cli/help/build-info.json
@@ -1,0 +1,4 @@
+{
+  "sha": "f086b86068d9aed5db519b96e41ea07824fea7d4",
+  "version": "0.0.0"
+}

--- a/aio/content/cli/help/build-info.json
+++ b/aio/content/cli/help/build-info.json
@@ -1,4 +1,4 @@
 {
-  "sha": "f086b86068d9aed5db519b96e41ea07824fea7d4",
-  "version": "0.0.0"
+  "branchName": "15.1.x",
+  "sha": "115ae81174033436db34655089521fc4be5b09e6"
 }

--- a/aio/content/cli/help/build.json
+++ b/aio/content/cli/help/build.json
@@ -1,0 +1,250 @@
+{
+  "name": "build",
+  "command": "ng build [project]",
+  "shortDescription": "Compiles an Angular application or library into an output directory named dist/ at the given output path.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/build/long-description.md",
+  "longDescription": "The command can be used to build a project of type \"application\" or \"library\".\nWhen used to build a library, a different builder is invoked, and only the `ts-config`, `configuration`, and `watch` options are applied.\nAll other options apply only to building applications.\n\nThe application builder uses the [webpack](https://webpack.js.org/) build tool, with default configuration options specified in the workspace configuration file (`angular.json`) or with a named alternative configuration.\nA \"development\" configuration is created by default when you use the CLI to create the project, and you can use that configuration by specifying the `--configuration development`.\n\nThe configuration options generally correspond to the command options.\nYou can override individual configuration defaults by specifying the corresponding options on the command line.\nThe command can accept option names given in either dash-case or camelCase.\nNote that in the configuration file, you must specify names in camelCase.\n\nSome additional options can only be set through the configuration file,\neither by direct editing or with the `ng config` command.\nThese include `assets`, `styles`, and `scripts` objects that provide runtime-global resources to include in the project.\nResources in CSS, such as images and fonts, are automatically written and fingerprinted at the root of the output folder.\n\nFor further details, see [Workspace Configuration](guide/workspace-config).\n",
+  "aliases": [
+    "b"
+  ],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "allowed-common-js-dependencies",
+      "type": "array",
+      "description": "A list of CommonJS packages that are allowed to be used without a build time warning."
+    },
+    {
+      "name": "aot",
+      "type": "boolean",
+      "default": true,
+      "description": "Build using Ahead of Time compilation."
+    },
+    {
+      "name": "base-href",
+      "type": "string",
+      "description": "Base url for the application being built."
+    },
+    {
+      "name": "build-optimizer",
+      "type": "boolean",
+      "default": true,
+      "description": "Enables advanced build optimizations when using the 'aot' option."
+    },
+    {
+      "name": "common-chunk",
+      "type": "boolean",
+      "default": true,
+      "description": "Generate a seperate bundle containing code used across multiple bundles."
+    },
+    {
+      "name": "configuration",
+      "type": "string",
+      "aliases": [
+        "c"
+      ],
+      "description": "One or more named builder configurations as a comma-separated list as specified in the \"configurations\" section in angular.json.\nThe builder uses the named configurations to run the given target.\nFor more information, see https://angular.io/guide/workspace-config#alternate-build-configurations."
+    },
+    {
+      "name": "cross-origin",
+      "type": "string",
+      "default": "none",
+      "enum": [
+        "none",
+        "anonymous",
+        "use-credentials"
+      ],
+      "description": "Define the crossorigin attribute setting of elements that provide CORS support."
+    },
+    {
+      "name": "delete-output-path",
+      "type": "boolean",
+      "default": true,
+      "description": "Delete the output path before building."
+    },
+    {
+      "name": "deploy-url",
+      "type": "string",
+      "deprecated": "Use \"baseHref\" option, \"APP_BASE_HREF\" DI token or a combination of both instead. For more information, see https://angular.io/guide/deployment#the-deploy-url.",
+      "description": "URL where files will be deployed."
+    },
+    {
+      "name": "extract-licenses",
+      "type": "boolean",
+      "default": true,
+      "description": "Extract all licenses in a separate file."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "i18n-duplicate-translation",
+      "type": "string",
+      "default": "warning",
+      "enum": [
+        "warning",
+        "error",
+        "ignore"
+      ],
+      "description": "How to handle duplicate translations for i18n."
+    },
+    {
+      "name": "i18n-missing-translation",
+      "type": "string",
+      "default": "warning",
+      "enum": [
+        "warning",
+        "error",
+        "ignore"
+      ],
+      "description": "How to handle missing translations for i18n."
+    },
+    {
+      "name": "index",
+      "type": "string",
+      "description": "Configures the generation of the application's HTML index."
+    },
+    {
+      "name": "inline-style-language",
+      "type": "string",
+      "default": "css",
+      "enum": [
+        "css",
+        "less",
+        "sass",
+        "scss"
+      ],
+      "description": "The stylesheet language to use for the application's inline component styles."
+    },
+    {
+      "name": "localize",
+      "type": "boolean",
+      "description": "Translate the bundles in one or more locales."
+    },
+    {
+      "name": "main",
+      "type": "string",
+      "description": "The full path for the main entry point to the app, relative to the current workspace."
+    },
+    {
+      "name": "named-chunks",
+      "type": "boolean",
+      "default": false,
+      "description": "Use file name for lazy loaded chunks."
+    },
+    {
+      "name": "ngsw-config-path",
+      "type": "string",
+      "description": "Path to ngsw-config.json."
+    },
+    {
+      "name": "optimization",
+      "type": "boolean",
+      "default": true,
+      "description": "Enables optimization of the build output. Including minification of scripts and styles, tree-shaking, dead-code elimination, inlining of critical CSS and fonts inlining. For more information, see https://angular.io/guide/workspace-config#optimization-configuration."
+    },
+    {
+      "name": "output-hashing",
+      "type": "string",
+      "default": "none",
+      "enum": [
+        "none",
+        "all",
+        "media",
+        "bundles"
+      ],
+      "description": "Define the output filename cache-busting hashing mode."
+    },
+    {
+      "name": "output-path",
+      "type": "string",
+      "description": "The full path for the new output directory, relative to the current workspace.\nBy default, writes output to a folder named dist/ in the current project."
+    },
+    {
+      "name": "poll",
+      "type": "number",
+      "description": "Enable and define the file watching poll time period in milliseconds."
+    },
+    {
+      "name": "polyfills",
+      "type": "string",
+      "description": "Polyfills to be included in the build."
+    },
+    {
+      "name": "preserve-symlinks",
+      "type": "boolean",
+      "description": "Do not use the real path when resolving modules. If unset then will default to `true` if NodeJS option --preserve-symlinks is set."
+    },
+    {
+      "name": "progress",
+      "type": "boolean",
+      "default": true,
+      "description": "Log progress to the console while building."
+    },
+    {
+      "name": "project",
+      "type": "string",
+      "description": "The name of the project to build. Can be an application or a library.",
+      "positional": 0
+    },
+    {
+      "name": "resources-output-path",
+      "type": "string",
+      "description": "The path where style resources will be placed, relative to outputPath."
+    },
+    {
+      "name": "service-worker",
+      "type": "boolean",
+      "default": false,
+      "description": "Generates a service worker config for production builds."
+    },
+    {
+      "name": "source-map",
+      "type": "boolean",
+      "default": false,
+      "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration."
+    },
+    {
+      "name": "stats-json",
+      "type": "boolean",
+      "default": false,
+      "description": "Generates a 'stats.json' file which can be analyzed using tools such as 'webpack-bundle-analyzer'."
+    },
+    {
+      "name": "subresource-integrity",
+      "type": "boolean",
+      "default": false,
+      "description": "Enables the use of subresource integrity validation."
+    },
+    {
+      "name": "ts-config",
+      "type": "string",
+      "description": "The full path for the TypeScript configuration file, relative to the current workspace."
+    },
+    {
+      "name": "vendor-chunk",
+      "type": "boolean",
+      "default": false,
+      "description": "Generate a seperate bundle containing only vendor libraries. This option should only be used for development to reduce the incremental compilation time."
+    },
+    {
+      "name": "verbose",
+      "type": "boolean",
+      "default": false,
+      "description": "Adds more details to output logging."
+    },
+    {
+      "name": "watch",
+      "type": "boolean",
+      "default": false,
+      "description": "Run build when files change."
+    },
+    {
+      "name": "web-worker-ts-config",
+      "type": "string",
+      "description": "TypeScript configuration for Web Worker modules."
+    }
+  ]
+}

--- a/aio/content/cli/help/cache.json
+++ b/aio/content/cli/help/cache.json
@@ -1,0 +1,54 @@
+{
+  "name": "cache",
+  "command": "ng cache",
+  "shortDescription": "Configure persistent disk cache and retrieve cache statistics.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/cache/long-description.md",
+  "longDescription": "Angular CLI saves a number of cachable operations on disk by default.\n\nWhen you re-run the same build, the build system restores the state of the previous build and re-uses previously performed operations, which decreases the time taken to build and test your applications and libraries.\n\nTo amend the default cache settings, add the `cli.cache` object to your [Workspace Configuration](guide/workspace-config).\nThe object goes under `cli.cache` at the top level of the file, outside the `projects` sections.\n\n```jsonc\n{\n  \"$schema\": \"./node_modules/@angular/cli/lib/config/schema.json\",\n  \"version\": 1,\n  \"cli\": {\n    \"cache\": {\n      // ...\n    }\n  },\n  \"projects\": {}\n}\n```\n\nFor more information, see [cache options](guide/workspace-config#cache-options).\n\n### Cache environments\n\nBy default, disk cache is only enabled for local environments. The value of environment can be one of the following:\n\n- `all` - allows disk cache on all machines.\n- `local` - allows disk cache only on development machines.\n- `ci` - allows disk cache only on continuous integration (CI) systems.\n\nTo change the environment setting to `all`, run the following command:\n\n```bash\nng config cli.cache.environment all\n```\n\nFor more information, see `environment` in [cache options](guide/workspace-config#cache-options).\n\n<div class=\"alert is-helpful\">\n\nThe Angular CLI checks for the presence and value of the `CI` environment variable to determine in which environment it is running.\n\n</div>\n\n### Cache path\n\nBy default, `.angular/cache` is used as a base directory to store cache results.\n\nTo change this path to `.cache/ng`, run the following command:\n\n```bash\nng config cli.cache.path \".cache/ng\"\n```\n",
+  "aliases": [],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    }
+  ],
+  "subcommands": [
+    {
+      "name": "clean",
+      "command": "clean",
+      "shortDescription": "Deletes persistent disk cache from disk.",
+      "options": [],
+      "aliases": [],
+      "deprecated": false
+    },
+    {
+      "name": "disable",
+      "command": "disable",
+      "shortDescription": "Disables persistent disk cache for all projects in the workspace.",
+      "options": [],
+      "aliases": [
+        "off"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "enable",
+      "command": "enable",
+      "shortDescription": "Enables disk cache for all projects in the workspace.",
+      "options": [],
+      "aliases": [
+        "on"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "info",
+      "command": "info",
+      "shortDescription": "Prints persistent disk cache configuration and statistics in the console.",
+      "options": [],
+      "aliases": [],
+      "deprecated": false
+    }
+  ]
+}

--- a/aio/content/cli/help/completion.json
+++ b/aio/content/cli/help/completion.json
@@ -1,0 +1,26 @@
+{
+  "name": "completion",
+  "command": "ng completion",
+  "shortDescription": "Set up Angular CLI autocompletion for your terminal.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/completion/long-description.md",
+  "longDescription": "Setting up autocompletion configures your terminal, so pressing the `<TAB>` key while in the middle\nof typing will display various commands and options available to you. This makes it very easy to\ndiscover and use CLI commands without lots of memorization.\n\n![A demo of Angular CLI autocompletion in a terminal. The user types several partial `ng` commands,\nusing autocompletion to finish several arguments and list contextual options.\n](generated/images/guide/cli/completion.gif)\n\n## Automated setup\n\nThe CLI should prompt and ask to set up autocompletion for you the first time you use it (v14+).\nSimply answer \"Yes\" and the CLI will take care of the rest.\n\n```\n$ ng serve\n? Would you like to enable autocompletion? This will set up your terminal so pressing TAB while typing Angular CLI commands will show possible options and autocomplete arguments. (Enabling autocompletion will modify configuration files in your home directory.) Yes\nAppended `source <(ng completion script)` to `/home/my-username/.bashrc`. Restart your terminal or run:\n\nsource <(ng completion script)\n\nto autocomplete `ng` commands.\n\n# Serve output...\n```\n\nIf you already refused the prompt, it won't ask again. But you can run `ng completion` to\ndo the same thing automatically.\n\nThis modifies your terminal environment to load Angular CLI autocompletion, but can't update your\ncurrent terminal session. Either restart it or run `source <(ng completion script)` directly to\nenable autocompletion in your current session.\n\nTest it out by typing `ng ser<TAB>` and it should autocomplete to `ng serve`. Ambiguous arguments\nwill show all possible options and their documentation, such as `ng generate <TAB>`.\n\n## Manual setup\n\nSome users may have highly customized terminal setups, possibly with configuration files checked\ninto source control with an opinionated structure. `ng completion` only ever appends Angular's setup\nto an existing configuration file for your current shell, or creates one if none exists. If you want\nmore control over exactly where this configuration lives, you can manually set it up by having your\nshell run at startup:\n\n```bash\nsource <(ng completion script)\n```\n\nThis is equivalent to what `ng completion` will automatically set up, and gives power users more\nflexibility in their environments when desired.\n\n## Platform support\n\nAngular CLI supports autocompletion for the Bash and Zsh shells on MacOS and Linux operating\nsystems. On Windows, Git Bash and [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/)\nusing Bash or Zsh are supported.\n\n## Global install\n\nAutocompletion works by configuring your terminal to invoke the Angular CLI on startup to load the\nsetup script. This means the terminal must be able to find and execute the Angular CLI, typically\nthrough a global install that places the binary on the user's `$PATH`. If you get\n`command not found: ng`, make sure the CLI is installed globally which you can do with the `-g`\nflag:\n\n```bash\nnpm install -g @angular/cli\n```\n",
+  "aliases": [],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    }
+  ],
+  "subcommands": [
+    {
+      "name": "script",
+      "command": "script",
+      "shortDescription": "Generate a bash and zsh real-time type-ahead autocompletion script.",
+      "options": [],
+      "aliases": [],
+      "deprecated": false
+    }
+  ]
+}

--- a/aio/content/cli/help/config.json
+++ b/aio/content/cli/help/config.json
@@ -1,0 +1,37 @@
+{
+  "name": "config",
+  "command": "ng config [json-path] [value]",
+  "shortDescription": "Retrieves or sets Angular configuration values in the angular.json file for the workspace.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/config/long-description.md",
+  "longDescription": "A workspace has a single CLI configuration file, `angular.json`, at the top level.\nThe `projects` object contains a configuration object for each project in the workspace.\n\nYou can edit the configuration directly in a code editor,\nor indirectly on the command line using this command.\n\nThe configurable property names match command option names,\nexcept that in the configuration file, all names must use camelCase,\nwhile on the command line options can be given dash-case.\n\nFor further details, see [Workspace Configuration](guide/workspace-config).\n\nFor configuration of CLI usage analytics, see [ng analytics](cli/analytics).\n",
+  "aliases": [],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "global",
+      "type": "boolean",
+      "aliases": [
+        "g"
+      ],
+      "default": false,
+      "description": "Access the global configuration in the caller's home directory."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "json-path",
+      "type": "string",
+      "description": "The configuration key to set or query, in JSON path format. For example: \"a[3].foo.bar[2]\". If no new value is provided, returns the current value of this key.",
+      "positional": 0
+    },
+    {
+      "name": "value",
+      "type": "string",
+      "description": "If provided, a new value for the given configuration key.",
+      "positional": 1
+    }
+  ]
+}

--- a/aio/content/cli/help/deploy.json
+++ b/aio/content/cli/help/deploy.json
@@ -1,0 +1,30 @@
+{
+  "name": "deploy",
+  "command": "ng deploy [project]",
+  "shortDescription": "Invokes the deploy builder for a specified project or for the default project in the workspace.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/deploy/long-description.md",
+  "longDescription": "The command takes an optional project name, as specified in the `projects` section of the `angular.json` workspace configuration file.\nWhen a project name is not supplied, executes the `deploy` builder for the default project.\n\nTo use the `ng deploy` command, use `ng add` to add a package that implements deployment capabilities to your favorite platform.\nAdding the package automatically updates your workspace configuration, adding a deployment\n[CLI builder](guide/cli-builder).\nFor example:\n\n```json\n\"projects\": {\n  \"my-project\": {\n    ...\n    \"architect\": {\n      ...\n      \"deploy\": {\n        \"builder\": \"@angular/fire:deploy\",\n        \"options\": {}\n      }\n    }\n  }\n}\n```\n",
+  "aliases": [],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "configuration",
+      "type": "string",
+      "aliases": [
+        "c"
+      ],
+      "description": "One or more named builder configurations as a comma-separated list as specified in the \"configurations\" section in angular.json.\nThe builder uses the named configurations to run the given target.\nFor more information, see https://angular.io/guide/workspace-config#alternate-build-configurations."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "project",
+      "type": "string",
+      "description": "The name of the project to build. Can be an application or a library.",
+      "positional": 0
+    }
+  ]
+}

--- a/aio/content/cli/help/doc.json
+++ b/aio/content/cli/help/doc.json
@@ -1,0 +1,36 @@
+{
+  "name": "doc",
+  "command": "ng doc <keyword>",
+  "shortDescription": "Opens the official Angular documentation (angular.io) in a browser, and searches for a given keyword.",
+  "aliases": [
+    "d"
+  ],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "keyword",
+      "type": "string",
+      "description": "The keyword to search for, as provided in the search bar in angular.io.",
+      "positional": 0
+    },
+    {
+      "name": "search",
+      "type": "boolean",
+      "aliases": [
+        "s"
+      ],
+      "default": false,
+      "description": "Search all of angular.io. Otherwise, searches only API reference documentation."
+    },
+    {
+      "name": "version",
+      "type": "string",
+      "description": "Contains the version of Angular to use for the documentation. If not provided, the command uses your current Angular core version."
+    }
+  ]
+}

--- a/aio/content/cli/help/e2e.json
+++ b/aio/content/cli/help/e2e.json
@@ -1,0 +1,30 @@
+{
+  "name": "e2e",
+  "command": "ng e2e [project]",
+  "shortDescription": "Builds and serves an Angular application, then runs end-to-end tests.",
+  "aliases": [
+    "e"
+  ],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "configuration",
+      "type": "string",
+      "aliases": [
+        "c"
+      ],
+      "description": "One or more named builder configurations as a comma-separated list as specified in the \"configurations\" section in angular.json.\nThe builder uses the named configurations to run the given target.\nFor more information, see https://angular.io/guide/workspace-config#alternate-build-configurations."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "project",
+      "type": "string",
+      "description": "The name of the project to build. Can be an application or a library.",
+      "positional": 0
+    }
+  ]
+}

--- a/aio/content/cli/help/extract-i18n.json
+++ b/aio/content/cli/help/extract-i18n.json
@@ -1,0 +1,66 @@
+{
+  "name": "extract-i18n",
+  "command": "ng extract-i18n [project]",
+  "shortDescription": "Extracts i18n messages from source code.",
+  "aliases": [],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "browser-target",
+      "type": "string",
+      "description": "A browser builder target to extract i18n messages in the format of `project:target[:configuration]`. You can also pass in more than one configuration name as a comma-separated list. Example: `project:target:production,staging`."
+    },
+    {
+      "name": "configuration",
+      "type": "string",
+      "aliases": [
+        "c"
+      ],
+      "description": "One or more named builder configurations as a comma-separated list as specified in the \"configurations\" section in angular.json.\nThe builder uses the named configurations to run the given target.\nFor more information, see https://angular.io/guide/workspace-config#alternate-build-configurations."
+    },
+    {
+      "name": "format",
+      "type": "string",
+      "default": "xlf",
+      "enum": [
+        "xmb",
+        "xlf",
+        "xlif",
+        "xliff",
+        "xlf2",
+        "xliff2",
+        "json",
+        "arb",
+        "legacy-migrate"
+      ],
+      "description": "Output format for the generated file."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "out-file",
+      "type": "string",
+      "description": "Name of the file to output."
+    },
+    {
+      "name": "output-path",
+      "type": "string",
+      "description": "Path where output will be placed."
+    },
+    {
+      "name": "progress",
+      "type": "boolean",
+      "default": true,
+      "description": "Log progress to the console."
+    },
+    {
+      "name": "project",
+      "type": "string",
+      "description": "The name of the project to build. Can be an application or a library.",
+      "positional": 0
+    }
+  ]
+}

--- a/aio/content/cli/help/generate.json
+++ b/aio/content/cli/help/generate.json
@@ -1,0 +1,909 @@
+{
+  "name": "generate",
+  "command": "ng generate <schematic>",
+  "shortDescription": "Generates and/or modifies files based on a schematic.",
+  "aliases": [
+    "g"
+  ],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "defaults",
+      "type": "boolean",
+      "default": false,
+      "description": "Disable interactive input prompts for options with a default."
+    },
+    {
+      "name": "dry-run",
+      "type": "boolean",
+      "default": false,
+      "description": "Run through and reports activity without writing out results."
+    },
+    {
+      "name": "force",
+      "type": "boolean",
+      "default": false,
+      "description": "Force overwriting of existing files."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "interactive",
+      "type": "boolean",
+      "default": true,
+      "description": "Enable interactive input prompts."
+    },
+    {
+      "name": "schematic",
+      "type": "string",
+      "description": "The [collection:schematic] to run.",
+      "positional": 0
+    }
+  ],
+  "subcommands": [
+    {
+      "name": "app-shell",
+      "command": "app-shell",
+      "shortDescription": "Generates an application shell for running a server-side version of an app.",
+      "options": [
+        {
+          "name": "app-id",
+          "type": "string",
+          "default": "serverApp",
+          "description": "The application ID to use in withServerTransition()."
+        },
+        {
+          "name": "main",
+          "type": "string",
+          "default": "main.server.ts",
+          "description": "The name of the main entry-point file."
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the related client app."
+        },
+        {
+          "name": "root-module-class-name",
+          "type": "string",
+          "default": "AppServerModule",
+          "description": "The name of the root module class."
+        },
+        {
+          "name": "root-module-file-name",
+          "type": "string",
+          "default": "app.server.module.ts",
+          "description": "The name of the root module file"
+        },
+        {
+          "name": "route",
+          "type": "string",
+          "default": "shell",
+          "description": "Route path used to produce the application shell."
+        }
+      ],
+      "aliases": [],
+      "deprecated": false
+    },
+    {
+      "name": "application",
+      "command": "application [name]",
+      "shortDescription": "Generates a new basic application definition in the \"projects\" subfolder of the workspace.",
+      "options": [
+        {
+          "name": "inline-style",
+          "type": "boolean",
+          "aliases": [
+            "s"
+          ],
+          "description": "Include styles inline in the root component.ts file. Only CSS styles can be included inline. Default is false, meaning that an external styles file is created and referenced in the root component.ts file."
+        },
+        {
+          "name": "inline-template",
+          "type": "boolean",
+          "aliases": [
+            "t"
+          ],
+          "description": "Include template inline in the root component.ts file. Default is false, meaning that an external template file is created and referenced in the root component.ts file. "
+        },
+        {
+          "name": "minimal",
+          "type": "boolean",
+          "default": false,
+          "description": "Create a bare-bones project without any testing frameworks. (Use for learning purposes only.)"
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the new application.",
+          "positional": 0
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "aliases": [
+            "p"
+          ],
+          "default": "app",
+          "description": "A prefix to apply to generated selectors."
+        },
+        {
+          "name": "project-root",
+          "type": "string",
+          "description": "The root directory of the new application."
+        },
+        {
+          "name": "routing",
+          "type": "boolean",
+          "default": false,
+          "description": "Create a routing NgModule."
+        },
+        {
+          "name": "skip-install",
+          "type": "boolean",
+          "default": false,
+          "description": "Skip installing dependency packages."
+        },
+        {
+          "name": "skip-package-json",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not add dependencies to the \"package.json\" file."
+        },
+        {
+          "name": "skip-tests",
+          "type": "boolean",
+          "aliases": [
+            "S"
+          ],
+          "default": false,
+          "description": "Do not create \"spec.ts\" test files for the application."
+        },
+        {
+          "name": "strict",
+          "type": "boolean",
+          "default": true,
+          "description": "Creates an application with stricter bundle budgets settings."
+        },
+        {
+          "name": "style",
+          "type": "string",
+          "default": "css",
+          "enum": [
+            "css",
+            "scss",
+            "sass",
+            "less"
+          ],
+          "description": "The file extension or preprocessor to use for style files."
+        },
+        {
+          "name": "view-encapsulation",
+          "type": "string",
+          "enum": [
+            "Emulated",
+            "None",
+            "ShadowDom"
+          ],
+          "description": "The view encapsulation strategy to use in the new application."
+        }
+      ],
+      "aliases": [
+        "app"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "class",
+      "command": "class [name]",
+      "shortDescription": "Creates a new, generic class definition in the given or default project.",
+      "options": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the new class.",
+          "positional": 0
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "skip-tests",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not create \"spec.ts\" test files for the new class."
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "description": "Adds a developer-defined type to the filename, in the format \"name.type.ts\"."
+        }
+      ],
+      "aliases": [
+        "cl"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "component",
+      "command": "component [name]",
+      "shortDescription": "Creates a new, generic component definition in the given or default project.",
+      "options": [
+        {
+          "name": "change-detection",
+          "type": "string",
+          "aliases": [
+            "c"
+          ],
+          "default": "Default",
+          "enum": [
+            "Default",
+            "OnPush"
+          ],
+          "description": "The change detection strategy to use in the new component."
+        },
+        {
+          "name": "display-block",
+          "type": "boolean",
+          "aliases": [
+            "b"
+          ],
+          "default": false,
+          "description": "Specifies if the style will contain `:host { display: block; }`."
+        },
+        {
+          "name": "export",
+          "type": "boolean",
+          "default": false,
+          "description": "The declaring NgModule exports this component."
+        },
+        {
+          "name": "flat",
+          "type": "boolean",
+          "default": false,
+          "description": "Create the new files at the top level of the current project."
+        },
+        {
+          "name": "inline-style",
+          "type": "boolean",
+          "aliases": [
+            "s"
+          ],
+          "default": false,
+          "description": "Include styles inline in the component.ts file. Only CSS styles can be included inline. By default, an external styles file is created and referenced in the component.ts file."
+        },
+        {
+          "name": "inline-template",
+          "type": "boolean",
+          "aliases": [
+            "t"
+          ],
+          "default": false,
+          "description": "Include template inline in the component.ts file. By default, an external template file is created and referenced in the component.ts file."
+        },
+        {
+          "name": "module",
+          "type": "string",
+          "aliases": [
+            "m"
+          ],
+          "description": "The declaring NgModule."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the component.",
+          "positional": 0
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "aliases": [
+            "p"
+          ],
+          "description": "The prefix to apply to the generated component selector."
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "selector",
+          "type": "string",
+          "description": "The HTML selector to use for this component."
+        },
+        {
+          "name": "skip-import",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not import this component into the owning NgModule."
+        },
+        {
+          "name": "skip-selector",
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies if the component should have a selector or not."
+        },
+        {
+          "name": "skip-tests",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not create \"spec.ts\" test files for the new component."
+        },
+        {
+          "name": "standalone",
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the generated component is standalone."
+        },
+        {
+          "name": "style",
+          "type": "string",
+          "default": "css",
+          "enum": [
+            "css",
+            "scss",
+            "sass",
+            "less",
+            "none"
+          ],
+          "description": "The file extension or preprocessor to use for style files, or 'none' to skip generating the style file."
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "default": "Component",
+          "description": "Adds a developer-defined type to the filename, in the format \"name.type.ts\"."
+        },
+        {
+          "name": "view-encapsulation",
+          "type": "string",
+          "aliases": [
+            "v"
+          ],
+          "enum": [
+            "Emulated",
+            "None",
+            "ShadowDom"
+          ],
+          "description": "The view encapsulation strategy to use in the new component."
+        }
+      ],
+      "aliases": [
+        "c"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "directive",
+      "command": "directive [name]",
+      "shortDescription": "Creates a new, generic directive definition in the given or default project.",
+      "options": [
+        {
+          "name": "export",
+          "type": "boolean",
+          "default": false,
+          "description": "The declaring NgModule exports this directive."
+        },
+        {
+          "name": "flat",
+          "type": "boolean",
+          "default": true,
+          "description": "When true (the default), creates the new files at the top level of the current project."
+        },
+        {
+          "name": "module",
+          "type": "string",
+          "aliases": [
+            "m"
+          ],
+          "description": "The declaring NgModule."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the new directive.",
+          "positional": 0
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "aliases": [
+            "p"
+          ],
+          "description": "A prefix to apply to generated selectors."
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "selector",
+          "type": "string",
+          "description": "The HTML selector to use for this directive."
+        },
+        {
+          "name": "skip-import",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not import this directive into the owning NgModule."
+        },
+        {
+          "name": "skip-tests",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not create \"spec.ts\" test files for the new class."
+        },
+        {
+          "name": "standalone",
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the generated directive is standalone."
+        }
+      ],
+      "aliases": [
+        "d"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "enum",
+      "command": "enum [name]",
+      "shortDescription": "Generates a new, generic enum definition for the given or default project.",
+      "options": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the enum.",
+          "positional": 0
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project in which to create the enum. Default is the configured default project for the workspace."
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "description": "Adds a developer-defined type to the filename, in the format \"name.type.ts\"."
+        }
+      ],
+      "aliases": [
+        "e"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "environments",
+      "command": "environments",
+      "shortDescription": "Generates and configures environment files for a project.",
+      "options": [
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        }
+      ],
+      "aliases": [],
+      "deprecated": false
+    },
+    {
+      "name": "guard",
+      "command": "guard [name]",
+      "shortDescription": "Generates a new, generic route guard definition in the given or default project.",
+      "options": [
+        {
+          "name": "flat",
+          "type": "boolean",
+          "default": true,
+          "description": "When true (the default), creates the new files at the top level of the current project."
+        },
+        {
+          "name": "functional",
+          "type": "boolean",
+          "default": false,
+          "description": "Specifies whether to generate a guard as a function."
+        },
+        {
+          "name": "implements",
+          "type": "array",
+          "aliases": [
+            "guardType"
+          ],
+          "description": "Specifies which type of guard to create."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the new route guard.",
+          "positional": 0
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "skip-tests",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not create \"spec.ts\" test files for the new guard."
+        }
+      ],
+      "aliases": [
+        "g"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "interceptor",
+      "command": "interceptor [name]",
+      "shortDescription": "Creates a new, generic interceptor definition in the given or default project.",
+      "options": [
+        {
+          "name": "flat",
+          "type": "boolean",
+          "default": true,
+          "description": "When true (the default), creates files at the top level of the project."
+        },
+        {
+          "name": "functional",
+          "type": "boolean",
+          "default": false,
+          "description": "Creates the interceptor as a `HttpInterceptorFn`."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the interceptor.",
+          "positional": 0
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "skip-tests",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not create \"spec.ts\" test files for the new interceptor."
+        }
+      ],
+      "aliases": [],
+      "deprecated": false
+    },
+    {
+      "name": "interface",
+      "command": "interface [name] [type]",
+      "shortDescription": "Creates a new, generic interface definition in the given or default project.",
+      "options": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the interface.",
+          "positional": 0
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "description": "A prefix to apply to generated selectors."
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "type",
+          "type": "string",
+          "description": "Adds a developer-defined type to the filename, in the format \"name.type.ts\".",
+          "positional": 1
+        }
+      ],
+      "aliases": [
+        "i"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "library",
+      "command": "library [name]",
+      "shortDescription": "Creates a new, generic library project in the current workspace.",
+      "options": [
+        {
+          "name": "entry-file",
+          "type": "string",
+          "default": "public-api",
+          "description": "The path at which to create the library's public API file, relative to the workspace root."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the library.",
+          "positional": 0
+        },
+        {
+          "name": "prefix",
+          "type": "string",
+          "aliases": [
+            "p"
+          ],
+          "default": "lib",
+          "description": "A prefix to apply to generated selectors."
+        },
+        {
+          "name": "project-root",
+          "type": "string",
+          "description": "The root directory of the new library."
+        },
+        {
+          "name": "skip-install",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not install dependency packages."
+        },
+        {
+          "name": "skip-package-json",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not add dependencies to the \"package.json\" file. "
+        },
+        {
+          "name": "skip-ts-config",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not update \"tsconfig.json\" to add a path mapping for the new library. The path mapping is needed to use the library in an app, but can be disabled here to simplify development."
+        }
+      ],
+      "aliases": [
+        "lib"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "module",
+      "command": "module [name]",
+      "shortDescription": "Creates a new, generic NgModule definition in the given or default project.",
+      "options": [
+        {
+          "name": "flat",
+          "type": "boolean",
+          "default": false,
+          "description": "Create the new files at the top level of the current project root. "
+        },
+        {
+          "name": "module",
+          "type": "string",
+          "aliases": [
+            "m"
+          ],
+          "description": "The declaring NgModule."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the NgModule.",
+          "positional": 0
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "route",
+          "type": "string",
+          "description": "The route path for a lazy-loaded module. When supplied, creates a component in the new module, and adds the route to that component in the `Routes` array declared in the module provided in the `--module` option."
+        },
+        {
+          "name": "routing",
+          "type": "boolean",
+          "default": false,
+          "description": "Create a routing module."
+        },
+        {
+          "name": "routing-scope",
+          "type": "string",
+          "default": "Child",
+          "enum": [
+            "Child",
+            "Root"
+          ],
+          "description": "The scope for the new routing module."
+        }
+      ],
+      "aliases": [
+        "m"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "pipe",
+      "command": "pipe [name]",
+      "shortDescription": "Creates a new, generic pipe definition in the given or default project.",
+      "options": [
+        {
+          "name": "export",
+          "type": "boolean",
+          "default": false,
+          "description": "The declaring NgModule exports this pipe."
+        },
+        {
+          "name": "flat",
+          "type": "boolean",
+          "default": true,
+          "description": "When true (the default) creates files at the top level of the project."
+        },
+        {
+          "name": "module",
+          "type": "string",
+          "aliases": [
+            "m"
+          ],
+          "description": "The declaring NgModule."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the pipe.",
+          "positional": 0
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "skip-import",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not import this pipe into the owning NgModule."
+        },
+        {
+          "name": "skip-tests",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not create \"spec.ts\" test files for the new pipe."
+        },
+        {
+          "name": "standalone",
+          "type": "boolean",
+          "default": false,
+          "description": "Whether the generated pipe is standalone."
+        }
+      ],
+      "aliases": [
+        "p"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "resolver",
+      "command": "resolver [name]",
+      "shortDescription": "Generates a new, generic resolver definition in the given or default project.",
+      "options": [
+        {
+          "name": "flat",
+          "type": "boolean",
+          "default": true,
+          "description": "When true (the default), creates the new files at the top level of the current project."
+        },
+        {
+          "name": "functional",
+          "type": "boolean",
+          "default": false,
+          "description": "Creates the resolver as a `ResolveFn`."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the new resolver.",
+          "positional": 0
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "skip-tests",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not create \"spec.ts\" test files for the new resolver."
+        }
+      ],
+      "aliases": [
+        "r"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "service",
+      "command": "service [name]",
+      "shortDescription": "Creates a new, generic service definition in the given or default project.",
+      "options": [
+        {
+          "name": "flat",
+          "type": "boolean",
+          "default": true,
+          "description": "When true (the default), creates files at the top level of the project."
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the service.",
+          "positional": 0
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "skip-tests",
+          "type": "boolean",
+          "default": false,
+          "description": "Do not create \"spec.ts\" test files for the new service."
+        }
+      ],
+      "aliases": [
+        "s"
+      ],
+      "deprecated": false
+    },
+    {
+      "name": "service-worker",
+      "command": "service-worker",
+      "shortDescription": "Pass this schematic to the \"run\" command to create a service worker",
+      "options": [
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "default": "build",
+          "description": "The target to apply service worker to."
+        }
+      ],
+      "aliases": [],
+      "deprecated": false
+    },
+    {
+      "name": "web-worker",
+      "command": "web-worker [name]",
+      "shortDescription": "Creates a new, generic web worker definition in the given or default project.",
+      "options": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "The name of the worker.",
+          "positional": 0
+        },
+        {
+          "name": "project",
+          "type": "string",
+          "description": "The name of the project."
+        },
+        {
+          "name": "snippet",
+          "type": "boolean",
+          "default": true,
+          "description": "Add a worker creation snippet in a sibling file of the same name."
+        }
+      ],
+      "aliases": [],
+      "deprecated": false
+    }
+  ]
+}

--- a/aio/content/cli/help/lint.json
+++ b/aio/content/cli/help/lint.json
@@ -1,0 +1,30 @@
+{
+  "name": "lint",
+  "command": "ng lint [project]",
+  "shortDescription": "Runs linting tools on Angular application code in a given project folder.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/lint/long-description.md",
+  "longDescription": "The command takes an optional project name, as specified in the `projects` section of the `angular.json` workspace configuration file.\nWhen a project name is not supplied, executes the `lint` builder for all projects.\n\nTo use the `ng lint` command, use `ng add` to add a package that implements linting capabilities. Adding the package automatically updates your workspace configuration, adding a lint [CLI builder](guide/cli-builder).\nFor example:\n\n```json\n\"projects\": {\n  \"my-project\": {\n    ...\n    \"architect\": {\n      ...\n      \"lint\": {\n        \"builder\": \"@angular-eslint/builder:lint\",\n        \"options\": {}\n      }\n    }\n  }\n}\n```\n",
+  "aliases": [],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "configuration",
+      "type": "string",
+      "aliases": [
+        "c"
+      ],
+      "description": "One or more named builder configurations as a comma-separated list as specified in the \"configurations\" section in angular.json.\nThe builder uses the named configurations to run the given target.\nFor more information, see https://angular.io/guide/workspace-config#alternate-build-configurations."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "project",
+      "type": "string",
+      "description": "The name of the project to build. Can be an application or a library.",
+      "positional": 0
+    }
+  ]
+}

--- a/aio/content/cli/help/new.json
+++ b/aio/content/cli/help/new.json
@@ -1,0 +1,175 @@
+{
+  "name": "new",
+  "command": "ng new [name]",
+  "shortDescription": "Creates a new Angular workspace.",
+  "aliases": [
+    "n"
+  ],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "collection",
+      "type": "string",
+      "aliases": [
+        "c"
+      ],
+      "description": "A collection of schematics to use in generating the initial application."
+    },
+    {
+      "name": "commit",
+      "type": "boolean",
+      "default": true,
+      "description": "Initial git repository commit information."
+    },
+    {
+      "name": "create-application",
+      "type": "boolean",
+      "default": true,
+      "description": "Create a new initial application project in the 'src' folder of the new workspace. When false, creates an empty workspace with no initial application. You can then use the generate application command so that all applications are created in the projects folder."
+    },
+    {
+      "name": "defaults",
+      "type": "boolean",
+      "default": false,
+      "description": "Disable interactive input prompts for options with a default."
+    },
+    {
+      "name": "directory",
+      "type": "string",
+      "description": "The directory name to create the workspace in."
+    },
+    {
+      "name": "dry-run",
+      "type": "boolean",
+      "default": false,
+      "description": "Run through and reports activity without writing out results."
+    },
+    {
+      "name": "force",
+      "type": "boolean",
+      "default": false,
+      "description": "Force overwriting of existing files."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "inline-style",
+      "type": "boolean",
+      "aliases": [
+        "s"
+      ],
+      "description": "Include styles inline in the component TS file. By default, an external styles file is created and referenced in the component TypeScript file."
+    },
+    {
+      "name": "inline-template",
+      "type": "boolean",
+      "aliases": [
+        "t"
+      ],
+      "description": "Include template inline in the component TS file. By default, an external template file is created and referenced in the component TypeScript file."
+    },
+    {
+      "name": "interactive",
+      "type": "boolean",
+      "default": true,
+      "description": "Enable interactive input prompts."
+    },
+    {
+      "name": "minimal",
+      "type": "boolean",
+      "default": false,
+      "description": "Create a workspace without any testing frameworks. (Use for learning purposes only.)"
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "description": "The name of the new workspace and initial project.",
+      "positional": 0
+    },
+    {
+      "name": "new-project-root",
+      "type": "string",
+      "default": "projects",
+      "description": "The path where new projects will be created, relative to the new workspace root."
+    },
+    {
+      "name": "package-manager",
+      "type": "string",
+      "enum": [
+        "npm",
+        "yarn",
+        "pnpm",
+        "cnpm"
+      ],
+      "description": "The package manager used to install dependencies."
+    },
+    {
+      "name": "prefix",
+      "type": "string",
+      "aliases": [
+        "p"
+      ],
+      "default": "app",
+      "description": "The prefix to apply to generated selectors for the initial project."
+    },
+    {
+      "name": "routing",
+      "type": "boolean",
+      "description": "Generate a routing module for the initial project."
+    },
+    {
+      "name": "skip-git",
+      "type": "boolean",
+      "aliases": [
+        "g"
+      ],
+      "default": false,
+      "description": "Do not initialize a git repository."
+    },
+    {
+      "name": "skip-install",
+      "type": "boolean",
+      "default": false,
+      "description": "Do not install dependency packages."
+    },
+    {
+      "name": "skip-tests",
+      "type": "boolean",
+      "aliases": [
+        "S"
+      ],
+      "default": false,
+      "description": "Do not generate \"spec.ts\" test files for the new project."
+    },
+    {
+      "name": "strict",
+      "type": "boolean",
+      "default": true,
+      "description": "Creates a workspace with stricter type checking and stricter bundle budgets settings. This setting helps improve maintainability and catch bugs ahead of time. For more information, see https://angular.io/guide/strict-mode"
+    },
+    {
+      "name": "style",
+      "type": "string",
+      "enum": [
+        "css",
+        "scss",
+        "sass",
+        "less"
+      ],
+      "description": "The file extension or preprocessor to use for style files."
+    },
+    {
+      "name": "view-encapsulation",
+      "type": "string",
+      "enum": [
+        "Emulated",
+        "None",
+        "ShadowDom"
+      ],
+      "description": "The view encapsulation strategy to use in the initial project."
+    }
+  ]
+}

--- a/aio/content/cli/help/run.json
+++ b/aio/content/cli/help/run.json
@@ -1,0 +1,22 @@
+{
+  "name": "run",
+  "command": "ng run <target>",
+  "shortDescription": "Runs an Architect target with an optional custom builder configuration defined in your project.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/run/long-description.md",
+  "longDescription": "Architect is the tool that the CLI uses to perform complex tasks such as compilation, according to provided configurations.\nThe CLI commands run Architect targets such as `build`, `serve`, `test`, and `lint`.\nEach named target has a default configuration, specified by an \"options\" object,\nand an optional set of named alternate configurations in the \"configurations\" object.\n\nFor example, the \"serve\" target for a newly generated app has a predefined\nalternate configuration named \"production\".\n\nYou can define new targets and their configuration options in the \"architect\" section\nof the `angular.json` file.\nIf you do so, you can run them from the command line using the `ng run` command.\nExecute the command using the following format.\n\n```\nng run project:target[:configuration]\n```\n",
+  "aliases": [],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "target",
+      "type": "string",
+      "description": "The Architect target to run.",
+      "positional": 0
+    }
+  ]
+}

--- a/aio/content/cli/help/serve.json
+++ b/aio/content/cli/help/serve.json
@@ -1,0 +1,126 @@
+{
+  "name": "serve",
+  "command": "ng serve [project]",
+  "shortDescription": "Builds and serves your application, rebuilding on file changes.",
+  "aliases": [
+    "s"
+  ],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "allowed-hosts",
+      "type": "array",
+      "description": "List of hosts that are allowed to access the dev server."
+    },
+    {
+      "name": "browser-target",
+      "type": "string",
+      "description": "A browser builder target to serve in the format of `project:target[:configuration]`. You can also pass in more than one configuration name as a comma-separated list. Example: `project:target:production,staging`."
+    },
+    {
+      "name": "configuration",
+      "type": "string",
+      "aliases": [
+        "c"
+      ],
+      "description": "One or more named builder configurations as a comma-separated list as specified in the \"configurations\" section in angular.json.\nThe builder uses the named configurations to run the given target.\nFor more information, see https://angular.io/guide/workspace-config#alternate-build-configurations."
+    },
+    {
+      "name": "disable-host-check",
+      "type": "boolean",
+      "default": false,
+      "description": "Don't verify connected clients are part of allowed hosts."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "hmr",
+      "type": "boolean",
+      "default": false,
+      "description": "Enable hot module replacement."
+    },
+    {
+      "name": "host",
+      "type": "string",
+      "default": "localhost",
+      "description": "Host to listen on."
+    },
+    {
+      "name": "live-reload",
+      "type": "boolean",
+      "default": true,
+      "description": "Whether to reload the page on change, using live-reload."
+    },
+    {
+      "name": "open",
+      "type": "boolean",
+      "aliases": [
+        "o"
+      ],
+      "default": false,
+      "description": "Opens the url in default browser."
+    },
+    {
+      "name": "poll",
+      "type": "number",
+      "description": "Enable and define the file watching poll time period in milliseconds."
+    },
+    {
+      "name": "port",
+      "type": "number",
+      "default": 4200,
+      "description": "Port to listen on."
+    },
+    {
+      "name": "project",
+      "type": "string",
+      "description": "The name of the project to build. Can be an application or a library.",
+      "positional": 0
+    },
+    {
+      "name": "proxy-config",
+      "type": "string",
+      "description": "Proxy configuration file. For more information, see https://angular.io/guide/build#proxying-to-a-backend-server."
+    },
+    {
+      "name": "public-host",
+      "type": "string",
+      "description": "The URL that the browser client (or live-reload client, if enabled) should use to connect to the development server. Use for a complex dev server setup, such as one with reverse proxies."
+    },
+    {
+      "name": "serve-path",
+      "type": "string",
+      "description": "The pathname where the application will be served."
+    },
+    {
+      "name": "ssl",
+      "type": "boolean",
+      "default": false,
+      "description": "Serve using HTTPS."
+    },
+    {
+      "name": "ssl-cert",
+      "type": "string",
+      "description": "SSL certificate to use for serving HTTPS."
+    },
+    {
+      "name": "ssl-key",
+      "type": "string",
+      "description": "SSL key to use for serving HTTPS."
+    },
+    {
+      "name": "verbose",
+      "type": "boolean",
+      "description": "Adds more details to output logging."
+    },
+    {
+      "name": "watch",
+      "type": "boolean",
+      "default": true,
+      "description": "Rebuild on change."
+    }
+  ]
+}

--- a/aio/content/cli/help/test.json
+++ b/aio/content/cli/help/test.json
@@ -1,0 +1,122 @@
+{
+  "name": "test",
+  "command": "ng test [project]",
+  "shortDescription": "Runs unit tests in a project.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/test/long-description.md",
+  "longDescription": "Takes the name of the project, as specified in the `projects` section of the `angular.json` workspace configuration file.\nWhen a project name is not supplied, it will execute for all projects.\n",
+  "aliases": [
+    "t"
+  ],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "browsers",
+      "type": "string",
+      "description": "Override which browsers tests are run against."
+    },
+    {
+      "name": "code-coverage",
+      "type": "boolean",
+      "default": false,
+      "description": "Output a code coverage report."
+    },
+    {
+      "name": "code-coverage-exclude",
+      "type": "array",
+      "description": "Globs to exclude from code coverage."
+    },
+    {
+      "name": "configuration",
+      "type": "string",
+      "aliases": [
+        "c"
+      ],
+      "description": "One or more named builder configurations as a comma-separated list as specified in the \"configurations\" section in angular.json.\nThe builder uses the named configurations to run the given target.\nFor more information, see https://angular.io/guide/workspace-config#alternate-build-configurations."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "include",
+      "type": "array",
+      "description": "Globs of files to include, relative to workspace or project root. \nThere are 2 special cases:\n - when a path to directory is provided, all spec files ending \".spec.@(ts|tsx)\" will be included\n - when a path to a file is provided, and a matching spec file exists it will be included instead."
+    },
+    {
+      "name": "inline-style-language",
+      "type": "string",
+      "default": "css",
+      "enum": [
+        "css",
+        "less",
+        "sass",
+        "scss"
+      ],
+      "description": "The stylesheet language to use for the application's inline component styles."
+    },
+    {
+      "name": "karma-config",
+      "type": "string",
+      "description": "The name of the Karma configuration file."
+    },
+    {
+      "name": "main",
+      "type": "string",
+      "description": "The name of the main entry-point file."
+    },
+    {
+      "name": "poll",
+      "type": "number",
+      "description": "Enable and define the file watching poll time period in milliseconds."
+    },
+    {
+      "name": "polyfills",
+      "type": "string",
+      "description": "Polyfills to be included in the build."
+    },
+    {
+      "name": "preserve-symlinks",
+      "type": "boolean",
+      "description": "Do not use the real path when resolving modules. If unset then will default to `true` if NodeJS option --preserve-symlinks is set."
+    },
+    {
+      "name": "progress",
+      "type": "boolean",
+      "default": true,
+      "description": "Log progress to the console while building."
+    },
+    {
+      "name": "project",
+      "type": "string",
+      "description": "The name of the project to build. Can be an application or a library.",
+      "positional": 0
+    },
+    {
+      "name": "reporters",
+      "type": "array",
+      "description": "Karma reporters to use. Directly passed to the karma runner."
+    },
+    {
+      "name": "source-map",
+      "type": "boolean",
+      "default": true,
+      "description": "Output source maps for scripts and styles. For more information, see https://angular.io/guide/workspace-config#source-map-configuration."
+    },
+    {
+      "name": "ts-config",
+      "type": "string",
+      "description": "The name of the TypeScript configuration file."
+    },
+    {
+      "name": "watch",
+      "type": "boolean",
+      "description": "Run build when files change."
+    },
+    {
+      "name": "web-worker-ts-config",
+      "type": "string",
+      "description": "TypeScript configuration for Web Worker modules."
+    }
+  ]
+}

--- a/aio/content/cli/help/update.json
+++ b/aio/content/cli/help/update.json
@@ -1,0 +1,83 @@
+{
+  "name": "update",
+  "command": "ng update [packages..]",
+  "shortDescription": "Updates your workspace and its dependencies. See https://update.angular.io/.",
+  "longDescriptionRelativePath": "@angular/cli/src/commands/update/long-description.md",
+  "longDescription": "Perform a basic update to the current stable release of the core framework and CLI by running the following command.\n\n```\nng update @angular/cli @angular/core\n```\n\nTo update to the next beta or pre-release version, use the `--next` option.\n\nTo update from one major version to another, use the format\n\n```\nng update @angular/cli@^<major_version> @angular/core@^<major_version>\n```\n\nWe recommend that you always update to the latest patch version, as it contains fixes we released since the initial major release.\nFor example, use the following command to take the latest 10.x.x version and use that to update.\n\n```\nng update @angular/cli@^10 @angular/core@^10\n```\n\nFor detailed information and guidance on updating your application, see the interactive [Angular Update Guide](https://update.angular.io/).\n",
+  "aliases": [],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "allow-dirty",
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to allow updating when the repository contains modified or untracked files."
+    },
+    {
+      "name": "create-commits",
+      "type": "boolean",
+      "aliases": [
+        "C"
+      ],
+      "default": false,
+      "description": "Create source control commits for updates and migrations."
+    },
+    {
+      "name": "force",
+      "type": "boolean",
+      "default": false,
+      "description": "Ignore peer dependency version mismatches."
+    },
+    {
+      "name": "from",
+      "type": "string",
+      "description": "Version from which to migrate from. Only available with a single package being updated, and only with 'migrate-only'."
+    },
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    },
+    {
+      "name": "migrate-only",
+      "type": "boolean",
+      "description": "Only perform a migration, do not update the installed version."
+    },
+    {
+      "name": "name",
+      "type": "string",
+      "description": "The name of the migration to run. Only available with a single package being updated, and only with 'migrate-only' option."
+    },
+    {
+      "name": "next",
+      "type": "boolean",
+      "default": false,
+      "description": "Use the prerelease version, including beta and RCs."
+    },
+    {
+      "name": "packages",
+      "type": "array",
+      "default": [],
+      "description": "The names of package(s) to update.",
+      "positional": 0
+    },
+    {
+      "name": "packages",
+      "type": "string",
+      "default": [],
+      "description": "The names of package(s) to update.",
+      "positional": 0
+    },
+    {
+      "name": "to",
+      "type": "string",
+      "description": "Version up to which to apply migrations. Only available with a single package being updated, and only with 'migrate-only' option. Requires 'from' to be specified. Default to the installed version detected."
+    },
+    {
+      "name": "verbose",
+      "type": "boolean",
+      "default": false,
+      "description": "Display additional details about internal operations during execution."
+    }
+  ]
+}

--- a/aio/content/cli/help/version.json
+++ b/aio/content/cli/help/version.json
@@ -1,0 +1,16 @@
+{
+  "name": "version",
+  "command": "ng version",
+  "shortDescription": "Outputs Angular CLI version.",
+  "aliases": [
+    "v"
+  ],
+  "deprecated": false,
+  "options": [
+    {
+      "name": "help",
+      "type": "boolean",
+      "description": "Shows a help message for this command in the console."
+    }
+  ]
+}

--- a/aio/scripts/update-cli-help/README.md
+++ b/aio/scripts/update-cli-help/README.md
@@ -1,0 +1,3 @@
+# Generating data for `angular.io/cli`
+
+This script updates the Angular CLI help JSON files stored in `aio/content/cli/help`. This files are used to generate the [angular.io CLI](https://angular.io/cli) pages.

--- a/aio/scripts/update-cli-help/index.mjs
+++ b/aio/scripts/update-cli-help/index.mjs
@@ -10,8 +10,8 @@ const GITHUB_API = 'https://api.github.com/repos/';
 const CLI_BUILDS_REPO = 'angular/cli-builds';
 const GITHUB_API_CLI_BUILDS = posix.join(GITHUB_API, CLI_BUILDS_REPO);
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const CLI_HELP_CONTENT_PATH = resolvePath(__dirname, '../../content/cli/help');
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const CLI_HELP_CONTENT_PATH = resolvePath(scriptDir, '../../content/cli/help');
 const CLI_SHA_PATH = join(CLI_HELP_CONTENT_PATH, 'build-info.json');
 
 async function main() {
@@ -43,7 +43,7 @@ async function main() {
   execSync('git init', execOptions);
   execSync('git remote add origin https://github.com/angular/cli-builds.git', execOptions);
   // fetch a commit
-  execSync(`git fetch origin ${latestSha}`, execOptions);
+  execSync(`git fetch origin ${latestSha} --depth=1`, execOptions);
   // reset this repository's main branch to the commit of interest
   execSync('git reset --hard FETCH_HEAD', execOptions);
 

--- a/aio/scripts/update-cli-help/index.mjs
+++ b/aio/scripts/update-cli-help/index.mjs
@@ -28,7 +28,7 @@ async function main() {
   const changedHelpFiles = affectedFiles.filter((file) => file.startsWith('help/'));
 
   if (changedHelpFiles.length === 0) {
-    console.log`No 'help/**' files changed between ${currentSha} and ${latestSha}.`;
+    console.log(`No 'help/**' files changed between ${currentSha} and ${latestSha}.`);
 
     return;
   }

--- a/aio/scripts/update-cli-help/index.mjs
+++ b/aio/scripts/update-cli-help/index.mjs
@@ -1,0 +1,136 @@
+import {execSync} from 'node:child_process';
+import {readFile, writeFile, mkdtemp, realpath, rm, rename} from 'node:fs/promises';
+import {tmpdir} from 'os';
+import {get} from 'node:https';
+import {dirname, resolve as resolvePath, posix, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {existsSync} from 'node:fs';
+
+const GITHUB_API = 'https://api.github.com/repos/';
+const CLI_BUILDS_REPO = 'angular/cli-builds';
+const GITHUB_API_CLI_BUILDS = posix.join(GITHUB_API, CLI_BUILDS_REPO);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_HELP_CONTENT_PATH = resolvePath(__dirname, '../../content/cli/help');
+const CLI_SHA_PATH = join(CLI_HELP_CONTENT_PATH, 'build-info.json');
+
+async function main() {
+  if (!existsSync(CLI_SHA_PATH)) {
+    throw new Error(`${CLI_SHA_PATH} does not exist.`);
+  }
+
+  const branch = process.env.GITHUB_REF;
+  const {sha: currentSha} = JSON.parse(await readFile(CLI_SHA_PATH, 'utf-8'));
+  const latestSha = await getShaFromCliBuilds(branch);
+
+  console.log(`Comparing ${currentSha}...${latestSha}.`);
+  const affectedFiles = await getAffectedFiles(currentSha, latestSha);
+  const changedHelpFiles = affectedFiles.filter((file) => file.startsWith('help/'));
+
+  if (changedHelpFiles.length === 0) {
+    console.log`No 'help/**' files changed between ${currentSha} and ${latestSha}.`;
+
+    return;
+  }
+
+  console.log(
+    `The below help files changed between ${currentSha} and ${latestSha}:\n` +
+      changedHelpFiles.map((f) => '* ' + f).join('\n')
+  );
+
+  const temporaryDir = await realpath(await mkdtemp(join(tmpdir(), 'cli-src-')));
+  const execOptions = {cwd: temporaryDir, stdio: 'inherit'};
+  execSync('git init', execOptions);
+  execSync('git remote add origin https://github.com/angular/cli-builds.git', execOptions);
+  // fetch a commit
+  execSync(`git fetch origin ${latestSha}`, execOptions);
+  // reset this repository's main branch to the commit of interest
+  execSync('git reset --hard FETCH_HEAD', execOptions);
+
+  // Delete current contents
+  await rm(CLI_HELP_CONTENT_PATH, {recursive: true, force: true});
+
+  // Move Help contents
+  await rename(join(temporaryDir, 'help'), CLI_HELP_CONTENT_PATH);
+
+  const {version} = JSON.parse(await readFile(join(temporaryDir, 'package.json'), 'utf-8'));
+
+  // Write SHA to file.
+  await writeFile(
+    CLI_SHA_PATH,
+    JSON.stringify(
+      {
+        sha: latestSha,
+        version,
+      },
+      undefined,
+      2
+    )
+  );
+
+  console.log('\nChanges: ');
+  execSync(`git status --porcelain`, {stdio: 'inherit'});
+
+  console.log(`Successfully updated help files in '${CLI_HELP_CONTENT_PATH}'.\n`);
+}
+
+/**
+ * Get SHA of a branch.
+ *
+ * @param {string} branch
+ * @param {string} headSha
+ * @returns Promise<string>
+ */
+async function getShaFromCliBuilds(branch) {
+  const sha = await httpGet(`${GITHUB_API_CLI_BUILDS}/commits/${branch}`, {
+    headers: {Accept: 'application/vnd.github.VERSION.sha'},
+  });
+
+  if (!sha) {
+    throw new Error(`Unable to extract the SHA for '${branch}'.`);
+  }
+
+  return sha;
+}
+
+/**
+ * Get the affected files.
+ *
+ * @param {string} baseSha
+ * @param {string} headSha
+ * @returns Promise<string[]>
+ */
+async function getAffectedFiles(baseSha, headSha) {
+  const {files} = JSON.parse(
+    await httpGet(`${GITHUB_API_CLI_BUILDS}/compare/${baseSha}...${headSha}`)
+  );
+  return files.map((f) => f.filename);
+}
+
+function httpGet(url, options = {}) {
+  options.headers ??= {};
+  options.headers['Authorization'] = `token ${process.env.GITHUB_TOKEN}`;
+  // User agent is required
+  // https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#user-agent-required
+  options.headers['User-Agent'] = `AIO_Angular_CLI_Sources_Update`;
+
+  return new Promise((resolve, reject) => {
+    get(url, options, (res) => {
+      let data = '';
+      res
+        .on('data', (chunk) => {
+          data += chunk;
+        })
+        .on('end', () => {
+          resolve(data);
+        });
+    }).on('error', (e) => {
+      reject(e);
+    });
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/aio/tools/transforms/angular-content-package/BUILD.bazel
+++ b/aio/tools/transforms/angular-content-package/BUILD.bazel
@@ -11,6 +11,7 @@ js_library(
     visibility = ["//aio/tools/transforms:__subpackages__"],
     deps = [
         "//aio/content",
+        "//aio/content/cli",
         "//aio/content/examples",
         "//aio/src/assets",
         "//aio/tools/transforms",

--- a/aio/tools/transforms/cli-docs-package/BUILD.bazel
+++ b/aio/tools/transforms/cli-docs-package/BUILD.bazel
@@ -20,13 +20,15 @@ js_library(
         "@aio_npm//dgeni",
         "@aio_npm//json5",
         "@aio_npm//semver",
-        "@angular_cli_src//:files_for_docgen",
     ],
 )
 
 jasmine_node_test(
     name = "test",
     srcs = glob(["**/*.spec.js"]),
+    data = [
+        "//aio/content/cli",
+    ],
     env = {
         "GIT_BIN": "$(GIT_BIN_PATH)",
     },

--- a/aio/tools/transforms/cli-docs-package/index.js
+++ b/aio/tools/transforms/cli-docs-package/index.js
@@ -1,5 +1,4 @@
 const {resolve} = require('canonical-path');
-const semver = require('semver');
 const Package = require('dgeni').Package;
 const basePackage = require('../angular-base-package');
 const contentPackage = require('../content-package');
@@ -46,11 +45,10 @@ module.exports =
 
         .config(function(renderDocsProcessor) {
 
-          const cliPackage = require(resolve(CLI_SOURCE_HELP_PATH, 'build-info.json'));
-          const version = semver.clean(cliPackage.version);
+          const {branchName} = require(resolve(CLI_SOURCE_HELP_PATH, 'build-info.json'));
           const repo = 'angular-cli';
           const owner = 'angular';
-          const cliVersionInfo = {gitRepoInfo: {owner, repo}, currentVersion: {raw: version}};
+          const cliVersionInfo = {gitRepoInfo: {owner, repo}, currentVersion: {branchName}};
 
           // Add the cli version data to the renderer, for use in things like github links
           renderDocsProcessor.extraData.cliVersionInfo = cliVersionInfo;

--- a/aio/tools/transforms/cli-docs-package/index.js
+++ b/aio/tools/transforms/cli-docs-package/index.js
@@ -1,27 +1,10 @@
-const {runfiles} = require('@bazel/runfiles');
 const {resolve} = require('canonical-path');
-const { existsSync } = require('fs');
 const semver = require('semver');
 const Package = require('dgeni').Package;
 const basePackage = require('../angular-base-package');
 const contentPackage = require('../content-package');
 const {CONTENTS_PATH, TEMPLATES_PATH, requireFolder} = require('../config');
-
-const CLI_SOURCE_PATH = resolveCliSourcePath();
-const CLI_SOURCE_HELP_PATH = resolve(CLI_SOURCE_PATH, 'help');
-
-// The cli sources are downloaded as an external repository, so where
-// to resolve them depends on whether we are running dgeni under a build
-// target or a test target.
-function resolveCliSourcePath() {
-  // Case: build, find in execroot
-  const path = resolve('external', 'angular_cli_src');
-  if (existsSync(path)) {
-    return path;
-  }
-  // Case: bazel test, find in runfiles
-  return runfiles.resolve('angular_cli_src');
-}
+const CLI_SOURCE_HELP_PATH = resolve(CONTENTS_PATH, 'cli/help');
 
 // Define the dgeni package for generating the docs
 module.exports =
@@ -41,11 +24,12 @@ module.exports =
             {
               basePath: CLI_SOURCE_HELP_PATH,
               include: resolve(CLI_SOURCE_HELP_PATH, '*.json'),
+              exclude: resolve(CLI_SOURCE_HELP_PATH, 'build-info.json'),
               fileReader: 'cliCommandFileReader'
             },
             {
               basePath: CONTENTS_PATH,
-              include: resolve(CONTENTS_PATH, 'cli/**'),
+              include: resolve(CONTENTS_PATH, 'cli/**/*.md'),
               fileReader: 'contentFileReader'
             },
           ]);
@@ -62,11 +46,10 @@ module.exports =
 
         .config(function(renderDocsProcessor) {
 
-          const cliPackage = require(resolve(CLI_SOURCE_PATH, 'package.json'));
-          const repoUrlParts = cliPackage.repository.url.replace(/\.git$/, '').split('/');
+          const cliPackage = require(resolve(CLI_SOURCE_HELP_PATH, 'build-info.json'));
           const version = semver.clean(cliPackage.version);
-          const repo = repoUrlParts.pop();
-          const owner = repoUrlParts.pop();
+          const repo = 'angular-cli';
+          const owner = 'angular';
           const cliVersionInfo = {gitRepoInfo: {owner, repo}, currentVersion: {raw: version}};
 
           // Add the cli version data to the renderer, for use in things like github links

--- a/aio/tools/transforms/templates/lib/githubLinks.html
+++ b/aio/tools/transforms/templates/lib/githubLinks.html
@@ -7,7 +7,7 @@ https://github.com/{$ versionInfo.gitRepoInfo.owner $}/{$ versionInfo.gitRepoInf
 {%- endmacro %}
 
 {% macro githubVersionedUrl(versionInfo) -%}
-{% set version = versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw -%}
+{% set version = versionInfo.currentVersion.isSnapshot and versionInfo.currentVersion.SHA or versionInfo.currentVersion.raw or versionInfo.currentVersion.branchName -%}
 {$ githubBaseUrl(versionInfo) $}/tree/{$ version $}
 {%- endmacro %}
 


### PR DESCRIPTION
This commits adds an action to update the Angular CLI help contents that are used by AIO to generate CLI guides.

This also changes the setup to include the files are source files instead of having to clone the repository each time. This also simplifies the PR review process of the PR opened by the action.
