### PR TITLE
refactor(platform-browser): remove ununsed functions.

### DIFF
--- a/packages/platform-browser/src/dom/util.ts
+++ b/packages/platform-browser/src/dom/util.ts
@@ -8,18 +8,6 @@
 
 import {ɵglobal as global} from '@angular/core';
 
-const CAMEL_CASE_REGEXP = /([A-Z])/g;
-const DASH_CASE_REGEXP = /-([a-z])/g;
-
-
-export function camelCaseToDashCase(input: string): string {
-  return input.replace(CAMEL_CASE_REGEXP, (...m: string[]) => '-' + m[1].toLowerCase());
-}
-
-export function dashCaseToCamelCase(input: string): string {
-  return input.replace(DASH_CASE_REGEXP, (...m: string[]) => m[1].toUpperCase());
-}
-
 /**
  * Exports the value under a given `name` in the global property `ng`. For example `ng.probe` if
  * `name` is `'probe'`.


### PR DESCRIPTION
Both `camelCaseToDashCase` and `dashCaseToCamelCase` haven't been used since 2.2.0.

[Last use found](
https://github.com/angular/angular/commit/d708a8859ca3078a98e371b33ad560096070ad00#diff-0cea5e1a9c2b7a3ac986615cb98502bd6a24b2687f7146c73e8cdfbadcdc682a). 


## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)



## Does this PR introduce a breaking change?

- [x] No
