### PR TITLE
feat(core): add optional support for typing SimpleChanges keys

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1316,10 +1316,9 @@ export class SimpleChange {
 }
 
 // @public
-export interface SimpleChanges {
-    // (undocumented)
-    [propName: string]: SimpleChange;
-}
+export type SimpleChanges<KEYS extends string = string> = {
+    [KEY in KEYS]: SimpleChange;
+};
 
 // @public
 export interface SkipSelf {

--- a/packages/core/src/interface/simple_change.ts
+++ b/packages/core/src/interface/simple_change.ts
@@ -34,6 +34,6 @@ export class SimpleChange {
  *
  * @publicApi
  */
-export interface SimpleChanges {
-  [propName: string]: SimpleChange;
-}
+export type SimpleChanges<KEYS extends string = string> = {
+  [KEY in KEYS]: SimpleChange
+};


### PR DESCRIPTION
Allows consumers to opt-into strongly typing the keys of the SimpleChanges object. Non-breaking change which reverts to type string if no value for the generic is provided.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Currently, implementing `OnChanges` forces us to access properties on the `SimpleChanges` object via square brackets due to the fact that the keys are typed as string. 

```js
ngOnChanges(changes: SimpleChanges: void {
  // does not work
  if(changes.age || changes.isLoading) {
  }

  // works
  if(changes['age'])

}
```

Issue Number: N/A

## What is the new behavior?

In order to increase type safety, without introducing a breaking change, implementors of `OnChanges` can now provide a set of keys for the `SimpleChanges` object.

```js
ngOnChanges(changes: SimpleChanges<'age', 'isLoading'>): void {
  // works
  if(changes.age || changes.isLoading) {
  }

  // typescript complains
  if(changes.test)
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

