### PR TITLE
refactor(router): remove unused router event parameter in scroll constructor

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -950,15 +950,12 @@ export type RunGuardsAndResolvers = 'pathParamsChange' | 'pathParamsOrQueryParam
 // @public
 export class Scroll {
     constructor(
-    routerEvent: NavigationEnd,
     position: [number, number] | null,
     anchor: string | null);
     // (undocumented)
     readonly anchor: string | null;
     // (undocumented)
     readonly position: [number, number] | null;
-    // (undocumented)
-    readonly routerEvent: NavigationEnd;
     // (undocumented)
     toString(): string;
     // (undocumented)

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -582,9 +582,6 @@ export class Scroll {
 
   constructor(
       /** @docsNotRequired */
-      readonly routerEvent: NavigationEnd,
-
-      /** @docsNotRequired */
       readonly position: [number, number]|null,
 
       /** @docsNotRequired */

--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -12,7 +12,6 @@ import {Unsubscribable} from 'rxjs';
 
 import {NavigationEnd, NavigationStart, Scroll} from './events';
 import {NavigationTransitions} from './navigation_transition';
-import {Router} from './router';
 import {UrlSerializer} from './url_tree';
 
 export const ROUTER_SCROLLER = new InjectionToken<RouterScroller>('');
@@ -60,7 +59,7 @@ export class RouterScroller implements OnDestroy {
         this.restoredId = e.restoredState ? e.restoredState.navigationId : 0;
       } else if (e instanceof NavigationEnd) {
         this.lastId = e.id;
-        this.scheduleScrollEvent(e, this.urlSerializer.parse(e.urlAfterRedirects).fragment);
+        this.scheduleScrollEvent(this.urlSerializer.parse(e.urlAfterRedirects).fragment);
       }
     });
   }
@@ -86,7 +85,7 @@ export class RouterScroller implements OnDestroy {
     });
   }
 
-  private scheduleScrollEvent(routerEvent: NavigationEnd, anchor: string|null): void {
+  private scheduleScrollEvent(anchor: string|null): void {
     this.zone.runOutsideAngular(() => {
       // The scroll event needs to be delayed until after change detection. Otherwise, we may
       // attempt to restore the scroll position before the router outlet has fully rendered the
@@ -94,8 +93,7 @@ export class RouterScroller implements OnDestroy {
       setTimeout(() => {
         this.zone.run(() => {
           this.transitions.events.next(new Scroll(
-              routerEvent, this.lastSource === 'popstate' ? this.store[this.restoredId] : null,
-              anchor));
+              this.lastSource === 'popstate' ? this.store[this.restoredId] : null, anchor));
         });
       }, 0);
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The `Scroll` class constructor required an unused `routerEvent` parameter.


## What is the new behavior?

The `Scroll` constructor no longer needs the `routerEvent` parameter. 
## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No


If an application uses `new Scroll(routerEvent, position, anchor)`, it can now be simplified to `new Scroll(position, anchor)`.


## Other information
