### PR TITLE
build(devtools): fix issue where esbuild configs were not being set properly in DevTools builds

### DIFF
--- a/devtools/tools/esbuild/esbuild-esm-prod.config.mjs
+++ b/devtools/tools/esbuild/esbuild-esm-prod.config.mjs
@@ -9,6 +9,6 @@
 import createConfig from './esbuild-base.config.mjs';
 
 export default {
-  ...createConfig({enableLinker: true, optimize: true}),
+  ...(await createConfig({enableLinker: true, optimize: true})),
   format: 'esm',
 };

--- a/devtools/tools/esbuild/esbuild-esm.config.mjs
+++ b/devtools/tools/esbuild/esbuild-esm.config.mjs
@@ -9,6 +9,6 @@
 import createConfig from './esbuild-base.config.mjs';
 
 export default {
-  ...createConfig({enableLinker: true, optimize: false}),
+  ...(await createConfig({enableLinker: true, optimize: false})),
   format: 'esm',
 };

--- a/devtools/tools/esbuild/esbuild-iife.config.mjs
+++ b/devtools/tools/esbuild/esbuild-iife.config.mjs
@@ -9,6 +9,6 @@
 import createConfig from './esbuild-base.config.mjs';
 
 export default {
-  ...createConfig({enableLinker: false, optimize: false}),
+  ...(await createConfig({enableLinker: false, optimize: false})),
   format: 'iife',
 };

--- a/devtools/tools/esbuild/esbuild-spec.config.mjs
+++ b/devtools/tools/esbuild/esbuild-spec.config.mjs
@@ -9,7 +9,7 @@
 import createConfig from './esbuild-base.config.mjs';
 
 export default {
-  ...createConfig({enableLinker: true, optimize: false}),
+  ...(await createConfig({enableLinker: true, optimize: false})),
   // Use the `iife` format for the test entry-point as tests should run immediately.
   // For browser tests which are wrapped in an AMD header and footer, this works as well.
   format: 'iife',


### PR DESCRIPTION
Previously, a [createConfig](https://github.com/angular/angular/commit/c841da82c2f97df26184bc06d60c55d0540fd647#diff-52d65d7b28c762ca451e37a01517ed8631f54e98cb1c1887c74ea40ffb7bba3f) helper function was created to consolidate common esbuild configurations for DevTools. This function is asynchronous, but when it was used to set the configuration in various esbuild config files, it was used as if it was synchronous.

This commit fixes this issue by wrapping the output of the function in await, so that it propagates the configurations to esbuild correctly.
