### PR TITLE
refactor(common): remove deprecated `XhrFactory` export from `http` entrypoint

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -73,7 +73,6 @@ v15 - v18
 
 | Area                                | API or Feature                                                                                             | Deprecated in | May be removed in |
 |:---                                 |:---                                                                                                        |:---           |:---               |
-| `@angular/common/http`              | [`XhrFactory`](api/common/http/XhrFactory)                                                                 | v12           | v15         |
 | `@angular/compiler-cli`             | [Input setter coercion](#input-setter-coercion)                                                            | v13           | v15         |
 | `@angular/compiler-cli`             | [`fullTemplateTypeCheck`](#full-template-type-check)                                                       | v13           | v15         |
 | `@angular/core`                     | [Factory-based signature of `ApplicationRef.bootstrap`](#core)                                             | v13           | v15         |
@@ -145,14 +144,6 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 |:---                                                                                           |:---                                                 |:---                   |:---     |
 | [`NgComponentOutlet.ngComponentOutletNgModuleFactory`](api/common/NgComponentOutlet)          | `NgComponentOutlet.ngComponentOutletNgModule`       | v14                   | Use the `ngComponentOutletNgModule` input instead. This input doesn't require resolving NgModule factory. |
 | [`DatePipe` - `DATE_PIPE_DEFAULT_TIMEZONE`](api/common/DATE_PIPE_DEFAULT_TIMEZONE) |`{ provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: { timezone: '-1200' }` | v15                    | Use the `DATE_PIPE_DEFAULT_OPTIONS` injection token, which can configure multiple settings at once instead. |
-
-<a id="common-http"></a>
-
-### &commat;angular/common/http
-
-| API                                        | Replacement                       | Deprecation announced | Details |
-|:---                                        |:---                               |:---                   |:---     |
-| [`XhrFactory`](api/common/http/XhrFactory) | `XhrFactory` in `@angular/common` | v12                   | The `XhrFactory` has moved from `@angular/common/http` to `@angular/common`. |
 
 <a id="core"></a>
 
@@ -383,7 +374,7 @@ The injector no longer requires the Reflect polyfill, reducing application size 
 ### Router class and InjectionToken guards and resolvers
 
 Class and injection token guards and resolvers are deprecated. Instead, `Route`
-objects should use functional-style guards and resolvers. Class-based guards can 
+objects should use functional-style guards and resolvers. Class-based guards can
 be converted to functions by instead using `inject` to get dependencies.
 
 For testing a function `canActivate` guard, using `TestBed` and `TestBed.runInInjectionContext` is recommended.
@@ -408,8 +399,8 @@ const route = {
 This deprecation only affects the support for class and
 `InjectionToken` guards at the `Route` definition. `Injectable` classes
 and `InjectionToken` providers are _not_ deprecated in the general
-sense. That said, the interfaces like `CanActivate`, 
-`CanDeactivate`, etc.  will be deleted in a future release of Angular. Simply removing the 
+sense. That said, the interfaces like `CanActivate`,
+`CanDeactivate`, etc.  will be deleted in a future release of Angular. Simply removing the
 `implements CanActivate` from the injectable class and updating the route definition
 to be a function like `canActivate: [() => inject(MyGuard).canActivate()]` is sufficient
 to get rid of the deprecation warning.

--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -11,7 +11,7 @@ import { InjectionToken } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Provider } from '@angular/core';
-import { XhrFactory as XhrFactory_2 } from '@angular/common';
+import { XhrFactory } from '@angular/common';
 
 // @public
 export const HTTP_INTERCEPTORS: InjectionToken<HttpInterceptor[]>;
@@ -2129,7 +2129,7 @@ export interface HttpUserEvent<T> {
 
 // @public
 export class HttpXhrBackend implements HttpBackend {
-    constructor(xhrFactory: XhrFactory_2);
+    constructor(xhrFactory: XhrFactory);
     handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<HttpXhrBackend, never>;
@@ -2185,12 +2185,6 @@ export function withXsrfConfiguration({ cookieName, headerName }: {
     cookieName?: string;
     headerName?: string;
 }): HttpFeature<HttpFeatureKind.CustomXsrfConfiguration>;
-
-// @public @deprecated
-export type XhrFactory = XhrFactory_2;
-
-// @public @deprecated
-export const XhrFactory: typeof XhrFactory_2;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -6,40 +6,16 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {XhrFactory as XhrFactory_fromAngularCommon} from '@angular/common';
-
-/**
- * A wrapper around the `XMLHttpRequest` constructor.
- *
- * @publicApi
- * @see `XhrFactory`
- * @deprecated
- * `XhrFactory` has moved, please import `XhrFactory` from `@angular/common` instead.
- */
-export type XhrFactory = XhrFactory_fromAngularCommon;
-/**
- * A wrapper around the `XMLHttpRequest` constructor.
- *
- * @publicApi
- * @see `XhrFactory`
- * @deprecated
- * `XhrFactory` has moved, please import `XhrFactory` from `@angular/common` instead.
- */
-export const XhrFactory = XhrFactory_fromAngularCommon;
-
 export {HttpBackend, HttpHandler} from './src/backend';
 export {HttpClient} from './src/client';
 export {HttpContext, HttpContextToken} from './src/context';
 export {HttpHeaders} from './src/headers';
-export {HTTP_INTERCEPTORS, HttpInterceptor, HttpInterceptorHandler as ɵHttpInterceptorHandler, HttpInterceptorFn, HttpHandlerFn} from './src/interceptor';
+export {HTTP_INTERCEPTORS, HttpHandlerFn, HttpInterceptor, HttpInterceptorFn, HttpInterceptorHandler as ɵHttpInterceptorHandler, HttpInterceptorHandler as ɵHttpInterceptingHandler} from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
 export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule} from './src/module';
 export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec} from './src/params';
-export {HttpFeature, HttpFeatureKind, provideHttpClient, withJsonpSupport, withNoXsrfProtection, withXsrfConfiguration, withInterceptors, withInterceptorsFromDi, withRequestsMadeViaParent} from './src/provider';
+export {HttpFeature, HttpFeatureKind, provideHttpClient, withInterceptors, withInterceptorsFromDi, withJsonpSupport, withNoXsrfProtection, withRequestsMadeViaParent, withXsrfConfiguration} from './src/provider';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpStatusCode, HttpUploadProgressEvent, HttpUserEvent} from './src/response';
 export {HttpXhrBackend} from './src/xhr';
 export {HttpXsrfTokenExtractor} from './src/xsrf';
-
-// This re-export exists because g3 depends on this old private name.
-export {HttpInterceptorHandler as ɵHttpInterceptingHandler} from './src/interceptor';


### PR DESCRIPTION

The deprecated `XhrFactory` export from `@angular/common/http` has been removed.

BREAKING CHANGE:

Deprecated `XhrFactory` export from `@angular/common/http` has been removed. Use `XhrFactory` from `@angular/common` instead.
