### PR TITLE
docs(router): `canMatch` route guard method parameter update in provided sample's `canAccess`

### DIFF
--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -915,7 +915,7 @@ export type CanDeactivateFn<T> =
  * ```
  * class UserToken {}
  * class Permissions {
- *   canAccess(user: UserToken, id: string, segments: UrlSegment[]): boolean {
+ *   canAccess(user: UserToken, route: Route, segments: UrlSegment[]): boolean {
  *     return true;
  *   }
  * }


### PR DESCRIPTION
Very cosmetic, but necessary (I guess): 

I updated the ```canAccess``` method second parameter name and type in the provided doc sample. As it stands, it triggers `TS(2345):  Argument of type 'Route' is not assignable to parameter of type 'string'`.
