### PR TITLE
ci: add several dependencies to renovate ignore list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,22 @@
     "remark",
     "remark-html",
     "selenium-webdriver",
-    "watchr"
+    "watchr",
+    "rxjs",
+    "glob",
+    "chalk",
+    "convert-source-map",
+    "@rollup/plugin-node-resolve",
+    "hast-util-is-element",
+    "hast-util-has-property",
+    "hast-util-to-string",
+    "rehype-slug",
+    "rollup",
+    "systemjs",
+    "unist-util-filter",
+    "unist-util-source",
+    "unist-util-visit",
+    "unist-util-visit-parents"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Add ignored dependencies in Renovate config. These have been collected from the dependency dashboard (https://github.com/angular/angular/issues/46728)

The reason for this change is that Renovate is re-opened dependency updates for ignored PRs.
