### PR TITLE
feat(forms): hasValidator support for composite validators.

### DIFF
--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -10,7 +10,7 @@ import {SimpleChange} from '@angular/core';
 import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {AbstractControl, CheckboxControlValueAccessor, ControlValueAccessor, DefaultValueAccessor, FormArray, FormArrayName, FormControl, FormControlDirective, FormControlName, FormGroup, FormGroupDirective, FormGroupName, NgControl, NgForm, NgModel, NgModelGroup, SelectControlValueAccessor, SelectMultipleControlValueAccessor, ValidationErrors, Validator, Validators} from '@angular/forms';
 import {selectValueAccessor} from '@angular/forms/src/directives/shared';
-import {composeValidators} from '@angular/forms/src/validators';
+import {composeValidators, hasValidator} from '@angular/forms/src/validators';
 
 import {asyncValidator} from './util';
 
@@ -122,6 +122,16 @@ class CustomValidatorDirective implements Validator {
           const dummy1 = () => ({'dummy1': true});
           const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
           expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
+        });
+
+        it('should be compatible with hasValidators', () => {
+          const dummy1 = () => ({'dummy1': true});
+          const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
+          expect(hasValidator(v, dummy1)).toBeTrue();
+
+          const dummy2 = () => ({'dummy2': true});
+          const v2 = composeValidators([v, dummy2]);
+          expect(hasValidator(v2, dummy1)).toBeTrue();
         });
       });
     });


### PR DESCRIPTION
The commit brings the support of hasValidator for composite validators. Use case: A composite validator containing Validator.required will now return `true` when calling  `hasValidator(Validators.required)`.

Partial fixes: #47141, still needs an components update. 

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?


- [x] No
