### PR TITLE
perf(core): prioritize checking the producer that marked a consumer as dirty

### DIFF
--- a/packages/core/src/signals/src/watch.ts
+++ b/packages/core/src/signals/src/watch.ts
@@ -24,7 +24,7 @@ export class Watch implements Consumer {
 
   private dirty = false;
 
-  constructor(private watch: () => void, private schedule: (watch: Watch) => void) {}
+  constructor(private watch: () => void, public schedule: (watch: Watch) => void) {}
 
   notify(): void {
     if (!this.dirty) {


### PR DESCRIPTION
Each consumer that has been marked as stale has to verify if one of its
producers has actually changed in the pull phase of the reactivity algorithm.
This involves iterating over all producers to see if any of them reports an
actual value change.

This commit implements an optimization where the producer that marks a consumer
as dirty will be captured in the consumer, such that the consumer can
prioritize checking that particular producer. This is beneficial, since it is
a likely candidate to actually report a change.

---

Based on top of #49215; only the third commit is new.