### PR TITLE
refactor(core): rename TNode.tViews to TNode.tView

### DIFF
--- a/packages/core/src/linker/template_ref.ts
+++ b/packages/core/src/linker/template_ref.ts
@@ -79,7 +79,7 @@ const R3TemplateRef = class TemplateRef<T> extends ViewEngineTemplateRef<T> {
   }
 
   override createEmbeddedView(context: T, injector?: Injector): EmbeddedViewRef<T> {
-    const embeddedTView = this._declarationTContainer.tViews as TView;
+    const embeddedTView = this._declarationTContainer.tView as TView;
     const embeddedLView = createLView(
         this._declarationLView, embeddedTView, context, LViewFlags.CheckAlways, null,
         embeddedTView.declTNode, null, null, null, null, injector || null);
@@ -117,7 +117,7 @@ export function injectTemplateRef<T>(): TemplateRef<T>|null {
  */
 export function createTemplateRef<T>(hostTNode: TNode, hostLView: LView): TemplateRef<T>|null {
   if (hostTNode.type & TNodeType.Container) {
-    ngDevMode && assertDefined(hostTNode.tViews, 'TView must be allocated');
+    ngDevMode && assertDefined(hostTNode.tView, 'TView must be allocated');
     return new R3TemplateRef(
         hostLView, hostTNode as TContainerNode, createElementRef(hostTNode, hostLView));
   }

--- a/packages/core/src/render3/i18n/i18n_util.ts
+++ b/packages/core/src/render3/i18n/i18n_util.ts
@@ -15,6 +15,7 @@ import {LView, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
 import {setI18nHandling} from '../node_manipulation';
 import {getInsertInFrontOfRNodeWithI18n, processI18nInsertBefore} from '../node_manipulation_i18n';
+
 import {addTNodeAndUpdateInsertBeforeIndex} from './i18n_insert_before_index';
 
 
@@ -35,7 +36,7 @@ export function getTIcu(tView: TView, index: number): TIcu|null {
   const value = tView.data[index] as null | TIcu | TIcuContainerNode | string;
   if (value === null || typeof value === 'string') return null;
   if (ngDevMode &&
-      !(value.hasOwnProperty('tViews') || value.hasOwnProperty('currentCaseLViewIndex'))) {
+      !(value.hasOwnProperty('tView') || value.hasOwnProperty('currentCaseLViewIndex'))) {
     throwError('We expect to get \'null\'|\'TIcu\'|\'TIcuContainer\', but got: ' + value);
   }
   // Here the `value.hasOwnProperty('currentCaseLViewIndex')` is a polymorphic read as it can be
@@ -66,7 +67,7 @@ export function setTIcu(tView: TView, index: number, tIcu: TIcu): void {
   const tNode = tView.data[index] as null | TIcuContainerNode;
   ngDevMode &&
       assertEqual(
-          tNode === null || tNode.hasOwnProperty('tViews'), true,
+          tNode === null || tNode.hasOwnProperty('tView'), true,
           'We expect to get \'null\'|\'TIcuContainer\'');
   if (tNode === null) {
     tView.data[index] = tIcu;

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -704,13 +704,12 @@ export function storeCleanupWithContext(
 /**
  * Constructs a TNode object from the arguments.
  *
- * @param tView `TView` to which this `TNode` belongs (used only in `ngDevMode`)
+ * @param tView `TView` to which this `TNode` belongs
  * @param tParent Parent `TNode`
  * @param type The type of the node
  * @param index The index of the TNode in TView.data, adjusted for HEADER_OFFSET
  * @param tagName The tag name of the node
  * @param attrs The attributes defined on this node
- * @param tViews Any TViews attached to this node
  * @returns the TNode object
  */
 export function createTNode(
@@ -760,7 +759,7 @@ export function createTNode(
     initialInputs: undefined,
     inputs: null,
     outputs: null,
-    tViews: null,
+    tView: null,
     next: null,
     prev: null,
     projectionNext: null,

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -15,6 +15,7 @@ import {HEADER_OFFSET, LView, RENDERER, TView, TViewType} from '../interfaces/vi
 import {appendChild} from '../node_manipulation';
 import {getLView, getTView, setCurrentTNode} from '../state';
 import {getConstant} from '../util/view_utils';
+
 import {addToViewTree, createDirectivesInstances, createLContainer, createTView, getOrCreateTNode, resolveDirectives, saveResolvedLocalsInData} from './shared';
 
 
@@ -34,7 +35,7 @@ function templateFirstCreatePass(
   resolveDirectives(tView, lView, tNode, getConstant<string[]>(tViewConsts, localRefsIndex));
   registerPostOrderHooks(tView, tNode);
 
-  const embeddedTView = tNode.tViews = createTView(
+  const embeddedTView = tNode.tView = createTView(
       TViewType.Embedded, tNode, templateFn, decls, vars, tView.directiveRegistry,
       tView.pipeRegistry, null, tView.schemas, tViewConsts);
 

--- a/packages/core/src/render3/interfaces/node.ts
+++ b/packages/core/src/render3/interfaces/node.ts
@@ -532,26 +532,14 @@ export interface TNode {
   outputs: PropertyAliases|null;
 
   /**
-   * The TView or TViews attached to this node.
-   *
-   * If this TNode corresponds to an LContainer with inline views, the container will
-   * need to store separate static data for each of its view blocks (TView[]). Otherwise,
-   * nodes in inline views with the same index as nodes in their parent views will overwrite
-   * each other, as they are in the same template.
-   *
-   * Each index in this array corresponds to the static data for a certain
-   * view. So if you had V(0) and V(1) in a container, you might have:
-   *
-   * [
-   *   [{tagName: 'div', attrs: ...}, null],     // V(0) TView
-   *   [{tagName: 'button', attrs ...}, null]    // V(1) TView
+   * The TView attached to this node.
    *
    * If this TNode corresponds to an LContainer with a template (e.g. structural
    * directive), the template's TView will be stored here.
    *
-   * If this TNode corresponds to an element, tViews will be null .
+   * If this TNode corresponds to an element, tView will be `null`.
    */
-  tViews: TView|TView[]|null;
+  tView: TView|null;
 
   /**
    * The next sibling node. Necessary so we can propagate through the root nodes of a view
@@ -774,7 +762,7 @@ export interface TElementNode extends TNode {
    * retrieved using viewData[HOST_NODE]).
    */
   parent: TElementNode|TElementContainerNode|null;
-  tViews: null;
+  tView: null;
 
   /**
    * If this is a component TNode with projection, this will be an array of projected
@@ -800,7 +788,7 @@ export interface TTextNode extends TNode {
    * retrieved using LView.node).
    */
   parent: TElementNode|TElementContainerNode|null;
-  tViews: null;
+  tView: null;
   projection: null;
 }
 
@@ -822,7 +810,7 @@ export interface TContainerNode extends TNode {
    * - They are dynamically created
    */
   parent: TElementNode|TElementContainerNode|null;
-  tViews: TView|TView[]|null;
+  tView: TView|null;
   projection: null;
   value: null;
 }
@@ -833,7 +821,7 @@ export interface TElementContainerNode extends TNode {
   index: number;
   child: TElementNode|TTextNode|TContainerNode|TElementContainerNode|TProjectionNode|null;
   parent: TElementNode|TElementContainerNode|null;
-  tViews: null;
+  tView: null;
   projection: null;
 }
 
@@ -843,7 +831,7 @@ export interface TIcuContainerNode extends TNode {
   index: number;
   child: null;
   parent: TElementNode|TElementContainerNode|null;
-  tViews: null;
+  tView: null;
   projection: null;
   value: TIcu;
 }
@@ -858,7 +846,7 @@ export interface TProjectionNode extends TNode {
    * retrieved using LView.node).
    */
   parent: TElementNode|TElementContainerNode|null;
-  tViews: null;
+  tView: null;
 
   /** Index of the projection node. (See TNode.projection for more info.) */
   projection: number;

--- a/packages/core/test/render3/instructions_spec.ts
+++ b/packages/core/test/render3/instructions_spec.ts
@@ -282,7 +282,7 @@ describe('instructions', () => {
   });
 
   describe('performance counters', () => {
-    it('should create tViews only once for each nested level', () => {
+    it('should create tView only once for each nested level', () => {
       @Component({
         selector: 'nested-loops',
         standalone: true,

--- a/packages/core/test/render3/is_shape_of.ts
+++ b/packages/core/test/render3/is_shape_of.ts
@@ -165,7 +165,7 @@ const ShapeOfTNode: ShapeOf<TNode> = {
   initialInputs: true,
   inputs: true,
   outputs: true,
-  tViews: true,
+  tView: true,
   next: true,
   prev: true,
   projectionNext: true,


### PR DESCRIPTION
Previously (at the early days of Ivy) a TNode used to keep an array of TViews, but the logic was changed since that time, but the `tViews` field remained on TNode interface (+ corresponding typings).

This commit renames TNode.tViews to TNode.tView and cleans up typings.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No