### PR TITLE
feat(compiler-cli): DI mode for ctors with default values

### DIFF
--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -420,6 +420,11 @@ export interface CtorParameter {
    * Any `Decorator`s which are present on the parameter, or `null` if none are present.
    */
   decorators: Decorator[]|null;
+
+  /**
+   * Whether the parameter has an initialization expression.
+   */
+  hasInitializer: boolean;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -85,6 +85,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
         typeValueReference,
         typeNode: originalTypeNode,
         decorators,
+        hasInitializer: node.initializer !== undefined,
       };
     });
   }

--- a/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
@@ -70,6 +70,8 @@ export interface SimpleChanges {
   [propName: string]: any;
 }
 
+export declare function inject(type: any, options?: any): void;
+
 export type ɵɵNgModuleDeclaration<ModuleT, DeclarationsT, ImportsT, ExportsT> = unknown;
 export type ɵɵDirectiveDeclaration<DirT, SelectorT, ExportAsT, InputsT, OutputsT, QueriesT> =
     unknown;

--- a/packages/core/src/di/jit/constructor.ts
+++ b/packages/core/src/di/jit/constructor.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Type} from '../../interface/type';
+
+/**
+ * Heuristically determine if a `type` has a constructor that should be treated as "fully optional"
+ * (that is, invokable without passing arguments).
+ *
+ * To determine this, the class `.toString()` is used to access the code of the class, and the
+ * heuristic looks for the constructor method. If a constructor is found with its first argument
+ * having a default value initializer, then the constructor is considered to be fully optional.
+ *
+ * This is only a heuristic as different downlevelings of classes might break this rudimentary
+ * parsing of the code, as might other edge cases in the class code (using the string 'constructor('
+ * in other places) or extensive use of other syntax (like destructuring) in the constructor itself.
+ */
+export function isProbablyFullyOptionalConstructor(type: Type<any>): boolean {
+  const code = type.toString();
+
+  // Only accept ECMAScript classes.
+  if (!code.startsWith('class ')) {
+    return false;
+  }
+
+  // Look for the constructor if one exists.
+  const ctorPos = code.indexOf('constructor(');
+  if (ctorPos === -1) {
+    // Without a constructor, either:
+    //  - the constructor is inherited from the base class, or
+    //  - there's actually no constructor.
+    //
+    // In either case, we want to fall back to the normal JIT compilation for constructor factories,
+    // which will do the right thing in both cases.
+    return false;
+  }
+
+  const ctor = code.substring(ctorPos + 'constructor('.length);
+
+  // We scan the constructor's first parameter and attempt to determine if it has an optional
+  // assignment. This is complicated by the fact that the first parameter could be destructured.
+  let destructuringOpeners = 0;
+  for (const char of ctor) {
+    switch (char) {
+      case '{':
+      case '[':
+        // Some kind of destructuring operation. Keep track of the number of openers as that
+        // determines the syntactic context of future characters.
+        destructuringOpeners++;
+        break;
+      case '}':
+      case ']':
+        destructuringOpeners--;
+        if (destructuringOpeners < 0) {
+          // Something went wrong - we saw more closing characters than opening characters.
+          return false;
+        }
+        break;
+      case ',':
+        // Commas are fine inside destructuring operations, but if we encounter a comma outside of
+        // destructuring, we've moved on to the second parameter without finding an optional
+        // assignment, which means this constructor is not fully optional.
+        if (destructuringOpeners === 0) {
+          // This comma is outside of destructuring, which means this constructor is not fully
+          // optional.
+          return false;
+        }
+        break;
+      case '=':
+        // Finding an assignment inside of destructuring means that we're making individual fields
+        // optional and not the whole first parameter.
+        if (destructuringOpeners > 0) {
+          return false;
+        }
+
+        // Otherwise, this is an optional assignment for the first parameter. Since non-optional
+        // parameters cannot follow optional ones, this means the whole constructor is legal to call
+        // with no arguments.
+        //
+        // Note that this is a looser condition than the AOT compiler enforces, since we only
+        // require initialization of the first parameter and not all parameters. That is, we could
+        // be looking at a signature `constructor(a = X, y?)` which the AOT compiler would not see
+        // as "fully optional". This is a limitation of how much syntax we want to "parse" for this
+        // heuristic.
+        return true;
+      case ')':
+        // We're leaving the constructor context without finding an optional assignment.
+        return false;
+    }
+  }
+
+  return false;
+}

--- a/packages/core/src/di/jit/util.ts
+++ b/packages/core/src/di/jit/util.ts
@@ -13,6 +13,8 @@ import {ReflectionCapabilities} from '../../reflection/reflection_capabilities';
 import {Host, Inject, Optional, Self, SkipSelf} from '../metadata';
 import {Attribute} from '../metadata_attr';
 
+import {isProbablyFullyOptionalConstructor} from './constructor';
+
 let _reflect: ReflectionCapabilities|null = null;
 
 export function getReflect(): ReflectionCapabilities {
@@ -20,6 +22,10 @@ export function getReflect(): ReflectionCapabilities {
 }
 
 export function reflectDependencies(type: Type<any>): R3DependencyMetadataFacade[] {
+  if (isProbablyFullyOptionalConstructor(type)) {
+    // Types with fully optional constructors are reflected as having no-arg constructors.
+    return [];
+  }
   return convertDependencies(getReflect().parameters(type));
 }
 


### PR DESCRIPTION
Previously, the AOT compiler would attempt to generate DI constructor calls for all constructors, and report errors if explicit type annotations or other problems prevented them from being generated.

This commit adds a new feature which specially handles constructors that have default values specificed for all parameters. When the compiler encounters such a constructor, it now generates a zero-arg constructor call (`new ClassName()`) as the factory function instead of a normal DI call. This means that the default values (the initializers) of all parameters will be used.

With this feature, the constructor form:

```typescript
constructor(foo = inject(FooService), bar = inject(BarService)) {}
```

now works correctly. Such a constructor can use DI in production, and have these default values overridden for tests.


Fixes #47606