### PR TITLE
build: temporarily disable windows ci

### DIFF
--- a/.circleci/bazel.windows.rc
+++ b/.circleci/bazel.windows.rc
@@ -9,9 +9,3 @@ try-import %workspace%/.circleci/bazel.common.rc
 # Manually set the local resources used in windows CI runs
 build --local_ram_resources=120000
 build --local_cpu_resources=32
-
-# All windows jobs run on master and should use http caching
-build --remote_http_cache=https://storage.googleapis.com/angular-team-cache
-build --remote_accept_cached=true
-build --remote_upload_local_results=true
-build --google_default_credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,11 +606,6 @@ jobs:
             nvm install $(cat .nvmrc)
             nvm use $(cat .nvmrc)
 
-      - restore_cache:
-          keys:
-            - *cache_key_win
-            - *cache_key_win_fallback
-
       - run:
           name: Debug information for flakiness of Windows job
           command: |


### PR DESCRIPTION
Temporarily disable Windows CI due to an infra issue