### PR TITLE
docs: add note that CLI version 15 doesn't create karma.conf.js in new projects

### DIFF
--- a/aio/content/guide/testing-code-coverage.md
+++ b/aio/content/guide/testing-code-coverage.md
@@ -2,7 +2,7 @@
 
 # Find out how much code you're testing
 
-The CLI can run unit tests and create code coverage reports.
+The Angular CLI can run unit tests and create code coverage reports.
 Code coverage reports show you any parts of your code base that might not be properly tested by your unit tests.
 
 <div class="alert is-helpful">
@@ -19,10 +19,10 @@ ng test --no-watch --code-coverage
 
 </code-example>
 
-When the tests are complete, the command creates a new `/coverage` folder in the project.
+When the tests are complete, the command creates a new `/coverage` directory in the project.
 Open the `index.html` file to see a report with your source code and code coverage values.
 
-If you want to create code-coverage reports every time you test, set the following option in the CLI configuration file, `angular.json`:
+If you want to create code-coverage reports every time you test, set the following option in the Angular CLI configuration file, `angular.json`:
 
 <code-example format="json" language="json">
 
@@ -41,6 +41,14 @@ If your team decides on a set minimum amount to be unit tested, enforce this min
 
 For example, suppose you want the code base to have a minimum of 80% code coverage.
 To enable this, open the [Karma](https://karma-runner.github.io) test platform configuration file, `karma.conf.js`, and add the `check` property in the `coverageReporter:` key.
+
+<div class="alert is-helpful">
+
+**NOTE:**
+
+Angular CLI version 15 doesn't automatically create `karma.conf.js` in new projects. Find out more about fine-tuning Karma [here](guide/testing#configuration).
+
+</div>
 
 <code-example format="javascript" language="javascript">
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
*aio/content/guide/testing-code-coverage.md* doesn't mention that Angular CLI version 15 doesn't automatically create `karma.conf.js` file in new projects. The issue can be found [here](https://github.com/angular/angular/issues/48364).

Closes : #48364


## What is the new behavior?
*testing-code-coverage.md* now displays an informational alert summarizing the update and provides a link to *aio/content/guide/testing.md#configuration* for more detailed instructions to manually setup `karma.conf.js`. Certain words were also simplified based on the linter error messages from Vale, and CLI now explicitly refers to the Angular CLI.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
N/A
