### PR TITLE
refactor(core): hydration logic for simple element and text nodes

### DIFF
--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -9,6 +9,8 @@
 import {PLATFORM_ID} from '../application_tokens';
 import {ENVIRONMENT_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders} from '../di';
 import {inject} from '../di/injector_compatibility';
+import {enableLocateOrCreateElementNodeImpl} from '../render3/instructions/element';
+import {enableLocateOrCreateTextNodeImpl} from '../render3/instructions/text';
 
 import {IS_HYDRATION_FEATURE_ENABLED, PRESERVE_HOST_CONTENT} from './tokens';
 import {enableRetrieveHydrationInfoImpl} from './utils';
@@ -35,6 +37,8 @@ function enableHydrationRuntimeSupport() {
   if (!isHydrationSupportEnabled) {
     isHydrationSupportEnabled = true;
     enableRetrieveHydrationInfoImpl();
+    enableLocateOrCreateElementNodeImpl();
+    enableLocateOrCreateTextNodeImpl();
   }
 }
 

--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {TNode} from '../render3/interfaces/node';
+import {LView} from '../render3/interfaces/view';
+
+/**
+ * Verifies whether a given node matches an expected criteria,
+ * based on internal data structure state.
+ */
+export function validateMatchingNode(
+    node: Node, nodeType: number, tagName: string|null, lView: LView, tNode: TNode): void {
+  if (node.nodeType !== nodeType ||
+      (node.nodeType === Node.ELEMENT_NODE &&
+       (node as HTMLElement).tagName.toLowerCase() !== tagName?.toLowerCase())) {
+    // TODO: improve error message and use RuntimeError instead.
+    throw new Error(`Unexpected node found during hydration.`);
+  }
+}

--- a/packages/core/src/hydration/node_lookup_utils.ts
+++ b/packages/core/src/hydration/node_lookup_utils.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {TNode} from '../render3/interfaces/node';
+import {RElement, RNode} from '../render3/interfaces/renderer_dom';
+import {LView, TView} from '../render3/interfaces/view';
+import {getNativeByTNode} from '../render3/util/view_utils';
+import {assertDefined} from '../util/assert';
+
+import {DehydratedView} from './interfaces';
+
+/**
+ * Locate a node in DOM tree that corresponds to a given TNode.
+ *
+ * @param hydrationInfo The hydration annotation data
+ * @param tView the current tView
+ * @param lView the current lView
+ * @param tNode the current tNode
+ * @returns an RNode that represents a given tNode
+ */
+export function locateNextRNode<T extends RNode>(
+    hydrationInfo: DehydratedView, tView: TView, lView: LView<unknown>, tNode: TNode): T|null {
+  let native: RNode|null = null;
+  if (tView.firstChild === tNode) {
+    // We create a first node in this view, so we use a reference
+    // to the first child in this DOM segment.
+    native = hydrationInfo.firstChild;
+  } else {
+    // Locate a node based on a previous sibling or a parent node.
+    const previousTNodeParent = tNode.prev === null;
+    const previousTNode = tNode.prev ?? tNode.parent;
+    ngDevMode &&
+        assertDefined(
+            previousTNode,
+            'Unexpected state: current TNode does not have a connection ' +
+                'to the previous node or a parent node.');
+    const previousRElement = getNativeByTNode(previousTNode!, lView);
+    if (previousTNodeParent) {
+      native = (previousRElement as RElement).firstChild;
+    } else {
+      native = previousRElement.nextSibling;
+    }
+  }
+  return native as T;
+}

--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -5,11 +5,15 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {validateMatchingNode} from '../../hydration/error_handling';
+import {locateNextRNode} from '../../hydration/node_lookup_utils';
+import {markRNodeAsClaimedByHydration} from '../../hydration/utils';
 import {assertEqual, assertIndexInRange} from '../../util/assert';
-import {TElementNode, TNodeType} from '../interfaces/node';
-import {HEADER_OFFSET, RENDERER, T_HOST} from '../interfaces/view';
+import {TElementNode, TNode, TNodeType} from '../interfaces/node';
+import {RText} from '../interfaces/renderer_dom';
+import {HEADER_OFFSET, HYDRATION, LView, RENDERER, T_HOST, TView} from '../interfaces/view';
 import {appendChild, createTextNode} from '../node_manipulation';
-import {getBindingIndex, getLView, getTView, setCurrentTNode} from '../state';
+import {getBindingIndex, getLView, getTView, lastNodeWasCreated, setCurrentTNode, wasLastNodeCreated} from '../state';
 
 import {getOrCreateTNode} from './shared';
 
