### PR TITLE
refactor: remove unnecessary file

### DIFF
--- a/packages/core/src/di/provider_collection.ts
+++ b/packages/core/src/di/provider_collection.ts
@@ -13,9 +13,9 @@ import {getFactoryDef} from '../render3/definition_factory';
 import {throwCyclicDependencyError, throwInvalidProviderError} from '../render3/errors_di';
 import {stringifyForError} from '../render3/util/stringify_utils';
 import {deepForEach} from '../util/array_utils';
+import {EMPTY_ARRAY} from '../util/empty';
 import {getClosureSafeProperty} from '../util/property';
 import {stringify} from '../util/stringify';
-import {EMPTY_ARRAY} from '../view';
 
 import {resolveForwardRef} from './forward_ref';
 import {ENVIRONMENT_INITIALIZER} from './initializer_token';

--- a/packages/core/src/view/index.ts
+++ b/packages/core/src/view/index.ts
@@ -1,9 +1,0 @@
-/**
- * @license
- * Copyright Google LLC All Rights Reserved.
- *
- * Use of this source code is governed by an MIT-style license that can be
- * found in the LICENSE file at https://angular.io/license
- */
-
-export {EMPTY_ARRAY} from '../util/empty';


### PR DESCRIPTION
Small refactor, `core/src/view/index` had only a single export from a file located in the same package, no need to keep it.


## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)