### PR TITLE
ci: use readonly github token for querying CLI snapshot repo

### DIFF
--- a/aio/scripts/update-cli-help/index.mjs
+++ b/aio/scripts/update-cli-help/index.mjs
@@ -113,7 +113,9 @@ async function getAffectedFiles(baseSha, headSha) {
 
 function httpGet(url, options = {}) {
   options.headers ??= {};
-  options.headers['Authorization'] = `token ${process.env.GITHUB_TOKEN}`;
+  options.headers[
+    'Authorization'
+  ] = `token ${process.env.ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN}`;
   // User agent is required
   // https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#user-agent-required
   options.headers['User-Agent'] = `AIO_Angular_CLI_Sources_Update`;


### PR DESCRIPTION
Currently the Github action-triggered code uses the `GITHUB_TOKEN` for querying the CLI snapshot
builds repository. This does not work because the Github actions token is scoped to the originating
repository, even for queries to a read public repository.

We fix this by using a personal access token. The token is readonly and only exists to avoid
potential rate limiting.

Note: The token is created using an robot account that doesn't have any write permissions anyway.