### PR TITLE
fix(migrations): delete barrel exports in standalone migration

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/util.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/util.ts
@@ -175,6 +175,10 @@ export class UniqueItemTracker<K, V> {
     }
   }
 
+  get(key: K): Set<V>|undefined {
+    return this._nodes.get(key);
+  }
+
   getEntries(): IterableIterator<[K, Set<V>]> {
     return this._nodes.entries();
   }


### PR DESCRIPTION
Adds some logic to automatically delete `export * from './foo'` style imports. Previously they weren't being picked up, because finding all the references using the language service doesn't include barrel exports.