@@ -38,9 +42,47 @@ export function ɵɵtext(index: number, value: string = ''): void {
       getOrCreateTNode(tView, adjustedIndex, TNodeType.Text, value, null) :
       tView.data[adjustedIndex] as TElementNode;
 
-  const textNative = lView[adjustedIndex] = createTextNode(lView[RENDERER], value);
-  appendChild(tView, lView, textNative, tNode);
+  const textNative = _locateOrCreateTextNode(tView, lView, tNode, value);
+  lView[adjustedIndex] = textNative;
+
+  if (wasLastNodeCreated()) {
+    appendChild(tView, lView, textNative, tNode);
+  }
 
   // Text nodes are self closing.
   setCurrentTNode(tNode, false);
+}
+
+let _locateOrCreateTextNode: typeof locateOrCreateTextNodeImpl =
+    (tView: TView, lView: LView, tNode: TNode, value: string) => {
+      lastNodeWasCreated(true);
+      return createTextNode(lView[RENDERER], value);
+    };
+
+/**
+ * Enables hydration code path (to lookup existing elements in DOM)
+ * in addition to the regular creation mode of text nodes.
+ */
+function locateOrCreateTextNodeImpl(
+    tView: TView, lView: LView, tNode: TNode, value: string): RText {
+  const hydrationInfo = lView[HYDRATION];
+  const isNodeCreationMode = !hydrationInfo;
+  lastNodeWasCreated(isNodeCreationMode);
+
+  // Regular creation mode.
+  if (isNodeCreationMode) {
+    return createTextNode(lView[RENDERER], value);
+  }
+
+  // Hydration mode, looking up an existing element in DOM.
+  const textNative = locateNextRNode(hydrationInfo, tView, lView, tNode) as RText;
+
+  ngDevMode && validateMatchingNode(textNative as Node, Node.TEXT_NODE, null, lView, tNode);
+  ngDevMode && markRNodeAsClaimedByHydration(textNative);
+
+  return textNative;
+}
+
+export function enableLocateOrCreateTextNodeImpl() {
+  _locateOrCreateTextNode = locateOrCreateTextNodeImpl;
 }

