### PR TITLE
refactor(localize): bundle message digest algorithm directly in npm package

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -27,7 +27,7 @@
     "uncompressed": {
       "runtime": 926,
       "main": 124195,
-      "polyfills": 35252
+      "polyfills": 34628
     }
   },
   "cli-hello-world-lazy": {

--- a/packages/localize/BUILD.bazel
+++ b/packages/localize/BUILD.bazel
@@ -1,4 +1,5 @@
-load("//tools:defaults.bzl", "api_golden_test_npm_package", "extract_types", "ng_package", "ts_library")
+load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_package", "ts_library")
+load("//packages/bazel:index.bzl", "types_bundle")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -17,8 +18,10 @@ ts_library(
     ],
 )
 
-extract_types(
+types_bundle(
     name = "api_type_definitions",
+    entry_point = "localize.d.ts",
+    output_name = "localize/index.d.ts",
     deps = [":localize"],
 )
 
@@ -34,8 +37,12 @@ ng_package(
         "//packages/localize/tools:npm_package",
     ],
     skip_type_bundling = [
-        # For the primary entry-point we disable type bundling because API extractor
+        # For the primary entry-point we disable automatic type bundling because API extractor
         # does not properly handle module augumentation.
+        # To workaround this issue, type bundling is done as a separate step for all types
+        # except the main `index.d.ts` file which contains the module augmentation. The main
+        # file is reference in the package.json and also imports the bundle types. The bundled
+        # types are created via `api_type_definitions` above.
         # TODO: Remove once https://github.com/microsoft/rushstack/issues/2090 is solved.
         "",
     ],

--- a/packages/localize/index.ts
+++ b/packages/localize/index.ts
@@ -16,7 +16,7 @@ export * from './localize';
 // with
 // /// <reference types="@angular/localize" />
 
-import {LocalizeFn} from './src/localize';
+import {ɵLocalizeFn} from './localize';
 
 // `declare global` allows us to escape the current module and place types on the global namespace
 declare global {
@@ -112,5 +112,5 @@ declare global {
    * @param expressions a collection of the values of each placeholder in the template string.
    * @returns the translated string, with the `messageParts` and `expressions` interleaved together.
    */
-  const $localize: LocalizeFn;
+  const $localize: ɵLocalizeFn;
 }

--- a/packages/localize/src/utils/src/messages.ts
+++ b/packages/localize/src/utils/src/messages.ts
@@ -5,7 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {computeMsgId} from '@angular/compiler';
+// This module specifier is intentionally a relative path to allow bundling the code directly
+// into the package.
+import {computeMsgId} from '../../../../compiler/src/i18n/digest';
 
 import {BLOCK_MARKER, ID_SEPARATOR, LEGACY_ID_INDICATOR, MEANING_SEPARATOR} from './constants';
 
@@ -13,7 +15,7 @@ import {BLOCK_MARKER, ID_SEPARATOR, LEGACY_ID_INDICATOR, MEANING_SEPARATOR} from
  * Re-export this helper function so that users of `@angular/localize` don't need to actively import
  * from `@angular/compiler`.
  */
-export {computeMsgId} from '@angular/compiler';
+export {computeMsgId};
 
 /**
  * A string containing a translation source message.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #48163


## What is the new behavior?
The main entry point for the `@angular/localize` package no longer imports the `@angular/compiler` package and now has no external dependencies. This allows the main functionality of the package to be used without requiring any other Angular packages. Only the message digest algorithm implementation from the `@angular/compiler` package was being used and this code is now bundled directly into the final npm package for `@angular/localize`.
The `tooling` secondary entry point still leverages and requires Angular related packages (`@angular/compiler`/`@angular/compiler-cli`). However, the tooling functionality is not intended to be used and/or bundled in a web application.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
