### PR TITLE
feature/hasValidator-composites

### DIFF
--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1008,6 +1008,9 @@
     "name": "includeViewProviders"
   },
   {
+    "name": "includesValidator"
+  },
+  {
     "name": "incrementInitPhaseFlags"
   },
   {
@@ -1078,6 +1081,9 @@
   },
   {
     "name": "isComponentHost"
+  },
+  {
+    "name": "isCompositeValidator"
   },
   {
     "name": "isContentQueryHost"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -969,6 +969,9 @@
     "name": "includeViewProviders"
   },
   {
+    "name": "includesValidator"
+  },
+  {
     "name": "incrementInitPhaseFlags"
   },
   {
@@ -1039,6 +1042,9 @@
   },
   {
     "name": "isComponentHost"
+  },
+  {
+    "name": "isCompositeValidator"
   },
   {
     "name": "isContentQueryHost"

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -126,6 +126,16 @@ export const NG_ASYNC_VALIDATORS =
 const EMAIL_REGEXP =
     /^(?=.{1,254}$)(?=.{1,64}@)[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
+
+interface CompositeValidatorFn extends ValidatorFn {
+  compositeList: ValidatorFn[];
+}
+
+interface CompositeAsyncValidatorFn extends AsyncValidatorFn {
+  compositeList: AsyncValidatorFn[];
+}
+
+
 /**
  * @description
  * Provides a set of built-in validators that can be used by form controls.
@@ -566,7 +576,7 @@ export function nullValidator(control: AbstractControl): ValidationErrors|null {
   return null;
 }
 
-function isPresent(o: any): boolean {
+function isPresent<T>(o: T|undefined|null): o is T {
   return o != null;
 }
 
@@ -627,14 +637,16 @@ export function normalizeValidators<V>(validators: (V|Validator|AsyncValidator)[
  * Merges synchronous validators into a single validator function.
  * See `Validators.compose` for additional information.
  */
-function compose(validators: (ValidatorFn|null|undefined)[]|null): ValidatorFn|null {
+function compose(validators: (ValidatorFn|null|undefined)[]|null): CompositeValidatorFn|null {
   if (!validators) return null;
-  const presentValidators: ValidatorFn[] = validators.filter(isPresent) as any;
+  const presentValidators = validators.filter(isPresent);
   if (presentValidators.length == 0) return null;
 
-  return function(control: AbstractControl) {
+  const fn = function(control: AbstractControl) {
     return mergeErrors(executeValidators<ValidatorFn>(control, presentValidators));
   };
+
+  return Object.assign(fn, {compositeList: presentValidators});
 }
 
 /**
@@ -650,16 +662,18 @@ export function composeValidators(validators: Array<Validator|ValidatorFn>): Val
  * Merges asynchronous validators into a single validator function.
  * See `Validators.composeAsync` for additional information.
  */
-function composeAsync(validators: (AsyncValidatorFn|null)[]): AsyncValidatorFn|null {
+function composeAsync(validators: (AsyncValidatorFn|null)[]): CompositeAsyncValidatorFn|null {
   if (!validators) return null;
-  const presentValidators: AsyncValidatorFn[] = validators.filter(isPresent) as any;
+  const presentValidators = validators.filter(isPresent);
   if (presentValidators.length == 0) return null;
 
-  return function(control: AbstractControl) {
+  const fn = function(control: AbstractControl) {
     const observables =
         executeValidators<AsyncValidatorFn>(control, presentValidators).map(toObservable);
     return forkJoin(observables).pipe(map(mergeErrors));
   };
+
+  return Object.assign(fn, {compositeList: presentValidators});
 }
 
 /**
@@ -712,6 +726,14 @@ export function makeValidatorsArray<T extends ValidatorFn|AsyncValidatorFn>(vali
 }
 
 /**
+ * Composite validator predicate
+ */
+function isCompositeValidator(validator: ValidatorFn|AsyncValidatorFn):
+    validator is CompositeValidatorFn|CompositeAsyncValidatorFn {
+  return 'compositeList' in validator;
+}
+
+/**
  * Determines whether a validator or validators array has a given validator.
  *
  * @param validators The validator or validators to compare against.
@@ -719,8 +741,23 @@ export function makeValidatorsArray<T extends ValidatorFn|AsyncValidatorFn>(vali
  * @returns Whether the validator is present.
  */
 export function hasValidator<T extends ValidatorFn|AsyncValidatorFn>(
-    validators: T|T[]|null, validator: T): boolean {
-  return Array.isArray(validators) ? validators.includes(validator) : validators === validator;
+    validators: T|T[]|null, validator: T, includeComposite: boolean = false): boolean {
+  if (validators === null) {
+    return false;
+  } else if (Array.isArray(validators)) {
+    return includesValidator(validators, validator, includeComposite);
+  } else if (isCompositeValidator(validators)) {
+    return includesValidator(validators.compositeList, validator, includeComposite);
+  }
+  return validators === validator;
+}
+
+function includesValidator<T extends AsyncValidatorFn|ValidatorFn|CompositeValidatorFn>(
+    validators: T[], validator: T, includeComposite: boolean): boolean {
+  return validators.some(
+      (v) => isCompositeValidator(v) && includeComposite ?
+          includesValidator(v.compositeList, validator, includeComposite) :
+          validators.includes(validator));
 }
 
 /**

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -10,7 +10,7 @@ import {SimpleChange} from '@angular/core';
 import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {AbstractControl, CheckboxControlValueAccessor, ControlValueAccessor, DefaultValueAccessor, FormArray, FormArrayName, FormControl, FormControlDirective, FormControlName, FormGroup, FormGroupDirective, FormGroupName, NgControl, NgForm, NgModel, NgModelGroup, SelectControlValueAccessor, SelectMultipleControlValueAccessor, ValidationErrors, Validator, Validators} from '@angular/forms';
 import {selectValueAccessor} from '@angular/forms/src/directives/shared';
-import {composeValidators} from '@angular/forms/src/validators';
+import {composeValidators, hasValidator} from '@angular/forms/src/validators';
 
 import {asyncValidator} from './util';
 
@@ -122,6 +122,18 @@ class CustomValidatorDirective implements Validator {
           const dummy1 = () => ({'dummy1': true});
           const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
           expect(v(new FormControl(''))).toEqual({'dummy1': true, 'custom': true});
+        });
+
+        it('should be compatible with hasValidators', () => {
+          const dummy1 = () => ({'dummy1': true});
+          const v = composeValidators([dummy1, new CustomValidatorDirective()])!;
+          expect(hasValidator(v, dummy1, true)).toBeTrue();
+
+          const dummy2 = () => ({'dummy2': true});
+          const v2 = composeValidators([v, dummy2]);
+          expect(hasValidator(v2, dummy1, true)).toBeTrue();
+
+          expect(hasValidator([dummy1, ...(v2 ? [v2] : [])], dummy2, true)).toBeTrue();
         });
       });
     });


### PR DESCRIPTION
The commit brings the support of hasValidator for composite validators. Use case: A composite validator containing Validator.required will now return `true` when calling  `hasValidator(Validators.required)`.

Partial fixes: #47141, still needs an components update. 

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?


- [x] No
