### PR TITLE
refactor(core): Remove `isListLikeIterable` from private export.

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -32,7 +32,6 @@ export {coerceToBoolean as ɵcoerceToBoolean} from './util/coercion';
 export {devModeEqual as ɵdevModeEqual} from './util/comparison';
 export {makeDecorator as ɵmakeDecorator} from './util/decorators';
 export {global as ɵglobal} from './util/global';
-export {isListLikeIterable as ɵisListLikeIterable} from './util/iterable';
 export {isObservable as ɵisObservable, isPromise as ɵisPromise, isSubscribable as ɵisSubscribable} from './util/lang';
 export {stringify as ɵstringify} from './util/stringify';
 export {NOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR as ɵNOT_FOUND_CHECK_ONLY_ELEMENT_INJECTOR} from './view/provider_flags';


### PR DESCRIPTION
#48433 removed the last external usage of `isListLikeIterable`. We can now remove it from the private exports.


## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [x] No. 
