### PR TITLE
docs: Use of $any() has no runtime incidence.

### DIFF
--- a/aio/content/guide/template-expression-operators.md
+++ b/aio/content/guide/template-expression-operators.md
@@ -59,6 +59,8 @@ The `$any()` cast function also works with `this` to allow access to undeclared 
 
 The `$any()` cast function works anywhere in a binding expression where a method call is valid.
 
+Also note that `$any()` has only an incidence on the typing. There is no method call in the generated code; the `$any()` function is entirely compiled away.
+
 <!-- links -->
 
 <!-- external links -->


### PR DESCRIPTION
Some users are woried about `$any()` as function calls are to be avoided in templates. This sentence clarifies the situation.

fixes #48781