### PR TITLE
fix(migrations): return correct alias when conflicting import exists

### DIFF
--- a/packages/core/schematics/utils/import_manager.ts
+++ b/packages/core/schematics/utils/import_manager.ts
@@ -170,7 +170,7 @@ export class ImportManager {
     if (symbolName) {
       const {propertyName, name} = this._getImportParts(sourceFile, symbolName, alias);
       const importMap = this.newImports.get(sourceFile)!.namedImports;
-      identifier = propertyName || name;
+      identifier = name;
 
       if (!importMap.has(moduleName)) {
         importMap.set(moduleName, []);


### PR DESCRIPTION
Fixes that the `ImportManager` was returning the `propertyName` instead of the `name` when there's an import with a conflicting identifier.