### PR TITLE
fix(zone.js): revert Mocha it.skip, describe.skip method patch

### DIFF
--- a/packages/zone.js/lib/mocha/mocha.ts
+++ b/packages/zone.js/lib/mocha/mocha.ts
@@ -115,7 +115,7 @@ Zone.__load_patch('mocha', (global: any, Zone: ZoneType) => {
     return mochaOriginal.describe.apply(this, wrapDescribeInZone(arguments));
   };
 
-  global.xdescribe = global.suite.skip = function() {
+  global.xdescribe = global.suite.skip = global.describe.skip = function() {
     return mochaOriginal.describe.skip.apply(this, wrapDescribeInZone(arguments));
   };
 
@@ -127,7 +127,7 @@ Zone.__load_patch('mocha', (global: any, Zone: ZoneType) => {
     return mochaOriginal.it.apply(this, wrapTestInZone(arguments));
   };
 
-  global.xit = global.xspecify = function() {
+  global.xit = global.xspecify = global.it.skip = function() {
     return mochaOriginal.it.skip.apply(this, wrapTestInZone(arguments));
   };
 

--- a/packages/zone.js/package.json
+++ b/packages/zone.js/package.json
@@ -18,7 +18,7 @@
     "jest": "^29.0",
     "jest-environment-jsdom": "^29.0.3",
     "jest-environment-node": "^29.0.3",
-    "mocha": "^10.0.0",
+    "mocha": "^10.2.0",
     "mock-require": "3.0.3",
     "promises-aplus-tests": "^2.1.2"
   },

--- a/packages/zone.js/test/mocha-patch.spec.ts
+++ b/packages/zone.js/test/mocha-patch.spec.ts
@@ -60,6 +60,12 @@ ifEnvSupports('Mocha', function() {
     });
   });
 
+  (describe as any).skip('skip describe', () => {
+    test('test', () => {
+      fail('should not be here');
+    });
+  });
+
   suite('Mocha TDD-style', () => {
     let testZone: Zone|null = null;
     let beforeEachZone: Zone|null = null;
@@ -93,6 +99,10 @@ ifEnvSupports('Mocha', function() {
 
     suiteTeardown(() => {
       expect(suiteSetupZone).toBe(Zone.current);
+    });
+
+    (it as any).skip('test skip', () => {
+      fail('should not be here');
     });
   });
 

--- a/packages/zone.js/yarn.lock
+++ b/packages/zone.js/yarn.lock
@@ -812,11 +812,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@ungap/promise-all-settled@1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
-  integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
-
 abab@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
@@ -2673,12 +2668,11 @@ mkdirp@0.5.1:
   dependencies:
     minimist "0.0.8"
 
-mocha@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.0.0.tgz#205447d8993ec755335c4b13deba3d3a13c4def9"
-  integrity sha512-0Wl+elVUD43Y0BqPZBzZt8Tnkw9CMUdNYnUsTfOM1vuhJVZL+kiesFYsqwBkEEuEixaiPe5ZQdqDgX2jddhmoA==
+mocha@^10.2.0:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
+  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
   dependencies:
-    "@ungap/promise-all-settled" "1.1.2"
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
     chokidar "3.5.3"


### PR DESCRIPTION
Close https://github.com/angular/angular/issues/46297

In the previous commit https://github.com/angular/angular/pull/45047 The `it.skip` and `describe.skip` is wrongly deleted, should keep the patch for these methods.
