### PR TITLE
fix(language-service): update packages/language-service/build.sh script to work with vscode-ng-language-service's new Bazel build

### DIFF
--- a/packages/language-service/build.sh
+++ b/packages/language-service/build.sh
@@ -38,6 +38,6 @@ npm_package(
   visibility = ["//visibility:public"],
 )
 EOT
-_sedi 's#\# PLACE_HOLDER_FOR_packages/language-service/build.sh_IN_angular_REPO#data = ["//.angular_packages/language-service:package.json"], \# FOR TESTING ONLY! DO NOT COMMIT THIS LINE!#' WORKSPACE
+_sedi 's#\# PLACE_HOLDER_FOR_angular/angular_packages/language-service/build.sh#"//.angular_packages/language-service:package.json", \# FOR TESTING ONLY! DO NOT COMMIT THIS LINE!#' WORKSPACE
 yarn add @angular/language-service@file:".angular_packages/language-service"
 popd


### PR DESCRIPTION
2nd half of https://github.com/angular/vscode-ng-language-service/pull/1846. `npm_traslate_lock` in vscode-ng-language-service now has a data attribute so sed should only add another item to the list instead of adding a duplicate data attribute.
