### PR TITLE
refactor(router): Remove zone code from router scroller

### DIFF
--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -180,10 +180,9 @@ export function withInMemoryScrolling(options: InMemoryScrollingOptions = {}):
     provide: ROUTER_SCROLLER,
     useFactory: () => {
       const viewportScroller = inject(ViewportScroller);
-      const zone = inject(NgZone);
       const transitions = inject(NavigationTransitions);
       const urlSerializer = inject(UrlSerializer);
-      return new RouterScroller(urlSerializer, transitions, viewportScroller, zone, options);
+      return new RouterScroller(urlSerializer, transitions, viewportScroller, options);
     },
   }];
   return routerFeature(RouterFeatureKind.InMemoryScrollingFeature, providers);

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -160,14 +160,13 @@ export function provideRouterScroller(): Provider {
     provide: ROUTER_SCROLLER,
     useFactory: () => {
       const viewportScroller = inject(ViewportScroller);
-      const zone = inject(NgZone);
       const config: ExtraOptions = inject(ROUTER_CONFIGURATION);
       const transitions = inject(NavigationTransitions);
       const urlSerializer = inject(UrlSerializer);
       if (config.scrollOffset) {
         viewportScroller.setOffset(config.scrollOffset);
       }
-      return new RouterScroller(urlSerializer, transitions, viewportScroller, zone, config);
+      return new RouterScroller(urlSerializer, transitions, viewportScroller, config);
     },
   };
 }

--- a/packages/router/src/router_scroller.ts
+++ b/packages/router/src/router_scroller.ts
@@ -29,8 +29,7 @@ export class RouterScroller implements OnDestroy {
   /** @nodoc */
   constructor(
       readonly urlSerializer: UrlSerializer, private transitions: NavigationTransitions,
-      public readonly viewportScroller: ViewportScroller, private readonly zone: NgZone,
-      private options: {
+      public readonly viewportScroller: ViewportScroller, private options: {
         scrollPositionRestoration?: 'disabled'|'enabled'|'top',
         anchorScrolling?: 'disabled'|'enabled'
       } = {}) {
@@ -93,17 +92,13 @@ export class RouterScroller implements OnDestroy {
 
   private scheduleScrollEvent(routerEvent: NavigationEnd|NavigationSkipped, anchor: string|null):
       void {
-    this.zone.runOutsideAngular(() => {
-      // The scroll event needs to be delayed until after change detection. Otherwise, we may
-      // attempt to restore the scroll position before the router outlet has fully rendered the
-      // component by executing its update block of the template function.
-      setTimeout(() => {
-        this.zone.run(() => {
-          this.transitions.events.next(new Scroll(
-              routerEvent, this.lastSource === 'popstate' ? this.store[this.restoredId] : null,
-              anchor));
-        });
-      }, 0);
+    // The scroll event needs to be delayed until after change detection. Otherwise, we may
+    // attempt to restore the scroll position before the router outlet has fully rendered the
+    // component by executing its update block of the template function.
+    setTimeout(() => {
+      this.transitions.events.next(new Scroll(
+          routerEvent, this.lastSource === 'popstate' ? this.store[this.restoredId] : null,
+          anchor));
     });
   }
 

--- a/packages/router/test/router_scroller.spec.ts
+++ b/packages/router/test/router_scroller.spec.ts
@@ -32,8 +32,8 @@ describe('RouterScroller', () => {
         'viewportScroller',
         ['getScrollPosition', 'scrollToPosition', 'scrollToAnchor', 'setHistoryScrollRestoration']);
     setScroll(viewportScroller, 0, 0);
-    const scroller = new RouterScroller(
-        new DefaultUrlSerializer(), {events} as any, viewportScroller, fakeZone as any);
+    const scroller =
+        new RouterScroller(new DefaultUrlSerializer(), {events} as any, viewportScroller);
 
     expect((scroller as any).options.scrollPositionRestoration).toBe('disabled');
     expect((scroller as any).options.anchorScrolling).toBe('disabled');
@@ -197,7 +197,7 @@ describe('RouterScroller', () => {
     setScroll(viewportScroller, 0, 0);
 
     const scroller = new RouterScroller(
-        new DefaultUrlSerializer(), transitions, viewportScroller, fakeZone as any,
+        new DefaultUrlSerializer(), transitions, viewportScroller,
         {scrollPositionRestoration, anchorScrolling});
     scroller.init();
 


### PR DESCRIPTION
This zone code was added with the incorrect assumption that it would avoid scheduling a new change detection by creating the timeout outside of the Angular zone. However, it has recently been (re)discovered that calling `zone.run` when you are outside the angular zone results in a synchronous change detection. With that, this bit of code doesn't actually accomplish what it set out to do so it can be removed.

minimal repro: https://stackblitz.com/edit/angular-hbzbqs?file=src%2Fmain.ts
