### PR TITLE
Handle forward references in same file imports

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/scope.ts
@@ -21,6 +21,7 @@ export interface PotentialImport {
   // If no moduleSpecifier is present, the given symbol name is already in scope.
   moduleSpecifier?: string;
   symbolName: string;
+  isForwardReference: boolean;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -720,7 +720,11 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     const emitted = emittedRef.expression;
     if (emitted instanceof WrappedNodeExpr) {
       // An appropriate identifier is already in scope.
-      return {kind, symbolName: emitted.node.text};
+      return {
+        kind,
+        symbolName: emitted.node.text,
+        isForwardReference: emitted.node.getStart() > inContext.getStart()
+      };
     } else if (
         emitted instanceof ExternalExpr && emitted.value.moduleName !== null &&
         emitted.value.name !== null) {
@@ -728,6 +732,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
         kind,
         moduleSpecifier: emitted.value.moduleName,
         symbolName: emitted.value.name,
+        isForwardReference: false,
       };
     }
     return null;

--- a/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
@@ -118,7 +118,18 @@ function getComponentImportExpressions(
             ref.node.getSourceFile(), importLocation.symbolName, importLocation.moduleSpecifier);
         imports.push(identifier);
       } else {
-        imports.push(ts.factory.createIdentifier(importLocation.symbolName));
+        const identifier = ts.factory.createIdentifier(importLocation.symbolName);
+
+        if (importLocation.isForwardReference) {
+          const forwardRefExpression =
+              tracker.addImport(ref.node.getSourceFile(), 'forwardRef', '@angular/core');
+          const arrowFunction = ts.factory.createArrowFunction(
+              undefined, undefined, [], undefined, undefined, identifier);
+          imports.push(
+              ts.factory.createCallExpression(forwardRefExpression, undefined, [arrowFunction]));
+        } else {
+          imports.push(identifier);
+        }
       }
 
       seenImports.add(importLocation.symbolName);

--- a/packages/core/schematics/test/standalone_migration_spec.ts
+++ b/packages/core/schematics/test/standalone_migration_spec.ts
@@ -1158,6 +1158,46 @@ describe('standalone migration', () => {
     `));
   });
 
+  it('should generate a forwardRef for forward reference within the same file', async () => {
+    writeFile('decls.ts', `
+      import {Component, Directive} from '@angular/core';
+
+      @Component({
+        selector: 'comp',
+        template: '<div my-dir></div>'
+      })
+      export class MyComp {}
+
+      @Directive({selector: '[my-dir]'})
+      export class MyDir {}
+    `);
+
+    writeFile('module.ts', `
+      import {NgModule} from '@angular/core';
+      import {MyComp, MyDir} from './decls';
+
+      @NgModule({declarations: [MyComp, MyDir]})
+      export class Mod {}
+    `);
+
+    await runMigration('convert-to-standalone');
+
+    expect(stripWhitespace(tree.readContent('decls.ts'))).toEqual(stripWhitespace(`
+      import {Component, Directive, forwardRef} from '@angular/core';
+
+      @Component({
+        selector: 'comp',
+        template: '<div my-dir></div>',
+        standalone: true,
+        imports: [forwardRef(() => MyDir)]
+      })
+      export class MyComp {}
+
+      @Directive({selector: '[my-dir]', standalone: true})
+      export class MyDir {}
+    `));
+  });
+
   it('should remove a module that only has imports and exports', async () => {
     writeFile('app.module.ts', `
       import {NgModule} from '@angular/core';

--- a/packages/language-service/src/codefixes/fix_missing_import.ts
+++ b/packages/language-service/src/codefixes/fix_missing_import.ts
@@ -74,11 +74,33 @@ function getCodeActions(
     const currMatchSymbol = currMatch.tsSymbol.valueDeclaration!;
     const potentialImports =
         checker.getPotentialImportsFor(currMatch.ref, importOn, PotentialImportMode.Normal);
-    for (let potentialImport of potentialImports) {
-      let [fileImportChanges, importName] = updateImportsForTypescriptFile(
-          tsChecker, importOn.getSourceFile(), potentialImport, currMatchSymbol.getSourceFile());
+    for (const potentialImport of potentialImports) {
+      const fileImportChanges: ts.TextChange[] = [];
+      let importName: string;
+      let forwardRefName: string|null = null;
+
+      if (potentialImport.moduleSpecifier) {
+        const [importChanges, generatedImportName] = updateImportsForTypescriptFile(
+            tsChecker, importOn.getSourceFile(), potentialImport.symbolName,
+            potentialImport.moduleSpecifier, currMatchSymbol.getSourceFile());
+        importName = generatedImportName;
+        fileImportChanges.push(...importChanges);
+      } else {
+        if (potentialImport.isForwardReference) {
+          // Note that we pass the `importOn` file twice since we know that the potential import
+          // is within the same file, because it doesn't have a `moduleSpecifier`.
+          const [forwardRefImports, generatedForwardRefName] = updateImportsForTypescriptFile(
+              tsChecker, importOn.getSourceFile(), 'forwardRef', '@angular/core',
+              importOn.getSourceFile());
+          fileImportChanges.push(...forwardRefImports);
+          forwardRefName = generatedForwardRefName;
+        }
+        importName = potentialImport.symbolName;
+      }
+
       // Always update the trait import, although the TS import might already be present.
-      let traitImportChanges = updateImportsForAngularTrait(checker, importOn, importName);
+      const traitImportChanges =
+          updateImportsForAngularTrait(checker, importOn, importName, forwardRefName);
       if (traitImportChanges.length === 0) continue;
 
       let description = `Import ${importName}`;

--- a/packages/language-service/test/ts_utils_spec.ts
+++ b/packages/language-service/test/ts_utils_spec.ts
@@ -163,17 +163,17 @@ describe('TS util', () => {
     });
 
     it('addElementToArrayLiteral', () => {
-      let arr = ensureArrayWithIdentifier(ts.factory.createIdentifier('foo'));
+      let arr = ensureArrayWithIdentifier('foo', ts.factory.createIdentifier('foo'));
       arr = addElementToArrayLiteral(arr!, ts.factory.createIdentifier('bar'));
       expect(print(arr)).toEqual('[foo, bar]');
     });
 
     it('ensureArrayWithIdentifier', () => {
-      let arr = ensureArrayWithIdentifier(ts.factory.createIdentifier('foo'));
+      let arr = ensureArrayWithIdentifier('foo', ts.factory.createIdentifier('foo'));
       expect(print(arr!)).toEqual('[foo]');
-      arr = ensureArrayWithIdentifier(ts.factory.createIdentifier('bar'), arr!);
+      arr = ensureArrayWithIdentifier('bar', ts.factory.createIdentifier('bar'), arr!);
       expect(print(arr!)).toEqual('[foo, bar]');
-      arr = ensureArrayWithIdentifier(ts.factory.createIdentifier('bar'), arr!);
+      arr = ensureArrayWithIdentifier('bar', ts.factory.createIdentifier('bar'), arr!);
       expect(arr).toEqual(null);
     });
 


### PR DESCRIPTION
When we automatically generate imports within the same file, we may have to create a `forwardRef` in order for the code to compile. This PR is composed of the following changes:

1. Adds a `isForwardReference` field to `PotentialImport`.
2. Updates the language service to generate a `forwardRef`.
3. Updates the standalone migration to generate a `forwardRef`.