### PR TITLE
docs(router): Update functional guard and resolver docs

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -384,34 +384,11 @@ The injector no longer requires the Reflect polyfill, reducing application size 
 
 ### Router class and InjectionToken guards and resolvers
 
-This deprecation only affects the support for class and
-`InjectionToken` guards at the `Route` definition. `Injectable` classes
-and `InjectionToken` providers are _not_ deprecated in the general
-sense. That said, the interfaces like `CanActivate`, 
-`CanDeactivate`, etc.  will not be retained in the public API. Simply removing the 
-`implements CanActivate` from the injectable class and updating the route definition
-to be a function like `canActivate: [() => inject(MyGuard).canActivate()]` is sufficient
-to get rid of the deprecation warning.
+Class and injection token guards and resolvers are deprecated. Instead, `Route`
+objects should use functional-style guards and resolvers. Class-based guards can 
+be converted to functions by instead using `inject` to get dependencies.
 
-Functional guards are robust enough to even support the existing
-class-based guards through a transform:
-
-```
-function mapToCanMatch(providers: Array<Type<{canMatch: CanMatchFn}>>): CanMatchFn[] {
-  return providers.map(provider => (...params) => inject(provider).canMatch(...params));
-}
-const route = {
-  path: 'admin',
-  canMatch: mapToCanMatch([AdminGuard]),
-};
-```
-
-That is to say that guards can continue to be implemented as classes and then converted
-to functions at the route definition.
-
-Class-based guards can be converted to functions by instead using `inject` to get dependencies.
-
-For testing, using `TestBed` and `TestBed.runInInjectionContext` is recommended.
+For testing a function `canActivate` guard, using `TestBed` and `TestBed.runInInjectionContext` is recommended.
 Test mocks and stubs can be provided through DI with `{provide: X, useValue: StubX}`.
 Functional guards can also be written in a way that's either testable with
 `runInContext` or by passing mock implementations of dependencies.
