### PR TITLE
fix(compiler): type-only symbols incorrectly retained when downlevelling custom decorators

### DIFF
--- a/packages/compiler-cli/src/transformers/downlevel_decorators_transform/downlevel_decorators_transform.ts
+++ b/packages/compiler-cli/src/transformers/downlevel_decorators_transform/downlevel_decorators_transform.ts
@@ -576,8 +576,9 @@ export function getDownlevelDecoratorsTransform(
         modifiers = [...decoratorsToKeep, ...(classModifiers || [])];
       }
 
-      return ts.factory.createClassDeclaration(
-          modifiers, classDecl.name, classDecl.typeParameters, classDecl.heritageClauses, members);
+      return ts.factory.updateClassDeclaration(
+          classDecl, modifiers, classDecl.name, classDecl.typeParameters, classDecl.heritageClauses,
+          members);
     }
 
     /**


### PR DESCRIPTION
In #47167 an `updateClassDeclaration` call was swapped out with a `createClassDeclaration` which caused a regression where interface references were being retained when using a custom decorator in a project that has `emitDecoratorMetadata` enabled.

These changes switch back to use `updateClassDeclaration`.

Fixes #48448.