### PR TITLE
docs: clarify ActivatedRouter injection location

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -134,7 +134,7 @@ To get information from a route:
     *   [`ActivatedRoute`](api/router/ActivatedRoute)
     *   [`ParamMap`](api/router/ParamMap)
 
-1.  Inject an instance of `ActivatedRoute` by adding it to your application's constructor:
+1.  Inject an instance of `ActivatedRoute` by adding it to your component's constructor:
 
     <code-example header="In the component class (excerpt)" path="router/src/app/heroes/hero-detail/hero-detail.component.ts" region="activated-route"></code-example>
 


### PR DESCRIPTION
The example in the code snippet below this line of text shows `ActivatedRouter` being injected into a component's constructor. When I read instruction to inject A`ActivatedRouter` into **application's** constructor, I assumed this meant the constructor for `app.component.ts`. 

Editing to clarify/match code example below.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [n/a] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Current text instructs user to inject ActivatedRouter into the "application's" constructor. (I read this and first thought that this referred to the constructor for app.component.) 

Code block below instruction shows ActivatedRouter being injected into the constructor for "the component class". 

Issue Number: N/A

## What is the new behavior?
Modify instructions to instruct user to inject ActivatedRouter into the **component's** constructor. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
