### PR TITLE
fix(compiler-cli): resolve deprecation warning

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_constructor.ts
@@ -111,7 +111,6 @@ export function generateInlineTypeCtor(
 
   // Create the type constructor method declaration.
   return ts.factory.createMethodDeclaration(
-      /* decorators */ undefined,
       /* modifiers */[ts.factory.createModifier(ts.SyntaxKind.StaticKeyword)],
       /* asteriskToken */ undefined,
       /* name */ meta.fnName,


### PR DESCRIPTION
This commit updates one usage of the `ts.factory.createMethodDeclaration` API to avoid a deprecated function signature, which avoids logging a warning.