### PR TITLE
refactor(platform-browser): handle #24571 todos

### DIFF
--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -32,7 +32,9 @@ export class EventManager {
    * Initializes an instance of the event-manager service.
    */
   constructor(@Inject(EVENT_MANAGER_PLUGINS) plugins: EventManagerPlugin[], private _zone: NgZone) {
-    plugins.forEach(p => p.manager = this);
+    plugins.forEach((plugin) => {
+      plugin.manager = this;
+    });
     this._plugins = plugins.slice().reverse();
   }
 
@@ -94,7 +96,7 @@ export class EventManager {
 export abstract class EventManagerPlugin {
   constructor(private _doc: any) {}
 
-  // TODO(issue/24571): remove '!'.
+  // Using non-null assertion because it's set by EventManager's constructor
   manager!: EventManager;
 
   abstract supports(eventName: string): boolean;

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
-import {Compiler, Component, ComponentFactoryResolver, CUSTOM_ELEMENTS_SCHEMA, Directive, Inject, Injectable, InjectionToken, Injector, Input, NgModule, Optional, Pipe, SkipSelf, Type, ɵstringify as stringify} from '@angular/core';
+import {Compiler, Component, ComponentFactoryResolver, CUSTOM_ELEMENTS_SCHEMA, Directive, Inject, Injectable, InjectionToken, Injector, Input, NgModule, Optional, Pipe, SkipSelf, Type} from '@angular/core';
 import {fakeAsync, getTestBed, inject, TestBed, tick, waitForAsync, withModule} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
@@ -92,7 +92,6 @@ class TestViewProvidersComp {
 
 @Directive({selector: '[someDir]', host: {'[title]': 'someDir'}})
 class SomeDirective {
-  // TODO(issue/24571): remove '!'.
   @Input() someDir!: string;
 }
 
@@ -762,7 +761,6 @@ const bTok = new InjectionToken<string>('b');
               testDir = this;
             }
 
-            // TODO(issue/24571): remove '!'.
             @Input('test') test!: string;
           }
 


### PR DESCRIPTION
This commit removes the remaining TODO(issue/24571) in platform-browser code base.

See also the PRs about #24571 : 

*#48241
* #49220
* #49221
* #49231
* #49233