### PR TITLE
refactor(platform-server): Implement hydration state transfer machinery

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -733,12 +733,13 @@ function optionsReducer<T extends Object>(dst: any, objs: T|T[]): T {
 export class ApplicationRef {
   /** @internal */
   private _bootstrapListeners: ((compRef: ComponentRef<any>) => void)[] = [];
-  private _views: InternalViewRef[] = [];
   private _runningTick: boolean = false;
   private _stable = true;
   private _onMicrotaskEmptySubscription: Subscription;
   private _destroyed = false;
   private _destroyListeners: Array<() => void> = [];
+  /** @internal */
+  _views: InternalViewRef[] = [];
 
   /**
    * Indicates whether this instance was destroyed.

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -6,8 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken} from './di';
-
+import {InjectionToken} from './di/injection_token';
 
 /**
  * A [DI token](guide/glossary#di-token "DI token definition") representing a unique string ID, used

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -18,6 +18,9 @@ export {InternalEnvironmentProviders as ɵInternalEnvironmentProviders, isEnviro
 export {INJECTOR_SCOPE as ɵINJECTOR_SCOPE} from './di/scope';
 export {XSS_SECURITY_URL as ɵXSS_SECURITY_URL} from './error_details_base_url';
 export {formatRuntimeError as ɵformatRuntimeError, RuntimeError as ɵRuntimeError} from './errors';
+export {annotateForHydration as ɵannotateForHydration} from './hydration/annotate';
+export {provideHydrationSupport as ɵprovideHydrationSupport} from './hydration/api';
+export {IS_HYDRATION_FEATURE_ENABLED as ɵIS_HYDRATION_FEATURE_ENABLED} from './hydration/tokens';
 export {CurrencyIndex as ɵCurrencyIndex, ExtraLocaleDataIndex as ɵExtraLocaleDataIndex, findLocaleData as ɵfindLocaleData, getLocaleCurrencyCode as ɵgetLocaleCurrencyCode, getLocalePluralCase as ɵgetLocalePluralCase, LocaleDataIndex as ɵLocaleDataIndex, registerLocaleData as ɵregisterLocaleData, unregisterAllLocaleData as ɵunregisterLocaleData} from './i18n/locale_data_api';
 export {DEFAULT_LOCALE_ID as ɵDEFAULT_LOCALE_ID} from './i18n/localization';
 export {ComponentFactory as ɵComponentFactory} from './linker/component_factory';

--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {ApplicationRef} from '../application_ref';
+import {TNode} from '../render3/interfaces/node';
+import {RElement} from '../render3/interfaces/renderer_dom';
+import {isLContainer} from '../render3/interfaces/type_checks';
+import {HEADER_OFFSET, HOST, LView, RENDERER, TVIEW} from '../render3/interfaces/view';
+import {unwrapRNode} from '../render3/util/view_utils';
+import {TransferState} from '../transfer_state';
+
+import {SerializedView} from './interfaces';
+import {getComponentLViewForHydration, NGH_ATTR_NAME, NGH_DATA_KEY} from './utils';
+
+/**
+ * A collection that tracks all serialized views (`ngh` DOM annotations)
+ * to avoid duplication. An attempt to add a duplicate view results in the
+ * collection returning the index of the previously collected serialized view.
+ * This reduces the number of annotations needed for a given page.
+ */
+class SerializedViewCollection {
+  private views: SerializedView[] = [];
+  private indexByContent = new Map<string, number>();
+
+  add(serializedView: SerializedView): number {
+    const viewAsString = JSON.stringify(serializedView);
+    if (!this.indexByContent.has(viewAsString)) {
+      const index = this.views.length;
+      this.views.push(serializedView);
+      this.indexByContent.set(viewAsString, index);
+      return index;
+    }
+    return this.indexByContent.get(viewAsString)!;
+  }
+
+  getAll(): SerializedView[] {
+    return this.views;
+  }
+}
+
+/**
+ * Describes a context available during the serialization
+ * process. The context is used to share and collect information
+ * during the serialization.
+ */
+interface HydrationContext {
+  serializedViewCollection: SerializedViewCollection;
+}
+
+/**
+ * Annotates all components bootstrapped in a given ApplicationRef
+ * with info needed for hydration.
+ *
+ * @param appRef An instance of an ApplicationRef.
+ * @param doc A reference to the current Document instance.
+ */
+export function annotateForHydration(appRef: ApplicationRef, doc: Document) {
+  const serializedViewCollection = new SerializedViewCollection();
+  const viewRefs = appRef._views;
+  for (const viewRef of viewRefs) {
+    const lView = getComponentLViewForHydration(viewRef);
+    // An `lView` might be `null` if a `ViewRef` represents
+    // an embedded view (not a component view).
+    if (lView !== null) {
+      const hostElement = lView[HOST];
+      if (hostElement) {
+        const context: HydrationContext = {
+          serializedViewCollection,
+        };
+        annotateHostElementForHydration(hostElement as HTMLElement, lView, context);
+      }
+    }
+  }
+  const allSerializedViews = serializedViewCollection.getAll();
+  if (allSerializedViews.length > 0) {
+    const transferState = appRef.injector.get(TransferState);
+    transferState.set(NGH_DATA_KEY, allSerializedViews);
+  }
+}
+
+/**
+ * Serializes the lView data into a SerializedView object that will later be added
+ * to the TransferState storage and referenced using the `ngh` attribute on a host
+ * element.
+ *
+ * @param lView the lView we are serializing
+ * @param context the hydration context
+ * @returns the `SerializedView` object containing the data to be added to the host node
+ */
+function serializeLView(lView: LView, context: HydrationContext): SerializedView {
+  const ngh: SerializedView = {};
+  const tView = lView[TVIEW];
+  // Iterate over DOM element references in an LView.
+  for (let i = HEADER_OFFSET; i < tView.bindingStartIndex; i++) {
+    const tNode = tView.data[i] as TNode;
+    // Local refs (e.g. <div #localRef>) take up an extra slot in LViews
+    // to store the same element. In this case, there is no information in
+    // a corresponding slot in TNode data structure. If that's the case, just
+    // skip this slot and move to the next one.
+    if (!tNode) {
+      continue;
+    }
+    if (isLContainer(lView[i])) {
+      // TODO: serialization of LContainers will be added
+      // in followup PRs.
+    } else if (Array.isArray(lView[i])) {
+      // This is a component, annotate the host node with an `ngh` attribute.
+      const targetNode = unwrapRNode(lView[i][HOST]!);
+      annotateHostElementForHydration(targetNode as RElement, lView[i], context);
+    }
+  }
+  return ngh;
+}
+
+/**
+ * Physically adds the `ngh` attribute and serialized data to the host element.
+ *
+ * @param element The Host element to be annotated
+ * @param lView The associated LView
+ * @param context The hydration context
+ */
+function annotateHostElementForHydration(
+    element: RElement, lView: LView, context: HydrationContext): void {
+  const ngh = serializeLView(lView, context);
+  const index = context.serializedViewCollection.add(ngh);
+  const renderer = lView[RENDERER];
+  renderer.setAttribute(element, NGH_ATTR_NAME, index.toString());
+}

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {PLATFORM_ID} from '../application_tokens';
+import {ENVIRONMENT_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders} from '../di';
+import {inject} from '../di/injector_compatibility';
+
+import {IS_HYDRATION_FEATURE_ENABLED, PRESERVE_HOST_CONTENT} from './tokens';
+import {enableRetrieveHydrationInfoImpl} from './utils';
+
+
+/**
+ * Indicates whether the hydration-related code was added,
+ * prevents adding it multiple times.
+ */
+let isHydrationSupportEnabled = false;
+
+/**
+ * Brings the necessary hydration code in tree-shakable manner.
+ * The code is only present when the `provideHydrationSupport` is
+ * invoked. Otherwise, this code is tree-shaken away during the
+ * build optimization step.
+ *
+ * This technique allows us to swap implementations of methods so
+ * tree shaking works appropriately when hydration is disabled or
+ * enabled. It brings in the appropriate version of the method that
+ * supports hydration only when enabled.
+ */
+function enableHydrationRuntimeSupport() {
+  if (!isHydrationSupportEnabled) {
+    isHydrationSupportEnabled = true;
+    enableRetrieveHydrationInfoImpl();
+  }
+}
+
+/**
+ * Detects whether the code is invoked in a browser.
+ * Later on, this check should be replaced with a tree-shakable
+ * flag (e.g. `!isServer`).
+ */
+function isBrowser(): boolean {
+  return inject(PLATFORM_ID) === 'browser';
+}
+
+/**
+ * Returns a set of providers required to setup hydration support
+ * for an application that is server side rendered.
+ *
+ * ## NgModule-based bootstrap
+ *
+ * You can add the function call to the root AppModule of an application:
+ * ```
+ * import {provideHydrationSupport} from '@angular/core';
+ *
+ * @NgModule({
+ *   providers: [
+ *     // ... other providers ...
+ *     provideHydrationSupport()
+ *   ],
+ *   declarations: [AppComponent],
+ *   bootstrap: [AppComponent]
+ * })
+ * class AppModule {}
+ * ```
+ *
+ * ## Standalone-based bootstrap
+ *
+ * Add the function to the `bootstrapApplication` call:
+ * ```
+ * import {provideHydrationSupport} from '@angular/core';
+ *
+ * bootstrapApplication(RootComponent, {
+ *   providers: [
+ *     // ... other providers ...
+ *     provideHydrationSupport()
+ *   ]
+ * });
+ * ```
+ *
+ * The function sets up an internal flag that would be recognized during
+ * the server side rendering time as well, so there is no need to
+ * configure or change anything in NgUniversal to enable the feature.
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export function provideHydrationSupport(): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    {
+      provide: ENVIRONMENT_INITIALIZER,
+      useValue: () => {
+        // Since this function is used across both server and client,
+        // make sure that the runtime code is only added when invoked
+        // on the client. Moving forward, the `isBrowser` check should
+        // be replaced with a tree-shakable alternative (e.g. `isServer`
+        // flag).
+        if (isBrowser()) {
+          enableHydrationRuntimeSupport();
+        }
+      },
+      multi: true,
+    },
+    {
+      provide: IS_HYDRATION_FEATURE_ENABLED,
+      useValue: true,
+    },
+    {
+      provide: PRESERVE_HOST_CONTENT,
+      // Preserve host element content only in a browser
+      // environment. On a server, an application is rendered
+      // from scratch, so the host content needs to be empty.
+      useFactory: () => isBrowser(),
+    }
+  ]);
+}

--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {RNode} from '../render3/interfaces/renderer_dom';
+
+/**
+ * Serialized data structure that contains relevant hydration
+ * annotation information that describes a given hydration boundary
+ * (e.g. a component).
+ */
+export interface SerializedView {}
+
+/**
+ * An object that contains hydration-related information serialized
+ * on the server, as well as the necessary references to segments of
+ * the DOM, to facilitate the hydration process for a given hydration
+ * boundary on the client.
+ */
+export interface DehydratedView {
+  /**
+   * The readonly hydration annotation data.
+   */
+  data: Readonly<SerializedView>;
+
+  /**
+   * A reference to the first child in a DOM segment associated
+   * with a given hydration boundary.
+   */
+  firstChild: RNode|null;
+}

--- a/packages/core/src/hydration/tokens.ts
+++ b/packages/core/src/hydration/tokens.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {InjectionToken} from '../di/injection_token';
+
+const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
+
+/**
+ * Internal token that specifies whether hydration is enabled.
+ */
+export const IS_HYDRATION_FEATURE_ENABLED =
+    new InjectionToken<boolean>(NG_DEV_MODE ? 'IS_HYDRATION_FEATURE_ENABLED' : '');
+
+// By default (in client rendering mode), we remove all the contents
+// of the host element and render an application after that.
+export const PRESERVE_HOST_CONTENT_DEFAULT = false;
+
+/**
+ * Internal token that indicates whether host element content should be
+ * retained during the bootstrap.
+ */
+export const PRESERVE_HOST_CONTENT =
+    new InjectionToken<boolean>(NG_DEV_MODE ? 'PRESERVE_HOST_CONTENT' : '', {
+      providedIn: 'root',
+      factory: () => PRESERVE_HOST_CONTENT_DEFAULT,
+    });

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -1,0 +1,117 @@
+
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injector} from '../di/injector';
+import {ViewRef} from '../linker/view_ref';
+import {RElement} from '../render3/interfaces/renderer_dom';
+import {isRootView} from '../render3/interfaces/type_checks';
+import {HEADER_OFFSET, LView, TVIEW, TViewType} from '../render3/interfaces/view';
+import {makeStateKey, TransferState} from '../transfer_state';
+import {assertDefined} from '../util/assert';
+
+import {DehydratedView, SerializedView} from './interfaces';
+
+/**
+ * The name of the key used in the TransferState collection,
+ * where hydration information is located.
+ */
+const TRANSFER_STATE_TOKEN_ID = '__ɵnghData__';
+
+/**
+ * Lookup key used to reference DOM hydration data (ngh) in `TransferState`.
+ */
+export const NGH_DATA_KEY = makeStateKey<Array<SerializedView>>(TRANSFER_STATE_TOKEN_ID);
+
+/**
+ * The name of the attribute that would be added to host component
+ * nodes and contain a reference to a particular slot in transferred
+ * state that contains the necessary hydration info for this component.
+ */
+export const NGH_ATTR_NAME = 'ngh';
+
+/**
+ * Reference to a function that reads `ngh` attribute value from a given RNode
+ * and retrieves hydration information from the TransferState using that value
+ * as an index. Returns `null` by default, when hydration is not enabled.
+ *
+ * @param rNode Component's host element.
+ * @param injector Injector that this component has access to.
+ */
+let _retrieveHydrationInfoImpl: typeof retrieveHydrationInfoImpl =
+    (rNode: RElement, injector: Injector) => null;
+
+export function retrieveHydrationInfoImpl(rNode: RElement, injector: Injector): DehydratedView|
+    null {
+  const nghAttrValue = rNode.getAttribute(NGH_ATTR_NAME);
+  if (nghAttrValue == null) return null;
+
+  let data: SerializedView = {};
+  // An element might have an empty `ngh` attribute value (e.g. `<comp ngh="" />`),
+  // which means that no special annotations are required. Do not attempt to read
+  // from the TransferState in this case.
+  if (nghAttrValue !== '') {
+    const transferState = injector.get(TransferState, null, {optional: true});
+    if (transferState !== null) {
+      const nghData = transferState.get(NGH_DATA_KEY, []);
+
+      // The nghAttrValue is always a number referencing an index
+      // in the hydration TransferState data.
+      data = nghData[Number(nghAttrValue)];
+
+      // If the `ngh` attribute exists and has a non-empty value,
+      // the hydration info *must* be present in the TransferState.
+      // If there is no data for some reasons, this is an error.
+      ngDevMode && assertDefined(data, 'Unable to retrieve hydration info from the TransferState.');
+    }
+  }
+  const dehydratedView: DehydratedView = {
+    data,
+    firstChild: rNode.firstChild ?? null,
+  };
+  // The `ngh` attribute is cleared from the DOM node now
+  // that the data has been retrieved.
+  rNode.removeAttribute(NGH_ATTR_NAME);
+  return dehydratedView;
+}
+
+/**
+ * Sets the implementation for the `retrieveNghInfo` function.
+ */
+export function enableRetrieveHydrationInfoImpl() {
+  _retrieveHydrationInfoImpl = retrieveHydrationInfoImpl;
+}
+
+/**
+ * Retrieves hydration info by reading the value from the `ngh` attribute
+ * and accessing a corresponding slot in TransferState storage.
+ */
+export function retrieveHydrationInfo(rNode: RElement, injector: Injector): DehydratedView|null {
+  return _retrieveHydrationInfoImpl(rNode, injector);
+}
+
+/**
+ * Retrieves an instance of a component LView from a given ViewRef.
+ * Returns an instance of a component LView or `null` in case of an embedded view.
+ */
+export function getComponentLViewForHydration(viewRef: ViewRef): LView|null {
+  // Reading an internal field from `ViewRef` instance.
+  let lView = (viewRef as any)._lView as LView;
+  const tView = lView[TVIEW];
+  // A registered ViewRef might represent an instance of an
+  // embedded view, in which case we do not need to annotate it.
+  if (tView.type === TViewType.Embedded) {
+    return null;
+  }
+  // Check if it's a root view and if so, retrieve component's
+  // LView from the first slot after the header.
+  if (isRootView(lView)) {
+    lView = lView[HEADER_OFFSET];
+  }
+  return lView;
+}

--- a/packages/core/src/linker/template_ref.ts
+++ b/packages/core/src/linker/template_ref.ts
@@ -82,7 +82,7 @@ const R3TemplateRef = class TemplateRef<T> extends ViewEngineTemplateRef<T> {
     const embeddedTView = this._declarationTContainer.tViews as TView;
     const embeddedLView = createLView(
         this._declarationLView, embeddedTView, context, LViewFlags.CheckAlways, null,
-        embeddedTView.declTNode, null, null, null, null, injector || null);
+        embeddedTView.declTNode, null, null, null, null, injector || null, null);
 
     const declarationLContainer = this._declarationLView[this._declarationTContainer.index];
     ngDevMode && assertLContainer(declarationLContainer);

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -13,6 +13,8 @@ import {InjectFlags, InjectOptions} from '../di/interface/injector';
 import {ProviderToken} from '../di/provider_token';
 import {EnvironmentInjector} from '../di/r3_injector';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
+import {DehydratedView} from '../hydration/interfaces';
+import {retrieveHydrationInfo} from '../hydration/utils';
 import {Type} from '../interface/type';
 import {ComponentFactory as AbstractComponentFactory, ComponentRef as AbstractComponentRef} from '../linker/component_factory';
 import {ComponentFactoryResolver as AbstractComponentFactoryResolver} from '../linker/component_factory_resolver';
@@ -36,7 +38,7 @@ import {ComponentDef, DirectiveDef, HostDirectiveDefs} from './interfaces/defini
 import {PropertyAliasValue, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType} from './interfaces/node';
 import {Renderer, RendererFactory} from './interfaces/renderer';
 import {RElement, RNode} from './interfaces/renderer_dom';
-import {CONTEXT, HEADER_OFFSET, LView, LViewFlags, TVIEW, TViewType} from './interfaces/view';
+import {CONTEXT, HEADER_OFFSET, HYDRATION, INJECTOR, LView, LViewFlags, TVIEW, TViewType} from './interfaces/view';
 import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from './namespaces';
 import {createElementNode, setupStaticAttributes, writeDirectClass} from './node_manipulation';
 import {extractAttrsAndClassesFromSelector, stringifyCSSSelectorList} from './node_selector_matcher';
@@ -168,7 +170,8 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
     // dynamically. Default to 'div' if this component did not specify any tag name in its selector.
     const elementName = this.componentDef.selectors[0][0] as string || 'div';
     const hostRNode = rootSelectorOrNode ?
-        locateHostElement(hostRenderer, rootSelectorOrNode, this.componentDef.encapsulation) :
+        locateHostElement(
+            hostRenderer, rootSelectorOrNode, this.componentDef.encapsulation, rootViewInjector) :
         createElementNode(hostRenderer, elementName, getNamespace(elementName));
 
     const rootFlags = this.componentDef.onPush ? LViewFlags.Dirty | LViewFlags.IsRoot :
@@ -178,7 +181,7 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
     const rootTView = createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, null);
     const rootLView = createLView(
         null, rootTView, null, rootFlags, null, null, rendererFactory, hostRenderer, sanitizer,
-        rootViewInjector, null);
+        rootViewInjector, null, null);
 
     // rootView is the parent when bootstrapping
     // TODO(misko): it looks like we are entering view here but we don't really need to as