--- a/packages/core/src/render3/interfaces/renderer_dom.ts
+++ b/packages/core/src/render3/interfaces/renderer_dom.ts
@@ -61,9 +61,9 @@ export interface RNode {
  * listeners on Element.
  */
 export interface RElement extends RNode {
+  firstChild: RNode|null;
   style: RCssStyleDeclaration;
   classList: RDomTokenList;
-  firstChild: RNode|null;
   className: string;
   tagName: string;
   textContent: string|null;

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -742,3 +742,21 @@ export function namespaceHTMLInternal() {
 export function getNamespace(): string|null {
   return instructionState.lFrame.currentNamespace;
 }
+
+let _wasLastNodeCreated = true;
+
+/**
+ * Retrieves a global flag that indicates whether the most recent DOM node
+ * was created or hydrated.
+ */
+export function wasLastNodeCreated(): boolean {
+  return _wasLastNodeCreated;
+}
+
+/**
+ * Sets a global flag to indicate whether the most recent DOM node
+ * was created or hydrated.
+ */
+export function lastNodeWasCreated(flag: boolean): void {
+  _wasLastNodeCreated = flag;
+}

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -48,6 +48,8 @@ declare global {
     rendererAppendChild: number;
     rendererInsertBefore: number;
     rendererCreateComment: number;
+    hydratedNodes: number;
+    hydratedComponents: number;
   }
 }
 
@@ -77,6 +79,8 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
     rendererAppendChild: 0,
     rendererInsertBefore: 0,
     rendererCreateComment: 0,
+    hydratedNodes: 0,
+    hydratedComponents: 0,
   };
 
   // Make sure to refer to ngDevMode as ['ngDevMode'] for closure.

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -642,6 +642,9 @@
     "name": "_keyMap"
   },
   {
+    "name": "_locateOrCreateElementNode"
+  },
+  {
     "name": "_platformInjector"
   },
   {
@@ -658,6 +661,9 @@
   },
   {
     "name": "_testabilityGetter"
+  },
+  {
+    "name": "_wasLastNodeCreated"
   },
   {
     "name": "_wrapInTimeout"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -471,6 +471,9 @@
     "name": "_keyMap"
   },
   {
+    "name": "_locateOrCreateElementNode"
+  },
+  {
     "name": "_platformInjector"
   },
   {
@@ -484,6 +487,9 @@
   },
   {
     "name": "_testabilityGetter"
+  },
+  {
+    "name": "_wasLastNodeCreated"
   },
   {
     "name": "_wrapInTimeout"
@@ -900,6 +906,9 @@
     "name": "iterator"
   },
   {
+    "name": "lastNodeWasCreated"
+  },
+  {
     "name": "leaveDI"
   },
   {
@@ -1129,6 +1138,9 @@
   },
   {
     "name": "walkProviderTree"
+  },
+  {
+    "name": "wasLastNodeCreated"
   },
   {
     "name": "writeDirectClass"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -639,6 +639,12 @@
     "name": "_keyMap"
   },
   {
+    "name": "_locateOrCreateElementNode"
+  },
+  {
+    "name": "_locateOrCreateTextNode"
+  },
+  {
     "name": "_platformInjector"
   },
   {
@@ -652,6 +658,9 @@
   },
   {
     "name": "_testabilityGetter"
+  },
+  {
+    "name": "_wasLastNodeCreated"
   },
   {
     "name": "_wrapInTimeout"
@@ -1272,6 +1281,9 @@
     "name": "keyValueArraySet"
   },
   {
+    "name": "lastNodeWasCreated"
+  },
+  {
     "name": "leaveDI"
   },
   {
@@ -1615,6 +1627,9 @@
   },
   {
     "name": "walkProviderTree"
+  },
+  {
+    "name": "wasLastNodeCreated"
   },
   {
     "name": "wrapListener"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -627,6 +627,12 @@
     "name": "_keyMap"
   },
   {
+    "name": "_locateOrCreateElementNode"
+  },
+  {
+    "name": "_locateOrCreateTextNode"
+  },
+  {
     "name": "_platformInjector"
   },
   {
@@ -640,6 +646,9 @@
   },
   {
     "name": "_testabilityGetter"
+  },
+  {
+    "name": "_wasLastNodeCreated"
   },
   {
     "name": "_wrapInTimeout"
@@ -1230,6 +1239,9 @@
     "name": "keyValueArraySet"
   },
   {
+    "name": "lastNodeWasCreated"
+  },
+  {
     "name": "leaveDI"
   },
   {
@@ -1591,6 +1603,9 @@
   },
   {
     "name": "walkProviderTree"
+  },
+  {
+    "name": "wasLastNodeCreated"
   },
   {
     "name": "wrapListener"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -831,6 +831,12 @@
     "name": "_keyMap"
   },
   {
+    "name": "_locateOrCreateElementNode"
+  },
+  {
+    "name": "_locateOrCreateTextNode"
+  },
+  {
     "name": "_platformInjector"
   },
   {
@@ -844,6 +850,9 @@
   },
   {
     "name": "_stripIndexHtml"
+  },
+  {
+    "name": "_wasLastNodeCreated"
   },
   {
     "name": "_wrapInTimeout"
@@ -1572,6 +1581,9 @@
     "name": "last2"
   },
   {
+    "name": "lastNodeWasCreated"
+  },
+  {
     "name": "leaveDI"
   },
   {
@@ -1981,6 +1993,9 @@
   },
   {
     "name": "walkProviderTree"
+  },
+  {
+    "name": "wasLastNodeCreated"
   },
   {
     "name": "wrapIntoObservable"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -426,6 +426,9 @@
     "name": "_keyMap"
   },
   {
+    "name": "_locateOrCreateTextNode"
+  },
+  {
     "name": "_platformInjector"
   },
   {
@@ -436,6 +439,9 @@
   },
   {
     "name": "_retrieveHydrationInfoImpl"
+  },
+  {
+    "name": "_wasLastNodeCreated"
   },
   {
     "name": "_wrapInTimeout"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -549,6 +549,12 @@
     "name": "_keyMap"
   },
   {
+    "name": "_locateOrCreateElementNode"
+  },
+  {
+    "name": "_locateOrCreateTextNode"
+  },
+  {
     "name": "_platformInjector"
   },
   {
@@ -562,6 +568,9 @@
   },
   {
     "name": "_testabilityGetter"
+  },
+  {
+    "name": "_wasLastNodeCreated"
   },
   {
     "name": "_wrapInTimeout"
@@ -1083,6 +1092,9 @@
     "name": "keyValueArraySet"
   },
   {
+    "name": "lastNodeWasCreated"
+  },
+  {
     "name": "leaveDI"
   },
   {
@@ -1357,6 +1369,9 @@
   },
   {
     "name": "walkProviderTree"
+  },
+  {
+    "name": "wasLastNodeCreated"
   },
   {
     "name": "wrapListener"


### PR DESCRIPTION
This commit incrementally builds on top of https://github.com/angular/angular/pull/49271 and adds the logic to hydrate elements and text nodes that don't have any Angular features (like *ngIf/*ngFor, etc) and are not content-projected.

The subsequent commits will extend the logic further to support more complex scenarios.

Co-authored-by: @jessicajaniuk 

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No