### PR TITLE
refactor(server): remove deprecated `renderModuleFactory`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -79,7 +79,6 @@ v15 - v18
 | `@angular/core`                     | [Factory-based signature of `ApplicationRef.bootstrap`](#core)                                             | v13           | v15         |
 | `@angular/core`                     | [`PlatformRef.bootstrapModuleFactory`](#core)                                                              | v13           | v15         |
 | `@angular/core`                     | [Factory-based signature of `ViewContainerRef.createComponent`](api/core/ViewContainerRef#createComponent) | v13           | v15         |
-| `@angular/platform-server`          | [`renderModuleFactory`](#platform-server)                                                                  | v13           | v15         |
 | `@angular/upgrade`                  | [Factory-based signature of `downgradeModule`](#upgrade-static)                                            | v13           | v15         |
 | template syntax                     | [`bind-`, `on-`, `bindon-`, and `ref-`](#bind-syntax)                                                      | v13           | v15         |
 
@@ -228,7 +227,6 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 
 | API                                                              | Replacement                                        | Deprecation announced | Details |
 |:---                                                              |:---                                                |:---                   |:---     |
-| [`renderModuleFactory`](api/platform-server/renderModuleFactory) | [`renderModule`](api/platform-server/renderModule) | v13                   | This symbol is no longer necessary. See [JIT API changes due to ViewEngine deprecation](#jit-api-changes) for additional context. |
 | [`ServerTransferStateModule`](api/platform-server/ServerTransferStateModule) | No replacement needed.  | v14.1                   | The `TransferState` class is available for injection without importing additional modules during server side rendering, when `ServerModule` is imported or `renderApplication` function is used for bootstrap. |
 
 <a id="forms"></a>
@@ -383,7 +381,7 @@ The injector no longer requires the Reflect polyfill, reducing application size 
 ### Router class and InjectionToken guards and resolvers
 
 Class and injection token guards and resolvers are deprecated. Instead, `Route`
-objects should use functional-style guards and resolvers. Class-based guards can 
+objects should use functional-style guards and resolvers. Class-based guards can
 be converted to functions by instead using `inject` to get dependencies.
 
 For testing a function `canActivate` guard, using `TestBed` and `TestBed.runInInjectionContext` is recommended.
@@ -408,8 +406,8 @@ const route = {
 This deprecation only affects the support for class and
 `InjectionToken` guards at the `Route` definition. `Injectable` classes
 and `InjectionToken` providers are _not_ deprecated in the general
-sense. That said, the interfaces like `CanActivate`, 
-`CanDeactivate`, etc.  will be deleted in a future release of Angular. Simply removing the 
+sense. That said, the interfaces like `CanActivate`,
+`CanDeactivate`, etc.  will be deleted in a future release of Angular. Simply removing the
 `implements CanActivate` from the injectable class and updating the route definition
 to be a function like `canActivate: [() => inject(MyGuard).canActivate()]` is sufficient
 to get rid of the deprecation warning.

--- a/aio/content/guide/universal.md
+++ b/aio/content/guide/universal.md
@@ -228,7 +228,7 @@ It accepts an object with the following properties:
 
 | Properties       | Details |
 |:---              |:---     |
-| `bootstrap`      | The root `NgModule` or `NgModule` factory to use for bootstrapping the application when rendering on the server. For the example application, it is `AppServerModule`. It's the bridge between the Universal server-side renderer and the Angular application. |
+| `bootstrap`      | The root `NgModule` to use for bootstrapping the application when rendering on the server. For the example application, it is `AppServerModule`. It's the bridge between the Universal server-side renderer and the Angular application. |
 | `extraProviders` | This property is optional and lets you specify dependency providers that apply only when rendering the application on the server. Do this when your application needs information that can only be determined by the currently running server instance.       |
 
 The `ngExpressEngine()` function returns a `Promise` callback that resolves to the rendered page.
@@ -313,7 +313,7 @@ You don't need to do anything to make relative URLs work on the server.
 
 If, for some reason, you are not using an `@nguniversal/*-engine` package, you might need to handle it yourself.
 
-The recommended solution is to pass the full request URL to the `options` argument of [renderModule()](api/platform-server/renderModule) or [renderModuleFactory()](api/platform-server/renderModuleFactory) \(depending on what you use to render `AppServerModule` on the server\).
+The recommended solution is to pass the full request URL to the `options` argument of [renderModule()](api/platform-server/renderModule).
 This option is the least intrusive as it does not require any changes to the application.
 Here, "request URL" refers to the URL of the request as a response to which the application is being rendered on the server.
 For example, if the client requested `https://my-server.com/dashboard` and you are rendering the application on the server to respond to that request, `options.url` should be set to `https://my-server.com/dashboard`.

--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -10,7 +10,6 @@ import * as i1 from '@angular/common/http';
 import * as i2 from '@angular/platform-browser/animations';
 import * as i3 from '@angular/platform-browser';
 import { InjectionToken } from '@angular/core';
-import { NgModuleFactory } from '@angular/core';
 import { PlatformRef } from '@angular/core';
 import { Provider } from '@angular/core';
 import { StaticProvider } from '@angular/core';
@@ -60,13 +59,6 @@ export function renderApplication<T>(rootComponent: Type<T>, options: {
 // @public
 export function renderModule<T>(moduleType: Type<T>, options: {
     document?: string | Document;
-    url?: string;
-    extraProviders?: StaticProvider[];
-}): Promise<string>;
-
-// @public @deprecated
-export function renderModuleFactory<T>(moduleFactory: NgModuleFactory<T>, options: {
-    document?: string;
     url?: string;
     extraProviders?: StaticProvider[];
 }): Promise<string>;

--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -10,7 +10,7 @@ export {PlatformState} from './platform_state';
 export {platformDynamicServer, platformServer, ServerModule} from './server';
 export {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';
 export {ServerTransferStateModule} from './transfer_state';
-export {renderApplication, renderModule, renderModuleFactory} from './utils';
+export {renderApplication, renderModule} from './utils';
 
 export * from './private_export';
 export {VERSION} from './version';

--- a/packages/platform-server/src/tokens.ts
+++ b/packages/platform-server/src/tokens.ts
@@ -50,7 +50,7 @@ export interface PlatformConfig {
 export const INITIAL_CONFIG = new InjectionToken<PlatformConfig>('Server.INITIAL_CONFIG');
 
 /**
- * A function that will be executed when calling `renderApplication`, `renderModuleFactory` or
+ * A function that will be executed when calling `renderApplication` or
  * `renderModule` just before current platform state is rendered to string.
  *
  * @publicApi

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -6,14 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, EnvironmentProviders, importProvidersFrom, InjectionToken, NgModuleFactory, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵinternalCreateApplication as internalCreateApplication, ɵisPromise} from '@angular/core';
+import {ApplicationRef, EnvironmentProviders, importProvidersFrom, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵinternalCreateApplication as internalCreateApplication, ɵisPromise} from '@angular/core';
 import {BrowserModule, ɵTRANSITION_ID} from '@angular/platform-browser';
 import {first} from 'rxjs/operators';
 
 import {PlatformState} from './platform_state';
-import {platformDynamicServer, platformServer, ServerModule} from './server';
+import {platformDynamicServer, ServerModule} from './server';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG} from './tokens';
-import {TRANSFER_STATE_SERIALIZATION_PROVIDERS} from './transfer_state';
 
 interface PlatformOptions {
   document?: string|Document;
@@ -201,32 +200,4 @@ export function renderApplication<T>(rootComponent: Type<T>, options: {
     ...(options.providers ?? []),
   ];
   return _render(platform, internalCreateApplication({rootComponent, appProviders}));
-}
-
-/**
- * Bootstraps an application using provided {@link NgModuleFactory} and serializes the page content
- * to string.
- *
- * @param moduleFactory An instance of the {@link NgModuleFactory} that should be used for
- *     bootstrap.
- * @param options Additional configuration for the render operation:
- *  - `document` - the document of the page to render, either as an HTML string or
- *                 as a reference to the `document` instance.
- *  - `url` - the URL for the current render request.
- *  - `extraProviders` - set of platform level providers for the current render request.
- *
- * @publicApi
- *
- * @deprecated
- * This symbol is no longer necessary as of Angular v13.
- * Use {@link renderModule} API instead.
- */
-export function renderModuleFactory<T>(moduleFactory: NgModuleFactory<T>, options: {
-  document?: string,
-  url?: string,
-  extraProviders?: StaticProvider[],
-}): Promise<string> {
-  const {document, url, extraProviders: platformProviders} = options;
-  const platform = _getPlatform(platformServer, {document, url, platformProviders});
-  return _render(platform, platform.bootstrapModuleFactory(moduleFactory));
 }

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -10,10 +10,10 @@ import {animate, AnimationBuilder, state, style, transition, trigger} from '@ang
 import {DOCUMENT, isPlatformServer, PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
 import {HTTP_INTERCEPTORS, HttpClient, HttpClientModule, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
-import {ApplicationRef, CompilerFactory, Component, destroyPlatform, getPlatform, HostListener, Inject, inject as coreInject, Injectable, Input, NgModule, NgZone, PLATFORM_ID, PlatformRef, ViewEncapsulation} from '@angular/core';
-import {inject, TestBed, waitForAsync} from '@angular/core/testing';
+import {ApplicationRef, Component, destroyPlatform, getPlatform, HostListener, Inject, inject as coreInject, Injectable, Input, NgModule, NgZone, PLATFORM_ID, ViewEncapsulation} from '@angular/core';
+import {TestBed, waitForAsync} from '@angular/core/testing';
 import {BrowserModule, makeStateKey, Title, TransferState} from '@angular/platform-browser';
-import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformDynamicServer, PlatformState, renderModule, renderModuleFactory, ServerModule} from '@angular/platform-server';
+import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformDynamicServer, PlatformState, renderModule, ServerModule} from '@angular/platform-server';
 import {Observable} from 'rxjs';
 import {first} from 'rxjs/operators';
 
@@ -702,18 +702,6 @@ describe('platform-server integration', () => {
                called = true;
              });
        }));
-
-    it('using renderModuleFactory should work',
-       waitForAsync(inject([PlatformRef], (defaultPlatform: PlatformRef) => {
-         const compilerFactory: CompilerFactory =
-             defaultPlatform.injector.get(CompilerFactory, null)!;
-         const moduleFactory =
-             compilerFactory.createCompiler().compileModuleSync(AsyncServerModule);
-         renderModuleFactory(moduleFactory, {document: doc}).then(output => {
-           expect(output).toBe(expectedOutput);
-           called = true;
-         });
-       })));
 
     // Run the set of tests with regular and standalone components.
     [true, false].forEach((isStandalone: boolean) => {


### PR DESCRIPTION
The deprecated `renderModuleFactory` has been removed as it is no longer necessary with Ivy.

BREAKING CHANGE: `renderModuleFactory` has been removed. Use `renderModule` instead.

//CC @AndrewKushnir 
