### PR TITLE
test(docs-infra): increase jasmine default timeout for e2e specs

### DIFF
--- a/aio/tests/e2e/src/test-init.e2e-spec.ts
+++ b/aio/tests/e2e/src/test-init.e2e-spec.ts
@@ -1,0 +1,9 @@
+/**
+ * @file Spec file loaded by Protractor. It is not guaranteed
+ *   to load before other spec files. Jasmine tests execute after all
+ *   files are loaded, so this file can be used for initialization.
+ */
+
+// Increase the timeout for specs as Selenium & Protractor is slow.
+// Default Protractor timeout is 30 seconds.
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;


### PR DESCRIPTION
Similar to the Saucelabs job, the jasmine default timeout can be increased to avoid the
common jasmine timeouts. We cannot control how fast Selenium e.g. loads a page or not.