### PR TITLE
refactor(bazel): remove unnecessary banner stamping code

### DIFF
--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -13,7 +13,6 @@ It packages your library following the Angular Package Format, see the
 specification of this format at https://goo.gl/jB3GVv
 """
 
-load("@rules_nodejs//nodejs:providers.bzl", "StampSettingInfo")
 load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo", "JSEcmaScriptModuleInfo", "LinkablePackageInfo", "NpmPackageInfo", "node_modules_aspect")
 load("@build_bazel_rules_nodejs//internal/linker:link_node_modules.bzl", "LinkerPackageMappingInfo")
 load(
@@ -159,9 +158,6 @@ def _write_rollup_config(
 
     externals = WELL_KNOWN_EXTERNALS + ctx.attr.externals
 
-    # Whether the --stamp flag is applied in the context of the action's execution.
-    stamp = ctx.attr.stamp[StampSettingInfo].value
-
     # Pass external & globals through a templated config file because on Windows there is
     # an argument limit and we there might be a lot of globals which need to be passed to
     # rollup.
@@ -174,7 +170,6 @@ def _write_rollup_config(
             "TMPL_module_mappings": str(mappings),
             "TMPL_node_modules_root": _compute_node_modules_root(ctx),
             "TMPL_root_dir": root_dir,
-            "TMPL_stamp_data": "\"%s\"" % ctx.version_file.path if (stamp and ctx.version_file) else "undefined",
             "TMPL_workspace_name": ctx.workspace_name,
             "TMPL_external": ", ".join(["'%s'" % e for e in externals]),
             "TMPL_downlevel_to_es2015": "true" if downlevel_to_es2015 else "false",
@@ -212,14 +207,9 @@ def _run_rollup(ctx, bundle_name, rollup_config, entry_point, inputs, js_output,
     # bazel rule prints nothing on success.
     args.add("--silent")
 
-    # Whether the --stamp flag is applied in the context of the action's execution.
-    stamp = ctx.attr.stamp[StampSettingInfo].value
-
     other_inputs = [rollup_config]
     if ctx.file.license_banner:
         other_inputs.append(ctx.file.license_banner)
-    if stamp and ctx.version_file:
-        other_inputs.append(ctx.version_file)
     ctx.actions.run(
         progress_message = "ng_package: Rollup %s (%s)" % (bundle_name, entry_point.short_path),
         mnemonic = "AngularPackageRollup",
@@ -561,8 +551,7 @@ _NG_PACKAGE_ATTRS = dict(PKG_NPM_ATTRS, **{
     "license_banner": attr.label(
         doc = """A .txt file passed to the `banner` config option of rollup.
         The contents of the file will be copied to the top of the resulting bundles.
-        Note that you can replace a version placeholder in the license file, by using
-        the special version `0.0.0-PLACEHOLDER`. See the section on stamping in the README.""",
+        Configured substitutions are applied like with other files in the package.""",
         allow_single_file = [".txt"],
     ),
     "deps": attr.label_list(

--- a/packages/bazel/src/ng_package/rollup.config.js
+++ b/packages/bazel/src/ng_package/rollup.config.js
@@ -25,7 +25,6 @@ function log_verbose(...m) {
 const workspaceName = 'TMPL_workspace_name';
 const rootDir = 'TMPL_root_dir';
 const bannerFile = TMPL_banner_file;
-const stampData = TMPL_stamp_data;
 const moduleMappings = TMPL_module_mappings;
 const downlevelToES2015 = TMPL_downlevel_to_es2015;
 const nodeModulesRoot = 'TMPL_node_modules_root';
@@ -35,7 +34,6 @@ log_verbose(`running with
   workspaceName: ${workspaceName}
   rootDir: ${rootDir}
   bannerFile: ${bannerFile}
-  stampData: ${stampData}
   moduleMappings: ${JSON.stringify(moduleMappings)}
   nodeModulesRoot: ${nodeModulesRoot}
 `);
@@ -133,19 +131,9 @@ function resolveBazel(importee, importer) {
   return resolved;
 }
 
-let banner = '';
+let bannerContent = '';
 if (bannerFile) {
-  banner = fs.readFileSync(bannerFile, {encoding: 'utf-8'});
-  if (stampData) {
-    const versionTag = fs.readFileSync(stampData, {encoding: 'utf-8'})
-                           .split('\n')
-                           .find((s) => s.startsWith('STABLE_PROJECT_VERSION'));
-    // Don't assume STABLE_PROJECT_VERSION exists
-    if (versionTag) {
-      const version = versionTag.split(' ')[1].trim();
-      banner = banner.replace(/0.0.0-PLACEHOLDER/, version);
-    }
-  }
+  bannerContent = fs.readFileSync(bannerFile, {encoding: 'utf-8'});
 }
 
 // Transform that is enabled for ES2015 FESM generation. It transforms existing ES2020
@@ -217,7 +205,7 @@ const config = {
   plugins,
   external: [TMPL_external],
   output: {
-    banner,
+    banner: bannerContent,
   },
 };
 


### PR DESCRIPTION
The `ng_package` rule supports replacing `0.0.0-PLACEHOLDER` in license files that are
inserted as part of rollup. This requires additional logic to detect stamping, reading the
status files and then replacing the placeholder.

All of this already handled as part of normal package substitutions and we can
replace this unnecessary complexity.

See: https://github.com/bazelbuild/rules_nodejs/blob/da50feb23f911b8b6932d31bbff284fb21b44b6c/internal/pkg_npm/pkg_npm.bzl#L195