### PR TITLE
fix(http): export XSRF_DEFAULT_COOKIE_NAME and XSRF_DEFAULT_HEADER_NAME

### DIFF
--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -2192,6 +2192,12 @@ export type XhrFactory = XhrFactory_2;
 // @public @deprecated
 export const XhrFactory: typeof XhrFactory_2;
 
+// @public (undocumented)
+export const XSRF_DEFAULT_COOKIE_NAME = "XSRF-TOKEN";
+
+// @public (undocumented)
+export const XSRF_DEFAULT_HEADER_NAME = "X-XSRF-TOKEN";
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -39,7 +39,7 @@ export {HttpFeature, HttpFeatureKind, provideHttpClient, withJsonpSupport, withN
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpStatusCode, HttpUploadProgressEvent, HttpUserEvent} from './src/response';
 export {HttpXhrBackend} from './src/xhr';
-export {HttpXsrfTokenExtractor} from './src/xsrf';
+export {HttpXsrfTokenExtractor, XSRF_DEFAULT_COOKIE_NAME, XSRF_DEFAULT_HEADER_NAME} from './src/xsrf';
 
 // This re-export exists because g3 depends on this old private name.
 export {HttpInterceptorHandler as ɵHttpInterceptingHandler} from './src/interceptor';


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The XSRF tokens are not publicly exported, making it impossible for now to configure `provideHttpClient` in the same way `HttpClientModule` does:

```
provideHttpClient(
  withInterceptorsFromDi(),
  withXsrfConfiguration({
    cookieName: XSRF_DEFAULT_COOKIE_NAME,
    headerName: XSRF_DEFAULT_HEADER_NAME,
  })
)
```

## What is the new behavior?

This PR exports the tokens

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
