### PR TITLE
dynamic-form example: default type attribute of input element to 'text' instead of '' + CSS

### DIFF
--- a/aio/content/examples/dynamic-form/src/app/dynamic-form-question.component.html
+++ b/aio/content/examples/dynamic-form/src/app/dynamic-form-question.component.html
@@ -4,7 +4,7 @@
 
   <div [ngSwitch]="question.controlType">
 
-    <input *ngSwitchCase="'textbox'" [formControlName]="question.key"
+    <input class="dynamicInput" *ngSwitchCase="'textbox'" [formControlName]="question.key"
             [id]="question.key" [type]="question.type">
 
     <select [id]="question.key" *ngSwitchCase="'dropdown'" [formControlName]="question.key">

--- a/aio/content/examples/dynamic-form/src/app/question-textbox.ts
+++ b/aio/content/examples/dynamic-form/src/app/question-textbox.ts
@@ -3,4 +3,5 @@ import { QuestionBase } from './question-base';
 
 export class TextboxQuestion extends QuestionBase<string> {
   override controlType = 'textbox';
+  override type: string = this.type !== '' ? this.type : 'text';
 }

--- a/aio/content/examples/dynamic-form/src/assets/sample.css
+++ b/aio/content/examples/dynamic-form/src/assets/sample.css
@@ -5,3 +5,7 @@
 .form-row{
   margin-top: 10px;
 }
+
+input[type='text'].dynamicInput {
+  all: revert;
+}


### PR DESCRIPTION
fix(docs-infra): default type attribute of input element to 'text' instead of '' and overshadow global CSS rule for input[type='text']

missing value for type attribute seems unintended but only defaulting it to 'text' without changing the CSS would have messed up the style for this example

Fixes #48895

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #48995


## What is the new behavior?
behavior is unchanged but code is safer

## Does this PR introduce a breaking change?

- [ ] Yes
- [ X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
