### PR TITLE
fix(common): add generic type to NgTemplateOutlet to remove loose typing of ngTemplateOutletContext

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -703,17 +703,17 @@ export class NgSwitchDefault {
 }
 
 // @public
-export class NgTemplateOutlet implements OnChanges {
+export class NgTemplateOutlet<T = unknown> implements OnChanges {
     constructor(_viewContainerRef: ViewContainerRef);
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
-    ngTemplateOutlet: TemplateRef<any> | null;
-    ngTemplateOutletContext: Object | null;
+    ngTemplateOutlet!: TemplateRef<T>
+    ngTemplateOutletContext!: T
     ngTemplateOutletInjector: Injector | null;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgTemplateOutlet, "[ngTemplateOutlet]", never, { "ngTemplateOutletContext": "ngTemplateOutletContext"; "ngTemplateOutlet": "ngTemplateOutlet"; "ngTemplateOutletInjector": "ngTemplateOutletInjector"; }, {}, never, never, true, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgTemplateOutlet<T>, "[ngTemplateOutlet]", never, { "ngTemplateOutletContext": "ngTemplateOutletContext"; "ngTemplateOutlet": "ngTemplateOutlet"; "ngTemplateOutletInjector": "ngTemplateOutletInjector"; }, {}, never, never, true, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<NgTemplateOutlet, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<NgTemplateOutlet<T>, never>;
 }
 
 // @public

--- a/packages/common/src/directives/ng_template_outlet.ts
+++ b/packages/common/src/directives/ng_template_outlet.ts
@@ -16,7 +16,7 @@ import {Directive, EmbeddedViewRef, Injector, Input, OnChanges, SimpleChanges, T
  * Inserts an embedded view from a prepared `TemplateRef`.
  *
  * You can attach a context object to the `EmbeddedViewRef` by setting `[ngTemplateOutletContext]`.
- * `[ngTemplateOutletContext]` should be an object, the object's keys will be available for binding
+ * `[ngTemplateOutletContext]` should be a strongly type object, the object's keys will be available for binding
  * by the local template `let` declarations.
  *
  * @usageNotes
@@ -24,7 +24,7 @@ import {Directive, EmbeddedViewRef, Injector, Input, OnChanges, SimpleChanges, T
  * <ng-container *ngTemplateOutlet="templateRefExp; context: contextExp"></ng-container>
  * ```
  *
- * Using the key `$implicit` in the context object will set its value as default.
+ * Using the key `$implicit` in the context strongly typed object will set its value as default.
  *
  * ### Example
  *
@@ -36,24 +36,23 @@ import {Directive, EmbeddedViewRef, Injector, Input, OnChanges, SimpleChanges, T
   selector: '[ngTemplateOutlet]',
   standalone: true,
 })
-export class NgTemplateOutlet implements OnChanges {
-  private _viewRef: EmbeddedViewRef<any>|null = null;
-
+export class NgTemplateOutlet<T = unknown> implements OnChanges {
+  private _viewRef!: EmbeddedViewRef<T>| null;
   /**
-   * A context object to attach to the {@link EmbeddedViewRef}. This should be an
-   * object, the object's keys will be available for binding by the local template `let`
+   * A context typed object to attach to the {@link EmbeddedViewRef}. This should be a typed
+   * object. The object's keys will be available for binding by the local template `let`
    * declarations.
-   * Using the key `$implicit` in the context object will set its value as default.
+   * Using the key `$implicit` in the context typed object will set its value as default.
    */
-  @Input() public ngTemplateOutletContext: Object|null = null;
+  @Input() public ngTemplateOutletContext!: T;
 
   /**
-   * A string defining the template reference and optionally the context object for the template.
+   * A string defining the typed template reference and optionally the context typed object for the template.
    */
-  @Input() public ngTemplateOutlet: TemplateRef<any>|null = null;
+  @Input() public ngTemplateOutlet!: TemplateRef<T>;
 
   /** Injector to be used within the embedded view. */
-  @Input() public ngTemplateOutletInjector: Injector|null = null;
+  @Input() public ngTemplateOutletInjector!: Injector;
 
   constructor(private _viewContainerRef: ViewContainerRef) {}
 

--- a/packages/compiler-cli/src/ngtsc/testing/fake_common/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/fake_common/index.ts
@@ -57,11 +57,11 @@ export declare class NgIf<T = unknown> {
       ctx is NgIfContext<Exclude<T, false|0|''|null|undefined>>;
 }
 
-export declare class NgTemplateOutlet {
-  ngTemplateOutlet: TemplateRef<any>|null;
-  ngTemplateOutletContext: Object|null;
+export declare class NgTemplateOutlet<T = unknown> {
+  ngTemplateOutlet: TemplateRef<T>
+  ngTemplateOutletContext: T;
 
-  static ɵdir: ɵɵDirectiveDeclaration < NgTemplateOutlet, '[ngTemplateOutlet]', never, {
+  static ɵdir: ɵɵDirectiveDeclaration < NgTemplateOutlet<unknown>, '[ngTemplateOutlet]', never, {
     'ngTemplateOutlet': 'ngTemplateOutlet';
     'ngTemplateOutletContext': 'ngTemplateOutletContext';
   }


### PR DESCRIPTION

This PR is a report and an attempt to fix an issue in one of the common directives `NgTemplateOutlet`. 


Yesterday, we faced a very critical issue across our platform components which consume a shared-ui library that relies heavily on `NgTemplateOutlet`. `NgTemplateOutlet` is an essential building block of our UI system. Currently at development time, the compiler is totally silent when it comes to object keys passed from backend APIs  responses to the bound properties of this shared-ui library. 

This is due to the loosely typing nature of the `'[ngTemplateOutlet]'` directive's context. 


A very minimal/simple reproduction here: 

```
import { Component } from '@angular/core';

interface IData {
    estimation: number;
}
@Component({
  selector: 'my-app',

  template: `

  <ng-container *ngTemplateOutlet="templateRef; context:{$implicit: data}"></ng-container>


  <ng-template #templateRef let-current>
          <p>  {{current.estimation}} </p>
          <br/>
          <p> {{current.NONEXISTINGKEY}}</p> //<----- Compiler is still happy ! 🙄
  </ng-template>

  `,
})
export class AppComponent {
  public data: IData = {
    estimation: 20_000
  };
}

```

[Stackblitz-link ](https://stackblitz.com/edit/angular-ivy-albr2y?file=src%2Fmain.ts,src%2Fpolyfills.ts)

Such behaviour can be overseen when the components are being compiled successfully.  Unfortunately, the compiler is blind when it comes to detecting whether the bound/interpolated keys from the outlet context are compatible with the desired shape (type/interface). 

This is an attempt to make `ngTemplateOutlet` more aware of the shape passed to it.

I assume that there might be other parts relevant to this that may need to be updated. For now, I limit my changes to what I found to be directly relevant to this issue. I hope this will not have any side effects or limitations. Please provide feedback if this make sense or not and help correct current change if it is somehow/somewhere wrong. 

Note: Our TypeScript strict configs are enabled when such bug occurred.

If there is a parallel running discussion relevant to this I would appreciate it a lot if you can refer/mention it here or ping me there


@crisbeto I ping you here because I saw you made some changes a few months ago in these files I touched ! 


Thank you 👍🏻
