### PR TITLE
feat(core): expose ngZone bootstrap options in `internalCreateApplication`

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -191,8 +191,9 @@ export function internalCreateApplication(config: {
   rootComponent?: Type<unknown>,
   appProviders?: Array<Provider|EnvironmentProviders>,
   platformProviders?: Provider[],
+  ngZoneBootstrapOptions?: BootstrapOptions,
 }): Promise<ApplicationRef> {
-  const {rootComponent, appProviders, platformProviders} = config;
+  const {rootComponent, appProviders, platformProviders, ngZoneBootstrapOptions} = config;
 
   if (NG_DEV_MODE && rootComponent !== undefined) {
     assertStandaloneComponentType(rootComponent);
@@ -200,7 +201,8 @@ export function internalCreateApplication(config: {
 
   const platformInjector = createOrReusePlatformInjector(platformProviders as StaticProvider[]);
 
-  const ngZone = getNgZone('zone.js', getNgZoneOptions());
+  const ngZone = getNgZone(
+      ngZoneBootstrapOptions?.ngZone || 'zone.js', getNgZoneOptions(ngZoneBootstrapOptions));
 
   return ngZone.run(() => {
     // Create root application injector based on a set of providers configured at the platform


### PR DESCRIPTION
Exposes the `BootstrapOptions` that were previously available on module bootstrap to allow developers to specify custom NgZone options to standalone components bootstrap.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
When bootstrapping modules, the developer is able to provide custom NgZone options. This was not exposed again when switching to bootstrapping standalone components.

Issue Number: N/A


## What is the new behavior?
This is now exposed again interanally and it's up to each platform to provide the options.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

NativeScript uses a custom NgZone to handle threading, so this option was missing for implementing a `bootstrapApplication`.
