### PR TITLE
feat(router): Expose information about the last successful `Navigation`

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -678,6 +678,7 @@ export class Router {
     // @deprecated
     isActive(url: string | UrlTree, exact: boolean): boolean;
     isActive(url: string | UrlTree, matchOptions: IsActiveMatchOptions): boolean;
+    get lastSuccessfulNavigation(): Navigation | null;
     // @deprecated
     malformedUriErrorHandler: (error: URIError, urlSerializer: UrlSerializer, url: string) => UrlTree;
     navigate(commands: any[], extras?: NavigationExtras): Promise<boolean>;

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -421,6 +421,14 @@ export class Router {
   }
 
   /**
+   * The `Navigation` object of the most recent navigation to succeed and `null` if there
+   *     has not been a successful navigation yet.
+   */
+  get lastSuccessfulNavigation(): Navigation|null {
+    return this.navigationTransitions.lastSuccessfulNavigation;
+  }
+
+  /**
    * Resets the route configuration used for navigation and generating links.
    *
    * @param config The route array for the new configuration.


### PR DESCRIPTION
The `Router` already has the `getCurrentNavigation()` helper function to expose information about the ongoing navigation.
`lastSuccessfulNavigation` is actually already exposed in the `Navigation` object. This commit only _slightly_ extends the current API surface by providing access to the `lastSuccessfulNavigation` object outside of an ongoing navigation.

fixes #45685
