### PR TITLE
build(docs-infra): convert base64 png images post npm install for StackBlitz

### DIFF
--- a/aio/tools/examples/shared/boilerplate/cli/package.json
+++ b/aio/tools/examples/shared/boilerplate/cli/package.json
@@ -9,7 +9,8 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "postinstall": "node postinstall.js"
   },
   "private": true,
   "dependencies": {

--- a/aio/tools/examples/shared/boilerplate/cli/postinstall.js
+++ b/aio/tools/examples/shared/boilerplate/cli/postinstall.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const ASSETS_DIR = './src/assets';
+
+fs.readdirSync(ASSETS_DIR)
+  .map(fileName => `${ASSETS_DIR}/${fileName}`)
+  .filter(filePath => filePath.endsWith('.base64.png'))
+  .forEach(filePath => {
+    const base64Content = fs.readFileSync(filePath, 'utf-8');
+    const pngPath = filePath.replace('.base64', '');
+
+    fs.writeFileSync(pngPath, Buffer.from(base64Content, 'base64'));
+    console.log(`Converted ${filePath} to ${pngPath}.`);
+  });


### PR DESCRIPTION
- Fixes: https://github.com/angular/angular/issues/48773
- An alternate approach to https://github.com/angular/angular/pull/48774

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [x] Build related changes

## What is the current behavior?
For Stackblitz, following code converts and renames png images:
https://github.com/angular/angular/blob/9e1e5ccdfe1f25a9995f70e3c64ae72551af7562/aio/tools/stackblitz-builder/builder.mjs#L185-L187
StackBlitz's [POST API doesn't support binary images](https://web.archive.org/web/20221208032635/https://developer.stackblitz.com/platform/api/post-api) at the moment.

Due to this deployed code on StackBlitz gets `*.base64.png` files and not original `*.png` files. And all the png images in output are broken.


## What is the new behavior?
On StackBlitz After `npm install` execute postinstall script to convert `*.base64.png` images to binary `*.png` images.
![aio_fix](https://user-images.githubusercontent.com/87750369/213465451-911805fb-10fc-4557-8aaf-6da59a9055eb.png)



## Other information

With this approach we can keep using `png` files for the demos, no content change is required.
If StackBlitz POST API starts supporting binary files in future then we simply have to remove the postinstall hook.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No