### PR TITLE
feat(core): drop support for `zone.js`  versions `<=0.12.0`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "rxjs": "^6.5.3 || ^7.4.0",
-    "zone.js": "~0.11.4 || ~0.12.0 || ~0.13.0"
+    "zone.js": "~0.13.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
BREAKING CHANGE: `zone.js` versions `0.11.x` and `0.12.x` are not longer supported.
