### PR TITLE
build: remove core-js-bundle from dependencies 

### DIFF
--- a/integration/cli-hello-world-ivy-i18n/package.json
+++ b/integration/cli-hello-world-ivy-i18n/package.json
@@ -24,7 +24,6 @@
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/router": "file:../../dist/packages-dist/router",
-    "core-js": "file:../../node_modules/core-js",
     "rxjs": "file:../../node_modules/rxjs",
     "tslib": "file:../../node_modules/tslib",
     "zone.js": "file:../../dist/zone.js-dist/archive/zone.js.tgz"

--- a/integration/dynamic-compiler/package.json
+++ b/integration/dynamic-compiler/package.json
@@ -34,7 +34,6 @@
     "@angular/platform-browser": "file:../../dist/packages-dist/platform-browser",
     "@angular/platform-browser-dynamic": "file:../../dist/packages-dist/platform-browser-dynamic",
     "@angular/platform-server": "file:../../dist/packages-dist/platform-server",
-    "core-js": "file:../../node_modules/core-js",
     "rxjs": "file:../../node_modules/rxjs",
     "zone.js": "file:../../dist/zone.js-dist/archive/zone.js.tgz"
   }

--- a/integration/npm_package_archives.bzl
+++ b/integration/npm_package_archives.bzl
@@ -6,7 +6,6 @@ NPM_PACKAGE_ARCHIVES = [
     "@rollup/plugin-node-resolve",
     "@rollup/plugin-commonjs",
     "check-side-effects",
-    "core-js",
     "google-closure-compiler",
     "jasmine",
     "typescript",

--- a/karma-js.conf.js
+++ b/karma-js.conf.js
@@ -35,7 +35,6 @@ module.exports = function(config) {
       {pattern: 'node_modules/angular-1.8/angular?(.min).js', included: false, watched: false},
       {pattern: 'node_modules/angular-mocks-1.8/angular-mocks.js', included: false, watched: false},
 
-      'node_modules/core-js-bundle/index.js',
       'node_modules/jasmine-ajax/lib/mock-ajax.js',
 
       // Static test assets.

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "chalk": "^4.1.0",
     "chokidar": "^3.5.1",
     "convert-source-map": "^1.5.1",
-    "core-js-bundle": "^3.10.2",
     "d3": "^7.0.0",
     "diff": "^5.0.0",
     "document-register-element": "^1.7.2",

--- a/packages/elements/test/BUILD.bazel
+++ b/packages/elements/test/BUILD.bazel
@@ -30,7 +30,6 @@ filegroup(
     testonly = True,
     # do not sort
     srcs = [
-        "@npm//:node_modules/core-js-bundle/index.js",
         # Required for browsers that do not natively support Custom Elements.
         "@npm//:node_modules/@webcomponents/custom-elements/custom-elements.min.js",
         "@npm//:node_modules/reflect-metadata/Reflect.js",

--- a/packages/zone.js/karma-build-jasmine.es2015.conf.js
+++ b/packages/zone.js/karma-build-jasmine.es2015.conf.js
@@ -1,11 +1,5 @@
 
 module.exports = function(config) {
   require('./karma-build-jasmine.conf.js')(config);
-  for (let i = 0; i < config.files.length; i++) {
-    if (config.files[i] === 'node_modules/core-js-bundle/index.js') {
-      config.files.splice(i, 1);
-      break;
-    }
-  }
   config.client.entrypoint = 'browser_es2015_entry_point';
 };

--- a/packages/zone.js/karma-build.conf.js
+++ b/packages/zone.js/karma-build.conf.js
@@ -8,7 +8,6 @@
 
 module.exports = function(config) {
   require('./karma-base.conf.js')(config);
-  config.files.push('node_modules/core-js-bundle/index.js');
   config.files.push('build/test/browser-env-setup.js');
   config.files.push('build/test/wtf_mock.js');
   config.files.push('build/test/test_fake_polyfill.js');

--- a/packages/zone.js/karma-dist-sauce-jasmine.es2015.conf.js
+++ b/packages/zone.js/karma-dist-sauce-jasmine.es2015.conf.js
@@ -2,13 +2,6 @@
 module.exports = function(config) {
   require('./karma-dist-jasmine.conf.js')(config);
   require('./sauce.es2015.conf')(config);
-  const files = config.files;
-  config.files = [];
-  for (let i = 0; i < files.length; i++) {
-    if (files[i] !== 'node_modules/core-js-bundle/index.js' || files[i] === 'build/test/main.js') {
-      config.files.push(files[i]);
-    }
-  }
   config.files.push('build/test/wtf_mock.js');
   config.files.push('build/test/test_fake_polyfill.js');
   config.files.push('build/test/custom_error.js');

--- a/packages/zone.js/karma-dist.conf.js
+++ b/packages/zone.js/karma-dist.conf.js
@@ -8,7 +8,6 @@
 
 module.exports = function(config) {
   require('./karma-base.conf.js')(config);
-  config.files.push('node_modules/core-js-bundle/index.js');
   config.files.push('build/test/browser-env-setup.js');
   config.files.push('build/test/wtf_mock.js');
   config.files.push('build/test/test_fake_polyfill.js');

--- a/packages/zone.js/karma-evergreen-dist.conf.js
+++ b/packages/zone.js/karma-evergreen-dist.conf.js
@@ -8,14 +8,6 @@
 
 module.exports = function(config) {
   require('./karma-base.conf.js')(config);
-  const files = config.files;
-  config.files = [];
-  for (let i = 0; i < files.length; i++) {
-    if (files[i] !== 'node_modules/core-js-bundle/index.js') {
-      config.files.push(files[i]);
-    }
-  }
-
   config.files.push('build/test/browser-env-setup.js');
   config.files.push('build/test/wtf_mock.js');
   config.files.push('build/test/test_fake_polyfill.js');

--- a/packages/zone.js/test/webdriver/test.html
+++ b/packages/zone.js/test/webdriver/test.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <script src='../../node_modules/core-js-bundle/index.js'></script>
     <script src='../../dist/zone.js'></script>
 </head>
 <body>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6916,11 +6916,6 @@ copy-webpack-plugin@11.0.0:
     schema-utils "^4.0.0"
     serialize-javascript "^6.0.0"
 
-core-js-bundle@^3.10.2:
-  version "3.23.4"
-  resolved "https://registry.yarnpkg.com/core-js-bundle/-/core-js-bundle-3.23.4.tgz#fb4ea6b4d5a0ba3166da1c8936bc18b9328a292b"
-  integrity sha512-E5kP515mQPnHj0LL0Z4UyQ8VHrhugJaq3GOropUnR/fU3QA3Xxs3vRgt6CwNDpgHYiruDa0jqHwNHwk5FbcwFg==
-
 core-js-compat@^3.25.1:
   version "3.25.3"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.25.3.tgz#d6a442a03f4eade4555d4e640e6a06151dd95d38"


### PR DESCRIPTION
This is no longer needed as Angular is ever green.
