### PR TITLE
build: update dependency terser to 5.16.3 [security] 

### DIFF
--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -6,6 +6,9 @@
     "name": "ANIMATION_MODULE_TYPE"
   },
   {
+    "name": "ANY_STATE"
+  },
+  {
     "name": "APP_BOOTSTRAP_LISTENER"
   },
   {
@@ -13,6 +16,9 @@
   },
   {
     "name": "APP_INITIALIZER"
+  },
+  {
+    "name": "AUTO_STYLE"
   },
   {
     "name": "AnimationAstBuilderContext"
@@ -28,6 +34,9 @@
   },
   {
     "name": "AnimationEngine"
+  },
+  {
+    "name": "AnimationFactory"
   },
   {
     "name": "AnimationGroupPlayer"
@@ -69,6 +78,12 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "BLOOM_BUCKET_BITS"
+  },
+  {
+    "name": "BLOOM_MASK"
+  },
+  {
     "name": "BROWSER_ANIMATIONS_PROVIDERS"
   },
   {
@@ -108,6 +123,9 @@
     "name": "COMPONENT_REGEX"
   },
   {
+    "name": "CONTAINER_HEADER_OFFSET"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -124,6 +142,9 @@
   },
   {
     "name": "ComponentFactoryResolver2"
+  },
+  {
+    "name": "ComponentRef"
   },
   {
     "name": "ComponentRef2"
@@ -147,10 +168,16 @@
     "name": "DIMENSIONAL_PROP_SET"
   },
   {
+    "name": "DI_DECORATOR_FLAG"
+  },
+  {
     "name": "DOCUMENT2"
   },
   {
     "name": "DefaultDomRenderer2"
+  },
+  {
+    "name": "DomAdapter"
   },
   {
     "name": "DomEventsPlugin"
@@ -186,6 +213,9 @@
     "name": "ENVIRONMENT_INITIALIZER"
   },
   {
+    "name": "ERROR_ORIGINAL_ERROR"
+  },
+  {
     "name": "EVENT_MANAGER_PLUGINS"
   },
   {
@@ -214,6 +244,12 @@
   },
   {
     "name": "FALSE_BOOLEAN_VALUES"
+  },
+  {
+    "name": "GenericBrowserDomAdapter"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
   },
   {
     "name": "INJECTOR2"
@@ -252,6 +288,15 @@
     "name": "MODIFIER_KEY_GETTERS"
   },
   {
+    "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "MOVED_VIEWS"
+  },
+  {
+    "name": "MapOperator"
+  },
+  {
     "name": "MapSubscriber"
   },
   {
@@ -262,6 +307,9 @@
   },
   {
     "name": "NAMESPACE_URIS"
+  },
+  {
+    "name": "NATIVE"
   },
   {
     "name": "NEW_LINE"
@@ -297,6 +345,15 @@
     "name": "NG_PROV_DEF"
   },
   {
+    "name": "NG_TEMPLATE_SELECTOR"
+  },
+  {
+    "name": "NG_TEMP_TOKEN_PATH"
+  },
+  {
+    "name": "NG_TOKEN_PATH"
+  },
+  {
     "name": "NOT_FOUND"
   },
   {
@@ -309,6 +366,12 @@
     "name": "NO_CHANGE"
   },
   {
+    "name": "NO_NEW_LINE"
+  },
+  {
+    "name": "NO_PARENT_INJECTOR"
+  },
+  {
     "name": "NULL_INJECTOR"
   },
   {
@@ -316,6 +379,12 @@
   },
   {
     "name": "NULL_REMOVED_QUERIED_STATE"
+  },
+  {
+    "name": "NgModuleFactory"
+  },
+  {
+    "name": "NgModuleFactory2"
   },
   {
     "name": "NgModuleRef"
@@ -342,6 +411,9 @@
     "name": "NullInjector"
   },
   {
+    "name": "ONE_SECOND"
+  },
+  {
     "name": "ObjectUnsubscribedError"
   },
   {
@@ -366,6 +438,9 @@
     "name": "R3Injector"
   },
   {
+    "name": "REMOVAL_FLAG"
+  },
+  {
     "name": "RefCountOperator"
   },
   {
@@ -384,6 +459,9 @@
     "name": "RootComponent"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
@@ -396,6 +474,12 @@
     "name": "SHARED_ANIMATION_PROVIDERS"
   },
   {
+    "name": "SIMPLE_CHANGES_STORE"
+  },
+  {
+    "name": "SOURCE"
+  },
+  {
     "name": "SafeSubscriber"
   },
   {
@@ -406,6 +490,9 @@
   },
   {
     "name": "SharedStylesHost"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SimpleInnerSubscriber"
@@ -459,6 +546,9 @@
     "name": "TRUE_BOOLEAN_VALUES"
   },
   {
+    "name": "TYPE"
+  },
+  {
     "name": "Testability"
   },
   {
@@ -481,6 +571,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "WebAnimationsPlayer"
@@ -522,7 +615,13 @@
     "name": "_flattenGroupPlayersRecur"
   },
   {
+    "name": "_getInsertInFrontOfRNodeWithI18n"
+  },
+  {
     "name": "_global"
+  },
+  {
+    "name": "_icuContainerIterate"
   },
   {
     "name": "_injectImplementation"
@@ -532,6 +631,9 @@
   },
   {
     "name": "_platformInjector"
+  },
+  {
+    "name": "_processI18nInsertBefore"
   },
   {
     "name": "_query"
@@ -1170,6 +1272,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "profiler"
+  },
+  {
     "name": "promise"
   },
   {
@@ -1354,6 +1459,9 @@
   },
   {
     "name": "writeStyleAttribute"
+  },
+  {
+    "name": "ɵPRE_STYLE"
   },
   {
     "name": "ɵɵdefineComponent"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -24,6 +24,12 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "BLOOM_BUCKET_BITS"
+  },
+  {
+    "name": "BLOOM_MASK"
+  },
+  {
     "name": "BROWSER_MODULE_PROVIDERS"
   },
   {
@@ -45,6 +51,9 @@
     "name": "COMPONENT_REGEX"
   },
   {
+    "name": "CONTAINER_HEADER_OFFSET"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -63,6 +72,9 @@
     "name": "ComponentFactoryResolver2"
   },
   {
+    "name": "ComponentRef"
+  },
+  {
     "name": "ComponentRef2"
   },
   {
@@ -72,6 +84,9 @@
     "name": "ConnectableSubscriber"
   },
   {
+    "name": "DI_DECORATOR_FLAG"
+  },
+  {
     "name": "DOCUMENT2"
   },
   {
@@ -79,6 +94,9 @@
   },
   {
     "name": "DepComponent"
+  },
+  {
+    "name": "DomAdapter"
   },
   {
     "name": "DomEventsPlugin"
@@ -100,6 +118,9 @@
   },
   {
     "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
+    "name": "ERROR_ORIGINAL_ERROR"
   },
   {
     "name": "EVENT_MANAGER_PLUGINS"
@@ -124,6 +145,12 @@
   },
   {
     "name": "EventManagerPlugin"
+  },
+  {
+    "name": "GenericBrowserDomAdapter"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
   },
   {
     "name": "INJECTOR2"
@@ -159,6 +186,15 @@
     "name": "MODIFIER_KEY_GETTERS"
   },
   {
+    "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "MOVED_VIEWS"
+  },
+  {
+    "name": "MapOperator"
+  },
+  {
     "name": "MapSubscriber"
   },
   {
@@ -172,6 +208,9 @@
   },
   {
     "name": "NAMESPACE_URIS"
+  },
+  {
+    "name": "NATIVE"
   },
   {
     "name": "NEW_LINE"
@@ -207,6 +246,15 @@
     "name": "NG_PROV_DEF"
   },
   {
+    "name": "NG_TEMPLATE_SELECTOR"
+  },
+  {
+    "name": "NG_TEMP_TOKEN_PATH"
+  },
+  {
+    "name": "NG_TOKEN_PATH"
+  },
+  {
     "name": "NOT_FOUND"
   },
   {
@@ -219,7 +267,19 @@
     "name": "NO_CHANGE"
   },
   {
+    "name": "NO_NEW_LINE"
+  },
+  {
+    "name": "NO_PARENT_INJECTOR"
+  },
+  {
     "name": "NULL_INJECTOR"
+  },
+  {
+    "name": "NgModuleFactory"
+  },
+  {
+    "name": "NgModuleFactory2"
   },
   {
     "name": "NgModuleRef"
@@ -273,10 +333,19 @@
     "name": "RendererStyleFlags2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
   },
   {
     "name": "SERVER_TRANSITION_PROVIDERS"
+  },
+  {
+    "name": "SIMPLE_CHANGES_STORE"
+  },
+  {
+    "name": "SOURCE"
   },
   {
     "name": "SafeSubscriber"
@@ -289,6 +358,9 @@
   },
   {
     "name": "SharedStylesHost"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SimpleInnerSubscriber"
@@ -330,6 +402,9 @@
     "name": "TRANSITION_ID"
   },
   {
+    "name": "TYPE"
+  },
+  {
     "name": "Testability"
   },
   {
@@ -351,6 +426,9 @@
     "name": "ViewEncapsulation"
   },
   {
+    "name": "ViewRef"
+  },
+  {
     "name": "_DOM"
   },
   {
@@ -366,7 +444,13 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_getInsertInFrontOfRNodeWithI18n"
+  },
+  {
     "name": "_global"
+  },
+  {
+    "name": "_icuContainerIterate"
   },
   {
     "name": "_injectImplementation"
@@ -376,6 +460,9 @@
   },
   {
     "name": "_platformInjector"
+  },
+  {
+    "name": "_processI18nInsertBefore"
   },
   {
     "name": "_randomChar"
@@ -877,6 +964,9 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "profiler"
   },
   {
     "name": "promise"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -36,6 +36,12 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "BLOOM_BUCKET_BITS"
+  },
+  {
+    "name": "BLOOM_MASK"
+  },
+  {
     "name": "BROWSER_MODULE_PROVIDERS"
   },
   {
@@ -72,6 +78,9 @@
     "name": "COMPOSITION_BUFFER_MODE"
   },
   {
+    "name": "CONTAINER_HEADER_OFFSET"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -93,6 +102,9 @@
     "name": "ComponentFactoryResolver2"
   },
   {
+    "name": "ComponentRef"
+  },
+  {
     "name": "ComponentRef2"
   },
   {
@@ -108,6 +120,9 @@
     "name": "DEFAULT_VALUE_ACCESSOR"
   },
   {
+    "name": "DI_DECORATOR_FLAG"
+  },
+  {
     "name": "DOCUMENT2"
   },
   {
@@ -121,6 +136,9 @@
   },
   {
     "name": "DefaultValueAccessor"
+  },
+  {
+    "name": "DomAdapter"
   },
   {
     "name": "DomEventsPlugin"
@@ -145,6 +163,9 @@
   },
   {
     "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
+    "name": "ERROR_ORIGINAL_ERROR"
   },
   {
     "name": "EVENT_MANAGER_PLUGINS"
@@ -201,6 +222,12 @@
     "name": "FormsExampleModule"
   },
   {
+    "name": "GenericBrowserDomAdapter"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
+  },
+  {
     "name": "INJECTOR2"
   },
   {
@@ -240,6 +267,12 @@
     "name": "MODIFIER_KEY_GETTERS"
   },
   {
+    "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "MOVED_VIEWS"
+  },
+  {
     "name": "MapOperator"
   },
   {
@@ -255,6 +288,9 @@
     "name": "NAMESPACE_URIS"
   },
   {
+    "name": "NATIVE"
+  },
+  {
     "name": "NEW_LINE"
   },
   {
@@ -262,6 +298,12 @@
   },
   {
     "name": "NG_COMP_DEF"
+  },
+  {
+    "name": "NG_DEV_MODE3"
+  },
+  {
+    "name": "NG_DEV_MODE4"
   },
   {
     "name": "NG_DIR_DEF"
@@ -294,6 +336,15 @@
     "name": "NG_PROV_DEF"
   },
   {
+    "name": "NG_TEMPLATE_SELECTOR"
+  },
+  {
+    "name": "NG_TEMP_TOKEN_PATH"
+  },
+  {
+    "name": "NG_TOKEN_PATH"
+  },
+  {
     "name": "NG_VALIDATORS"
   },
   {
@@ -312,6 +363,12 @@
     "name": "NO_CHANGE"
   },
   {
+    "name": "NO_NEW_LINE"
+  },
+  {
+    "name": "NO_PARENT_INJECTOR"
+  },
+  {
     "name": "NULL_INJECTOR"
   },
   {
@@ -325,6 +382,12 @@
   },
   {
     "name": "NgForOf"
+  },
+  {
+    "name": "NgModuleFactory"
+  },
+  {
+    "name": "NgModuleFactory2"
   },
   {
     "name": "NgModuleRef"
@@ -355,6 +418,9 @@
   },
   {
     "name": "Optional"
+  },
+  {
+    "name": "PARAMETERS"
   },
   {
     "name": "PLATFORM_DESTROY_LISTENERS"
@@ -417,7 +483,16 @@
     "name": "SERVER_TRANSITION_PROVIDERS"
   },
   {
+    "name": "SIMPLE_CHANGES_STORE"
+  },
+  {
+    "name": "SOURCE"
+  },
+  {
     "name": "SafeSubscriber"
+  },
+  {
+    "name": "SafeValueImpl"
   },
   {
     "name": "Sanitizer"
@@ -427,6 +502,9 @@
   },
   {
     "name": "SharedStylesHost"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SimpleInnerSubscriber"
@@ -471,6 +549,9 @@
     "name": "TRANSITION_ID"
   },
   {
+    "name": "TYPE"
+  },
+  {
     "name": "TemplateRef"
   },
   {
@@ -490,6 +571,9 @@
   },
   {
     "name": "VE_ViewContainerRef"
+  },
+  {
+    "name": "VIEW_REFS"
   },
   {
     "name": "Validators"
@@ -525,10 +609,16 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_getInsertInFrontOfRNodeWithI18n"
+  },
+  {
     "name": "_global"
   },
   {
     "name": "_hasInvalidParent"
+  },
+  {
+    "name": "_icuContainerIterate"
   },
   {
     "name": "_injectImplementation"
@@ -538,6 +628,9 @@
   },
   {
     "name": "_platformInjector"
+  },
+  {
+    "name": "_processI18nInsertBefore"
   },
   {
     "name": "_randomChar"
@@ -721,6 +814,9 @@
   },
   {
     "name": "defaultIterableDiffersFactory"
+  },
+  {
+    "name": "describeKey"
   },
   {
     "name": "destroyLView"
@@ -1128,6 +1224,9 @@
     "name": "isObject"
   },
   {
+    "name": "isObservable"
+  },
+  {
     "name": "isOptionsObj"
   },
   {
@@ -1306,6 +1405,9 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "profiler"
   },
   {
     "name": "promise"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -39,6 +39,12 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "BLOOM_BUCKET_BITS"
+  },
+  {
+    "name": "BLOOM_MASK"
+  },
+  {
     "name": "BROWSER_MODULE_PROVIDERS"
   },
   {
@@ -75,6 +81,9 @@
     "name": "COMPOSITION_BUFFER_MODE"
   },
   {
+    "name": "CONTAINER_HEADER_OFFSET"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -99,6 +108,9 @@
     "name": "ComponentFactoryResolver2"
   },
   {
+    "name": "ComponentRef"
+  },
+  {
     "name": "ComponentRef2"
   },
   {
@@ -114,6 +126,9 @@
     "name": "DEFAULT_VALUE_ACCESSOR"
   },
   {
+    "name": "DI_DECORATOR_FLAG"
+  },
+  {
     "name": "DOCUMENT2"
   },
   {
@@ -127,6 +142,9 @@
   },
   {
     "name": "DefaultValueAccessor"
+  },
+  {
+    "name": "DomAdapter"
   },
   {
     "name": "DomEventsPlugin"
@@ -148,6 +166,9 @@
   },
   {
     "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
+    "name": "ERROR_ORIGINAL_ERROR"
   },
   {
     "name": "EVENT_MANAGER_PLUGINS"
@@ -184,6 +205,12 @@
   },
   {
     "name": "FormsModule"
+  },
+  {
+    "name": "GenericBrowserDomAdapter"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
   },
   {
     "name": "INJECTOR2"
@@ -225,6 +252,12 @@
     "name": "MODIFIER_KEY_GETTERS"
   },
   {
+    "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "MOVED_VIEWS"
+  },
+  {
     "name": "MapOperator"
   },
   {
@@ -240,6 +273,9 @@
     "name": "NAMESPACE_URIS"
   },
   {
+    "name": "NATIVE"
+  },
+  {
     "name": "NEW_LINE"
   },
   {
@@ -247,6 +283,12 @@
   },
   {
     "name": "NG_COMP_DEF"
+  },
+  {
+    "name": "NG_DEV_MODE3"
+  },
+  {
+    "name": "NG_DEV_MODE4"
   },
   {
     "name": "NG_DIR_DEF"
@@ -276,6 +318,15 @@
     "name": "NG_PROV_DEF"
   },
   {
+    "name": "NG_TEMPLATE_SELECTOR"
+  },
+  {
+    "name": "NG_TEMP_TOKEN_PATH"
+  },
+  {
+    "name": "NG_TOKEN_PATH"
+  },
+  {
     "name": "NG_VALIDATORS"
   },
   {
@@ -292,6 +343,12 @@
   },
   {
     "name": "NO_CHANGE"
+  },
+  {
+    "name": "NO_NEW_LINE"
+  },
+  {
+    "name": "NO_PARENT_INJECTOR"
   },
   {
     "name": "NULL_INJECTOR"
@@ -316,6 +373,12 @@
   },
   {
     "name": "NgModelGroup"
+  },
+  {
+    "name": "NgModuleFactory"
+  },
+  {
+    "name": "NgModuleFactory2"
   },
   {
     "name": "NgModuleRef"
@@ -346,6 +409,9 @@
   },
   {
     "name": "Optional"
+  },
+  {
+    "name": "PARAMETERS"
   },
   {
     "name": "PLATFORM_DESTROY_LISTENERS"
@@ -405,7 +471,16 @@
     "name": "SERVER_TRANSITION_PROVIDERS"
   },
   {
+    "name": "SIMPLE_CHANGES_STORE"
+  },
+  {
+    "name": "SOURCE"
+  },
+  {
     "name": "SafeSubscriber"
+  },
+  {
+    "name": "SafeValueImpl"
   },
   {
     "name": "Sanitizer"
@@ -415,6 +490,9 @@
   },
   {
     "name": "SharedStylesHost"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SimpleInnerSubscriber"
@@ -459,6 +537,9 @@
     "name": "TRANSITION_ID"
   },
   {
+    "name": "TYPE"
+  },
+  {
     "name": "TemplateFormsComponent"
   },
   {
@@ -484,6 +565,9 @@
   },
   {
     "name": "VE_ViewContainerRef"
+  },
+  {
+    "name": "VIEW_REFS"
   },
   {
     "name": "ViewContainerRef"
@@ -516,7 +600,13 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_getInsertInFrontOfRNodeWithI18n"
+  },
+  {
     "name": "_global"
+  },
+  {
+    "name": "_icuContainerIterate"
   },
   {
     "name": "_injectImplementation"
@@ -526,6 +616,9 @@
   },
   {
     "name": "_platformInjector"
+  },
+  {
+    "name": "_processI18nInsertBefore"
   },
   {
     "name": "_randomChar"
@@ -691,6 +784,9 @@
   },
   {
     "name": "defaultIterableDiffersFactory"
+  },
+  {
+    "name": "describeKey"
   },
   {
     "name": "destroyLView"
@@ -1086,6 +1182,9 @@
     "name": "isObject"
   },
   {
+    "name": "isObservable"
+  },
+  {
     "name": "isOptionsObj"
   },
   {
@@ -1270,6 +1369,9 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "profiler"
   },
   {
     "name": "promise"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -18,10 +18,19 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "BLOOM_BUCKET_BITS"
+  },
+  {
+    "name": "BLOOM_MASK"
+  },
+  {
     "name": "BrowserDomAdapter"
   },
   {
     "name": "CIRCULAR"
+  },
+  {
+    "name": "CONTAINER_HEADER_OFFSET"
   },
   {
     "name": "ComponentFactory"
@@ -36,6 +45,9 @@
     "name": "ComponentFactoryResolver2"
   },
   {
+    "name": "ComponentRef"
+  },
+  {
     "name": "ComponentRef2"
   },
   {
@@ -45,7 +57,13 @@
     "name": "ConnectableSubscriber"
   },
   {
+    "name": "DI_DECORATOR_FLAG"
+  },
+  {
     "name": "DOCUMENT2"
+  },
+  {
+    "name": "DomAdapter"
   },
   {
     "name": "EMPTY_ARRAY"
@@ -60,6 +78,9 @@
     "name": "ENVIRONMENT_INITIALIZER"
   },
   {
+    "name": "ERROR_ORIGINAL_ERROR"
+  },
+  {
     "name": "ElementRef"
   },
   {
@@ -70,6 +91,12 @@
   },
   {
     "name": "EventEmitter"
+  },
+  {
+    "name": "GenericBrowserDomAdapter"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
   },
   {
     "name": "HelloWorldModule"
@@ -99,6 +126,15 @@
     "name": "LifecycleHooksFeature"
   },
   {
+    "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "MOVED_VIEWS"
+  },
+  {
+    "name": "MapOperator"
+  },
+  {
     "name": "MapSubscriber"
   },
   {
@@ -106,6 +142,9 @@
   },
   {
     "name": "MergeMapSubscriber"
+  },
+  {
+    "name": "NATIVE"
   },
   {
     "name": "NEW_LINE"
@@ -135,6 +174,15 @@
     "name": "NG_PROV_DEF"
   },
   {
+    "name": "NG_TEMPLATE_SELECTOR"
+  },
+  {
+    "name": "NG_TEMP_TOKEN_PATH"
+  },
+  {
+    "name": "NG_TOKEN_PATH"
+  },
+  {
     "name": "NOT_FOUND"
   },
   {
@@ -147,7 +195,19 @@
     "name": "NO_CHANGE"
   },
   {
+    "name": "NO_NEW_LINE"
+  },
+  {
+    "name": "NO_PARENT_INJECTOR"
+  },
+  {
     "name": "NULL_INJECTOR"
+  },
+  {
+    "name": "NgModuleFactory"
+  },
+  {
+    "name": "NgModuleFactory2"
   },
   {
     "name": "NgModuleRef"
@@ -195,13 +255,28 @@
     "name": "RefCountSubscriber"
   },
   {
+    "name": "RendererFactory2"
+  },
+  {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
+  },
+  {
+    "name": "SIMPLE_CHANGES_STORE"
+  },
+  {
+    "name": "SOURCE"
   },
   {
     "name": "SafeSubscriber"
   },
   {
     "name": "Sanitizer"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SimpleInnerSubscriber"
@@ -234,6 +309,9 @@
     "name": "TRACKED_LVIEWS"
   },
   {
+    "name": "TYPE"
+  },
+  {
     "name": "USE_VALUE"
   },
   {
@@ -244,6 +322,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "_DOM"
@@ -262,6 +343,9 @@
   },
   {
     "name": "_global"
+  },
+  {
+    "name": "_icuContainerIterate"
   },
   {
     "name": "_injectImplementation"
@@ -661,6 +745,9 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "profiler"
   },
   {
     "name": "promise"

--- a/packages/core/test/bundling/injection/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/injection/bundle.golden_symbols.json
@@ -3,6 +3,9 @@
     "name": "CIRCULAR"
   },
   {
+    "name": "DI_DECORATOR_FLAG"
+  },
+  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -48,16 +51,31 @@
     "name": "NG_PROV_DEF"
   },
   {
+    "name": "NG_TEMP_TOKEN_PATH"
+  },
+  {
+    "name": "NG_TOKEN_PATH"
+  },
+  {
     "name": "NOT_YET"
   },
   {
+    "name": "NO_NEW_LINE"
+  },
+  {
     "name": "NULL_INJECTOR"
+  },
+  {
+    "name": "NullInjector"
   },
   {
     "name": "R3Injector"
   },
   {
     "name": "RuntimeError"
+  },
+  {
+    "name": "SOURCE"
   },
   {
     "name": "ScopedService"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -21,6 +21,9 @@
     "name": "ActivatedRouteSnapshot"
   },
   {
+    "name": "ActivationStart"
+  },
+  {
     "name": "AnonymousSubject"
   },
   {
@@ -30,13 +33,25 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "ApplyRedirects"
+  },
+  {
     "name": "ArgumentOutOfRangeError"
+  },
+  {
+    "name": "BLOOM_BUCKET_BITS"
+  },
+  {
+    "name": "BLOOM_MASK"
   },
   {
     "name": "BOOTSTRAP_DONE"
   },
   {
     "name": "BROWSER_MODULE_PROVIDERS"
+  },
+  {
+    "name": "BaseRouteReuseStrategy"
   },
   {
     "name": "BehaviorSubject"
@@ -57,6 +72,9 @@
     "name": "COMPONENT_REGEX"
   },
   {
+    "name": "CONTAINER_HEADER_OFFSET"
+  },
+  {
     "name": "CanActivate"
   },
   {
@@ -73,6 +91,9 @@
   },
   {
     "name": "ChangeDetectorRef"
+  },
+  {
+    "name": "ChildActivationStart"
   },
   {
     "name": "ChildrenOutletContexts"
@@ -99,6 +120,9 @@
     "name": "ComponentFactoryResolver2"
   },
   {
+    "name": "ComponentRef"
+  },
+  {
     "name": "ComponentRef2"
   },
   {
@@ -114,7 +138,13 @@
     "name": "CreateUrlTreeStrategy"
   },
   {
+    "name": "DEFAULT_LOCALE_ID"
+  },
+  {
     "name": "DEFAULT_SERIALIZER"
+  },
+  {
+    "name": "DI_DECORATOR_FLAG"
   },
   {
     "name": "DOCUMENT2"
@@ -144,6 +174,9 @@
     "name": "DoOperator"
   },
   {
+    "name": "DomAdapter"
+  },
+  {
     "name": "DomRendererFactory2"
   },
   {
@@ -163,6 +196,9 @@
   },
   {
     "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
+    "name": "ERROR_ORIGINAL_ERROR"
   },
   {
     "name": "EVENT_MANAGER_PLUGINS"
@@ -207,10 +243,19 @@
     "name": "FinallySubscriber"
   },
   {
+    "name": "GenericBrowserDomAdapter"
+  },
+  {
     "name": "GuardsCheckEnd"
   },
   {
     "name": "GuardsCheckStart"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
+  },
+  {
+    "name": "IMPERATIVE_NAVIGATION"
   },
   {
     "name": "INITIAL_NAVIGATION"
@@ -276,10 +321,19 @@
     "name": "MODIFIER_KEY_GETTERS"
   },
   {
+    "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "MOVED_VIEWS"
+  },
+  {
     "name": "MapOperator"
   },
   {
     "name": "MapSubscriber"
+  },
+  {
+    "name": "MapToOperator"
   },
   {
     "name": "MapToSubscriber"
@@ -294,10 +348,22 @@
     "name": "NAMESPACE_URIS"
   },
   {
+    "name": "NATIVE"
+  },
+  {
+    "name": "NAVIGATION_CANCELING_ERROR"
+  },
+  {
     "name": "NEW_LINE"
   },
   {
     "name": "NG_COMP_DEF"
+  },
+  {
+    "name": "NG_DEV_MODE"
+  },
+  {
+    "name": "NG_DEV_MODE5"
   },
   {
     "name": "NG_DIR_DEF"
@@ -327,6 +393,15 @@
     "name": "NG_PROV_DEF"
   },
   {
+    "name": "NG_TEMPLATE_SELECTOR"
+  },
+  {
+    "name": "NG_TEMP_TOKEN_PATH"
+  },
+  {
+    "name": "NG_TOKEN_PATH"
+  },
+  {
     "name": "NONE"
   },
   {
@@ -340,6 +415,12 @@
   },
   {
     "name": "NO_CHANGE"
+  },
+  {
+    "name": "NO_NEW_LINE"
+  },
+  {
+    "name": "NO_PARENT_INJECTOR"
   },
   {
     "name": "NULL_INJECTOR"
@@ -387,6 +468,9 @@
     "name": "NoMatch"
   },
   {
+    "name": "NoMatch2"
+  },
+  {
     "name": "NodeInjector"
   },
   {
@@ -415,6 +499,12 @@
   },
   {
     "name": "PLATFORM_INITIALIZER"
+  },
+  {
+    "name": "PRIMARY_OUTLET"
+  },
+  {
+    "name": "ParamsAsMap"
   },
   {
     "name": "PathLocationStrategy"
@@ -525,6 +615,12 @@
     "name": "SEGMENT_RE"
   },
   {
+    "name": "SIMPLE_CHANGES_STORE"
+  },
+  {
+    "name": "SOURCE"
+  },
+  {
     "name": "SafeSubscriber"
   },
   {
@@ -547,6 +643,9 @@
   },
   {
     "name": "SharedStylesHost"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SimpleInnerSubscriber"
@@ -588,10 +687,16 @@
     "name": "TQueries_"
   },
   {
+    "name": "TQueryMetadata_"
+  },
+  {
     "name": "TQuery_"
   },
   {
     "name": "TRACKED_LVIEWS"
+  },
+  {
+    "name": "TYPE"
   },
   {
     "name": "TakeLastOperator"
@@ -663,6 +768,9 @@
     "name": "VE_ViewContainerRef"
   },
   {
+    "name": "VIEW_REFS"
+  },
+  {
     "name": "ViewContainerRef"
   },
   {
@@ -673,6 +781,9 @@
   },
   {
     "name": "ViewRef"
+  },
+  {
+    "name": "XSS_SECURITY_URL"
   },
   {
     "name": "_DOM"
@@ -690,7 +801,13 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_getInsertInFrontOfRNodeWithI18n"
+  },
+  {
     "name": "_global"
+  },
+  {
+    "name": "_icuContainerIterate"
   },
   {
     "name": "_injectImplementation"
@@ -700,6 +817,9 @@
   },
   {
     "name": "_platformInjector"
+  },
+  {
+    "name": "_processI18nInsertBefore"
   },
   {
     "name": "_randomChar"
@@ -745,9 +865,6 @@
   },
   {
     "name": "applyProjectionRecursive"
-  },
-  {
-    "name": "applyRedirects2"
   },
   {
     "name": "applyToElementOrContainer"
@@ -1039,6 +1156,9 @@
   },
   {
     "name": "forEachSingleProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -1605,6 +1725,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "profiler"
+  },
+  {
     "name": "promise"
   },
   {
@@ -1657,9 +1780,6 @@
   },
   {
     "name": "resetPreOrderHookFlags"
-  },
-  {
-    "name": "resolveData"
   },
   {
     "name": "resolveForwardRef"
@@ -1771,6 +1891,9 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "stripTrailingSlash"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -18,6 +18,12 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "BLOOM_BUCKET_BITS"
+  },
+  {
+    "name": "BLOOM_MASK"
+  },
+  {
     "name": "BROWSER_MODULE_PROVIDERS"
   },
   {
@@ -31,6 +37,9 @@
   },
   {
     "name": "COMPONENT_REGEX"
+  },
+  {
+    "name": "CONTAINER_HEADER_OFFSET"
   },
   {
     "name": "ChangeDetectionStrategy"
@@ -48,6 +57,9 @@
     "name": "ComponentFactoryResolver2"
   },
   {
+    "name": "ComponentRef"
+  },
+  {
     "name": "ComponentRef2"
   },
   {
@@ -57,10 +69,19 @@
     "name": "ConnectableSubscriber"
   },
   {
+    "name": "DEFAULT_LOCALE_ID"
+  },
+  {
+    "name": "DI_DECORATOR_FLAG"
+  },
+  {
     "name": "DOCUMENT2"
   },
   {
     "name": "DefaultDomRenderer2"
+  },
+  {
+    "name": "DomAdapter"
   },
   {
     "name": "DomRendererFactory2"
@@ -79,6 +100,9 @@
   },
   {
     "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
+    "name": "ERROR_ORIGINAL_ERROR"
   },
   {
     "name": "EVENT_MANAGER_PLUGINS"
@@ -106,6 +130,12 @@
   },
   {
     "name": "EventManagerPlugin"
+  },
+  {
+    "name": "GenericBrowserDomAdapter"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
   },
   {
     "name": "INJECTOR2"
@@ -141,6 +171,15 @@
     "name": "MODIFIER_KEY_GETTERS"
   },
   {
+    "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "MOVED_VIEWS"
+  },
+  {
+    "name": "MapOperator"
+  },
+  {
     "name": "MapSubscriber"
   },
   {
@@ -153,10 +192,16 @@
     "name": "NAMESPACE_URIS"
   },
   {
+    "name": "NATIVE"
+  },
+  {
     "name": "NEW_LINE"
   },
   {
     "name": "NG_COMP_DEF"
+  },
+  {
+    "name": "NG_DEV_MODE"
   },
   {
     "name": "NG_DIR_DEF"
@@ -183,6 +228,15 @@
     "name": "NG_PROV_DEF"
   },
   {
+    "name": "NG_TEMPLATE_SELECTOR"
+  },
+  {
+    "name": "NG_TEMP_TOKEN_PATH"
+  },
+  {
+    "name": "NG_TOKEN_PATH"
+  },
+  {
     "name": "NOT_FOUND"
   },
   {
@@ -193,6 +247,12 @@
   },
   {
     "name": "NO_CHANGE"
+  },
+  {
+    "name": "NO_NEW_LINE"
+  },
+  {
+    "name": "NO_PARENT_INJECTOR"
   },
   {
     "name": "NULL_INJECTOR"
@@ -243,7 +303,16 @@
     "name": "RendererStyleFlags2"
   },
   {
+    "name": "RootViewRef"
+  },
+  {
     "name": "RuntimeError"
+  },
+  {
+    "name": "SIMPLE_CHANGES_STORE"
+  },
+  {
+    "name": "SOURCE"
   },
   {
     "name": "SafeSubscriber"
@@ -256,6 +325,9 @@
   },
   {
     "name": "SharedStylesHost"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SimpleInnerSubscriber"
@@ -291,6 +363,9 @@
     "name": "TRACKED_LVIEWS"
   },
   {
+    "name": "TYPE"
+  },
+  {
     "name": "USE_VALUE"
   },
   {
@@ -301,6 +376,9 @@
   },
   {
     "name": "ViewEncapsulation"
+  },
+  {
+    "name": "ViewRef"
   },
   {
     "name": "_DOM"
@@ -318,7 +396,13 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_getInsertInFrontOfRNodeWithI18n"
+  },
+  {
     "name": "_global"
+  },
+  {
+    "name": "_icuContainerIterate"
   },
   {
     "name": "_injectImplementation"
@@ -328,6 +412,9 @@
   },
   {
     "name": "_platformInjector"
+  },
+  {
+    "name": "_processI18nInsertBefore"
   },
   {
     "name": "_randomChar"
@@ -475,6 +562,9 @@
   },
   {
     "name": "forEachSingleProvider"
+  },
+  {
+    "name": "formatRuntimeError"
   },
   {
     "name": "forwardRef"
@@ -750,6 +840,9 @@
     "name": "processInjectorTypesWithProviders"
   },
   {
+    "name": "profiler"
+  },
+  {
     "name": "promise"
   },
   {
@@ -841,6 +934,9 @@
   },
   {
     "name": "stringifyCSSSelector"
+  },
+  {
+    "name": "stringifyForError"
   },
   {
     "name": "subscribeTo"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -24,6 +24,12 @@
     "name": "ApplicationRef"
   },
   {
+    "name": "BLOOM_BUCKET_BITS"
+  },
+  {
+    "name": "BLOOM_MASK"
+  },
+  {
     "name": "BROWSER_MODULE_PROVIDERS"
   },
   {
@@ -45,6 +51,9 @@
     "name": "COMPONENT_REGEX"
   },
   {
+    "name": "CONTAINER_HEADER_OFFSET"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -63,6 +72,9 @@
     "name": "ComponentFactoryResolver2"
   },
   {
+    "name": "ComponentRef"
+  },
+  {
     "name": "ComponentRef2"
   },
   {
@@ -70,6 +82,9 @@
   },
   {
     "name": "ConnectableSubscriber"
+  },
+  {
+    "name": "DI_DECORATOR_FLAG"
   },
   {
     "name": "DOCUMENT2"
@@ -82,6 +97,9 @@
   },
   {
     "name": "DefaultIterableDifferFactory"
+  },
+  {
+    "name": "DomAdapter"
   },
   {
     "name": "DomEventsPlugin"
@@ -103,6 +121,9 @@
   },
   {
     "name": "ENVIRONMENT_INITIALIZER"
+  },
+  {
+    "name": "ERROR_ORIGINAL_ERROR"
   },
   {
     "name": "EVENT_MANAGER_PLUGINS"
@@ -127,6 +148,12 @@
   },
   {
     "name": "EventManagerPlugin"
+  },
+  {
+    "name": "GenericBrowserDomAdapter"
+  },
+  {
+    "name": "HAS_TRANSPLANTED_VIEWS"
   },
   {
     "name": "INJECTOR2"
@@ -168,6 +195,15 @@
     "name": "MODIFIER_KEY_GETTERS"
   },
   {
+    "name": "MONKEY_PATCH_KEY_NAME"
+  },
+  {
+    "name": "MOVED_VIEWS"
+  },
+  {
+    "name": "MapOperator"
+  },
+  {
     "name": "MapSubscriber"
   },
   {
@@ -178,6 +214,9 @@
   },
   {
     "name": "NAMESPACE_URIS"
+  },
+  {
+    "name": "NATIVE"
   },
   {
     "name": "NEW_LINE"
@@ -213,6 +252,15 @@
     "name": "NG_PROV_DEF"
   },
   {
+    "name": "NG_TEMPLATE_SELECTOR"
+  },
+  {
+    "name": "NG_TEMP_TOKEN_PATH"
+  },
+  {
+    "name": "NG_TOKEN_PATH"
+  },
+  {
     "name": "NOT_FOUND"
   },
   {
@@ -225,6 +273,12 @@
     "name": "NO_CHANGE"
   },
   {
+    "name": "NO_NEW_LINE"
+  },
+  {
+    "name": "NO_PARENT_INJECTOR"
+  },
+  {
     "name": "NULL_INJECTOR"
   },
   {
@@ -235,6 +289,12 @@
   },
   {
     "name": "NgIfContext"
+  },
+  {
+    "name": "NgModuleFactory"
+  },
+  {
+    "name": "NgModuleFactory2"
   },
   {
     "name": "NgModuleRef"
@@ -262,6 +322,9 @@
   },
   {
     "name": "Optional"
+  },
+  {
+    "name": "PARAMETERS"
   },
   {
     "name": "PLATFORM_DESTROY_LISTENERS"
@@ -306,7 +369,16 @@
     "name": "SERVER_TRANSITION_PROVIDERS"
   },
   {
+    "name": "SIMPLE_CHANGES_STORE"
+  },
+  {
+    "name": "SOURCE"
+  },
+  {
     "name": "SafeSubscriber"
+  },
+  {
+    "name": "SafeValueImpl"
   },
   {
     "name": "Sanitizer"
@@ -316,6 +388,9 @@
   },
   {
     "name": "SharedStylesHost"
+  },
+  {
+    "name": "SimpleChange"
   },
   {
     "name": "SimpleInnerSubscriber"
@@ -358,6 +433,9 @@
   },
   {
     "name": "TRANSITION_ID"
+  },
+  {
+    "name": "TYPE"
   },
   {
     "name": "TemplateRef"
@@ -411,6 +489,9 @@
     "name": "VE_ViewContainerRef"
   },
   {
+    "name": "VIEW_REFS"
+  },
+  {
     "name": "ViewContainerRef"
   },
   {
@@ -441,7 +522,13 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_getInsertInFrontOfRNodeWithI18n"
+  },
+  {
     "name": "_global"
+  },
+  {
+    "name": "_icuContainerIterate"
   },
   {
     "name": "_injectImplementation"
@@ -451,6 +538,9 @@
   },
   {
     "name": "_platformInjector"
+  },
+  {
+    "name": "_processI18nInsertBefore"
   },
   {
     "name": "_randomChar"
@@ -1087,6 +1177,9 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "profiler"
   },
   {
     "name": "promise"

--- a/tools/symbol-extractor/cli.ts
+++ b/tools/symbol-extractor/cli.ts
@@ -26,6 +26,8 @@ function main(argv: [string, string, string]|[string, string]): boolean {
   const goldenFilePath = runfiles.resolveWorkspaceRelative(argv[1]);
   const doUpdate = argv[2] == '--accept';
 
+  console.info('Input javascript file:', javascriptFilePath);
+
   const javascriptContent = fs.readFileSync(javascriptFilePath).toString();
   const goldenContent = fs.readFileSync(goldenFilePath).toString();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2631,7 +2631,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/resolve-uri@^3.0.3":
+"@jridgewell/resolve-uri@3.1.0", "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
@@ -2649,7 +2649,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13", "@jridgewell/sourcemap-codec@^1.4.14":
+"@jridgewell/sourcemap-codec@1.4.14", "@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.13", "@jridgewell/sourcemap-codec@^1.4.14":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
@@ -2662,13 +2662,21 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.8", "@jridgewell/trace-mapping@^0.3.9":
+"@jridgewell/trace-mapping@^0.3.7", "@jridgewell/trace-mapping@^0.3.8":
   version "0.3.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
   integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.9":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
+  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@jsdevtools/ono@^7.1.3":
   version "7.1.3"
@@ -4751,10 +4759,15 @@ acorn@^6.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
   integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
-acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.0:
+acorn@^8.4.1, acorn@^8.7.0:
   version "8.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.1.tgz#0197122c843d1bf6d0a5e83220a788f278f63c30"
   integrity sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==
+
+acorn@^8.5.0:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 acorn@^8.7.1:
   version "8.8.0"
@@ -15852,9 +15865,9 @@ terser@5.16.1:
     source-map-support "~0.5.20"
 
 terser@^5.0.0, terser@^5.7.2, terser@^5.8.0:
-  version "5.14.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.1.tgz#7c95eec36436cb11cf1902cc79ac564741d19eca"
-  integrity sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==
+  version "5.16.3"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.16.3.tgz#3266017a9b682edfe019b8ecddd2abaae7b39c6b"
+  integrity sha512-v8wWLaS/xt3nE9dgKEWhNUFP6q4kngO5B8eYFUuebsu7Dw/UNAnpUod6UHo04jSSkv8TzKHjZDSd7EXdDQAl8Q==
   dependencies:
     "@jridgewell/source-map" "^0.3.2"
     acorn "^8.5.0"


### PR DESCRIPTION
See individual commits.

Fixed up version of: #48990 

For concrete examples of the Terser diff/investigation:

**Before**:

<img width="651" alt="Screenshot 2023-02-08 at 16 49 06" src="https://user-images.githubusercontent.com/4987015/217587201-1e92cc86-a023-4f86-959d-d4cc9bfa1cf4.png">

<img width="775" alt="Screenshot 2023-02-08 at 16 49 15" src="https://user-images.githubusercontent.com/4987015/217587240-c41f691c-e941-41d6-841e-ce592fb12664.png">

**After**

<img width="782" alt="Screenshot 2023-02-08 at 16 49 20" src="https://user-images.githubusercontent.com/4987015/217587279-b6381296-f621-41af-9175-8d5b42050083.png">

<img width="779" alt="Screenshot 2023-02-08 at 16 49 26" src="https://user-images.githubusercontent.com/4987015/217587305-1bb1755c-4e34-409c-bb69-1a47d52733fa.png">


