### PR TITLE
refactor:  handle #24571 todos for examples/platform-server/elements

### DIFF
--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -276,7 +276,6 @@ describe('createCustomElement', () => {
   })
   class TestComponent {
     @Input() fooFoo: string = 'foo';
-    // TODO(issue/24571): remove '!'.
     @Input('barbar') barBar!: string;
 
     @Output() bazBaz = new EventEmitter<boolean>();

--- a/packages/examples/common/pipes/ts/lowerupper_pipe.ts
+++ b/packages/examples/common/pipes/ts/lowerupper_pipe.ts
@@ -18,8 +18,7 @@ import {Component} from '@angular/core';
   </div>`
 })
 export class LowerUpperPipeComponent {
-  // TODO(issue/24571): remove '!'.
-  value!: string;
+  value: string = '';
   change(value: string) {
     this.value = value;
   }

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -390,7 +390,6 @@ function createFalseAttributesComponents(standalone: boolean) {
     template: 'Works!',
   })
   class MyChildComponent {
-    // TODO(issue/24571): remove '!'.
     @Input() public attr!: boolean;
   }
 


### PR DESCRIPTION
This PR removes the remaining TODO(issue/24571) in the platform-server, examples & elements code base.

See individual commits, it's 1 one file per mentioned package. I didn't want to waist the time of the caretaker by doing an individual PR for each one ! 😊

See also the PRs about #24571 : 

*#48241
* #49220
* #49221
* #49231
* #49232