### PR TITLE
ci: set `fetch-depth: 0` in `update-events` and `update-cli-help` actions

### DIFF
--- a/.github/workflows/update-cli-help.yml
+++ b/.github/workflows/update-cli-help.yml
@@ -25,6 +25,8 @@ jobs:
           # account that is attempted to be used for authentication, instead the remote is set to
           # an authenticated URL.
           persist-credentials: false
+          # This is needed as otherwise the PR creation will fail with `shallow update not allowed` when the forked branch is not in sync.
+          fetch-depth: 0
       - name: Generate CLI help
         run: node aio/scripts/update-cli-help/index.mjs
         env:

--- a/.github/workflows/update-events.yml
+++ b/.github/workflows/update-events.yml
@@ -30,6 +30,8 @@ jobs:
           # account that is attempted to be used for authentication, instead the remote is set to
           # an authenticated URL.
           persist-credentials: false
+          # This is needed as otherwise the PR creation will fail with `shallow update not allowed` when the forked branch is not in sync.
+          fetch-depth: 0
       - name: Generate `events.json`
         run: node aio/scripts/generate-events/index.mjs --ignore-invalid-dates
       - name: Create a PR (if necessary)


### PR DESCRIPTION

This commits changes the fetch depth from 1 to 0 in the update-events` and `update-cli-help` actions. This is required as otherwise the PR creation would fail when the forked (https://github.com/angular-robot/angular) is not in sync with (https://github.com/angular/angular) ie the later has commits which are not in the former.
