### PR TITLE
refactor(core): Improve typings for EventEmitter.subscribe()

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -525,6 +525,11 @@ export interface EventEmitter<T> extends Subject<T> {
     new (isAsync?: boolean): EventEmitter<T>;
     emit(value?: T): void;
     subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
+    subscribe(observer: {
+        next?: (value: T) => void;
+        error?: (error: any) => void;
+        complete?: () => void;
+    }): Subscription;
     subscribe(observerOrNext?: any, error?: any, complete?: any): Subscription;
 }
 

--- a/packages/core/src/event_emitter.ts
+++ b/packages/core/src/event_emitter.ts
@@ -91,6 +91,15 @@ export interface EventEmitter<T> extends Subject<T> {
    */
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void):
       Subscription;
+
+  /**
+   * Registers handlers for events emitted by this instance.
+   * @param observer an observer object.
+   */
+  subscribe(observer:
+                {next?: (value: T) => void; error?: (error: any) => void; complete?: () => void;}):
+      Subscription;
+
   /**
    * Registers handlers for events emitted by this instance.
    * @param observerOrNext When supplied, a custom handler for emitted events, or an observer


### PR DESCRIPTION
When passed an observer object, the next callback had any as argument, this commit improves this behavior.

I don't know if this kind of change could be passed in a minor release. 

Fixes: #29016


## PR Type
What kind of change does this PR introduce?


- [x] Bugfix
- [x] Feature

## Does this PR introduce a breaking change?

- [x] Yes (Kinda ?) 