@@ -429,6 +406,33 @@ const route = {
   canActivate: [myGuardWithMockableDeps]
 }
 ```
+
+This deprecation only affects the support for class and
+`InjectionToken` guards at the `Route` definition. `Injectable` classes
+and `InjectionToken` providers are _not_ deprecated in the general
+sense. That said, the interfaces like `CanActivate`, 
+`CanDeactivate`, etc.  will be deleted in a future release of Angular. Simply removing the 
+`implements CanActivate` from the injectable class and updating the route definition
+to be a function like `canActivate: [() => inject(MyGuard).canActivate()]` is sufficient
+to get rid of the deprecation warning.
+
+Functional guards are robust enough to even support the existing
+class-based guards through a transform:
+
+```
+import {CanMatchFn} from '@angular/router';
+
+function mapToCanMatch(providers: Array<Type<{canMatch: CanMatchFn}>>): CanMatchFn[] {
+  return providers.map(provider => (...params) => inject(provider).canMatch(...params));
+}
+const route = {
+  path: 'admin',
+  canMatch: mapToCanMatch([AdminGuard]),
+};
+```
+
+That is to say that guards can continue to be implemented as classes and then converted
+to functions at the route definition.
 
 <a id="router-writable-properties"></a>
 

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -117,7 +117,7 @@ v15 - v18
 | `@angular/router`                   | [`RouterLinkWithHref` directive](#router)                                                                  | v15           | v17         |
 | `@angular/router`                   | [Router writeable properties](#router-writable-properties)                                                 | v15.1         | v17         |
 | `@angular/router`                   | [Router CanLoad guards](#router-can-load)                                                 | v15.1         | v17         |
-| `@angular/router`                   | [class and `InjectionToken` guards and resolvers](#router)                                                 | v15.2         | v17         |
+| `@angular/router`                   | [class and `InjectionToken` guards and resolvers](#router-class-and-injection-token-guards)                | v15.2         | v17         |
 
 ### Deprecated features with no planned removal version
 
@@ -379,6 +379,56 @@ The injector no longer requires the Reflect polyfill, reducing application size 
 **After**:
 
 <code-example path="deprecation-guide/src/app/app.component.ts" language="typescript" region="static-injector-example"></code-example>
+
+<a id="router-class-and-injection-token-guards"></a>
+
+### Router class and InjectionToken guards and resolvers
+
+This deprecation only affects the support for class and
+`InjectionToken` guards at the `Route` definition. `Injectable` classes
+and `InjectionToken` providers are _not_ deprecated in the general
+sense. That said, the interfaces like `CanActivate`, 
+`CanDeactivate`, etc.  will not be retained in the public API. Simply removing the 
+`implements CanActivate` from the injectable class and updating the route definition
+to be a function like `canActivate: [() => inject(MyGuard).canActivate()]` is sufficient
+to get rid of the deprecation warning.
+
+Functional guards are robust enough to even support the existing
+class-based guards through a transform:
+
+```
+function mapToCanMatch(providers: Array<Type<{canMatch: CanMatchFn}>>): CanMatchFn[] {
+  return providers.map(provider => (...params) => inject(provider).canMatch(...params));
+}
+const route = {
+  path: 'admin',
+  canMatch: mapToCanMatch([AdminGuard]),
+};
+```
+
+That is to say that guards can continue to be implemented as classes and then converted
+to functions at the route definition.
+
+Class-based guards can be converted to functions by instead using `inject` to get dependencies.
+
+For testing, using `TestBed` and `TestBed.runInInjectionContext` is recommended.
+Test mocks and stubs can be provided through DI with `{provide: X, useValue: StubX}`.
+Functional guards can also be written in a way that's either testable with
+`runInContext` or by passing mock implementations of dependencies.
+For example:
+
+```
+export function myGuardWithMockableDeps(
+  dep1 = inject(MyService),
+  dep2 = inject(MyService2),
+  dep3 = inject(MyService3),
+) { }
+
+const route = {
+  path: 'admin',
+  canActivate: [myGuardWithMockableDeps]
+}
+```
 
 <a id="router-writable-properties"></a>
 

--- a/packages.bzl
+++ b/packages.bzl
@@ -74,6 +74,7 @@ DOCS_ENTRYPOINTS = [
     "examples/platform-browser",
     "examples/router/activated-route",
     "examples/router/testing",
+    "examples/router",
     "examples/service-worker/push",
     "examples/service-worker/registration-options",
     "examples/test-utils",

--- a/packages/examples/router/BUILD.bazel
+++ b/packages/examples/router/BUILD.bazel
@@ -7,7 +7,6 @@ ng_module(
     srcs = glob(
         ["**/*.ts"],
     ),
-    generate_ve_shims = True,
     deps = [
         "//packages/core",
         "//packages/platform-browser",

--- a/packages/examples/router/BUILD.bazel
+++ b/packages/examples/router/BUILD.bazel
@@ -1,0 +1,26 @@
+load("//tools:defaults.bzl", "ng_module")
+
+package(default_visibility = ["//visibility:public"])
+
+ng_module(
+    name = "router",
+    srcs = glob(
+        ["**/*.ts"],
+    ),
+    generate_ve_shims = True,
+    deps = [
+        "//packages/core",
+        "//packages/platform-browser",
+        "//packages/platform-browser-dynamic",
+        "//packages/router",
+        "//packages/zone.js/lib",
+        "@npm//rxjs",
+    ],
+)
+
+filegroup(
+    name = "files_for_docgen",
+    srcs = glob([
+        "**/*.ts",
+    ]),
+)

--- a/packages/examples/router/route_functional_guards.ts
+++ b/packages/examples/router/route_functional_guards.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, inject, Injectable} from '@angular/core';
+import {bootstrapApplication} from '@angular/platform-browser';
+import {ActivatedRoute, ActivatedRouteSnapshot, CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanMatchFn, provideRouter, ResolveFn, Route, RouterStateSnapshot, UrlSegment} from '@angular/router';
+
+@Component({template: ''})
+export class App {
+}
+
+@Component({template: ''})
+export class TeamComponent {
+}
+
+// #docregion CanActivateFn
+@Injectable()
+class UserToken {
+}
+
+@Injectable()
+class PermissionsService {
+  canActivate(currentUser: UserToken, id: string): boolean {
+    return true;
+  }
+  canMatch(currentUser: UserToken): boolean {
+    return true;
+  }
+}
+
+const canActivateTeam: CanActivateFn =
+    (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+      return inject(PermissionsService).canActivate(inject(UserToken), route.params.id);
+    };
+// #enddocregion
+
+
+// #docregion CanActivateFnInRoute
+bootstrapApplication(App, {
+  providers: [provideRouter([
+    {
+      path: 'team/:id',
+      component: TeamComponent,
+      canActivate: [canActivateTeam],
+    },
+  ])]
+});
+// #enddocregion
+
+// #docregion CanActivateChildFn
+const canActivateChildExample: CanActivateChildFn =
+    (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+      return inject(PermissionsService).canActivate(inject(UserToken), route.params.id);
+    };
+
+bootstrapApplication(App, {
+  providers: [provideRouter([
+    {
+      path: 'team/:id',
+      component: TeamComponent,
+      canActivateChild: [canActivateChildExample],
+      children: [],
+    },
+  ])]
+});
+// #enddocregion
+
+// #docregion CanDeactivateFn
+@Component({template: ''})
+export class UserComponent {
+  hasUnsavedChanges = true;
+}
+
+bootstrapApplication(App, {
+  providers: [provideRouter([
+    {
+      path: 'user/:id',
+      component: UserComponent,
+      canDeactivate: [(component: UserComponent) => !component.hasUnsavedChanges],
+    },
+  ])]
+});
+// #enddocregion
+
+// #docregion CanMatchFn
+const canMatchTeam: CanMatchFn = (route: Route, segments: UrlSegment[]) => {
+  return inject(PermissionsService).canMatch(inject(UserToken));
+};
+
+bootstrapApplication(App, {
+  providers: [provideRouter([
+    {
+      path: 'team/:id',
+      component: TeamComponent,
+      canMatch: [canMatchTeam],
+    },
+  ])]
+});
+// #enddocregion
+
+// #docregion ResolveDataUse
+@Component({template: ''})
+export class HeroDetailComponent {
+  constructor(private activatedRoute: ActivatedRoute) {}
+
+  ngOnInit() {
+    this.activatedRoute.data.subscribe(
+        ({hero}) => {
+            // do something with your resolved data ...
+        });
+  }
+}
+// #enddocregion
+
+// #docregion ResolveFn
+interface Hero {
+  name: string;
+}
+@Injectable()
+export class HeroService {
+  getHero(id: string) {
+    return {name: `Superman-${id}`};
+  }
+}
+
+export const heroResolver: ResolveFn<Hero> =
+    (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+      return inject(HeroService).getHero(route.paramMap.get('id')!);
+    };
+
+bootstrapApplication(App, {
+  providers: [provideRouter([{
+    path: 'detail/:id',
+    component: HeroDetailComponent,
+    resolve: {hero: heroResolver},
+  }])]
+});
+// #enddocregion

--- a/packages/examples/router/route_functional_guards.ts
+++ b/packages/examples/router/route_functional_guards.ts
@@ -25,7 +25,7 @@ class UserToken {
 
 @Injectable()
 class PermissionsService {
-  canActivate(currentUser: UserToken, id: string): boolean {
+  canActivate(currentUser: UserToken, userId: string): boolean {
     return true;
   }
   canMatch(currentUser: UserToken): boolean {

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -41,7 +41,8 @@ export type OnSameUrlNavigation = 'reload'|'ignore';
 /**
  * The `InjectionToken` and `@Injectable` classes for guards and resolvers are deprecated in favor
  * of plain JavaScript functions instead.. Dependency injection can still be achieved using the
- * `inject` function from `@angular/core`.
+ * `inject` function from `@angular/core` and an injectable class can be used as a functional guard
+ * using `inject`: `canActivate: [() => inject(myGuard).canActivate()]`.
  *
  * @deprecated
  * @see CanMatchFn
@@ -784,7 +785,9 @@ export type CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSn
  * ```
  *
  * @publicApi
