### PR TITLE
refactor(core): hydration logic for `<ng-container>`s

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 466694,
+      "main": 467207,
       "polyfills": 33836,
       "styles": 74561,
       "light-theme": 92890,

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -10,6 +10,7 @@ import {PLATFORM_ID} from '../application_tokens';
 import {ENVIRONMENT_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders} from '../di';
 import {inject} from '../di/injector_compatibility';
 import {enableLocateOrCreateElementNodeImpl} from '../render3/instructions/element';
+import {enableLocateOrCreateElementContainerNodeImpl} from '../render3/instructions/element_container';
 import {enableLocateOrCreateTextNodeImpl} from '../render3/instructions/text';
 
 import {IS_HYDRATION_FEATURE_ENABLED, PRESERVE_HOST_CONTENT} from './tokens';
@@ -39,6 +40,7 @@ function enableHydrationRuntimeSupport() {
     enableRetrieveHydrationInfoImpl();
     enableLocateOrCreateElementNodeImpl();
     enableLocateOrCreateTextNodeImpl();
+    enableLocateOrCreateElementContainerNodeImpl();
   }
 }
 

--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -22,3 +22,13 @@ export function validateMatchingNode(
     throw new Error(`Unexpected node found during hydration.`);
   }
 }
+
+/**
+ * Verifies whether next sibling node exists.
+ */
+export function validateSiblingNodeExists(node: Node): void {
+  if (!node.nextSibling) {
+    // TODO: improve error message and use RuntimeError instead.
+    throw new Error(`Unexpected state: insufficient number of sibling nodes.`);
+  }
+}

--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -8,12 +8,44 @@
 
 import {RNode} from '../render3/interfaces/renderer_dom';
 
+/* Represents a key in NghDom that holds information about <ng-container>s. */
+export const ELEMENT_CONTAINERS = 'e';
+
+/**
+ * Represents element containers within this view, stored as key-value pairs
+ * where key is an index of a container in an LView (also used in the
+ * `elementContainerStart` instruction), the value is the number of root nodes
+ * in this container. This information is needed to locate an anchor comment
+ * node that goes after all container nodes.
+ */
+export interface SerializedElementContainers {
+  [key: number]: number;
+}
+
 /**
  * Serialized data structure that contains relevant hydration
  * annotation information that describes a given hydration boundary
  * (e.g. a component).
  */
-export interface SerializedView {}
+export interface SerializedView {
+  /**
+   * Serialized information about <ng-container>s.
+   */
+  [ELEMENT_CONTAINERS]?: SerializedElementContainers;
+}
+
+/**
+ * Represents a hydration-related element container structure
+ * at runtime, which includes a reference to a first node in
+ * a DOM segment that corresponds to a given element container.
+ */
+export interface DehydratedElementContainer {
+  /**
+   * A reference to the first child in a DOM segment associated
+   * with a first child in a given <ng-container>.
+   */
+  firstChild: RNode|null;
+}
 
 /**
  * An object that contains hydration-related information serialized
@@ -32,4 +64,12 @@ export interface DehydratedView {
    * with a given hydration boundary.
    */
   firstChild: RNode|null;
+
+  /**
+   * Collection of <ng-container>s in a given view,
+   * used as a set of pointers to first children in each
+   * <ng-container>, so that those pointers are reused by
+   * subsequent instructions.
+   */
+  ngContainers?: {[index: number]: DehydratedElementContainer};
 }

--- a/packages/core/src/hydration/node_lookup_utils.ts
+++ b/packages/core/src/hydration/node_lookup_utils.ts
@@ -6,13 +6,32 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {TNode} from '../render3/interfaces/node';
+import {TNode, TNodeType} from '../render3/interfaces/node';
 import {RElement, RNode} from '../render3/interfaces/renderer_dom';
-import {LView, TView} from '../render3/interfaces/view';
+import {HEADER_OFFSET, LView, TView} from '../render3/interfaces/view';
 import {getNativeByTNode} from '../render3/util/view_utils';
 import {assertDefined} from '../util/assert';
 
