### PR TITLE
refactor(core): Remove `ɵivyEnabled`

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -36,6 +36,3 @@ export {isListLikeIterable as ɵisListLikeIterable} from './util/iterable';
 export {isObservable as ɵisObservable, isPromise as ɵisPromise, isSubscribable as ɵisSubscribable} from './util/lang';
 export {stringify as ɵstringify} from './util/stringify';
 export {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from './view/provider_flags';
-
-// TODO(alxhub): allows tests to compile, can be removed when tests have been updated.
-export const ɵivyEnabled = true;


### PR DESCRIPTION
The unit tests have been updated in #44120, this export is unused now.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [x] No