### PR TITLE
refactor(router): remove unused parameter in navigation internal function

### DIFF
--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -546,7 +546,7 @@ export class NavigationTransitions {
                            if (!t.guardsResult) {
                              router.restoreHistory(t);
                              this.cancelNavigationTransition(
-                                 t, '', NavigationCancellationCode.GuardRejected, router);
+                                 t, '', NavigationCancellationCode.GuardRejected);
                              return false;
                            }
                            return true;
@@ -579,8 +579,7 @@ export class NavigationTransitions {
                                                  NG_DEV_MODE ?
                                                      `At least one route resolver didn't emit any value.` :
                                                      '',
-                                                 NavigationCancellationCode.NoDataFromResolver,
-                                                 router);
+                                                 NavigationCancellationCode.NoDataFromResolver);
                                            }
                                          }
                                        }),
@@ -686,7 +685,7 @@ export class NavigationTransitions {
                                  '';
                              this.cancelNavigationTransition(
                                  overallTransitionState, cancelationReason,
-                                 NavigationCancellationCode.SupersededByNewNavigation, router);
+                                 NavigationCancellationCode.SupersededByNewNavigation);
                            }
                            // Only clear current navigation if it is still set to the one that
                            // finalized.
@@ -763,8 +762,7 @@ export class NavigationTransitions {
   }
 
   private cancelNavigationTransition(
-      t: NavigationTransition, reason: string, code: NavigationCancellationCode,
-      router: InternalRouterInterface) {
+      t: NavigationTransition, reason: string, code: NavigationCancellationCode) {
     const navCancel =
         new NavigationCancel(t.id, this.urlSerializer.serialize(t.extractedUrl), reason, code);
     this.events.next(navCancel);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The internal `cancelNavigationTransition` required an unused `router` parameter.

## What is the new behavior?
This commit removes the parameter

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
