### PR TITLE
fix(compiler): resolve deprecation warning

### DIFF
--- a/packages/compiler-cli/src/ngtsc/transform/src/alias.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/alias.ts
@@ -10,7 +10,7 @@ import ts from 'typescript';
 
 export function aliasTransformFactory(exportStatements: Map<string, Map<string, [string, string]>>):
     ts.TransformerFactory<ts.SourceFile> {
-  return (context: ts.TransformationContext) => {
+  return () => {
     return (file: ts.SourceFile) => {
       if (ts.isBundle(file) || !exportStatements.has(file.fileName)) {
         return file;
@@ -19,10 +19,9 @@ export function aliasTransformFactory(exportStatements: Map<string, Map<string, 
       const statements = [...file.statements];
       exportStatements.get(file.fileName)!.forEach(([moduleName, symbolName], aliasName) => {
         const stmt = ts.factory.createExportDeclaration(
-            /* decorators */ undefined,
             /* modifiers */ undefined,
             /* isTypeOnly */ false,
-            /* exportClause */ ts.createNamedExports([ts.factory.createExportSpecifier(
+            /* exportClause */ ts.factory.createNamedExports([ts.factory.createExportSpecifier(
                 false, symbolName, aliasName)]),
             /* moduleSpecifier */ ts.factory.createStringLiteral(moduleName));
         statements.push(stmt);


### PR DESCRIPTION
Fixes a deprecation warning that was being logged by compiler when generating aliases, because we weren't going through `ts.factory` to create an AST node.