### PR TITLE
build: switch from `ng-comp-dev` to canonical dev-infra preview Firebase project

### DIFF
--- a/.github/workflows/aio-preview-deploy.yml
+++ b/.github/workflows/aio-preview-deploy.yml
@@ -17,8 +17,8 @@ permissions:
   pull-requests: write
 
 env:
-  # TODO(pgschwendtner): use a different project for framework previews here.
-  PREVIEW_PROJECT: ng-comp-dev
+  PREVIEW_PROJECT: ng-dev-previews
+  PREVIEW_SITE: ng-dev-previews-fw
 
 jobs:
   aio-deploy:
@@ -31,9 +31,8 @@ jobs:
         working-directory: aio/
         run: |
           # We can use `npx` as the Firebase deploy actions uses it too.
-          # The default site is used as we don't use multi-sites in the project.
           npx -y firebase-tools@latest target:clear --project ${{env.PREVIEW_PROJECT}} hosting aio
-          npx -y firebase-tools@latest target:apply --project ${{env.PREVIEW_PROJECT}} hosting aio ${{env.PREVIEW_PROJECT}}
+          npx -y firebase-tools@latest target:apply --project ${{env.PREVIEW_PROJECT}} hosting aio ${{env.PREVIEW_SITE}}
 
       - uses: angular/dev-infra/github-actions/deploy-previews/upload-artifacts-to-firebase@96fdaaa056f1cfa7ffbc4c69b7e9007279f76c94
         with:


### PR DESCRIPTION
We are going with a single canonical dev-infra Firebase/GCP project for previews. 
This commit switches to it.
