### PR TITLE
fix(migrations): add `enum` in `mode` option in `standalone` schema

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/index.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/index.ts
@@ -79,15 +79,13 @@ function standaloneMigration(tree: Tree, tsconfigPath: string, basePath: string,
   let pendingChanges: ChangesByFile;
   let filesToRemove: Set<ts.SourceFile>|null = null;
 
-  if (options.mode === MigrationMode.toStandalone) {
-    pendingChanges = toStandalone(sourceFiles, program, printer);
-  } else if (options.mode === MigrationMode.pruneModules) {
+  if (options.mode === MigrationMode.pruneModules) {
     const result = pruneNgModules(program, host, basePath, rootNames, sourceFiles, printer);
     pendingChanges = result.pendingChanges;
     filesToRemove = result.filesToRemove;
   } else {
-    throw new SchematicsException(
-        `Unknown schematic mode ${options.mode}. Cannot run the standalone migration.`);
+    /** MigrationMode.toStandalone */
+    pendingChanges = toStandalone(sourceFiles, program, printer);
   }
 
   for (const [file, changes] of pendingChanges.entries()) {

--- a/packages/core/schematics/ng-generate/standalone-migration/schema.json
+++ b/packages/core/schematics/ng-generate/standalone-migration/schema.json
@@ -7,6 +7,7 @@
     "mode": {
       "description": "Operation that should be performed by the migrator",
       "type": "string",
+      "enum": ["convert-to-standalone", "prune-ng-modules"],
       "default": "convert-to-standalone",
       "x-prompt": {
         "message": "Choose the type of migration:",

--- a/packages/core/schematics/test/standalone_migration_spec.ts
+++ b/packages/core/schematics/test/standalone_migration_spec.ts
@@ -178,13 +178,6 @@ describe('standalone migration', () => {
     expect(error).toBe('Cannot run standalone migration outside of the current project.');
   });
 
-  it('should throw an error if an unknown mode is passed in', async () => {
-    writeFile('dir.ts', 'console.log(123)');
-
-    await expectAsync(runMigration('does-not-exist', './'))
-        .toBeRejectedWithError(/Data path \"\/mode\" must be equal to one of the allowed values/);
-  });
-
   it('should throw an error if the passed in path is a file', async () => {
     let error: string|null = null;
 

--- a/packages/core/schematics/test/standalone_migration_spec.ts
+++ b/packages/core/schematics/test/standalone_migration_spec.ts
@@ -179,18 +179,10 @@ describe('standalone migration', () => {
   });
 
   it('should throw an error if an unknown mode is passed in', async () => {
-    let error: string|null = null;
-
     writeFile('dir.ts', 'console.log(123)');
 
-    try {
-      await runMigration('does-not-exist', './');
-    } catch (e: any) {
-      error = e.message;
-    }
-
-    expect(error).toBe(
-        'Unknown schematic mode does-not-exist. Cannot run the standalone migration.');
+    await expectAsync(runMigration('does-not-exist', './'))
+        .toBeRejectedWithError(/Data path \"\/mode\" must be equal to one of the allowed values/);
   });
 
   it('should throw an error if the passed in path is a file', async () => {


### PR DESCRIPTION
Currently the `mode` is validated during schematic execution. While this cover a case of incorrect value this caused other parts were the correct values cannot be determined.

Options in schemas are used for a number of reasons during runtime.

- These are used to build auto complete
- Validation of inputs prior of the schematic is built with meaningful errors such as suggested inputs.
- Generation of help output.

Eventually these should also be used to generate DTS. This is already done in the CLI to avoid having to write Types manually.
