### PR TITLE
docs(platform-browser): Sanitize method has more explicit documentation

### DIFF
--- a/packages/platform-browser/src/security/dom_sanitization_service.ts
+++ b/packages/platform-browser/src/security/dom_sanitization_service.ts
@@ -89,12 +89,13 @@ export interface SafeResourceUrl extends SafeValue {}
 @Injectable({providedIn: 'root', useExisting: forwardRef(() => DomSanitizerImpl)})
 export abstract class DomSanitizer implements Sanitizer {
   /**
-   * Sanitizes a value for use in the given SecurityContext.
+   * Gets a safe value from either a known safe value or a value with unknown safety.
    *
-   * If value is trusted for the context, this method will unwrap the contained safe value and use
-   * it directly. Otherwise, value will be sanitized to be safe in the given context, for example
-   * by replacing URLs that have an unsafe protocol part (such as `javascript:`). The implementation
-   * is responsible to make sure that the value can definitely be safely used in the given context.
+   * If the given value is already a `SafeValue`, this method returns the unwrapped value.
+   * If the security context is HTML and the given value is a plain string, this method
+   * sanitizes the string, removing any potentially unsafe content.
+   * For any other security context, this method throws an error if provided
+   * with a plain string.
    */
   abstract sanitize(context: SecurityContext, value: SafeValue|string|null): string|null;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I faced an issue, that documentation for sanitize method was misleading. After reading it I assumed that sanitize method will automatically sanitize the unsafe value. But it just tried to draw developer's attention to the unsafe value usage by throwing an error into the console. I found a few threads online related to this problem. Due to that fact, this improvement of the documentation should precede that other developers face the same misunderstanding as I did.