### PR TITLE
dynamic-form example: default type attribute of input element to 'text' instead of '' + CSS

### DIFF
--- a/aio/content/examples/dynamic-form/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/dynamic-form/e2e/src/app.e2e-spec.ts
@@ -1,21 +1,34 @@
-import { browser, element, by } from 'protractor';
+import {browser, by, element} from 'protractor';
 
 describe('Dynamic Form', () => {
+  beforeAll(() => browser.get(''));
 
-    beforeAll(() => browser.get(''));
+  it('should submit form', async () => {
+    const firstNameElement = element.all(by.css('input[id=firstName]')).get(0);
+    expect(await firstNameElement.getAttribute('value')).toEqual('Bombasto');
 
-    it('should submit form', async () => {
-      const firstNameElement = element.all(by.css('input[id=firstName]')).get(0);
-      expect(await firstNameElement.getAttribute('value')).toEqual('Bombasto');
+    const emailElement = element.all(by.css('input[id=emailAddress]')).get(0);
+    const email = 'test@test.com';
+    await emailElement.sendKeys(email);
+    expect(await emailElement.getAttribute('value')).toEqual(email);
 
-      const emailElement = element.all(by.css('input[id=emailAddress]')).get(0);
-      const email = 'test@test.com';
-      await emailElement.sendKeys(email);
-      expect(await emailElement.getAttribute('value')).toEqual(email);
-
-      await element(by.css('select option[value="solid"]')).click();
-      await element.all(by.css('button')).get(0).click();
-      expect(await element(by.cssContainingText('strong', 'Saved the following values')).isPresent()).toBe(true);
+    await element(by.css('select option[value="solid"]')).click();
+    await element.all(by.css('button')).get(0).click();
+    expect(await element(by.cssContainingText('strong', 'Saved the following values')).isPresent())
+        .toBe(true);
   });
 
+  it('should have both input fields with the same size', async () => {
+    const firstNameElement = element.all(by.css('input[id=firstName]')).get(0);
+    expect(await firstNameElement.getAttribute('type')).toEqual('text');
+    const widthFirstNameElement = await firstNameElement.getCssValue('width');
+    const paddingFirstNameElement = await firstNameElement.getCssValue('padding');
+
+    const emailElement = element.all(by.css('input[id=emailAddress]')).get(0);
+    const widthEmailElement = await emailElement.getCssValue('width');
+    const paddingEmailElement = await emailElement.getCssValue('padding');
+
+    expect(widthFirstNameElement).toEqual(widthEmailElement);
+    expect(paddingFirstNameElement).toEqual(paddingEmailElement);
+  });
 });

--- a/aio/content/examples/dynamic-form/src/app/dynamic-form-question.component.html
+++ b/aio/content/examples/dynamic-form/src/app/dynamic-form-question.component.html
@@ -4,7 +4,7 @@
 
   <div [ngSwitch]="question.controlType">
 
-    <input *ngSwitchCase="'textbox'" [formControlName]="question.key"
+    <input class="dynamicInput" *ngSwitchCase="'textbox'" [formControlName]="question.key"
             [id]="question.key" [type]="question.type">
 
     <select [id]="question.key" *ngSwitchCase="'dropdown'" [formControlName]="question.key">

--- a/aio/content/examples/dynamic-form/src/app/question-textbox.ts
+++ b/aio/content/examples/dynamic-form/src/app/question-textbox.ts
@@ -3,4 +3,5 @@ import { QuestionBase } from './question-base';
 
 export class TextboxQuestion extends QuestionBase<string> {
   override controlType = 'textbox';
+  override type: string = this.type !== '' ? this.type : 'text';
 }

--- a/aio/content/examples/dynamic-form/src/assets/sample.css
+++ b/aio/content/examples/dynamic-form/src/assets/sample.css
@@ -1,7 +1,13 @@
-.errorMessage{
-  color:red;
+.errorMessage {
+  color: red;
 }
 
-.form-row{
+.form-row {
   margin-top: 10px;
+}
+
+input[type='text'].dynamicInput {
+  box-sizing: revert;
+  width: revert;
+  padding: revert;
 }


### PR DESCRIPTION
fix(docs-infra): default type attribute of input element to 'text' instead of '' and overshadow global CSS rule for input[type='text']

missing value for type attribute seems unintended but only defaulting it to 'text' without changing the CSS would have messed up the style for this example

Fixes #48895

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #48895


## What is the new behavior?
behavior is unchanged but code is safer

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
