### PR TITLE
refactor(forms): removing a workaround comment

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -586,9 +586,6 @@ export function toObservable(value: any): Observable<any> {
 
 function mergeErrors(arrayOfErrors: (ValidationErrors|null)[]): ValidationErrors|null {
   let res: {[key: string]: any} = {};
-
-  // Not using Array.reduce here due to a Chrome 80 bug
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=1049982
   arrayOfErrors.forEach((errors: ValidationErrors|null) => {
     res = errors != null ? {...res!, ...errors} : res!;
   });


### PR DESCRIPTION
~~A [bug on Array.reduce](https://bugs.chromium.org/p/chromium/issues/detail?id=1049982) was found on M80 and also fixed on M80 (early 2020), there is no need to keep that workaround today.~~

~~This commit is mostly a revert of #35349~~.

Let's keep the workaround as it is clearer that `Array.reduce` use. 

## Does this PR introduce a breaking change?

- [x] No