### PR TITLE
fix(core): Improve DebugElement.query() return type

### DIFF
--- a/aio/content/examples/setup/src/app/app.component.spec.ts
+++ b/aio/content/examples/setup/src/app/app.component.spec.ts
@@ -16,7 +16,7 @@ describe('AppComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(AppComponent);
     comp = fixture.componentInstance;
-    de = fixture.debugElement.query(By.css('h1'));
+    de = fixture.debugElement.query(By.css('h1'))!;
   });
 
   it('should create component', () => expect(comp).toBeDefined());

--- a/aio/content/examples/testing/src/app/banner/banner-initial.component.spec.ts
+++ b/aio/content/examples/testing/src/app/banner/banner-initial.component.spec.ts
@@ -103,7 +103,7 @@ describe('BannerComponent (with beforeEach)', () => {
   // #docregion v4-test-5
   it('should find the <p> with fixture.debugElement.query(By.css)', () => {
     const bannerDe: DebugElement = fixture.debugElement;
-    const paragraphDe = bannerDe.query(By.css('p'));
+    const paragraphDe = bannerDe.query(By.css('p'))!;
     const p: HTMLElement = paragraphDe.nativeElement;
     expect(p.textContent).toEqual('banner works!');
   });

--- a/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
+++ b/aio/content/examples/testing/src/app/dashboard/dashboard-hero.component.spec.ts
@@ -48,7 +48,7 @@ describe('DashboardHeroComponent when tested directly', () => {
     comp = fixture.componentInstance;
 
     // find the hero's DebugElement and element
-    heroDe = fixture.debugElement.query(By.css('.hero'));
+    heroDe = fixture.debugElement.query(By.css('.hero'))!;
     heroEl = heroDe.nativeElement;
 
     // mock the hero supplied by the parent component

--- a/aio/content/examples/testing/src/app/demo/demo.testbed.spec.ts
+++ b/aio/content/examples/testing/src/app/demo/demo.testbed.spec.ts
@@ -203,7 +203,7 @@ describe('demo (with TestBed):', () => {
       click(heroes[0]);
       fixture.detectChanges();
 
-      const selected = fixture.debugElement.query(By.css('p'));
+      const selected = fixture.debugElement.query(By.css('p'))!;
       expect(selected).toHaveText(hero.name);
     });
 
@@ -213,7 +213,7 @@ describe('demo (with TestBed):', () => {
       const heroName = comp.heroes[0].name; // first hero's name
 
       fixture.detectChanges();
-      const ngForRow = fixture.debugElement.query(By.directive(IoComponent)); // first hero ngForRow
+      const ngForRow = fixture.debugElement.query(By.directive(IoComponent))!; // first hero ngForRow
 
       const hero = ngForRow.context.hero; // the hero object passed into the row
       expect(hero.name).withContext('ngRow.context.hero').toBe(heroName);
@@ -226,8 +226,8 @@ describe('demo (with TestBed):', () => {
 
     it('should support clicking a button', () => {
       const fixture = TestBed.createComponent(LightswitchComponent);
-      const btn = fixture.debugElement.query(By.css('button'));
-      const span = fixture.debugElement.query(By.css('span')).nativeElement;
+      const btn = fixture.debugElement.query(By.css('button'))!;
+      const span = fixture.debugElement.query(By.css('span'))!.nativeElement;
 
       fixture.detectChanges();
       expect(span.textContent)
@@ -248,7 +248,7 @@ describe('demo (with TestBed):', () => {
       fixture.detectChanges();
 
       const comp = fixture.componentInstance;
-      const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement as HTMLInputElement;
 
       expect(comp.name)
         .withContext(`At start name should be ${expectedOrigName} `)
@@ -295,8 +295,8 @@ describe('demo (with TestBed):', () => {
       const fixture = TestBed.createComponent(InputComponent);
       fixture.detectChanges();
 
-      const comp = fixture.componentInstance;
-      const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
+      const comp =  fixture.componentInstance;
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement as HTMLInputElement;
 
       expect(comp.name)
         .withContext(`At start name should be ${expectedOrigName} `)
@@ -335,8 +335,8 @@ describe('demo (with TestBed):', () => {
       fixture.detectChanges();
 
       const comp = fixture.componentInstance;
-      const input = fixture.debugElement.query(By.css('input')).nativeElement as HTMLInputElement;
-      const span = fixture.debugElement.query(By.css('span')).nativeElement as HTMLElement;
+      const input = fixture.debugElement.query(By.css('input'))!.nativeElement as HTMLInputElement;
+      const span = fixture.debugElement.query(By.css('span'))!.nativeElement as HTMLElement;
 
       // simulate user entering new name in input
       input.value = inputText;
@@ -356,7 +356,7 @@ describe('demo (with TestBed):', () => {
       const fixture = TestBed.createComponent(InputComponent);
       fixture.detectChanges();
 
-      const inputEl = fixture.debugElement.query(By.css('input'));
+      const inputEl = fixture.debugElement.query(By.css('input'))!;
 
       expect(inputEl.providerTokens).withContext('NgModel directive').toContain(NgModel);
 
@@ -659,7 +659,7 @@ describe('demo (with TestBed):', () => {
       fixture.detectChanges();
       getChild();
 
-      const btn = fixture.debugElement.query(By.css('button'));
+      const btn = fixture.debugElement.query(By.css('button'))!;
       click(btn);
 
       fixture.detectChanges();

--- a/aio/content/examples/testing/src/app/hero/hero-list.component.spec.ts
+++ b/aio/content/examples/testing/src/app/hero/hero-list.component.spec.ts
@@ -80,8 +80,8 @@ describe('HeroListComponent', () => {
   it('should find `HighlightDirective` with `By.directive', () => {
     // #docregion by
     // Can find DebugElement either by css selector or by directive
-    const h2 = fixture.debugElement.query(By.css('h2'));
-    const directive = fixture.debugElement.query(By.directive(HighlightDirective));
+    const h2 = fixture.debugElement.query(By.css('h2'))!;
+    const directive = fixture.debugElement.query(By.directive(HighlightDirective))!;
     // #enddocregion by
     expect(h2).toBe(directive);
   });
@@ -135,7 +135,7 @@ class Page {
     this.heroRows = Array.from(heroRowNodes);
 
     // Find the first element with an attached HighlightDirective
-    this.highlightDe = fixture.debugElement.query(By.directive(HighlightDirective));
+    this.highlightDe = fixture.debugElement.query(By.directive(HighlightDirective))!;
 
     // Get the component's injected router navigation spy
     const routerSpy = fixture.debugElement.injector.get(Router);

--- a/aio/content/examples/testing/src/app/shared/highlight.directive.spec.ts
+++ b/aio/content/examples/testing/src/app/shared/highlight.directive.spec.ts
@@ -33,7 +33,7 @@ describe('HighlightDirective', () => {
     des = fixture.debugElement.queryAll(By.directive(HighlightDirective));
 
     // the h2 without the HighlightDirective
-    bareH2 = fixture.debugElement.query(By.css('h2:not([highlight])'));
+    bareH2 = fixture.debugElement.query(By.css('h2:not([highlight])'))!;
   });
 
   // color tests

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -60,14 +60,28 @@ describe('AppComponent', () => {
     component.onResize(showTopMenuWidth + 1); // wide by default
 
     const de = fixture.debugElement;
+
     const docViewerDe = de.query(By.css('aio-doc-viewer'));
+    const _hamburger = de.query(By.css('.hamburger'))?.nativeElement;
+    const _sidenav = de.query(By.directive(MatSidenav))?.componentInstance;
+
+    if(docViewerDe === null) {
+      throw new Error('Could not find aio-doc-viewer');
+    } else if (_hamburger === null) {
+      throw new Error('Could not find .hamburger');
+    }  else if (_sidenav === null) {
+      throw new Error('Could not find MatSidenav');
+    }
+
+    sidenav = _sidenav;
+    hamburger = _hamburger;
 
     documentService = de.injector.get<DocumentService>(DocumentService);
+    locationService = de.injector.get<any>(LocationService);
     docViewer = docViewerDe.nativeElement;
     docViewerComponent = docViewerDe.componentInstance;
-    hamburger = de.query(By.css('.hamburger')).nativeElement;
-    locationService = de.injector.get<any>(LocationService);
-    sidenav = de.query(By.directive(MatSidenav)).componentInstance;
+
+
     tocService = de.injector.get<TocService>(TocService);
 
     return waitForDoc && awaitDocRendered();
@@ -273,8 +287,8 @@ describe('AppComponent', () => {
           });
 
           it('should close when clicking in gray content area overlay', () => {
-            const sidenavBackdrop = fixture.debugElement.query(By.css('.mat-drawer-backdrop')).nativeElement;
-            sidenavBackdrop.click();
+            const sidenavBackdrop = fixture.debugElement.query(By.css('.mat-drawer-backdrop'))?.nativeElement;
+            sidenavBackdrop?.click();
             fixture.detectChanges();
             expect(sidenav.opened).toBe(false);
           });
@@ -692,15 +706,15 @@ describe('AppComponent', () => {
 
     describe('footer', () => {
       it('should have version number', () => {
-        const versionEl: HTMLElement = fixture.debugElement.query(By.css('aio-footer')).nativeElement;
-        expect(versionEl.textContent).toContain(TestHttpClient.versionInfo.full);
+        const versionEl: HTMLElement = fixture.debugElement.query(By.css('aio-footer'))?.nativeElement;
+        expect(versionEl?.textContent).toContain(TestHttpClient.versionInfo.full);
       });
     });
 
     describe('aio-cookies-popup', () => {
       it('should have a cookies popup', () => {
         const cookiesPopupDe = fixture.debugElement.query(By.directive(CookiesPopupComponent));
-        expect(cookiesPopupDe.componentInstance).toBeInstanceOf(CookiesPopupComponent);
+        expect(cookiesPopupDe?.componentInstance).toBeInstanceOf(CookiesPopupComponent);
       });
     });
 
@@ -708,14 +722,14 @@ describe('AppComponent', () => {
       it('should show a message if the deployment mode is "archive"', async () => {
         createTestingModule('a/b', 'archive');
         await initializeTest();
-        const banner: HTMLElement = fixture.debugElement.query(By.css('aio-mode-banner')).nativeElement;
-        expect(banner.textContent).toContain('archived documentation for Angular v4');
+        const banner: HTMLElement = fixture.debugElement.query(By.css('aio-mode-banner'))?.nativeElement;
+        expect(banner?.textContent).toContain('archived documentation for Angular v4');
       });
 
       it('should show no message if the deployment mode is not "archive"', async () => {
         createTestingModule('a/b', 'stable');
         await initializeTest();
-        const banner: HTMLElement = fixture.debugElement.query(By.css('aio-mode-banner')).nativeElement;
+        const banner: HTMLElement = fixture.debugElement.query(By.css('aio-mode-banner'))?.nativeElement;
         expect(banner.textContent?.trim()).toEqual('');
       });
     });
@@ -752,7 +766,7 @@ describe('AppComponent', () => {
           fixture.detectChanges();
 
           const searchResults = fixture.debugElement.query(By.directive(SearchResultsComponent));
-          searchResults.nativeElement.click();
+          searchResults?.nativeElement.click();
           fixture.detectChanges();
 
           expect(component.showSearchResults).toBe(true);
@@ -763,7 +777,7 @@ describe('AppComponent', () => {
           fixture.detectChanges();
 
           const searchBox = fixture.debugElement.query(By.directive(SearchBoxComponent));
-          searchBox.nativeElement.click();
+          searchBox?.nativeElement.click();
           fixture.detectChanges();
 
           expect(component.showSearchResults).toBe(true);
@@ -779,23 +793,23 @@ describe('AppComponent', () => {
         it('should grab focus when the / key is pressed', () => {
           const searchBox: SearchBoxComponent = fixture.debugElement.query(
             By.directive(SearchBoxComponent)
-          ).componentInstance;
+          )?.componentInstance;
           spyOn(searchBox, 'focus');
           window.document.dispatchEvent(new KeyboardEvent('keyup', { key: '/' }));
           fixture.detectChanges();
-          expect(searchBox.focus).toHaveBeenCalled();
+          expect(searchBox?.focus).toHaveBeenCalled();
         });
 
         // eslint-disable-next-line max-len
         it('should set focus back to the search box when the search results are displayed and the escape key is pressed', () => {
           const searchBox: SearchBoxComponent = fixture.debugElement.query(
             By.directive(SearchBoxComponent)
-          ).componentInstance;
+          )?.componentInstance;
           spyOn(searchBox, 'focus');
           component.showSearchResults = true;
           window.document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
           fixture.detectChanges();
-          expect(searchBox.focus).toHaveBeenCalled();
+          expect(searchBox?.focus).toHaveBeenCalled();
         });
       });
 
@@ -827,7 +841,7 @@ describe('AppComponent', () => {
           fixture.detectChanges();
 
           const searchResultsComponent = fixture.debugElement.query(By.directive(SearchResultsComponent));
-          searchResultsComponent.triggerEventHandler('resultSelected', {});
+          searchResultsComponent?.triggerEventHandler('resultSelected', {});
           fixture.detectChanges();
           expect(component.showSearchResults).toBe(false);
         });
@@ -836,7 +850,7 @@ describe('AppComponent', () => {
           const searchService = TestBed.inject(SearchService) as Partial<SearchService> as MockSearchService;
           component.showSearchResults = false;
           const searchBox = fixture.debugElement.query(By.directive(SearchBoxComponent));
-          searchBox.triggerEventHandler('onFocus', 'some query');
+          searchBox?.triggerEventHandler('onFocus', 'some query');
           expect(searchService.search).toHaveBeenCalledWith('some query');
         });
 
@@ -844,7 +858,7 @@ describe('AppComponent', () => {
           const searchService = TestBed.inject(SearchService) as Partial<SearchService> as MockSearchService;
           component.showSearchResults = true;
           const searchBox = fixture.debugElement.query(By.directive(SearchBoxComponent));
-          searchBox.triggerEventHandler('onFocus', 'some query');
+          searchBox?.triggerEventHandler('onFocus', 'some query');
           expect(searchService.search).not.toHaveBeenCalled();
         });
       });
@@ -910,7 +924,7 @@ describe('AppComponent', () => {
     const getDocViewer = () => fixture.debugElement.query(By.css('aio-doc-viewer'));
     const triggerDocViewerEvent =
         (evt: 'docReady' | 'docRemoved' | 'docInserted' | 'docRendered') =>
-          getDocViewer().triggerEventHandler(evt, undefined);
+          getDocViewer()?.triggerEventHandler(evt, undefined);
 
     beforeEach(() => {
       createTestingModule('a/b');
@@ -957,25 +971,25 @@ describe('AppComponent', () => {
       it('should initially add the `no-animations` class until a document is rendered', () => {
         initializeTest(false);
         jasmine.clock().tick(1);  // triggers the HTTP response for the document
-        const sidenavContainer = fixture.debugElement.query(By.css('mat-sidenav-container')).nativeElement;
+        const sidenavContainer = fixture.debugElement.query(By.css('mat-sidenav-container'))?.nativeElement;
 
         expect(component.disableAnimations).toBe(true);
         expect(hamburger.classList.contains('no-animations')).toBe(true);
-        expect(sidenavContainer.classList.contains('no-animations')).toBe(true);
+        expect(sidenavContainer?.classList.contains('no-animations')).toBe(true);
 
         triggerDocViewerEvent('docInserted');
         jasmine.clock().tick(startedDelay);
         fixture.detectChanges();
         expect(component.disableAnimations).toBe(true);
         expect(hamburger.classList.contains('no-animations')).toBe(true);
-        expect(sidenavContainer.classList.contains('no-animations')).toBe(true);
+        expect(sidenavContainer?.classList.contains('no-animations')).toBe(true);
 
         triggerDocViewerEvent('docRendered');
         jasmine.clock().tick(startedDelay);
         fixture.detectChanges();
         expect(component.disableAnimations).toBe(false);
         expect(hamburger.classList.contains('no-animations')).toBe(false);
-        expect(sidenavContainer.classList.contains('no-animations')).toBe(false);
+        expect(sidenavContainer?.classList.contains('no-animations')).toBe(false);
       });
 
       it('should initially disable animations on the DocViewer for the first rendering', () => {
@@ -1010,23 +1024,23 @@ describe('AppComponent', () => {
 
         // Initially, `isTransitioning` is true.
         expect(component.isTransitioning).toBe(true);
-        expect(toolbar.classes.transitioning).toBe(true);
+        expect(toolbar?.classes.transitioning).toBe(true);
 
         triggerDocViewerEvent('docRendered');
         fixture.detectChanges();
         expect(component.isTransitioning).toBe(false);
-        expect(toolbar.classes.transitioning).toBeFalsy();
+        expect(toolbar?.classes.transitioning).toBeFalsy();
 
         // While a document is being rendered, `isTransitioning` is set to true.
         triggerDocViewerEvent('docReady');
         fixture.detectChanges();
         expect(component.isTransitioning).toBe(true);
-        expect(toolbar.classes.transitioning).toBe(true);
+        expect(toolbar?.classes.transitioning).toBe(true);
 
         triggerDocViewerEvent('docRendered');
         fixture.detectChanges();
         expect(component.isTransitioning).toBe(false);
-        expect(toolbar.classes.transitioning).toBeFalsy();
+        expect(toolbar?.classes.transitioning).toBeFalsy();
       });
 
       it('should update the sidenav state as soon as a new document is inserted (but not before)', () => {
@@ -1111,15 +1125,15 @@ describe('AppComponent', () => {
 
         navigateTo('guide/pipes');
         expect(component.pageId).toEqual('guide-pipes');
-        expect(container.properties.id).toEqual('guide-pipes');
+        expect(container?.properties.id).toEqual('guide-pipes');
 
         navigateTo('news');
         expect(component.pageId).toEqual('news');
-        expect(container.properties.id).toEqual('news');
+        expect(container?.properties.id).toEqual('news');
 
         navigateTo('');
         expect(component.pageId).toEqual('home');
-        expect(container.properties.id).toEqual('home');
+        expect(container?.properties.id).toEqual('home');
       });
 
       it('should not be affected by changes to the query', () => {
@@ -1130,7 +1144,7 @@ describe('AppComponent', () => {
         navigateTo('guide/other?search=http');
 
         expect(component.pageId).toEqual('guide-other');
-        expect(container.properties.id).toEqual('guide-other');
+        expect(container?.properties.id).toEqual('guide-other');
       });
     });
 

--- a/aio/src/app/custom-elements/live-example/live-example.component.spec.ts
+++ b/aio/src/app/custom-elements/live-example/live-example.component.spec.ts
@@ -215,7 +215,7 @@ describe('LiveExampleComponent', () => {
       testPath = '/tutorial/tour-of-heroes/toh-pt1';
       setHostTemplate('<live-example embedded></live-example>');
       testComponent(() => {
-        expect(getDownloadAnchor().href).toContain('/toh-pt1/toh-pt1.zip');
+        expect(getDownloadAnchor()?.href).toContain('/toh-pt1/toh-pt1.zip');
       });
     });
 

--- a/aio/src/app/custom-elements/search/file-not-found-search.component.spec.ts
+++ b/aio/src/app/custom-elements/search/file-not-found-search.component.spec.ts
@@ -43,8 +43,8 @@ describe('FileNotFoundSearchComponent', () => {
   });
 
   it('should pass through any results to the `aio-search-results` component', () => {
-    const searchResultsComponent = fixture.debugElement.query(By.directive(SearchResultsComponent)).componentInstance;
-    expect(searchResultsComponent.searchResults).toBe(null);
+    const searchResultsComponent = fixture.debugElement.query(By.directive(SearchResultsComponent))?.componentInstance;
+    expect(searchResultsComponent?.searchResults).toBe(null);
 
     const results = { query: 'base initial url', results: []};
     searchResultSubject.next(results);

--- a/aio/src/app/custom-elements/toc/toc.component.spec.ts
+++ b/aio/src/app/custom-elements/toc/toc.component.spec.ts
@@ -14,10 +14,10 @@ describe('TocComponent', () => {
 
   let page: {
     listItems: DebugElement[];
-    tocHeading: DebugElement;
-    tocHeadingButtonEmbedded: DebugElement;
-    tocH1Heading: DebugElement;
-    tocMoreButton: DebugElement;
+    tocHeading: DebugElement|null;
+    tocHeadingButtonEmbedded: DebugElement|null;
+    tocH1Heading: DebugElement|null;
+    tocMoreButton: DebugElement|null;
   };
 
   function setPage(): typeof page {
@@ -176,7 +176,7 @@ describe('TocComponent', () => {
         describe('after click tocHeading button', () => {
 
           beforeEach(() => {
-            page.tocHeadingButtonEmbedded.nativeElement.click();
+            page.tocHeadingButtonEmbedded?.nativeElement.click();
             fixture.detectChanges();
           });
 
@@ -193,13 +193,13 @@ describe('TocComponent', () => {
           });
 
           it('should be "collapsed" after clicking again', () => {
-            page.tocHeadingButtonEmbedded.nativeElement.click();
+            page.tocHeadingButtonEmbedded?.nativeElement.click();
             fixture.detectChanges();
             expect(tocComponent.isCollapsed).toEqual(true);
           });
 
           it('should not scroll after clicking again', () => {
-            page.tocHeadingButtonEmbedded.nativeElement.click();
+            page.tocHeadingButtonEmbedded?.nativeElement.click();
             fixture.detectChanges();
             expect(scrollToTopSpy).not.toHaveBeenCalled();
           });
@@ -208,7 +208,7 @@ describe('TocComponent', () => {
         describe('after click tocMore button', () => {
 
           beforeEach(() => {
-            page.tocMoreButton.nativeElement.click();
+            page.tocMoreButton?.nativeElement.click();
             fixture.detectChanges();
           });
 
@@ -225,19 +225,19 @@ describe('TocComponent', () => {
           });
 
           it('should be "collapsed" after clicking again', () => {
-            page.tocMoreButton.nativeElement.click();
+            page.tocMoreButton?.nativeElement.click();
             fixture.detectChanges();
             expect(tocComponent.isCollapsed).toEqual(true);
           });
 
           it('should be "collapsed" after clicking tocHeadingButton', () => {
-            page.tocMoreButton.nativeElement.click();
+            page.tocMoreButton?.nativeElement.click();
             fixture.detectChanges();
             expect(tocComponent.isCollapsed).toEqual(true);
           });
 
           it('should scroll after clicking again', () => {
-            page.tocMoreButton.nativeElement.click();
+            page.tocMoreButton?.nativeElement.click();
             fixture.detectChanges();
             expect(scrollToTopSpy).toHaveBeenCalled();
           });

--- a/aio/src/app/layout/notification/notification.component.spec.ts
+++ b/aio/src/app/layout/notification/notification.component.spec.ts
@@ -25,6 +25,10 @@ describe('NotificationComponent', () => {
   function createComponent() {
     fixture = TestBed.createComponent(TestComponent);
     const debugElement = fixture.debugElement.query(By.directive(NotificationComponent));
+    if(!debugElement) {
+      throw new Error('No NotificationComponent found');
+    }
+
     component = debugElement.componentInstance;
     component.ngOnInit();
     fixture.detectChanges();
@@ -41,7 +45,7 @@ describe('NotificationComponent', () => {
       configTestingModule();
       createComponent();
       const button = fixture.debugElement.query(By.css('.action-button'));
-      expect(button.nativeElement.textContent).toEqual('Learn More');
+      expect(button?.nativeElement.textContent).toEqual('Learn More');
     });
 
     it('should process Angular directives', () => {
@@ -57,8 +61,8 @@ describe('NotificationComponent', () => {
     createComponent();
     spyOn(component, 'dismiss');
     component.dismissOnContentClick = true;
-    const message: HTMLSpanElement = fixture.debugElement.query(By.css('.messageholder')).nativeElement;
-    message.click();
+    const message: HTMLSpanElement = fixture.debugElement.query(By.css('.messageholder'))?.nativeElement;
+    message?.click();
     expect(component.dismiss).toHaveBeenCalled();
   });
 
@@ -67,8 +71,8 @@ describe('NotificationComponent', () => {
     createComponent();
     spyOn(component, 'dismiss');
     component.dismissOnContentClick = false;
-    const message: HTMLSpanElement = fixture.debugElement.query(By.css('.messageholder')).nativeElement;
-    message.click();
+    const message: HTMLSpanElement = fixture.debugElement.query(By.css('.messageholder'))?.nativeElement;
+    message?.click();
     expect(component.dismiss).not.toHaveBeenCalled();
   });
 
@@ -76,7 +80,7 @@ describe('NotificationComponent', () => {
     configTestingModule();
     createComponent();
     spyOn(component, 'dismiss');
-    fixture.debugElement.query(By.css('button')).triggerEventHandler('click', null);
+    fixture.debugElement.query(By.css('button'))?.triggerEventHandler('click', null);
     fixture.detectChanges();
     expect(component.dismiss).toHaveBeenCalled();
   });

--- a/aio/src/app/search/search-box/search-box.component.spec.ts
+++ b/aio/src/app/search/search-box/search-box.component.spec.ts
@@ -30,7 +30,11 @@ describe('SearchBoxComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HostComponent);
     host = fixture.componentInstance;
-    component = fixture.debugElement.query(By.directive(SearchBoxComponent)).componentInstance;
+    component = fixture.debugElement.query(By.directive(SearchBoxComponent))?.componentInstance;
+    if(!component) {
+      throw new Error('No SearchBoxComponent found');
+    }
+
     fixture.detectChanges();
   });
 
@@ -66,7 +70,9 @@ describe('SearchBoxComponent', () => {
 
     it('should pass through the value of the input box', fakeAsync(() => {
       const input = fixture.debugElement.query(By.css('input'));
-      input.nativeElement.value = 'some query (input)';
+      if(input) {
+        input.nativeElement.value = 'some query (input)';
+      }
       component.doSearch();
       tick(300);
       expect(host.searchHandler).toHaveBeenCalledWith('some query (input)');
@@ -74,8 +80,9 @@ describe('SearchBoxComponent', () => {
 
     it('should only send events if the search value has changed', fakeAsync(() => {
       const input = fixture.debugElement.query(By.css('input'));
-
+      if(input) {
       input.nativeElement.value = 'some query';
+      }
       component.doSearch();
       tick(300);
       expect(host.searchHandler).toHaveBeenCalledTimes(1);
@@ -84,7 +91,9 @@ describe('SearchBoxComponent', () => {
       tick(300);
       expect(host.searchHandler).toHaveBeenCalledTimes(1);
 
-      input.nativeElement.value = 'some other query';
+      if(input) {
+        input.nativeElement.value = 'some other query';
+      }
       component.doSearch();
       tick(300);
       expect(host.searchHandler).toHaveBeenCalledTimes(2);
@@ -95,7 +104,7 @@ describe('SearchBoxComponent', () => {
     it('should trigger a search', () => {
       const input = fixture.debugElement.query(By.css('input'));
       spyOn(component, 'doSearch');
-      input.triggerEventHandler('input', { });
+      input?.triggerEventHandler('input', { });
       expect(component.doSearch).toHaveBeenCalled();
     });
   });
@@ -104,7 +113,7 @@ describe('SearchBoxComponent', () => {
     it('should trigger a search', () => {
       const input = fixture.debugElement.query(By.css('input'));
       spyOn(component, 'doSearch');
-      input.triggerEventHandler('keyup', { });
+      input?.triggerEventHandler('keyup', { });
       expect(component.doSearch).toHaveBeenCalled();
     });
   });
@@ -112,8 +121,10 @@ describe('SearchBoxComponent', () => {
   describe('on focus', () => {
     it('should trigger the onFocus event', () => {
       const input = fixture.debugElement.query(By.css('input'));
-      input.nativeElement.value = 'some query (focus)';
-      input.triggerEventHandler('focus', { });
+      if(input) {
+        input.nativeElement.value = 'some query (focus)';
+        input.triggerEventHandler('focus', { });
+      }
       expect(host.focusHandler).toHaveBeenCalledWith('some query (focus)');
     });
   });
@@ -122,7 +133,7 @@ describe('SearchBoxComponent', () => {
     it('should trigger a search', () => {
       const input = fixture.debugElement.query(By.css('input'));
       spyOn(component, 'doSearch');
-      input.triggerEventHandler('click', { });
+      input?.triggerEventHandler('click', { });
       expect(component.doSearch).toHaveBeenCalled();
     });
   });
@@ -131,7 +142,7 @@ describe('SearchBoxComponent', () => {
     it('should set the focus to the input box', () => {
       const input = fixture.debugElement.query(By.css('input'));
       component.focus();
-      expect(document.activeElement).toBe(input.nativeElement);
+      expect(document.activeElement).toBe(input?.nativeElement);
     });
   });
 });

--- a/aio/src/app/shared/search-results/search-results.component.spec.ts
+++ b/aio/src/app/shared/search-results/search-results.component.spec.ts
@@ -301,7 +301,7 @@ describe('SearchResultsComponent', () => {
   describe('when a search result anchor is clicked', () => {
     let searchResult: SearchResult;
     let selected: SearchResult|null;
-    let anchor: DebugElement;
+    let anchor: DebugElement|null;
 
     beforeEach(() => {
       component.resultSelected.subscribe((result: SearchResult) => selected = result);
@@ -325,25 +325,25 @@ describe('SearchResultsComponent', () => {
     });
 
     it('should emit a "resultSelected" event', () => {
-      anchor.triggerEventHandler('click', {button: 0, ctrlKey: false, metaKey: false});
+      anchor?.triggerEventHandler('click', {button: 0, ctrlKey: false, metaKey: false});
       fixture.detectChanges();
       expect(selected).toBe(searchResult);
     });
 
     it('should not emit an event if mouse button is not zero (middle or right)', () => {
-      anchor.triggerEventHandler('click', {button: 1, ctrlKey: false, metaKey: false});
+      anchor?.triggerEventHandler('click', {button: 1, ctrlKey: false, metaKey: false});
       fixture.detectChanges();
       expect(selected).toBeNull();
     });
 
     it('should not emit an event if the `ctrl` key is pressed', () => {
-      anchor.triggerEventHandler('click', {button: 0, ctrlKey: true, metaKey: false});
+      anchor?.triggerEventHandler('click', {button: 0, ctrlKey: true, metaKey: false});
       fixture.detectChanges();
       expect(selected).toBeNull();
     });
 
     it('should not emit an event if the `meta` key is pressed', () => {
-      anchor.triggerEventHandler('click', {button: 0, ctrlKey: false, metaKey: true});
+      anchor?.triggerEventHandler('click', {button: 0, ctrlKey: false, metaKey: true});
       fixture.detectChanges();
       expect(selected).toBeNull();
     });

--- a/aio/src/app/shared/select/select.component.spec.ts
+++ b/aio/src/app/shared/select/select.component.spec.ts
@@ -25,7 +25,11 @@ describe('SelectComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HostComponent);
     host = fixture.componentInstance;
-    element = fixture.debugElement.query(By.directive(SelectComponent));
+    const _element = fixture.debugElement.query(By.directive(SelectComponent));
+    if(_element === null) {
+      throw new Error('No SelectComponent found');
+    }
+    element = _element;
     component = element.componentInstance;
   });
 
@@ -38,10 +42,10 @@ describe('SelectComponent', () => {
 
   describe('button', () => {
     it('should display the label if provided', () => {
-      expect(getButton().textContent?.trim()).toEqual('');
+      expect(getButton()?.textContent?.trim()).toEqual('');
       host.label = 'Label:';
       fixture.detectChanges();
-      expect(getButton().textContent?.trim()).toEqual('Label:');
+      expect(getButton()?.textContent?.trim()).toEqual('Label:');
     });
 
     it('should contain a symbol if hasSymbol is true', () => {
@@ -55,16 +59,16 @@ describe('SelectComponent', () => {
       host.showSymbol = true;
       host.selected = options[0];
       fixture.detectChanges();
-      expect(getButton().textContent).toContain(options[0].title);
+      expect(getButton()?.textContent).toContain(options[0].title);
       expect(getButtonSymbol()?.className).toContain(options[0].value);
     });
 
     it('should toggle the visibility of the options list when clicked', () => {
       host.options = options;
-      getButton().click();
+      getButton()?.click();
       fixture.detectChanges();
       expect(getOptionContainer()).not.toEqual(null);
-      getButton().click();
+      getButton()?.click();
       fixture.detectChanges();
       expect(getOptionContainer()).toEqual(null);
     });
@@ -73,12 +77,12 @@ describe('SelectComponent', () => {
       host.options = options;
       fixture.detectChanges();
       expect(component.disabled).toBeFalsy();
-      expect(getButton().classList).not.toContain('disabled');
+      expect(getButton()?.classList).not.toContain('disabled');
 
       host.disabled = true;
       fixture.detectChanges();
       expect(component.disabled).toBeTruthy();
-      expect(getButton().classList).toContain('disabled');
+      expect(getButton()?.classList).toContain('disabled');
     });
 
     it('should not toggle the visibility of the options list if disabled', () => {
@@ -86,7 +90,7 @@ describe('SelectComponent', () => {
       host.disabled = true;
 
       fixture.detectChanges();
-      getButton().click();
+      getButton()?.click();
       fixture.detectChanges();
       expect(getOptionContainer()).toEqual(null);
     });
@@ -96,7 +100,7 @@ describe('SelectComponent', () => {
     beforeEach(() => {
       host.options = options;
       host.showSymbol = true;
-      getButton().click(); // ensure the options are visible
+      getButton()?.click(); // ensure the options are visible
       fixture.detectChanges();
     });
 
@@ -110,7 +114,7 @@ describe('SelectComponent', () => {
       getOptions()[0].click();
       fixture.detectChanges();
       expect(host.onChange).toHaveBeenCalledWith({ option: options[0], index: 0 });
-      expect(getButton().textContent).toContain(options[0].title);
+      expect(getButton()?.textContent).toContain(options[0].title);
       expect(getButtonSymbol()?.className).toContain(options[0].value);
     });
 
@@ -135,7 +139,7 @@ describe('SelectComponent', () => {
 
     const pressKey = (key: string) => {
       const debugBtnElement = fixture.debugElement.query(By.css('.form-select-button'));
-      debugBtnElement.triggerEventHandler('keydown', { bubbles: true, cancelable: true, key, preventDefault(){} });
+      debugBtnElement?.triggerEventHandler('keydown', { bubbles: true, cancelable: true, key, preventDefault(){} });
       fixture.detectChanges();
     };
 
@@ -165,11 +169,11 @@ describe('SelectComponent', () => {
         host.showSymbol = true;
         host.options = options;
         openOptions();
-        expect(getButton().textContent).not.toContain(options[0].title);
+        expect(getButton()?.textContent).not.toContain(options[0].title);
         expect(getButtonSymbol()?.className).not.toContain(options[0].value);
         pressKey(key);
         expect(host.onChange).toHaveBeenCalledWith({ option: options[0], index: 0 });
-        expect(getButton().textContent).toContain(options[0].title);
+        expect(getButton()?.textContent).toContain(options[0].title);
         expect(getButtonSymbol()?.className).toContain(options[0].value);
       })
     );
@@ -180,7 +184,7 @@ describe('SelectComponent', () => {
       openOptions();
       pressKey('ArrowDown');
       expect(component.currentOptionIdx).toEqual(2);
-      expect(getCurrentOption().textContent).toEqual('Option C');
+      expect(getCurrentOption()?.textContent).toEqual('Option C');
     });
 
     it('should move to the previous option when the ArrowUp key is pressed', () => {
@@ -189,7 +193,7 @@ describe('SelectComponent', () => {
       openOptions();
       pressKey('ArrowUp');
       expect(component.currentOptionIdx).toEqual(0);
-      expect(getCurrentOption().textContent).toEqual('Option A');
+      expect(getCurrentOption()?.textContent).toEqual('Option A');
     });
 
     it('should do nothing when the ArrowDown key is pressed and the current option is the last', () => {
@@ -198,7 +202,7 @@ describe('SelectComponent', () => {
       openOptions();
       pressKey('ArrowDown');
       expect(component.currentOptionIdx).toEqual(2);
-      expect(getCurrentOption().textContent).toEqual('Option C');
+      expect(getCurrentOption()?.textContent).toEqual('Option C');
       expect(getOptionContainer()).toBeTruthy();
     });
 
@@ -208,7 +212,7 @@ describe('SelectComponent', () => {
       openOptions();
       pressKey('ArrowUp');
       expect(component.currentOptionIdx).toEqual(0);
-      expect(getCurrentOption().textContent).toEqual('Option A');
+      expect(getCurrentOption()?.textContent).toEqual('Option A');
       expect(getOptionContainer()).toBeTruthy();
     });
   });
@@ -235,12 +239,12 @@ class HostComponent {
   disabled = false;
 }
 
-function getButton(): HTMLButtonElement {
-  return element.query(By.css('.form-select-button')).nativeElement;
+function getButton(): HTMLButtonElement|undefined {
+  return element.query(By.css('.form-select-button'))?.nativeElement;
 }
 
 function getButtonSymbol(): HTMLElement | null {
-  return getButton().querySelector('.symbol');
+  return getButton()?.querySelector('.symbol') ?? null;
 }
 
 function getOptionContainer(): HTMLUListElement|null {
@@ -252,6 +256,6 @@ function getOptions(): HTMLLIElement[] {
   return element.queryAll(By.css('li')).map(de => de.nativeElement);
 }
 
-function getCurrentOption(): HTMLElement {
-  return element.query(By.css('[role=option].current')).nativeElement;
+function getCurrentOption(): HTMLElement|undefined {
+  return element.query(By.css('[role=option].current'))?.nativeElement;
 }

--- a/aio/src/app/shared/theme-picker/theme-toggle.component.spec.ts
+++ b/aio/src/app/shared/theme-picker/theme-toggle.component.spec.ts
@@ -31,7 +31,7 @@ describe('ThemeToggleComponent', () => {
 
   it('should toggle between light and dark mode', () => {
     expect(component.getThemeName()).toBe('light');
-    getToggleButton().click();
+    getToggleButton()?.click();
     expect(component.getThemeName()).toBe('dark');
   });
 
@@ -73,7 +73,7 @@ describe('ThemeToggleComponent', () => {
   });
 
   // Helpers
-  function getToggleButton(): HTMLButtonElement {
-    return fixture.debugElement.query(By.css('button')).nativeElement;
+  function getToggleButton(): HTMLButtonElement|undefined {
+    return fixture.debugElement.query(By.css('button'))?.nativeElement;
   }
 });

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -421,7 +421,7 @@ export class DebugElement extends DebugNode {
         [key: string]: any;
     };
     // (undocumented)
-    query(predicate: Predicate<DebugElement>): DebugElement;
+    query(predicate: Predicate<DebugElement>): DebugElement | null;
     // (undocumented)
     queryAll(predicate: Predicate<DebugElement>): DebugElement[];
     // (undocumented)

--- a/integration/cli-elements-universal/src/app/app.component.spec.ts
+++ b/integration/cli-elements-universal/src/app/app.component.spec.ts
@@ -29,6 +29,10 @@ describe('AppComponent', () => {
   it('should pass the app title to the `TitleComponent`', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const titleDebugElement = fixture.debugElement.query(By.directive(TestTitleComponent));
+    if(!titleDebugElement) {
+      throw new Error('No TestTitleComponent found')
+    }
+
     const titleComp: TestTitleComponent = titleDebugElement.componentInstance;
 
     fixture.detectChanges();

--- a/packages/compiler/test/i18n/integration_common.ts
+++ b/packages/compiler/test/i18n/integration_common.ts
@@ -58,35 +58,35 @@ export function validateHtml(
 
   cmp.count = 0;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('zero');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('zero');
+  expect(el.query(By.css('#i18n-7'))!.nativeElement).toHaveText('zero');
+  expect(el.query(By.css('#i18n-14'))!.nativeElement).toHaveText('zero');
   cmp.count = 1;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('un');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('un');
-  expect(el.query(By.css('#i18n-17')).nativeElement).toHaveText('un');
+  expect(el.query(By.css('#i18n-7'))!.nativeElement).toHaveText('un');
+  expect(el.query(By.css('#i18n-14'))!.nativeElement).toHaveText('un');
+  expect(el.query(By.css('#i18n-17'))!.nativeElement).toHaveText('un');
   cmp.count = 2;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('deux');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('deux');
-  expect(el.query(By.css('#i18n-17')).nativeElement).toHaveText('deux');
+  expect(el.query(By.css('#i18n-7'))!.nativeElement).toHaveText('deux');
+  expect(el.query(By.css('#i18n-14'))!.nativeElement).toHaveText('deux');
+  expect(el.query(By.css('#i18n-17'))!.nativeElement).toHaveText('deux');
   cmp.count = 3;
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-7')).nativeElement).toHaveText('beaucoup');
-  expect(el.query(By.css('#i18n-14')).nativeElement).toHaveText('beaucoup');
-  expect(el.query(By.css('#i18n-17')).nativeElement).toHaveText('beaucoup');
+  expect(el.query(By.css('#i18n-7'))!.nativeElement).toHaveText('beaucoup');
+  expect(el.query(By.css('#i18n-14'))!.nativeElement).toHaveText('beaucoup');
+  expect(el.query(By.css('#i18n-17'))!.nativeElement).toHaveText('beaucoup');
 
   cmp.sex = 'male';
   cmp.sexB = 'female';
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('homme');
-  expect(el.query(By.css('#i18n-8b')).nativeElement).toHaveText('femme');
+  expect(el.query(By.css('#i18n-8'))!.nativeElement).toHaveText('homme');
+  expect(el.query(By.css('#i18n-8b'))!.nativeElement).toHaveText('femme');
   cmp.sex = 'female';
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('femme');
+  expect(el.query(By.css('#i18n-8'))!.nativeElement).toHaveText('femme');
   cmp.sex = '0';
   tb.detectChanges();
-  expect(el.query(By.css('#i18n-8')).nativeElement).toHaveText('autre');
+  expect(el.query(By.css('#i18n-8'))!.nativeElement).toHaveText('autre');
 
   cmp.count = 123;
   tb.detectChanges();
@@ -115,7 +115,7 @@ export function validateHtml(
 }
 
 function expectHtml(el: DebugElement, cssSelector: string): any {
-  return expect(stringifyElement(el.query(By.css(cssSelector)).nativeElement));
+  return expect(stringifyElement(el.query(By.css(cssSelector))!.nativeElement));
 }
 
 export const HTML = `

--- a/packages/compiler/test/integration_spec.ts
+++ b/packages/compiler/test/integration_spec.ts
@@ -32,7 +32,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
            const template = `<div [dot.name]="'foo'"></div>`;
            fixture = createTestComponent(template);
            fixture.detectChanges();
-           const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+           const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
            expect(myDir.value).toEqual('foo');
          }));
     });

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -18,6 +18,7 @@ pkg_npm(
     visibility = ["//packages/core:__pkg__"],
     deps = [
         "//packages/core/schematics/migrations/block-template-entities:bundle",
+        "//packages/core/schematics/migrations/debug-element-query:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration:bundle",
     ],
 )

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -4,6 +4,11 @@
       "version": "17.0.0",
       "description": "Angular v17 introduces a new control flow syntax that uses the @ and } characters. This migration replaces the existing usages with their corresponding HTML entities.",
       "factory": "./migrations/block-template-entities/bundle"
+    },
+    "migration-debugElement-query": {
+      "description": "As of Angular v18, the type of `DebugElement.query` can return null. This migration automatically identifies usages and adds non-null assertions.",
+      "factory": "./migrations/debug-element-query/bundle",
+      "version": "18.0.0"
     }
   }
 }

--- a/packages/core/schematics/migrations/debug-element-query/BUILD.bazel
+++ b/packages/core/schematics/migrations/debug-element-query/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//tools:defaults.bzl", "esbuild", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "debug-element-query",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    entry_point = ":index.ts",
+    external = [
+        "@angular-devkit/*",
+        "typescript",
+    ],
+    format = "cjs",
+    platform = "node",
+    deps = [":debug-element-query"],
+)

--- a/packages/core/schematics/migrations/debug-element-query/README.md
+++ b/packages/core/schematics/migrations/debug-element-query/README.md
@@ -1,0 +1,19 @@
+
+## DebugElement query migration
+
+As of Angular v16, the type of `DebugElement.query` can return null. 
+This migration automatically identifies usages and adds non-null assertions.
+
+#### Before
+
+```ts
+    const input = fixture.debugElement.query(By.css('input'));
+    expect(input.nativeElement.value).toEqual('value');
+```
+
+#### After
+
+```ts
+    const input = fixture.debugElement.query(By.css('input'));
+    expect(input!.nativeElement.value).toEqual('value');  // <- Non-null assertion added during the migration.
+```

--- a/packages/core/schematics/migrations/debug-element-query/index.ts
+++ b/packages/core/schematics/migrations/debug-element-query/index.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {relative} from 'path';
+import ts from 'typescript';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {createMigrationProgram} from '../../utils/typescript/compiler_host';
+
+import {migrateFile} from './util';
+
+/** Migration that marks accesses of `DebugElement.query` as potentially null. */
+export default function(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot migrate DebugElement.query accesses.');
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runNativeDebugElementQueryAtMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+function runNativeDebugElementQueryAtMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const program = createMigrationProgram(tree, tsconfigPath, basePath);
+  const typeChecker = program.getTypeChecker();
+  const sourceFiles = program.getSourceFiles().filter(
+      (f) => !f.isDeclarationFile && !program.isSourceFileFromExternalLibrary(f));
+
+  const updateFn =
+      (sourceFile: ts.SourceFile, start: number, length: number, content: string,
+       basePath?: string) => {
+        const update = tree.beginUpdate(relative(basePath!, sourceFile.fileName));
+        update.insertRight(start + length, content);
+        tree.commitUpdate(update);
+      };
+
+  sourceFiles.forEach((sourceFile) => migrateFile(sourceFile, basePath, typeChecker, updateFn));
+}

--- a/packages/core/schematics/migrations/debug-element-query/util.ts
+++ b/packages/core/schematics/migrations/debug-element-query/util.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {getImportSpecifier} from '../../utils/typescript/imports';
+import {isNullableType, isReferenceToImport} from '../../utils/typescript/symbol';
+
+type UpdateFn =
+    (sourceFile: ts.SourceFile, start: number, length: number, content: string,
+     basePath?: string) => void;
+
+export function migrateFile(
+    sourceFile: ts.SourceFile, basePath: string, typeChecker: ts.TypeChecker, updateFn: UpdateFn) {
+  // We sort the nodes based on their position in the file and we offset the positions by one
+  // for each non-null assertion that we've added. We have to do it this way, rather than
+  // creating and printing a new AST node like in other migrations, because property access
+  // expressions can be nested (e.g. `control.parent.parent.value`), but the node positions
+  // aren't being updated as we're inserting new code. If we were to go through the AST,
+  // we'd have to update the `SourceFile` and start over after each operation.
+  findAtCalls(typeChecker, sourceFile)
+      .sort((a, b) => a.getStart() - b.getStart())
+      .forEach(
+          (node, index) =>
+              updateFn(sourceFile, node.getStart(), node.getWidth() + index, '!', basePath));
+}
+
+/**
+ * Finds the `PropertyAccessExpression`-s that are accessing the `parent` property in
+ * such a way that may result in a compilation error after the v11 type changes.
+ */
+export function findAtCalls(typeChecker: ts.TypeChecker, sourceFile: ts.SourceFile): ts.Node[] {
+  const results: ts.Node[] = [];
+
+  sourceFile.forEachChild(function walk(node: ts.Node) {
+    const parent = node.parent;
+    if (ts.isPropertyAccessExpression(node) && node.name.text === 'query' &&
+        ts.isCallExpression(node.parent) && !isNullCheck(node) && !isSafeAccess(node.parent) &&
+        results.indexOf(node) === -1 && isDebugElementReference(sourceFile, typeChecker, node) &&
+        isNullableType(typeChecker, node)) {
+      const lastToken = node.parent.expression.getLastToken();
+      if (lastToken) {
+        results.unshift(parent);
+      }
+    }
+    node.forEachChild(walk);
+  });
+
+  return results;
+}
+
+/**
+ * Checks whether a particular node is part of a null check. E.g. given:
+ * `control.parent ? control.parent.value : null` the null check would be `control.parent`.
+ */
+function isNullCheck(node: ts.Node): boolean {
+  if (!node.parent) {
+    return false;
+  }
+
+  // `control.parent && control.parent.value` where `node` is `control.parent`.
+  if (ts.isBinaryExpression(node.parent) && node.parent.left === node) {
+    return true;
+  }
+
+  // `control.parent && control.parent.parent && control.parent.parent.value`
+  // where `node` is `control.parent`.
+  if (node.parent.parent && ts.isBinaryExpression(node.parent.parent) &&
+      node.parent.parent.left === node.parent) {
+    return true;
+  }
+
+  // `if (control.parent) {...}` where `node` is `control.parent`.
+  if (ts.isIfStatement(node.parent) && node.parent.expression === node) {
+    return true;
+  }
+
+  // `control.parent ? control.parent.value : null` where `node` is `control.parent`.
+  if (ts.isConditionalExpression(node.parent) && node.parent.condition === node) {
+    return true;
+  }
+
+  return false;
+}
+
+/** Checks whether a property access is safe (e.g. `foo.parent?.value`). */
+function isSafeAccess(node: ts.Node): boolean {
+  return (
+      node.parent != null && ts.isPropertyAccessExpression(node.parent) &&
+      node.parent.expression === node && node.parent.questionDotToken != null);
+}
+
+/** Checks whether a property access is on an `DebugElement` coming from `@angular/core`. */
+function isDebugElementReference(
+    sourceFile: ts.SourceFile, typeChecker: ts.TypeChecker,
+    node: ts.PropertyAccessExpression): boolean {
+  let current: ts.Expression = node;
+  const debugElementImport = getImportSpecifier(sourceFile, '@angular/core', 'DebugElement');
+
+  while (ts.isPropertyAccessExpression(current)) {
+    const symbol = typeChecker.getTypeAtLocation(current.expression)?.getSymbol();
+
+    if (symbol && debugElementImport) {
+      return isReferenceToImport(typeChecker, current.expression, debugElementImport);
+    }
+
+    current = current.expression;
+  }
+  return false;
+}

--- a/packages/core/schematics/migrations/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/google3/BUILD.bazel
@@ -5,6 +5,7 @@ ts_library(
     srcs = glob(["**/*.ts"]),
     tsconfig = "//packages/core/schematics:tsconfig.json",
     deps = [
+        "//packages/core/schematics/migrations/debug-element-query",
         "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tslint",
         "@npm//tslint",
@@ -21,9 +22,19 @@ esbuild(
     deps = [":google3"],
 )
 
+esbuild(
+    name = "debug_element_query_cjs",
+    entry_point = ":debugElementQuery.ts",
+    format = "cjs",
+    output = "debugElementQueryCjsRule.js",
+    platform = "node",
+    deps = [":google3"],
+)
+
 filegroup(
     name = "google3_cjs",
     srcs = [
+        ":debug_element_query_cjs",
         ":wait_for_async_rule_cjs",
     ],
     visibility = ["//packages/core/schematics/test/google3:__pkg__"],

--- a/packages/core/schematics/migrations/google3/debugElementQuery.ts
+++ b/packages/core/schematics/migrations/google3/debugElementQuery.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Replacement, RuleFailure, Rules} from 'tslint';
+import ts from 'typescript';
+
+import {migrateFile} from '../debug-element-query/util';
+
+/** TSLint rule for Typed Forms migration. */
+export class Rule extends Rules.TypedRule {
+  override applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[] {
+    const typeChecker = program.getTypeChecker();
+
+    const failures: RuleFailure[] = [];
+
+    const rewriter =
+        (sourceFile: ts.SourceFile, startPos: number, origLength: number, text: string) => {
+          const failure = new RuleFailure(
+              sourceFile, startPos, startPos + origLength,
+              `DebugElement.query can return null so it need to be accessed safely`, this.ruleName,
+              new Replacement(startPos, origLength, text));
+          failures.push(failure);
+        };
+
+    migrateFile(sourceFile, '', typeChecker, rewriter);
+
+    return failures;
+  }
+}

--- a/packages/core/schematics/test/debug-element-query_spec.ts
+++ b/packages/core/schematics/test/debug-element-query_spec.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('DebugElement.query migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {lib: ['es2015'], strictNullChecks: true},
+    }));
+    writeFile('/angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('/node_modules/@angular/core/index.d.ts', `
+       export declare class DebugElement {
+          query(predicate: Predicate<DebugElement>): DebugElement|null {
+       }
+     `);
+
+    // Fake non-Angular package to make sure that we don't migrate packages we don't own.
+    writeFile('/node_modules/@not-angular/core/index.d.ts', `
+       export declare class DebugElement {
+          query(predicate: Predicate<DebugElement>): DebugElement|null {
+       }
+     `);
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  it('should add non-null assertions to accesses of DebugElement.query', async () => {
+    writeFile('/index.ts', `
+       import {DebugElement} from '@angular/core';
+       class App {
+         private _debugElement: DebugElement;
+         getElement(selector: string) {
+           return this._debugElement.query(By.css(selector)).nativeElement;
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`this._debugElement.query(By.css(selector))!.nativeElement`);
+  });
+
+  it('should not add non-null assertions to accesses of DebugElement.query', async () => {
+    writeFile('/index.ts', `
+       import {DebugElement} from '@angular/core';
+       class App {
+         private _debugElement: DebugElement;
+         getElement(selector: string) {
+            return this._debugElement.query(By.css(selector))?.nativeElement;
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`return this._debugElement.query(By.css(selector))?.nativeElement;`);
+  });
+
+  it('should add non-null assertions to accesses of DebugElement.query', async () => {
+    writeFile('/index.ts', `
+       import {DebugElement} from '@angular/core';
+       class App {
+         getElement(selector: string) {
+            return this._getElement().query(By.css(selector)).nativeElement;
+         }
+         private _getElement() {
+           return new DebugElement();
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`return this._getElement().query(By.css(selector))!.nativeElement;`);
+  });
+
+  it('should add non-null assertions to accesses of DebugElement.query', async () => {
+    writeFile('/index.ts', `
+       import {DebugElement} from '@angular/core';
+       class App {
+         getElement(selector: string) {
+           const element = (window.foo as DebugElement).query(selector);
+           return element.nativeElement;
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`const element = (window.foo as DebugElement).query(selector)!;`);
+  });
+
+  it('should not add non-null assertions if the symbol does not come from @angular/core',
+     async () => {
+       writeFile('/index.ts', `
+        import {DebugElement} from '@not-angular/core';
+        getElement(selector: string) {
+          return new DebugElement().query(By.css(selector)).nativeElement;
+        }
+      `);
+
+       await runMigration();
+       expect(tree.readContent('/index.ts'))
+           .toContain(`return new DebugElement().query(By.css(selector)).nativeElement;`);
+     });
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('migration-debugElement-query', {}, tree);
+  }
+});

--- a/packages/core/schematics/test/google3/debug-element-query_spec.ts
+++ b/packages/core/schematics/test/google3/debug-element-query_spec.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {runfiles} from '@bazel/runfiles';
+import {writeFileSync} from 'fs';
+import {dirname, join} from 'path';
+import shx from 'shelljs';
+import {Configuration, Linter} from 'tslint';
+
+describe('Google3 DebugElement at access migration', () => {
+  const rulesDirectory = dirname(
+      runfiles.resolvePackageRelative('../../migrations/google3/debugElementQueryCjsRule.js'));
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(process.env['TEST_TMPDIR']!, 'google3-test');
+    shx.mkdir('-p', tmpDir);
+
+    writeFile('/angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {architect: {build: {options: {tsConfig: './tsconfig.json'}}}}},
+    }));
+
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('testing.d.ts', `export declare class DebugElement {
+      query(predicate: Predicate<DebugElement>): DebugElement|null {
+   }`);
+
+    writeFile('tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        strictNullChecks: true,
+        module: 'es2015',
+        baseUrl: './',
+        paths: {
+          '@angular/core': ['testing.d.ts'],
+        },
+      },
+    }));
+  });
+
+  afterEach(() => shx.rm('-r', tmpDir));
+
+  const testFileLinting = (fileContent: string, numOfFailures: number) => {
+    writeFile('/index.ts', fileContent);
+    const linter = runTSLint(false);
+    const failures = linter.getResult().failures.map((failure) => failure.getFailure());
+
+    expect(failures.length).toBe(numOfFailures);
+    failures.forEach(
+        (failure) => expect(failure).toMatch(
+            /DebugElement.query can return null so it need to be accessed safely/));
+  };
+
+  it('should add ! to accesses to a DebugElement\'s query() return', () => {
+    const fileContent = `
+    import { DebugElement } from '@angular/core';
+       export class Foo implements OnInit {
+        debugElement = new DebugElement()
+         ngOnInit() {
+           console.log(this.debugElement.query(By.css('select')).value);
+         }
+       }
+     `;
+    const expectedFailures = 1;
+    testFileLinting(fileContent, expectedFailures);
+  });
+
+  function writeFile(fileName: string, content: string) {
+    writeFileSync(join(tmpDir, fileName), content);
+  }
+
+
+  function runTSLint(fix: boolean) {
+    const program = Linter.createProgram(join(tmpDir, 'tsconfig.json'));
+    const linter = new Linter({fix, rulesDirectory: [rulesDirectory]}, program);
+    const config = Configuration.parseConfigFile({rules: {'debugElementQueryCjs': true}});
+
+    program.getRootFileNames().forEach((fileName) => {
+      linter.lint(fileName, program.getSourceFile(fileName)!.getFullText(), config);
+    });
+
+    return linter;
+  }
+});

--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -302,7 +302,7 @@ export class DebugElement extends DebugNode {
   /**
    * @returns the first `DebugElement` that matches the predicate at any depth in the subtree.
    */
-  query(predicate: Predicate<DebugElement>): DebugElement {
+  query(predicate: Predicate<DebugElement>): DebugElement|null {
     const results = this.queryAll(predicate);
     return results[0] || null;
   }

--- a/packages/core/test/acceptance/attributes_spec.ts
+++ b/packages/core/test/acceptance/attributes_spec.ts
@@ -21,7 +21,7 @@ describe('attribute creation', () => {
     TestBed.configureTestingModule({declarations: [Comp]});
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
-    const div = fixture.debugElement.query(By.css('div')).nativeElement;
+    const div = fixture.debugElement.query(By.css('div'))!.nativeElement;
     expect(div.id).toEqual('test');
     expect(div.title).toEqual('Hello');
   });
@@ -38,7 +38,7 @@ describe('attribute creation', () => {
     fixture.detectChanges();
 
 
-    const div = fixture.debugElement.query(By.css('div')).nativeElement;
+    const div = fixture.debugElement.query(By.css('div'))!.nativeElement;
     const attrs = div.attributes;
 
     expect(attrs['id'].name).toEqual('id');
@@ -68,7 +68,7 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const a = fixture.debugElement.query(By.css('a')).nativeElement;
+    const a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     // NOTE: different browsers will add `//` into the URI.
     expect(a.href).toEqual('https://angular.io/robots.txt');
   });
@@ -86,7 +86,7 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const a = fixture.debugElement.query(By.css('a')).nativeElement;
+    const a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     // NOTE: different browsers will add `//` into the URI.
     expect(a.getAttribute('href')).toBe('https://angular.io/robots.txt');
     expect(a.getAttribute('id')).toBe('my-link');
@@ -106,7 +106,7 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const a = fixture.debugElement.query(By.css('a')).nativeElement;
+    const a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     // NOTE: different browsers will add `//` into the URI.
     expect(a.getAttribute('href')).toBe('https://angular.io/robots.txt');
     expect(a.id).toBe('my-link');
@@ -130,7 +130,7 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const button = fixture.debugElement.query(By.css('button')).nativeElement;
+    const button = fixture.debugElement.query(By.css('button'))!.nativeElement;
 
     expect(button.getAttribute('id')).toBe('my-custom-button');
     expect(button.getAttribute('tabindex')).toBe('11');
@@ -159,8 +159,8 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const button = fixture.debugElement.query(By.css('button')).nativeElement;
-    const span = fixture.debugElement.query(By.css('span')).nativeElement;
+    const button = fixture.debugElement.query(By.css('button'))!.nativeElement;
+    const span = fixture.debugElement.query(By.css('span'))!.nativeElement;
 
     expect(button.getAttribute('id')).toBe('my-custom-button');
     expect(button.getAttribute('tabindex')).toBe('11');
@@ -183,7 +183,7 @@ describe('attribute binding', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    const a = fixture.debugElement.query(By.css('a')).nativeElement;
+    const a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     // NOTE: different browsers will add `//` into the URI.
     expect(a.href.indexOf('unsafe:')).toBe(0);
 

--- a/packages/core/test/acceptance/content_spec.ts
+++ b/packages/core/test/acceptance/content_spec.ts
@@ -247,7 +247,7 @@ describe('projection', () => {
     TestBed.configureTestingModule({declarations: [Parent, Child], imports: [CommonModule]});
 
     const fixture = TestBed.createComponent(Parent);
-    const childDebugEl = fixture.debugElement.query(By.directive(Child));
+    const childDebugEl = fixture.debugElement.query(By.directive(Child))!;
     const childInstance = childDebugEl.injector.get(Child);
     const childElement = childDebugEl.nativeElement as HTMLElement;
 
@@ -296,7 +296,7 @@ describe('projection', () => {
     TestBed.configureTestingModule({declarations: [Parent, Child], imports: [CommonModule]});
 
     const fixture = TestBed.createComponent(Parent);
-    const childDebugEl = fixture.debugElement.query(By.directive(Child));
+    const childDebugEl = fixture.debugElement.query(By.directive(Child))!;
     const childInstance = childDebugEl.injector.get(Child);
 
     childInstance.showing = true;
@@ -348,7 +348,7 @@ describe('projection', () => {
        TestBed.configureTestingModule({declarations: [Parent, Trigger, Comp]});
 
        const fixture = TestBed.createComponent(Parent);
-       const trigger = fixture.debugElement.query(By.directive(Trigger)).injector.get(Trigger);
+       const trigger = fixture.debugElement.query(By.directive(Trigger))!.injector.get(Trigger);
        fixture.detectChanges();
 
        expect(getElementHtml(fixture.nativeElement)).toBe(`<button></button><comp></comp>`);
@@ -1090,7 +1090,7 @@ describe('projection', () => {
     const fixture = TestBed.createComponent(Root);
     fixture.detectChanges();
 
-    const projectedElement = fixture.debugElement.query(By.css('div'));
+    const projectedElement = fixture.debugElement.query(By.css('div'))!;
     const {ngProjectAs, title} = projectedElement.attributes;
     expect(ngProjectAs).toBe('projectMe');
     expect(title).toBe('some title');

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -1196,7 +1196,7 @@ describe('di', () => {
             fixture.detectChanges();
 
             const childComponent =
-                fixture.debugElement.query(By.directive(ChildComponent)).componentInstance;
+                fixture.debugElement.query(By.directive(ChildComponent))!.componentInstance;
             expect(childComponent.injector.get('token')).toBe('CHILD');
             expect(childComponent.parentInjector.get('token')).toBe('PARENT');
           });
@@ -2345,7 +2345,7 @@ describe('di', () => {
           fixture.detectChanges();
 
           const childComponent =
-              fixture.debugElement.query(By.directive(ChildComponent)).componentInstance;
+              fixture.debugElement.query(By.directive(ChildComponent))!.componentInstance;
           expect(childComponent.tokenViaInjector).toBe('PARENT');
           expect(childComponent.tokenViaConstructor).toBe(childComponent.tokenViaInjector);
         });

--- a/packages/core/test/acceptance/directive_spec.ts
+++ b/packages/core/test/acceptance/directive_spec.ts
@@ -47,7 +47,7 @@ describe('directives', () => {
       TestBed.overrideTemplate(TestComponent, `<span class="fade" [test]="false"></span>`);
 
       const fixture = TestBed.createComponent(TestComponent);
-      const testDir = fixture.debugElement.query(By.directive(TestDir)).injector.get(TestDir);
+      const testDir = fixture.debugElement.query(By.directive(TestDir))!.injector.get(TestDir);
       const spanEl = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -84,7 +84,7 @@ describe('directives', () => {
              `<span class="fade" [prop1]="true" [test]="false" [prop2]="true"></span>`);
 
          const fixture = TestBed.createComponent(TestComponent);
-         const testDir = fixture.debugElement.query(By.directive(TestDir)).injector.get(TestDir);
+         const testDir = fixture.debugElement.query(By.directive(TestDir))!.injector.get(TestDir);
          const spanEl = fixture.nativeElement.children[0];
          fixture.detectChanges();
 
@@ -140,7 +140,7 @@ describe('directives', () => {
           {declarations: [MyComponent, DirectiveA], imports: [CommonModule]});
       const fixture = TestBed.createComponent(MyComponent);
       fixture.detectChanges();
-      const directiveA = fixture.debugElement.query(By.css('span')).injector.get(DirectiveA);
+      const directiveA = fixture.debugElement.query(By.css('span'))!.injector.get(DirectiveA);
 
       expect(directiveA.viewContainerRef).toBeTruthy();
     });
@@ -230,7 +230,7 @@ describe('directives', () => {
       // "out" should not be part of reflected attributes
       expect(spanEl.hasAttribute('out')).toBe(false);
       expect(spanEl.getAttribute('class')).toBe('span');
-      expect(fixture.debugElement.query(By.directive(TestDir))).toBeTruthy();
+      expect(fixture.debugElement.query(By.directive(TestDir))!).toBeTruthy();
     });
 
     it('should not match directives based on attribute bindings', () => {
@@ -833,7 +833,7 @@ describe('directives', () => {
 
       TestBed.configureTestingModule({declarations: [TestComp, TestDir]});
       const fixture = TestBed.createComponent(TestComp);
-      const testDir = fixture.debugElement.query(By.css('span')).injector.get(TestDir);
+      const testDir = fixture.debugElement.query(By.css('span'))!.injector.get(TestDir);
 
       expect(fixture.componentInstance.value).toBe(false);
 
@@ -867,7 +867,7 @@ describe('directives', () => {
       fixture.detectChanges();
 
       const dirWithTitle =
-          fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+          fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
       const div = fixture.nativeElement.querySelector('div');
       expect(dirWithTitle.title).toBe('a');
       expect(div.getAttribute('title')).toBe('a');
@@ -887,7 +887,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          // We are checking the property here, not the attribute, because in the case of
          // [key]="value" we are always setting the property of the instance, and actually setting
@@ -910,7 +910,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('attr.title')).toBe('test');
@@ -932,7 +932,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('title')).toBe('b');
@@ -954,7 +954,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('title')).toBe('b');
@@ -974,7 +974,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('attr.title')).toBe('test');
@@ -997,7 +997,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('title')).toBe('b');
@@ -1019,7 +1019,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.getAttribute('title')).toBe('b');
@@ -1039,7 +1039,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('a');
          expect(div.title).toBe('');
@@ -1059,7 +1059,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('');
          expect(div.getAttribute('title')).toBe('a');
@@ -1079,7 +1079,7 @@ describe('directives', () => {
          fixture.detectChanges();
 
          const dirWithTitle =
-             fixture.debugElement.query(By.directive(DirWithTitle)).injector.get(DirWithTitle);
+             fixture.debugElement.query(By.directive(DirWithTitle))!.injector.get(DirWithTitle);
          const div = fixture.nativeElement.querySelector('div');
          expect(dirWithTitle.title).toBe('');
          expect(div.getAttribute('title')).toBe('a');

--- a/packages/core/test/acceptance/host_binding_spec.ts
+++ b/packages/core/test/acceptance/host_binding_spec.ts
@@ -189,7 +189,7 @@ describe('host bindings', () => {
       });
       const fixture = TestBed.createComponent(Comp);
       fixture.detectChanges();
-      const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir));
+      const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir))!;
       expect(queryResult.nativeElement.style.color).toBe('red');
     });
 
@@ -228,7 +228,7 @@ describe('host bindings', () => {
          });
          const fixture = TestBed.createComponent(App);
          fixture.detectChanges();
-         const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir));
+         const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir))!;
          expect(queryResult.nativeElement.style.color).toBe('green');
        });
 
@@ -277,7 +277,7 @@ describe('host bindings', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const queryResult = fixture.debugElement.query(By.directive(Comp));
+      const queryResult = fixture.debugElement.query(By.directive(Comp))!;
       expect(queryResult.nativeElement.style.color).toBe('red');
     });
 
@@ -345,7 +345,7 @@ describe('host bindings', () => {
       const fixture = TestBed.createComponent(Comp);
       fixture.detectChanges();
       await fixture.whenStable();  // wait for animations to complete
-      const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir));
+      const queryResult = fixture.debugElement.query(By.directive(AnimationPropDir))!;
       expect(queryResult.nativeElement.style.color).toBe('yellow');
       expect(events).toEqual(['@myAnimation.start', '@myAnimation.done']);
     });
@@ -422,7 +422,7 @@ describe('host bindings', () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
       await fixture.whenStable();  // wait for animations to complete
-      const queryResult = fixture.debugElement.query(By.directive(Comp));
+      const queryResult = fixture.debugElement.query(By.directive(Comp))!;
       expect(queryResult.nativeElement.style.color).toBe('yellow');
       expect(events).toEqual(['@myAnimation.start', '@myAnimation.done']);
     });

--- a/packages/core/test/acceptance/host_directives_spec.ts
+++ b/packages/core/test/acceptance/host_directives_spec.ts
@@ -2236,7 +2236,7 @@ describe('host directives', () => {
          TestBed.configureTestingModule({declarations: [App, Comp]});
          const fixture = TestBed.createComponent(App);
          fixture.detectChanges();
-         const node = fixture.debugElement.query(By.css('comp'));
+         const node = fixture.debugElement.query(By.css('comp'))!;
 
          expect(compInstance instanceof Comp).toBe(true);
          expect(node.componentInstance).toBe(compInstance);
@@ -2265,7 +2265,7 @@ describe('host directives', () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
       const expected = fixture.componentInstance.compInstance.elementRef.nativeElement;
-      const result = fixture.debugElement.query(By.directive(HostDir)).nativeElement;
+      const result = fixture.debugElement.query(By.directive(HostDir))!.nativeElement;
 
       expect(result).toBe(expected);
     });

--- a/packages/core/test/acceptance/i18n_spec.ts
+++ b/packages/core/test/acceptance/i18n_spec.ts
@@ -541,7 +541,7 @@ describe('runtime i18n', () => {
       const fixture = TestBed.createComponent(Cmp);
       fixture.detectChanges();
 
-      const a = fixture.debugElement.query(By.css('a'));
+      const a = fixture.debugElement.query(By.css('a'))!;
       const dir = a.injector.get(Dir);
       expect(dir.condition).toEqual(true);
     });

--- a/packages/core/test/acceptance/inherit_definition_feature_spec.ts
+++ b/packages/core/test/acceptance/inherit_definition_feature_spec.ts
@@ -701,7 +701,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir =
-            fixture.debugElement.query(By.directive(SubDirective)).injector.get(SubDirective);
+            fixture.debugElement.query(By.directive(SubDirective))!.injector.get(SubDirective);
 
         expect(subDir.foo).toBe('a');
         expect(subDir.bar).toBe('b');
@@ -783,7 +783,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(SubDirective));
+        const queryResult = fixture.debugElement.query(By.directive(SubDirective))!;
 
         expect(queryResult.nativeElement.tagName).toBe('P');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -822,7 +822,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(SubDirective));
+        const queryResult = fixture.debugElement.query(By.directive(SubDirective))!;
 
         expect(queryResult.nativeElement.title).toBe('test!!!');
       });
@@ -1259,7 +1259,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir =
-            fixture.debugElement.query(By.directive(SubDirective)).injector.get(SubDirective);
+            fixture.debugElement.query(By.directive(SubDirective))!.injector.get(SubDirective);
 
         expect(subDir.foo).toBe('a');
         expect(subDir.bar).toBe('b');
@@ -1347,7 +1347,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(SubDirective));
+        const queryResult = fixture.debugElement.query(By.directive(SubDirective))!;
 
         expect(queryResult.nativeElement.tagName).toBe('P');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -1389,7 +1389,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(SubDirective));
+        const queryResult = fixture.debugElement.query(By.directive(SubDirective))!;
 
         expect(queryResult.nativeElement.title).toBe('test!!!');
       });
@@ -1831,7 +1831,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir =
-            fixture.debugElement.query(By.directive(SubDirective)).injector.get(SubDirective);
+            fixture.debugElement.query(By.directive(SubDirective))!.injector.get(SubDirective);
 
         expect(subDir.foo).toBe('a');
         expect(subDir.bar).toBe('b');
@@ -1933,7 +1933,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(SubDirective));
+        const queryResult = fixture.debugElement.query(By.directive(SubDirective))!;
 
         expect(queryResult.nativeElement.tagName).toBe('P');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -1985,7 +1985,7 @@ describe('inheritance', () => {
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
         const p: HTMLParagraphElement =
-            fixture.debugElement.query(By.directive(SubDirective)).nativeElement;
+            fixture.debugElement.query(By.directive(SubDirective))!.nativeElement;
 
         expect(p.title).toBe('test1!!!');
         expect(p.accessKey).toBe('test2???');
@@ -2430,7 +2430,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir: MyComponent =
-            fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+            fixture.debugElement.query(By.directive(MyComponent))!.componentInstance;
 
         expect(subDir.foo).toEqual('a');
         expect(subDir.bar).toEqual('b');
@@ -2514,7 +2514,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -2554,7 +2554,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.title).toBe('test!!!');
       });
@@ -2988,7 +2988,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir: MyComponent =
-            fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+            fixture.debugElement.query(By.directive(MyComponent))!.componentInstance;
 
         expect(subDir.foo).toEqual('a');
         expect(subDir.bar).toEqual('b');
@@ -3078,7 +3078,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -3121,7 +3121,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.title).toBe('test!!!');
       });
@@ -3607,7 +3607,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir: MyComponent =
-            fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+            fixture.debugElement.query(By.directive(MyComponent))!.componentInstance;
 
         expect(subDir.foo).toEqual('a');
         expect(subDir.bar).toEqual('b');
@@ -3701,7 +3701,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -3753,7 +3753,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.title).toBe('test1!!!');
         expect(queryResult.nativeElement.accessKey).toBe('test2???');
@@ -4249,7 +4249,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const subDir: MyComponent =
-            fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+            fixture.debugElement.query(By.directive(MyComponent))!.componentInstance;
 
         expect(subDir.foo).toEqual('a');
         expect(subDir.bar).toEqual('b');
@@ -4342,7 +4342,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.css('my-comp'));
+        const queryResult = fixture.debugElement.query(By.css('my-comp'))!;
 
         expect(queryResult.nativeElement.style.color).toBe('red');
       });
@@ -4390,7 +4390,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.css('my-comp'));
+        const queryResult = fixture.debugElement.query(By.css('my-comp'))!;
 
         expect(queryResult.nativeElement.style.color).toBe('blue');
         expect(queryResult.nativeElement.style.opacity).toBe('0.5');
@@ -4432,7 +4432,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -4476,7 +4476,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.title).toBe('test!!!');
       });
@@ -4641,7 +4641,7 @@ describe('inheritance', () => {
       fixture.detectChanges();
 
       components.forEach(component => {
-        fixture.debugElement.query(By.directive(component)).nativeElement.click();
+        fixture.debugElement.query(By.directive(component))!.nativeElement.click();
       });
       expect(events).toEqual(
           ['BaseComponent.clicked', 'ChildComponent.clicked', 'GrandChildComponent.clicked']);
@@ -5046,7 +5046,7 @@ describe('inheritance', () => {
         fixture.detectChanges();
 
         const myComp: MyComponent =
-            fixture.debugElement.query(By.directive(MyComponent)).componentInstance;
+            fixture.debugElement.query(By.directive(MyComponent))!.componentInstance;
 
         expect(myComp.foo).toEqual('a');
         expect(myComp.bar).toEqual('b');
@@ -5172,7 +5172,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.css('my-comp'));
+        const queryResult = fixture.debugElement.query(By.css('my-comp'))!;
 
         expect(queryResult.nativeElement.style.color).toBe('blue');
         expect(queryResult.nativeElement.style.opacity).toBe('0.5');
@@ -5215,7 +5215,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.style.color).toBe('red');
@@ -5268,7 +5268,7 @@ describe('inheritance', () => {
         });
         const fixture = TestBed.createComponent(App);
         fixture.detectChanges();
-        const queryResult = fixture.debugElement.query(By.directive(MyComponent));
+        const queryResult = fixture.debugElement.query(By.directive(MyComponent))!;
 
         expect(queryResult.nativeElement.tagName).toBe('MY-COMP');
         expect(queryResult.nativeElement.title).toBe('test1!!!');

--- a/packages/core/test/acceptance/integration_spec.ts
+++ b/packages/core/test/acceptance/integration_spec.ts
@@ -1583,7 +1583,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [MyApp, ButtonSuperClass, ButtonSubClass]});
     const fixture = TestBed.createComponent(MyApp);
-    const button = fixture.debugElement.query(By.directive(ButtonSubClass));
+    const button = fixture.debugElement.query(By.directive(ButtonSubClass))!;
     fixture.detectChanges();
 
     button.nativeElement.click();
@@ -1612,7 +1612,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [MyApp, SuperComp, SubComp, SomeDir]});
     const fixture = TestBed.createComponent(MyApp);
-    const subInstance = fixture.debugElement.query(By.directive(SubComp)).componentInstance;
+    const subInstance = fixture.debugElement.query(By.directive(SubComp))!.componentInstance;
     fixture.detectChanges();
 
     expect(subInstance.dirs.length).toBe(1);
@@ -1690,7 +1690,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [MyApp, ButtonSubClass]});
     const fixture = TestBed.createComponent(MyApp);
-    const button = fixture.debugElement.query(By.directive(ButtonSubClass)).componentInstance;
+    const button = fixture.debugElement.query(By.directive(ButtonSubClass))!.componentInstance;
     fixture.detectChanges();
 
     expect(button.isDisabled).toBe(false);
@@ -1724,7 +1724,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [MyApp, ButtonSubClass]});
     const fixture = TestBed.createComponent(MyApp);
-    const button = fixture.debugElement.query(By.directive(ButtonSubClass)).componentInstance;
+    const button = fixture.debugElement.query(By.directive(ButtonSubClass))!.componentInstance;
 
     button.emitClick();
     fixture.detectChanges();
@@ -1747,7 +1747,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [SubButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton));
+    const button = fixture.debugElement.query(By.directive(SubButton))!;
     fixture.detectChanges();
 
     expect(button.nativeElement.getAttribute('tabindex')).toBe('-1');
@@ -1775,7 +1775,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [SubButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton));
+    const button = fixture.debugElement.query(By.directive(SubButton))!;
     fixture.detectChanges();
 
     expect(button.nativeElement.getAttribute('tabindex')).toBe('-1');
@@ -1806,7 +1806,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [SubButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton)).nativeElement;
+    const button = fixture.debugElement.query(By.directive(SubButton))!.nativeElement;
 
     button.click();
     fixture.detectChanges();
@@ -1835,7 +1835,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [SubButton, BaseButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton)).nativeElement;
+    const button = fixture.debugElement.query(By.directive(SubButton))!.nativeElement;
 
     button.click();
     fixture.detectChanges();
@@ -1868,7 +1868,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [SubButton, SuperBaseButton, BaseButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton)).nativeElement;
+    const button = fixture.debugElement.query(By.directive(SubButton))!.nativeElement;
 
     button.click();
     fixture.detectChanges();
@@ -1906,7 +1906,7 @@ describe('acceptance integration tests', () => {
     TestBed.configureTestingModule(
         {declarations: [SubButton, SuperBaseButton, SuperSuperBaseButton, BaseButton, App]});
     const fixture = TestBed.createComponent(App);
-    const button = fixture.debugElement.query(By.directive(SubButton)).nativeElement;
+    const button = fixture.debugElement.query(By.directive(SubButton))!.nativeElement;
 
     button.click();
     fixture.detectChanges();
@@ -2242,7 +2242,7 @@ describe('acceptance integration tests', () => {
 
     TestBed.configureTestingModule({declarations: [App, Child, GrandChild]});
     const fixture = TestBed.createComponent(App);
-    const grandChild = fixture.debugElement.query(By.directive(GrandChild)).componentInstance;
+    const grandChild = fixture.debugElement.query(By.directive(GrandChild))!.componentInstance;
     fixture.detectChanges();
     const leafLView = readPatchedLView(grandChild)!;
     const lViewIds: number[] = [];

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -1574,7 +1574,7 @@ describe('onInit', () => {
     fixture.componentInstance.createDynamicView();
     fixture.detectChanges();
 
-    const myComp = fixture.debugElement.query(By.directive(MyComp)).componentInstance;
+    const myComp = fixture.debugElement.query(By.directive(MyComp))!.componentInstance;
     expect(myComp.onInitCalled).toBe(true);
   });
 

--- a/packages/core/test/acceptance/listener_spec.ts
+++ b/packages/core/test/acceptance/listener_spec.ts
@@ -144,7 +144,7 @@ describe('event listeners', () => {
           <ng-template #template>
             <button (click)="this['mes' + 'sage'] = 'hello'">Click me</button>
           </ng-template>
-  
+
           <ng-container [ngTemplateOutlet]="template"></ng-container>
         `
          })
@@ -168,7 +168,7 @@ describe('event listeners', () => {
           <ng-template let-obj #template>
             <button (click)="obj.value = obj.value + '!'">Change</button>
           </ng-template>
-  
+
           <ng-container *ngTemplateOutlet="template; context: {$implicit: current}"></ng-container>
         `
       })
@@ -383,7 +383,7 @@ describe('event listeners', () => {
       const noOfEventListenersRegisteredSoFar = getNoOfNativeListeners();
       const fixture = TestBed.createComponent(TestCmpt);
       fixture.detectChanges();
-      const buttonDebugEl = fixture.debugElement.query(By.css('button'));
+      const buttonDebugEl = fixture.debugElement.query(By.css('button'))!;
 
       // We want to assert that only one native event handler was registered but still all
       // directives are notified when an event fires. This assertion can only be verified in
@@ -424,7 +424,7 @@ describe('event listeners', () => {
       });
       const fixture = TestBed.createComponent(TestCmpt);
       fixture.detectChanges();
-      const buttonDebugEl = fixture.debugElement.query(By.css('button'));
+      const buttonDebugEl = fixture.debugElement.query(By.css('button'))!;
 
       expect(buttonDebugEl.injector.get(LikesClicks).counter).toBe(0);
 
@@ -447,7 +447,7 @@ describe('event listeners', () => {
       const fixture = TestBed.createComponent(TestCmpt);
       fixture.detectChanges();
 
-      const buttonDebugEl = fixture.debugElement.query(By.css('button'));
+      const buttonDebugEl = fixture.debugElement.query(By.css('button'))!;
       const likesClicksDir = buttonDebugEl.injector.get(LikesClicks);
       const returnsFalseDir = buttonDebugEl.injector.get(ReturnsFalse);
       expect(likesClicksDir.counter).toBe(0);
@@ -825,7 +825,7 @@ describe('event listeners', () => {
               <ng-template #template add-global-listener>
                 <button>Click me!</button>
               </ng-template>
-  
+
               <ng-container [ngTemplateOutlet]="template"></ng-container>
             `
       })

--- a/packages/core/test/acceptance/property_binding_spec.ts
+++ b/packages/core/test/acceptance/property_binding_spec.ts
@@ -41,7 +41,7 @@ describe('property bindings', () => {
     TestBed.configureTestingModule({declarations: [Comp]});
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
-    let a = fixture.debugElement.query(By.css('a')).nativeElement;
+    let a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     expect(a.title).toBe('Hello');
 
     fixture.componentInstance.title = 'World';
@@ -60,7 +60,7 @@ describe('property bindings', () => {
     TestBed.configureTestingModule({declarations: [Comp]});
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
-    let a = fixture.debugElement.query(By.css('a')).nativeElement;
+    let a = fixture.debugElement.query(By.css('a'))!.nativeElement;
     expect(a.title).toBe('Hello');
 
     fixture.detectChanges();
@@ -75,7 +75,7 @@ describe('property bindings', () => {
 
     TestBed.configureTestingModule({declarations: [MyComp]});
     const fixture = TestBed.createComponent(MyComp);
-    const labelNode = fixture.debugElement.query(By.css('label'));
+    const labelNode = fixture.debugElement.query(By.css('label'))!;
 
     fixture.componentInstance.forValue = 'some-input';
     fixture.detectChanges();
@@ -103,7 +103,7 @@ describe('property bindings', () => {
 
        TestBed.configureTestingModule({declarations: [App, MyComp]});
        const fixture = TestBed.createComponent(App);
-       const myCompNode = fixture.debugElement.query(By.directive(MyComp));
+       const myCompNode = fixture.debugElement.query(By.directive(MyComp))!;
        fixture.componentInstance.forValue = 'hello';
        fixture.detectChanges();
        expect(myCompNode.nativeElement.getAttribute('for')).toBeFalsy();
@@ -152,7 +152,7 @@ describe('property bindings', () => {
     const fixture = TestBed.createComponent(Comp);
     fixture.detectChanges();
 
-    expect(fixture.debugElement.query(By.css('input')).nativeElement.required).toBe(false);
+    expect(fixture.debugElement.query(By.css('input'))!.nativeElement.required).toBe(false);
   });
 
   it('should support interpolation for properties', () => {
@@ -215,8 +215,8 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyButton, OtherDir]});
       const fixture = TestBed.createComponent(App);
-      const button = fixture.debugElement.query(By.directive(MyButton)).injector.get(MyButton);
-      const otherDir = fixture.debugElement.query(By.directive(OtherDir)).injector.get(OtherDir);
+      const button = fixture.debugElement.query(By.directive(MyButton))!.injector.get(MyButton);
+      const otherDir = fixture.debugElement.query(By.directive(OtherDir))!.injector.get(OtherDir);
       const buttonEl = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -248,7 +248,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyButton]});
       const fixture = TestBed.createComponent(App);
-      const button = fixture.debugElement.query(By.directive(MyButton)).injector.get(MyButton);
+      const button = fixture.debugElement.query(By.directive(MyButton))!.injector.get(MyButton);
       const buttonEl = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -281,7 +281,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, Comp]});
       const fixture = TestBed.createComponent(App);
-      const compDebugEl = fixture.debugElement.query(By.directive(Comp));
+      const compDebugEl = fixture.debugElement.query(By.directive(Comp))!;
       fixture.detectChanges();
 
       expect(compDebugEl.nativeElement.hasAttribute('id')).toBe(false);
@@ -303,9 +303,9 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyButton, OtherDisabledDir]});
       const fixture = TestBed.createComponent(App);
-      const button = fixture.debugElement.query(By.directive(MyButton)).injector.get(MyButton);
-      const otherDisabledDir =
-          fixture.debugElement.query(By.directive(OtherDisabledDir)).injector.get(OtherDisabledDir);
+      const button = fixture.debugElement.query(By.directive(MyButton))!.injector.get(MyButton);
+      const otherDisabledDir = fixture.debugElement.query(By.directive(
+          OtherDisabledDir))!.injector.get(OtherDisabledDir);
       const buttonEl = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -333,7 +333,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, OtherDir]});
       const fixture = TestBed.createComponent(App);
-      const otherDir = fixture.debugElement.query(By.directive(OtherDir)).injector.get(OtherDir);
+      const otherDir = fixture.debugElement.query(By.directive(OtherDir))!.injector.get(OtherDir);
       const buttonEl = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -368,7 +368,7 @@ describe('property bindings', () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
       let buttonElements = fixture.nativeElement.querySelectorAll('button');
-      const idDir = fixture.debugElement.query(By.directive(IdDir)).injector.get(IdDir);
+      const idDir = fixture.debugElement.query(By.directive(IdDir))!.injector.get(IdDir);
 
       expect(buttonElements.length).toBe(2);
       expect(buttonElements[0].hasAttribute('id')).toBe(false);
@@ -380,7 +380,7 @@ describe('property bindings', () => {
       fixture.componentInstance.id1 = 'four';
       fixture.detectChanges();
 
-      const otherDir = fixture.debugElement.query(By.directive(OtherDir)).injector.get(OtherDir);
+      const otherDir = fixture.debugElement.query(By.directive(OtherDir))!.injector.get(OtherDir);
       buttonElements = fixture.nativeElement.querySelectorAll('button');
       expect(buttonElements.length).toBe(2);
       expect(buttonElements[0].hasAttribute('id')).toBe(false);
@@ -411,7 +411,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
       const divElement = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -428,7 +428,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
       const divElement = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -447,8 +447,8 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir, MyDirB]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
-      const myDirB = fixture.debugElement.query(By.directive(MyDirB)).injector.get(MyDirB);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
+      const myDirB = fixture.debugElement.query(By.directive(MyDirB))!.injector.get(MyDirB);
       const divElement = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -466,7 +466,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
       const divElement = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -485,7 +485,7 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
       const divElement = fixture.nativeElement.children[0];
       fixture.detectChanges();
 
@@ -508,8 +508,8 @@ describe('property bindings', () => {
 
       TestBed.configureTestingModule({declarations: [App, MyDir, MyDirB]});
       const fixture = TestBed.createComponent(App);
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
-      const myDirB = fixture.debugElement.query(By.directive(MyDirB)).injector.get(MyDirB);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
+      const myDirB = fixture.debugElement.query(By.directive(MyDirB))!.injector.get(MyDirB);
       const fixtureElements = fixture.nativeElement.children;
 
       // TODO: Use destructuring once Domino supports native ES2015, or when jsdom is used.
@@ -542,8 +542,8 @@ describe('property bindings', () => {
       TestBed.configureTestingModule({declarations: [App, MyDir, MyDirB], imports: [CommonModule]});
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const myDir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
-      const myDirB = fixture.debugElement.query(By.directive(MyDirB)).injector.get(MyDirB);
+      const myDir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
+      const myDirB = fixture.debugElement.query(By.directive(MyDirB))!.injector.get(MyDirB);
       let divElements = fixture.nativeElement.querySelectorAll('div');
 
       expect(divElements.length).toBe(2);

--- a/packages/core/test/acceptance/property_interpolation_spec.ts
+++ b/packages/core/test/acceptance/property_interpolation_spec.ts
@@ -160,7 +160,7 @@ describe('property interpolation', () => {
     TestBed.configureTestingModule({declarations: [AppComp]});
     const fixture = TestBed.createComponent(AppComp);
     fixture.detectChanges();
-    const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+    const anchor = fixture.debugElement.query(By.css('a'))!.nativeElement;
     expect(anchor.getAttribute('href'))
         .toEqual(
             `http://g.com/?one=1&two=2&three=3&four=4&five=5&six=6&seven=7&eight=8&nine=9&ten=10`);

--- a/packages/core/test/acceptance/providers_spec.ts
+++ b/packages/core/test/acceptance/providers_spec.ts
@@ -47,7 +47,7 @@ describe('providers', () => {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
 
-      const otherDir = fixture.debugElement.query(By.css('div')).injector.get(OtherDirective);
+      const otherDir = fixture.debugElement.query(By.css('div'))!.injector.get(OtherDirective);
       expect(otherDir.dirs.length).toEqual(1);
       expect(otherDir.dirs[0] instanceof SubDirective).toBe(true);
     });
@@ -535,7 +535,7 @@ describe('providers', () => {
       });
 
       const fixture = TestBed.createComponent(TestComp);
-      const myCompInstance = fixture.debugElement.query(By.css('my-comp')).injector.get(MyComp);
+      const myCompInstance = fixture.debugElement.query(By.css('my-comp'))!.injector.get(MyComp);
       expect(myCompInstance.svc.value).toEqual('some value');
     });
 
@@ -551,7 +551,7 @@ describe('providers', () => {
       });
 
       const fixture = TestBed.createComponent(TestComp);
-      const myCompInstance = fixture.debugElement.query(By.css('div')).injector.get(MyDir);
+      const myCompInstance = fixture.debugElement.query(By.css('div'))!.injector.get(MyDir);
       expect(myCompInstance.svc.value).toEqual('some value');
     });
 

--- a/packages/core/test/acceptance/pure_function_spec.ts
+++ b/packages/core/test/acceptance/pure_function_spec.ts
@@ -37,7 +37,7 @@ describe('components using pure function instructions internally', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const myComp = fixture.debugElement.query(By.directive(MyComp)).componentInstance;
+      const myComp = fixture.debugElement.query(By.directive(MyComp))!.componentInstance;
 
       const firstArray = myComp.names;
       expect(firstArray).toEqual(['Nancy', 'Carson', 'Bess']);
@@ -79,7 +79,7 @@ describe('components using pure function instructions internally', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const myComp = fixture.debugElement.query(By.directive(MyComp)).componentInstance;
+      const myComp = fixture.debugElement.query(By.directive(MyComp))!.componentInstance;
       expect(myComp.names).toEqual(['Nancy', 'Carson', 'Bess']);
     });
 
@@ -111,7 +111,8 @@ describe('components using pure function instructions internally', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const manyPropComp = fixture.debugElement.query(By.directive(ManyPropComp)).componentInstance;
+      const manyPropComp =
+          fixture.debugElement.query(By.directive(ManyPropComp))!.componentInstance;
 
       expect(manyPropComp!.names1).toEqual(['Nancy', 'Carson']);
       expect(manyPropComp!.names2).toEqual(['George']);
@@ -190,7 +191,7 @@ describe('components using pure function instructions internally', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const myComp = fixture.debugElement.query(By.directive(MyComp)).componentInstance;
+      const myComp = fixture.debugElement.query(By.directive(MyComp))!.componentInstance;
 
       const firstArray = myComp.names;
       expect(firstArray).toEqual(['Nancy', 'Carson', 'Bess', 'Hannah']);
@@ -312,7 +313,7 @@ describe('components using pure function instructions internally', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const myComp = fixture.debugElement.query(By.directive(MyComp)).componentInstance;
+      const myComp = fixture.debugElement.query(By.directive(MyComp))!.componentInstance;
       const app = fixture.componentInstance;
 
       expect(myComp.names).toEqual([
@@ -358,7 +359,7 @@ describe('components using pure function instructions internally', () => {
 
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const objectComp = fixture.debugElement.query(By.directive(ObjectComp)).componentInstance;
+      const objectComp = fixture.debugElement.query(By.directive(ObjectComp))!.componentInstance;
 
       const firstObj = objectComp.config;
       expect(objectComp.config).toEqual({duration: 500, animation: 'slide'});
@@ -395,7 +396,7 @@ describe('components using pure function instructions internally', () => {
 
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const objectComp = fixture.debugElement.query(By.directive(ObjectComp)).componentInstance;
+      const objectComp = fixture.debugElement.query(By.directive(ObjectComp))!.componentInstance;
 
       expect(objectComp.config).toEqual({
         animation: 'slide',

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -385,7 +385,7 @@ describe('query logic', () => {
     it('should support selecting InjectionToken', () => {
       const fixture = TestBed.createComponent(TestInjectionTokenContentQueries);
       const instance =
-          fixture.debugElement.query(By.directive(TestInjectionTokenQueries)).componentInstance;
+          fixture.debugElement.query(By.directive(TestInjectionTokenQueries))!.componentInstance;
       fixture.detectChanges();
       expect(instance.contentFirstOption).toBeDefined();
       expect(instance.contentFirstOption instanceof TestComponentWithToken).toBe(true);
@@ -738,7 +738,7 @@ describe('query logic', () => {
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
 
-      const shallowComp = fixture.debugElement.query(By.directive(ShallowComp)).componentInstance;
+      const shallowComp = fixture.debugElement.query(By.directive(ShallowComp))!.componentInstance;
       const queryList = shallowComp!.foos;
       expect(queryList.length).toBe(0);
 
@@ -2161,10 +2161,10 @@ describe('query logic', () => {
         const fixture = TestBed.createComponent(TestComponent);
         fixture.detectChanges();
 
-        const lotsOfContentEl = fixture.debugElement.query(By.directive(QueryForLotsOfContent));
+        const lotsOfContentEl = fixture.debugElement.query(By.directive(QueryForLotsOfContent))!;
         const lotsOfContentInstance = lotsOfContentEl.injector.get(QueryForLotsOfContent);
 
-        const contentEl = fixture.debugElement.query(By.directive(QueryForContent));
+        const contentEl = fixture.debugElement.query(By.directive(QueryForContent))!;
         const contentInstance = contentEl.injector.get(QueryForContent);
 
         expect(lotsOfContentInstance.foos1.length).toBe(2);

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -1581,7 +1581,7 @@ describe('styling', () => {
       fixture.componentInstance.showing = true;
       fixture.detectChanges();
 
-      const childDir = fixture.debugElement.query(By.directive(ChildDir)).injector.get(ChildDir);
+      const childDir = fixture.debugElement.query(By.directive(ChildDir))!.injector.get(ChildDir);
       expect(childDir.parent).toBeInstanceOf(TestDir);
       expect(testDirDiv.classList).not.toContain('with-button');
       expect(fixture.debugElement.nativeElement.textContent).toContain('Hello');

--- a/packages/core/test/acceptance/view_container_ref_spec.ts
+++ b/packages/core/test/acceptance/view_container_ref_spec.ts
@@ -612,7 +612,7 @@ describe('ViewContainerRef', () => {
       TestBed.configureTestingModule({declarations: [EmbeddedViewInsertionComp, VCRefDirective]});
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(vcRefDir.vcref.length).toEqual(0);
@@ -641,7 +641,7 @@ describe('ViewContainerRef', () => {
     it('should retrieve a ViewRef from its index, and vice versa', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.createView('A');
@@ -662,7 +662,7 @@ describe('ViewContainerRef', () => {
     it('should handle out of bounds cases', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.createView('A');
@@ -700,7 +700,7 @@ describe('ViewContainerRef', () => {
       TestBed.configureTestingModule({declarations: [EmbeddedViewInsertionComp, VCRefDirective]});
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.createView('A');
@@ -818,7 +818,7 @@ describe('ViewContainerRef', () => {
     it('should detach the right embedded view when an index is specified', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       const viewA = vcRefDir.createView('A');
@@ -847,7 +847,7 @@ describe('ViewContainerRef', () => {
     it('should detach the last embedded view when no index is specified', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.createView('A');
@@ -911,7 +911,7 @@ describe('ViewContainerRef', () => {
     it('should remove the right embedded view when an index is specified', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       const viewA = vcRefDir.createView('A');
@@ -940,7 +940,7 @@ describe('ViewContainerRef', () => {
     it('should remove the last embedded view when no index is specified', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.createView('A');
@@ -961,7 +961,7 @@ describe('ViewContainerRef', () => {
     it('should throw when trying to insert a removed or destroyed view', () => {
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       const viewA = vcRefDir.createView('A');
@@ -1050,7 +1050,7 @@ describe('ViewContainerRef', () => {
 
       const fixture = TestBed.createComponent(TestComponent);
       const vcRef =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
 
       fixture.detectChanges();
       expect(getElementHtml(fixture.nativeElement))
@@ -1095,7 +1095,7 @@ describe('ViewContainerRef', () => {
           {declarations: [TestComponent, HeaderComponent, VCRefDirective]});
       const fixture = TestBed.createComponent(TestComponent);
       const vcRef =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement))
@@ -1211,7 +1211,7 @@ describe('ViewContainerRef', () => {
           {declarations: [Child, StarPipe, SomeComponent, VCRefDirective]});
       const fixture = TestBed.createComponent(SomeComponent);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       vcRefDir.vcref.createEmbeddedView(vcRefDir.tplRef!);
@@ -1245,7 +1245,7 @@ describe('ViewContainerRef', () => {
           {declarations: [EmbeddedViewInsertionComp, VCRefDirective, EmbeddedComponent]});
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual('<p vcref=""></p>');
@@ -1316,7 +1316,7 @@ describe('ViewContainerRef', () => {
 
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual('<p vcref=""></p>');
@@ -1347,7 +1347,7 @@ describe('ViewContainerRef', () => {
       });
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual('<p vcref=""></p>');
@@ -1384,7 +1384,7 @@ describe('ViewContainerRef', () => {
       });
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual('<p vcref=""></p>');
@@ -1409,7 +1409,7 @@ describe('ViewContainerRef', () => {
       });
       const fixture = TestBed.createComponent(EmbeddedViewInsertionComp);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement)).toEqual('<p vcref=""></p>');
@@ -1708,7 +1708,7 @@ describe('ViewContainerRef', () => {
 
       TestBed.configureTestingModule({declarations: [Child, Parent, InsertionDir]});
       const fixture = TestBed.createComponent(Parent);
-      const child = fixture.debugElement.query(By.directive(Child)).componentInstance;
+      const child = fixture.debugElement.query(By.directive(Child))!.componentInstance;
       fixture.detectChanges();
 
       // Context should be inherited from the declaration point, not the
@@ -2013,7 +2013,7 @@ describe('ViewContainerRef', () => {
       });
       const fixture = TestBed.createComponent(SomeComponent);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
 
       fixture.detectChanges();
       expect(log).toEqual([
@@ -2094,7 +2094,7 @@ describe('ViewContainerRef', () => {
           {declarations: [SomeComponent, VCRefDirective, ComponentWithHooks]});
       const fixture = TestBed.createComponent(SomeComponent);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
 
       fixture.detectChanges();
       expect(log).toEqual([
@@ -2222,7 +2222,7 @@ describe('ViewContainerRef', () => {
       TestBed.configureTestingModule({declarations: [Child, Parent, VCRefDirective]});
       const fixture = TestBed.createComponent(Parent);
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
       fixture.detectChanges();
 
       expect(getElementHtml(fixture.nativeElement))
@@ -2263,7 +2263,7 @@ describe('ViewContainerRef', () => {
       const fixture = TestBed.createComponent(Parent);
       fixture.detectChanges();
       const vcRefDir =
-          fixture.debugElement.query(By.directive(VCRefDirective)).injector.get(VCRefDirective);
+          fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(VCRefDirective);
 
       expect(getElementHtml(fixture.nativeElement))
           .toEqual(
@@ -2334,8 +2334,8 @@ describe('ViewContainerRef', () => {
            TestBed.configureTestingModule(
                {declarations: [Parent, ChildWithSelector, VCRefDirective]});
            const fixture = TestBed.createComponent(Parent);
-           const vcRefDir = fixture.debugElement.query(By.directive(VCRefDirective))
-                                .injector.get(VCRefDirective);
+           const vcRefDir = fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(
+               VCRefDirective);
            fixture.detectChanges();
 
            expect(getElementHtml(fixture.nativeElement))
@@ -2404,8 +2404,8 @@ describe('ViewContainerRef', () => {
            TestBed.configureTestingModule(
                {declarations: [Parent, ChildWithSelector, VCRefDirective]});
            const fixture = TestBed.createComponent(Parent);
-           const vcRefDir = fixture.debugElement.query(By.directive(VCRefDirective))
-                                .injector.get(VCRefDirective);
+           const vcRefDir = fixture.debugElement.query(By.directive(VCRefDirective))!.injector.get(
+               VCRefDirective);
            fixture.detectChanges();
 
            expect(getElementHtml(fixture.nativeElement))

--- a/packages/core/test/acceptance/view_insertion_spec.ts
+++ b/packages/core/test/acceptance/view_insertion_spec.ts
@@ -173,7 +173,7 @@ describe('view insertion', () => {
       });
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
-      const comp = fixture.debugElement.query(By.directive(Comp)).injector.get(Comp);
+      const comp = fixture.debugElement.query(By.directive(Comp))!.injector.get(Comp);
 
       expect(comp.container.indexOf(comp.view0)).toBe(0);
       expect(comp.container.indexOf(comp.view1)).toBe(1);

--- a/packages/core/test/debug/debug_node_spec.ts
+++ b/packages/core/test/debug/debug_node_spec.ts
@@ -462,7 +462,7 @@ class TestCmptWithPropInterpolation {
       const fixture = TestBed.createComponent(TestApp);
       fixture.detectChanges();
 
-      const debugElement = fixture.debugElement.query(By.directive(ExampleDirectiveA));
+      const debugElement = fixture.debugElement.query(By.directive(ExampleDirectiveA))!;
       expect(debugElement).toBeTruthy();
     });
 
@@ -611,7 +611,7 @@ class TestCmptWithPropInterpolation {
       const fixture = TestBed.createComponent(MyComponent);
       fixture.detectChanges();
 
-      expect(fixture.debugElement.query(By.css('.myclass'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('.myclass'))!).toBeTruthy();
     });
 
     it('should not throw when calling DebugRenderer2.destroyNode twice in a row', () => {
@@ -666,11 +666,11 @@ class TestCmptWithPropInterpolation {
       });
 
       it('should find the dynamic elements from fixture root', () => {
-        expect(fixture.debugElement.query(By.css('.myclass'))).toBeTruthy();
+        expect(fixture.debugElement.query(By.css('.myclass'))!).toBeTruthy();
       });
 
       it('can use a dynamic element as root for another query', () => {
-        const inner = fixture.debugElement.query(By.css('.inner'));
+        const inner = fixture.debugElement.query(By.css('.inner'))!;
         expect(inner).toBeTruthy();
         expect(inner.query(By.css('.myclass'))).toBeTruthy();
       });
@@ -741,7 +741,7 @@ class TestCmptWithPropInterpolation {
       });
 
       it('when using the out-of-context element as the DebugElement query root', () => {
-        const debugElOutsideAngularContext = el.query(By.css('ul'));
+        const debugElOutsideAngularContext = el.query(By.css('ul'))!;
         expect(debugElOutsideAngularContext.queryAll(By.css('li')).length).toBe(1);
         expect(debugElOutsideAngularContext.query(By.css('li'))).toBeDefined();
       });
@@ -847,7 +847,7 @@ class TestCmptWithPropInterpolation {
         const fixture = TestBed.createComponent(TestCmptWithPropBindings);
         fixture.detectChanges();
 
-        const button = fixture.debugElement.query(By.css('button'));
+        const button = fixture.debugElement.query(By.css('button'))!;
         expect(button.properties['disabled']).toEqual(true);
         expect(button.properties['tabIndex']).toEqual(1337);
         expect(button.properties['title']).toEqual('hello');
@@ -879,7 +879,7 @@ class TestCmptWithPropInterpolation {
         const fixture = TestBed.createComponent(TestCmptWithPropInterpolation);
         fixture.detectChanges();
 
-        const button = fixture.debugElement.query(By.css('button'));
+        const button = fixture.debugElement.query(By.css('button'))!;
         expect(button.properties['title']).not.toEqual('goes to input');
       });
 
@@ -887,7 +887,7 @@ class TestCmptWithPropInterpolation {
         TestBed.overrideTemplate(TestCmptWithRenderer, `<button></button>`);
         const fixture = TestBed.createComponent(TestCmptWithRenderer);
         fixture.detectChanges();
-        const button = fixture.debugElement.query(By.css('button'));
+        const button = fixture.debugElement.query(By.css('button'))!;
         fixture.componentInstance.renderer.setProperty(button.nativeElement, 'title', 'myTitle');
         expect(button.properties['title']).toBe('myTitle');
       });
@@ -899,7 +899,7 @@ class TestCmptWithPropInterpolation {
         fixture.detectChanges();
 
         const host = fixture.debugElement;
-        const button = fixture.debugElement.query(By.css('button'));
+        const button = fixture.debugElement.query(By.css('button'))!;
         expect(Object.keys(host.properties).filter(key => key.startsWith('__'))).toEqual([]);
         expect(Object.keys(host.properties).filter(key => key.startsWith('on'))).toEqual([]);
         expect(Object.keys(button.properties).filter(key => key.startsWith('__'))).toEqual([]);
@@ -913,7 +913,7 @@ class TestCmptWithPropInterpolation {
         fixture.detectChanges();
 
         const host = fixture.debugElement;
-        const button = fixture.debugElement.query(By.css('button'));
+        const button = fixture.debugElement.query(By.css('button'))!;
 
         expect(button.properties['title']).toEqual('myTitle');
       });
@@ -972,7 +972,7 @@ class TestCmptWithPropInterpolation {
 
       TestBed.configureTestingModule({declarations: [TestComponent]});
       const fixture = TestBed.createComponent(TestComponent);
-      const button = fixture.debugElement.query(By.css('button'));
+      const button = fixture.debugElement.query(By.css('button'))!;
 
       expect(() => {
         button.triggerEventHandler('click');
@@ -997,7 +997,7 @@ class TestCmptWithPropInterpolation {
                TestCmpt, `<parent-comp><child-comp></child-comp></parent-comp>`);
            fixture = TestBed.createComponent(TestCmpt);
 
-           const debugEl = fixture.debugElement.query(By.directive(ChildComp));
+           const debugEl = fixture.debugElement.query(By.directive(ChildComp))!;
            expect(debugEl.componentInstance).toBeInstanceOf(ChildComp);
          });
 
@@ -1021,7 +1021,7 @@ class TestCmptWithPropInterpolation {
            fixture = TestBed.createComponent(TestCmpt);
            fixture.detectChanges();
 
-           const debugEl = fixture.debugElement.query(By.directive(MyDir));
+           const debugEl = fixture.debugElement.query(By.directive(MyDir))!;
            expect(debugEl.componentInstance).toBeInstanceOf(TestCmpt);
          });
 
@@ -1050,7 +1050,7 @@ class TestCmptWithPropInterpolation {
 
            const fixture = TestBed.createComponent(TestApp);
            fixture.detectChanges();
-           const debugNode = fixture.debugElement.query(By.directive(ExampleComponent));
+           const debugNode = fixture.debugElement.query(By.directive(ExampleComponent))!;
 
            expect(debugNode.context instanceof ExampleComponent).toBe(true);
          });
@@ -1062,7 +1062,7 @@ class TestCmptWithPropInterpolation {
 
            const fixture = TestBed.createComponent(TestApp);
            fixture.detectChanges();
-           const debugNode = fixture.debugElement.query(By.css('span'));
+           const debugNode = fixture.debugElement.query(By.css('span'))!;
 
            expect(debugNode.context instanceof NgIfContext).toBe(true);
          });
@@ -1074,7 +1074,7 @@ class TestCmptWithPropInterpolation {
 
            const fixture = TestBed.createComponent(TestApp);
            fixture.detectChanges();
-           const debugNode = fixture.debugElement.query(By.directive(MyDir));
+           const debugNode = fixture.debugElement.query(By.directive(MyDir))!;
 
            expect(debugNode.context instanceof TestApp).toBe(true);
          });
@@ -1091,7 +1091,7 @@ class TestCmptWithPropInterpolation {
       // so that it can't be reached via querySelector.
       parent.appendChild(content);
 
-      expect(fixture.debugElement.query(By.css('.content'))).toBeTruthy();
+      expect(fixture.debugElement.query(By.css('.content'))!).toBeTruthy();
 
       getDOM().remove(content);
     });
@@ -1099,7 +1099,7 @@ class TestCmptWithPropInterpolation {
     it('should support components with ViewContainerRef', () => {
       fixture = TestBed.createComponent(TestCmptWithViewContainerRef);
 
-      const divEl = fixture.debugElement.query(By.css('div'));
+      const divEl = fixture.debugElement.query(By.css('div'))!;
       expect(divEl).not.toBeNull();
     });
 
@@ -1107,10 +1107,10 @@ class TestCmptWithPropInterpolation {
       TestBed.overrideTemplate(TestCmpt, `<span><div id="a"><div id="b"></div></div></span>`);
       fixture = TestBed.createComponent(TestCmpt);
 
-      const divA = fixture.debugElement.query(By.css('div'));
+      const divA = fixture.debugElement.query(By.css('div'))!;
       expect(divA.nativeElement.getAttribute('id')).toBe('a');
 
-      const divB = divA.query(By.css('div'));
+      const divB = divA.query(By.css('div'))!;
       expect(divB.nativeElement.getAttribute('id')).toBe('b');
     });
 
@@ -1164,7 +1164,7 @@ class TestCmptWithPropInterpolation {
       const fixture = TestBed.createComponent(MyComp);
       fixture.detectChanges();
 
-      const firstDiv = fixture.debugElement.query(By.css('div'));
+      const firstDiv = fixture.debugElement.query(By.css('div'))!;
       const firstDivChildren = firstDiv.queryAll(By.css('span'));
 
       expect(firstDivChildren.map(child => child.nativeNode.textContent.trim())).toEqual([
@@ -1205,7 +1205,7 @@ class TestCmptWithPropInterpolation {
       const fixture = TestBed.createComponent(Comp);
       fixture.detectChanges();
 
-      expect(fixture.debugElement.query(By.css('div')).attributes['xlink:href']).toBe('foo');
+      expect(fixture.debugElement.query(By.css('div'))!.attributes['xlink:href']).toBe('foo');
     });
 
     it('should include attributes added via Renderer2 in DebugNode.attributes', () => {
@@ -1218,7 +1218,7 @@ class TestCmptWithPropInterpolation {
 
       TestBed.configureTestingModule({declarations: [Comp]});
       const fixture = TestBed.createComponent(Comp);
-      const div = fixture.debugElement.query(By.css('div'));
+      const div = fixture.debugElement.query(By.css('div'))!;
 
       fixture.componentInstance.renderer.setAttribute(div.nativeElement, 'foo', 'bar');
 
@@ -1249,7 +1249,7 @@ class TestCmptWithPropInterpolation {
       const fixture = TestBed.createComponent(App);
       fixture.detectChanges();
 
-      const button = fixture.debugElement.query(By.directive(CancelButton));
+      const button = fixture.debugElement.query(By.directive(CancelButton))!;
       button.triggerEventHandler('cancel', {});
 
       expect(calls).toBe(1, 'Expected calls to be 1 after one event.');
@@ -1292,8 +1292,8 @@ class TestCmptWithPropInterpolation {
 
     const fixture = TestBed.configureTestingModule({declarations: [Wrapper, MyComponent]})
                         .createComponent(Wrapper);
-    expect(fixture.debugElement.query(e => e.name === 'myComponent')).toBeTruthy();
-    expect(fixture.debugElement.query(e => e.name === 'div')).toBeTruthy();
+    expect(fixture.debugElement.query(e => e.name === 'myComponent'))!.toBeTruthy();
+    expect(fixture.debugElement.query(e => e.name === 'div'))!.toBeTruthy();
   });
 
   it('does not call event listeners added outside angular context', () => {

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -1354,8 +1354,8 @@ describe(`ChangeDetection`, () => {
                       {declarations: [MainComp, OuterComp, InnerComp, DummyDirective]})
                   .createComponent(MainComp);
         mainComp = ctx.componentInstance;
-        outerComp = ctx.debugElement.query(By.directive(OuterComp)).injector.get(OuterComp);
-        innerComp = ctx.debugElement.query(By.directive(InnerComp)).injector.get(InnerComp);
+        outerComp = ctx.debugElement.query(By.directive(OuterComp))!.injector.get(OuterComp);
+        innerComp = ctx.debugElement.query(By.directive(InnerComp))!.injector.get(InnerComp);
       });
 
       it('should dirty check projected views in regular order', () => {

--- a/packages/core/test/linker/projection_integration_spec.ts
+++ b/packages/core/test/linker/projection_integration_spec.ts
@@ -426,14 +426,14 @@ describe('projection', () => {
 
     expect(main.nativeElement).toHaveText('TREE(0:)');
 
-    const tree = main.debugElement.query(By.directive(Tree));
+    const tree = main.debugElement.query(By.directive(Tree))!;
     let manualDirective: ManualViewportDirective = tree.queryAllNodes(By.directive(
         ManualViewportDirective))[0].injector.get(ManualViewportDirective);
     manualDirective.show();
     main.detectChanges();
     expect(main.nativeElement).toHaveText('TREE(0:TREE2(1:))');
 
-    const tree2 = main.debugElement.query(By.directive(Tree2));
+    const tree2 = main.debugElement.query(By.directive(Tree2))!;
     manualDirective = tree2.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(
         ManualViewportDirective);
     manualDirective.show();
@@ -639,7 +639,7 @@ describe('projection', () => {
     });
     const main = TestBed.createComponent(MainComp);
 
-    const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent));
+    const conditionalComp = main.debugElement.query(By.directive(ConditionalContentComponent))!;
 
     const viewViewportDir =
         conditionalComp.queryAllNodes(By.directive(ManualViewportDirective))[0].injector.get(

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -88,7 +88,7 @@ describe('regressions', () => {
 
          TestBed.configureTestingModule({declarations: [MyDir, MyComp]});
          const fixture = TestBed.createComponent(MyComp);
-         const dir = fixture.debugElement.query(By.directive(MyDir)).injector.get(MyDir) as MyDir;
+         const dir = fixture.debugElement.query(By.directive(MyDir))!.injector.get(MyDir) as MyDir;
 
          fixture.detectChanges();
          expect(dir.setterCalls).toEqual({'a': null, 'b': 2});
@@ -256,7 +256,7 @@ describe('regressions', () => {
 
     const ctx =
         TestBed.configureTestingModule({declarations: [MyComp, MyDir]}).createComponent(MyComp);
-    const dir = <MyDir>ctx.debugElement.query(By.directive(MyDir)).injector.get(MyDir);
+    const dir = <MyDir>ctx.debugElement.query(By.directive(MyDir))!.injector.get(MyDir);
 
     expect(dir.template).toBeUndefined();
 

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -580,7 +580,7 @@ describe('TestBed', () => {
     const hello = TestBed.createComponent(HelloWorld);
     hello.detectChanges();
 
-    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp'));
+    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp'))!;
     expect(greetingByCss.nativeElement).toHaveText('Hello World!');
     expect(greetingByCss.componentInstance).toBeInstanceOf(GreetingCmp);
   });
@@ -589,7 +589,7 @@ describe('TestBed', () => {
     const hello = TestBed.createComponent(HelloWorld);
 
     hello.detectChanges();
-    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp'));
+    const greetingByCss = hello.debugElement.query(By.css('greeting-cmp'))!;
     expect(greetingByCss.nativeElement).toHaveText('Hello World!');
 
     greetingByCss.componentInstance.name = 'TestBed!';
@@ -601,7 +601,7 @@ describe('TestBed', () => {
     const fixture = TestBed.createComponent(ComponentWithPropBindings);
     fixture.detectChanges();
 
-    const divElement = fixture.debugElement.query(By.css('div'));
+    const divElement = fixture.debugElement.query(By.css('div'))!;
     expect(divElement.properties['id']).toEqual('one');
     expect(divElement.properties['title']).toEqual('some title');
   });
@@ -610,7 +610,7 @@ describe('TestBed', () => {
     const fixture = TestBed.createComponent(ComponentWithPropBindings);
     fixture.detectChanges();
 
-    const paragraphEl = fixture.debugElement.query(By.css('p'));
+    const paragraphEl = fixture.debugElement.query(By.css('p'))!;
     expect(paragraphEl.properties['title']).toEqual('( some label - some title )');
     expect(paragraphEl.properties['id']).toEqual('[ some label ] [ some title ]');
   });
@@ -618,7 +618,7 @@ describe('TestBed', () => {
   it('should give access to the node injector', () => {
     const fixture = TestBed.createComponent(HelloWorld);
     fixture.detectChanges();
-    const injector = fixture.debugElement.query(By.css('greeting-cmp')).injector;
+    const injector = fixture.debugElement.query(By.css('greeting-cmp'))!.injector;
 
     // from the node injector
     const greetingCmp = injector.get(GreetingCmp);
@@ -648,7 +648,7 @@ describe('TestBed', () => {
 
   it('should give access to local refs on a node', () => {
     const withRefsCmp = TestBed.createComponent(WithRefsCmp);
-    const firstDivDebugEl = withRefsCmp.debugElement.query(By.css('div'));
+    const firstDivDebugEl = withRefsCmp.debugElement.query(By.css('div'))!;
     // assert that a native element is referenced by a local ref
     expect(firstDivDebugEl.references['firstDiv'].tagName.toLowerCase()).toBe('div');
   });
@@ -657,7 +657,7 @@ describe('TestBed', () => {
     const hello = TestBed.createComponent(HelloWorld);
     hello.detectChanges();
 
-    const greetingByDirective = hello.debugElement.query(By.directive(GreetingCmp));
+    const greetingByDirective = hello.debugElement.query(By.directive(GreetingCmp))!;
     expect(greetingByDirective.componentInstance).toBeInstanceOf(GreetingCmp);
   });
 
@@ -1849,7 +1849,7 @@ describe('TestBed', () => {
          let fixture = TestBed.createComponent(RootCmp);
          fixture.detectChanges();
 
-         let childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp));
+         let childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp))!;
          expect(childCmpInstance.componentInstance).toBeInstanceOf(ChildCmp);
          expect(fixture.nativeElement.textContent).toBe('Child comp');
 
@@ -1866,7 +1866,7 @@ describe('TestBed', () => {
          expect(spy).toHaveBeenCalledTimes(1);
          fixture.detectChanges();
 
-         childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp));
+         childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp))!;
          expect(childCmpInstance).toBeNull();
          expect(fixture.nativeElement.textContent).toBe('');
 
@@ -1881,7 +1881,7 @@ describe('TestBed', () => {
          fixture = TestBed.createComponent(RootCmp);
          fixture.detectChanges();
 
-         childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp));
+         childCmpInstance = fixture.debugElement.query(By.directive(ChildCmp))!;
          expect(childCmpInstance).toBeNull();
          expect(fixture.nativeElement.textContent).toBe('');
        });

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -113,7 +113,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.detectChanges();
 
         // model -> view
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('old value');
 
         input.nativeElement.value = 'updated value';
@@ -128,7 +128,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('loginValue');
       });
 
@@ -137,7 +137,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = new FormGroup({'login': new FormControl('loginValue')});
         fixture.detectChanges();
 
-        const form = fixture.debugElement.query(By.css('form'));
+        const form = fixture.debugElement.query(By.css('form'))!;
         expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
       });
 
@@ -147,7 +147,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         input.nativeElement.value = 'updatedValue';
         dispatchEvent(input.nativeElement, 'input');
 
@@ -164,7 +164,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = new FormGroup({'login': new FormControl('newValue')});
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('newValue');
       });
 
@@ -177,7 +177,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = newForm;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         input.nativeElement.value = 'Nancy';
         dispatchEvent(input.nativeElement, 'input');
         fixture.detectChanges();
@@ -271,7 +271,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.detectChanges();
 
         let emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
-        expect(emailInput.nativeElement.value).toEqual('email');
+        expect(emailInput!.nativeElement.value).toEqual('email');
 
         const newForm = new FormGroup({
           'signin': new FormGroup({'login': new FormControl(''), 'password': new FormControl('')})
@@ -279,8 +279,8 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = newForm;
         fixture.detectChanges();
 
-        emailInput = fixture.debugElement.query(By.css('[formControlName="email"]'));
-        expect(emailInput as any).toBe(null);  // TODO: remove `any` after #22449 is closed.
+        emailInput = fixture.debugElement!.query(By.css('[formControlName="email"]'));
+        expect(emailInput).toBe(null);
       });
 
       it('should strip array controls that are not found', () => {
@@ -356,7 +356,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           form.addControl('login', new FormControl('newValue'));
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.value).toEqual('newValue');
 
           input.nativeElement.value = 'user input';
@@ -414,7 +414,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           form.addControl('cities', new FormArray([new FormControl('LA')]));
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.value).toEqual('LA');
 
           input.nativeElement.value = 'MTV';
@@ -460,7 +460,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           newArr.removeAt(0);
           fixture.detectChanges();
 
-          firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
+          firstInput = fixture.debugElement.query(By.css('input'))!.nativeElement;
           firstInput.value = 'last one';
           dispatchEvent(firstInput, 'input');
           fixture.detectChanges();
@@ -470,7 +470,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           newArr.get([0])!.setValue('set value');
           fixture.detectChanges();
 
-          firstInput = fixture.debugElement.query(By.css('input')).nativeElement;
+          firstInput = fixture.debugElement.query(By.css('input'))!.nativeElement;
           expect(firstInput.value).toEqual('set value');
         });
 
@@ -492,7 +492,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           newArr.removeAt(0);
           fixture.detectChanges();
 
-          const formEl = fixture.debugElement.query(By.css('form'));
+          const formEl = fixture.debugElement.query(By.css('form'))!;
           expect(() => dispatchEvent(formEl.nativeElement, 'submit')).not.toThrowError();
         });
 
@@ -613,7 +613,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         login.setValue('newValue');
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('newValue');
       });
 
@@ -625,7 +625,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
              fixture.componentInstance.control = control;
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input'));
+             const input = fixture.debugElement.query(By.css('input'))!;
              expect(input.nativeElement.disabled).toBe(true);
 
              control.enable();
@@ -640,7 +640,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.disabled).toBe(true);
 
           control.enable();
@@ -658,7 +658,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
              control.disable();
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input'));
+             const input = fixture.debugElement.query(By.css('input'))!;
              expect(input.nativeElement.disabled).toBe(true);
 
              control.enable();
@@ -694,7 +694,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           control.disable();
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('my-input'));
+          const input = fixture.debugElement.query(By.css('my-input'))!;
           expect(input.nativeElement.getAttribute('disabled')).toBe(null);
         });
       });
@@ -891,7 +891,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const loginEl = fixture.debugElement.query(By.css('input'));
+        const loginEl = fixture.debugElement.query(By.css('input'))!;
         expect(login.touched).toBe(false);
 
         dispatchEvent(loginEl.nativeElement, 'blur');
@@ -907,7 +907,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.event = null!;
         fixture.detectChanges();
 
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
         dispatchEvent(formEl, 'submit');
 
         fixture.detectChanges();
@@ -922,7 +922,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         const formGroupDir = fixture.debugElement.children[0].injector.get(FormGroupDirective);
         expect(formGroupDir.submitted).toBe(false);
 
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
         dispatchEvent(formEl, 'submit');
 
         fixture.detectChanges();
@@ -936,7 +936,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const loginEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
         expect(loginEl.value).toBe('some value');
 
         form.reset({'login': 'reset value'});
@@ -950,7 +950,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const loginEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
         expect(loginEl.value).toBe('some value');
 
         form.reset();
@@ -969,7 +969,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           expect(login.dirty).toBe(true);
         });
 
-        const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+        const loginEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
         loginEl.value = 'newValue';
 
         dispatchEvent(loginEl, 'input');
@@ -983,7 +983,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
            fixture.componentInstance.form = form;
            fixture.detectChanges();
 
-           const loginEl = fixture.debugElement.query(By.css('input')).nativeElement;
+           const loginEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
            loginEl.value = 'newValue';
            dispatchEvent(loginEl, 'input');
 
@@ -1011,7 +1011,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         const fixture = initReactiveFormsTest(FormComp);
         fixture.detectChanges();
 
-        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
         // Expect no classes added to the <form> element since it has no
         // reactive directives attached and only ReactiveForms module is used.
         expect(sortedClassList(form)).toEqual([]);
@@ -1032,12 +1032,12 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         const fixture = initReactiveFormsTest(FormComp);
         fixture.detectChanges();
 
-        const form = fixture.debugElement.query(By.css('form')).nativeElement;
+        const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
         // Expect no classes added to the <form> element since it has no
         // reactive directives attached and only ReactiveForms module is used.
         expect(sortedClassList(form)).toEqual([]);
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
         expect(sortedClassList(input)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
       });
 
@@ -1047,7 +1047,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
         expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
         dispatchEvent(input, 'blur');
@@ -1068,7 +1068,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
            fixture.debugElement.componentInstance.control = control;
            fixture.detectChanges();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
 
            dispatchEvent(input, 'blur');
@@ -1090,7 +1090,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
            fixture.debugElement.componentInstance.control = control;
            fixture.detectChanges();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
            dispatchEvent(input, 'blur');
@@ -1122,8 +1122,8 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
 
         expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
@@ -1158,8 +1158,8 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
 
         expect(sortedClassList(formEl)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
@@ -1199,8 +1199,8 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
         const [loginInput, passwordInput] =
             fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement);
-        const arrEl = fixture.debugElement.query(By.css('div')).nativeElement;
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const arrEl = fixture.debugElement.query(By.css('div'))!.nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
 
         expect(passwordInput).toBeDefined();
         expect(sortedClassList(loginInput)).not.toContain('ng-submitted');
@@ -1230,9 +1230,9 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
-        const arrEl = fixture.debugElement.query(By.css('div')).nativeElement;
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
+        const arrEl = fixture.debugElement.query(By.css('div'))!.nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
 
         expect(sortedClassList(input)).not.toContain('ng-submitted');
         expect(sortedClassList(arrEl)).not.toContain('ng-submitted');
@@ -1267,8 +1267,8 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         const [loginInput, passwordInput] =
             fixture.debugElement.queryAll(By.css('input')).map(el => el.nativeElement);
 
-        const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-        const groupEl = fixture.debugElement.query(By.css('div')).nativeElement;
+        const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
+        const groupEl = fixture.debugElement.query(By.css('div'))!.nativeElement;
         loginInput.value = 'Nancy';
         // Input and blur events, as in a real interaction, cause the form to be touched and
         // dirtied.
@@ -1304,7 +1304,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1334,7 +1334,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.form = form;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1366,7 +1366,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           control.setValue('Nancy');
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           expect(input.value)
               .withContext('Expected value to propagate to view immediately.')
               .toEqual('Nancy');
@@ -1384,7 +1384,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
           expect(control.dirty).withContext('Expected control to start out pristine.').toBe(false);
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1411,7 +1411,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               .withContext('Expected control to start out untouched.')
               .toBe(false);
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
@@ -1427,7 +1427,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
@@ -1460,7 +1460,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'aa';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1483,7 +1483,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
           expect(input.value).withContext('Expected value to be set in the view.').toEqual('Nancy');
           expect(control.value)
@@ -1500,7 +1500,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'aa';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1572,7 +1572,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           const sub =
               merge(control.valueChanges, control.statusChanges).subscribe(val => values.push(val));
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1602,7 +1602,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           const sub =
               merge(control.valueChanges, control.statusChanges).subscribe(val => values.push(val));
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
           expect(values)
@@ -1650,7 +1650,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'aa';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1674,7 +1674,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1706,7 +1706,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.cityArray = cityArray;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1783,7 +1783,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.form = form;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           expect(input.value)
               .withContext('Expected initial value to propagate to view.')
               .toEqual('Nancy');
@@ -1802,7 +1802,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1824,7 +1824,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               .withContext('Expected form validation not to run on blur.')
               .toBe(false);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1843,12 +1843,12 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1884,7 +1884,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           formGroup.setValue({login: 'Nancy'});
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           expect(input.value)
               .withContext('Expected view value to update immediately.')
               .toEqual('Nancy');
@@ -1902,7 +1902,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'input');
           fixture.detectChanges();
 
@@ -1913,7 +1913,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
           expect(formGroup.dirty).withContext('Expected dirty not to change on blur.').toBe(false);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1926,7 +1926,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
@@ -1934,7 +1934,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               .withContext('Expected touched not to change until submit.')
               .toBe(false);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1948,7 +1948,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -1968,7 +1968,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               .withContext('Expected touched to stay false on reset.')
               .toBe(false);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -1997,7 +1997,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               formGroup.statusChanges);
           const sub = streams.subscribe(val => values.push(val));
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -2013,7 +2013,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               .withContext('Expected no valueChanges or statusChanges on blur')
               .toEqual([]);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -2038,14 +2038,14 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               formGroup.statusChanges);
           const sub = streams.subscribe(val => values.push(val));
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
           expect(values)
               .withContext('Expected no valueChanges or statusChanges if value unchanged.')
               .toEqual([]);
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -2101,7 +2101,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           formGroup.get('signin.login')!.setValidators(validatorSpy);
           formGroup.get('signin')!.setValidators(groupValidatorSpy);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -2115,7 +2115,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           dispatchEvent(input, 'blur');
           fixture.detectChanges();
 
@@ -2124,7 +2124,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
           expect(formGroup.touched).withContext('Expected group to become untouched.').toBe(false);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -2140,7 +2140,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.form = formGroup;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -2162,7 +2162,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               .withContext('Expected no validation to occur until submit.')
               .toBe(false);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -2179,7 +2179,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.componentInstance.cityArray = cityArray;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
           input.value = 'Nancy';
           dispatchEvent(input, 'input');
           fixture.detectChanges();
@@ -2192,7 +2192,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               .toBe(false);
 
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -2234,7 +2234,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
               .withContext('Expected no validation to occur until submit.')
               .toBe(false);
 
-          const form = fixture.debugElement.query(By.css('form')).nativeElement;
+          const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(form, 'submit');
           fixture.detectChanges();
 
@@ -2356,7 +2356,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            expect(input.value).toEqual('oldValue');
 
            input.value = 'updatedValue';
@@ -2374,7 +2374,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            expect(input.value).toEqual('oldValue');
 
            input.value = 'updatedValue';
@@ -2392,7 +2392,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            input.value = 'aa';
            input.setSelectionRange(1, 2);
            dispatchEvent(input, 'input');
@@ -2413,7 +2413,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            input.value = 'Nancy';
            dispatchEvent(input, 'input');
            fixture.detectChanges();
@@ -2423,7 +2423,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
                .withContext('Expected ngModel value to remain unchanged on input.')
                .toEqual('initial');
 
-           const form = fixture.debugElement.query(By.css('form')).nativeElement;
+           const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
            dispatchEvent(form, 'submit');
            fixture.detectChanges();
            tick();
@@ -2441,7 +2441,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 
-        const checkbox = fixture.debugElement.query(By.css('input'));
+        const checkbox = fixture.debugElement.query(By.css('input'))!;
         expect(checkbox.nativeElement.checked).toBe(false);
         expect(control.hasError('required')).toEqual(true);
 
@@ -2496,10 +2496,10 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const required = fixture.debugElement.query(By.css('[required]'));
-        const minLength = fixture.debugElement.query(By.css('[minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[pattern]'));
+        const required = fixture.debugElement.query(By.css('[required]'))!;
+        const minLength = fixture.debugElement.query(By.css('[minlength]'))!;
+        const maxLength = fixture.debugElement.query(By.css('[maxlength]'))!;
+        const pattern = fixture.debugElement.query(By.css('[pattern]'))!;
 
         required.nativeElement.value = '';
         minLength.nativeElement.value = '1';
@@ -2545,10 +2545,10 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.pattern = '.{3,}';
         fixture.detectChanges();
 
-        const required = fixture.debugElement.query(By.css('[name=required]'));
-        const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+        const required = fixture.debugElement.query(By.css('[name=required]'))!;
+        const minLength = fixture.debugElement.query(By.css('[name=minlength]'))!;
+        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'))!;
+        const pattern = fixture.debugElement.query(By.css('[name=pattern]'))!;
 
         required.nativeElement.value = '';
         minLength.nativeElement.value = '1';
@@ -2589,10 +2589,10 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.form = form;
         fixture.detectChanges();
 
-        const required = fixture.debugElement.query(By.css('[name=required]'));
-        const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-        const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+        const required = fixture.debugElement.query(By.css('[name=required]'))!;
+        const minLength = fixture.debugElement.query(By.css('[name=minlength]'))!;
+        const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'))!;
+        const pattern = fixture.debugElement.query(By.css('[name=pattern]'))!;
 
         required.nativeElement.value = '';
         minLength.nativeElement.value = '1';
@@ -2702,7 +2702,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
            expect(form.hasError('uniqLogin', ['login'])).toEqual(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            input.nativeElement.value = 'expected';
            dispatchEvent(input.nativeElement, 'input');
            tick(100);
@@ -2717,7 +2717,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.detectChanges();
         expect(form.valid).toEqual(true);
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         input.nativeElement.value = '';
         dispatchEvent(input.nativeElement, 'input');
 
@@ -2735,7 +2735,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
            expect(form.hasError('required', ['login'])).toEqual(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            input.nativeElement.value = 'wrong value';
            dispatchEvent(input.nativeElement, 'input');
 
@@ -2761,7 +2761,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
            expect(control.hasError('required')).toEqual(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            input.nativeElement.value = 'expected';
            dispatchEvent(input.nativeElement, 'input');
 
@@ -2792,7 +2792,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
 
            // Setting a value in the form control that will trigger the registered asynchronous
            // validation
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            input.nativeElement.value = 'angul';
            dispatchEvent(input.nativeElement, 'input');
 
@@ -2852,7 +2852,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
                .withContext(`Expected source observable to emit once on init.`)
                .toEqual(1);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            input.nativeElement.value = 'a';
            dispatchEvent(input.nativeElement, 'input');
            fixture.detectChanges();
@@ -2888,7 +2888,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.detectChanges();
 
           const form = fixture.componentInstance.form;
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
           interface minmax {
             minlength: number|null;
@@ -2977,7 +2977,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
           fixture.detectChanges();
 
           const form = fixture.componentInstance.form;
-          const input = fixture.debugElement.query(By.css('input')).nativeElement;
+          const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
           interface minmax {
             min: number|null;
@@ -3060,7 +3060,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             fixture.componentInstance.form = new FormGroup({'pin': control});
             fixture.detectChanges();
 
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
+            const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
             const form = fixture.componentInstance.form;
 
             expect(input.value).toEqual('5');
@@ -3103,7 +3103,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             fixture.componentInstance.max = 10.35;
             fixture.detectChanges();
 
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
+            const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
             const form = fixture.componentInstance.form;
 
             expect(input.getAttribute('max')).toEqual('10.35');
@@ -3138,7 +3138,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             fixture.componentInstance.form = new FormGroup({'pin': control});
             fixture.detectChanges();
 
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
+            const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
             const form = fixture.componentInstance.form;
 
             expect(input.value).toEqual('5');
@@ -3165,7 +3165,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             fixture.componentInstance.form = new FormGroup({'pin': control});
             fixture.detectChanges();
 
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
+            const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
             const form = fixture.componentInstance.form;
 
             expect(input.value).toEqual('5');
@@ -3208,7 +3208,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             fixture.componentInstance.min = 10.25;
             fixture.detectChanges();
 
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
+            const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
             const form = fixture.componentInstance.form;
 
             expect(input.getAttribute('min')).toEqual('10.25');
@@ -3243,7 +3243,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             fixture.componentInstance.form = new FormGroup({'pin': control});
             fixture.detectChanges();
 
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
+            const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
             const form = fixture.componentInstance.form;
 
             expect(input.value).toEqual('5');
@@ -3273,7 +3273,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             fixture.componentInstance.form = new FormGroup({'pin': control});
             fixture.detectChanges();
 
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
+            const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
             const form = fixture.componentInstance.form;
 
             expect(input.value).toEqual('');
@@ -3295,7 +3295,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             fixture.componentInstance.form = new FormGroup({'pin': control});
             fixture.detectChanges();
 
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
+            const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
             const form = fixture.componentInstance.form;
 
             expect(input.value).toEqual('5');
@@ -3329,7 +3329,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
             fixture.componentInstance.max = -10;
             fixture.detectChanges();
 
-            const input = fixture.debugElement.query(By.css('input')).nativeElement;
+            const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
             const form = fixture.componentInstance.form;
 
             expect(input.value).toEqual('-30');
@@ -3676,7 +3676,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.control = new FormControl('oldValue');
         fixture.detectChanges();
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
+        const inputEl = fixture.debugElement.query(By.css('input'))!;
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 
@@ -3707,7 +3707,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.control = new FormControl('oldValue');
         fixture.detectChanges();
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
+        const inputEl = fixture.debugElement.query(By.css('input'))!;
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 
@@ -3735,7 +3735,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         fixture.componentInstance.control = new FormControl('oldValue');
         fixture.detectChanges();
 
-        const inputEl = fixture.debugElement.query(By.css('input'));
+        const inputEl = fixture.debugElement.query(By.css('input'))!;
         const inputNativeEl = inputEl.nativeElement;
         expect(inputNativeEl.value).toEqual('oldValue');
 

--- a/packages/forms/test/template_integration_spec.ts
+++ b/packages/forms/test/template_integration_spec.ts
@@ -33,7 +33,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            // model -> view
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            expect(input.value).toEqual('oldValue');
 
            input.value = 'updatedValue';
@@ -71,7 +71,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
         const fixture = TestBed.createComponent(AppComponent);
         // We need the Await as `ngModel` writes data asynchronously into the DOM
         await fixture.detectChanges();
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.properties['checked']).toBe(true);
         expect(input.nativeElement.checked).toBe(true);
       });
@@ -83,7 +83,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const form = fixture.debugElement.query(By.css('form'));
+           const form = fixture.debugElement.query(By.css('form'))!;
            expect(form.nativeElement.getAttribute('novalidate')).toEqual('');
          }));
 
@@ -93,7 +93,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const form = fixture.debugElement.query(By.css('form'));
+           const form = fixture.debugElement.query(By.css('form'))!;
            expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
          }));
 
@@ -175,7 +175,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.whenStable().then(() => {
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              expect(sortedClassList(input)).toEqual(['ng-invalid', 'ng-pristine', 'ng-untouched']);
 
              dispatchEvent(input, 'blur');
@@ -188,7 +188,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              expect(sortedClassList(input)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -210,7 +210,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.whenStable().then(() => {
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              expect(sortedClassList(input)).toEqual(['ng-pending', 'ng-pristine', 'ng-untouched']);
 
              dispatchEvent(input, 'blur');
@@ -232,9 +232,9 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.componentInstance.first = '';
            fixture.detectChanges();
 
-           const form = fixture.debugElement.query(By.css('form')).nativeElement;
-           const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')).nativeElement;
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
+           const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]'))!.nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
            // ngModelGroup creates its control asynchronously
            fixture.whenStable().then(() => {
@@ -260,7 +260,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              expect(sortedClassList(modelGroup)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
              expect(sortedClassList(form)).toEqual(['ng-dirty', 'ng-touched', 'ng-valid']);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -276,9 +276,9 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
         fixture.componentInstance.other = '';
         fixture.detectChanges();
 
-        const form = fixture.debugElement.query(By.css('form')).nativeElement;
-        const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]')).nativeElement;
-        const input = fixture.debugElement.query(By.css('input')).nativeElement;
+        const form = fixture.debugElement.query(By.css('form'))!.nativeElement;
+        const modelGroup = fixture.debugElement.query(By.css('[ngModelGroup]'))!.nativeElement;
+        const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
         fixture.whenStable().then(() => {
           fixture.detectChanges();
@@ -286,7 +286,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
           expect(sortedClassList(form)).toEqual(['ng-pristine', 'ng-untouched', 'ng-valid']);
 
-          const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+          const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
           dispatchEvent(formEl, 'submit');
           fixture.detectChanges();
 
@@ -314,7 +314,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
       it('should not add novalidate when ngNoForm is used', () => {
         const fixture = initTest(NgNoFormComp);
         fixture.detectChanges();
-        const form = fixture.debugElement.query(By.css('form'));
+        const form = fixture.debugElement.query(By.css('form'))!;
         expect(form.nativeElement.hasAttribute('novalidate')).toEqual(false);
       });
 
@@ -508,7 +508,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value)
                  .withContext('Expected initial view value to be set.')
@@ -532,7 +532,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value)
                  .withContext('Expected view value to update on programmatic change.')
@@ -552,7 +552,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -580,7 +580,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -619,7 +619,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -643,7 +643,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -673,7 +673,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              const sub =
                  merge(form.valueChanges!, form.statusChanges!).subscribe(val => values.push(val));
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -704,7 +704,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                  .withContext('Expected ngModelChanges not to fire.')
                  .toEqual([]);
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              dispatchEvent(input, 'blur');
              fixture.detectChanges();
 
@@ -776,7 +776,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value)
                  .withContext('Expected initial view value to be set.')
@@ -802,7 +802,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              expect(input.value)
                  .withContext('Expected view value to update on programmatic change.')
@@ -823,7 +823,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -844,7 +844,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                  .toEqual('Carson');
              expect(form.valid).withContext('Expected validation not to run on blur.').toBe(false);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -861,13 +861,13 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
              tick();
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
              tick();
@@ -910,7 +910,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              form.control.get('name')!.setValidators(groupValidatorSpy);
              form.control.get('name.last')!.setValidators(validatorSpy);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -925,7 +925,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -944,7 +944,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                  .withContext('Expected dirtiness not to update on blur.')
                  .toBe(false);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -958,7 +958,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -973,7 +973,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                  .withContext('Expected touched not to update on blur.')
                  .toBe(false);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -987,7 +987,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -1010,7 +1010,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                  .withContext('Expected touched to stay false on reset.')
                  .toBe(false);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -1039,7 +1039,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              const sub =
                  merge(form.valueChanges!, form.statusChanges!).subscribe(val => values.push(val));
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -1057,7 +1057,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                  .withContext('Expected no valueChanges or statusChanges on blur.')
                  .toEqual([]);
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -1075,7 +1075,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+             const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
              dispatchEvent(formEl, 'submit');
              fixture.detectChanges();
 
@@ -1083,7 +1083,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                  .withContext('Expected ngModelChanges not to fire if value unchanged.')
                  .toEqual([]);
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Carson';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -1171,7 +1171,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              input.value = 'Nancy Drew';
              dispatchEvent(input, 'input');
              fixture.detectChanges();
@@ -1276,7 +1276,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const fixture = initTest(NgModelForm);
            fixture.componentInstance.event = null!;
 
-           const form = fixture.debugElement.query(By.css('form'));
+           const form = fixture.debugElement.query(By.css('form'))!;
            dispatchEvent(form.nativeElement, 'submit');
            tick();
 
@@ -1290,7 +1290,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const form = fixture.debugElement.children[0].injector.get(NgForm);
            expect(form.submitted).toBe(false);
 
-           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
+           const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
            dispatchEvent(formEl, 'submit');
            tick();
 
@@ -1304,8 +1304,8 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const formEl = fixture.debugElement.query(By.css('form'));
-           const input = fixture.debugElement.query(By.css('input'));
+           const formEl = fixture.debugElement.query(By.css('form'))!;
+           const input = fixture.debugElement.query(By.css('input'))!;
 
            expect(input.nativeElement.value).toBe('should be cleared');       // view value
            expect(fixture.componentInstance.name).toBe('should be cleared');  // ngModel value
@@ -1323,7 +1323,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
       it('should reset the form submit state when reset button is clicked', fakeAsync(() => {
            const fixture = initTest(NgModelForm);
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const formEl = fixture.debugElement.query(By.css('form'));
+           const formEl = fixture.debugElement.query(By.css('form'))!;
 
            dispatchEvent(formEl.nativeElement, 'submit');
            fixture.detectChanges();
@@ -1370,7 +1370,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              expect(form.get('name')!.dirty).toBe(true);
            });
 
-           const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+           const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
            inputEl.value = 'newValue';
 
            dispatchEvent(inputEl, 'input');
@@ -1383,8 +1383,8 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm).form;
-           const formEl = fixture.debugElement.query(By.css('form')).nativeElement;
-           const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
+           const formEl = fixture.debugElement.query(By.css('form'))!.nativeElement;
+           const inputEl = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
            inputEl.value = 'newValue';
            dispatchEvent(inputEl, 'input');
@@ -1436,7 +1436,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css(`[name="first"]`));
+           const input = fixture.debugElement.query(By.css(`[name="first"]`))!;
            expect(input.nativeElement.disabled).toBe(true);
          }));
 
@@ -1451,7 +1451,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                const form = fixture.debugElement.children[0].injector.get(NgForm);
                expect(form.control.get('name')!.disabled).toBe(true);
 
-               const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+               const customInput = fixture.debugElement.query(By.css('[name="custom"]'))!;
                expect(customInput.nativeElement.disabled).toEqual(true);
              });
            });
@@ -1473,7 +1473,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const form = fixture.debugElement.children[0].injector.get(NgForm);
            expect(form.control.get('name')!.disabled).toBe(true);
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            expect(input.nativeElement.disabled).toEqual(true);
 
            form.control.enable();
@@ -1492,7 +1492,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const control =
                fixture.debugElement.children[0].injector.get(NgForm).control.get('checkbox')!;
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            expect(input.nativeElement.checked).toBe(false);
            expect(control.hasError('required')).toBe(false);
 
@@ -1536,7 +1536,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            const control =
                fixture.debugElement.children[0].injector.get(NgForm).control.get('email')!;
 
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
            expect(control.hasError('email')).toBe(false);
 
            fixture.componentInstance.validatorEnabled = true;
@@ -1579,10 +1579,10 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const required = fixture.debugElement.query(By.css('[name=required]'));
-           const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-           const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+           const required = fixture.debugElement.query(By.css('[name=required]'))!;
+           const minLength = fixture.debugElement.query(By.css('[name=minlength]'))!;
+           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'))!;
+           const pattern = fixture.debugElement.query(By.css('[name=pattern]'))!;
 
            required.nativeElement.value = '';
            minLength.nativeElement.value = '1';
@@ -1622,7 +1622,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
 
            input.nativeElement.value = '';
            dispatchEvent(input.nativeElement, 'input');
@@ -1644,7 +1644,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
 
            input.nativeElement.value = '';
            dispatchEvent(input.nativeElement, 'input');
@@ -1666,7 +1666,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            tick();
 
            const form = fixture.debugElement.children[0].injector.get(NgForm);
-           const input = fixture.debugElement.query(By.css('input'));
+           const input = fixture.debugElement.query(By.css('input'))!;
 
            input.nativeElement.value = '';
            dispatchEvent(input.nativeElement, 'input');
@@ -1686,10 +1686,10 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const required = fixture.debugElement.query(By.css('[name=required]'));
-           const minLength = fixture.debugElement.query(By.css('[name=minlength]'));
-           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'));
-           const pattern = fixture.debugElement.query(By.css('[name=pattern]'));
+           const required = fixture.debugElement.query(By.css('[name=required]'))!;
+           const minLength = fixture.debugElement.query(By.css('[name=minlength]'))!;
+           const maxLength = fixture.debugElement.query(By.css('[name=maxlength]'))!;
+           const pattern = fixture.debugElement.query(By.css('[name=pattern]'))!;
 
            required.nativeElement.value = '';
            minLength.nativeElement.value = '1';
@@ -1753,7 +1753,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
 
       it('should update control status', fakeAsync(() => {
            const fixture = initTest(NgModelChangeState);
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input'))!;
            const inputNativeEl = inputEl.nativeElement;
            const onNgModelChange = jasmine.createSpy('onNgModelChange');
            fixture.componentInstance.onNgModelChange = onNgModelChange;
@@ -1787,7 +1787,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = '';
@@ -1831,7 +1831,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = '';
@@ -1866,7 +1866,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = '11';
@@ -1889,7 +1889,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = 11;
@@ -1916,7 +1916,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = '';
@@ -1961,7 +1961,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = '';
@@ -1995,7 +1995,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = '11';
@@ -2018,7 +2018,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = 11;
@@ -2049,13 +2049,13 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const min = fixture.debugElement.query(By.directive(MinValidator));
+           const min = fixture.debugElement.query(By.directive(MinValidator))!;
            expect(min).toBeNull();
 
-           const max = fixture.debugElement.query(By.directive(MaxValidator));
+           const max = fixture.debugElement.query(By.directive(MaxValidator))!;
            expect(max).toBeNull();
 
-           const cd = fixture.debugElement.query(By.directive(CustomDirective));
+           const cd = fixture.debugElement.query(By.directive(CustomDirective))!;
            expect(cd).toBeDefined();
 
            expect(validateFnSpy).not.toHaveBeenCalled();
@@ -2096,10 +2096,10 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const mv = fixture.debugElement.query(By.directive(MaxValidator));
+           const mv = fixture.debugElement.query(By.directive(MaxValidator))!;
            expect(mv).toBeNull();
 
-           const cd = fixture.debugElement.query(By.directive(CustomDirective));
+           const cd = fixture.debugElement.query(By.directive(CustomDirective))!;
            expect(cd).toBeDefined();
 
            expect(validateFnSpy).not.toHaveBeenCalled();
@@ -2118,10 +2118,10 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const maxValidator = fixture.debugElement.query(By.directive(MaxValidator));
+           const maxValidator = fixture.debugElement.query(By.directive(MaxValidator))!;
            expect(maxValidator).toBeNull();
 
-           const minValidator = fixture.debugElement.query(By.directive(MinValidator));
+           const minValidator = fixture.debugElement.query(By.directive(MinValidator))!;
            expect(minValidator).toBeNull();
 
            expect(maxValidateFnSpy).not.toHaveBeenCalled();
@@ -2143,7 +2143,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              const fixture = initTest(MinLengthMaxLengthComponent);
              fixture.detectChanges();
              tick();
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              const control =
@@ -2231,7 +2231,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              const fixture = initTest(MinLengthMaxLengthComponent);
              fixture.detectChanges();
              tick();
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
 
              const form = fixture.debugElement.children[0].injector.get(NgForm);
              const control =
@@ -2315,7 +2315,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
              fixture.detectChanges();
              tick();
 
-             const input = fixture.debugElement.query(By.css('input')).nativeElement;
+             const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
              const form = fixture.debugElement.children[0].injector.get(NgForm);
 
              input.value = '';
@@ -2350,7 +2350,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = '';
@@ -2386,7 +2386,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = '';
@@ -2421,7 +2421,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = 10;
@@ -2466,7 +2466,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            const maxValidateFnSpy = spyOn(MaxValidator.prototype, 'validate');
@@ -2489,7 +2489,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            const form = fixture.debugElement.children[0].injector.get(NgForm);
 
            input.value = '-30';
@@ -2594,7 +2594,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
     describe('IME events', () => {
       it('should determine IME event handling depending on platform by default', fakeAsync(() => {
            const fixture = initTest(StandaloneNgModel);
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input'))!;
            const inputNativeEl = inputEl.nativeElement;
            fixture.componentInstance.name = 'oldValue';
            fixture.detectChanges();
@@ -2629,7 +2629,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                StandaloneNgModel,
                {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: true}]}});
            const fixture = initTest(StandaloneNgModel);
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input'))!;
            const inputNativeEl = inputEl.nativeElement;
            fixture.componentInstance.name = 'oldValue';
            fixture.detectChanges();
@@ -2661,7 +2661,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
                {set: {providers: [{provide: COMPOSITION_BUFFER_MODE, useValue: false}]}});
            const fixture = initTest(StandaloneNgModel);
 
-           const inputEl = fixture.debugElement.query(By.css('input'));
+           const inputEl = fixture.debugElement.query(By.css('input'))!;
            const inputNativeEl = inputEl.nativeElement;
            fixture.componentInstance.name = 'oldValue';
            fixture.detectChanges();
@@ -2687,7 +2687,7 @@ import {NgModelCustomComp, NgModelCustomWrapper} from './value_accessor_integrat
            fixture.detectChanges();
            tick();
 
-           const input = fixture.debugElement.query(By.css('input')).nativeElement;
+           const input = fixture.debugElement.query(By.css('input'))!.nativeElement;
            input.value = 'aa';
            input.selectionStart = 1;
            dispatchEvent(input, 'input');

--- a/packages/forms/test/value_accessor_integration_spec.ts
+++ b/packages/forms/test/value_accessor_integration_spec.ts
@@ -29,7 +29,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       expect(input.nativeElement.value).toEqual('old');
 
       input.nativeElement.value = 'new';
@@ -46,7 +46,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       expect(input.nativeElement.value).toEqual('old');
 
       input.nativeElement.value = 'new';
@@ -62,7 +62,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.componentInstance.form = form;
       fixture.detectChanges();
 
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       form.valueChanges.subscribe({
         next: (value) => {
           throw 'Should not happen';
@@ -82,7 +82,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const textarea = fixture.debugElement.query(By.css('textarea'));
+      const textarea = fixture.debugElement.query(By.css('textarea'))!;
       expect(textarea.nativeElement.value).toEqual('old');
 
       textarea.nativeElement.value = 'new';
@@ -101,7 +101,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
       fixture.detectChanges();
 
       // model -> view
-      const input = fixture.debugElement.query(By.css('input'));
+      const input = fixture.debugElement.query(By.css('input'))!;
       expect(input.nativeElement.checked).toBe(true);
 
       input.nativeElement.checked = false;
@@ -119,7 +119,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         fixture.detectChanges();
 
         // model -> view
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('10');
 
         input.nativeElement.value = '20';
@@ -135,7 +135,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         fixture.componentInstance.control = control;
         fixture.detectChanges();
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         input.nativeElement.value = '';
         dispatchEvent(input.nativeElement, 'input');
 
@@ -160,7 +160,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
             throw 'Input[number] should not react to change event';
           }
         });
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
 
         input.nativeElement.value = '5';
         dispatchEvent(input.nativeElement, 'change');
@@ -174,7 +174,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
         control.setValue(null);
 
-        const input = fixture.debugElement.query(By.css('input'));
+        const input = fixture.debugElement.query(By.css('input'))!;
         expect(input.nativeElement.value).toEqual('');
       });
     });
@@ -187,8 +187,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select'))!;
+          const sfOption = fixture.debugElement.query(By.css('option'))!;
           expect(select.nativeElement.value).toEqual('SF');
           expect(sfOption.nativeElement.selected).toBe(true);
 
@@ -207,8 +207,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select'))!;
+          const sfOption = fixture.debugElement.query(By.css('option'))!;
           expect(select.nativeElement.value).toEqual('0: Object');
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -225,8 +225,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           const fixture = initTest(FormControlSelectWithCompareFn);
           fixture.detectChanges();
 
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select'))!;
+          const sfOption = fixture.debugElement.query(By.css('option'))!;
           expect(select.nativeElement.value).toEqual('0: Object');
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -238,7 +238,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
           // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
           // will select the second option (NY).
-          const select = fixture.debugElement.query(By.css('select'));
+          const select = fixture.debugElement.query(By.css('select'))!;
           select.nativeElement.value = '1: Object';
           dispatchEvent(select.nativeElement, 'change');
           fixture.detectChanges();
@@ -268,7 +268,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
              const nycOption = fixture.debugElement.queryAll(By.css('option'))[1];
 
              // model -> view
@@ -298,7 +298,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
              const buffalo = fixture.debugElement.queryAll(By.css('option'))[2];
              expect(select.nativeElement.value).toEqual('2: Object');
              expect(buffalo.nativeElement.selected).toBe(true);
@@ -312,7 +312,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
              expect(select.nativeElement.value).toEqual('1: Object');
 
              comp.cities.pop();
@@ -334,7 +334,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
              const secondNYC = fixture.debugElement.queryAll(By.css('option'))[2];
              expect(select.nativeElement.value).toEqual('2: Object');
              expect(secondNYC.nativeElement.selected).toBe(true);
@@ -347,7 +347,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              comp.selectedCity = null;
              fixture.detectChanges();
 
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
 
              select.nativeElement.value = '2: Object';
              dispatchEvent(select.nativeElement, 'change');
@@ -379,8 +379,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
-             const sfOption = fixture.debugElement.query(By.css('option'));
+             const select = fixture.debugElement.query(By.css('select'))!;
+             const sfOption = fixture.debugElement.query(By.css('option'))!;
              expect(select.nativeElement.value).toEqual('0: Object');
              expect(sfOption.nativeElement.selected).toBe(true);
            }));
@@ -395,7 +395,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
              // Option IDs start out as 0 and 1, so setting the select value to "1: Object"
              // will select the second option (NY).
-             const select = fixture.debugElement.query(By.css('select'));
+             const select = fixture.debugElement.query(By.css('select'))!;
              select.nativeElement.value = '1: Object';
              dispatchEvent(select.nativeElement, 'change');
              fixture.detectChanges();
@@ -425,8 +425,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           const fixture = initTest(FormControlSelectMultiple);
           fixture.detectChanges();
 
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select'))!;
+          const sfOption = fixture.debugElement.query(By.css('option'))!;
           expect(select.nativeElement.value).toEqual(`0: 'SF'`);
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -436,8 +436,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           const fixture = initTest(FormControlSelectMultipleNgValue);
           fixture.detectChanges();
 
-          const select = fixture.debugElement.query(By.css('select'));
-          const sfOption = fixture.debugElement.query(By.css('option'));
+          const select = fixture.debugElement.query(By.css('select'))!;
+          const sfOption = fixture.debugElement.query(By.css('option'))!;
           expect(select.nativeElement.value).toEqual('0: Object');
           expect(sfOption.nativeElement.selected).toBe(true);
         });
@@ -455,8 +455,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const select = fixture.debugElement.query(By.css('select'));
-             const sfOption = fixture.debugElement.query(By.css('option'));
+             const select = fixture.debugElement.query(By.css('select'))!;
+             const sfOption = fixture.debugElement.query(By.css('option'))!;
              expect(select.nativeElement.value).toEqual('0: Object');
              expect(sfOption.nativeElement.selected).toBe(true);
            }));
@@ -483,7 +483,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
         };
 
         const selectOptionViaUI = (valueString: string): void => {
-          const select = fixture.debugElement.query(By.css('select'));
+          const select = fixture.debugElement.query(By.css('select'))!;
           select.nativeElement.value = valueString;
           dispatchEvent(select.nativeElement, 'change');
           detectChangesAndTick();
@@ -557,8 +557,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
            fixture.detectChanges();
            tick();
 
-           const select = fixture.debugElement.query(By.css('select'));
-           const sfOption = fixture.debugElement.query(By.css('option'));
+           const select = fixture.debugElement.query(By.css('select'))!;
+           const sfOption = fixture.debugElement.query(By.css('option'))!;
            expect(select.nativeElement.value).toEqual('0: Object');
            expect(sfOption.nativeElement.selected).toBe(true);
          }));
@@ -685,7 +685,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           });
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('[value="no"]'));
+          const input = fixture.debugElement.query(By.css('[value="no"]'))!;
           dispatchEvent(input.nativeElement, 'change');
 
           fixture.detectChanges();
@@ -862,7 +862,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              tick();
 
-             const form = fixture.debugElement.query(By.css('form'));
+             const form = fixture.debugElement.query(By.css('form'))!;
              dispatchEvent(form.nativeElement, 'reset');
              fixture.detectChanges();
              tick();
@@ -941,7 +941,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.value).toEqual('10');
 
           input.nativeElement.value = '20';
@@ -957,7 +957,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.componentInstance.control = control;
           fixture.detectChanges();
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           input.nativeElement.value = '';
           dispatchEvent(input.nativeElement, 'input');
 
@@ -979,7 +979,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
           control.setValue(null);
 
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.value).toEqual('');
         });
       });
@@ -991,7 +991,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.componentInstance.val = 4;
              fixture.detectChanges();
              tick();
-             const input = fixture.debugElement.query(By.css('input'));
+             const input = fixture.debugElement.query(By.css('input'))!;
              expect(input.nativeElement.value).toBe('4');
              fixture.detectChanges();
              tick();
@@ -1014,7 +1014,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
           fixture.detectChanges();
 
           // model -> view
-          const input = fixture.debugElement.query(By.css('input'));
+          const input = fixture.debugElement.query(By.css('input'))!;
           expect(input.nativeElement.value).toEqual('!aa!');
 
           input.nativeElement.value = '!bb!';
@@ -1035,7 +1035,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.componentInstance.form = new FormGroup({'login': new FormControl('aa')});
              fixture.detectChanges();
 
-             const input = fixture.debugElement.query(By.css('my-input'));
+             const input = fixture.debugElement.query(By.css('my-input'))!;
              expect(input.componentInstance.value).toEqual('!aa!');
 
              input.componentInstance.value = '!bb!';
@@ -1081,8 +1081,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
             expect(fixture.componentInstance.form.status).toEqual('DISABLED');
             expect(fixture.componentInstance.form.get('login')!.status).toEqual('DISABLED');
-            expect(fixture.debugElement.query(By.directive(CvaWithDisabledState))
-                       .nativeElement.textContent)
+            expect(fixture.debugElement.query(By.directive(
+                       CvaWithDisabledState))!.nativeElement.textContent)
                 .toContain('DISABLED');
           });
 
@@ -1094,8 +1094,8 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
 
             expect(fixture.componentInstance.form.status).toEqual('VALID');
             expect(fixture.componentInstance.form.get('login')!.status).toEqual('VALID');
-            expect(fixture.debugElement.query(By.directive(CvaWithDisabledState))
-                       .nativeElement.textContent)
+            expect(fixture.debugElement.query(By.directive(
+                       CvaWithDisabledState))!.nativeElement.textContent)
                 .toContain('ENABLED');
           });
         });
@@ -1120,7 +1120,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
                fixture.detectChanges();
                fixture.whenStable().then(() => {
                  // model -> view
-                 const customInput = fixture.debugElement.query(By.css('[name="custom"]'));
+                 const customInput = fixture.debugElement.query(By.css('[name="custom"]'))!;
                  expect(customInput.nativeElement.value).toEqual('Nancy');
 
                  customInput.nativeElement.value = 'Carson';
@@ -1179,7 +1179,7 @@ import {dispatchEvent} from '@angular/platform-browser/testing/src/browser_util'
              fixture.detectChanges();
              await fixture.whenStable();
 
-             const child = fixture.debugElement.query(By.css('child'));
+             const child = fixture.debugElement.query(By.css('child'))!;
              // Let's ensure that the initial value has been set, because previously
              // it wasn't set inside an `OnPush` component.
              expect(child.nativeElement.innerHTML).toEqual('Value: Nancy');
@@ -1223,7 +1223,7 @@ describe('value accessors in reactive forms with custom options', () => {
       expect(fixture.componentInstance.form.status).toEqual('VALID');
       expect(fixture.componentInstance.form.get('login')!.status).toEqual('VALID');
       expect(
-          fixture.debugElement.query(By.directive(CvaWithDisabledState)).nativeElement.textContent)
+          fixture.debugElement.query(By.directive(CvaWithDisabledState))!.nativeElement.textContent)
           .toContain('UNSET');
     });
   });

--- a/packages/platform-browser/test/dom/dom_renderer_spec.ts
+++ b/packages/platform-browser/test/dom/dom_renderer_spec.ts
@@ -111,7 +111,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
          const fixture = TestBed.createComponent(SomeApp);
          fixture.detectChanges();
 
-         const cmp = fixture.debugElement.query(By.css('cmp-shadow')).nativeElement;
+         const cmp = fixture.debugElement.query(By.css('cmp-shadow'))!.nativeElement;
          const shadow = cmp.shadowRoot.querySelector('.shadow');
 
          expect(window.getComputedStyle(shadow).color).toEqual('rgb(255, 0, 0)');

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -610,7 +610,7 @@ describe('createUrlTreeFromSnapshot', async () => {
 
        router.initialNavigation();
        advance(fixture);
-       fixture.debugElement.query(By.directive(MainPageComponent)).componentInstance.navigate();
+       fixture.debugElement.query(By.directive(MainPageComponent))!!.componentInstance.navigate();
        advance(fixture);
        expect(fixture.nativeElement.innerHTML).toContain('child works!');
      }));

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -2459,7 +2459,7 @@ describe('Integration', () => {
          router.navigateByUrl('/child');
          advance(fixture);
 
-         const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
+         const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData))!.injector!;
          const cmp = pInj.get(NestedComponentWithData);
          expect(cmp.data).toEqual([{prop: 4}]);
        })));
@@ -2485,7 +2485,7 @@ describe('Integration', () => {
          router.navigateByUrl('/child');
          advance(fixture);
 
-         const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
+         const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData))!.injector!;
          const cmp = pInj.get(NestedComponentWithData);
          expect(cmp.data).toEqual([{prop: 'inner'}]);
        })));
@@ -2512,7 +2512,7 @@ describe('Integration', () => {
          router.navigateByUrl('/nested');
          advance(fixture);
 
-         const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
+         const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData))!.injector!;
          const cmp = pInj.get(NestedComponentWithData);
          // Issue 34361 - `prop` should contain value defined in `data` object from the nested
          // route.
@@ -2538,7 +2538,7 @@ describe('Integration', () => {
          router.navigateByUrl('/route');
          advance(fixture);
 
-         const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData)).injector!;
+         const pInj = fixture.debugElement.query(By.directive(NestedComponentWithData))!.injector!;
          const cmp = pInj.get(NestedComponentWithData);
          expect(cmp.data).toEqual([{prop: 10}]);
        })));
@@ -2688,7 +2688,7 @@ describe('Integration', () => {
 
          teamCmp.routerLink = ['/team/0'];
          advance(fixture);
-         const anchor = fixture.debugElement.query(By.css('a')).nativeElement;
+         const anchor = fixture.debugElement.query(By.css('a'))!.nativeElement;
          anchor.click();
          advance(fixture);
          expect(fixture.nativeElement).toHaveText('team 0 [ , right:  ]');
@@ -2696,7 +2696,7 @@ describe('Integration', () => {
 
          teamCmp.routerLink = ['/team/1'];
          advance(fixture);
-         const button = fixture.debugElement.query(By.css('button')).nativeElement;
+         const button = fixture.debugElement.query(By.css('button'))!.nativeElement;
          button.click();
          advance(fixture);
          expect(fixture.nativeElement).toHaveText('team 1 [ , right:  ]');
@@ -5554,7 +5554,7 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/team/22/link;exact=true');
 
          const linkComponent =
-             fixture.debugElement.query(By.directive(DummyLinkCmp)).componentInstance as
+             fixture.debugElement.query(By.directive(DummyLinkCmp))!.componentInstance as
              DummyLinkCmp;
 
          expect(linkComponent.isLinkActivated).toEqual(true);
@@ -5689,8 +5689,8 @@ describe('Integration', () => {
          expect(location.path()).toEqual('/lazy/parent/child');
          expect(fixture.nativeElement).toHaveText('parent[child]');
 
-         const pInj = fixture.debugElement.query(By.directive(Parent)).injector!;
-         const cInj = fixture.debugElement.query(By.directive(Child)).injector!;
+         const pInj = fixture.debugElement.query(By.directive(Parent))!.injector!;
+         const cInj = fixture.debugElement.query(By.directive(Child))!.injector!;
 
          expect(pInj.get('moduleName')).toEqual('parent');
          expect(pInj.get('fromParent')).toEqual('from parent');
@@ -5797,7 +5797,7 @@ describe('Integration', () => {
 
          expect(fixture.nativeElement).toHaveText('lazy');
          const lzc =
-             fixture.debugElement.query(By.directive(LazyLoadedComponent)).componentInstance;
+             fixture.debugElement.query(By.directive(LazyLoadedComponent))!.componentInstance;
          expect(lzc.injectedService).toBe(lzc.resolvedService);
        })));
 
@@ -6011,7 +6011,7 @@ describe('Integration', () => {
          expect(fixture.nativeElement)
              .toHaveText('team 22 [ user john, right: [right outlet component: simple] ]');
          const rightCmp: RightComponent =
-             fixture.debugElement.query(By.directive(RightComponent)).componentInstance;
+             fixture.debugElement.query(By.directive(RightComponent))!.componentInstance;
          // Ensure we don't accidentally add `EmptyOutletComponent` via `standardizeConfig`
          expect(rightCmp.route.routeConfig?.component).not.toBeDefined();
 
@@ -6520,7 +6520,7 @@ describe('Integration', () => {
 
          // Then
          const relativeLinkCmp =
-             fixture.debugElement.query(By.directive(RelativeLinkCmp)).componentInstance;
+             fixture.debugElement.query(By.directive(RelativeLinkCmp))!.componentInstance;
          expect(relativeLinkCmp.links.first.urlTree.toString()).toEqual('/root/childRoot');
          expect(relativeLinkCmp.links.last.urlTree.toString()).toEqual('/root/childRoot');
        }));
@@ -6852,27 +6852,27 @@ describe('Integration', () => {
          // Activate 'a'
          router.navigate(['a']);
          advance(fixture);
-         expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
+         expect(fixture.debugElement.query(By.directive(SimpleCmp))!).toBeTruthy();
 
          // Deactivate 'a' and detach the route
          router.navigate(['b']);
          advance(fixture);
-         expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeNull();
+         expect(fixture.debugElement.query(By.directive(SimpleCmp))!).toBeNull();
 
          // Activate 'a' again, the route should be re-attached
          router.navigate(['a']);
          advance(fixture);
-         expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
+         expect(fixture.debugElement.query(By.directive(SimpleCmp))!).toBeTruthy();
 
          // Hide the router-outlet, SimpleCmp should be destroyed
          fixture.componentInstance.showRouterOutlet = false;
          advance(fixture);
-         expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeNull();
+         expect(fixture.debugElement.query(By.directive(SimpleCmp))!).toBeNull();
 
          // Show the router-outlet, SimpleCmp should be re-created
          fixture.componentInstance.showRouterOutlet = true;
          advance(fixture);
-         expect(fixture.debugElement.query(By.directive(SimpleCmp))).toBeTruthy();
+         expect(fixture.debugElement.query(By.directive(SimpleCmp))!).toBeTruthy();
        }));
 
     it('should allow to attach parent route with fresh child route', fakeAsync(() => {

--- a/packages/router/test/regression_integration.spec.ts
+++ b/packages/router/test/regression_integration.spec.ts
@@ -50,8 +50,8 @@ describe('Integration', () => {
 
          const router: Router = TestBed.inject(Router);
          const fixture = createRoot(router, LinkComponent);
-         const firstLink = fixture.debugElement.query(p => p.nativeElement.id === 'first-link');
-         const secondLink = fixture.debugElement.query(p => p.nativeElement.id === 'second-link');
+         const firstLink = fixture.debugElement.query(p => p.nativeElement.id === 'first-link')!;
+         const secondLink = fixture.debugElement.query(p => p.nativeElement.id === 'second-link')!;
          router.navigateByUrl('/link-a');
          advance(fixture);
 

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -21,7 +21,7 @@ describe('RouterLink', () => {
         {imports: [RouterModule.forRoot([])], declarations: [LinkComponent]});
     const fixture = TestBed.createComponent(LinkComponent);
     fixture.detectChanges();
-    const link = fixture.debugElement.query(By.css('div')).nativeElement;
+    const link = fixture.debugElement.query(By.css('div'))!.nativeElement;
     expect(link.tabIndex).toEqual(1);
 
     fixture.nativeElement.link = null;
@@ -56,7 +56,7 @@ describe('RouterLink', () => {
       });
       fixture = TestBed.createComponent(LinkComponent);
       fixture.detectChanges();
-      link = fixture.debugElement.query(By.css('div')).nativeElement;
+      link = fixture.debugElement.query(By.css('div'))!.nativeElement;
       router = TestBed.inject(Router);
 
       spyOn(router, 'navigateByUrl');
@@ -84,7 +84,7 @@ describe('RouterLink', () => {
     });
 
     it('should coerce boolean input values', () => {
-      const dir = fixture.debugElement.query(By.directive(RouterLink)).injector.get(RouterLink);
+      const dir = fixture.debugElement.query(By.directive(RouterLink))!.injector.get(RouterLink);
 
       for (const truthy of [true, '', 'true', 'anything']) {
         fixture.componentInstance.preserveFragment = truthy;
@@ -135,7 +135,7 @@ describe('RouterLink', () => {
         });
         fixture = TestBed.createComponent(LinkComponent);
         fixture.detectChanges();
-        link = fixture.debugElement.query(By.css('a')).nativeElement;
+        link = fixture.debugElement.query(By.css('a'))!.nativeElement;
       });
 
       it('null, removes href', () => {
@@ -153,7 +153,7 @@ describe('RouterLink', () => {
       });
 
       it('should coerce boolean input values', () => {
-        const dir = fixture.debugElement.query(By.directive(RouterLink)).injector.get(RouterLink);
+        const dir = fixture.debugElement.query(By.directive(RouterLink))!.injector.get(RouterLink);
 
         for (const truthy of [true, '', 'true', 'anything']) {
           fixture.componentInstance.preserveFragment = truthy;
@@ -188,7 +188,7 @@ describe('RouterLink', () => {
       });
       const fixture = TestBed.createComponent(LinkComponent);
       fixture.detectChanges();
-      const link = fixture.debugElement.query(By.css('a')).nativeElement;
+      const link = fixture.debugElement.query(By.css('a'))!.nativeElement;
 
       expect(link.outerHTML).toContain('href');
     });

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -273,15 +273,15 @@ describe('standalone in Router API', () => {
          router.navigateByUrl('/home');
          advance(root);
          expect(canActivateLog).toEqual(['service1', 'service2']);
-         expect(root.debugElement.query(By.directive(ParentCmp)).componentInstance.service.name)
+         expect(root.debugElement.query(By.directive(ParentCmp))!.componentInstance.service.name)
              .toEqual('service1');
-         expect(root.debugElement.query(By.directive(ChildCmp)).componentInstance.service.name)
+         expect(root.debugElement.query(By.directive(ChildCmp))!.componentInstance.service.name)
              .toEqual('service2');
 
          router.navigateByUrl('/home/child2');
          advance(root);
          expect(canActivateLog).toEqual(['service1', 'service2', 'service3']);
-         expect(root.debugElement.query(By.directive(ChildCmp2)).componentInstance.service.name)
+         expect(root.debugElement.query(By.directive(ChildCmp2))!.componentInstance.service.name)
              .toEqual('service3');
        }));
   });


### PR DESCRIPTION
`DebugElement.query()` can return null, let's reflect that on the return type. This commit also provides a migration to insert non-null assertions after `DebugElement.query()` on existing code bases.

Fixes #22449

## PR Type
What kind of change does this PR introduce?

- [x] Feature


## Does this PR introduce a breaking change?

- [x] Yes, should target the next major. 