### PR TITLE
fix(bazel): stop publishing @angular/bazel package to npm

### DIFF
--- a/.ng-dev/release.mts
+++ b/.ng-dev/release.mts
@@ -6,7 +6,6 @@ export const release: ReleaseConfig = {
   representativeNpmPackage: '@angular/core',
   npmPackages: [
     {name: '@angular/animations'},
-    {name: '@angular/bazel'},
     {name: '@angular/common'},
     {name: '@angular/compiler'},
     {name: '@angular/compiler-cli'},

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -17,8 +17,6 @@ Our semver, timed-release cycle and deprecation policy currently applies to thes
 
 One intentional omission from this list is `@angular/compiler`, which is currently considered a low level API and is subject to internal changes. These changes will not affect any applications or libraries using the higher-level APIs (the command line interface or JIT compilation via `@angular/platform-browser-dynamic`). Only very specific use-cases, such as tooling integration for IDEs and linters, require direct access to the compiler API. If you are working on this kind of integration, please reach out to us first.
 
-Package `@angular/bazel` is currently an Angular Labs project and not covered by the public API guarantees.
-
 Additionally only the command line usage (not direct use of APIs) of `@angular/compiler-cli` is covered.
 
 Other projects developed by the Angular team like angular-cli, Angular Material, will be covered by these or similar guarantees in the future as they mature.

--- a/packages.bzl
+++ b/packages.bzl
@@ -20,7 +20,6 @@ def _exclude_pkgs(packages, *args):
 # All framework packages published to NPM.
 ALL_PACKAGES = [
     "@angular/animations",
-    "@angular/bazel",
     "@angular/benchpress",
     "@angular/common",
     "@angular/compiler",

--- a/packages/bazel/BUILD.bazel
+++ b/packages/bazel/BUILD.bazel
@@ -27,7 +27,6 @@ pkg_npm(
         "//packages/bazel/": "//@angular/bazel/",
         "@npm//@bazel/concatjs/internal:": "//@bazel/concatjs/internal:",
     },
-    tags = ["release-with-framework"],
     # Do not add more to this list.
     # Dependencies on the full npm_package cause long re-builds.
     visibility = [


### PR DESCRIPTION
We are no longer publishing the `@angular/bazel` package in preparation for its removal from the angular/angular repo. The piece that we still rely on for our own infrastructure will be moved to angular/dev-infra.
