### PR TITLE
Revert "build: pin dependency aspect_bazel_lib to de8d9ca (#48887)"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -52,7 +52,7 @@ http_archive(
 # Fetch Aspect lib for utilities like write_source_files
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "7ea8e76b325150f5da49791426355a5c2bfc09be31ac1e8c5e9e4d33ad658933",
+    sha256 = "4b2e774387bae6242879820086b7b738d49bf3d0659522ea5d9363be01a27582",
     strip_prefix = "bazel-lib-1.23.2",
     url = "https://github.com/aspect-build/bazel-lib/archive/refs/tags/v1.23.2.tar.gz",
 )


### PR DESCRIPTION
This reverts commit b0a5b3873a1c5ac932d95c5af0b2a726ad9dca33.

@devversion #48884 caused CI to fail: https://app.circleci.com/pipelines/github/angular/angular/55883/workflows/35331307-c5b5-4ad4-b827-4fdab03e0cd7/jobs/1284273