### PR TITLE
fix(forms): Return non nullable control when using NonNullableFormBuilder 

### DIFF
--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -89,7 +89,7 @@ export type ɵElement<T, N extends null> =
   // FormControlState object container, which produces a nullable control.
   [T] extends [FormControlState<infer U>] ? FormControl<U|N> :
   // A ControlConfig tuple, which produces a nullable control.
-  [T] extends [PermissiveControlConfig<infer U>] ? FormControl<Exclude<U, ValidatorConfig| PermissiveAbstractControlOptions>|N> :
+  [T] extends [PermissiveControlConfig<infer U>] ? FormControl<Exclude<NonNullable<U>, ValidatorConfig| PermissiveAbstractControlOptions>|N> :
   FormControl<T|N>;
 
 // clang-format on

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -9,7 +9,7 @@
 // These tests mainly check the types of strongly typed form controls, which is generally enforced
 // at compile time.
 
-import {FormBuilder, NonNullableFormBuilder, UntypedFormBuilder} from '../src/form_builder';
+import {ControlConfig, FormBuilder, NonNullableFormBuilder, UntypedFormBuilder} from '../src/form_builder';
 import {AbstractControl, FormArray, FormControl, FormGroup, UntypedFormArray, UntypedFormControl, UntypedFormGroup, Validators} from '../src/forms';
 import {FormRecord} from '../src/model/form_group';
 
@@ -1068,6 +1068,17 @@ describe('Typed Class', () => {
           let t1 = c.controls;
           t1 = null as unknown as ControlsType;
         }
+      });
+
+      it('from a non nullable formBuilder', () => {
+        const cc: ControlConfig<string> = ['me@mail.com', Validators.required];
+        let nnfb: NonNullableFormBuilder = new FormBuilder().nonNullable;
+
+        type ControlsType = { email: FormControl<string>; };
+        const c = nnfb.group({email: cc});
+        let t: ControlsType = c.controls;
+        let t1 = c.controls;
+        t1 = null as unknown as ControlsType;
       });
 
       it('from objects with FormControlStates nested inside ControlConfigs', () => {


### PR DESCRIPTION
`NonNullableFormBuilder` should only return non nullable controls.

fixes #48631



## PR Type
What kind of change does this PR introduce?


- [x] Bugfix


## Does this PR introduce a breaking change?

- [x] No
