### PR TITLE
fix(platform-server): bundle @angular/domino in via esbuild

### DIFF
--- a/packages/core/test/render3/BUILD.bazel
+++ b/packages/core/test/render3/BUILD.bazel
@@ -59,6 +59,7 @@ ts_library(
         "//packages/common",
         "//packages/compiler",
         "//packages/platform-server",
+        "//packages/platform-server:bundled_domino_lib",
         "//packages/zone.js/lib:zone_d_ts",
     ],
 )

--- a/packages/core/test/render3/load_domino.ts
+++ b/packages/core/test/render3/load_domino.ts
@@ -13,7 +13,7 @@ import {ɵgetDOM as getDOM} from '@angular/common';
 import {DominoAdapter} from '@angular/platform-server/src/domino_adapter';
 
 if (typeof window == 'undefined') {
-  const domino = require('domino');
+  const domino = require('../../../platform-server/src/bundled-domino');
 
   DominoAdapter.makeCurrent();
   (global as any).document = getDOM().getDefaultDocument();

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -1,4 +1,5 @@
-load("//tools:defaults.bzl", "api_golden_test_npm_package", "ng_module", "ng_package", "tsec_test")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//tools:defaults.bzl", "api_golden_test_npm_package", "esbuild", "ng_module", "ng_package", "tsec_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -10,8 +11,10 @@ ng_module(
             "*.ts",
             "src/**/*.ts",
         ],
+        exclude = ["src/bundled-domino.d.ts"],
     ),
     deps = [
+        ":bundled_domino_lib",
         "//packages/animations/browser",
         "//packages/common",
         "//packages/common/http",
@@ -28,6 +31,22 @@ ng_module(
     ],
 )
 
+esbuild(
+    name = "bundled_domino",
+    entry_point = "@npm//:node_modules/domino/lib/index.js",
+    format = "esm",
+    output = "src/bundled-domino.mjs",
+    deps = ["@npm//domino"],
+)
+
+js_library(
+    name = "bundled_domino_lib",
+    srcs = [
+        "src/bundled-domino.d.ts",
+        ":bundled_domino",
+    ],
+)
+
 tsec_test(
     name = "tsec_test",
     target = "platform-server",
@@ -40,7 +59,6 @@ ng_package(
         "package.json",
     ],
     externals = [
-        "domino",
         "xhr2",
     ],
     tags = [

--- a/packages/platform-server/init/test/BUILD.bazel
+++ b/packages/platform-server/init/test/BUILD.bazel
@@ -12,8 +12,8 @@ ts_library(
     testonly = True,
     srcs = glob(["**/*.ts"]),
     deps = [
+        "//packages/platform-server:bundled_domino_lib",
         "//packages/platform-server/init",
-        "@npm//domino",
     ],
 )
 

--- a/packages/platform-server/init/test/shims_spec.ts
+++ b/packages/platform-server/init/test/shims_spec.ts
@@ -5,8 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import domino from 'domino';
-
+import domino from '../../src/bundled-domino';
 import {applyShims} from '../src/shims';
 
 describe('applyShims()', () => {

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -16,7 +16,6 @@
     "@angular/platform-browser-dynamic": "0.0.0-PLACEHOLDER"
   },
   "dependencies": {
-    "domino": "https://github.com/angular/domino.git#4280d0380df839d97b81e7680877ad5b55500e77",
     "tslib": "^2.3.0",
     "xhr2": "^0.2.0"
   },

--- a/packages/platform-server/src/bundled-domino.d.ts
+++ b/packages/platform-server/src/bundled-domino.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import domino from 'domino';
+
+export default domino;

--- a/packages/platform-server/src/domino_adapter.ts
+++ b/packages/platform-server/src/domino_adapter.ts
@@ -8,7 +8,8 @@
 
 import {ɵsetRootDomAdapter as setRootDomAdapter} from '@angular/common';
 import {ɵBrowserDomAdapter as BrowserDomAdapter} from '@angular/platform-browser';
-import domino from 'domino';
+
+import domino from './bundled-domino';
 
 export function setDomTypes() {
   // Make all Domino types available in the global env.

--- a/packages/private/testing/BUILD.bazel
+++ b/packages/private/testing/BUILD.bazel
@@ -17,6 +17,6 @@ ng_module(
     module_name = "@angular/private/testing",
     deps = [
         "//packages/core",
-        "@npm//domino",
+        "//packages/platform-server:bundled_domino_lib",
     ],
 )

--- a/packages/private/testing/src/utils.ts
+++ b/packages/private/testing/src/utils.ts
@@ -112,15 +112,17 @@ let savedDocument: Document|undefined = undefined;
 let savedRequestAnimationFrame: ((callback: FrameRequestCallback) => number)|undefined = undefined;
 let savedNode: typeof Node|undefined = undefined;
 let requestAnimationFrameCount = 0;
-let domino: typeof import('domino')|null|undefined = undefined;
+let domino: typeof import('../../../platform-server/src/bundled-domino')['default']|null|undefined =
+    undefined;
 
-async function loadDominoOrNull(): Promise<typeof import('domino')|null> {
+async function loadDominoOrNull():
+    Promise<typeof import('../../../platform-server/src/bundled-domino')['default']|null> {
   if (domino !== undefined) {
     return domino;
   }
 
   try {
-    return domino = (await import('domino')).default;
+    return domino = (await import('../../../platform-server/src/bundled-domino')).default;
   } catch {
     return domino = null;
   }

--- a/tools/testing/BUILD.bazel
+++ b/tools/testing/BUILD.bazel
@@ -35,9 +35,9 @@ ts_library(
         "//packages/compiler",
         "//packages/core/testing",
         "//packages/platform-server",
+        "//packages/platform-server:bundled_domino_lib",
         "//packages/platform-server/testing",
         "//packages/zone.js/lib",
-        "@npm//domino",
     ],
 )
 

--- a/tools/testing/node_tests.init.ts
+++ b/tools/testing/node_tests.init.ts
@@ -17,7 +17,7 @@ import '@angular/compiler'; // For JIT mode. Must be in front of any other @angu
 import {TestBed} from '@angular/core/testing';
 import {ServerTestingModule, platformServerTesting} from '@angular/platform-server/testing/src/server';
 import {DominoAdapter} from '@angular/platform-server/src/domino_adapter';
-import domino from 'domino';
+import domino from '../../packages/platform-server/src/bundled-domino';
 
 TestBed.initTestEnvironment(ServerTestingModule, platformServerTesting());
 DominoAdapter.makeCurrent();


### PR DESCRIPTION
This removes one line that should effectively bundle the angular fork of domino in via esbuild.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We're not bundling @angular/domino in with platform-server.

Issue Number: #49228


## What is the new behavior?
We _are_ bundling @angular/domino in with platform-server.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