-import {DehydratedView} from './interfaces';
+import {validateSiblingNodeExists} from './error_handling';
+import {DehydratedElementContainer, DehydratedView} from './interfaces';
+
+/** Whether current TNode is a first node in an <ng-container>. */
+function isFirstElementInNgContainer(tNode: TNode): boolean {
+  return !tNode.prev && tNode.parent?.type === TNodeType.ElementContainer;
+}
+
+/** Returns first element from a DOM segment that corresponds to this <ng-container>. */
+function getDehydratedNgContainer(
+    hydrationInfo: DehydratedView, tContainerNode: TNode): DehydratedElementContainer {
+  const noOffsetIndex = tContainerNode.index - HEADER_OFFSET;
+  const ngContainer = hydrationInfo.ngContainers?.[noOffsetIndex]!;
+  ngDevMode &&
+      assertDefined(
+          ngContainer,
+          'Unexpected state: no hydration info available for a given TNode, ' +
+              'which represents an element container.');
+  return ngContainer;
+}
 
 /**
  * Locate a node in DOM tree that corresponds to a given TNode.
@@ -33,18 +52,35 @@ export function locateNextRNode<T extends RNode>(
   } else {
     // Locate a node based on a previous sibling or a parent node.
     const previousTNodeParent = tNode.prev === null;
-    const previousTNode = tNode.prev ?? tNode.parent;
+    const previousTNode = (tNode.prev ?? tNode.parent)!;
     ngDevMode &&
         assertDefined(
             previousTNode,
             'Unexpected state: current TNode does not have a connection ' +
                 'to the previous node or a parent node.');
-    const previousRElement = getNativeByTNode(previousTNode!, lView);
-    if (previousTNodeParent) {
-      native = (previousRElement as RElement).firstChild;
+    const previousRElement = getNativeByTNode(previousTNode, lView);
+    if (isFirstElementInNgContainer(tNode)) {
+      const ngContainer = getDehydratedNgContainer(hydrationInfo, tNode.parent!);
+      native = ngContainer.firstChild ?? null;
     } else {
-      native = previousRElement.nextSibling;
+      if (previousTNodeParent) {
+        native = (previousRElement as RElement).firstChild;
+      } else {
+        native = previousRElement.nextSibling;
+      }
     }
   }
   return native as T;
+}
+
+/**
+ * Skips over a specified number of nodes and returns the next sibling node after that.
+ */
+export function siblingAfter<T extends RNode>(skip: number, from: RNode): T|null {
+  let currentNode = from;
+  for (let i = 0; i < skip; i++) {
+    ngDevMode && validateSiblingNodeExists(currentNode as Node);
+    currentNode = currentNode.nextSibling!;
+  }
+  return currentNode as T;
 }

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -15,7 +15,7 @@ import {HEADER_OFFSET, LView, TVIEW, TViewType} from '../render3/interfaces/view
 import {makeStateKey, TransferState} from '../transfer_state';
 import {assertDefined} from '../util/assert';
 
-import {DehydratedView, SerializedView} from './interfaces';
+import {DehydratedView, ELEMENT_CONTAINERS, SerializedView} from './interfaces';
 
 /**
  * The name of the key used in the TransferState collection,
@@ -151,4 +151,14 @@ export function markRNodeAsClaimedByHydration(node: RNode, checkIfAlreadyClaimed
 
 export function isRNodeClaimedForHydration(node: RNode): boolean {
   return !!(node as ClaimedNode).__claimed;
+}
+
+export function storeNgContainerInfo(
+    hydrationInfo: DehydratedView, index: number, firstChild: RNode): void {
+  hydrationInfo.ngContainers ??= {};
+  hydrationInfo.ngContainers[index] = {firstChild};
+}
+
+export function getNgContainerSize(hydrationInfo: DehydratedView, index: number): number|null {
+  return hydrationInfo.data[ELEMENT_CONTAINERS]?.[index] ?? null;
 }

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -466,6 +466,110 @@ describe('platform-server integration', () => {
           verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
         });
       });
+
+      describe('ng-container', () => {
+        it('should support empty containers', async () => {
+          @Component({
+            standalone: true,
+            selector: 'app',
+            template: `
+              This is an empty container: <ng-container></ng-container>
+            `,
+          })
+          class SimpleComponent {
+          }
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+          resetTViewsFor(SimpleComponent);
+
+          const appRef = await hydrate(html, SimpleComponent);
+          const compRef = getComponentRef<SimpleComponent>(appRef);
+          appRef.tick();
+
+          const clientRootNode = compRef.location.nativeElement;
+          verifyAllNodesClaimedForHydration(clientRootNode);
+          verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+        });
+
+        it('should support non-empty containers', async () => {
+          @Component({
+            standalone: true,
+            selector: 'app',
+            template: `
+              This is a non-empty container:
+              <ng-container>
+                <h1>Hello world!</h1>
+              </ng-container>
+              <div>Post-container element</div>
+            `,
+          })
+          class SimpleComponent {
+          }
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+          resetTViewsFor(SimpleComponent);
+
+          const appRef = await hydrate(html, SimpleComponent);
+          const compRef = getComponentRef<SimpleComponent>(appRef);
+          appRef.tick();
+
+          const clientRootNode = compRef.location.nativeElement;
+          verifyAllNodesClaimedForHydration(clientRootNode);
+          verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+        });
+
+        it('should support nested containers', async () => {
+          @Component({
+            standalone: true,
+            selector: 'app',
+            template: `
+              This is a non-empty container:
+              <ng-container>
+                <ng-container>
+                  <ng-container>
+                    <h1>Hello world!</h1>
+                  </ng-container>
+                </ng-container>
+              </ng-container>
+              <div>Post-container element</div>
+              <ng-container>
+                <div>Tags between containers</div>
+                <ng-container>
+                  <div>More tags between containers</div>
+                  <ng-container>
+                    <h1>Hello world!</h1>
+                  </ng-container>
+                </ng-container>
+              </ng-container>
+            `,
+          })
+          class SimpleComponent {
+          }
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+          resetTViewsFor(SimpleComponent);
+
+          const appRef = await hydrate(html, SimpleComponent);
+          const compRef = getComponentRef<SimpleComponent>(appRef);
+          appRef.tick();
+
+          const clientRootNode = compRef.location.nativeElement;
+          verifyAllNodesClaimedForHydration(clientRootNode);
+          verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This commit incrementally builds on top of https://github.com/angular/angular/pull/49285 and adds the logic to hydrate `<ng-container>`s and their contents. This implementation supports simple `<ng-container>`s that don't have any Angular features (like *ngIf/*ngFor, etc) and are not content-projected.

The subsequent commits will extend the logic further to support more complex scenarios.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No