### PR TITLE
feat(zone.js): support lazy loading zone-testing so the loading order will not be an issue.

### DIFF
--- a/integration/cli-hello-world/src/test.ts
+++ b/integration/cli-hello-world/src/test.ts
@@ -1,11 +1,11 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
+import 'zone.js/testing';
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -5,12 +5,15 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-const _Zone: any = typeof Zone !== 'undefined' ? Zone : null;
-const fakeAsyncTestModule = _Zone && _Zone[_Zone.__symbol__('fakeAsyncTest')];
 
 const fakeAsyncTestModuleNotLoadedErrorMessage =
     `zone-testing.js is needed for the fakeAsync() test helper but could not be found.
         Please make sure that your environment includes zone.js/testing`;
+
+function getFakeAsyncTestModule() {
+  const _Zone: any = typeof Zone !== 'undefined' ? Zone : null;
+  return _Zone && _Zone[_Zone.__symbol__('fakeAsyncTest')];
+}
 
 /**
  * Clears out the shared fake async zone for a test.
@@ -19,6 +22,7 @@ const fakeAsyncTestModuleNotLoadedErrorMessage =
  * @publicApi
  */
 export function resetFakeAsyncZone(): void {
+  const fakeAsyncTestModule = getFakeAsyncTestModule();
   if (fakeAsyncTestModule) {
     return fakeAsyncTestModule.resetFakeAsyncZone();
   }
@@ -49,6 +53,7 @@ export function resetFakeAsyncZone(): void {
  * @publicApi
  */
 export function fakeAsync(fn: Function): (...args: any[]) => any {
+  const fakeAsyncTestModule = getFakeAsyncTestModule();
   if (fakeAsyncTestModule) {
     return fakeAsyncTestModule.fakeAsync(fn);
   }
@@ -123,6 +128,7 @@ export function tick(
     millis: number = 0, tickOptions: {processNewMacroTasksSynchronously: boolean} = {
       processNewMacroTasksSynchronously: true
     }): void {
+  const fakeAsyncTestModule = getFakeAsyncTestModule();
   if (fakeAsyncTestModule) {
     return fakeAsyncTestModule.tick(millis, tickOptions);
   }
@@ -141,6 +147,7 @@ export function tick(
  * @publicApi
  */
 export function flush(maxTurns?: number): number {
+  const fakeAsyncTestModule = getFakeAsyncTestModule();
   if (fakeAsyncTestModule) {
     return fakeAsyncTestModule.flush(maxTurns);
   }
@@ -153,6 +160,7 @@ export function flush(maxTurns?: number): number {
  * @publicApi
  */
 export function discardPeriodicTasks(): void {
+  const fakeAsyncTestModule = getFakeAsyncTestModule();
   if (fakeAsyncTestModule) {
     return fakeAsyncTestModule.discardPeriodicTasks();
   }
@@ -165,6 +173,7 @@ export function discardPeriodicTasks(): void {
  * @publicApi
  */
 export function flushMicrotasks(): void {
+  const fakeAsyncTestModule = getFakeAsyncTestModule();
   if (fakeAsyncTestModule) {
     return fakeAsyncTestModule.flushMicrotasks();
   }

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -18,6 +18,23 @@ function getFakeAsyncTestModule() {
 /**
  * Clears out the shared fake async zone for a test.
  * To be called in a global `beforeEach`.
+ * There are several patterns of bundles loading
+ * (`zone-testing` and `@angular/core/testing`) order here.
+
+ * 1. loading `zone-testing` before `@angular/core/testing`.
+ * This is the default pattern, and Angular CLI generated `test.ts` does
+ * in this way, the `beforeEach` will be patched by `zone-testing`, and
+ * `resetFakeAsyncZone` also use the logic from `zone-testing`.
+
+ * 2. loading `zone-testing` after `@angular/core/testing`, and using older version
+ * of `zone-testing`. the `beforeEach` will not be patched by `zone-testing` when
+ * `@angular/core/testing` is loaded, so the logic in `before_each.ts` to set a
+ * global `beforeEach` to reset ProxyZoneSpec will not work, so we need to throw
+ * error to let the user load `zone-testing` first.
+ *
+ * 3. loading `zone-testing` after `@angular/core/testing`, and using newer version
+ * of `zone-testing` (0.11.4+). In this case, the logic to reset ProxyZoneSpec delegate
+ * is implemented in the `zone-testing` bundle. Everything should work fine.
  *
  * @publicApi
  */

--- a/packages/zone.js/lib/jest/jest.ts
+++ b/packages/zone.js/lib/jest/jest.ts
@@ -131,6 +131,14 @@ Zone.__load_patch('jest', (context: any, Zone: ZoneType, api: _ZonePrivate) => {
     };
   });
 
+  const beforeEach = context['beforeEach'];
+  if (beforeEach) {
+    beforeEach(() => {
+      const proxyZoneSpec = ProxyZoneSpec.get();
+      proxyZoneSpec && proxyZoneSpec.resetDelegate();
+    });
+  }
+
   (Zone as any).patchJestObject = function patchJestObject(Timer: any, isModern = false) {
     // check whether currently the test is inside fakeAsync()
     function isPatchingFakeTimer() {

--- a/packages/zone.js/lib/mocha/mocha.ts
+++ b/packages/zone.js/lib/mocha/mocha.ts
@@ -151,6 +151,11 @@ Zone.__load_patch('mocha', (global: any, Zone: ZoneType) => {
     return mochaOriginal.beforeEach.apply(this, wrapTestInZone(arguments));
   };
 
+  global.beforeEach(() => {
+    const proxyZoneSpec = ProxyZoneSpec.get();
+    proxyZoneSpec && proxyZoneSpec.resetDelegate();
+  });
+
   ((originalRunTest, originalRun) => {
     Mocha.Runner.prototype.runTest = function(fn: Function) {
       Zone.current.scheduleMicroTask('mocha.forceTask', () => {


### PR DESCRIPTION
Close https://github.com/angular/angular/issues/48386

Angular requires to load zone-testing before loading @angular/core/testing,
since zone-testing provide fakeAsync/async test util methods.
So if the user load the bundles with wrong order, please load zone-testing
error will be thrown.
This PR make fakeAsync loading Zone object lazyly, so even the
zone-testing is loaded after @angular/core/testing, the test will
still be success.