### PR TITLE
devtools: Support for Sets in component properties.

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -13,13 +13,15 @@ import {getKeys} from './object-utils';
 // todo(aleksanderbodurri) pull this out of this file
 const METADATA_PROPERTY_NAME = '__ngContext__';
 
+type NestedType = PropType.Array|PropType.Object;
+
 export interface CompositeType {
-  type: Extract<PropType, PropType.Array|PropType.Object>;
+  type: Extract<PropType, NestedType>;
   prop: any;
 }
 
 export interface TerminalType {
-  type: Exclude<PropType, PropType.Array|PropType.Object>;
+  type: Exclude<PropType, NestedType>;
   prop: any;
 }
 
@@ -43,6 +45,7 @@ const serializable: {[key in PropType]: boolean} = {
   [PropType.Undefined]: true,
   [PropType.Unknown]: true,
   [PropType.Array]: false,
+  [PropType.Set]: false,
   [PropType.BigInt]: false,
   [PropType.Function]: false,
   [PropType.HTMLNode]: false,
@@ -52,6 +55,7 @@ const serializable: {[key in PropType]: boolean} = {
 
 const typeToDescriptorPreview: Formatter<string> = {
   [PropType.Array]: (prop: any) => `Array(${prop.length})`,
+  [PropType.Set]: (prop: any) => `Set(${prop.size})`,
   [PropType.BigInt]: (prop: any) => truncate(prop.toString()),
   [PropType.Boolean]: (prop: any) => truncate(prop.toString()),
   [PropType.String]: (prop: any) => `"${prop}"`,
@@ -74,52 +78,57 @@ const typeToDescriptorPreview: Formatter<string> = {
 type Key = string|number;
 const ignoreList: Set<Key> = new Set([METADATA_PROPERTY_NAME, '__ngSimpleChanges__']);
 
-const shallowPropTypeToTreeMetaData = {
-  [PropType.String]: {
-    editable: true,
-    expandable: false,
-  },
-  [PropType.BigInt]: {
-    editable: false,
-    expandable: false,
-  },
-  [PropType.Boolean]: {
-    editable: true,
-    expandable: false,
-  },
-  [PropType.Number]: {
-    editable: true,
-    expandable: false,
-  },
-  [PropType.Date]: {
-    editable: false,
-    expandable: false,
-  },
-  [PropType.Null]: {
-    editable: true,
-    expandable: false,
-  },
-  [PropType.Undefined]: {
-    editable: true,
-    expandable: false,
-  },
-  [PropType.Symbol]: {
-    editable: false,
-    expandable: false,
-  },
-  [PropType.Function]: {
-    editable: false,
-    expandable: false,
-  },
-  [PropType.HTMLNode]: {
-    editable: false,
-    expandable: false,
-  },
-  [PropType.Unknown]: {
-    editable: false,
-    expandable: false,
-  },
-};
+const shallowPropTypeToTreeMetaData:
+    Record<Exclude<PropType, NestedType>, {editable: boolean, expandable: boolean}> = {
+      [PropType.String]: {
+        editable: true,
+        expandable: false,
+      },
+      [PropType.BigInt]: {
+        editable: false,
+        expandable: false,
+      },
+      [PropType.Boolean]: {
+        editable: true,
+        expandable: false,
+      },
+      [PropType.Number]: {
+        editable: true,
+        expandable: false,
+      },
+      [PropType.Date]: {
+        editable: false,
+        expandable: false,
+      },
+      [PropType.Null]: {
+        editable: true,
+        expandable: false,
+      },
+      [PropType.Undefined]: {
+        editable: true,
+        expandable: false,
+      },
+      [PropType.Symbol]: {
+        editable: false,
+        expandable: false,
+      },
+      [PropType.Function]: {
+        editable: false,
+        expandable: false,
+      },
+      [PropType.HTMLNode]: {
+        editable: false,
+        expandable: false,
+      },
+      [PropType.Unknown]: {
+        editable: false,
+        expandable: false,
+      },
+      [PropType.Set]: {
+        editable: false,
+        expandable: false,
+      },
+    };
 
 const isEditable = (instance: any, propName: string|number, propData: TerminalType) => {
   if (typeof propName === 'symbol') {

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
@@ -33,6 +33,15 @@ const QUERY_1_2 = [
               },
             ],
           },
+          {
+            name: 3,
+            children: [
+              {
+                name: 0,
+                children: [],
+              },
+            ],
+          },
         ],
       },
     ],
@@ -52,6 +61,7 @@ const dir1 = {
           two: 1,
         },
       ],
+      new Set(['foo', 'bar']),
     ],
   },
 };
@@ -93,7 +103,7 @@ describe('deeplySerializeSelectedProperties', () => {
             type: PropType.Array,
             expandable: true,
             editable: false,
-            preview: 'Array(3)',
+            preview: 'Array(4)',
           },
         },
       },
@@ -120,7 +130,7 @@ describe('deeplySerializeSelectedProperties', () => {
             type: PropType.Array,
             editable: false,
             expandable: true,
-            preview: 'Array(3)',
+            preview: 'Array(4)',
             value: [
               {
                 type: PropType.Array,
@@ -144,6 +154,13 @@ describe('deeplySerializeSelectedProperties', () => {
                     },
                   },
                 ],
+              },
+              {
+                type: PropType.Set,
+                editable: false,
+                expandable: false,
+                preview: 'Set(2)',
+
               },
             ],
           },

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.ts
@@ -44,6 +44,8 @@ const getPropType = (prop: any): PropType => {
   if (type === 'object') {
     if (Array.isArray(prop)) {
       return PropType.Array;
+    } else if (prop instanceof Set) {
+      return PropType.Set;
     } else if (Object.prototype.toString.call(prop) === '[object Date]') {
       return PropType.Date;
     } else if (prop instanceof Node) {

--- a/devtools/projects/protocol/src/lib/messages.ts
+++ b/devtools/projects/protocol/src/lib/messages.ts
@@ -40,6 +40,7 @@ export enum PropType {
   Object,
   Date,
   Array,
+  Set,
   Unknown,
 }
 


### PR DESCRIPTION
With this commit it is now possible to expand the Sets (like Arrays or Object) on the property list. 

Fixes #49312