### PR TITLE
docs: fixing typo in angular compiler options

### DIFF
--- a/aio/content/guide/angular-compiler-options.md
+++ b/aio/content/guide/angular-compiler-options.md
@@ -220,7 +220,7 @@ When you use the Angular CLI command `ng new --strict`, it is set to `true` in t
 
 When `true`, enables [strict template type checking](guide/template-typecheck#strict-mode).
 
-The strictness flags that this open enables allow you to turn on and off specific types of strict template type checking.
+The strictness flags that this option enables allow you to turn on and off specific types of strict template type checking.
 See [troubleshooting template errors](guide/template-typecheck#troubleshooting-template-errors).
 
 When you use the Angular CLI command `ng new --strict`, it is set to `true` in the new project's configuration.


### PR DESCRIPTION
Docs typo fix: The strictness flags that this "option" enables instead of "open".

Fixes #49078
