### PR TITLE
refactor(core): Remove `isObservable()` in favor `isSubscribable()`.

### DIFF
--- a/packages/core/src/application_init.ts
+++ b/packages/core/src/application_init.ts
@@ -9,7 +9,7 @@
 import {Observable} from 'rxjs';
 
 import {inject, Injectable, InjectionToken} from './di';
-import {isObservable, isPromise} from './util/lang';
+import {isPromise, isSubscribable} from './util/lang';
 
 /**
  * A [DI token](guide/glossary#di-token "DI token definition") that you can use to provide
@@ -118,7 +118,7 @@ export class ApplicationInitStatus {
       const initResult = appInits();
       if (isPromise(initResult)) {
         asyncInitPromises.push(initResult);
-      } else if (isObservable(initResult)) {
+      } else if (isSubscribable(initResult)) {
         const observableAsPromise = new Promise<void>((resolve, reject) => {
           initResult.subscribe({complete: resolve, error: reject});
         });

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -31,6 +31,6 @@ export {coerceToBoolean as ɵcoerceToBoolean} from './util/coercion';
 export {devModeEqual as ɵdevModeEqual} from './util/comparison';
 export {makeDecorator as ɵmakeDecorator} from './util/decorators';
 export {global as ɵglobal} from './util/global';
-export {isObservable as ɵisObservable, isPromise as ɵisPromise, isSubscribable as ɵisSubscribable} from './util/lang';
+export {isPromise as ɵisPromise, isSubscribable as ɵisSubscribable} from './util/lang';
 export {stringify as ɵstringify} from './util/stringify';
 export {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from './view/provider_flags';

--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -8,7 +8,7 @@
 
 
 import {assertIndexInRange} from '../../util/assert';
-import {isObservable} from '../../util/lang';
+import {isSubscribable} from '../../util/lang';
 import {PropertyAliasValue, TNode, TNodeType} from '../interfaces/node';
 import {GlobalTargetResolver, Renderer} from '../interfaces/renderer';
 import {RElement} from '../interfaces/renderer_dom';
@@ -202,7 +202,7 @@ function listenerInternal(
         const directiveInstance = lView[index];
         const output = directiveInstance[minifiedName];
 
-        if (ngDevMode && !isObservable(output)) {
+        if (ngDevMode && !isSubscribable(output)) {
           throw new Error(`@Output ${minifiedName} not initialized in '${
               directiveInstance.constructor.name}'.`);
         }

--- a/packages/core/src/util/lang.ts
+++ b/packages/core/src/util/lang.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Observable, Subscribable} from 'rxjs';
+import {Subscribable} from 'rxjs';
 
 /**
  * Determine if the argument is shaped like a Promise
@@ -20,18 +20,6 @@ export function isPromise<T = any>(obj: any): obj is Promise<T> {
 /**
  * Determine if the argument is a Subscribable
  */
