### PR TITLE
feat(common): Add support for trackByKey to ngFor 

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -519,9 +519,10 @@ class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCheck {
     set ngForTrackBy(fn: TrackByFunction<T>);
     // (undocumented)
     get ngForTrackBy(): TrackByFunction<T>;
+    set ngForTrackByKey(key: keyof T);
     static ngTemplateContextGuard<T, U extends NgIterable<T>>(dir: NgForOf<T, U>, ctx: any): ctx is NgForOfContext<T, U>;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgForOf<any, any>, "[ngFor][ngForOf]", never, { "ngForOf": "ngForOf"; "ngForTrackBy": "ngForTrackBy"; "ngForTemplate": "ngForTemplate"; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgForOf<any, any>, "[ngFor][ngForOf]", never, { "ngForOf": "ngForOf"; "ngForTrackBy": "ngForTrackBy"; "ngForTrackByKey": "ngForTrackByKey"; "ngForTemplate": "ngForTemplate"; }, {}, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgForOf<any, any>, never>;
 }

--- a/packages/common/src/directives/ng_for_of.ts
+++ b/packages/common/src/directives/ng_for_of.ts
@@ -179,6 +179,16 @@ export class NgForOf<T, U extends NgIterable<T> = NgIterable<T>> implements DoCh
     return this._trackByFn;
   }
 
+  /**
+   * Specifies a `TrackByFunction` that returns the value for the given key.
+   *
+   * @see `TrackByFunction`
+   */
+  @Input()
+  set ngForTrackByKey(key: keyof T) {
+    this._trackByFn = (index: number, item: T) => item[key];
+  }
+
   private _ngForOf: U|undefined|null = null;
   private _ngForOfDirty: boolean = true;
   private _differ: IterableDiffer<T>|null = null;

--- a/packages/common/test/directives/ng_for_spec.ts
+++ b/packages/common/test/directives/ng_for_spec.ts
@@ -326,6 +326,15 @@ let thisArg: any;
            detectChangesAndExpectText('abc');
          }));
 
+      it('should track By Key`', waitForAsync(() => {
+           const template = `<p *ngFor="let item of items; trackByKey: value">{{ item.name }}</p>`;
+           fixture = createTestComponent(template);
+           fixture.componentInstance.items =
+               [{id: 1, name: 'foo'}, {id: 2, name: 'bar'}, {id: 3, name: 'baz'}];
+           fixture.componentInstance.value = 'id';
+           detectChangesAndExpectText('foobarbaz');
+         }));
+
       it('should set the context to the component instance', waitForAsync(() => {
            const template =
                `<p *ngFor="let item of items; trackBy: trackByContext.bind(this)"></p>`;


### PR DESCRIPTION
With trackByKey it is possible trackBy without passing a specific callback function. This way, for the basic cases, there is no need anymore to define a `trackBy` function in the component. 

See #48503

## PR Type
What kind of change does this PR introduce?


- [x] Feature

## Does this PR introduce a breaking change?

- [x] No


