### PR TITLE
fix(migrations): Fixed file format issue with lint

### DIFF
--- a/packages/core/schematics/utils/typescript/compiler_host.ts
+++ b/packages/core/schematics/utils/typescript/compiler_host.ts
@@ -8,6 +8,7 @@
 import {Tree} from '@angular-devkit/schematics';
 import {dirname, relative, resolve} from 'path';
 import ts from 'typescript';
+
 import {parseTsconfigFile} from './parse_tsconfig';
 
 export type FakeReadFileFn = (fileName: string) => string|undefined;


### PR DESCRIPTION
A file was out of format and throwing lint errors. This fixes it.
