### PR TITLE
refactor(platform-browser): move `ApplicationConfig` to core

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -50,6 +50,11 @@ export const APP_ID: InjectionToken<string>;
 export const APP_INITIALIZER: InjectionToken<readonly (() => Observable<unknown> | Promise<unknown> | void)[]>;
 
 // @public
+export interface ApplicationConfig {
+    providers: Array<Provider | EnvironmentProviders>;
+}
+
+// @public
 export class ApplicationInitStatus {
     constructor(appInits: ReadonlyArray<() => Observable<unknown> | Promise<unknown> | void>);
     // (undocumented)

--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -4,11 +4,11 @@
 
 ```ts
 
+import { ApplicationConfig as ApplicationConfig_2 } from '@angular/core';
 import { ApplicationRef } from '@angular/core';
 import { ComponentRef } from '@angular/core';
 import { DebugElement } from '@angular/core';
 import { DebugNode } from '@angular/core';
-import { EnvironmentProviders } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/common';
 import { InjectionToken } from '@angular/core';
@@ -26,10 +26,8 @@ import { ɵTransferState as TransferState } from '@angular/core';
 import { Type } from '@angular/core';
 import { Version } from '@angular/core';
 
-// @public
-export interface ApplicationConfig {
-    providers: Array<Provider | EnvironmentProviders>;
-}
+// @public @deprecated
+export type ApplicationConfig = ApplicationConfig_2;
 
 // @public
 export function bootstrapApplication(rootComponent: Type<unknown>, options?: ApplicationConfig): Promise<ApplicationRef>;

--- a/packages/core/src/application_config.ts
+++ b/packages/core/src/application_config.ts
@@ -1,0 +1,22 @@
+
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {EnvironmentProviders, Provider} from './di';
+
+/**
+ * Set of config options available during the application bootstrap operation.
+ *
+ * @publicApi
+ */
+export interface ApplicationConfig {
+  /**
+   * List of providers that should be available to the root component and all its children.
+   */
+  providers: Array<Provider|EnvironmentProviders>;
+}

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -40,6 +40,7 @@ export {Sanitizer} from './sanitization/sanitizer';
 export {createNgModule, createNgModuleRef, createEnvironmentInjector} from './render3/ng_module_ref';
 export {createComponent, reflectComponentType, ComponentMirror} from './render3/component';
 export {isStandalone} from './render3/definition';
+export {ApplicationConfig} from './application_config';
 
 import {global} from './util/global';
 if (typeof ngDevMode !== 'undefined' && ngDevMode) {

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, DOCUMENT, XhrFactory, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {APP_ID, ApplicationModule, ApplicationRef, createPlatformFactory, EnvironmentProviders, ErrorHandler, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalCreateApplication as internalCreateApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
+import {APP_ID, ApplicationConfig as ApplicationConfigFromCore, ApplicationModule, ApplicationRef, createPlatformFactory, ErrorHandler, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalCreateApplication as internalCreateApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
 import {SERVER_TRANSITION_PROVIDERS, TRANSITION_ID} from './browser/server-transition';
@@ -25,13 +25,13 @@ const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
  * Set of config options available during the application bootstrap operation.
  *
  * @publicApi
+ *
+ * @deprecated
+ * `ApplicationConfig` has moved, please import `ApplicationConfig` from `@angular/core` instead.
  */
-export interface ApplicationConfig {
-  /**
-   * List of providers that should be available to the root component and all its children.
-   */
-  providers: Array<Provider|EnvironmentProviders>;
-}
+// The below is a workaround to add a deprecated message.
+type ApplicationConfig = ApplicationConfigFromCore;
+export {ApplicationConfig};
 
 /**
  * Bootstraps an instance of an Angular application and renders a standalone component as the
@@ -136,7 +136,8 @@ function createProvidersConfig(options?: ApplicationConfig) {
  */
 export function provideProtractorTestingSupport(): Provider[] {
   // Return a copy to prevent changes to the original array in case any in-place
-  // alterations are performed to the `provideProtractorTestingSupport` call results in app code.
+  // alterations are performed to the `provideProtractorTestingSupport` call results in app
+  // code.
   return [...TESTABILITY_PROVIDERS];
 }
 


### PR DESCRIPTION
This is needed to provide the merge configuration method which will reside in core.

DEPRECATED: `ApplicationConfig` has moved, please import `ApplicationConfig` from `@angular/core` instead.
