### PR TITLE
release: bump version to 16.0.0-next.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-srcs",
-  "version": "15.3.0-next.0",
+  "version": "16.0.0-next.0",
   "private": true,
   "description": "Angular - a web framework for modern web apps",
   "homepage": "https://github.com/angular/angular",


### PR DESCRIPTION
We should be on 16.0.0-next.0 rather than 15.3.0-next.0 as we don't plan to release a 15.3.x in this cycle.