### PR TITLE
docs: remove duplicate entry in the navigation

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -948,11 +948,6 @@
                   "url": "guide/event-binding-concepts",
                   "title": "How event binding works",
                   "tooltip": "About event binding."
-                },
-                {
-                  "url": "guide/template-reference-variables",
-                  "title": "Template variables",
-                  "tooltip": "Introductory guide to referring to DOM elements within a template."
                 }
               ]
             },


### PR DESCRIPTION
`template-reference-variables` was present twice in the navigation  breaking the current page selection for this item.

Fixes #47337
 
## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes