### PR TITLE
docs(router): fix error handler deprecation

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -179,8 +179,8 @@ export class Router {
    * A handler for navigation errors in this NgModule.
    *
    * @deprecated Subscribe to the `Router` events and watch for `NavigationError` instead.
-   *   `provideRouter` has the `withErrorHandler` feature to make this easier.
-   * @see `withErrorHandler`
+   *   `provideRouter` has the `withNavigationErrorHandler` feature to make this easier.
+   * @see `withNavigationErrorHandler`
    */
   errorHandler = this.options.errorHandler || defaultErrorHandler;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The deprecation mentions `withErrorHandler` whereas the feature is called `withNavigationErrorHandler` since 15eccef4ebf58c889b2a28988ebcc297e3cd2df6.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
