### PR TITLE
ci: correctly interpolate `ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/update-cli-help.yml
+++ b/.github/workflows/update-cli-help.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Generate CLI help
         run: node aio/scripts/update-cli-help/index.mjs
         env:
-          ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN: ${secrets.ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN}
+          ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN: ${{ secrets.ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN }}
       - name: Create a PR (if necessary)
         uses: angular/dev-infra/github-actions/create-pr-for-changes@ad1374e8222825244b36a91d0f085f8fc3c7126d
         with:


### PR DESCRIPTION
Previously, a single curly bracket was used to interpolate the `ANGULAR_CLI_BUILDS_READONLY_GITHUB_TOKEN` value which caused the value not to be provided correctly.
