### PR TITLE
fix(bazel): always include LICENSE file

### DIFF
--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -504,6 +504,9 @@ def _ng_package_impl(ctx):
         # placeholder
         packager_args.add("")
 
+    packager_inputs.append(ctx.file._license)
+    packager_args.add(ctx.file._license.path)
+
     packager_args.add(_serialize_files_for_arg(fesm2020))
     packager_args.add(_serialize_files_for_arg(esm2020))
     packager_args.add(_serialize_files_for_arg(fesm2015))
@@ -572,6 +575,7 @@ _NG_PACKAGE_ATTRS = dict(PKG_NPM_ATTRS, **{
         cfg = partial_compilation_transition,
     ),
     "readme_md": attr.label(allow_single_file = [".md"]),
+    "_license": attr.label(allow_single_file = True, default = "//:LICENSE"),
     "primary_bundle_name": attr.string(
         doc = "Name to use when generating bundle files for the primary entry-point.",
     ),

--- a/packages/bazel/src/ng_package/packager.ts
+++ b/packages/bazel/src/ng_package/packager.ts
@@ -114,6 +114,9 @@ function main(args: string[]): void {
       // Path to the package's README.md.
       readmeMd,
 
+      // Path to the package's LICENSE.
+      license,
+
       // List of rolled-up flat ES2020 modules
       fesm2020Arg,
 
@@ -139,6 +142,10 @@ function main(args: string[]): void {
 
   if (readmeMd) {
     copyFile(readmeMd, 'README.md');
+  }
+
+  if (license) {
+    copyFile(license, 'LICENSE');
   }
 
   /**


### PR DESCRIPTION
For packages released by the Angular team, the license file should always be included in the released package. This fix adds the file to the generated npm package.
