### PR TITLE
refactor(core): use lower-level API to annotate `TransferState` class

### DIFF
--- a/packages/core/src/transfer_state.ts
+++ b/packages/core/src/transfer_state.ts
@@ -7,8 +7,8 @@
  */
 
 import {APP_ID} from './application_tokens';
-import {Injectable} from './di/injectable';
 import {inject} from './di/injector_compatibility';
+import {ɵɵdefineInjectable} from './di/interface/defs';
 import {getDocument} from './render3/interfaces/document';
 
 export function escapeTransferStateContent(text: string): string {
@@ -70,6 +70,12 @@ export function makeStateKey<T = void>(key: string): StateKey<T> {
   return key as StateKey<T>;
 }
 
+function initTransferState() {
+  const transferState = new TransferState();
+  transferState.store = retrieveTransferredState(getDocument(), inject(APP_ID));
+  return transferState;
+}
+
 /**
  * A key value store that is transferred from the application on the server side to the application
  * on the client side.
@@ -85,14 +91,19 @@ export function makeStateKey<T = void>(key: string): StateKey<T> {
  *
  * @publicApi
  */
-@Injectable({providedIn: 'root'})
 export class TransferState {
-  private store: {[k: string]: unknown|undefined} = {};
-  private onSerializeCallbacks: {[k: string]: () => unknown | undefined} = {};
+  /** @nocollapse */
+  static ɵprov =
+      /** @pureOrBreakMyCode */ ɵɵdefineInjectable({
+        token: TransferState,
+        providedIn: 'root',
+        factory: initTransferState,
+      });
 
-  constructor() {
-    this.store = retrieveTransferredState(getDocument(), inject(APP_ID));
-  }
+  /** @internal */
+  store: {[k: string]: unknown|undefined} = {};
+
+  private onSerializeCallbacks: {[k: string]: () => unknown | undefined} = {};
 
   /**
    * Get the value corresponding to a key. Return `defaultValue` if key is not found.


### PR DESCRIPTION
This commit updates the `TransferState` class and replaces the `@Injectable` decorator with a lower-level function call. This is a common practice for tokens defined in `core`, for example:

* https://github.com/angular/angular/blob/main/packages/core/src/change_detection/differs/iterable_differs.ts#L193-L196
* https://github.com/angular/angular/blob/main/packages/core/src/di/injector.ts#L121-L126

This is needed to avoid circular references when using `TransferState` in other locations in `core`, for example: https://github.com/angular/angular/pull/49271. Circular dependencies are coming from the fact t hat the `@Injectable` from the `packages/core/src/di/injectable.ts` file refers to a number of extra symbols.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No