### PR TITLE
refactor(common): remove `BrowserPlatformLocation` from  private exports.

### DIFF
--- a/packages/common/src/private_export.ts
+++ b/packages/common/src/private_export.ts
@@ -7,4 +7,3 @@
  */
 
 export {DomAdapter as ɵDomAdapter, getDOM as ɵgetDOM, setRootDomAdapter as ɵsetRootDomAdapter} from './dom_adapter';
-export {BrowserPlatformLocation as ɵBrowserPlatformLocation} from './location/platform_location';


### PR DESCRIPTION
Small PR to avoid any confusion : `BrowserPlatformLocation` was add to the public API by #48488.

Edit: I'm seeing a [lot of usage on GH](https://github.com/search?q=%C9%B5BrowserPlatformLocation&type=code) of `ɵBrowserPlatformLocation`. Should we provide a migration ? 