@@ -320,7 +323,7 @@ function createRootComponentTNode(lView: LView, rNode: RNode): TElementNode {
 /**
  * Creates the root component view and the root component node.
  *
- * @param rNode Render host element.
+ * @param hostRNode Render host element.
  * @param rootComponentDef ComponentDef
  * @param rootView The parent view where the host node is stored
  * @param rendererFactory Factory to be used for creating child renderers.
@@ -330,17 +333,23 @@ function createRootComponentTNode(lView: LView, rNode: RNode): TElementNode {
  * @returns Component view created
  */
 function createRootComponentView(
-    tNode: TElementNode, rNode: RElement|null, rootComponentDef: ComponentDef<any>,
+    tNode: TElementNode, hostRNode: RElement|null, rootComponentDef: ComponentDef<any>,
     rootDirectives: DirectiveDef<any>[], rootView: LView, rendererFactory: RendererFactory,
     hostRenderer: Renderer, sanitizer?: Sanitizer|null): LView {
   const tView = rootView[TVIEW];
-  applyRootComponentStyling(rootDirectives, tNode, rNode, hostRenderer);
+  applyRootComponentStyling(rootDirectives, tNode, hostRNode, hostRenderer);
 
-  const viewRenderer = rendererFactory.createRenderer(rNode, rootComponentDef);
+  // Hydration info is on the host element and needs to be retreived
+  // and passed to the component LView.
+  let hydrationInfo: DehydratedView|null = null;
+  if (hostRNode !== null) {
+    hydrationInfo = retrieveHydrationInfo(hostRNode, rootView[INJECTOR]!);
+  }
+  const viewRenderer = rendererFactory.createRenderer(hostRNode, rootComponentDef);
   const componentView = createLView(
       rootView, getOrCreateComponentTView(rootComponentDef), null,
       rootComponentDef.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, rootView[tNode.index],
-      tNode, rendererFactory, viewRenderer, sanitizer || null, null, null);
+      tNode, rendererFactory, viewRenderer, sanitizer || null, null, null, hydrationInfo);
 
   if (tView.firstCreatePass) {
     markAsComponentHost(tView, tNode, rootDirectives.length - 1);

--- a/packages/core/src/render3/interfaces/renderer_dom.ts
+++ b/packages/core/src/render3/interfaces/renderer_dom.ts
@@ -63,9 +63,11 @@ export interface RNode {
 export interface RElement extends RNode {
   style: RCssStyleDeclaration;
   classList: RDomTokenList;
+  firstChild: RNode|null;
   className: string;
   tagName: string;
   textContent: string|null;
+  getAttribute(name: string): string|null;
   setAttribute(name: string, value: string|TrustedHTML|TrustedScript|TrustedScriptURL): void;
   removeAttribute(name: string): void;
   setAttributeNS(

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -8,6 +8,7 @@
 
 import {Injector} from '../../di/injector';
 import {ProviderToken} from '../../di/provider_token';
+import {DehydratedView} from '../../hydration/interfaces';
 import {SchemaMetadata} from '../../metadata/schema';
 import {Sanitizer} from '../../sanitization/sanitizer';
 
@@ -49,6 +50,8 @@ export const QUERIES = 19;
 export const ID = 20;
 export const EMBEDDED_VIEW_INJECTOR = 21;
 export const ON_DESTROY_HOOKS = 22;
+export const HYDRATION = 23;
+
 /**
  * Size of LView's header. Necessary to adjust for it when setting slots.
  *
@@ -56,7 +59,7 @@ export const ON_DESTROY_HOOKS = 22;
  * instruction index into `LView` index. All other indexes should be in the `LView` index space and
  * there should be no need to refer to `HEADER_OFFSET` anywhere else.
  */
-export const HEADER_OFFSET = 23;
+export const HEADER_OFFSET = 24;
 
 
 // This interface replaces the real LView interface if it is an arg or a
@@ -322,6 +325,11 @@ export interface LView<T = unknown> extends Array<any> {
 
   /** Unique ID of the view. Used for `__ngContext__` lookups in the `LView` registry. */
   [ID]: number;
+
+  /**
+   * A container related to hydration annotation information that's associated with this LView.
+   */
+  [HYDRATION]: DehydratedView|null;
 
   /**
    * Optional injector assigned to embedded views that takes

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -438,6 +438,9 @@
     "name": "PLATFORM_INITIALIZER"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
     "name": "PlatformRef"
   },
   {
@@ -649,6 +652,9 @@
   },
   {
     "name": "_randomChar"
+  },
+  {
+    "name": "_retrieveHydrationInfoImpl"
   },
   {
     "name": "_testabilityGetter"
@@ -1336,6 +1342,9 @@
   },
   {
     "name": "resolveTimingValue"
+  },
+  {
+    "name": "retrieveHydrationInfo"
   },
   {
     "name": "roundOffset"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -321,6 +321,9 @@
     "name": "PLATFORM_INITIALIZER"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
     "name": "PlatformRef"
   },
   {
@@ -475,6 +478,9 @@
   },
   {
     "name": "_randomChar"
+  },
+  {
+    "name": "_retrieveHydrationInfoImpl"
   },
   {
     "name": "_testabilityGetter"
@@ -1015,6 +1021,9 @@
   },
   {
     "name": "resolveForwardRef"
+  },
+  {
+    "name": "retrieveHydrationInfo"
   },
   {
     "name": "rxSubscriber"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -300,10 +300,10 @@
     "name": "NG_COMP_DEF"
   },
   {
-    "name": "NG_DEV_MODE3"
+    "name": "NG_DEV_MODE4"
   },
   {
-    "name": "NG_DEV_MODE4"
+    "name": "NG_DEV_MODE5"
   },
   {
     "name": "NG_DIR_DEF"
@@ -436,6 +436,9 @@
   },
   {
     "name": "PLATFORM_INITIALIZER"
+  },
+  {
+    "name": "PRESERVE_HOST_CONTENT"
   },
   {
     "name": "PlatformRef"
@@ -643,6 +646,9 @@
   },
   {
     "name": "_randomChar"
+  },
+  {
+    "name": "_retrieveHydrationInfoImpl"
   },
   {
     "name": "_testabilityGetter"
@@ -1465,6 +1471,9 @@
   },
   {
     "name": "resolveProvider"
+  },
+  {
+    "name": "retrieveHydrationInfo"
   },
   {
     "name": "rxSubscriber"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -285,10 +285,10 @@
     "name": "NG_COMP_DEF"
   },
   {
-    "name": "NG_DEV_MODE3"
+    "name": "NG_DEV_MODE4"
   },
   {
-    "name": "NG_DEV_MODE4"
+    "name": "NG_DEV_MODE5"
   },
   {
     "name": "NG_DIR_DEF"
@@ -427,6 +427,9 @@
   },
   {
     "name": "PLATFORM_INITIALIZER"
+  },
+  {
+    "name": "PRESERVE_HOST_CONTENT"
   },
   {
     "name": "PlatformRef"
@@ -631,6 +634,9 @@
   },
   {
     "name": "_randomChar"
+  },
+  {
+    "name": "_retrieveHydrationInfoImpl"
   },
   {
     "name": "_testabilityGetter"
@@ -1441,6 +1447,9 @@
   },
   {
     "name": "resolvedPromise2"
+  },
+  {
+    "name": "retrieveHydrationInfo"
   },
   {
     "name": "rxSubscriber"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -246,6 +246,9 @@
     "name": "PLATFORM_INITIALIZER"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
     "name": "PlatformRef"
   },
   {
@@ -355,6 +358,9 @@
   },
   {
     "name": "_platformInjector"
+  },
+  {
+    "name": "_retrieveHydrationInfoImpl"
   },
   {
     "name": "_wrapInTimeout"
@@ -790,6 +796,9 @@
   },
   {
     "name": "resolveForwardRef"
+  },
+  {
+    "name": "retrieveHydrationInfo"
   },
   {
     "name": "rxSubscriber"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -360,10 +360,10 @@
     "name": "NG_COMP_DEF"
   },
   {
-    "name": "NG_DEV_MODE"
+    "name": "NG_DEV_MODE2"
   },
   {
-    "name": "NG_DEV_MODE5"
+    "name": "NG_DEV_MODE6"
   },
   {
     "name": "NG_DIR_DEF"
@@ -505,6 +505,9 @@
   },
   {
     "name": "PLATFORM_INITIALIZER"
+  },
+  {
+    "name": "PRESERVE_HOST_CONTENT"
   },
   {
     "name": "PRIMARY_OUTLET"
@@ -832,6 +835,9 @@
   },
   {
     "name": "_randomChar"
+  },
+  {
+    "name": "_retrieveHydrationInfoImpl"
   },
   {
     "name": "_stripIndexHtml"
@@ -1771,6 +1777,9 @@
   },
   {
     "name": "resolveForwardRef"
+  },
+  {
+    "name": "retrieveHydrationInfo"
   },
   {
     "name": "rootRoute"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -201,7 +201,7 @@
     "name": "NG_COMP_DEF"
   },
   {
-    "name": "NG_DEV_MODE"
+    "name": "NG_DEV_MODE2"
   },
   {
     "name": "NG_DIR_DEF"
@@ -292,6 +292,9 @@
   },
   {
     "name": "PLATFORM_INITIALIZER"
+  },
+  {
+    "name": "PRESERVE_HOST_CONTENT"
   },
   {
     "name": "R3Injector"
@@ -427,6 +430,9 @@
   },
   {
     "name": "_randomChar"
+  },
+  {
+    "name": "_retrieveHydrationInfoImpl"
   },
   {
     "name": "_wrapInTimeout"
@@ -886,6 +892,9 @@
   },
   {
     "name": "resolveForwardRef"
+  },
+  {
+    "name": "retrieveHydrationInfo"
   },
   {
     "name": "rxSubscriber"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -342,6 +342,9 @@
     "name": "PLATFORM_INITIALIZER"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT"
+  },
+  {
     "name": "PlatformRef"
   },
   {
@@ -553,6 +556,9 @@
   },
   {
     "name": "_randomChar"
+  },
+  {
+    "name": "_retrieveHydrationInfoImpl"
   },
   {
     "name": "_testabilityGetter"
@@ -1222,6 +1228,9 @@
   },
   {
     "name": "resolveForwardRef"
+  },
+  {
+    "name": "retrieveHydrationInfo"
   },
   {
     "name": "rxSubscriber"

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -141,7 +141,7 @@ describe('di', () => {
     it('should handle initial undefined state', () => {
       const contentView = createLView(
           null, createTView(TViewType.Component, null, null, 1, 0, null, null, null, null, null),
-          {}, LViewFlags.CheckAlways, null, null, {} as any, {} as any, null, null, null);
+          {}, LViewFlags.CheckAlways, null, null, {} as any, {} as any, null, null, null, null);
       enterView(contentView);
       try {
         const parentTNode = getOrCreateTNode(contentView[TVIEW], 0, TNodeType.Element, null, null);

--- a/packages/core/test/render3/instructions/shared_spec.ts
+++ b/packages/core/test/render3/instructions/shared_spec.ts
@@ -43,7 +43,7 @@ export function enterViewWithOneDiv() {
   const tNode = tView.firstChild = createTNode(tView, null!, TNodeType.Element, 0, 'div', null);
   const lView = createLView(
       null, tView, null, LViewFlags.CheckAlways, null, null, rendererFactory, renderer, null, null,
-      null);
+      null, null);
   lView[HEADER_OFFSET] = div;
   tView.data[HEADER_OFFSET] = tNode;
   enterView(lView);

--- a/packages/core/test/render3/perf/directive_instantiate/index.ts
+++ b/packages/core/test/render3/perf/directive_instantiate/index.ts
@@ -76,7 +76,7 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const rootLView = createLView(
     null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
-    LViewFlags.IsRoot, null, null, null, null, null, null, null);
+    LViewFlags.IsRoot, null, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(

--- a/packages/core/test/render3/perf/element_text_create/index.ts
+++ b/packages/core/test/render3/perf/element_text_create/index.ts
@@ -65,7 +65,7 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const rootLView = createLView(
     null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
-    LViewFlags.IsRoot, null, null, null, null, null, null, null);
+    LViewFlags.IsRoot, null, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(

--- a/packages/core/test/render3/perf/listeners/index.ts
+++ b/packages/core/test/render3/perf/listeners/index.ts
@@ -67,7 +67,7 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const rootLView = createLView(
     null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
-    LViewFlags.IsRoot, null, null, null, null, null, null, null);
+    LViewFlags.IsRoot, null, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(

--- a/packages/core/test/render3/perf/ng_template/index.ts
+++ b/packages/core/test/render3/perf/ng_template/index.ts
@@ -64,7 +64,7 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const rootLView = createLView(
     null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
-    LViewFlags.IsRoot, null, null, null, null, null, null, null);
+    LViewFlags.IsRoot, null, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(

--- a/packages/core/test/render3/perf/setup.ts
+++ b/packages/core/test/render3/perf/setup.ts
@@ -23,7 +23,7 @@ export function createAndRenderLView(
     parentLView: LView, tView: TView, hostTNode: TElementNode): LView {
   const embeddedLView = createLView(
       parentLView, tView, {}, LViewFlags.CheckAlways, null, hostTNode, rendererFactory, renderer,
-      null, null, null);
+      null, null, null, null);
   renderView(tView, embeddedLView, null);
   return embeddedLView;
 }
@@ -55,7 +55,7 @@ export function setupTestHarness(
   const hostNode = renderer.createElement('div');
   const hostLView = createLView(
       null, hostTView, {}, LViewFlags.CheckAlways | LViewFlags.IsRoot, hostNode, null,
-      rendererFactory, renderer, null, null, null);
+      rendererFactory, renderer, null, null, null, null);
   const mockRCommentNode = renderer.createComment('');
   const lContainer =
       createLContainer(mockRCommentNode, hostLView, mockRCommentNode, tContainerNode);
@@ -71,7 +71,7 @@ export function setupTestHarness(
   function createEmbeddedLView(): LView {
     const embeddedLView = createLView(
         hostLView, embeddedTView, embeddedViewContext, LViewFlags.CheckAlways, null, viewTNode,
-        rendererFactory, renderer, null, null, null);
+        rendererFactory, renderer, null, null, null, null);
     renderView(embeddedTView, embeddedLView, embeddedViewContext);
     return embeddedLView;
   }

--- a/packages/core/test/render3/perf/view_destroy_hook/index.ts
+++ b/packages/core/test/render3/perf/view_destroy_hook/index.ts
@@ -53,7 +53,7 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 
 const rootLView = createLView(
     null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
-    LViewFlags.IsRoot, null, null, null, null, null, null, null);
+    LViewFlags.IsRoot, null, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(

--- a/packages/core/test/render3/view_fixture.ts
+++ b/packages/core/test/render3/view_fixture.ts
@@ -69,7 +69,7 @@ export class ViewFixture {
     const hostTView = createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, null);
     const hostLView = createLView(
         null, hostTView, {}, LViewFlags.CheckAlways | LViewFlags.IsRoot, null, null,
-        rendererFactory, hostRenderer, sanitizer || null, null, null);
+        rendererFactory, hostRenderer, sanitizer || null, null, null, null);
 
     let template = noop;
     if (create) {
@@ -92,7 +92,7 @@ export class ViewFixture {
         createTNode(hostTView, null, TNodeType.Element, 0, 'host-element', null) as TElementNode;
     this.lView = createLView(
         hostLView, this.tView, context || {}, LViewFlags.CheckAlways, this.host, hostTNode,
-        rendererFactory, hostRenderer, null, null, null);
+        rendererFactory, hostRenderer, null, null, null, null);
 
     if (this.createFn) {
       renderView(this.tView, this.lView, this.context);

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, EnvironmentProviders, importProvidersFrom, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵgetComponentDef as getComponentDef, ɵinternalCreateApplication as internalCreateApplication, ɵisPromise} from '@angular/core';
+import {ApplicationRef, EnvironmentProviders, importProvidersFrom, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵannotateForHydration as annotateForHydration, ɵgetComponentDef as getComponentDef, ɵinternalCreateApplication as internalCreateApplication, ɵIS_HYDRATION_FEATURE_ENABLED as IS_HYDRATION_FEATURE_ENABLED, ɵisPromise} from '@angular/core';
 import {BrowserModule, ɵTRANSITION_ID} from '@angular/platform-browser';
 import {first} from 'rxjs/operators';
 
@@ -68,6 +68,10 @@ the server-rendered app can be properly bootstrapped into a client app.`);
           const platformState = platform.injector.get(PlatformState);
 
           const asyncPromises: Promise<any>[] = [];
+
+          if (applicationRef.injector.get(IS_HYDRATION_FEATURE_ENABLED, false)) {
+            annotateForHydration(applicationRef, platformState.getDocument());
+          }
 
           // Run any BEFORE_APP_SERIALIZED callbacks just before rendering to string.
           const callbacks = environmentInjector.get(BEFORE_APP_SERIALIZED, null);

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -1,0 +1,273 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {APP_ID, ApplicationRef, Component, ComponentRef, destroyPlatform, getPlatform, inject, Provider, TemplateRef, Type, ViewChild, ɵprovideHydrationSupport as provideHydrationSupport, ɵsetDocument} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {bootstrapApplication} from '@angular/platform-browser';
+
+import {renderApplication} from '../src/utils';
+
+/**
+ * The name of the attribute that contains a slot index
+ * inside the TransferState storage where hydration info
+ * could be found.
+ */
+const NGH_ATTR_NAME = 'ngh';
+
+const NGH_ATTR_REGEXP = new RegExp(` ${NGH_ATTR_NAME}=".*?"`, 'g');
+
+/**
+ * Drop utility attributes such as `ng-version`, `ng-server-context` and `ngh`,
+ * so that it's easier to make assertions in tests.
+ */
+function stripUtilAttributes(html: string, keepNgh: boolean): string {
+  html = html.replace(/ ng-version=".*?"/g, '')  //
+             .replace(/ ng-server-context=".*?"/g, '');
+  if (!keepNgh) {
+    html = html.replace(NGH_ATTR_REGEXP, '');
+  }
+  return html;
+}
+
+function getComponentRef<T>(appRef: ApplicationRef): ComponentRef<T> {
+  return appRef.components[0];
+}
+
+/**
+ * Extracts a portion of HTML located inside of the `<body>` element.
+ * This content belongs to the application view (and supporting TransferState
+ * scripts) rendered on the server.
+ */
+function getAppContents(html: string): string {
+  const result = stripUtilAttributes(html, true).match(/<body>(.*?)<\/body>/s);
+  if (!result) {
+    throw new Error('Invalid HTML structure is provided.');
+  }
+  return result[1];
+}
+
+/**
+ * Converts a static HTML to a DOM structure.
+ *
+ * @param html the rendered html in test
+ * @param doc the document object
+ * @returns a div element containing a copy of the app contents
+ */
+function convertHtmlToDom(html: string, doc: Document): HTMLElement {
+  const contents = getAppContents(html);
+  const container = doc.createElement('div');
+  container.innerHTML = contents;
+  return container;
+}
+
+describe('platform-server integration', () => {
+  beforeEach(() => {
+    if (getPlatform()) destroyPlatform();
+  });
+
+  afterAll(() => destroyPlatform());
+
+  describe('hydration', () => {
+    const appId = 'simple-cmp';
+
+    let doc: Document;
+
+    beforeEach(() => {
+      doc = TestBed.inject(DOCUMENT);
+    });
+
+    afterEach(() => {
+      doc.body.textContent = '';
+    });
+
+    /**
+     * This renders the application with server side rendering logic.
+     *
+     * @param component the test component to be rendered
+     * @param doc the document
+     * @param envProviders the environment providers
+     * @returns a promise containing the server rendered app as a string
+     */
+    async function ssr(
+        component: Type<unknown>, doc?: string, envProviders?: Provider[]): Promise<string> {
+      const defaultHtml = '<html><head></head><body><app></app></body></html>';
+      const providers = [
+        ...(envProviders ?? []),
+        {provide: APP_ID, useValue: appId},
+        provideHydrationSupport(),
+      ];
+      return renderApplication(component, {
+        document: doc ?? defaultHtml,
+        appId,
+        providers,
+      });
+    }
+
+    /**
+     * This bootstraps an application with existing html and enables hydration support
+     * causing hydration to be invoked.
+     *
+     * @param html the server side rendered DOM string to be hydrated
+     * @param component the root component
+     * @param envProviders the environment providers
+     * @returns a promise with the application ref
+     */
+    async function hydrate(html: string, component: Type<unknown>, envProviders?: Provider[]):
+        Promise<ApplicationRef> {
+      // Destroy existing platform, a new one will be created later by the `bootstrapApplication`.
+      destroyPlatform();
+
+      // Get HTML contents of the `<app>`, create a DOM element and append it into the body.
+      const container = convertHtmlToDom(html, doc);
+      Array.from(container.children).forEach(node => doc.body.appendChild(node));
+
+      function _document(): any {
+        ɵsetDocument(doc);
+        global.document = doc;  // needed for `DefaultDomRenderer2`
+        return doc;
+      }
+
+      const providers = [
+        ...(envProviders ?? []),
+        {provide: APP_ID, useValue: appId},
+        {provide: DOCUMENT, useFactory: _document, deps: []},
+        provideHydrationSupport(),
+      ];
+      return bootstrapApplication(component, {providers});
+    }
+
+    describe('annotations', () => {
+      it('should add hydration annotations to component host nodes during ssr', async () => {
+        @Component({
+          standalone: true,
+          selector: 'nested',
+          template: 'This is a nested component.',
+        })
+        class NestedComponent {
+        }
+
+        @Component({
+          standalone: true,
+          selector: 'app',
+          imports: [NestedComponent],
+          template: `
+            <nested />
+          `,
+        })
+        class SimpleComponent {
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+        expect(ssrContents).toContain(`<nested ${NGH_ATTR_NAME}`);
+      });
+
+      it('should skip local ref slots while producing hydration annotations', async () => {
+        @Component({
+          standalone: true,
+          selector: 'nested',
+          template: 'This is a nested component.',
+        })
+        class NestedComponent {
+        }
+
+        @Component({
+          standalone: true,
+          selector: 'app',
+          imports: [NestedComponent],
+          template: `
+            <div #localRef></div>
+            <nested />
+          `,
+        })
+        class SimpleComponent {
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+        expect(ssrContents).toContain(`<nested ${NGH_ATTR_NAME}`);
+      });
+
+      it('should skip embedded views from an ApplicationRef during annotation', async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          template: `
+            <ng-template #tmpl>Hi!</ng-template>
+          `,
+        })
+        class SimpleComponent {
+          @ViewChild('tmpl', {read: TemplateRef}) tmplRef!: TemplateRef<unknown>;
+          private appRef = inject(ApplicationRef);
+
+          ngAfterViewInit() {
+            const viewRef = this.tmplRef.createEmbeddedView({});
+            this.appRef.attachView(viewRef);
+          }
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+      });
+    });
+
+    describe('server rendering', () => {
+      it('should wipe out existing host element content when server side rendering', async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          template: `
+            <div>Some content</div>
+          `,
+        })
+        class SimpleComponent {
+        }
+
+        const extraChildNodes = '<!--comment--> Some text! <b>and a tag</b>';
+        const doc = `<html><head></head><body><app>${extraChildNodes}</app></body></html>`;
+        const html = await ssr(SimpleComponent, doc);
+        const ssrContents = getAppContents(html);
+
+        // We expect that the existing content of the host node is fully removed.
+        expect(ssrContents).not.toContain(extraChildNodes);
+        expect(ssrContents).toContain('<app ngh="0"><div>Some content</div></app>');
+      });
+    });
+
+    describe('hydration', () => {
+      it('should remove ngh attributes after hydation on the client', async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          template: 'Hi!',
+        })
+        class SimpleComponent {
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+        const appRef = await hydrate(html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const appHostNode = compRef.location.nativeElement;
+        expect(appHostNode.getAttribute(NGH_ATTR_NAME)).toBeNull();
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Important note**: this is a first commit in a series of commits that will be needed to support non-destructive hydration. Stay tuned for further updates!

This commit lays the foundation on top of which more hydration logic will be added in follow up PRs. This PR includes:

* Initial serialization of hydration data
* Data transfer of hydration annotations from server side to client
* Accessing hydration info and populating internal data structures
* Initial APIs (currently private) that enable hydration (in a tree-shakable manner)
* Cleanup of annotations post hydration
* Initial test infrastructure and basic test cases

This commit does **not** expose any public APIs. They'll be exposed later, when more hydration logic is implemented to a state when it can cover most common use-cases.

Co-authored-by: @AndrewKushnir.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

