### PR TITLE
build(zone.js): remove legacy browsers support

### DIFF
--- a/packages/zone.js/bundles.bzl
+++ b/packages/zone.js/bundles.bzl
@@ -7,7 +7,7 @@ _DIR = "//packages/zone.js/lib:"
 
 BUNDLES_ENTRY_POINTS = {
     "zone": {
-        "es5": _DIR + "browser/rollup-legacy-main",
+        "es5": _DIR + "browser/rollup-main",
         "es2015": _DIR + "browser/rollup-main",
     },
     "zone-mix": {
@@ -104,7 +104,7 @@ BUNDLES_ENTRY_POINTS = {
         "entrypoint": _DIR + "testing/zone-testing",
     },
     "zone-testing-bundle": {
-        "es5": _DIR + "browser/rollup-legacy-test-main",
+        "es5": _DIR + "browser/rollup-test-main",
         "es2015": _DIR + "browser/rollup-test-main",
     },
     "zone-testing-node-bundle": {


### PR DESCRIPTION
Close #47209

Remove legacy browsers support, so we don't need to patch EventTarget for very old browsers and cause issues in the new environment.

