### PR TITLE
Various standalone migrations improvements

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/index.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/index.ts
@@ -72,6 +72,9 @@ function standaloneMigration(
       {
         _enableTemplateTypeChecker: true,  // Required for the template type checker to work.
         compileNonExportedClasses: true,   // We want to migrate non-exported classes too.
+        // Avoid checking libraries to speed up the migration.
+        skipLibCheck: true,
+        skipDefaultLibCheck: true,
       });
   const program = createProgram({rootNames, host, options}) as NgtscProgram;
   const printer = ts.createPrinter();

--- a/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/to-standalone.ts
@@ -569,7 +569,8 @@ function analyzeTestingModules(
 
     const importsProp = findLiteralProperty(obj, 'imports');
     const importElements = importsProp && hasNgModuleMetadataElements(importsProp) ?
-        importsProp.initializer.elements :
+        // Filter out calls since they may be a `ModuleWithProviders`.
+        importsProp.initializer.elements.filter(el => !ts.isCallExpression(el)) :
         null;
 
     for (const decl of declarations) {

--- a/packages/core/schematics/utils/typescript/compiler_host.ts
+++ b/packages/core/schematics/utils/typescript/compiler_host.ts
@@ -92,8 +92,9 @@ function createMigrationCompilerHost(
  */
 export function canMigrateFile(
     basePath: string, sourceFile: ts.SourceFile, program: ts.Program): boolean {
-  // We shouldn't migrate .d.ts files or files from an external library.
-  if (sourceFile.isDeclarationFile || program.isSourceFileFromExternalLibrary(sourceFile)) {
+  // We shouldn't migrate .d.ts files, files from an external library or type checking files.
+  if (sourceFile.fileName.endsWith('.ngtypecheck.ts') || sourceFile.isDeclarationFile ||
+      program.isSourceFileFromExternalLibrary(sourceFile)) {
     return false;
   }
 

--- a/packages/core/schematics/utils/typescript/compiler_host.ts
+++ b/packages/core/schematics/utils/typescript/compiler_host.ts
@@ -39,17 +39,19 @@ export function createMigrationProgram(
  * @param fakeFileRead Optional file reader function. Can be used to overwrite files in
  *   the TypeScript program, or to add in-memory files (e.g. to add global types).
  * @param additionalFiles Additional file paths that should be added to the program.
+ * @param optionOverrides Overrides of the parsed compiler options.
  */
 export function createProgramOptions(
     tree: Tree, tsconfigPath: string, basePath: string, fakeFileRead?: FakeReadFileFn,
-    additionalFiles?: string[]) {
+    additionalFiles?: string[], optionOverrides?: ts.CompilerOptions) {
   // Resolve the tsconfig path to an absolute path. This is needed as TypeScript otherwise
   // is not able to resolve root directories in the given tsconfig. More details can be found
   // in the following issue: https://github.com/microsoft/TypeScript/issues/37731.
   tsconfigPath = resolve(basePath, tsconfigPath);
   const parsed = parseTsconfigFile(tsconfigPath, dirname(tsconfigPath));
-  const host = createMigrationCompilerHost(tree, parsed.options, basePath, fakeFileRead);
-  return {rootNames: parsed.fileNames.concat(additionalFiles || []), options: parsed.options, host};
+  const options = optionOverrides ? {...parsed.options, ...optionOverrides} : parsed.options;
+  const host = createMigrationCompilerHost(tree, options, basePath, fakeFileRead);
+  return {rootNames: parsed.fileNames.concat(additionalFiles || []), options, host};
 }
 
 function createMigrationCompilerHost(


### PR DESCRIPTION
Includes the following improvements to the standalone migration. There is more info in each of the commits:
1. Only excludes bootstrapped declarations from the first step of the migration, rather than all of them.
2. Migrates tests when switching the root module to standalone.
3. Doesn't copy over `ModuleWithProviders` when migrating tests.
4. Preserves the project's tsconfig when constructing the migration program.
5. Reduces the number of files that the migration has to load in order to speed it up.
6. Corrects any standalone declarations that might still be left in the `declarations` array from a previous migration. This is primarily targeted towards tests.

Fixes #48944.
Fixes #48971.