### PR TITLE
refactor(compiler): remove remaining usage of getMutableClone

### DIFF
--- a/packages/compiler-cli/src/ngtsc/imports/index.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/index.ts
@@ -10,6 +10,7 @@ export {AliasingHost, AliasStrategy, PrivateExportAliasingHost, UnifiedModulesAl
 export {ImportRewriter, NoopImportRewriter, R3SymbolsImportRewriter, validateAndRewriteCoreSymbol} from './src/core';
 export {DefaultImportTracker} from './src/default';
 export {AbsoluteModuleStrategy, assertSuccessfulReferenceEmit, EmittedReference, FailedEmitResult, ImportedFile, ImportFlags, LocalIdentifierStrategy, LogicalProjectStrategy, ReferenceEmitKind, ReferenceEmitResult, ReferenceEmitStrategy, ReferenceEmitter, RelativePathStrategy, UnifiedModulesStrategy} from './src/emitter';
+export {isAliasImportDeclaration, loadIsReferencedAliasDeclarationPatch} from './src/patch_alias_reference_resolution';
 export {Reexport} from './src/reexport';
 export {OwningModule, Reference} from './src/references';
 export {ModuleResolver} from './src/resolver';

--- a/packages/compiler-cli/src/ngtsc/imports/src/default.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/default.ts
@@ -11,6 +11,8 @@ import ts from 'typescript';
 
 import {getSourceFile} from '../../util/src/typescript';
 
+import {loadIsReferencedAliasDeclarationPatch} from './patch_alias_reference_resolution';
+
 const DefaultImportDeclaration = Symbol('DefaultImportDeclaration');
 
 interface WithDefaultImportDeclaration {
@@ -57,29 +59,31 @@ export function getDefaultImportDeclaration(expr: WrappedNodeExpr<unknown>): ts.
  * a dangling reference, as TS will elide the import because it was only used in the type position
  * originally.
  *
- * To avoid this, the compiler must "touch" the imports with `ts.getMutableClone`, and should
- * only do this for imports which are actually consumed. The `DefaultImportTracker` keeps track of
- * these imports as they're encountered and emitted, and implements a transform which can correctly
- * flag the imports as required.
+ * To avoid this, the compiler must patch the emit resolver, and should only do this for imports
+ * which are actually consumed. The `DefaultImportTracker` keeps track of these imports as they're
+ * encountered and emitted, and implements a transform which can correctly flag the imports as
+ * required.
  *
  * This problem does not exist for non-default imports as the compiler can easily insert
  * "import * as X" style imports for those, and the "X" identifier survives transformation.
  */
 export class DefaultImportTracker {
   /**
-   * A `Map` which tracks the `Set` of `ts.ImportDeclaration`s for default imports that were used in
-   * a given `ts.SourceFile` and need to be preserved.
+   * A `Map` which tracks the `Set` of `ts.ImportClause`s for default imports that were used in
+   * a given file name.
    */
-  private sourceFileToUsedImports = new Map<ts.SourceFile, Set<ts.ImportDeclaration>>();
+  private sourceFileToUsedImports = new Map<string, Set<ts.ImportClause>>();
 
   recordUsedImport(importDecl: ts.ImportDeclaration): void {
-    const sf = getSourceFile(importDecl);
+    if (importDecl.importClause) {
+      const sf = getSourceFile(importDecl);
 
-    // Add the default import declaration to the set of used import declarations for the file.
-    if (!this.sourceFileToUsedImports.has(sf)) {
-      this.sourceFileToUsedImports.set(sf, new Set<ts.ImportDeclaration>());
+      // Add the default import declaration to the set of used import declarations for the file.
+      if (!this.sourceFileToUsedImports.has(sf.fileName)) {
+        this.sourceFileToUsedImports.set(sf.fileName, new Set<ts.ImportClause>());
+      }
+      this.sourceFileToUsedImports.get(sf.fileName)!.add(importDecl.importClause);
     }
-    this.sourceFileToUsedImports.get(sf)!.add(importDecl);
   }
 
   /**
@@ -89,65 +93,25 @@ export class DefaultImportTracker {
    * This transformer must run after any other transformers which call `recordUsedImport`.
    */
   importPreservingTransformer(): ts.TransformerFactory<ts.SourceFile> {
-    return (context: ts.TransformationContext) => {
-      return (sf: ts.SourceFile) => {
-        return this.transformSourceFile(sf);
+    return context => {
+      let clausesToPreserve: Set<ts.Declaration>|null = null;
+
+      return sourceFile => {
+        const clausesForFile = this.sourceFileToUsedImports.get(sourceFile.fileName);
+
+        if (clausesForFile !== undefined) {
+          for (const clause of clausesForFile) {
+            // Initialize the patch lazily so that apps that
+            // don't use default imports aren't patched.
+            if (clausesToPreserve === null) {
+              clausesToPreserve = loadIsReferencedAliasDeclarationPatch(context);
+            }
+            clausesToPreserve.add(clause);
+          }
+        }
+
+        return sourceFile;
       };
     };
-  }
-
-  /**
-   * Process a `ts.SourceFile` and replace any `ts.ImportDeclaration`s.
-   */
-  private transformSourceFile(sf: ts.SourceFile): ts.SourceFile {
-    const originalSf = ts.getOriginalNode(sf) as ts.SourceFile;
-    // Take a fast path if no import declarations need to be preserved in the file.
-    if (!this.sourceFileToUsedImports.has(originalSf)) {
-      return sf;
-    }
-
-    // There are declarations that need to be preserved.
-    const importsToPreserve = this.sourceFileToUsedImports.get(originalSf)!;
-
-    // Generate a new statement list which preserves any imports present in `importsToPreserve`.
-    const statements = sf.statements.map(stmt => {
-      if (ts.isImportDeclaration(stmt) && importsToPreserve.has(stmt)) {
-        // Preserving an import that's marked as unreferenced (type-only) is tricky in TypeScript.
-        //
-        // Various approaches have been tried, with mixed success:
-        //
-        // 1. Using `ts.updateImportDeclaration` does not cause the import to be retained.
-        //
-        // 2. Using `ts.factory.createImportDeclaration` with the same `ts.ImportClause` causes the
-        //    import to correctly be retained, but when emitting CommonJS module format code,
-        //    references to the imported value will not match the import variable.
-        //
-        // 3. Emitting "import * as" imports instead generates the correct import variable, but
-        //    references are missing the ".default" access. This happens to work for tsickle code
-        //    with goog.module transformations as tsickle strips the ".default" anyway.
-        //
-        // 4. It's possible to trick TypeScript by setting `ts.NodeFlag.Synthesized` on the import
-        //    declaration. This causes the import to be correctly retained and generated, but can
-        //    violate invariants elsewhere in the compiler and cause crashes.
-        //
-        // 5. Using `ts.getMutableClone` seems to correctly preserve the import and correctly
-        //    generate references to the import variable across all module types.
-        //
-        // Therefore, option 5 is the one used here. It seems to be implemented as the correct way
-        // to perform option 4, which preserves all the compiler's invariants.
-        //
-        // TODO(alxhub): discuss with the TypeScript team and determine if there's a better way to
-        // deal with this issue.
-        // tslint:disable-next-line: ban
-        stmt = ts.getMutableClone(stmt);
-      }
-      return stmt;
-    });
-
-    // Save memory - there's no need to keep these around once the transform has run for the given
-    // file.
-    this.sourceFileToUsedImports.delete(originalSf);
-
-    return ts.factory.updateSourceFile(sf, statements);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/imports/src/patch_alias_reference_resolution.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/patch_alias_reference_resolution.ts
@@ -11,7 +11,7 @@ import ts from 'typescript';
 /**
  * Describes a TypeScript transformation context with the internal emit
  * resolver exposed. There are requests upstream in TypeScript to expose
- * that as public API: https://github.com/microsoft/TypeScript/issues/17516..
+ * that as public API: https://github.com/microsoft/TypeScript/issues/17516.
  */
 interface TransformationContextWithResolver extends ts.TransformationContext {
   getEmitResolver: () => EmitResolver;
@@ -61,7 +61,7 @@ interface EmitResolver {
  * The patch we apply to tell TypeScript about actual referenced aliases (i.e. imported symbols),
  * matches conceptually with the logic that runs internally in TypeScript when the
  * `emitDecoratorMetadata` flag is enabled. TypeScript basically surfaces the same problem and
- * solves it conceptually the same way, but obviously doesn't need to access an `@internal` API.
+ * solves it conceptually the same way, but obviously doesn't need to access an internal API.
  *
  * The set that is returned by this function is meant to be filled with import declaration nodes
  * that have been referenced in a value-position by the transform, such the installed patch can
@@ -129,9 +129,8 @@ function isTransformationContextWithEmitResolver(context: ts.TransformationConte
  */
 function throwIncompatibleTransformationContextError(): never {
   throw Error(
-      'Unable to downlevel Angular decorators due to an incompatible TypeScript ' +
-      'version.\nIf you recently updated TypeScript and this issue surfaces now, consider ' +
-      'downgrading.\n\n' +
+      'Angular compiler is incompatible with this version of the TypeScript compiler.\n\n' +
+      'If you recently updated TypeScript and this issue surfaces now, consider downgrading.\n\n' +
       'Please report an issue on the Angular repositories when this issue ' +
       'surfaces and you are using a supposedly compatible TypeScript version.');
 }

--- a/packages/compiler-cli/src/transformers/downlevel_decorators_transform/BUILD.bazel
+++ b/packages/compiler-cli/src/transformers/downlevel_decorators_transform/BUILD.bazel
@@ -6,6 +6,7 @@ ts_library(
     name = "downlevel_decorators_transform",
     srcs = glob(["*.ts"]),
     deps = [
+        "//packages/compiler-cli/src/ngtsc/imports",
         "//packages/compiler-cli/src/ngtsc/reflection",
         "//packages/compiler-cli/src/ngtsc/ts_compatibility",
         "@npm//typescript",

--- a/packages/compiler-cli/src/transformers/downlevel_decorators_transform/downlevel_decorators_transform.ts
+++ b/packages/compiler-cli/src/transformers/downlevel_decorators_transform/downlevel_decorators_transform.ts
@@ -8,9 +8,8 @@
 
 import ts from 'typescript';
 
+import {isAliasImportDeclaration, loadIsReferencedAliasDeclarationPatch} from '../../ngtsc/imports';
 import {Decorator, ReflectionHost} from '../../ngtsc/reflection';
-
-import {isAliasImportDeclaration, loadIsReferencedAliasDeclarationPatch} from './patch_alias_reference_resolution';
 
 /**
  * Whether a given decorator should be treated as an Angular decorator.


### PR DESCRIPTION
Uses an alternate approach of preserving default imports that doesn't involve the `getMutableClone` function that is being removed in TypeScript 5.0.

The alternate approach was already used in the downlevel transform and it works by patching the EmitResolver of the current transformation context to tell TypeScript to preserve the import.