### PR TITLE
feat(forms): make DefaultValueAccessor directive standalone

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -198,7 +198,7 @@ export class DefaultValueAccessor extends BaseControlValueAccessor implements Co
     constructor(renderer: Renderer2, elementRef: ElementRef, _compositionMode: boolean);
     writeValue(value: any): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<DefaultValueAccessor, "input:not([type=checkbox])[formControlName],textarea[formControlName],input:not([type=checkbox])[formControl],textarea[formControl],input:not([type=checkbox])[ngModel],textarea[ngModel],[ngDefaultControl]", never, {}, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<DefaultValueAccessor, "input:not([type=checkbox])[formControlName],textarea[formControlName],input:not([type=checkbox])[formControl],textarea[formControl],input:not([type=checkbox])[ngModel],textarea[ngModel],[ngDefaultControl]", never, {}, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<DefaultValueAccessor, [null, null, { optional: true; }]>;
 }

--- a/packages/forms/src/directives.ts
+++ b/packages/forms/src/directives.ts
@@ -45,11 +45,10 @@ export {NgSelectOption, SelectControlValueAccessor} from './directives/select_co
 export {NgSelectMultipleOption, SelectMultipleControlValueAccessor} from './directives/select_multiple_control_value_accessor';
 export {CALL_SET_DISABLED_STATE} from './directives/shared';
 
-export const SHARED_FORM_DIRECTIVES: Type<any>[] = [
+const SHARED_FORM_DIRECTIVES: Type<any>[] = [
   NgNoValidate,
   NgSelectOption,
   NgSelectMultipleOption,
-  DefaultValueAccessor,
   NumberValueAccessor,
   RangeValueAccessor,
   CheckboxControlValueAccessor,
@@ -78,8 +77,8 @@ export const REACTIVE_DRIVEN_DIRECTIVES: Type<any>[] =
  */
 @NgModule({
   declarations: SHARED_FORM_DIRECTIVES,
-  imports: [RadioControlRegistryModule],
-  exports: SHARED_FORM_DIRECTIVES,
+  imports: [RadioControlRegistryModule, DefaultValueAccessor],
+  exports: [...SHARED_FORM_DIRECTIVES, DefaultValueAccessor],
 })
 export class ɵInternalFormsSharedModule {
 }

--- a/packages/forms/src/directives/default_value_accessor.ts
+++ b/packages/forms/src/directives/default_value_accessor.ts
@@ -81,7 +81,8 @@ export const COMPOSITION_BUFFER_MODE = new InjectionToken<boolean>('CompositionE
     '(compositionstart)': '$any(this)._compositionStart()',
     '(compositionend)': '$any(this)._compositionEnd($event.target.value)'
   },
-  providers: [DEFAULT_VALUE_ACCESSOR]
+  providers: [DEFAULT_VALUE_ACCESSOR],
+  standalone: true,
 })
 export class DefaultValueAccessor extends BaseControlValueAccessor implements ControlValueAccessor {
   /** Whether the user is creating a composition string (IME events). */

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SimpleChange} from '@angular/core';
-import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
+import {Component, SimpleChange} from '@angular/core';
+import {fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 import {AbstractControl, CheckboxControlValueAccessor, ControlValueAccessor, DefaultValueAccessor, FormArray, FormArrayName, FormControl, FormControlDirective, FormControlName, FormGroup, FormGroupDirective, FormGroupName, NgControl, NgForm, NgModel, NgModelGroup, SelectControlValueAccessor, SelectMultipleControlValueAccessor, ValidationErrors, Validator, Validators} from '@angular/forms';
 import {selectValueAccessor} from '@angular/forms/src/directives/shared';
 import {composeValidators} from '@angular/forms/src/validators';
@@ -37,6 +37,23 @@ class CustomValidatorDirective implements Validator {
 
     beforeEach(() => {
       defaultAccessor = new DefaultValueAccessor(null!, null!, null!);
+    });
+
+    describe('DefaultValueAccessor', () => {
+      it('should be available as a standalone directive', () => {
+        @Component({
+          selector: 'test-component',
+          hostDirectives: [DefaultValueAccessor],
+          template: `<input />`,
+        })
+        class TestComponent {
+        }
+
+        const fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+
+        expect(fixture.componentInstance).toBeTruthy();
+      });
     });
 
     describe('shared', () => {


### PR DESCRIPTION
This commit make the DefaultValueAccessor directive standalone allowing it to be used as hostDirective

Fixes #48607

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature

## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
