### PR TITLE
feat(server): `renderApplication` now accepts a bootstrapping method

### DIFF
--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ApplicationRef } from '@angular/core';
 import { EnvironmentProviders } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/common/http';
@@ -46,6 +47,13 @@ export class PlatformState {
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<PlatformState>;
 }
+
+// @public
+export function renderApplication<T>(bootstrap: () => Promise<ApplicationRef>, options: {
+    document?: string | Document;
+    url?: string;
+    platformProviders?: Provider[];
+}): Promise<string>;
 
 // @public
 export function renderApplication<T>(rootComponent: Type<T>, options: {

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -219,6 +219,7 @@ export {
 export {
   setDocument as ɵsetDocument
 } from './render3/interfaces/document';
+export { getComponentDef as ɵgetComponentDef} from './render3/definition';
 export {
   compileComponent as ɵcompileComponent,
   compileDirective as ɵcompileDirective,
@@ -280,5 +281,6 @@ export {
 export {
   noSideEffects as ɵnoSideEffects,
 } from './util/closure';
+
 
 // clang-format on

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, EnvironmentProviders, importProvidersFrom, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵinternalCreateApplication as internalCreateApplication, ɵisPromise} from '@angular/core';
+import {ApplicationRef, EnvironmentProviders, importProvidersFrom, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵgetComponentDef as getComponentDef, ɵinternalCreateApplication as internalCreateApplication, ɵisPromise} from '@angular/core';
 import {BrowserModule, ɵTRANSITION_ID} from '@angular/platform-browser';
 import {first} from 'rxjs/operators';
 
@@ -155,9 +155,35 @@ export function renderModule<T>(moduleType: Type<T>, options: {
 
 /**
  * Bootstraps an instance of an Angular application and renders it to a string.
+
+ * ```typescript
+ * const bootstrap = () => bootstrapApplication(RootComponent, appConfig);
+ * const output: string = await renderApplication(bootstrap);
+ * ```
  *
- * Note: the root component passed into this function *must* be a standalone one (should have the
- * `standalone: true` flag in the `@Component` decorator config).
+ * @param bootstrap A method that when invoked returns a promise that returns an `ApplicationRef`
+ *     instance once resolved.
+ * @param options Additional configuration for the render operation:
+ *  - `document` - the document of the page to render, either as an HTML string or
+ *                 as a reference to the `document` instance.
+ *  - `url` - the URL for the current render request.
+ *  - `platformProviders` - the platform level providers for the current render request.
+ *
+ * @returns A Promise, that returns serialized (to a string) rendered page, once resolved.
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export function renderApplication<T>(bootstrap: () => Promise<ApplicationRef>, options: {
+  document?: string|Document,
+  url?: string,
+  platformProviders?: Provider[],
+}): Promise<string>;
+/**
+ * Bootstraps an instance of an Angular application and renders it to a string.
+ *
+ * Note: the root component passed into this function *must* be a standalone one (should have
+ * the `standalone: true` flag in the `@Component` decorator config).
  *
  * ```typescript
  * @Component({
@@ -186,18 +212,40 @@ export function renderModule<T>(moduleType: Type<T>, options: {
  * @developerPreview
  */
 export function renderApplication<T>(rootComponent: Type<T>, options: {
+  /** @deprecated use `APP_ID` token to set the application ID. */
   appId: string,
   document?: string|Document,
   url?: string,
   providers?: Array<Provider|EnvironmentProviders>,
   platformProviders?: Provider[],
-}): Promise<string> {
-  const {document, url, platformProviders, appId} = options;
+}): Promise<string>;
+export function renderApplication<T>(
+    rootComponentOrBootstrapFn: Type<T>|(() => Promise<ApplicationRef>), options: {
+      appId?: string,
+      document?: string|Document,
+      url?: string,
+      providers?: Array<Provider|EnvironmentProviders>,
+      platformProviders?: Provider[],
+    }): Promise<string> {
+  const {document, url, platformProviders, appId = ''} = options;
   const platform = _getPlatform(platformDynamicServer, {document, url, platformProviders});
+
+  if (isApplicationBootstrapFn(rootComponentOrBootstrapFn)) {
+    return _render(platform, rootComponentOrBootstrapFn());
+  }
+
   const appProviders = [
     importProvidersFrom(BrowserModule.withServerTransition({appId})),
     importProvidersFrom(ServerModule),
     ...(options.providers ?? []),
   ];
-  return _render(platform, internalCreateApplication({rootComponent, appProviders}));
+
+  return _render(
+      platform,
+      internalCreateApplication({rootComponent: rootComponentOrBootstrapFn, appProviders}));
+}
+
+function isApplicationBootstrapFn(value: unknown): value is() => Promise<ApplicationRef> {
+  // We can differentiate between a component and a bootstrap function by reading `cmp`:
+  return typeof value === 'function' && !getComponentDef(value);
 }

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -230,7 +230,7 @@ export function renderApplication<T>(
   const {document, url, platformProviders, appId = ''} = options;
   const platform = _getPlatform(platformDynamicServer, {document, url, platformProviders});
 
-  if (isApplicationBootstrapFn(rootComponentOrBootstrapFn)) {
+  if (isBootstrapFn(rootComponentOrBootstrapFn)) {
     return _render(platform, rootComponentOrBootstrapFn());
   }
 
@@ -245,7 +245,7 @@ export function renderApplication<T>(
       internalCreateApplication({rootComponent: rootComponentOrBootstrapFn, appProviders}));
 }
 
-function isApplicationBootstrapFn(value: unknown): value is() => Promise<ApplicationRef> {
+function isBootstrapFn(value: unknown): value is() => Promise<ApplicationRef> {
   // We can differentiate between a component and a bootstrap function by reading `cmp`:
   return typeof value === 'function' && !getComponentDef(value);
 }


### PR DESCRIPTION
The `renderApplication` now also accepts a bootstrapping function call with return `Promise<ApplicationRef>`as the first parameter.

Example:
```ts
 const bootstrap = () => bootstrapApplication(RootComponent, appConfig);

 const output: string = await renderApplication(bootstrap);
```
