### PR TITLE
Miscellaneous improvements to standalone migration

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/schema.json
+++ b/packages/core/schematics/ng-generate/standalone-migration/schema.json
@@ -30,13 +30,9 @@
     },
     "path": {
       "type": "string",
-      "$default": {
-        "$source": "workingDirectory"
-      },
       "description": "Path relative to the project root which should be migrated",
       "x-prompt": "Which path in your project should be migrated?",
       "default": "./"
     }
-  },
-  "required": ["mode", "path"]
+  }
 }

--- a/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
@@ -437,6 +437,11 @@ function analyzeTestingModules(
 
   for (const obj of testObjects) {
     const declarations = extractDeclarationsFromTestObject(obj, typeChecker);
+
+    if (declarations.length === 0) {
+      continue;
+    }
+
     const importsProp = findLiteralProperty(obj, 'imports');
     const importElements = importsProp && hasNgModuleMetadataElements(importsProp) ?
         importsProp.initializer.elements :

--- a/packages/core/schematics/test/standalone_migration_spec.ts
+++ b/packages/core/schematics/test/standalone_migration_spec.ts
@@ -1043,6 +1043,34 @@ describe('standalone migration', () => {
     `));
   });
 
+  it('should not change testing objects with no declarations', async () => {
+    const initialContent = `
+      import {NgModule, Component} from '@angular/core';
+      import {TestBed} from '@angular/core/testing';
+      import {ButtonModule} from './button.module';
+      import {MatCardModule} from '@angular/material/card';
+
+      describe('bootrstrapping an app', () => {
+        it('should work', () => {
+          TestBed.configureTestingModule({
+            imports: [ButtonModule, MatCardModule]
+          });
+          const fixture = TestBed.createComponent(App);
+          expect(fixture.nativeElement.innerHTML).toBe('<hello>Hello</hello>');
+        });
+      });
+
+      @Component({template: 'hello'})
+      class App {}
+    `;
+
+    writeFile('app.spec.ts', initialContent);
+
+    await runMigration('convert-to-standalone');
+
+    expect(tree.readContent('app.spec.ts')).toBe(initialContent);
+  });
+
   it('should migrate tests with a component declared through Catalyst', async () => {
     writeFile('app.spec.ts', `
       import {NgModule, Component} from '@angular/core';


### PR DESCRIPTION
Includes the following small improvements to the standalone migration:

1. Avoids reformatting test modules unnecessarily when they don't have any declarations.
2. Fixes an error that was being throwing when the migration is run with `--defaults`.

Fixes #48845.