### PR TITLE
fix(migrations): use NgForOf instead of NgFor

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/index.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/index.ts
@@ -18,7 +18,7 @@ import {canMigrateFile, createProgramOptions} from '../../utils/typescript/compi
 import {pruneNgModules} from './prune-modules';
 import {toStandaloneBootstrap} from './standalone-bootstrap';
 import {toStandalone} from './to-standalone';
-import {ChangesByFile, normalizePath} from './util';
+import {ChangesByFile, knownInternalAliasRemapper, normalizePath} from './util';
 
 enum MigrationMode {
   toStandalone = 'convert-to-standalone',
@@ -106,7 +106,8 @@ function standaloneMigration(
         referenceLookupExcludedFiles);
   } else {
     // This shouldn't happen, but default to `MigrationMode.toStandalone` just in case.
-    pendingChanges = toStandalone(sourceFiles, program, printer);
+    pendingChanges =
+        toStandalone(sourceFiles, program, printer, undefined, knownInternalAliasRemapper);
   }
 
   for (const [file, changes] of pendingChanges.entries()) {

--- a/packages/core/schematics/ng-generate/standalone-migration/util.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/util.ts
@@ -7,6 +7,7 @@
  */
 
 import {NgtscProgram} from '@angular/compiler-cli';
+import {PotentialImport} from '@angular/compiler-cli/private/migrations';
 import {dirname, relative} from 'path';
 import ts from 'typescript';
 
@@ -381,4 +382,12 @@ export function getRelativeImportPath(fromFile: string, toFile: string): string 
 /** Normalizes a path to use posix separators. */
 export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/');
+}
+
+/** Function used to remap the generated `imports` for a component to known shorter aliases. */
+export function knownInternalAliasRemapper(imports: PotentialImport[]) {
+  return imports.map(
+      current => current.moduleSpecifier === '@angular/common' && current.symbolName === 'NgForOf' ?
+          {...current, symbolName: 'NgFor'} :
+          current);
 }

--- a/packages/core/schematics/test/standalone_migration_spec.ts
+++ b/packages/core/schematics/test/standalone_migration_spec.ts
@@ -106,6 +106,8 @@ describe('standalone migration', () => {
         static ɵmod: ɵɵNgModuleDeclaration<CommonModule, never,
           [typeof NgIf, typeof NgForOf], [typeof NgIf, typeof NgForOf]>;
       }
+
+      export {NgForOf as NgFor};
     `);
 
     writeFile('/node_modules/@angular/router/index.d.ts', `
@@ -816,7 +818,7 @@ describe('standalone migration', () => {
 
     const myCompContent = tree.readContent('comp.ts');
 
-    expect(myCompContent).toContain(`import { NgForOf, NgIf } from '@angular/common';`);
+    expect(myCompContent).toContain(`import { NgFor, NgIf } from '@angular/common';`);
     expect(stripWhitespace(myCompContent)).toContain(stripWhitespace(`
       @Component({
         selector: 'my-comp',
@@ -826,7 +828,7 @@ describe('standalone migration', () => {
           </div>
         \`,
         standalone: true,
-        imports: [NgForOf, NgIf]
+        imports: [NgFor, NgIf]
       })
     `));
     expect(stripWhitespace(myCompContent)).toContain(stripWhitespace(`


### PR DESCRIPTION
Adds a function that allows for the import resolution for files to be customized in the standalone migration. Externally it's only use is to change `NgForOf` to `NgFor`, but we'll need it internally to deduplicate some Material modules.

Fixes #49006.