### PR TITLE
ci: expose ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN secret as env

### DIFF
--- a/.github/workflows/update-cli-help.yml
+++ b/.github/workflows/update-cli-help.yml
@@ -27,9 +27,8 @@ jobs:
           persist-credentials: false
       - name: Generate CLI help
         run: node aio/scripts/update-cli-help/index.mjs
-        with:
-          env:
-            ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN: ${secrets.ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN}
+        env:
+          ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN: ${secrets.ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN}
       - name: Create a PR (if necessary)
         uses: angular/dev-infra/github-actions/create-pr-for-changes@ad1374e8222825244b36a91d0f085f8fc3c7126d
         with:

--- a/.github/workflows/update-cli-help.yml
+++ b/.github/workflows/update-cli-help.yml
@@ -27,6 +27,9 @@ jobs:
           persist-credentials: false
       - name: Generate CLI help
         run: node aio/scripts/update-cli-help/index.mjs
+        with:
+          env:
+            ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN: ${secrets.ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN}
       - name: Create a PR (if necessary)
         uses: angular/dev-infra/github-actions/create-pr-for-changes@ad1374e8222825244b36a91d0f085f8fc3c7126d
         with:


### PR DESCRIPTION

Encrypted secrets need to be provided explicitly in workflow steps to be used.

See: https://docs.github.com/en/actions/security-guides/encrypted-secrets for more info.