### PR TITLE
refactor(router): Remove warning for an invalid ActivatedRoute

### DIFF
--- a/packages/router/src/create_url_tree_strategy.ts
+++ b/packages/router/src/create_url_tree_strategy.ts
@@ -53,10 +53,6 @@ export class CreateUrlTreeUsingSnapshot implements CreateUrlTreeStrategy {
       // Note: the difference between having this fallback for invalid `ActivatedRoute` setups and
       // just throwing is ~500 test failures. Fixing all of those tests by hand is not feasible at
       // the moment.
-      if (NG_DEV_MODE) {
-        console.warn(
-            `The ActivatedRoute has an invalid structure. This is likely due to an incomplete mock in tests.`);
-      }
       if (typeof commands[0] !== 'string' || !commands[0].startsWith('/')) {
         // Navigations that were absolute in the old way of creating UrlTrees
         // would still work because they wouldn't attempt to match the


### PR DESCRIPTION
This warning was put in place to surface an error when developers use an ActivatedRoute with an invalid structure in tests. However, there isn't a clear path to fixing it and the tests continue to pass (ideally - that's what the recovery code is there for). Rather than surfacing an error that developers would be confused by and likely ignore, it would be better to not warn at all unless there is a clearer action to take to resolve the issue.

resolves #49116
