### PR TITLE
fix(migrations): migrate HttpClientModule to provideHttpClient()

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/standalone-bootstrap.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/standalone-bootstrap.ts
@@ -308,6 +308,22 @@ function migrateImportsForBootstrapCall(
             tracker.addImport(sourceFile, 'provideNoopAnimations', animationsImport), [], []));
         continue;
       }
+
+      // `HttpClientModule` can be replaced with `provideHttpClient()`.
+      const httpClientModule = 'common/http';
+      const httpClientImport = `@angular/${httpClientModule}`;
+      if (isClassReferenceInAngularModule(
+              element, 'HttpClientModule', httpClientModule, typeChecker)) {
+        const callArgs = [
+          // we add `withInterceptorsFromDi()` to the call to ensure that class-based interceptors
+          // still work
+          ts.factory.createCallExpression(
+              tracker.addImport(sourceFile, 'withInterceptorsFromDi', httpClientImport), [], [])
+        ];
+        providersInNewCall.push(ts.factory.createCallExpression(
+            tracker.addImport(sourceFile, 'provideHttpClient', httpClientImport), [], callArgs));
+        continue;
+      }
     }
 
     const target =

--- a/packages/core/schematics/test/standalone_migration_spec.ts
+++ b/packages/core/schematics/test/standalone_migration_spec.ts
@@ -124,6 +124,16 @@ describe('standalone migration', () => {
       }
     `);
 
+    writeFile('/node_modules/@angular/common/http/index.d.ts', `
+      import {ModuleWithProviders} from '@angular/core';
+
+      export declare class HttpClientModule {
+          static ɵfac: i0.ɵɵFactoryDeclaration<HttpClientModule, never>;
+          static ɵmod: i0.ɵɵNgModuleDeclaration<HttpClientModule, never, never, never>;
+          static ɵinj: i0.ɵɵInjectorDeclaration<HttpClientModule>;
+      }
+    `);
+
     writeFile('/node_modules/@angular/core/testing/index.d.ts', `
       export declare class TestBed {
         static configureTestingModule(config: any): any;
@@ -3271,6 +3281,43 @@ describe('standalone migration', () => {
       }).catch(e => console.error(e));
     `));
   });
+
+  it('should convert HttpClientModule references to provideHttpClient(withInterceptorsFromDi())',
+     async () => {
+       writeFile('main.ts', `
+      import {AppModule} from './app/app.module';
+      import {platformBrowser} from '@angular/platform-browser';
+
+      platformBrowser().bootstrapModule(AppModule).catch(e => console.error(e));
+    `);
+
+       writeFile('./app/app.module.ts', `
+      import {NgModule, Component} from '@angular/core';
+      import {HttpClientModule} from '@angular/common/http';
+
+      @Component({template: 'hello'})
+      export class AppComponent {}
+
+      @NgModule({
+        declarations: [AppComponent],
+        bootstrap: [AppComponent],
+        imports: [HttpClientModule]
+      })
+      export class AppModule {}
+    `);
+
+       await runMigration('standalone-bootstrap');
+
+       expect(stripWhitespace(tree.readContent('main.ts'))).toBe(stripWhitespace(`
+      import {AppComponent} from './app/app.module';
+      import {platformBrowser, bootstrapApplication} from '@angular/platform-browser';
+      import {withInterceptorsFromDi, provideHttpClient} from '@angular/common/http';
+
+      bootstrapApplication(AppComponent, {
+        providers: [provideHttpClient(withInterceptorsFromDi())]
+      }).catch(e => console.error(e));
+    `));
+     });
 
   it('should omit standalone directives from the imports array from the importProvidersFrom call',
      async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #48948

The `standalone-bootstrap` migration migrates `HttpClientModule` imports to  `importProvidersFrom(HttpClientModule)`.


## What is the new behavior?

The `standalone-bootstrap` migration now migrates `HttpClientModule` imports to `provideHttpClient(withInterceptorsFromDi())` instead of `importProvidersFrom(HttpClientModule)`.

The `withInterceptorsFromDi()` feature is added to make sure class-based interceptors still works if there are any in the application.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
