### PR TITLE
fix(common): invalid ImageKit transformation

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
+++ b/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
@@ -13,7 +13,7 @@ import {createImageLoader, ImageLoaderConfig, ImageLoaderInfo} from './image_loa
  */
 export const imageKitLoaderInfo: ImageLoaderInfo = {
   name: 'ImageKit',
-  testUrl: isImageKitUrl
+  testUrl: isImageKitUrl,
 };
 
 const IMAGE_KIT_LOADER_REGEX = /https?\:\/\/[^\/]+\.imagekit\.io\/.+/;
@@ -39,12 +39,18 @@ export const provideImageKitLoader = createImageLoader(
     createImagekitUrl,
     ngDevMode ? ['https://ik.imagekit.io/mysite', 'https://subdomain.mysite.com'] : undefined);
 
-export function createImagekitUrl(path: string, config: ImageLoaderConfig) {
+export function createImagekitUrl(path: string, config: ImageLoaderConfig): string {
   // Example of an ImageKit image URL:
   // https://ik.imagekit.io/demo/tr:w-300,h-300/medium_cafe_B1iTdD0C.jpg
-  let params = `tr:q-auto`;  // applies the "auto quality" transformation
-  if (config.width) {
-    params += `,w-${config.width}`;
+  const {src, width} = config;
+  let urlSegments: string[];
+
+  if (width) {
+    const params = `tr:w-${width}`;
+    urlSegments = [path, params, src];
+  } else {
+    urlSegments = [path, src];
   }
-  return `${path}/${params}/${config.src}`;
+
+  return urlSegments.join('/');
 }

--- a/packages/common/test/image_loaders/image_loader_spec.ts
+++ b/packages/common/test/image_loaders/image_loader_spec.ts
@@ -82,7 +82,7 @@ describe('Built-in image directive loaders', () => {
       const loader = createCloudinaryLoader(path);
       expect(loader({src: 'img.png'})).toBe(`${path}/image/upload/f_auto,q_auto/img.png`);
       expect(loader({
-        src: 'marketing/img-2.png'
+        src: 'marketing/img-2.png',
       })).toBe(`${path}/image/upload/f_auto,q_auto/marketing/img-2.png`);
     });
 
@@ -126,8 +126,16 @@ describe('Built-in image directive loaders', () => {
     it('should construct an image loader with the given path', () => {
       const path = 'https://ik.imageengine.io/imagetest';
       const loader = createImageKitLoader(path);
-      expect(loader({src: 'img.png'})).toBe(`${path}/tr:q-auto/img.png`);
-      expect(loader({src: 'marketing/img-2.png'})).toBe(`${path}/tr:q-auto/marketing/img-2.png`);
+      expect(loader({src: 'img.png'})).toBe(`${path}/img.png`);
+      expect(loader({src: 'marketing/img-2.png'})).toBe(`${path}/marketing/img-2.png`);
+    });
+
+    it('should construct an image loader with the given path', () => {
+      const path = 'https://ik.imageengine.io/imagetest';
+      const loader = createImageKitLoader(path);
+      expect(loader({src: 'img.png', width: 100})).toBe(`${path}/tr:w-100/img.png`);
+      expect(loader({src: 'marketing/img-2.png', width: 200}))
+          .toBe(`${path}/tr:w-200/marketing/img-2.png`);
     });
 
     describe('input validation', () => {
@@ -148,13 +156,13 @@ describe('Built-in image directive loaders', () => {
       it('should handle a trailing forward slash on the path', () => {
         const path = 'https://ik.imageengine.io/imagetest';
         const loader = createImageKitLoader(`${path}/`);
-        expect(loader({src: 'img.png'})).toBe(`${path}/tr:q-auto/img.png`);
+        expect(loader({src: 'img.png'})).toBe(`${path}/img.png`);
       });
 
       it('should handle a leading forward slash on the image src', () => {
         const path = 'https://ik.imageengine.io/imagetest';
         const loader = createImageKitLoader(path);
-        expect(loader({src: '/img.png'})).toBe(`${path}/tr:q-auto/img.png`);
+        expect(loader({src: '/img.png'})).toBe(`${path}/img.png`);
       });
     });
   });


### PR DESCRIPTION
`q-auto` is an invalid/unsupported transformation and should not be used

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The `ImageLoader` for ImageKit is using an invalid/unsupported transformation (`q-auto`).
Being that I could not find any mention of this transformation in [the official documentation](https://docs.imagekit.io/features/image-transformations/resize-crop-and-other-transformations#quality-q), I contacted ImageKit's support and they said:
> q-auto while would result in different sizes because of some internal implementations, being an unsupported, undocumented feature, it should not be used in any application.

Issue Number: N/A


## What is the new behavior?
The `q-auto` invalid transformation is not used. Instead, we rely on the default quality value from ImageKit's dashboard, which unless modified is 80 (`q-80`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Unless modified (and if not overwritten via URL), ImageKit applies the following transformations:

<img width="460" alt="Captura de pantalla 2023-02-25 a las 1 07 30" src="https://user-images.githubusercontent.com/6851095/221323688-64826c67-48d5-4a6a-b5ac-4dc070eb3aed.png">

- Automatic format (`f-auto`)
- Quality = 80 (`q-80`)