### PR TITLE
docs: Add NG8107 entry : Optional chain not nullable extended diagnostic

### DIFF
--- a/aio/content/extended-diagnostics/NG8107.md
+++ b/aio/content/extended-diagnostics/NG8107.md
@@ -1,0 +1,86 @@
+@name Optional chain not nullable
+
+@description
+
+This diagnostic detects when the left side of an optional chain operation (`.?`) does not include `null` or `undefined` in its type in Angular templates.
+
+<code-example format="typescript" language="typescript">
+
+import {Component} from '&commat;angular/core';
+
+&commat;Component({
+  template: `<div>{{ foo?.bar }}</div>`,
+  // &hellip;
+})
+class MyComponent {
+  // `foo` is declared as an object which *cannot* be `null` or `undefined`.
+  foo: { bar: string} = { bar: 'bar'};
+}
+
+</code-example>
+
+## What should I do instead?
+
+Update the template and declared type to be in sync. Double-check the type of the input and confirm whether it is actually expected to be nullable.
+
+If the input should be nullable, add `null` or `undefined` to its type to indicate this.
+
+<code-example format="typescript" language="typescript">
+
+import {Component} from '&commat;angular/core';
+
+&commat;Component({
+  // If `foo` is nullish, `bar` won't be evaluated and the express will return the nullish value (`null` or `undefined`).  
+  template: `<div>{{ foo?.bar }}</div>`,
+  // &hellip;
+})
+class MyComponent {
+  foo: { bar: string} | null = { bar: 'bar'};
+}
+
+</code-example>
+
+If the input should not be nullable, delete the `?` operator.
+
+<code-example format="typescript" language="typescript">
+
+import {Component} from '&commat;angular/core';
+
+&commat;Component({
+  // Template always displays `bar` as `foo` is guaranteed to never be `null` or `undefined`
+  template: `<div>{{ foo.bar }}</div>`,
+  // &hellip;
+})
+class MyComponent {
+  foo: { bar: string} = { bar: 'bar'};
+}
+
+</code-example>
+
+## What if I can't avoid this?
+
+This diagnostic can be disabled by editing the project's `tsconfig.json` file:
+
+<code-example format="json" language="json">
+
+{
+  "angularCompilerOptions": {
+    "extendedDiagnostics": {
+      "checks": {
+        "optionalChainNotNullable": "suppress"
+      }
+    }
+  }
+}
+
+</code-example>
+
+See [extended diagnostic configuration](extended-diagnostics#configuration) for more info.
+
+<!-- links -->
+
+<!-- external links -->
+
+<!-- end links -->
+
+@reviewed 2023-03-02

--- a/aio/content/extended-diagnostics/index.md
+++ b/aio/content/extended-diagnostics/index.md
@@ -11,9 +11,10 @@ Currently, Angular supports the following extended diagnostics:
 *   [NG8101 - `invalidBananaInBox`](extended-diagnostics/NG8101)
 *   [NG8102 - `nullishCoalescingNotNullable`](extended-diagnostics/NG8102)
 *   [NG8103 - `missingControlFlowDirective`](extended-diagnostics/NG8103)
+*   [NG8104 - `textAttributeNotBinding`](extended-diagnostics/NG8104)
 *   [NG8105 - `missingNgForOfLet`](extended-diagnostics/NG8105)
 *   [NG8106 - `suffixNotSupported`](extended-diagnostics/NG8106)
-*   [NG8104 - `textAttributeNotBinding`](extended-diagnostics/NG8104)
+*   [NG8107 - `optionalChainNotNullable`](extended-diagnostics/NG8107)
 
 ## Configuration
 


### PR DESCRIPTION
With this addition, the extended diagnostic list is complete in the docs. 