### PR TITLE
perf(core): store producers and consumers in a linear array structure

### DIFF
--- a/packages/core/src/signals/src/computed.ts
+++ b/packages/core/src/signals/src/computed.ts
@@ -8,6 +8,7 @@
 
 import {createSignalFromFunction, defaultEquals, Signal, ValueEqualityFn} from './api';
 import {Consumer, ConsumerId, consumerPollValueStatus, Edge, nextReactiveId, Producer, producerAccessed, ProducerId, producerNotifyConsumers, setActiveConsumer} from './graph';
+import {LinearMap} from './linear_map';
 import {WeakRef} from './weak_ref';
 
 /**
@@ -71,8 +72,8 @@ class ComputedImpl<T> implements Producer, Consumer {
 
   readonly id = nextReactiveId();
   readonly ref = new WeakRef(this);
-  readonly producers = new Map<ProducerId, Edge>();
-  readonly consumers = new Map<ConsumerId, Edge>();
+  readonly producers = new LinearMap<ProducerId, Edge>();
+  readonly consumers = new LinearMap<ConsumerId, Edge>();
   trackingVersion = 0;
   valueVersion = 0;
 

--- a/packages/core/src/signals/src/linear_map.ts
+++ b/packages/core/src/signals/src/linear_map.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export class LinearMap<K, V> extends Array<K|V|null> {
+  private emptyIndex: number|null = null;
+
+  get(key: K): V|undefined {
+    for (let i = 0, len = this.length; i < len; i += 2) {
+      const k = this[i];
+      if (k === null) {
+        if (this.emptyIndex === null || this.emptyIndex > i) {
+          this.emptyIndex = i;
+        }
+      } else if (k === key) {
+        return this[i + 1] as V;
+      }
+    }
+  }
+
+  set(key: K, value: V): void {
+    if (this.emptyIndex !== null) {
+      this[this.emptyIndex] = key;
+      this[this.emptyIndex + 1] = value;
+      this.emptyIndex = null;
+      return
+    }
+    for (let i = 0, len = this.length; i < len; i += 2) {
+      if (this[i] === null) {
+        this[i] = key;
+        this[i + 1] = value;
+        return;
+      }
+    }
+    this.push(key, value);
+  }
+
+  delete(key: K): void {
+    for (let i = 0, len = this.length; i < len; i += 2) {
+      if (this[i] === key) {
+        this[i] = this[i + 1] = null;
+        if (this.emptyIndex === null || this.emptyIndex > i) {
+          this.emptyIndex = i;
+        }
+        break;
+      }
+    }
+  }
+
+  deleteIndex(i: number): void {
+    this[i] = this[i + 1] = null;
+  }
+}

--- a/packages/core/src/signals/src/signal.ts
+++ b/packages/core/src/signals/src/signal.ts
@@ -8,6 +8,7 @@
 
 import {createSignalFromFunction, defaultEquals, Signal, ValueEqualityFn} from './api';
 import {ConsumerId, Edge, nextReactiveId, Producer, producerAccessed, producerNotifyConsumers} from './graph';
+import {LinearMap} from './linear_map';
 import {WeakRef} from './weak_ref';
 
 /**
@@ -42,7 +43,7 @@ class SettableSignalImpl<T> implements Producer {
 
   readonly id = nextReactiveId();
   readonly ref = new WeakRef(this);
-  readonly consumers = new Map<ConsumerId, Edge>();
+  readonly consumers = new LinearMap<ConsumerId, Edge>();
   valueVersion = 0;
 
   checkForChangedValue(): void {

--- a/packages/core/src/signals/src/watch.ts
+++ b/packages/core/src/signals/src/watch.ts
@@ -24,7 +24,7 @@ export class Watch implements Consumer {
 
   private dirty = false;
 
-  constructor(private watch: () => void, private schedule: (watch: Watch) => void) {}
+  constructor(private watch: () => void, public schedule: (watch: Watch) => void) {}
 
   notify(): void {
     if (!this.dirty) {

--- a/packages/core/src/signals/src/watch.ts
+++ b/packages/core/src/signals/src/watch.ts
@@ -7,6 +7,7 @@
  */
 
 import {Consumer, consumerPollValueStatus, Edge, nextReactiveId, Producer, ProducerId, setActiveConsumer} from './graph';
+import {LinearMap} from './linear_map';
 import {WeakRef} from './weak_ref';
 
 /**
@@ -19,7 +20,7 @@ import {WeakRef} from './weak_ref';
 export class Watch implements Consumer {
   readonly id = nextReactiveId();
   readonly ref = new WeakRef(this);
-  readonly producers = new Map<ProducerId, Edge>();
+  readonly producers = new LinearMap<ProducerId, Edge>();
   trackingVersion = 0;
 
   private dirty: Producer|boolean = false;


### PR DESCRIPTION
This commit swaps out the `Map` storage for producers and consumers to use a
linear array as data structure, with keys being stored at even indices and
values at odd indices. The primary benefit of this data structure is that it
provides faster iteration.

Deleting elements inserts `null` values into both the key and value slots,
meaning that the array never shrinks in size. These empty slots are reused
when inserting new elements.

---

Based on top of #49216; only the fourth commit is new.