### PR TITLE
build(bazel): prevent remote cache misses on dgeni build

### DIFF
--- a/aio/BUILD.bazel
+++ b/aio/BUILD.bazel
@@ -86,7 +86,7 @@ npm_package_bin(
     },
     exec_properties = ENABLE_NETWORK,
     output_dir = True,
-    stamp = "@rules_nodejs//nodejs/stamp:always",
+    stamp = "@rules_nodejs//nodejs/stamp:use_stamp_flag",
     # Makes remote git calls to get previous versions
     tags = [
         "requires-network",

--- a/aio/tools/transforms/angular-base-package/services/bazelStampedProperties.js
+++ b/aio/tools/transforms/angular-base-package/services/bazelStampedProperties.js
@@ -10,6 +10,10 @@ const fs = require('fs');
  * @returns a map of key-value pairs
  */
 module.exports = function bazelStampedProperties() {
+  if (!process.env.BAZEL_VERSION_FILE) {
+    // Bazel stamping not enabled with --stamp
+    return {};
+  }
   const volatileStatus = fs.readFileSync(process.env.BAZEL_VERSION_FILE, 'utf8');
   const properties = {};
   for (const match of `\n${volatileStatus}`.matchAll(/^([^\s]+)\s+(.*)/gm)) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `test_aio` step always has a cache miss on `//aio:dgeni`.

Using 'always' as the stamp attribute caused stable-status.txt to always be included as an input, which has different values on different ci executors causing a cache miss.

We run the regular aio build without stamping on ci so only include status files when stamping is explicitly enabled.

## What is the new behavior?

Cache hit on ci. Note that this does not fix the caching issues for the `test_aio_local` step which must enable stamping for architect to work with local angular packages. I will look into those issues separately.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Note that even when there is a cache hit you will often see dgeni output in the ci logs. This is because Bazel also caches stdout and seeing this output does not indicate that dgeni is re-running. Outputting the json execution log confirms the cache hit.
