### PR TITLE
fix(core): makeEnvironmentProviders should accept EnvironmentProviders

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -884,7 +884,7 @@ export class KeyValueDiffers {
 export const LOCALE_ID: InjectionToken<string>;
 
 // @public
-export function makeEnvironmentProviders(providers: Provider[]): EnvironmentProviders;
+export function makeEnvironmentProviders(providers: (Provider | EnvironmentProviders)[]): EnvironmentProviders;
 
 // @public
 export enum MissingTranslationStrategy {

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -352,7 +352,7 @@ export type EnvironmentProviders = {
 };
 
 export interface InternalEnvironmentProviders extends EnvironmentProviders {
-  ɵproviders: Provider[];
+  ɵproviders: (Provider|EnvironmentProviders)[];
 
   /**
    * If present, indicates that the `EnvironmentProviders` were derived from NgModule providers.
@@ -362,8 +362,9 @@ export interface InternalEnvironmentProviders extends EnvironmentProviders {
   ɵfromNgModule?: true;
 }
 
-export function isEnvironmentProviders(value: Provider|InternalEnvironmentProviders):
-    value is InternalEnvironmentProviders {
+export function isEnvironmentProviders(
+    value: Provider|EnvironmentProviders|
+    InternalEnvironmentProviders): value is InternalEnvironmentProviders {
   return value && !!(value as InternalEnvironmentProviders).ɵproviders;
 }
 

--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -28,7 +28,8 @@ import {INJECTOR_DEF_TYPES} from './internal_tokens';
  * Wrap an array of `Provider`s into `EnvironmentProviders`, preventing them from being accidentally
  * referenced in `@Component in a component injector.
  */
-export function makeEnvironmentProviders(providers: Provider[]): EnvironmentProviders {
+export function makeEnvironmentProviders(providers: (Provider|EnvironmentProviders)[]):
+    EnvironmentProviders {
   return {
     ɵproviders: providers,
   } as unknown as EnvironmentProviders;

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -516,8 +516,7 @@ function couldBeInjectableType(value: any): value is ProviderToken<any> {
 }
 
 function forEachSingleProvider(
-    providers: Array<Provider|InternalEnvironmentProviders>,
-    fn: (provider: SingleProvider) => void): void {
+    providers: Array<Provider|EnvironmentProviders>, fn: (provider: SingleProvider) => void): void {
   for (const provider of providers) {
     if (Array.isArray(provider)) {
       forEachSingleProvider(provider, fn);


### PR DESCRIPTION
`makeEnvironmentProviders` constructs the wrapped `EnvironmentProviders` type, which can only be used in environment injectors (not element injectors). It makes sense that `makeEnvironmentProviders` should be able to accept existing `EnvironmentProviders`-wrapped providers, since it will be providing the same guarantee, but the current types do not allow this.

This commit fixes the typings to allow nesting `EnvironmentProviders` and adds a test to verify that it will work.