### PR TITLE
fix(common): make Location.normalize() return the correct path when the base path contains characters that interfere with regex syntax.

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -304,12 +304,11 @@ function _stripBasePath(basePath: string, url: string): string {
   if (!basePath || !url.startsWith(basePath)) {
     return url;
   }
-  if (url.length === basePath.length) {
-    return '';
+  const strippedUrl = url.substring(basePath.length);
+  if (strippedUrl === '' || ['/', ';', '?', '#'].includes(strippedUrl[0])) {
+    return strippedUrl;
   }
-  return ['/', ';', '?', '#'].includes(url[basePath.length]) ?
-    url.substring(basePath.length) :
-    url;
+  return url;
 }
 
 function _stripIndexHtml(url: string): string {

--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -301,9 +301,15 @@ export function createLocation() {
 }
 
 function _stripBasePath(basePath: string, url: string): string {
-  return basePath && new RegExp(`^${basePath}([/;?#]|$)`).test(url) ?
-      url.substring(basePath.length) :
-      url;
+  if (!basePath || !url.startsWith(basePath)) {
+    return url;
+  }
+  if (url.length === basePath.length) {
+    return '';
+  }
+  return ['/', ';', '?', '#'].includes(url[basePath.length]) ?
+    url.substring(basePath.length) :
+    url;
 }
 
 function _stripIndexHtml(url: string): string {

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -286,5 +286,18 @@ describe('Location Class', () => {
       expect(location.normalize(baseHref + matrixParams)).toBe(matrixParams);
       expect(location.normalize(baseHref + fragment)).toBe(fragment);
     });
+
+    it('in case APP_BASE_HREF contains characters that have special meaning in a regex', () => {
+      const baseHref = 'c:/users/name(test)/en';
+      const path = '/test-path';
+
+      TestBed.configureTestingModule({providers: [{provide: APP_BASE_HREF, useValue: baseHref}]});
+
+      const location = TestBed.inject(Location);
+
+      expect(location.normalize(path)).toBe(path);
+      expect(location.normalize(baseHref)).toBe('');
+      expect(location.normalize(baseHref + path)).toBe(path);
+    });
   });
 });


### PR DESCRIPTION
Fix the function stripping the base path from the URL, as the current implementation uses the base path as part of a regex, which wrongly makes paths fails that contain characters such as a parenthesis (example: C:/Users/MyUser(Test)/project).

Fixes #49179

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ x ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When an Angular project build is served from a base path containing characters that are special characters in a regex, the Angular router does not work anymore. (for example C:/Users/MyUser(Test)/my-project).
Issue Number: 49179


## What is the new behavior?
Paths containing such characters will not break routing anymore.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
