### PR TITLE
refactor(core):  Application ref/init code cleaning

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -51,13 +51,12 @@ export const APP_INITIALIZER: InjectionToken<readonly (() => Observable<unknown>
 
 // @public
 export class ApplicationInitStatus {
-    constructor(appInits: ReadonlyArray<() => Observable<unknown> | Promise<unknown> | void>);
     // (undocumented)
     readonly done = false;
     // (undocumented)
     readonly donePromise: Promise<any>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<ApplicationInitStatus, [{ optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ApplicationInitStatus, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<ApplicationInitStatus>;
 }

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,8 +2,8 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 908,
-      "main": 126185,
-      "polyfills": 33824
+      "main": 125669,
+      "polyfills": 33792
     }
   },
   "cli-hello-world-ivy-minimal": {
@@ -19,8 +19,8 @@
   "cli-hello-world-ivy-i18n": {
     "uncompressed": {
       "runtime": 926,
-      "main": 124522,
-      "polyfills": 34628
+      "main": 124504,
+      "polyfills": 34676
     }
   },
   "cli-hello-world-lazy": {
@@ -41,15 +41,15 @@
   "animations": {
     "uncompressed": {
       "runtime": 898,
-      "main": 157195,
-      "polyfills": 33897
+      "main": 157177,
+      "polyfills": 33782
     }
   },
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 918,
-      "main": 85043,
-      "polyfills": 33945
+      "main": 85026,
+      "polyfills": 33802
     }
   },
   "hello_world__closure": {

--- a/packages/core/test/application_init_spec.ts
+++ b/packages/core/test/application_init_spec.ts
@@ -5,8 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ApplicationInitStatus} from '@angular/core/src/application_init';
+import {APP_INITIALIZER, ApplicationInitStatus} from '@angular/core/src/application_init';
 import {EMPTY, Observable, Subscriber} from 'rxjs';
+
+import {TestBed} from '../testing';
 
 describe('ApplicationInitStatus', () => {
   let status: ApplicationInitStatus;
@@ -16,7 +18,8 @@ describe('ApplicationInitStatus', () => {
 
   describe('no initializers', () => {
     beforeEach(() => {
-      status = new ApplicationInitStatus([]);
+      TestBed.configureTestingModule({providers: [{provide: APP_INITIALIZER, useValue: []}]});
+      status = TestBed.inject(ApplicationInitStatus);
     });
 
     it('should return true for `done`', () => {
@@ -42,7 +45,9 @@ describe('ApplicationInitStatus', () => {
         resolve = res;
         reject = rej;
       });
-      status = new ApplicationInitStatus([() => promise]);
+      TestBed.configureTestingModule(
+          {providers: [{provide: APP_INITIALIZER, useValue: [() => promise]}]});
+      status = TestBed.inject(ApplicationInitStatus);
     });
 
     it('should update the status once all async promise initializers are done', async () => {
@@ -85,7 +90,10 @@ describe('ApplicationInitStatus', () => {
       const observable = new Observable((res) => {
         subscriber = res;
       });
-      status = new ApplicationInitStatus([() => observable]);
+
+      TestBed.configureTestingModule(
+          {providers: [{provide: APP_INITIALIZER, useValue: [() => observable]}]});
+      status = TestBed.inject(ApplicationInitStatus);
     });
 
     it('should update the status once all async observable initializers are completed',
@@ -124,7 +132,10 @@ describe('ApplicationInitStatus', () => {
        async () => {
          // Create a status instance using an initializer that returns the `EMPTY` Observable
          // which completes synchronously upon subscription.
-         status = new ApplicationInitStatus([() => EMPTY]);
+         TestBed.resetTestingModule();
+         TestBed.configureTestingModule(
+             {providers: [{provide: APP_INITIALIZER, useValue: [() => EMPTY]}]});
+         status = TestBed.inject(ApplicationInitStatus);
 
          runInitializers();
 

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1041,6 +1041,9 @@
     "name": "initializeDirectives"
   },
   {
+    "name": "inject"
+  },
+  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -792,6 +792,9 @@
     "name": "initializeDirectives"
   },
   {
+    "name": "inject"
+  },
+  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1116,6 +1116,9 @@
     "name": "initializeDirectives"
   },
   {
+    "name": "inject"
+  },
+  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1077,6 +1077,9 @@
     "name": "initializeDirectives"
   },
   {
+    "name": "inject"
+  },
+  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -612,6 +612,9 @@
     "name": "incrementInitPhaseFlags"
   },
   {
+    "name": "inject"
+  },
+  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -702,6 +702,9 @@
     "name": "incrementInitPhaseFlags"
   },
   {
+    "name": "inject"
+  },
+  {
     "name": "injectArgs"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -948,6 +948,9 @@
     "name": "initializeDirectives"
   },
   {
+    "name": "inject"
+  },
+  {
     "name": "injectArgs"
   },
   {


### PR DESCRIPTION
* With tsc improvements some types can be refined.
* Removing unnecessary non-null assertions.
* Using std native methods instand of custom functions
* Using @ts-expect-error instead of `any` type assertion to keep code navigation.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No