### PR TITLE
fix(forms): reset() call with null values on nested group

### DIFF
--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -483,8 +483,9 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
       value: ɵTypedOrUntyped<TControl, ɵFormGroupValue<TControl>, any> = {} as unknown as
           ɵFormGroupValue<TControl>,
       options: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
-    this._forEachChild((control, name) => {
-      control.reset((value as any)[name], {onlySelf: true, emitEvent: options.emitEvent});
+    this._forEachChild((control: AbstractControl, name) => {
+      control.reset(
+          value ? (value as any)[name] : null, {onlySelf: true, emitEvent: options.emitEvent});
     });
     this._updatePristine(options);
     this._updateTouched(options);

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -693,6 +693,19 @@ describe('FormGroup', () => {
       expect(g.disabled).toBe(false);
     });
 
+    it('should be able to reset a nested control with null', () => {
+      const g = new FormGroup({
+        id: new FormControl(2),
+        nested: new FormGroup<any>({
+          id: new FormControl(3),
+        }),
+      });
+
+      g.reset({id: 1, nested: null});
+      expect(g.get('nested')?.value).toEqual({id: null});
+      expect(g.get('nested.id')?.value).toBe(null);
+    });
+
     describe('reset() events', () => {
       let form: FormGroup, c3: FormControl, logger: any[];
 


### PR DESCRIPTION
Non typed forms allow to pass null to nested groups when calling `formGroup.reset()`, this commit prevents an undefined access.

fixes #20509

## PR Type
What kind of change does this PR introduce?



- [x] Bugfix


## Does this PR introduce a breaking change?

- [x] No idea. [May require a TGP if I understand @dylhunn](https://github.com/angular/angular/issues/20509#issuecomment-1188438050)
