### PR TITLE
fix(migrations): duplicated comments on migrated classes

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
@@ -286,11 +286,11 @@ function addPropertyToAngularDecorator(
     return node;
   }
 
-  return ts.factory.updateDecorator(
-      node,
-      ts.factory.createCallExpression(node.expression.expression, node.expression.typeArguments, [
-        ts.factory.createObjectLiteralExpression(literalProperties, literalProperties.length > 1)
-      ]));
+  // Use `createDecorator` instead of `updateDecorator`, because
+  // the latter ends up duplicating the node's leading comment.
+  return ts.factory.createDecorator(ts.factory.createCallExpression(
+      node.expression.expression, node.expression.typeArguments,
+      [ts.factory.createObjectLiteralExpression(literalProperties, literalProperties.length > 1)]));
 }
 
 /** Checks if a node is a `PropertyAssignment` with a name. */

--- a/packages/core/schematics/test/standalone_migration_spec.ts
+++ b/packages/core/schematics/test/standalone_migration_spec.ts
@@ -1294,6 +1294,34 @@ describe('standalone migration', () => {
     `));
   });
 
+  it('should not duplicate doc strings', async () => {
+    writeFile('module.ts', `
+      import {NgModule, Directive} from '@angular/core';
+
+      /** Directive used for testing. */
+      @Directive({selector: '[dir]'})
+      export class MyDir {}
+
+      /** Module used for testing. */
+      @NgModule({declarations: [MyDir]})
+      export class Mod {}
+    `);
+
+    await runMigration('convert-to-standalone');
+
+    expect(stripWhitespace(tree.readContent('module.ts'))).toBe(stripWhitespace(`
+      import {NgModule, Directive} from '@angular/core';
+
+      /** Directive used for testing. */
+      @Directive({selector: '[dir]', standalone: true})
+      export class MyDir {}
+
+      /** Module used for testing. */
+      @NgModule({imports: [MyDir]})
+      export class Mod {}
+    `));
+  });
+
   it('should remove a module that only has imports and exports', async () => {
     writeFile('app.module.ts', `
       import {NgModule} from '@angular/core';


### PR DESCRIPTION
Fixes that the migration was duplicating the comments on class nodes that were being converted to standalone.

Fixes #48943.