### PR TITLE
Several fixes for universal example.

### DIFF
--- a/aio/content/examples/universal/server.ts
+++ b/aio/content/examples/universal/server.ts
@@ -1,15 +1,15 @@
 import 'zone.js/node';
 
+import { APP_BASE_HREF } from '@angular/common';
 import { ngExpressEngine } from '@nguniversal/express-engine';
 import * as express from 'express';
+import { existsSync } from 'fs';
 import { join } from 'path';
 
 import { AppServerModule } from './src/main.server';
-import { APP_BASE_HREF } from '@angular/common';
-import { existsSync } from 'fs';
 
 // The Express app is exported so that it can be used by serverless Functions.
-export function app() {
+export function app(): express.Express {
   const server = express();
   const distFolder = join(process.cwd(), 'dist/browser');
   const indexHtml = existsSync(join(distFolder, 'index.original.html')) ? 'index.original.html' : 'index';
@@ -48,8 +48,8 @@ export function app() {
   return server;
 }
 
-function run() {
-  const port = process.env.PORT || 4000;
+function run(): void {
+  const port = process.env['PORT'] || 4000;
 
   // Start up the Node server
   const server = app();

--- a/aio/content/examples/universal/src/main.server.ts
+++ b/aio/content/examples/universal/src/main.server.ts
@@ -1,9 +1,1 @@
-import { enableProdMode } from '@angular/core';
-
-import { environment } from './environments/environment';
-
-if (environment.production) {
-  enableProdMode();
-}
-
 export { AppServerModule } from './app/app.server.module';

--- a/aio/content/examples/universal/tsconfig.server.json
+++ b/aio/content/examples/universal/tsconfig.server.json
@@ -2,14 +2,9 @@
   "extends": "./tsconfig.app.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app-server",
-    "module": "commonjs",
     "types": ["node"]
   },
   "files": [
-    "src/main.server.ts",
     "server.ts"
-  ],
-  "angularCompilerOptions": {
-    "entryModule": "./src/app/app.server.module#AppServerModule"
-  }
+  ]
 }

--- a/aio/tools/example-zipper/exampleZipper.mjs
+++ b/aio/tools/example-zipper/exampleZipper.mjs
@@ -57,8 +57,9 @@ export class ExampleZipper {
     return archive;
   }
 
-  _getExampleType(sourceFolder) {
-    const filePath = path.join(sourceFolder, EXAMPLE_CONFIG_NAME);
+  _getExampleType(exampleDirName) {
+    const filePath = path.join(exampleDirName, EXAMPLE_CONFIG_NAME);
+
     try {
       return this._loadJson(filePath).projectType || 'cli';
     } catch (err) { // empty file, so it is cli
@@ -89,7 +90,6 @@ export class ExampleZipper {
     const jsonFileName = configFileName.replace(/^.*[\\\/]/, '');
     let relativeDirName = path.basename(sourceDirName);
     let exampleZipName;
-    const exampleType = this._getExampleType(path.join(sourceDirName, relativeDirName));
     if (relativeDirName.indexOf('/') !== -1) { // Special example
       exampleZipName = relativeDirName.split('/').join('-');
     } else {
@@ -97,6 +97,7 @@ export class ExampleZipper {
     }
 
     const exampleDirName = path.dirname(configFileName);
+    const exampleType = this._getExampleType(exampleDirName);
     const outputFileName = path.join(outputDirName, exampleZipName + '.zip');
     let defaultIncludes = ['**/*.ts', '**/*.js', '**/*.es6', '**/*.css', '**/*.html', '**/*.md', '**/*.json', '**/*.png', '**/*.svg'];
     let alwaysIncludes = [


### PR DESCRIPTION

**fix(docs-infra): correctly read example type**
    
Prior to this change the universal example was broken as the example type was not retrieved correctly in bazel which caused the `_renameFile` method to be called with incorrect context.
    
Closes #48664

---

**docs: update universal example**
    
This change updates the universal example to align with latest CLI changes.