### PR TITLE
refactor(docs-infra): Drop deprecated rxjs multicasting operators

### DIFF
--- a/aio/src/app/custom-elements/contributor/contributor.service.ts
+++ b/aio/src/app/custom-elements/contributor/contributor.service.ts
@@ -1,13 +1,13 @@
-import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
 
-import { ConnectableObservable, Observable } from 'rxjs';
-import { map, publishLast } from 'rxjs/operators';
+import {AsyncSubject, connectable, Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
 
-import { Contributor, ContributorGroup } from './contributors.model';
+import {Contributor, ContributorGroup} from './contributors.model';
 
 // TODO(andrewjs): Look into changing this so that we don't import the service just to get the const
-import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
+import {CONTENT_URL_PREFIX} from 'app/documents/document.service';
 
 const contributorsPath = CONTENT_URL_PREFIX + 'contributors.json';
 const knownGroups = ['Angular', 'Collaborators', 'GDE'];
@@ -23,11 +23,11 @@ export class ContributorService {
   private getContributors() {
     const contributors = this.http.get<{[key: string]: Contributor}>(contributorsPath).pipe(
       // Create group map
-      map(contribs => {
-        const contribMap: { [name: string]: Contributor[]} = {};
-        Object.keys(contribs).forEach(key => {
+      map((contribs) => {
+        const contribMap: {[name: string]: Contributor[]} = {};
+        Object.keys(contribs).forEach((key) => {
           const contributor = contribs[key];
-          contributor.groups.forEach(group => {
+          contributor.groups.forEach((group) => {
             const contribGroup = contribMap[group] || (contribMap[group] = []);
             contribGroup.push(contributor);
           });
@@ -37,31 +37,33 @@ export class ContributorService {
       }),
 
       // Flatten group map into sorted group array of sorted contributors
-      map(cmap => Object.keys(cmap).map(key => {
-          const order = knownGroups.indexOf(key);
-          return {
-            name: key,
-            order: order === -1 ? knownGroups.length : order,
-            contributors: cmap[key].sort(compareContributors)
-          } as ContributorGroup;
-        })
-        .sort(compareGroups)
-      ),
-
-      publishLast(),
+      map((cmap) =>
+        Object.keys(cmap)
+          .map((key) => {
+            const order = knownGroups.indexOf(key);
+            return {
+              name: key,
+              order: order === -1 ? knownGroups.length : order,
+              contributors: cmap[key].sort(compareContributors),
+            };
+          })
+          .sort(compareGroups)
+      )
     );
 
-    (contributors as ConnectableObservable<ContributorGroup[]>).connect();
-    return contributors;
+    const connectableContributors = connectable(contributors, {
+      connector: () => new AsyncSubject(),
+      resetOnDisconnect: false,
+    });
+    connectableContributors.connect();
+    return connectableContributors;
   }
 }
 
 function compareContributors(l: Contributor, r: Contributor) {
- return l.name.toUpperCase() > r.name.toUpperCase() ? 1 : -1;
+  return l.name.toUpperCase() > r.name.toUpperCase() ? 1 : -1;
 }
 
 function compareGroups(l: ContributorGroup, r: ContributorGroup) {
-  return l.order === r.order ?
-    (l.name > r.name ? 1 : -1) :
-     l.order > r.order ? 1 : -1;
+  return l.order === r.order ? (l.name > r.name ? 1 : -1) : l.order > r.order ? 1 : -1;
 }

--- a/aio/src/app/custom-elements/events/events.service.ts
+++ b/aio/src/app/custom-elements/events/events.service.ts
@@ -1,12 +1,12 @@
-import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
 
-import { ConnectableObservable, Observable, of } from 'rxjs';
-import { catchError, publishLast } from 'rxjs/operators';
+import {AsyncSubject, connectable, Observable, of} from 'rxjs';
+import {catchError} from 'rxjs/operators';
 
-import { AngularEvent } from './events.component';
-import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
-import { Logger } from 'app/shared/logger.service';
+import {AngularEvent} from './events.component';
+import {CONTENT_URL_PREFIX} from 'app/documents/document.service';
+import {Logger} from 'app/shared/logger.service';
 
 const eventsPath = CONTENT_URL_PREFIX + 'events.json';
 
@@ -19,14 +19,17 @@ export class EventsService {
   }
 
   private getEvents() {
-    const events = this.http.get<any>(eventsPath).pipe(
-      catchError(error => {
+    const eventsSource = this.http.get<any>(eventsPath).pipe(
+      catchError((error) => {
         this.logger.error(new Error(`${eventsPath} request failed: ${error.message}`));
         return of([]);
-      }),
-      publishLast()
+      })
     );
-    (events as ConnectableObservable<AngularEvent[]>).connect();
+    const events = connectable(eventsSource, {
+      connector: () => new AsyncSubject(),
+      resetOnDisconnect: false,
+    });
+    events.connect();
     return events;
   }
 }

--- a/aio/src/app/custom-elements/resource/resource.service.ts
+++ b/aio/src/app/custom-elements/resource/resource.service.ts
@@ -1,11 +1,11 @@
-import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import {Injectable} from '@angular/core';
+import {HttpClient} from '@angular/common/http';
 
-import { ConnectableObservable, Observable } from 'rxjs';
-import { map, publishLast } from 'rxjs/operators';
+import {AsyncSubject, connectable, Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
 
-import { Category, Resource, SubCategory } from './resource.model';
-import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
+import {Category, Resource, SubCategory} from './resource.model';
+import {CONTENT_URL_PREFIX} from 'app/documents/document.service';
 
 const resourcesPath = CONTENT_URL_PREFIX + 'resources.json';
 
@@ -18,13 +18,12 @@ export class ResourceService {
   }
 
   private getCategories(): Observable<Category[]> {
-
-    const categories = this.http.get<any>(resourcesPath).pipe(
-      map(data => mkCategories(data)),
-      publishLast(),
-    );
-
-    (categories as ConnectableObservable<Category[]>).connect();
+    const categoriesSrc = this.http.get<any>(resourcesPath).pipe(map((data) => mkCategories(data)));
+    const categories = connectable(categoriesSrc, {
+      connector: () => new AsyncSubject(),
+      resetOnDisconnect: false,
+    });
+    categories.connect();
     return categories;
   }
 }
@@ -32,15 +31,15 @@ export class ResourceService {
 // Extract sorted Category[] from resource JSON data
 function mkCategories(categoryJson: any): Category[] {
   return Object.keys(categoryJson).map(catKey => {
-    const cat = categoryJson[catKey];
-    return {
-      id: makeId(catKey),
-      title: catKey,
-      order: cat.order,
+      const cat = categoryJson[catKey];
+      return {
+        id: makeId(catKey),
+        title: catKey,
+        order: cat.order,
       subCategories: mkSubCategories(cat.subCategories, catKey)
-    } as Category;
-  })
-  .sort(compareCats);
+      } as Category;
+    })
+    .sort(compareCats);
 }
 
 // Extract sorted SubCategory[] from JSON category data
@@ -53,20 +52,20 @@ function mkSubCategories(subCategoryJson: any, catKey: string): SubCategory[] {
         order: sub.order,
         resources: mkResources(sub.resources, subKey, catKey)
       } as SubCategory;
-  })
-  .sort(compareCats);
+    })
+    .sort(compareCats);
 }
 
 // Extract sorted Resource[] from JSON subcategory data
 function mkResources(resourceJson: any, subKey: string, catKey: string): Resource[] {
   return Object.keys(resourceJson).map(resKey => {
-    const res = resourceJson[resKey];
-    res.category = catKey;
-    res.subCategory = subKey;
-    res.id = makeId(resKey);
-    return res as Resource;
-  })
-  .sort(compareTitles);
+      const res = resourceJson[resKey];
+      res.category = catKey;
+      res.subCategory = subKey;
+      res.id = makeId(resKey);
+      return res as Resource;
+    })
+    .sort(compareTitles);
 }
 
 function compareCats(l: Category | SubCategory, r: Category | SubCategory) {
@@ -74,7 +73,7 @@ function compareCats(l: Category | SubCategory, r: Category | SubCategory) {
 }
 
 function compareTitles(l: {title: string}, r: {title: string}) {
- return l.title.toUpperCase() > r.title.toUpperCase() ? 1 : -1;
+  return l.title.toUpperCase() > r.title.toUpperCase() ? 1 : -1;
 }
 
 function makeId(title: string) {

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -18,7 +18,7 @@ export class LocationService {
     .pipe(map(url => this.stripSlashes(url)));
 
   currentPath = this.currentUrl.pipe(
-    map(url => (url.match(/[^?#]*/) || [])[0]),  // strip query and hash
+    map(url => (url.match(/[^?#]*/) || [''])[0]),  // strip query and hash
     tap(path => this.analyticsService.locationChanged(path)),
   );
 


### PR DESCRIPTION
RxJS has deprecated the `publishReplay` & `publishLast` operators which will be removed in RxJS 8. `connectable()` should be used instead.



## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes


## Does this PR introduce a breaking change?


- [x] No
