### PR TITLE
fix(animations): fix non-animatable warning on easing

### DIFF
--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -123,12 +123,16 @@ function checkNonAnimatableInTimelines(
     return;
   }
 
+  const propsToIgnore = new Set<string>(['easing']);
+
   const invalidNonAnimatableProps = new Set<string>();
 
   timelines.forEach(({keyframes}) => {
     const nonAnimatablePropsInitialValues = new Map<string, string|number>();
     keyframes.forEach(keyframe => {
-      for (const [prop, value] of keyframe.entries()) {
+      const entriesToCheck =
+          Array.from(keyframe.entries()).filter(([prop]) => !propsToIgnore.has(prop));
+      for (const [prop, value] of entriesToCheck) {
         if (!driver.validateAnimatableStyleProperty!(prop)) {
           if (nonAnimatablePropsInitialValues.has(prop) && !invalidNonAnimatableProps.has(prop)) {
             const propInitialValue = nonAnimatablePropsInitialValues.get(prop);

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -123,7 +123,13 @@ function checkNonAnimatableInTimelines(
     return;
   }
 
-  const propsToIgnore = new Set<string>(['easing']);
+  const propsToIgnore = new Set<string>([
+    // 'easing' is a utility/synthetic prop we use to represent
+    // easing functions, it represents a property of the animation
+    // which is not animatable but different values can be used
+    // in different steps
+    'easing'
+  ]);
 
   const invalidNonAnimatableProps = new Set<string>();
 

--- a/packages/animations/browser/src/dsl/animation_transition_factory.ts
+++ b/packages/animations/browser/src/dsl/animation_transition_factory.ts
@@ -123,7 +123,7 @@ function checkNonAnimatableInTimelines(
     return;
   }
 
-  const propsToIgnore = new Set<string>([
+  const allowedNonAnimatableProps = new Set<string>([
     // 'easing' is a utility/synthetic prop we use to represent
     // easing functions, it represents a property of the animation
     // which is not animatable but different values can be used
@@ -137,7 +137,7 @@ function checkNonAnimatableInTimelines(
     const nonAnimatablePropsInitialValues = new Map<string, string|number>();
     keyframes.forEach(keyframe => {
       const entriesToCheck =
-          Array.from(keyframe.entries()).filter(([prop]) => !propsToIgnore.has(prop));
+          Array.from(keyframe.entries()).filter(([prop]) => !allowedNonAnimatableProps.has(prop));
       for (const [prop, value] of entriesToCheck) {
         if (!driver.validateAnimatableStyleProperty!(prop)) {
           if (nonAnimatablePropsInitialValues.has(prop) && !invalidNonAnimatableProps.has(prop)) {

--- a/packages/core/test/animation/animation_integration_spec.ts
+++ b/packages/core/test/animation/animation_integration_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {animate, animateChild, animation, AnimationEvent, AnimationMetadata, AnimationOptions, AUTO_STYLE, group, keyframes, query, state, style, transition, trigger, useAnimation, ɵPRE_STYLE as PRE_STYLE} from '@angular/animations';
+import {animate, animateChild, animation, AnimationEvent, AnimationMetadata, AnimationOptions, AUTO_STYLE, group, keyframes, query, sequence, state, style, transition, trigger, useAnimation, ɵPRE_STYLE as PRE_STYLE} from '@angular/animations';
 import {AnimationDriver, ɵAnimationEngine, ɵNoopAnimationDriver as NoopAnimationDriver} from '@angular/animations/browser';
 import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/browser/testing';
 import {ChangeDetectorRef, Component, HostBinding, HostListener, Inject, RendererFactory2, ViewChild} from '@angular/core';
@@ -4409,6 +4409,16 @@ describe('animation tests', function() {
                    position: 'absolute',
                  })]),
          ]);
+         expect(spyWarn).not.toHaveBeenCalled();
+       });
+
+    it('should not show a warning if a different easing function is used in different steps',
+       () => {
+         const spyWarn = spyOn(console, 'warn');
+         buildAndAnimateSimpleTestComponent([sequence([
+           animate('1s ease-in', style({background: 'red'})),
+           animate('1s ease-out', style({background: 'green'})),
+         ])]);
          expect(spyWarn).not.toHaveBeenCalled();
        });
   });


### PR DESCRIPTION
the easing property isn't animatable but it can be used in different animation steps, different values for such property shouldn't thus cause non-animatable warnings

resolves #48571

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Unwanted warnings for different easing functions get displayed in dev mode

Issue Number: #48571

## What is the new behavior?
No unwanted warnings for different easing functions get displayed in dev mode


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

