### PR TITLE
ci: fix snapshot publish github credential preparation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,9 +452,7 @@ jobs:
       - run: git config --global --unset "url.ssh://git@github.com.insteadof"
       - run:
           name: Prepare GitHub credentials
-          command: |
-            # Ensure we never accidentally print the token to stdout/stderr.
-            {echo "https://${SNAPSHOT_BUILDS_GITHUB_TOKEN}:@github.com" > $HOME/.git_credentials} &> /dev/null
+          command: echo "https://${SNAPSHOT_BUILDS_GITHUB_TOKEN}:@github.com" > ${HOME}/.git_credentials
       - run: ./scripts/ci/publish-build-artifacts.sh
 
   aio_misc:


### PR DESCRIPTION
It looks like the wrapping in `&> /dev/null` breaks for some reason. We don't need it as
CircleCI will remove secrets from logs if they would leak for some reason.