### PR TITLE
fix(compiler-cli): incorrectly detecting forward refs when symbol already exists in file

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -719,12 +719,19 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     }
     const emitted = emittedRef.expression;
     if (emitted instanceof WrappedNodeExpr) {
+      let isForwardReference = false;
+      if (emitted.node.getStart() > inContext.getStart()) {
+        const declaration = this.programDriver.getProgram()
+                                .getTypeChecker()
+                                .getTypeAtLocation(emitted.node)
+                                .getSymbol()
+                                ?.declarations?.[0];
+        if (declaration && declaration.getSourceFile() === inContext.getSourceFile()) {
+          isForwardReference = true;
+        }
+      }
       // An appropriate identifier is already in scope.
-      return {
-        kind,
-        symbolName: emitted.node.text,
-        isForwardReference: emitted.node.getStart() > inContext.getStart()
-      };
+      return {kind, symbolName: emitted.node.text, isForwardReference};
     } else if (
         emitted instanceof ExternalExpr && emitted.value.moduleName !== null &&
         emitted.value.name !== null) {


### PR DESCRIPTION
In #48898 the `isForwardRef` flag was added to indicate whether a reference should be wrapped in a `forwardRef`. This logic assumed that the node can't be referring to another node within the same file, however from testing it looks like that's not actually the case, because we hit the same code path when an external import to the same symbol exists already.