### PR TITLE
refactor(common): Use isPromise from @angular/core

### DIFF
--- a/packages/common/upgrade/src/location_shim.ts
+++ b/packages/common/upgrade/src/location_shim.ts
@@ -7,11 +7,12 @@
  */
 
 import {Location, LocationStrategy, PlatformLocation} from '@angular/common';
+import {ɵisPromise as isPromise} from '@angular/core';
 import {UpgradeModule} from '@angular/upgrade/static';
 import {ReplaySubject} from 'rxjs';
 
 import {UrlCodec} from './params';
-import {deepEqual, isAnchor, isPromise} from './utils';
+import {deepEqual, isAnchor} from './utils';
 
 const PATH_MATCH = /^([^?#]*)(\?([^#]*))?(#(.*))?$/;
 const DOUBLE_SLASH_REGEX = /^\s*[\\/]{2,}/;

--- a/packages/common/upgrade/src/utils.ts
+++ b/packages/common/upgrade/src/utils.ts
@@ -30,9 +30,3 @@ export function deepEqual(a: any, b: any): boolean {
 export function isAnchor(el: (Node&ParentNode)|Element|null): el is HTMLAnchorElement {
   return (<HTMLAnchorElement>el).href !== undefined;
 }
-
-export function isPromise<T = any>(obj: any): obj is Promise<T> {
-  // allow any Promise/A+ compliant thenable.
-  // It's up to the caller to ensure that obj.then conforms to the spec
-  return !!obj && typeof obj.then === 'function';
-}


### PR DESCRIPTION
This commit removes `isPromise()` from Common as it's a duplicate function that can be imported from `@angular/core`.


## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [x] No
