### PR TITLE
refactor(platform-browser): move TransferState init logic into its constructor

### DIFF
--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -229,6 +229,7 @@ export class Title {
 
 // @public
 export class TransferState {
+    constructor();
     get<T>(key: StateKey<T>, defaultValue: T): T;
     hasKey<T>(key: StateKey<T>): boolean;
     get isEmpty(): boolean;

--- a/packages/platform-browser/src/browser/transfer_state.ts
+++ b/packages/platform-browser/src/browser/transfer_state.ts
@@ -83,19 +83,14 @@ export function makeStateKey<T = void>(key: string): StateKey<T> {
  *
  * @publicApi
  */
-@Injectable({
-  providedIn: 'root',
-  useFactory: () => {
-    const doc = inject(DOCUMENT);
-    const appId = inject(APP_ID);
-    const state = new TransferState();
-    state.store = retrieveTransferredState(doc, appId);
-    return state;
-  }
-})
+@Injectable({providedIn: 'root'})
 export class TransferState {
   private store: {[k: string]: unknown|undefined} = {};
   private onSerializeCallbacks: {[k: string]: () => unknown | undefined} = {};
+
+  constructor() {
+    this.store = retrieveTransferredState(inject(DOCUMENT), inject(APP_ID));
+  }
 
   /**
    * Get the value corresponding to a key. Return `defaultValue` if key is not found.


### PR DESCRIPTION
This commit updates the TransferState class to move its init logic from the `useFactory` function to its constructor. The change is needed to make the init behavior consistent across different injection scenarios and tolerate the issue described in https://github.com/angular/angular/issues/49190.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No