### PR TITLE
fix(compiler-cli): update `@babel/core` dependency and lock version

### DIFF
--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -53,7 +53,7 @@
     }
   },
   "dependencies": {
-    "@babel/core": "^7.17.2",
+    "@babel/core": "7.19.3",
     "@jridgewell/sourcemap-codec": "^1.4.14",
     "reflect-metadata": "^0.1.2",
     "chokidar": "^3.0.0",


### PR DESCRIPTION
Similar to how the `@babel/core` dependency is managed for the localize NPM package, the version should be locked. Also the version should correspond to the version we install for building & testing.

Currently the Babel version allowed by the compiler-cli may not work given the ESM -> CJS interop. causing errors like:

```
import { types as t } from "@babel/core";
         ^^^^^
SyntaxError: Named export 'types' not found. The requested module '@babel/core' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from '@babel/core';
const { types: t } = pkg;
```

We can only be confident about the interop if we know the version installed- is the one we test. The error above
does not surface in integration tests because the Angular CLI brings a more recent Babel version. In components
this failed because we had an older version of Babel that breaks the NodeJS CJS/ESM interop.

Notes: 

* It previously worked because we had a "hacky" file to make the `@babel/core` import work (back when the repo also executed the linker code as CommonJS).  See: https://github.com/angular/angular/blob/61e69c87e6b577f1c5a71fb5c39c3bd6125c4b91/packages/localize/tools/src/babel_core.ts
* We cannot simply use the default import for e.g. `@babel/template` because the types are incorrect. This is a separate issue, but long-term it would be ideal to use the default import always, or have Babel ship an ESM distribution. The latter is in-progress, see https://github.com/babel/babel/issues/15269