### PR TITLE
fix(language-service): expose `package.json` for vscode extension resolution

### DIFF
--- a/packages/language-service/package.json
+++ b/packages/language-service/package.json
@@ -14,6 +14,9 @@
       "types": "./index.d.ts",
       "default": "./index.js"
     },
+    "./package.json": {
+      "default": "./package.json"
+    },
     "./api": {
       "types": "./api.d.ts",
       "default": "./api_bundle.js"


### PR DESCRIPTION
The VSCode extension looks for `@angular/language-service/package.json` using `require`. This
currently breaks as of the ESM changes because we introduced the `exports` field but did not
expose the `package.json`.

This commit fixes it.

Co-authored-By: Andrew Scott <atscott@google.com>
Co-authored-By: Dylan Hunn <dylhunn@gmail.com>