### PR TITLE
refactor(bazel): extract the helper patchNgHostWithFileNameToModuleName to its own file for 1P use

### DIFF
--- a/packages/bazel/src/ngc-wrapped/BUILD.bazel
+++ b/packages/bazel/src/ngc-wrapped/BUILD.bazel
@@ -7,6 +7,7 @@ ts_library(
         "extract_i18n.ts",
         "index.ts",
         "ngc-wrapped-main.ts",
+        "utils.ts",
     ],
     module_name = "@angular/bazel",
     visibility = [

--- a/packages/bazel/src/ngc-wrapped/index.ts
+++ b/packages/bazel/src/ngc-wrapped/index.ts
@@ -15,13 +15,14 @@ import * as path from 'path';
 import * as tsickle from 'tsickle';
 import ts from 'typescript';
 
+import {EXT, patchNgHostWithFileNameToModuleName as patchNgHost, relativeToRootDirs} from './utils';
+
 // Add devmode for blaze internal
 interface BazelOptions extends tscw.BazelOptions {
   allowedInputs?: string[];
   unusedInputsListPath?: string;
 }
 
-const EXT = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
 const NGC_GEN_FILES = /^(.*?)\.(ngfactory|ngsummary|ngstyle|shim\.ngstyle)(.*)$/;
 // FIXME: we should be able to add the assets to the tsconfig so FileLoader
 // knows about them
@@ -31,8 +32,6 @@ const BAZEL_BIN = /\b(blaze|bazel)-out\b.*?\bbin\b/;
 
 // Note: We compile the content of node_modules with plain ngc command line.
 const ALL_DEPS_COMPILED_WITH_BAZEL = false;
-
-const NODE_MODULES = 'node_modules/';
 
 export async function main(args: string[]) {
   if (tscw.runAsWorker(args)) {
@@ -128,17 +127,6 @@ export async function runOneBuild(
     console.error(ng.formatDiagnostics(diagnostics));
   }
   return diagnostics.every(d => d.category !== ts.DiagnosticCategory.Error);
-}
-
-export function relativeToRootDirs(filePath: string, rootDirs: string[]): string {
-  if (!filePath) return filePath;
-  // NB: the rootDirs should have been sorted longest-first
-  for (let i = 0; i < rootDirs.length; i++) {
-    const dir = rootDirs[i];
-    const rel = path.posix.relative(dir, filePath);
-    if (rel.indexOf('.') != 0) return rel;
-  }
-  return filePath;
 }
 
 export function compile({
@@ -298,8 +286,9 @@ export function compile({
   };
 
   const ngHost = ng.createCompilerHost({options: compilerOpts, tsHost: bazelHost});
-  patchNgHostWithFileNameToModuleName(
-      ngHost, compilerOpts, bazelOpts, rootDirs, !!useManifestPathsAsModuleName);
+  patchNgHost(
+      ngHost, compilerOpts, rootDirs, bazelOpts.workspaceName, bazelOpts.compilationTargetSrc,
+      !!useManifestPathsAsModuleName);
 
   ngHost.toSummaryFileName = (fileName: string, referringSrcFileName: string) => path.posix.join(
       bazelOpts.workspaceName, relativeToRootDirs(fileName, rootDirs).replace(EXT, ''));
@@ -476,107 +465,13 @@ function gatherDiagnosticsForInputsOnly(
 }
 
 /**
- * Adds support for the optional `fileNameToModuleName` operation to a given `ng.CompilerHost`.
- *
- * This is used within `ngc-wrapped` and the Bazel compilation flow, but is exported here to allow
- * for other consumers of the compiler to access this same logic. For example, the xi18n operation
- * in g3 configures its own `ng.CompilerHost` which also requires `fileNameToModuleName` to work
- * correctly.
+ * @deprecated
+ * Kept here just for compatibility with 1P tools. To be removed soon after 1P update.
  */
 export function patchNgHostWithFileNameToModuleName(
     ngHost: ng.CompilerHost, compilerOpts: ng.CompilerOptions, bazelOpts: BazelOptions,
     rootDirs: string[], useManifestPathsAsModuleName: boolean): void {
-  const fileNameToModuleNameCache = new Map<string, string>();
-  ngHost.fileNameToModuleName = (importedFilePath: string, containingFilePath?: string) => {
-    const cacheKey = `${importedFilePath}:${containingFilePath}`;
-    // Memoize this lookup to avoid expensive re-parses of the same file
-    // When run as a worker, the actual ts.SourceFile is cached
-    // but when we don't run as a worker, there is no cache.
-    // For one example target in g3, we saw a cache hit rate of 7590/7695
-    if (fileNameToModuleNameCache.has(cacheKey)) {
-      return fileNameToModuleNameCache.get(cacheKey)!;
-    }
-    const result = doFileNameToModuleName(importedFilePath, containingFilePath);
-    fileNameToModuleNameCache.set(cacheKey, result);
-    return result;
-  };
-
-  function doFileNameToModuleName(importedFilePath: string, containingFilePath?: string): string {
-    const relativeTargetPath = relativeToRootDirs(importedFilePath, rootDirs).replace(EXT, '');
-    const manifestTargetPath = `${bazelOpts.workspaceName}/${relativeTargetPath}`;
-    if (useManifestPathsAsModuleName === true) {
-      return manifestTargetPath;
-    }
-
-    // Unless manifest paths are explicitly enforced, we initially check if a module name is
-    // set for the given source file. The compiler host from `@bazel/concatjs` sets source
-    // file module names if the compilation targets either UMD or AMD. To ensure that the AMD
-    // module names match, we first consider those.
-    try {
-      const sourceFile = ngHost.getSourceFile(importedFilePath, ts.ScriptTarget.Latest);
-      if (sourceFile && sourceFile.moduleName) {
-        return sourceFile.moduleName;
-      }
-    } catch (err) {
-      // File does not exist or parse error. Ignore this case and continue onto the
-      // other methods of resolving the module below.
-    }
-
-    // It can happen that the ViewEngine compiler needs to write an import in a factory file,
-    // and is using an ngsummary file to get the symbols.
-    // The ngsummary comes from an upstream ng_module rule.
-    // The upstream rule based its imports on ngsummary file which was generated from a
-    // metadata.json file that was published to npm in an Angular library.
-    // However, the ngsummary doesn't propagate the 'importAs' from the original metadata.json
-    // so we would normally not be able to supply the correct module name for it.
-    // For example, if the rootDir-relative filePath is
-    //  node_modules/@angular/material/toolbar/typings/index
-    // we would supply a module name
-    //  @angular/material/toolbar/typings/index
-    // but there is no JavaScript file to load at this path.
-    // This is a workaround for https://github.com/angular/angular/issues/29454
-    if (importedFilePath.indexOf('node_modules') >= 0) {
-      const maybeMetadataFile = importedFilePath.replace(EXT, '') + '.metadata.json';
-      if (fs.existsSync(maybeMetadataFile)) {
-        const moduleName = (JSON.parse(fs.readFileSync(maybeMetadataFile, {encoding: 'utf-8'})) as {
-                             importAs: string
-                           }).importAs;
-        if (moduleName) {
-          return moduleName;
-        }
-      }
-    }
-
-    if ((compilerOpts.module === ts.ModuleKind.UMD || compilerOpts.module === ts.ModuleKind.AMD) &&
-        ngHost.amdModuleName) {
-      const amdName = ngHost.amdModuleName({fileName: importedFilePath} as ts.SourceFile);
-      if (amdName !== undefined) {
-        return amdName;
-      }
-    }
-
-    // If no AMD module name has been set for the source file by the `@bazel/concatjs` compiler
-    // host, and the target file is not part of a flat module node module package, we use the
-    // following rules (in order):
-    //    1. If target file is part of `node_modules/`, we use the package module name.
-    //    2. If no containing file is specified, or the target file is part of a different
-    //       compilation unit, we use a Bazel manifest path. Relative paths are not possible
-    //       since we don't have a containing file, and the target file could be located in the
-    //       output directory, or in an external Bazel repository.
-    //    3. If both rules above didn't match, we compute a relative path between the source files
-    //       since they are part of the same compilation unit.
-    // Note that we don't want to always use (2) because it could mean that compilation outputs
-    // are always leaking Bazel-specific paths, and the output is not self-contained. This could
-    // break `esm2015` or `esm5` output for Angular package release output
-    // Omit the `node_modules` prefix if the module name of an NPM package is requested.
-    if (relativeTargetPath.startsWith(NODE_MODULES)) {
-      return relativeTargetPath.slice(NODE_MODULES.length);
-    } else if (
-        containingFilePath == null || !bazelOpts.compilationTargetSrc.includes(importedFilePath)) {
-      return manifestTargetPath;
-    }
-    const containingFileDir = path.dirname(relativeToRootDirs(containingFilePath, rootDirs));
-    const relativeImportPath = path.posix.relative(containingFileDir, relativeTargetPath);
-    return relativeImportPath.startsWith('.') ? relativeImportPath : `./${relativeImportPath}`;
-  }
+  patchNgHost(
+      ngHost, compilerOpts, rootDirs, bazelOpts.workspaceName, bazelOpts.compilationTargetSrc,
+      useManifestPathsAsModuleName);
 }

--- a/packages/bazel/src/ngc-wrapped/utils.ts
+++ b/packages/bazel/src/ngc-wrapped/utils.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ *
+ * @fileoverview A set of common helpers related to ng compiler wrapper.
+ */
+
+import {CompilerHost as NgCompilerHost} from '@angular/compiler-cli';
+import * as fs from 'fs';
+import * as path from 'path';
+import ts from 'typescript';
+
+const NODE_MODULES = 'node_modules/';
+
+export const EXT = /(\.ts|\.d\.ts|\.js|\.jsx|\.tsx)$/;
+
+export function relativeToRootDirs(filePath: string, rootDirs: string[]): string {
+  if (!filePath) return filePath;
+  // NB: the rootDirs should have been sorted longest-first
+  for (let i = 0; i < rootDirs.length; i++) {
+    const dir = rootDirs[i];
+    const rel = path.posix.relative(dir, filePath);
+    if (rel.indexOf('.') !== 0) return rel;
+  }
+  return filePath;
+}
+
+/**
+ * Adds support for the optional `fileNameToModuleName` operation to a given `ng.CompilerHost`.
+ *
+ * This is used within `ngc-wrapped` and the Bazel compilation flow, but is exported here to allow
+ * for other consumers of the compiler to access this same logic. For example, the xi18n operation
+ * in g3 configures its own `ng.CompilerHost` which also requires `fileNameToModuleName` to work
+ * correctly.
+ */
+export function patchNgHostWithFileNameToModuleName(
+    ngHost: NgCompilerHost, compilerOpts: ts.CompilerOptions, rootDirs: string[],
+    workspaceName: string, compilationTargetSrc: string[],
+    useManifestPathsAsModuleName: boolean): void {
+  const fileNameToModuleNameCache = new Map<string, string>();
+  ngHost.fileNameToModuleName = (importedFilePath: string, containingFilePath?: string) => {
+    const cacheKey = `${importedFilePath}:${containingFilePath}`;
+    // Memoize this lookup to avoid expensive re-parses of the same file
+    // When run as a worker, the actual ts.SourceFile is cached
+    // but when we don't run as a worker, there is no cache.
+    // For one example target in g3, we saw a cache hit rate of 7590/7695
+    if (fileNameToModuleNameCache.has(cacheKey)) {
+      return fileNameToModuleNameCache.get(cacheKey)!;
+    }
+    const result = doFileNameToModuleName(importedFilePath, containingFilePath);
+    fileNameToModuleNameCache.set(cacheKey, result);
+    return result;
+  };
+
+  function doFileNameToModuleName(importedFilePath: string, containingFilePath?: string): string {
+    const relativeTargetPath = relativeToRootDirs(importedFilePath, rootDirs).replace(EXT, '');
+    const manifestTargetPath = `${workspaceName}/${relativeTargetPath}`;
+    if (useManifestPathsAsModuleName === true) {
+      return manifestTargetPath;
+    }
+
+    // Unless manifest paths are explicitly enforced, we initially check if a module name is
+    // set for the given source file. The compiler host from `@bazel/concatjs` sets source
+    // file module names if the compilation targets either UMD or AMD. To ensure that the AMD
+    // module names match, we first consider those.
+    try {
+      const sourceFile = ngHost.getSourceFile(importedFilePath, ts.ScriptTarget.Latest);
+      if (sourceFile && sourceFile.moduleName) {
+        return sourceFile.moduleName;
+      }
+    } catch (err) {
+      // File does not exist or parse error. Ignore this case and continue onto the
+      // other methods of resolving the module below.
+    }
+
+    // It can happen that the ViewEngine compiler needs to write an import in a factory file,
+    // and is using an ngsummary file to get the symbols.
+    // The ngsummary comes from an upstream ng_module rule.
+    // The upstream rule based its imports on ngsummary file which was generated from a
+    // metadata.json file that was published to npm in an Angular library.
+    // However, the ngsummary doesn't propagate the 'importAs' from the original metadata.json
+    // so we would normally not be able to supply the correct module name for it.
+    // For example, if the rootDir-relative filePath is
+    //  node_modules/@angular/material/toolbar/typings/index
+    // we would supply a module name
+    //  @angular/material/toolbar/typings/index
+    // but there is no JavaScript file to load at this path.
+    // This is a workaround for https://github.com/angular/angular/issues/29454
+    if (importedFilePath.indexOf('node_modules') >= 0) {
+      const maybeMetadataFile = importedFilePath.replace(EXT, '') + '.metadata.json';
+      if (fs.existsSync(maybeMetadataFile)) {
+        const moduleName = (JSON.parse(fs.readFileSync(maybeMetadataFile, {encoding: 'utf-8'})) as {
+                             importAs: string
+                           }).importAs;
+        if (moduleName) {
+          return moduleName;
+        }
+      }
+    }
+
+    if ((compilerOpts.module === ts.ModuleKind.UMD || compilerOpts.module === ts.ModuleKind.AMD) &&
+        ngHost.amdModuleName) {
+      const amdName = ngHost.amdModuleName({fileName: importedFilePath} as ts.SourceFile);
+      if (amdName !== undefined) {
+        return amdName;
+      }
+    }
+
+    // If no AMD module name has been set for the source file by the `@bazel/concatjs` compiler
+    // host, and the target file is not part of a flat module node module package, we use the
+    // following rules (in order):
+    //    1. If target file is part of `node_modules/`, we use the package module name.
+    //    2. If no containing file is specified, or the target file is part of a different
+    //       compilation unit, we use a Bazel manifest path. Relative paths are not possible
+    //       since we don't have a containing file, and the target file could be located in the
+    //       output directory, or in an external Bazel repository.
+    //    3. If both rules above didn't match, we compute a relative path between the source files
+    //       since they are part of the same compilation unit.
+    // Note that we don't want to always use (2) because it could mean that compilation outputs
+    // are always leaking Bazel-specific paths, and the output is not self-contained. This could
+    // break `esm2015` or `esm5` output for Angular package release output
+    // Omit the `node_modules` prefix if the module name of an NPM package is requested.
+    if (relativeTargetPath.startsWith(NODE_MODULES)) {
+      return relativeTargetPath.slice(NODE_MODULES.length);
+    } else if (containingFilePath == null || !compilationTargetSrc.includes(importedFilePath)) {
+      return manifestTargetPath;
+    }
+    const containingFileDir = path.dirname(relativeToRootDirs(containingFilePath, rootDirs));
+    const relativeImportPath = path.posix.relative(containingFileDir, relativeTargetPath);
+    return relativeImportPath.startsWith('.') ? relativeImportPath : `./${relativeImportPath}`;
+  }
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
