### PR TITLE
refactor: remove duplicate key from component metadata

### DIFF
--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -125,7 +125,6 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
           encapsulation,
           interpolation: metadata.interpolation,
           viewProviders: metadata.viewProviders || null,
-          isStandalone: !!metadata.standalone,
         };
 
         compilationDepth++;


### PR DESCRIPTION
Small PR : 
`directiveMetadata()` already assigns the `standalone` property to the `R3ComponentMetadataFacade` there is no need to do it twice.


## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)