### PR TITLE
refactor(forms): cleanup type any in forms tests

### DIFF
--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -112,14 +112,14 @@ class CustomValidatorDirective implements Validator {
 
       describe('composeValidators', () => {
         it('should compose functions', () => {
-          const dummy1 = (_: any /** TODO #9100 */) => ({'dummy1': true});
-          const dummy2 = (_: any /** TODO #9100 */) => ({'dummy2': true});
+          const dummy1 = () => ({'dummy1': true});
+          const dummy2 = () => ({'dummy2': true});
           const v = composeValidators([dummy1, dummy2])!;
           expect(v(new FormControl(''))).toEqual({'dummy1': true, 'dummy2': true});
         });
 
         it('should compose validator directives', () => {
-          const dummy1 = (_: any /** TODO #9100 */) => ({'dummy1': true});
+          const dummy1 = () => ({'dummy1': true});
           const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
           expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
         });
@@ -309,10 +309,10 @@ class CustomValidatorDirective implements Validator {
     });
 
     describe('NgForm', () => {
-      let form: any /** TODO #9100 */;
+      let form: NgForm;
       let formModel: FormGroup;
-      let loginControlDir: any /** TODO #9100 */;
-      let personControlGroupDir: any /** TODO #9100 */;
+      let loginControlDir: NgModel;
+      let personControlGroupDir: NgModelGroup;
 
       beforeEach(() => {
         form = new NgForm([], []);
@@ -384,7 +384,7 @@ class CustomValidatorDirective implements Validator {
       });
 
       it('should set up sync validator', fakeAsync(() => {
-           const formValidator = (c: any /** TODO #9100 */) => ({'custom': true});
+           const formValidator = () => ({'custom': true});
            const f = new NgForm([formValidator], []);
 
            tick();
@@ -402,8 +402,8 @@ class CustomValidatorDirective implements Validator {
     });
 
     describe('FormGroupName', () => {
-      let formModel: any /** TODO #9100 */;
-      let controlGroupDir: any /** TODO #9100 */;
+      let formModel: FormGroup;
+      let controlGroupDir: FormGroupName;
 
       beforeEach(() => {
         formModel = new FormGroup({'login': new FormControl(null)});
@@ -481,9 +481,9 @@ class CustomValidatorDirective implements Validator {
     });
 
     describe('FormControlDirective', () => {
-      let controlDir: any /** TODO #9100 */;
-      let control: any /** TODO #9100 */;
-      const checkProperties = function(control: AbstractControl) {
+      let controlDir: FormControlDirective;
+      let control: FormControl;
+      const checkProperties = function(control: FormControl) {
         expect(controlDir.control).toBe(control);
         expect(controlDir.value).toBe(control.value);
         expect(controlDir.valid).toBe(control.valid);
@@ -648,8 +648,8 @@ class CustomValidatorDirective implements Validator {
     });
 
     describe('FormControlName', () => {
-      let formModel: any /** TODO #9100 */;
-      let controlNameDir: any /** TODO #9100 */;
+      let formModel: FormControl;
+      let controlNameDir: FormControlName;
 
       beforeEach(() => {
         formModel = new FormControl('name');

--- a/packages/forms/test/form_array_spec.ts
+++ b/packages/forms/test/form_array_spec.ts
@@ -850,7 +850,7 @@ describe('FormArray', () => {
 
   describe('valueChanges', () => {
     let a: FormArray;
-    let c1: any /** TODO #9100 */, c2: any /** TODO #9100 */;
+    let c1: FormControl, c2: FormControl;
 
     beforeEach(() => {
       c1 = new FormControl('old1');

--- a/packages/forms/test/form_builder_spec.ts
+++ b/packages/forms/test/form_builder_spec.ts
@@ -11,10 +11,10 @@ import {FormBuilder, NonNullableFormBuilder, ReactiveFormsModule, UntypedFormBui
 import {of} from 'rxjs';
 
 (function() {
-function syncValidator(_: any /** TODO #9100 */): any /** TODO #9100 */ {
+function syncValidator() {
   return null;
 }
-function asyncValidator(_: any /** TODO #9100 */) {
+function asyncValidator() {
   return Promise.resolve(null);
 }
 

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {fakeAsync, tick} from '@angular/core/testing';
-import {FormArray, FormControl, FormGroup, Validators} from '@angular/forms';
+import {AsyncValidatorFn, FormArray, FormControl, FormGroup, Validators} from '@angular/forms';
 
 import {asyncValidator, asyncValidatorReturningObservable} from './util';
 
@@ -16,7 +16,7 @@ function otherAsyncValidator() {
   return Promise.resolve({'other': true});
 }
 
-function syncValidator(_: any /** TODO #9100 */): any /** TODO #9100 */ {
+function syncValidator() {
   return null;
 }
 
@@ -1105,7 +1105,7 @@ describe('FormControl', () => {
     it('should fire an event after the status has been updated to pending', fakeAsync(() => {
          const c = new FormControl('old', Validators.required, asyncValidator('expected'));
 
-         const log: any[] /** TODO #9100 */ = [];
+         const log: string[] = [];
          c.valueChanges.subscribe({next: (value: any) => log.push(`value: '${value}'`)});
 
          c.statusChanges.subscribe({next: (status: any) => log.push(`status: '${status}'`)});
@@ -1133,7 +1133,7 @@ describe('FormControl', () => {
 
     // TODO: remove the if statement after making observable delivery sync
     it('should update set errors and status before emitting an event', done => {
-      c.valueChanges.subscribe((value: any /** TODO #9100 */) => {
+      c.valueChanges.subscribe(() => {
         expect(c.valid).toEqual(false);
         expect(c.errors).toEqual({'required': true});
         done();
@@ -1507,7 +1507,8 @@ describe('FormControl', () => {
       });
 
       it('should throw when sync validator passed into async validator param', () => {
-        const fn = () => new FormControl('', syncValidator, syncValidator);
+        const fn = () =>
+            new FormControl('', syncValidator, syncValidator as unknown as AsyncValidatorFn);
         // test for the specific error since without the error check it would still throw an error
         // but
         // not a meaningful one


### PR DESCRIPTION
Removing every type any in forms with a reference to #9100


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [x] No