### PR TITLE
refactor(compiler-cli): Export the interface PluginCompilerHost for 1p use

### DIFF
--- a/packages/compiler-cli/index.ts
+++ b/packages/compiler-cli/index.ts
@@ -26,7 +26,7 @@ export * from './src/ngtsc/logging';
 export * from './src/ngtsc/file_system';
 
 // Exports for dealing with the `ngtsc` program.
-export {NgTscPlugin} from './src/ngtsc/tsc_plugin';
+export {NgTscPlugin, PluginCompilerHost} from './src/ngtsc/tsc_plugin';
 export {NgtscProgram} from './src/ngtsc/program';
 export {OptimizeFor} from './src/ngtsc/typecheck/api';
 

--- a/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
+++ b/packages/compiler-cli/src/ngtsc/tsc_plugin.ts
@@ -28,7 +28,7 @@ import {OptimizeFor} from './typecheck/api';
  * Currently mirrored from @bazel/concatjs/internal/tsc_wrapped/plugin_api (with the naming of
  * `fileNameToModuleName` corrected).
  */
-interface PluginCompilerHost extends ts.CompilerHost, Partial<UnifiedModulesHost> {
+export interface PluginCompilerHost extends ts.CompilerHost, Partial<UnifiedModulesHost> {
   readonly inputFiles: ReadonlyArray<string>;
 }
 


### PR DESCRIPTION
Some 1p module which uses the method TscPlugin.wrapHost requires to import this type to make its internal class definitions compatible with this type.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
