### PR TITLE
docs: remove p tags in Template binding example

### DIFF
--- a/aio/content/guide/what-is-angular.md
+++ b/aio/content/guide/what-is-angular.md
@@ -82,7 +82,7 @@ When the application loads the component and its template, the user sees the fol
 
 <code-example format="shell" language="html">
 
-&lt;p&gt;Hello, World!&lt;/p&gt;
+Hello, World!
 
 </code-example>
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
In the Templates example it says that the user sees a string with `<p>` tags which is not true.

![image](https://user-images.githubusercontent.com/36966980/214374105-50c8048b-ba57-4428-9f3b-f5c79432081f.png)

Issue Number: N/A


## What is the new behavior?
When binding the variable, this is what an end-user would see, a plain string without any `<p>` tags

![image](https://user-images.githubusercontent.com/36966980/214373815-31b508b0-c515-40f6-9025-b43149eda991.png)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
