### PR TITLE
fix(platform-browser):KeyEventsPlugin should keep the same behavior

### DIFF
--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -600,9 +600,6 @@
     "name": "getCurrentTNodePlaceholderOk"
   },
   {
-    "name": "getDOM"
-  },
-  {
     "name": "getDeclarationTNode"
   },
   {

--- a/packages/platform-browser/src/dom/events/key_events.ts
+++ b/packages/platform-browser/src/dom/events/key_events.ts
@@ -78,12 +78,9 @@ export class KeyEventsPlugin extends EventManagerPlugin {
   override addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
     const parsedEvent = KeyEventsPlugin.parseEventName(eventName)!;
 
-    const outsideHandler =
-        KeyEventsPlugin.eventCallback(parsedEvent['fullKey'], handler, this.manager.getZone());
+    const outsideHandler = KeyEventsPlugin.eventCallback(parsedEvent['fullKey'], handler);
 
-    return this.manager.getZone().runOutsideAngular(() => {
-      return getDOM().onAndCancel(element, parsedEvent['domEventName'], outsideHandler);
-    });
+    return this.manager.addEventListener(element, parsedEvent['domEventName'], outsideHandler);
   }
 
   /**
@@ -178,10 +175,10 @@ export class KeyEventsPlugin extends EventManagerPlugin {
    * @param zone The zone in which the event occurred.
    * @returns A callback function.
    */
-  static eventCallback(fullKey: string, handler: Function, zone: NgZone): Function {
+  static eventCallback(fullKey: string, handler: Function): Function {
     return (event: KeyboardEvent) => {
       if (KeyEventsPlugin.matchEventFullKeyCode(event, fullKey)) {
-        zone.runGuarded(() => handler(event));
+        handler(event);
       }
     };
   }


### PR DESCRIPTION
Close #45698

KeyEventsPlugin now has different behavior with EventsPlugin, it will always run inside ngZone with ngZone.runGuarded() no matter the component is initialized inside or outside of NgZone, this PR make sure KeyEventsPlugin bahave the same with other events.
