### PR TITLE
fix(docs-infra): Error logs links point to the archived version of the docs

### DIFF
--- a/packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
+++ b/packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
@@ -6,6 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {VERSION} from '@angular/compiler';
+
+// tslint:disable-next-line: no-toplevel-property-access
+const versionSubDomain = VERSION.major !== '0' ? `v${VERSION.major}.` : '';
+
 /**
  * Base URL for the error details page.
  *
@@ -13,4 +18,4 @@
  *  - packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
  *  - packages/core/src/error_details_base_url.ts
  */
-export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';
+export const ERROR_DETAILS_PAGE_BASE_URL = `https://${versionSubDomain}angular.io/errors`;

--- a/packages/core/src/error_details_base_url.ts
+++ b/packages/core/src/error_details_base_url.ts
@@ -6,6 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {VERSION} from './version';
+
+// tslint:disable-next-line: no-toplevel-property-access
+const versionSubDomain = VERSION.major !== '0' ? `v${VERSION.major}.` : '';
+
 /**
  * Base URL for the error details page.
  *
@@ -13,7 +18,7 @@
  *  - packages/compiler-cli/src/ngtsc/diagnostics/src/error_details_base_url.ts
  *  - packages/core/src/error_details_base_url.ts
  */
-export const ERROR_DETAILS_PAGE_BASE_URL = 'https://angular.io/errors';
+export const ERROR_DETAILS_PAGE_BASE_URL = `https://${versionSubDomain}angular.io/errors`;
 
 /**
  * URL for the XSS security documentation.


### PR DESCRIPTION
In order to point the right context, links in error messages will target the archived version of the online doc site (v*.angular.io).

See #44650

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [x] No