### PR TITLE
build: never cache monitoring bazel test target

### DIFF
--- a/aio/tests/deployment/e2e/BUILD.bazel
+++ b/aio/tests/deployment/e2e/BUILD.bazel
@@ -8,8 +8,11 @@ ts_library(
 )
 
 TEST_TAGS = [
-    # Test is run manually in `test-production.sh`,
+    # Test is run manually in `test-production.sh`, and requires an URL to be set.
     "manual",
+    # Never cache this test because it's non-hermetic and relies on
+    # the remote URL. Bazel will not know when the target site changed.
+    "no-cache",
     # Cannot run remotely because `protractor_web_test_suite` does not support `exec_properties`.
     "no-remote-exec",
     # This test requires an external host. If running in sandbox, allow network access.


### PR DESCRIPTION
We recently switched some of the monitoring e2e tests to Bazel. These tests should never be cached because they rely on an external URL and on network access. The URL itself might stay the same for quite a while, but the underlying site might change based on new deployments. Bazel only sees the URL and caches the test then. We want to avoid this.