### PR TITLE
docs: consistent table width with min-width 100%

### DIFF
--- a/aio/src/styles/2-modules/table/_table-theme.scss
+++ b/aio/src/styles/2-modules/table/_table-theme.scss
@@ -7,6 +7,7 @@
   $is-dark-theme: map.get($theme, is-dark);
 
   table {
+    min-width: 100%;
     box-shadow: 0 2px 2px rgba(constants.$mediumgray, 0.24), 0 0 2px rgba(if($is-dark-theme, constants.$white, constants.$black), 0.12);
     background-color: if($is-dark-theme, mat.get-color-from-palette($background, background), constants.$white);
 


### PR DESCRIPTION
Let's have a consistent min-width of the tables across AIO to improve the look of the docs.

fixes #43840



## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes


