### PR TITLE
fix(router): add error message when using loadComponent with an NgModule

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -248,6 +248,9 @@ export {
 export {
   compilePipe as ɵcompilePipe,
 } from './render3/jit/pipe';
+export {
+  isNgModule as ɵisNgModule
+} from './render3/jit/util';
 export { Profiler as ɵProfiler, ProfilerEvent as ɵProfilerEvent } from './render3/profiler';
 export {
   publishDefaultGlobalUtils as ɵpublishDefaultGlobalUtils

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createEnvironmentInjector, EnvironmentInjector, isStandalone, Type, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {createEnvironmentInjector, EnvironmentInjector, isStandalone, Type, ɵNG_MOD_DEF as NG_MOD_DEF, ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {EmptyOutletComponent} from '../components/empty_outlet';
 import {RuntimeErrorCode} from '../errors';
@@ -57,7 +57,13 @@ export function validateConfig(
 }
 
 export function assertStandalone(fullPath: string, component: Type<unknown>|undefined) {
-  if (component && !isStandalone(component)) {
+  if (component && (component as any)[NG_MOD_DEF]) {
+    throw new RuntimeError(
+        RuntimeErrorCode.INVALID_ROUTE_CONFIG,
+        `Invalid configuration of route '${
+            fullPath}'. You are using 'loadComponent' with a module, ` +
+            `but it must be used with standalone components. Use 'loadChildren' instead.`);
+  } else if (component && !isStandalone(component)) {
     throw new RuntimeError(
         RuntimeErrorCode.INVALID_ROUTE_CONFIG,
         `Invalid configuration of route '${fullPath}'. The component must be standalone.`);

--- a/packages/router/src/utils/config.ts
+++ b/packages/router/src/utils/config.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createEnvironmentInjector, EnvironmentInjector, isStandalone, Type, ɵNG_MOD_DEF as NG_MOD_DEF, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {createEnvironmentInjector, EnvironmentInjector, isStandalone, Type, ɵisNgModule as isNgModule, ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {EmptyOutletComponent} from '../components/empty_outlet';
 import {RuntimeErrorCode} from '../errors';
@@ -57,7 +57,7 @@ export function validateConfig(
 }
 
 export function assertStandalone(fullPath: string, component: Type<unknown>|undefined) {
-  if (component && (component as any)[NG_MOD_DEF]) {
+  if (component && isNgModule(component)) {
     throw new RuntimeError(
         RuntimeErrorCode.INVALID_ROUTE_CONFIG,
         `Invalid configuration of route '${

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -337,6 +337,23 @@ describe('standalone in Router API', () => {
          TestBed.inject(Router).navigateByUrl('/home');
          expect(() => advance(root)).toThrowError(/.*home.*component must be standalone/);
        }));
+
+    it('throws error when loadComponent is used with a module', fakeAsync(() => {
+         @NgModule()
+         class LazyModule {
+         }
+
+         TestBed.configureTestingModule({
+           imports: [RouterTestingModule.withRoutes([{
+             path: 'home',
+             loadComponent: () => LazyModule,
+           }])],
+         });
+
+         const root = TestBed.createComponent(RootCmp);
+         TestBed.inject(Router).navigateByUrl('/home');
+         expect(() => advance(root)).toThrowError(/.*home.*Use 'loadChildren' instead/);
+       }));
   });
   describe('default export unwrapping', () => {
     it('should work for loadComponent', async () => {


### PR DESCRIPTION
Add a more specific error message when defining a lazy-loaded route using `loadComponent` and passing it an `NgModule` instead of a standalone component, when the user should actually be using `loadChildren`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

Issue Number: #48945


## What is the new behavior?

Users are prompted with the error:
`Invalid configuration of route 'XYZ'. You are using 'loadComponent' with a module, but it must be used with standalone components. Use 'loadChildren' instead.`


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
I wasn't sure how to check if the value was a NgModule. If there's a better way please let me know.