### PR TITLE
Revert "fix(common): Update `Location` to get a normalized URL valid …

### DIFF
--- a/packages/common/src/location/location.ts
+++ b/packages/common/src/location/location.ts
@@ -301,9 +301,7 @@ export function createLocation() {
 }
 
 function _stripBasePath(basePath: string, url: string): string {
-  return basePath && new RegExp(`^${basePath}([/;?#]|$)`).test(url) ?
-      url.substring(basePath.length) :
-      url;
+  return basePath && url.startsWith(basePath) ? url.substring(basePath.length) : url;
 }
 
 function _stripIndexHtml(url: string): string {

--- a/packages/common/test/location/location_spec.ts
+++ b/packages/common/test/location/location_spec.ts
@@ -266,25 +266,4 @@ describe('Location Class', () => {
       expect(location.normalize(url)).toBe(route);
     });
   });
-
-  describe('location.normalize(url) should return properly normalized url', () => {
-    it('in case url starts with the substring equals APP_BASE_HREF', () => {
-      const baseHref = '/en';
-      const path = '/enigma';
-      const queryParams = '?param1=123';
-      const matrixParams = ';param1=123';
-      const fragment = '#anchor1';
-
-      TestBed.configureTestingModule({providers: [{provide: APP_BASE_HREF, useValue: baseHref}]});
-
-      const location = TestBed.inject(Location);
-
-      expect(location.normalize(path)).toBe(path);
-      expect(location.normalize(baseHref)).toBe('');
-      expect(location.normalize(baseHref + path)).toBe(path);
-      expect(location.normalize(baseHref + queryParams)).toBe(queryParams);
-      expect(location.normalize(baseHref + matrixParams)).toBe(matrixParams);
-      expect(location.normalize(baseHref + fragment)).toBe(fragment);
-    });
-  });
 });


### PR DESCRIPTION
…in case a represented URL starts with the substring equals `APP_BASE_HREF` (#48489)"

This reverts commit 68ce4f6ab495f78858281b902e6433fe90ed6dbf.

Fixes #49179
