### PR TITLE
refactor(core): add previous sibling node reference to TNode

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -235,6 +235,7 @@ export function createTNodeAtIndex(
         // In the case of i18n the `currentTNode` may already be linked, in which case we don't want
         // to break the links which i18n created.
         currentTNode.next = tNode;
+        tNode.prev = currentTNode;
       }
     }
   }
@@ -759,6 +760,7 @@ export function createTNode(
     outputs: null,
     tViews: null,
     next: null,
+    prev: null,
     projectionNext: null,
     child: null,
     parent: tParent,

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -560,6 +560,12 @@ export interface TNode {
   next: TNode|null;
 
   /**
+   * The previous sibling node.
+   * This simplifies operations when we need a pointer to the previous node.
+   */
+  prev: TNode|null;
+
+  /**
    * The next projected sibling. Since in Angular content projection works on the node-by-node
    * basis the act of projecting nodes might change nodes relationship at the insertion point
    * (target view). At the same time we need to keep initial relationship between nodes as

--- a/packages/core/test/render3/is_shape_of.ts
+++ b/packages/core/test/render3/is_shape_of.ts
@@ -167,6 +167,7 @@ const ShapeOfTNode: ShapeOf<TNode> = {
   outputs: true,
   tViews: true,
   next: true,
+  prev: true,
   projectionNext: true,
   child: true,
   parent: true,


### PR DESCRIPTION
This commit updates the `TNode` interface to include a reference to the previous sibling node. Currently, TNode has references to the next sibling and parent nodes, but in followup changes (💧) we'd need to have access to previous TNodes (to determine position of the current node).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No