### PR TITLE
fix(compiler-cli): do not persist component analysis if template/styles are missing

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -318,8 +318,8 @@ export class ComponentDecoratorHandler implements
       template = preanalyzed;
     } else {
       const templateDecl = parseTemplateDeclaration(
-          decorator, component, containingFile, this.evaluator, this.resourceLoader,
-          this.defaultPreserveWhitespaces);
+          node, decorator, component, containingFile, this.evaluator, this.depTracker,
+          this.resourceLoader, this.defaultPreserveWhitespaces);
       template = extractTemplate(
           node, templateDecl, this.evaluator, this.depTracker, this.resourceLoader, {
             enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
@@ -353,6 +353,13 @@ export class ComponentDecoratorHandler implements
           this.depTracker.addResourceDependency(node.getSourceFile(), absoluteFrom(resourceUrl));
         }
       } catch {
+        if (this.depTracker !== null) {
+          // The analysis of this file cannot be re-used if one of the style URLs could
+          // not be resolved or loaded. Future builds should re-analyze and re-attempt
+          // resolution/loading.
+          this.depTracker.recordDependencyAnalysisFailure(node.getSourceFile());
+        }
+
         if (diagnostics === undefined) {
           diagnostics = [];
         }


### PR DESCRIPTION
Consider the following scenario:

1. A TS file with a component and templateUrl exists
2. The template file does not exist.
3. First build: ngtsc will properly report the error, via a FatalDiagnosticError
4. The template file is now created
5. Second build: ngtsc still reports the same errror.

Ngtsc persists the analysis data of the component and never invalidates it when the template/style
file becomes available later.

This breaks incremental builds and potentially common workflows where resource files are added
later after the TS file is created. This did not surface as an issue in the Angular CLI yet because Webpack 
requires users to re-start the process when a new file is added. With ESBuild this will change and this
also breaks incremental builds with Bazel/Blaze workers.

To fix this, we have a few options:

* Invalidate the analysis when e.g. the template file is missing. Never caching it means that it will be
re-analyzed on every build iteration.
* Add the resource dependency to ngtsc's incremental file graph. ngtsc will then know via `host.getModifiedResources` when the file becomes available- and fresh analysis of component would occur.

The first approach is straightforward to implement and was chosen here. The second approach would
allow ngtsc to re-use more of the analysis when we know that e.g. the template file still not there, but it 
ncreases complexity unnecessarily because there is no **single** obvious resource path for e.g. a `templateUrl`.
The URL is attempted to be resolved using multiple strategies, such as TS program root dirs, or there is support
for a custom resolution through `host.resourceNameToFileName`.

It would be possible to determine some candidate paths and add them to the dependency tracker, but it
seems incomplete given possible external resolvers like `resourceNameToFileName` and also would likely 
not have a sufficient-enough impact given that a broken component decorator is not expected to remain
for too long between N incremental build iterations.