### PR TITLE
fix(language-service): ship `/api` entry-point

### DIFF
--- a/packages/language-service/BUILD.bazel
+++ b/packages/language-service/BUILD.bazel
@@ -30,9 +30,19 @@ esbuild(
     deps = [":factory_lib"],
 )
 
+esbuild(
+    name = "api_bundle",
+    entry_point = ":api.ts",
+    format = "cjs",
+    deps = [":api"],
+)
+
 extract_types(
-    name = "factory_types",
-    deps = [":factory_lib"],
+    name = "types",
+    deps = [
+        ":api",
+        ":factory_lib",
+    ],
 )
 
 pkg_npm(
@@ -55,8 +65,9 @@ pkg_npm(
         "//integration:__subpackages__",
     ],
     deps = [
+        ":api_bundle",
         ":factory_bundle",
-        ":factory_types",
+        ":types",
         "//packages/language-service/bundles:language-service.js",
     ],
 )

--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -9,6 +9,16 @@
   "engines": {
     "node": "^14.20.0 || ^16.13.0 || >=18.10.0"
   },
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
+    "./api": {
+      "types": "./api.d.ts",
+      "default": "./api_bundle.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/angular/angular.git",


### PR DESCRIPTION
The `/api` entry-point was accidentally dropped when we switched the compilation in the repo to
full ESM- thinking the entry-point is not needed externally.

We re-add it because the VSCode repo extension relies on it for checking whether
`ts.LanguageService` is an Angular one.
