### PR TITLE
fix(compiler): incorrect code when non-null assertion is used after a safe access

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
@@ -165,3 +165,60 @@ export declare class MyModule {
     static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: safe_access_non_null.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.val = null;
+    }
+    foo(val) {
+        return val;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    {{ val?.foo!.bar }}
+    {{ val?.[0].foo!.bar }}
+    {{ foo(val)?.foo!.bar }}
+    {{ $any(val)?.foo!.bar }}
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {{ val?.foo!.bar }}
+    {{ val?.[0].foo!.bar }}
+    {{ foo(val)?.foo!.bar }}
+    {{ $any(val)?.foo!.bar }}
+  `
+                }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [MyApp] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: safe_access_non_null.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    val: any;
+    foo(val: unknown): unknown;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
@@ -51,6 +51,23 @@
           "failureMessage": "Incorrect template"
         }
       ]
+    },
+    {
+      "description": "should handle non-null assertions after a safe access",
+      "inputFiles": [
+        "safe_access_non_null.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "safe_access_non_null_template.js",
+              "generated": "safe_access_non_null.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_non_null.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_non_null.ts
@@ -1,0 +1,21 @@
+import {Component, NgModule} from '@angular/core';
+
+@Component({
+  template: `
+    {{ val?.foo!.bar }}
+    {{ val?.[0].foo!.bar }}
+    {{ foo(val)?.foo!.bar }}
+    {{ $any(val)?.foo!.bar }}
+  `
+})
+export class MyApp {
+  val: any = null;
+
+  foo(val: unknown) {
+    return val;
+  }
+}
+
+@NgModule({declarations: [MyApp]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_non_null_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_non_null_template.js
@@ -1,0 +1,9 @@
+template: function MyApp_Template(rf, $ctx$) {
+  if (rf & 1) {
+    i0.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    let $tmp_0_0$;
+    i0.ɵɵtextInterpolate4(" ", $ctx$.val == null ? null : $ctx$.val.foo.bar, " ", $ctx$.val == null ? null : $ctx$.val[0].foo.bar, " ", ($tmp_0_0$ = $ctx$.foo($ctx$.val)) == null ? null : $tmp_0_0$.foo.bar, " ", ($tmp_0_0$ = $ctx$.val) == null ? null : $tmp_0_0$.foo.bar, " ");
+  }
+}

--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -717,7 +717,7 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
         return null;
       },
       visitNonNullAssert(ast: cdAst.NonNullAssert) {
-        return null;
+        return visit(this, ast.expression);
       },
       visitPropertyRead(ast: cdAst.PropertyRead) {
         return visit(this, ast.receiver);

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -2332,6 +2332,27 @@ describe('acceptance integration tests', () => {
     expect(strong.textContent).toBe('Hello Frodo');
   });
 
+  it('should not throw for a non-null assertion after a safe access', () => {
+    @Component({
+      template: `
+        {{ val?.foo!.bar }}
+        {{ val?.[0].foo!.bar }}
+        {{ foo(val)?.foo!.bar }}
+        {{ $any(val)?.foo!.bar }}
+      `,
+    })
+    class Comp {
+      val: any = null;
+
+      foo(val: unknown) {
+        return val;
+      }
+    }
+
+    TestBed.configureTestingModule({declarations: [Comp]});
+    expect(() => TestBed.createComponent(Comp).detectChanges()).not.toThrow();
+  });
+
   describe('tView.firstUpdatePass', () => {
     function isFirstUpdatePass() {
       const lView = getLView();


### PR DESCRIPTION
Fixes that the expression converter was producing code that throws a runtime error if a non-null assertion is used as a part of a safe read, write or call.

Fixes #48742.