### PR TITLE
docs: making footer copyright year dynamic

### DIFF
--- a/aio/src/app/layout/footer/footer.component.html
+++ b/aio/src/app/layout/footer/footer.component.html
@@ -10,7 +10,7 @@
 </div>
 
 <p>
-  Super-powered by Google ©2010-2022.
+  Super-powered by Google ©2010-{{ currentYear }}.
 </p>
 <p>
   Code licensed under an <a href="license" title="License text">MIT-style License</a>.

--- a/aio/src/app/layout/footer/footer.component.ts
+++ b/aio/src/app/layout/footer/footer.component.ts
@@ -9,4 +9,8 @@ import { NavigationNode, VersionInfo } from 'app/navigation/navigation.service';
 export class FooterComponent {
   @Input() nodes: NavigationNode[];
   @Input() versionInfo: VersionInfo | undefined;
+
+  get currentYear(): number {
+    return new Date().getFullYear();
+  }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Angular documentation website's footer copyright year is hard coded, so it shows the following `Super-powered by Google ©2010-2022`, but we are in 2023, so the years need to be `2010-2023`

Issue Number: #48811


## What is the new behavior?
Now the footer will display the current copyright year dynamically, it will change every new year dynamically.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
