### PR TITLE
refactor(docs-infra): Enable @typescript-eslint/quotes rule for aio content

### DIFF
--- a/aio/content/examples/.eslintrc.json
+++ b/aio/content/examples/.eslintrc.json
@@ -88,7 +88,7 @@
         "no-use-before-define": "off",
         "prefer-arrow/prefer-arrow-functions": "off",
         "quotes": "off",
-        "@typescript-eslint/quotes": ["off", "single", {"avoidEscape": true}], // TODO: Fix the code violating this rule and enable it.
+        "@typescript-eslint/quotes": ["error", "single", {"avoidEscape": true, "allowTemplateLiterals": true }],
         "semi": "error"
       }
     }

--- a/aio/content/examples/animations/src/app/querying.component.ts
+++ b/aio/content/examples/animations/src/app/querying.component.ts
@@ -66,9 +66,9 @@ import { HEROES } from './mock-heroes';
     ]),
     trigger('animateMe', [
       transition('* <=> *', animate('500ms cubic-bezier(.68,-0.73,.26,1.65)', keyframes([
-        style({ backgroundColor: "transparent", color: '*', offset: 0 }),
-        style({ backgroundColor: "blue", color: 'white', offset: 0.2 }),
-        style({ backgroundColor: "transparent", color: '*', offset: 1 })
+        style({ backgroundColor: 'transparent', color: '*', offset: 0 }),
+        style({ backgroundColor: 'blue', color: 'white', offset: 0.2 }),
+        style({ backgroundColor: 'transparent', color: '*', offset: 1 })
       ])))
     ]),
   ]

--- a/aio/content/examples/first-app-lesson-04/src/app/home/home.component.ts
+++ b/aio/content/examples/first-app-lesson-04/src/app/home/home.component.ts
@@ -25,7 +25,7 @@ import { HousingLocation } from '../housinglocation';
 })
 
 export class HomeComponent {
-  private img_server = "https://storage.googleapis.com/angular-tutorial-assets/first-app/";
+  private img_server = 'https://storage.googleapis.com/angular-tutorial-assets/first-app/';
   onlyHouse: HousingLocation;
 
   constructor() {

--- a/aio/content/examples/first-app-lesson-05/src/app/home/home.component.ts
+++ b/aio/content/examples/first-app-lesson-05/src/app/home/home.component.ts
@@ -25,7 +25,7 @@ import { HousingLocation } from '../housinglocation';
 })
 
 export class HomeComponent {
-  private img_server = "https://storage.googleapis.com/angular-tutorial-assets/first-app/";
+  private img_server = 'https://storage.googleapis.com/angular-tutorial-assets/first-app/';
   onlyHouse: HousingLocation;
 
   constructor() {

--- a/aio/content/examples/first-app-lesson-06/src/app/home/home.component.ts
+++ b/aio/content/examples/first-app-lesson-06/src/app/home/home.component.ts
@@ -25,7 +25,7 @@ import { HousingLocation } from '../housinglocation';
 })
 
 export class HomeComponent {
-  private img_server = "https://storage.googleapis.com/angular-tutorial-assets/first-app/";
+  private img_server = 'https://storage.googleapis.com/angular-tutorial-assets/first-app/';
   onlyHouse: HousingLocation;
 
   constructor() {

--- a/aio/content/examples/first-app-lesson-07/src/app/home/home.component.ts
+++ b/aio/content/examples/first-app-lesson-07/src/app/home/home.component.ts
@@ -25,7 +25,7 @@ import { HousingLocation } from '../housinglocation';
 })
 
 export class HomeComponent {
-  private img_server = "https://storage.googleapis.com/angular-tutorial-assets/first-app/";
+  private img_server = 'https://storage.googleapis.com/angular-tutorial-assets/first-app/';
   onlyHouse: HousingLocation;
 
   constructor() {

--- a/aio/content/examples/first-app-lesson-08/src/app/home/home.component.ts
+++ b/aio/content/examples/first-app-lesson-08/src/app/home/home.component.ts
@@ -28,7 +28,7 @@ import { HousingLocation } from '../housinglocation';
 })
 
 export class HomeComponent {
-  private img_server = "https://storage.googleapis.com/angular-tutorial-assets/first-app/";
+  private img_server = 'https://storage.googleapis.com/angular-tutorial-assets/first-app/';
   housingLocationList: HousingLocation[] = [
     {
       id: 0,

--- a/aio/content/examples/first-app-lesson-09/src/app/housing.service.ts
+++ b/aio/content/examples/first-app-lesson-09/src/app/housing.service.ts
@@ -5,7 +5,7 @@ import { HousingLocation } from './housinglocation';
   providedIn: 'root'
 })
 export class HousingService {
-  private img_server = "https://storage.googleapis.com/angular-tutorial-assets/first-app/";
+  private img_server = 'https://storage.googleapis.com/angular-tutorial-assets/first-app/';
   protected housingLocationList: HousingLocation[] = [
     {
       id: 0,

--- a/aio/content/examples/first-app-lesson-10/src/app/housing.service.ts
+++ b/aio/content/examples/first-app-lesson-10/src/app/housing.service.ts
@@ -5,7 +5,7 @@ import { HousingLocation } from './housinglocation';
   providedIn: 'root'
 })
 export class HousingService {
-  private img_server = "https://storage.googleapis.com/angular-tutorial-assets/first-app/";
+  private img_server = 'https://storage.googleapis.com/angular-tutorial-assets/first-app/';
   protected housingLocationList: HousingLocation[] = [
     {
       id: 0,

--- a/aio/content/examples/first-app-lesson-11/src/app/housing.service.ts
+++ b/aio/content/examples/first-app-lesson-11/src/app/housing.service.ts
@@ -5,7 +5,7 @@ import { HousingLocation } from './housinglocation';
   providedIn: 'root'
 })
 export class HousingService {
-  private img_server = "https://storage.googleapis.com/angular-tutorial-assets/first-app/";
+  private img_server = 'https://storage.googleapis.com/angular-tutorial-assets/first-app/';
   protected housingLocationList: HousingLocation[] = [
     {
       id: 0,

--- a/aio/content/examples/first-app-lesson-12/src/app/housing.service.ts
+++ b/aio/content/examples/first-app-lesson-12/src/app/housing.service.ts
@@ -5,7 +5,7 @@ import { HousingLocation } from './housinglocation';
   providedIn: 'root'
 })
 export class HousingService {
-  private img_server = "https://storage.googleapis.com/angular-tutorial-assets/first-app/";
+  private img_server = 'https://storage.googleapis.com/angular-tutorial-assets/first-app/';
   protected housingLocationList: HousingLocation[] = [
     {
       id: 0,

--- a/aio/content/examples/first-app-lesson-13/src/app/housing.service.ts
+++ b/aio/content/examples/first-app-lesson-13/src/app/housing.service.ts
@@ -5,7 +5,7 @@ import { HousingLocation } from './housinglocation';
   providedIn: 'root'
 })
 export class HousingService {
-  private img_server = "https://storage.googleapis.com/angular-tutorial-assets/first-app/";
+  private img_server = 'https://storage.googleapis.com/angular-tutorial-assets/first-app/';
   protected housingLocationList: HousingLocation[] = [
     {
       id: 0,


### PR DESCRIPTION
The commit enables the `@typescript-eslint/quotes` rule which mendates single quotes over doubles and allows template literals with backticks.