### PR TITLE
docs(docs-infra): put prerequisites page 'guide/property-binding' before 'guide/attribute-binding'

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -184,6 +184,11 @@
                   "tooltip": "Introductory guide to binding."
                 },
                 {
+                  "url": "guide/property-binding",
+                  "title": "Property binding",
+                  "tooltip": "Learn how to use property binding."
+                },
+                {
                   "url": "guide/attribute-binding",
                   "title": "Attribute binding",
                   "tooltip": "Learn how to use attribute binding."
@@ -197,11 +202,6 @@
                   "url": "guide/event-binding",
                   "title": "Event binding",
                   "tooltip": "Learn how to use to event binding."
-                },
-                {
-                  "url": "guide/property-binding",
-                  "title": "Property binding",
-                  "tooltip": "Learn how to use property binding."
                 },
                 {
                   "url": "guide/two-way-binding",


### PR DESCRIPTION
Pages [guide/attribute-binding](https://angular.io/guide/attribute-binding#prerequisites) and [guide/class-binding](https://angular.io/guide/class-binding#prerequisites) have prerequisite of [guide/property-binding](https://angular.io/guide/property-binding) but in navigation the property binding page comes much later. The change puts the binding pages in prerequisite order.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Prerequisite document `guide/property-binding` comes later in navigation.

## What is the new behavior?
Navigation under 'template/binding' section follows the prerequisite order.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

This is a small inconvenience. As current `What’s next` sections [don't necessarily follow the order](https://angular.io/guide/property-binding#whats-next). I think better name for `What's next` section could be `See also` because we already have navigation on the left side. :thinking: 