### PR TITLE
refactor(router): use native functions instead of custom utils

### DIFF
--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1149,13 +1149,7 @@
     "name": "first"
   },
   {
-    "name": "flatten2"
-  },
-  {
     "name": "flattenUnsubscriptionErrors"
-  },
-  {
-    "name": "forEach"
   },
   {
     "name": "forEachSingleProvider"

--- a/packages/router/src/apply_redirects.ts
+++ b/packages/router/src/apply_redirects.ts
@@ -18,7 +18,6 @@ import {runCanLoadGuards} from './operators/check_guards';
 import {RouterConfigLoader} from './router_config_loader';
 import {Params, PRIMARY_OUTLET} from './shared';
 import {createRoot, squashSegmentGroup, UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from './url_tree';
-import {forEach} from './utils/collection';
 import {getOrCreateRouteInjectorIfNeeded, getOutlet, sortByMatchingOutlets} from './utils/config';
 import {isImmediateMatch, match, matchWithChecks, noLeftoversInUrl, split} from './utils/config_matching';
 import {isEmptyError} from './utils/type_guards';
@@ -400,7 +399,7 @@ class ApplyRedirects {
 
   private createQueryParams(redirectToParams: Params, actualParams: Params): Params {
     const res: Params = {};
-    forEach(redirectToParams, (v: any, k: string) => {
+    Object.entries(redirectToParams).forEach(([k, v]) => {
       const copySourceValue = typeof v === 'string' && v.startsWith(':');
       if (copySourceValue) {
         const sourceName = v.substring(1);
@@ -418,7 +417,7 @@ class ApplyRedirects {
     const updatedSegments = this.createSegments(redirectTo, group.segments, segments, posParams);
 
     let children: {[n: string]: UrlSegmentGroup} = {};
-    forEach(group.children, (child: UrlSegmentGroup, name: string) => {
+    Object.entries(group.children).forEach(([name, child]) => {
       children[name] = this.createSegmentGroup(redirectTo, child, segments, posParams);
     });
 

--- a/packages/router/src/create_url_tree.ts
+++ b/packages/router/src/create_url_tree.ts
@@ -12,7 +12,7 @@ import {RuntimeErrorCode} from './errors';
 import {ActivatedRoute, ActivatedRouteSnapshot} from './router_state';
 import {Params, PRIMARY_OUTLET} from './shared';
 import {createRoot, squashSegmentGroup, UrlSegment, UrlSegmentGroup, UrlTree} from './url_tree';
-import {forEach, last, shallowEqual} from './utils/collection';
+import {last, shallowEqual} from './utils/collection';
 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
 
@@ -172,7 +172,7 @@ function tree(
     queryParams: Params|null, fragment: string|null): UrlTree {
   let qp: any = {};
   if (queryParams) {
-    forEach(queryParams, (value: any, name: any) => {
+    Object.entries(queryParams).forEach(([name, value]) => {
       qp[name] = Array.isArray(value) ? value.map((v: any) => `${v}`) : `${value}`;
     });
   }
@@ -199,7 +199,7 @@ function replaceSegment(
     current: UrlSegmentGroup, oldSegment: UrlSegmentGroup,
     newSegment: UrlSegmentGroup): UrlSegmentGroup {
   const children: {[key: string]: UrlSegmentGroup} = {};
-  forEach(current.children, (c: UrlSegmentGroup, outletName: string) => {
+  Object.entries(current.children).forEach(([outletName, c]) => {
     if (c === oldSegment) {
       children[outletName] = newSegment;
     } else {
@@ -244,7 +244,7 @@ function computeNavigation(commands: any[]): Navigation {
     if (typeof cmd === 'object' && cmd != null) {
       if (cmd.outlets) {
         const outlets: {[k: string]: any} = {};
-        forEach(cmd.outlets, (commands: any, name: string) => {
+        Object.entries(cmd.outlets).forEach(([name, commands]) => {
           outlets[name] = typeof commands === 'string' ? commands.split('/') : commands;
         });
         return [...res, {outlets}];
@@ -415,7 +415,7 @@ function updateSegmentGroupChildren(
           segmentGroup.children[PRIMARY_OUTLET], startIndex, commands);
     }
 
-    forEach(outlets, (commands, outlet) => {
+    Object.entries(outlets).forEach(([outlet, commands]) => {
       if (typeof commands === 'string') {
         commands = [commands];
       }
@@ -424,7 +424,7 @@ function updateSegmentGroupChildren(
       }
     });
 
-    forEach(segmentGroup.children, (child: UrlSegmentGroup, childOutlet: string) => {
+    Object.entries(segmentGroup.children).forEach(([childOutlet, child]) => {
       if (outlets[childOutlet] === undefined) {
         children[childOutlet] = child;
       }
@@ -503,7 +503,7 @@ function createNewSegmentGroup(
 function createNewSegmentChildren(outlets: {[name: string]: unknown[]|string}):
     {[outlet: string]: UrlSegmentGroup} {
   const children: {[outlet: string]: UrlSegmentGroup} = {};
-  forEach(outlets, (commands, outlet) => {
+  Object.entries(outlets).forEach(([outlet, commands]) => {
     if (typeof commands === 'string') {
       commands = [commands];
     }
@@ -516,7 +516,7 @@ function createNewSegmentChildren(outlets: {[name: string]: unknown[]|string}):
 
 function stringify(params: {[key: string]: any}): {[key: string]: string} {
   const res: {[key: string]: string} = {};
-  forEach(params, (v: any, k: string) => res[k] = `${v}`);
+  Object.entries(params).forEach(([k, v]) => res[k] = `${v}`);
   return res;
 }
 

--- a/packages/router/src/operators/activate_routes.ts
+++ b/packages/router/src/operators/activate_routes.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ComponentFactoryResolver, EnvironmentInjector, NgModuleRef} from '@angular/core';
+import {ComponentFactoryResolver} from '@angular/core';
 import {MonoTypeOperatorFunction} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -15,7 +15,6 @@ import {NavigationTransition} from '../navigation_transition';
 import {DetachedRouteHandleInternal, RouteReuseStrategy} from '../route_reuse_strategy';
 import {ChildrenOutletContexts} from '../router_outlet_context';
 import {ActivatedRoute, advanceActivatedRoute, RouterState} from '../router_state';
-import {forEach} from '../utils/collection';
 import {getClosestRouteInjector} from '../utils/config';
 import {nodeChildrenAsMap, TreeNode} from '../utils/tree';
 
@@ -57,7 +56,7 @@ export class ActivateRoutes {
     });
 
     // De-activate the routes that will not be re-used
-    forEach(children, (v: TreeNode<ActivatedRoute>, childName: string) => {
+    Object.values(children).forEach((v: TreeNode<ActivatedRoute>) => {
       this.deactivateRouteAndItsChildren(v, contexts);
     });
   }

--- a/packages/router/src/private_export.ts
+++ b/packages/router/src/private_export.ts
@@ -11,5 +11,4 @@ export {ɵEmptyOutletComponent} from './components/empty_outlet';
 export {RestoredState as ɵRestoredState} from './navigation_transition';
 export {withPreloading as ɵwithPreloading} from './provide_router';
 export {ROUTER_PROVIDERS as ɵROUTER_PROVIDERS} from './router_module';
-export {flatten as ɵflatten} from './utils/collection';
 export {afterNextNavigation as ɵafterNextNavigation} from './utils/navigations';

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -23,7 +23,6 @@ import {createEmptyState, RouterState} from './router_state';
 import {Params} from './shared';
 import {UrlHandlingStrategy} from './url_handling_strategy';
 import {containsTree, IsActiveMatchOptions, isUrlTree, UrlSerializer, UrlTree} from './url_tree';
-import {flatten} from './utils/collection';
 import {standardizeConfig, validateConfig} from './utils/config';
 
 
@@ -303,7 +302,7 @@ export class Router {
   canceledNavigationResolution: 'replace'|'computed' =
       this.options.canceledNavigationResolution || 'replace';
 
-  config: Routes = flatten(inject(ROUTES, {optional: true}) ?? []);
+  config: Routes = inject(ROUTES, {optional: true})?.flat() ?? [];
 
   private readonly navigationTransitions = inject(NavigationTransitions);
   private readonly urlSerializer = inject(UrlSerializer);

--- a/packages/router/src/router_config_loader.ts
+++ b/packages/router/src/router_config_loader.ts
@@ -8,11 +8,11 @@
 
 import {Compiler, EnvironmentInjector, Injectable, InjectFlags, InjectionToken, Injector, NgModuleFactory, Type} from '@angular/core';
 import {ConnectableObservable, from, Observable, of, Subject} from 'rxjs';
-import {catchError, finalize, map, mergeMap, refCount, tap} from 'rxjs/operators';
+import {finalize, map, mergeMap, refCount, tap} from 'rxjs/operators';
 
 import {deprecatedLoadChildrenString} from './deprecated_load_children';
 import {DefaultExport, LoadChildren, LoadChildrenCallback, LoadedRouterConfig, Route, Routes} from './models';
-import {flatten, wrapIntoObservable} from './utils/collection';
+import {wrapIntoObservable} from './utils/collection';
 import {assertStandalone, standardizeConfig, validateConfig} from './utils/config';
 
 
@@ -105,7 +105,7 @@ export class RouterConfigLoader {
             // will get stuck in an infinite loop. The child module's Injector will look to
             // its parent `Injector` when it doesn't find any ROUTES so it will return routes
             // for it's parent module instead.
-            rawRoutes = flatten(injector.get(ROUTES, [], InjectFlags.Self | InjectFlags.Optional));
+            rawRoutes = injector.get(ROUTES, [], InjectFlags.Self | InjectFlags.Optional).flat();
           }
           const routes = rawRoutes.map(standardizeConfig);
           NG_DEV_MODE && validateConfig(routes, route.path, requireStandaloneComponents);

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -10,7 +10,7 @@ import {Injectable, ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {RuntimeErrorCode} from './errors';
 import {convertToParamMap, ParamMap, Params, PRIMARY_OUTLET} from './shared';
-import {equalArraysOrString, forEach, shallowEqual} from './utils/collection';
+import {equalArraysOrString, shallowEqual} from './utils/collection';
 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
 
@@ -252,7 +252,7 @@ export class UrlSegmentGroup {
       public segments: UrlSegment[],
       /** The list of children of this group */
       public children: {[key: string]: UrlSegmentGroup}) {
-    forEach(children, (v: any, k: any) => v.parent = this);
+    Object.values(children).forEach((v) => (v.parent = this));
   }
 
   /** Whether the segment has child segments */
@@ -334,12 +334,12 @@ export function equalPath(as: UrlSegment[], bs: UrlSegment[]): boolean {
 export function mapChildrenIntoArray<T>(
     segment: UrlSegmentGroup, fn: (v: UrlSegmentGroup, k: string) => T[]): T[] {
   let res: T[] = [];
-  forEach(segment.children, (child: UrlSegmentGroup, childOutlet: string) => {
+  Object.entries(segment.children).forEach(([childOutlet, child]) => {
     if (childOutlet === PRIMARY_OUTLET) {
       res = res.concat(fn(child, childOutlet));
     }
   });
-  forEach(segment.children, (child: UrlSegmentGroup, childOutlet: string) => {
+  Object.entries(segment.children).forEach(([childOutlet, child]) => {
     if (childOutlet !== PRIMARY_OUTLET) {
       res = res.concat(fn(child, childOutlet));
     }
@@ -422,7 +422,7 @@ function serializeSegment(segment: UrlSegmentGroup, root: boolean): string {
         '';
     const children: string[] = [];
 
-    forEach(segment.children, (v: UrlSegmentGroup, k: string) => {
+    Object.entries(segment.children).forEach(([k, v]) => {
       if (k !== PRIMARY_OUTLET) {
         children.push(`${k}:${serializeSegment(v, false)}`);
       }

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -52,33 +52,12 @@ export function equalArraysOrString(a: string|string[], b: string|string[]) {
 }
 
 /**
- * Flattens single-level nested arrays.
- */
-export function flatten<T>(arr: T[][]): T[] {
-  return Array.prototype.concat.apply([], arr);
-}
-
-/**
  * Return the last element of an array.
  */
 export function last<T>(a: T[]): T|null {
   return a.length > 0 ? a[a.length - 1] : null;
 }
 
-/**
- * Verifys all booleans in an array are `true`.
- */
-export function and(bools: boolean[]): boolean {
-  return !bools.some(v => !v);
-}
-
-export function forEach<K, V>(map: {[key: string]: V}, callback: (v: V, k: string) => void): void {
-  for (const prop in map) {
-    if (map.hasOwnProperty(prop)) {
-      callback(map[prop], prop);
-    }
-  }
-}
 
 export function wrapIntoObservable<T>(value: T|Promise<T>|Observable<T>): Observable<T> {
   if (isObservable(value)) {

--- a/packages/router/src/utils/config_matching.ts
+++ b/packages/router/src/utils/config_matching.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, Injector} from '@angular/core';
+import {EnvironmentInjector} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -15,7 +15,6 @@ import {runCanMatchGuards} from '../operators/check_guards';
 import {defaultUrlMatcher, PRIMARY_OUTLET} from '../shared';
 import {UrlSegment, UrlSegmentGroup, UrlSerializer} from '../url_tree';
 
-import {forEach} from './collection';
 import {getOrCreateRouteInjectorIfNeeded, getOutlet} from './config';
 
 export interface MatchResult {
@@ -72,7 +71,7 @@ export function match(
   if (!res) return {...noMatch};
 
   const posParams: {[n: string]: string} = {};
-  forEach(res.posParams!, (v: UrlSegment, k: string) => {
+  Object.entries(res.posParams ?? {}).forEach(([k, v]) => {
     posParams[k] = v.path;
   });
   const parameters = res.consumed.length > 0 ?

--- a/packages/router/src/utils/preactivation.ts
+++ b/packages/router/src/utils/preactivation.ts
@@ -12,7 +12,7 @@ import {RunGuardsAndResolvers} from '../models';
 import {ChildrenOutletContexts, OutletContext} from '../router_outlet_context';
 import {ActivatedRouteSnapshot, equalParamsAndUrlSegments, RouterStateSnapshot} from '../router_state';
 import {equalPath} from '../url_tree';
-import {forEach, shallowEqual} from '../utils/collection';
+import {shallowEqual} from '../utils/collection';
 import {nodeChildrenAsMap, TreeNode} from '../utils/tree';
 
 export class CanActivate {
@@ -78,10 +78,10 @@ function getChildRouteGuards(
   });
 
   // Process any children left from the current route (not active for the future route)
-  forEach(
-      prevChildren,
-      (v: TreeNode<ActivatedRouteSnapshot>, k: string) =>
-          deactivateRouteAndItsChildren(v, contexts!.getContext(k), checks));
+  Object.entries(prevChildren)
+      .forEach(
+          ([k, v]: [string, TreeNode<ActivatedRouteSnapshot>]) =>
+              deactivateRouteAndItsChildren(v, contexts!.getContext(k), checks));
 
   return checks;
 }
@@ -173,7 +173,7 @@ function deactivateRouteAndItsChildren(
   const children = nodeChildrenAsMap(route);
   const r = route.value;
 
-  forEach(children, (node: TreeNode<ActivatedRouteSnapshot>, childName: string) => {
+  Object.entries(children).forEach(([childName, node]) => {
     if (!r.component) {
       deactivateRouteAndItsChildren(node, context, checks);
     } else if (context) {

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -18,7 +18,7 @@ import {delay, filter, first, last, map, mapTo, takeWhile, tap} from 'rxjs/opera
 
 import {CanActivateChildFn, CanActivateFn, CanMatch, CanMatchFn, Data, ResolveFn} from '../src/models';
 import {provideRouter, withNavigationErrorHandler, withRouterConfig} from '../src/provide_router';
-import {forEach, wrapIntoObservable} from '../src/utils/collection';
+import {wrapIntoObservable} from '../src/utils/collection';
 import {getLoadedRoutes} from '../src/utils/config';
 
 const ROUTER_DIRECTIVES = [RouterLink, RouterLinkActive, RouterOutlet];
@@ -6345,7 +6345,7 @@ describe('Integration', () => {
             children[PRIMARY_OUTLET] = oldRoot.children[PRIMARY_OUTLET];
           }
 
-          forEach(wholeUrl.root.children, (v: any, k: any) => {
+          Object.entries(wholeUrl.root.children).forEach(([k, v]: [string, any]) => {
             if (k !== PRIMARY_OUTLET) {
               children[k] = v;
             }

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -9,7 +9,7 @@
 import {Location} from '@angular/common';
 import {provideLocationMocks} from '@angular/common/testing';
 import {Compiler, inject, Injector, ModuleWithProviders, NgModule} from '@angular/core';
-import {ChildrenOutletContexts, ExtraOptions, NoPreloading, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, TitleStrategy, UrlHandlingStrategy, UrlSerializer, ɵflatten as flatten, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS, ɵwithPreloading as withPreloading} from '@angular/router';
+import {ChildrenOutletContexts, ExtraOptions, NoPreloading, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, TitleStrategy, UrlHandlingStrategy, UrlSerializer, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS, ɵwithPreloading as withPreloading} from '@angular/router';
 
 function isUrlHandlingStrategy(opts: ExtraOptions|
                                UrlHandlingStrategy): opts is UrlHandlingStrategy {


### PR DESCRIPTION
Quick refactor on Router's collection utils : 

* `flatten()` => `flat()` (Something similar was done on Core with #48358) 
* `last()` => `at(-1)`
* `forEach()` => `Object.entries/values/keys().forEach()`
* `and()` => `every()`

