### PR TITLE
test(compiler-cli): test removing default import handling

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/di.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/di.ts
@@ -40,7 +40,7 @@ export function getConstructorDependencies(
     }
   }
   ctorParams.forEach((param, idx) => {
-    let token = valueReferenceToExpression(param.typeValueReference);
+    let token: Expression|null = null;
     let attributeNameType: Expression|null = null;
     let optional = false, self = false, skipSelf = false, host = false;
 
@@ -81,6 +81,10 @@ export function getConstructorDependencies(
             `Unexpected decorator ${name} on parameter.`);
       }
     });
+
+    if (token === null) {
+      token = valueReferenceToExpression(param.typeValueReference);
+    }
 
     if (token === null) {
       if (param.typeValueReference.kind !== TypeValueReferenceKind.UNAVAILABLE) {

--- a/packages/compiler-cli/src/ngtsc/imports/src/default.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/default.ts
@@ -139,7 +139,11 @@ export class DefaultImportTracker {
         // TODO(alxhub): discuss with the TypeScript team and determine if there's a better way to
         // deal with this issue.
         // tslint:disable-next-line: ban
-        stmt = ts.getMutableClone(stmt);
+        // stmt = ts.getMutableClone(stmt);
+
+        // stmt = createImportDeclaration(
+        //     ts.getModifiers(stmt), stmt.importClause, stmt.moduleSpecifier, stmt.assertClause);
+        throw new Error(`Unsupported import in ${stmt.getSourceFile().fileName}`);
       }
       return stmt;
     });


### PR DESCRIPTION
Testing out throwing an error for our only remaining call site of `getMutableClone`.