### PR TITLE
refactor(platform-browser): prepare the code to use `MockPlatformLocation` by default

### DIFF
--- a/packages/platform-browser/testing/BUILD.bazel
+++ b/packages/platform-browser/testing/BUILD.bazel
@@ -8,6 +8,7 @@ ng_module(
     name = "testing",
     srcs = glob(["**/*.ts"]),
     deps = [
+        "//packages/common/testing",
         "//packages/core",
         "//packages/core/testing",
         "//packages/platform-browser",

--- a/packages/platform-browser/testing/src/browser.ts
+++ b/packages/platform-browser/testing/src/browser.ts
@@ -5,10 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {PlatformLocation} from '@angular/common';
+import {MockPlatformLocation} from '@angular/common/testing';
 import {APP_ID, createPlatformFactory, NgModule, NgZone, PLATFORM_INITIALIZER, platformCore, StaticProvider} from '@angular/core';
 import {BrowserModule, ɵBrowserDomAdapter as BrowserDomAdapter} from '@angular/platform-browser';
 
 import {BrowserDetection, createNgZone} from './browser_util';
+import {ENABLE_MOCK_PLATFORM_LOCATION} from './mock_platform_location_flag';
 
 function initBrowserTests() {
   BrowserDomAdapter.makeCurrent();
@@ -36,6 +39,8 @@ export const platformBrowserTesting =
   providers: [
     {provide: APP_ID, useValue: 'a'},
     {provide: NgZone, useFactory: createNgZone},
+    (ENABLE_MOCK_PLATFORM_LOCATION ? [{provide: PlatformLocation, useClass: MockPlatformLocation}] :
+                                     []),
   ]
 })
 export class BrowserTestingModule {

--- a/packages/platform-browser/testing/src/mock_platform_location_flag.ts
+++ b/packages/platform-browser/testing/src/mock_platform_location_flag.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Controls whether the `MockPlatformLocation` class should be used
+ * as the `PlatformLocation` implementation when the `BrowserTestingModule`
+ * is imported.
+ *
+ * In v16, the value of this flag will be switched to `true` to enable
+ * the `MockPlatformLocation` by default.
+ */
+export const ENABLE_MOCK_PLATFORM_LOCATION = false;


### PR DESCRIPTION
This commit prepares the code of the `BrowserTestingModule` to include the `MockPlatformLocation` by deafult in the future. With this change, the set of providers to add the `MockPlatformLocation` would be disabled by a flag, which will be switched in v16.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No