-export function isSubscribable(obj: any|Subscribable<any>): obj is Subscribable<any> {
+export function isSubscribable<T>(obj: any|Subscribable<T>): obj is Subscribable<T> {
   return !!obj && typeof obj.subscribe === 'function';
 }
-
-/**
- * Determine if the argument is an Observable
- *
- * Strictly this tests that the `obj` is `Subscribable`, since `Observable`
- * types need additional methods, such as `lift()`. But it is adequate for our
- * needs since within the Angular framework code we only ever need to use the
- * `subscribe()` method, and RxJS has mechanisms to wrap `Subscribable` objects
- * into `Observable` as needed.
- */
-export const isObservable =
-    isSubscribable as ((obj: any|Observable<any>) => obj is Observable<any>);

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1221,9 +1221,6 @@
     "name": "isObject"
   },
   {
-    "name": "isObservable"
-  },
-  {
     "name": "isOptionsObj"
   },
   {
@@ -1243,6 +1240,9 @@
   },
   {
     "name": "isStylingValuePresent"
+  },
+  {
+    "name": "isSubscribable"
   },
   {
     "name": "isTemplateNode"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1179,9 +1179,6 @@
     "name": "isObject"
   },
   {
-    "name": "isObservable"
-  },
-  {
     "name": "isOptionsObj"
   },
   {
@@ -1201,6 +1198,9 @@
   },
   {
     "name": "isStylingValuePresent"
+  },
+  {
+    "name": "isSubscribable"
   },
   {
     "name": "isTemplateNode"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1524,9 +1524,6 @@
     "name": "isObject"
   },
   {
-    "name": "isObservable"
-  },
-  {
     "name": "isPositive"
   },
   {

--- a/packages/core/test/util/lang_spec.ts
+++ b/packages/core/test/util/lang_spec.ts
@@ -5,22 +5,23 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {isObservable} from '@angular/core/src/util/lang';
+import {isSubscribable} from '@angular/core/src/util/lang';
 import {of} from 'rxjs';
 
-describe('isObservable', () => {
-  it('should be true for an Observable', () => expect(isObservable(of(true))).toEqual(true));
+describe('isSubscribable', () => {
+  it('should be true for an Observable', () => expect(isSubscribable(of(true))).toEqual(true));
 
   it('should be true if the argument is the object with subscribe function',
-     () => expect(isObservable({subscribe: () => {}})).toEqual(true));
+     () => expect(isSubscribable({subscribe: () => {}})).toEqual(true));
 
   it('should be false if the argument is undefined',
-     () => expect(isObservable(undefined)).toEqual(false));
+     () => expect(isSubscribable(undefined)).toEqual(false));
 
-  it('should be false if the argument is null', () => expect(isObservable(null)).toEqual(false));
+  it('should be false if the argument is null', () => expect(isSubscribable(null)).toEqual(false));
 
-  it('should be false if the argument is an object', () => expect(isObservable({})).toEqual(false));
+  it('should be false if the argument is an object',
+     () => expect(isSubscribable({})).toEqual(false));
 
   it('should be false if the argument is a function',
-     () => expect(isObservable(() => {})).toEqual(false));
+     () => expect(isSubscribable(() => {})).toEqual(false));
 });

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken, ɵisObservable as isObservable, ɵisPromise as isPromise, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {InjectionToken, ɵisPromise as isPromise, ɵisSubscribable as isSubscribable, ɵRuntimeError as RuntimeError} from '@angular/core';
 import {forkJoin, from, Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 
@@ -572,7 +572,7 @@ function isPresent(o: any): boolean {
 
 export function toObservable(value: any): Observable<any> {
   const obs = isPromise(value) ? from(value) : value;
-  if (NG_DEV_MODE && !(isObservable(obs))) {
+  if (NG_DEV_MODE && !(isSubscribable(obs))) {
     let errorMessage = `Expected async validator to return Promise or Observable.`;
     // A synchronous validator will return object or null.
     if (typeof value === 'object') {

--- a/packages/router/src/utils/collection.ts
+++ b/packages/router/src/utils/collection.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵisObservable as isObservable, ɵisPromise as isPromise} from '@angular/core';
-import {from, Observable, of} from 'rxjs';
+import {ɵisPromise as isPromise} from '@angular/core';
+import {from, isObservable, Observable, of} from 'rxjs';
 
 import {Params} from '../shared';
 
@@ -57,7 +57,6 @@ export function equalArraysOrString(a: string|string[], b: string|string[]) {
 export function last<T>(a: T[]): T|null {
   return a.length > 0 ? a[a.length - 1] : null;
 }
-
 
 export function wrapIntoObservable<T>(value: T|Promise<T>|Observable<T>): Observable<T> {
   if (isObservable(value)) {


### PR DESCRIPTION
The private util `isObservable` was actually just testing the same thing as`isSubscribable()`. As the implementation is closer to the function's name, let's only keep ``isSubscribable`.

This commit also adds generic typing to improve the return type of the guard.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