- * @deprecated Use plain JavaScript functions instead.
+ * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
+ *     injectable class can be used as a functional guard using the `inject` function:
+ *     `canActivateChild: [() => inject(myGuard).canActivateChild()]`.
  * @see CanActivateChildFn
  */
 export interface CanActivateChild {
@@ -865,7 +868,9 @@ export type CanActivateChildFn = (childRoute: ActivatedRouteSnapshot, state: Rou
  * ```
  *
  * @publicApi
- * @deprecated Use plain JavaScript functions instead.
+ * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
+ *     injectable class can be used as a functional guard using the `inject` function:
+ *     `canDeactivate: [() => inject(myGuard).canDeactivate()]`.
  * @see CanDeactivateFn
  */
 export interface CanDeactivate<T> {
@@ -955,7 +960,9 @@ export type CanDeactivateFn<T> =
  * could not be used for a URL match but the catch-all `**` `Route` did instead.
  *
  * @publicApi
- * @deprecated Use plain JavaScript functions instead.
+ * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
+ *     injectable class can be used as a functional guard using the `inject` function:
+ *     `canMatch: [() => inject(myGuard).canMatch()]`.
  * @see CanMatchFn
  */
 export interface CanMatch {
@@ -1072,7 +1079,9 @@ export type CanMatchFn = (route: Route, segments: UrlSegment[]) =>
  * The order of execution is: BaseGuard, ChildGuard, BaseDataResolver, ChildDataResolver.
  *
  * @publicApi
- * @deprecated Use plain JavaScript functions instead.
+ * @deprecated Class-based `Route` resolvers are deprecated in favor of functional resolvers. An
+ * injectable class can be used as a functional guard using the `inject` function: `resolve:
+ * {'user': () => inject(UserResolver).resolve()}`.
  * @see ResolveFn
  */
 export interface Resolve<T> {

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -695,23 +695,6 @@ export interface LoadedRouterConfig {
  * class AppModule {}
  * ```
  *
- * You can alternatively provide an in-line function with the `CanActivateFn` signature:
- *
- * ```
- * @NgModule({
- *   imports: [
- *     RouterModule.forRoot([
- *       {
- *         path: 'team/:id',
- *         component: TeamComponent,
- *         canActivate: [(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => true]
- *       }
- *     ])
- *   ],
- * })
- * class AppModule {}
- * ```
- *
  * @publicApi
  * @deprecated Use plain JavaScript functions instead.
  * @see CanActivateFn
@@ -724,8 +707,21 @@ export interface CanActivate {
 /**
  * The signature of a function used as a `canActivate` guard on a `Route`.
  *
+ * If all guards return `true`, navigation continues. If any guard returns `false`,
+ * navigation is cancelled. If any guard returns a `UrlTree`, the current navigation
+ * is cancelled and a new navigation begins to the `UrlTree` returned from the guard.
+ *
+ * The following example implements and uses a `CanActivateChildFn` that checks whether the
+ * current user has permission to activate the requested route.
+ *
+ * {@example router/route_functional_guards.ts region="CanActivateFn"}
+
+ * Here, the defined guard function is provided as part of the `Route` object
+ * in the router configuration:
+
+ * {@example router/route_functional_guards.ts region="CanActivateFnInRoute"}
+ *
  * @publicApi
- * @see `CanActivate`
  * @see `Route`
  */
 export type CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) =>
@@ -787,28 +783,6 @@ export type CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSn
  * class AppModule {}
  * ```
  *
- * You can alternatively provide an in-line function with the `CanActivateChildFn` signature:
- *
- * ```
- * @NgModule({
- *   imports: [
- *     RouterModule.forRoot([
- *       {
- *         path: 'root',
- *         canActivateChild: [(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => true],
- *         children: [
- *           {
- *             path: 'team/:id',
- *             component: TeamComponent
- *           }
- *         ]
- *       }
- *     ])
- *   ],
- * })
- * class AppModule {}
- * ```
- *
  * @publicApi
  * @deprecated Use plain JavaScript functions instead.
  * @see CanActivateChildFn
@@ -821,8 +795,16 @@ export interface CanActivateChild {
 /**
  * The signature of a function used as a `canActivateChild` guard on a `Route`.
  *
+ * If all guards return `true`, navigation continues. If any guard returns `false`,
+ * navigation is cancelled. If any guard returns a `UrlTree`, the current navigation
+ * is cancelled and a new navigation begins to the `UrlTree` returned from the guard.
+ *
+ * The following example implements a `canActivate` function that checks whether the
+ * current user has permission to activate the requested route.
+ *
+ * {@example router/route_functional_guards.ts region="CanActivateChildFn"}
+ *
  * @publicApi
- * @see `CanActivateChild`
  * @see `Route`
  */
 export type CanActivateChildFn = (childRoute: ActivatedRouteSnapshot, state: RouterStateSnapshot) =>
@@ -882,24 +864,6 @@ export type CanActivateChildFn = (childRoute: ActivatedRouteSnapshot, state: Rou
  * class AppModule {}
  * ```
  *
- * You can alternatively provide an in-line function with the `CanDeactivateFn` signature:
- *
- * ```
- * @NgModule({
- *   imports: [
- *     RouterModule.forRoot([
- *       {
- *         path: 'team/:id',
- *         component: TeamComponent,
- *         canDeactivate: [(component: TeamComponent, currentRoute: ActivatedRouteSnapshot,
- * currentState: RouterStateSnapshot, nextState: RouterStateSnapshot) => true]
- *       }
- *     ])
- *   ],
- * })
- * class AppModule {}
- * ```
- *
  * @publicApi
  * @deprecated Use plain JavaScript functions instead.
  * @see CanDeactivateFn
@@ -914,8 +878,16 @@ export interface CanDeactivate<T> {
 /**
  * The signature of a function used as a `canDeactivate` guard on a `Route`.
  *
+ * If all guards return `true`, navigation continues. If any guard returns `false`,
+ * navigation is cancelled. If any guard returns a `UrlTree`, the current navigation
+ * is cancelled and a new navigation begins to the `UrlTree` returned from the guard.
+ *
+ * The following example implements and uses a `CanDeactivateFn` that checks whether the
+ * user component has unsaved changes before navigating away from the route.
+ *
+ * {@example router/route_functional_guards.ts region="CanDeactivateFn"}
+ *
  * @publicApi
- * @see `CanDeactivate`
  * @see `Route`
  */
 export type CanDeactivateFn<T> =
@@ -982,28 +954,6 @@ export type CanDeactivateFn<T> =
  * `team/:id` URL, but would load the `NotFoundComponent` because the `Route` for `'team/:id'`
  * could not be used for a URL match but the catch-all `**` `Route` did instead.
  *
- * You can alternatively provide an in-line function with the `CanMatchFn` signature:
- *
- * ```
- * @NgModule({
- *   imports: [
- *     RouterModule.forRoot([
- *       {
- *         path: 'team/:id',
- *         component: TeamComponent,
- *         loadChildren: () => import('./team').then(mod => mod.TeamModule),
- *         canMatch: [(route: Route, segments: UrlSegment[]) => true]
- *       },
- *       {
- *         path: '**',
- *         component: NotFoundComponent
- *       }
- *     ])
- *   ],
- * })
- * class AppModule {}
- * ```
- *
  * @publicApi
  * @deprecated Use plain JavaScript functions instead.
  * @see CanMatchFn
@@ -1014,10 +964,18 @@ export interface CanMatch {
 }
 
 /**
- * The signature of a function used as a `CanMatch` guard on a `Route`.
+ * The signature of a function used as a `canMatch` guard on a `Route`.
+ *
+ * If all guards return `true`, navigation continues and the `Router` will use the `Route` during
+ * activation. If any guard returns `false`, the `Route` is skipped for matching and other `Route`
+ * configurations are processed instead.
+ *
+ * The following example implements and uses a `CanMatchFn` that checks whether the
+ * current user has permission to access the team page.
+ *
+ * {@example router/route_functional_guards.ts region="CanMatchFn"}
  *
  * @publicApi
- * @see `CanMatch`
  * @see `Route`
  */
 export type CanMatchFn = (route: Route, segments: UrlSegment[]) =>
@@ -1068,29 +1026,6 @@ export type CanMatchFn = (route: Route, segments: UrlSegment[]) =>
  *   exports: [RouterModule]
  * })
  * export class AppRoutingModule {}
- * ```
- *
- * You can alternatively provide an in-line function with the `ResolveFn` signature:
- *
- * ```
- * export const myHero: Hero = {
- *   // ...
- * }
- *
- * @NgModule({
- *   imports: [
- *     RouterModule.forRoot([
- *       {
- *         path: 'detail/:id',
- *         component: HeroComponent,
- *         resolve: {
- *           hero: (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => myHero
- *         }
- *       }
- *     ])
- *   ],
- * })
- * export class AppModule {}
  * ```
  *
  * And you can access to your resolved data from `HeroComponent`:
@@ -1146,9 +1081,44 @@ export interface Resolve<T> {
 
 /**
  * Function type definition for a data provider.
+
+ * A data provider can be used with the router to resolve data during navigation.
+ * The router waits for the data to be resolved before the route is finally activated.
  *
- * @see `Route#resolve`.
+ * The following example implements a function that retrieves the data
+ * needed to activate the requested route.
+ *
+ * {@example router/route_functional_guards.ts region="ResolveFn"}
+ *
+ * And you can access to your resolved data from `HeroComponent`:
+ *
+ * {@example router/route_functional_guards.ts region="ResolveDataUse"}
+ *
+ * @usageNotes
+ *
+ * When both guard and resolvers are specified, the resolvers are not executed until
+ * all guards have run and succeeded.
+ * For example, consider the following route configuration:
+ *
+ * ```
+ * {
+ *  path: 'base'
+ *  canActivate: [baseGuard],
+ *  resolve: {data: baseDataResolver}
+ *  children: [
+ *   {
+ *     path: 'child',
+ *     canActivate: [childGuard],
+ *     component: ChildComponent,
+ *     resolve: {childData: childDataResolver}
+ *    }
+ *  ]
+ * }
+ * ```
+ * The order of execution is: baseGuard, childGuard, baseDataResolver, childDataResolver.
+ *
  * @publicApi
+ * @see Route
  */
 export type ResolveFn<T> = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) =>
     Observable<T>|Promise<T>|T;
@@ -1200,24 +1170,6 @@ export type ResolveFn<T> = (route: ActivatedRouteSnapshot, state: RouterStateSna
  *     ])
  *   ],
  *   providers: [CanLoadTeamSection, UserToken, Permissions]
- * })
- * class AppModule {}
- * ```
- *
- * You can alternatively provide an in-line function with the `CanLoadFn` signature:
- *
- * ```
- * @NgModule({
- *   imports: [
- *     RouterModule.forRoot([
- *       {
- *         path: 'team/:id',
- *         component: TeamComponent,
- *         loadChildren: () => import('./team').then(mod => mod.TeamModule),
- *         canLoad: [(route: Route, segments: UrlSegment[]) => true]
- *       }
- *     ])
- *   ],
  * })
  * class AppModule {}
  * ```


### PR DESCRIPTION
This commit updates the docs of the functional guards and resolvers to improve the migration experience when moving away from class-based equivalents.