### PR TITLE
perf(core): reduce effects queueing overhead

### DIFF
--- a/packages/core/src/signals/src/watch.ts
+++ b/packages/core/src/signals/src/watch.ts
@@ -24,7 +24,7 @@ export class Watch implements Consumer {
 
   private dirty = false;
 
-  constructor(private watch: () => void, private schedule: (watch: Watch) => void) {}
+  constructor(private watch: () => void, public schedule: (watch: Watch) => void) {}
 
   notify(): void {
     if (!this.dirty) {


### PR DESCRIPTION
perf(core): reduce effects queueing overhead
This commit improves the performance of effect queuing and flushing by reducing
`Set` operations.

The work to queue an effect has been reduced by avoiding a `globalWatches`
lookup, in favor of reassigning the scheduling callback to a become a no-op.

Flushing the queue has been made more efficient by clearing all queued watches
at once, instead of individually per watched item. If an effect throws an error
then it will prevent the watch queue from being cleared at all, but the
internal dirty logic of `Watch` will prevent watches from executing multiple
times when the queue is flushed again.

---

Based on top of #49214; only the second commit is new.