### PR TITLE
refactor(compiler): required inputs prerequisite refactors

### DIFF
--- a/packages/compiler-cli/linker/src/ast/ast_value.ts
+++ b/packages/compiler-cli/linker/src/ast/ast_value.ts
@@ -156,10 +156,12 @@ export class AstObject<T extends object, TExpression> {
    * Converts the AstObject to a raw JavaScript object, mapping each property value (as an
    * `AstValue`) to the generic type (`T`) via the `mapper` function.
    */
-  toLiteral<V>(mapper: (value: AstValue<ObjectValueType<T>, TExpression>) => V): Record<string, V> {
+  toLiteral<V>(mapper: (value: AstValue<ObjectValueType<T>, TExpression>, key: string) => V):
+      Record<string, V> {
     const result: Record<string, V> = {};
     for (const [key, expression] of this.obj) {
-      result[key] = mapper(new AstValue<ObjectValueType<T>, TExpression>(expression, this.host));
+      result[key] =
+          mapper(new AstValue<ObjectValueType<T>, TExpression>(expression, this.host), key);
     }
     return result;
   }

--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_directive_linker_1.ts
@@ -80,10 +80,11 @@ export function toR3DirectiveMeta<TExpression>(
 /**
  * Decodes the AST value for a single input to its representation as used in the metadata.
  */
-function toInputMapping<TExpression>(value: AstValue<string|[string, string], TExpression>):
-    string|[string, string] {
+function toInputMapping<TExpression>(
+    value: AstValue<string|[string, string], TExpression>,
+    key: string): {bindingPropertyName: string, classPropertyName: string} {
   if (value.isString()) {
-    return value.getString();
+    return {bindingPropertyName: value.getString(), classPropertyName: key};
   }
 
   const values = value.getArray().map(innerValue => innerValue.getString());
@@ -92,7 +93,7 @@ function toInputMapping<TExpression>(value: AstValue<string|[string, string], TE
         value.expression,
         'Unsupported input, expected a string or an array containing exactly two strings');
   }
-  return values as [string, string];
+  return {bindingPropertyName: values[0], classPropertyName: values[1]};
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -27,7 +27,7 @@ import {ExtendedTemplateChecker} from '../../../typecheck/extended/api';
 import {getSourceFile} from '../../../util/src/typescript';
 import {Xi18nContext} from '../../../xi18n';
 import {combineResolvers, compileDeclareFactory, compileNgFactoryDefField, compileResults, extractClassMetadata, extractSchemas, findAngularDecorator, forwardRefResolver, getDirectiveDiagnostics, getProviderDiagnostics, InjectableClassRegistry, isExpressionForwardReference, readBaseClass, resolveEnumValue, resolveImportedFile, resolveLiteral, resolveProvidersRequiringFactory, ResourceLoader, toFactoryMetadata, validateHostDirectives, wrapFunctionExpressionsInParens,} from '../../common';
-import {extractDirectiveMetadata, parseFieldArrayValue} from '../../directive';
+import {extractDirectiveMetadata, parseFieldStringArrayValue} from '../../directive';
 import {createModuleWithProvidersResolver, NgModuleSymbol} from '../../ng_module';
 
 import {checkCustomElementSelectorForErrors, makeCyclicImportInfo} from './diagnostics';
@@ -36,7 +36,6 @@ import {_extractTemplateStyleUrls, extractComponentStyleUrls, extractStyleResour
 import {ComponentSymbol} from './symbol';
 import {animationTriggerResolver, collectAnimationNames, validateAndFlattenComponentImports} from './util';
 
-const EMPTY_MAP = new Map<string, Expression>();
 const EMPTY_ARRAY: any[] = [];
 
 /**
@@ -153,7 +152,7 @@ export class ComponentDecoratorHandler implements
     // Extract inline styles, process, and cache for use in synchronous analyze phase
     let inlineStyles;
     if (component.has('styles')) {
-      const litStyles = parseFieldArrayValue(component, 'styles', this.evaluator);
+      const litStyles = parseFieldStringArrayValue(component, 'styles', this.evaluator);
       if (litStyles === null) {
         this.preanalyzeStylesCache.set(node, null);
       } else {
@@ -403,7 +402,7 @@ export class ComponentDecoratorHandler implements
       }
 
       if (component.has('styles')) {
-        const litStyles = parseFieldArrayValue(component, 'styles', this.evaluator);
+        const litStyles = parseFieldStringArrayValue(component, 'styles', this.evaluator);
         if (litStyles !== null) {
           inlineStyles = [...litStyles];
           styles.push(...litStyles);

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -10,7 +10,7 @@ import {AnimationTriggerNames, R3ClassMetadata, R3ComponentMetadata, R3TemplateD
 import ts from 'typescript';
 
 import {Reference} from '../../../imports';
-import {ClassPropertyMapping, ComponentResources, DirectiveTypeCheckMeta, HostDirectiveMeta} from '../../../metadata';
+import {ClassPropertyMapping, ComponentResources, DirectiveTypeCheckMeta, HostDirectiveMeta, InputMapping} from '../../../metadata';
 import {ClassDeclaration} from '../../../reflection';
 import {SubsetOfKeys} from '../../../util/src/typescript';
 
@@ -36,7 +36,7 @@ export interface ComponentAnalysisData {
   template: ParsedTemplateWithSource;
   classMetadata: R3ClassMetadata|null;
 
-  inputs: ClassPropertyMapping;
+  inputs: ClassPropertyMapping<InputMapping>;
   outputs: ClassPropertyMapping;
 
   /**

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -11,7 +11,7 @@ import ts from 'typescript';
 
 import {Reference, ReferenceEmitter} from '../../../imports';
 import {extractSemanticTypeParameters, SemanticDepGraphUpdater} from '../../../incremental/semantic_graph';
-import {ClassPropertyMapping, DirectiveTypeCheckMeta, extractDirectiveTypeCheckMeta, HostDirectiveMeta, MatchSource, MetadataReader, MetadataRegistry, MetaKind} from '../../../metadata';
+import {ClassPropertyMapping, DirectiveTypeCheckMeta, extractDirectiveTypeCheckMeta, HostDirectiveMeta, InputMapping, MatchSource, MetadataReader, MetadataRegistry, MetaKind} from '../../../metadata';
 import {PartialEvaluator} from '../../../partial_evaluator';
 import {PerfEvent, PerfRecorder} from '../../../perf';
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, ReflectionHost} from '../../../reflection';
@@ -37,7 +37,7 @@ export interface DirectiveHandlerData {
   meta: R3DirectiveMetadata;
   classMetadata: R3ClassMetadata|null;
   providersRequiringFactory: Set<Reference<ClassDeclaration>>|null;
-  inputs: ClassPropertyMapping;
+  inputs: ClassPropertyMapping<InputMapping>;
   outputs: ClassPropertyMapping;
   isPoisoned: boolean;
   isStructural: boolean;

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -11,7 +11,7 @@ import ts from 'typescript';
 
 import {ErrorCode, FatalDiagnosticError} from '../../../diagnostics';
 import {Reference, ReferenceEmitter} from '../../../imports';
-import {ClassPropertyMapping, HostDirectiveMeta} from '../../../metadata';
+import {ClassPropertyMapping, HostDirectiveMeta, InputMapping} from '../../../metadata';
 import {DynamicValue, EnumValue, PartialEvaluator, ResolvedValue} from '../../../partial_evaluator';
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, filterToMembersWithDecorator, isNamedClassDeclaration, ReflectionHost, reflectObjectLiteral} from '../../../reflection';
 import {HandlerFlags} from '../../../transform';
@@ -37,7 +37,7 @@ export function extractDirectiveMetadata(
     annotateForClosureCompiler: boolean, defaultSelector: string|null = null): {
   decorator: Map<string, ts.Expression>,
   metadata: R3DirectiveMetadata,
-  inputs: ClassPropertyMapping,
+  inputs: ClassPropertyMapping<InputMapping>,
   outputs: ClassPropertyMapping,
   isStructural: boolean;
   hostDirectives: HostDirectiveMeta[] | null, rawHostDirectives: ts.Expression | null,
@@ -74,19 +74,18 @@ export function extractDirectiveMetadata(
   const coreModule = isCore ? undefined : '@angular/core';
 
   // Construct the map of inputs both from the @Directive/@Component
-  // decorator, and the decorated
-  // fields.
-  const inputsFromMeta = parseFieldToPropertyMapping(directive, 'inputs', evaluator);
-  const inputsFromFields = parseDecoratedFields(
-      filterToMembersWithDecorator(decoratedElements, 'Input', coreModule), evaluator,
-      resolveInput);
+  // decorator, and the decorated fields.
+  const inputsFromMeta = parseInputsArray(directive, evaluator);
+  const inputsFromFields = parseInputFields(
+      filterToMembersWithDecorator(decoratedElements, 'Input', coreModule), evaluator);
+  const inputs = ClassPropertyMapping.fromMappedObject({...inputsFromMeta, ...inputsFromFields});
 
   // And outputs.
-  const outputsFromMeta = parseFieldToPropertyMapping(directive, 'outputs', evaluator);
-  const outputsFromFields =
-      parseDecoratedFields(
-          filterToMembersWithDecorator(decoratedElements, 'Output', coreModule), evaluator,
-          resolveOutput) as {[field: string]: string};
+  const outputsFromMeta = parseOutputsArray(directive, evaluator);
+  const outputsFromFields = parseOutputFields(
+      filterToMembersWithDecorator(decoratedElements, 'Output', coreModule), evaluator);
+  const outputs = ClassPropertyMapping.fromMappedObject({...outputsFromMeta, ...outputsFromFields});
+
   // Construct the list of queries.
   const contentChildFromFields = queriesFromFields(
       filterToMembersWithDecorator(decoratedElements, 'ContentChild', coreModule), reflector,
@@ -185,8 +184,6 @@ export function extractDirectiveMetadata(
   const sourceFile = clazz.getSourceFile();
   const type = wrapTypeReference(reflector, clazz);
   const internalType = new WrappedNodeExpr(reflector.getInternalNameOfClass(clazz));
-  const inputs = ClassPropertyMapping.fromMappedObject({...inputsFromMeta, ...inputsFromFields});
-  const outputs = ClassPropertyMapping.fromMappedObject({...outputsFromMeta, ...outputsFromFields});
   const rawHostDirectives = directive.get('hostDirectives') || null;
   const hostDirectives =
       rawHostDirectives === null ? null : extractHostDirectives(rawHostDirectives, evaluator);
@@ -448,7 +445,7 @@ function extractQueriesFromDecorator(
   return {content, view};
 }
 
-export function parseFieldArrayValue(
+export function parseFieldStringArrayValue(
     directive: Map<string, ts.Expression>, field: string, evaluator: PartialEvaluator): null|
     string[] {
   if (!directive.has(field)) {
@@ -512,76 +509,142 @@ function isPropertyTypeMember(member: ClassMember): boolean {
       member.kind === ClassMemberKind.Property;
 }
 
-/**
- * Interpret property mapping fields on the decorator (e.g. inputs or outputs) and return the
- * correctly shaped metadata object.
- */
-function parseFieldToPropertyMapping(
-    directive: Map<string, ts.Expression>, field: string,
-    evaluator: PartialEvaluator): {[field: string]: string} {
-  const metaValues = parseFieldArrayValue(directive, field, evaluator);
-  return metaValues ? parseInputOutputMappingArray(metaValues) : EMPTY_OBJECT;
-}
-
-function parseInputOutputMappingArray(values: string[]) {
+function parseMappingStringArray(values: string[]) {
   return values.reduce((results, value) => {
     if (typeof value !== 'string') {
       throw new Error('Mapping value must be a string');
     }
 
-    // Either the value is 'field' or 'field: property'. In the first case, `property` will
-    // be undefined, in which case the field name should also be used as the property name.
-    const [field, property] = value.split(':', 2).map(str => str.trim());
-    results[field] = property || field;
+    const [bindingPropertyName, fieldName] = parseMappingString(value);
+    results[fieldName] = bindingPropertyName;
     return results;
   }, {} as {[field: string]: string});
 }
 
+function parseMappingString(value: string): [bindingPropertyName: string, fieldName: string] {
+  // Either the value is 'field' or 'field: property'. In the first case, `property` will
+  // be undefined, in which case the field name should also be used as the property name.
+  const [fieldName, bindingPropertyName] = value.split(':', 2).map(str => str.trim());
+  return [bindingPropertyName ?? fieldName, fieldName];
+}
+
 /**
- * Parse property decorators (e.g. `Input` or `Output`) and return the correctly shaped metadata
- * object.
+ * Parse property decorators (e.g. `Input` or `Output`) and invoke callback with the parsed data.
  */
 function parseDecoratedFields(
     fields: {member: ClassMember, decorators: Decorator[]}[], evaluator: PartialEvaluator,
-    mapValueResolver: (publicName: string, internalName: string) =>
-        string | [string, string]): {[field: string]: string|[string, string]} {
-  return fields.reduce((results, field) => {
+    callback: (fieldName: string, fieldValue: ResolvedValue, decorator: Decorator) => void): void {
+  for (const field of fields) {
     const fieldName = field.member.name;
-    field.decorators.forEach(decorator => {
-      // The decorator either doesn't have an argument (@Input()) in which case the property
-      // name is used, or it has one argument (@Output('named')).
-      if (decorator.args == null || decorator.args.length === 0) {
-        results[fieldName] = fieldName;
-      } else if (decorator.args.length === 1) {
-        const property = evaluator.evaluate(decorator.args[0]);
-        if (typeof property !== 'string') {
-          throw createValueHasWrongTypeError(
-              Decorator.nodeForError(decorator), property,
-              `@${decorator.name} decorator argument must resolve to a string`);
-        }
-        results[fieldName] = mapValueResolver(property, fieldName);
-      } else {
-        // Too many arguments.
+
+    for (const decorator of field.decorators) {
+      if (decorator.args != null && decorator.args.length > 1) {
         throw new FatalDiagnosticError(
             ErrorCode.DECORATOR_ARITY_WRONG, Decorator.nodeForError(decorator),
             `@${decorator.name} can have at most one argument, got ${
                 decorator.args.length} argument(s)`);
       }
-    });
-    return results;
-  }, {} as {[field: string]: string | [string, string]});
+
+      const value = decorator.args != null && decorator.args.length > 0 ?
+          evaluator.evaluate(decorator.args[0]) :
+          null;
+
+      callback(fieldName, value, decorator);
+    }
+  }
 }
 
-function resolveInput(publicName: string, internalName: string): [string, string] {
-  return [publicName, internalName];
+/** Parses the `inputs` array of a directive/component decorator. */
+function parseInputsArray(
+    decoratorMetadata: Map<string, ts.Expression>,
+    evaluator: PartialEvaluator): Record<string, InputMapping> {
+  const inputsField = decoratorMetadata.get('inputs');
+
+  if (inputsField === undefined) {
+    return {};
+  }
+
+  const inputs = {} as Record<string, InputMapping>;
+  const inputsArray = evaluator.evaluate(inputsField);
+
+  // TODO(required-inputs): change the error wording here
+  if (!Array.isArray(inputsArray)) {
+    throw createValueHasWrongTypeError(
+        inputsField, inputsArray, `Failed to resolve @Directive.inputs to a string array`);
+  }
+
+  for (const value of inputsArray) {
+    // TODO(required-inputs): parse object-based config.
+    if (typeof value === 'string') {
+      // If the value is a string, we treat it as a mapping string.
+      const [bindingPropertyName, fieldName] = parseMappingString(value);
+      inputs[fieldName] = {bindingPropertyName, classPropertyName: fieldName, required: false};
+    } else {
+      // TODO(required-inputs): change the error wording here
+      throw createValueHasWrongTypeError(
+          inputsField, value, `Failed to resolve @Directive.inputs to a string array`);
+    }
+  }
+
+  return inputs;
 }
 
-function resolveOutput(publicName: string, internalName: string) {
-  return publicName;
+/** Parses the class members that are decorated as inputs. */
+function parseInputFields(
+    inputMembers: {member: ClassMember, decorators: Decorator[]}[],
+    evaluator: PartialEvaluator): Record<string, InputMapping> {
+  const inputs = {} as Record<string, InputMapping>;
+
+  parseDecoratedFields(inputMembers, evaluator, (fieldName, options, decorator) => {
+    let bindingPropertyName: string;
+
+    // TODO(required-inputs): parse object-based config.
+    if (options === null) {
+      bindingPropertyName = fieldName;
+    } else if (typeof options === 'string') {
+      bindingPropertyName = options;
+    } else {
+      // TODO(required-inputs): change the error wording here
+      throw createValueHasWrongTypeError(
+          Decorator.nodeForError(decorator), options,
+          `@${decorator.name} decorator argument must resolve to a string`);
+    }
+
+    inputs[fieldName] = {
+      bindingPropertyName: bindingPropertyName ?? fieldName,
+      classPropertyName: fieldName,
+      required: false
+    };
+  });
+
+  return inputs;
 }
-type StringMap<T> = {
-  [key: string]: T;
-};
+
+/** Parses the `outputs` array of a directive/component. */
+function parseOutputsArray(
+    directive: Map<string, ts.Expression>, evaluator: PartialEvaluator): Record<string, string> {
+  const metaValues = parseFieldStringArrayValue(directive, 'outputs', evaluator);
+  return metaValues ? parseMappingStringArray(metaValues) : EMPTY_OBJECT;
+}
+
+/** Parses the class members that are decorated as outputs. */
+function parseOutputFields(
+    outputMembers: {member: ClassMember, decorators: Decorator[]}[],
+    evaluator: PartialEvaluator): Record<string, string> {
+  const outputs = {} as Record<string, string>;
+
+  parseDecoratedFields(outputMembers, evaluator, (fieldName, bindingPropertyName, decorator) => {
+    if (bindingPropertyName != null && typeof bindingPropertyName !== 'string') {
+      throw createValueHasWrongTypeError(
+          Decorator.nodeForError(decorator), bindingPropertyName,
+          `@${decorator.name} decorator argument must resolve to a string`);
+    }
+
+    outputs[fieldName] = bindingPropertyName ?? fieldName;
+  });
+
+  return outputs;
+}
 
 function evaluateHostExpressionBindings(
     hostExpr: ts.Expression, evaluator: PartialEvaluator): ParsedHostBindings {
@@ -590,7 +653,7 @@ function evaluateHostExpressionBindings(
     throw createValueHasWrongTypeError(
         hostExpr, hostMetaMap, `Decorator host metadata must be an object`);
   }
-  const hostMetadata: StringMap<string|Expression> = {};
+  const hostMetadata: Record<string, string|Expression> = {};
   hostMetaMap.forEach((value, key) => {
     // Resolve Enum references to their declared value.
     if (value instanceof EnumValue) {
@@ -673,13 +736,13 @@ function extractHostDirectives(
  */
 function parseHostDirectivesMapping(
     field: 'inputs'|'outputs', resolvedValue: ResolvedValue, classReference: ClassDeclaration,
-    sourceExpression: ts.Expression): {[publicName: string]: string}|null {
+    sourceExpression: ts.Expression): {[bindingPropertyName: string]: string}|null {
   if (resolvedValue instanceof Map && resolvedValue.has(field)) {
     const nameForErrors = `@Directive.hostDirectives.${classReference.name.text}.${field}`;
     const rawInputs = resolvedValue.get(field);
 
     if (isStringArrayOrDie(rawInputs, nameForErrors, sourceExpression)) {
-      return parseInputOutputMappingArray(rawInputs);
+      return parseMappingStringArray(rawInputs);
     }
   }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -595,12 +595,12 @@ function parseInputFields(
     evaluator: PartialEvaluator): Record<string, InputMapping> {
   const inputs = {} as Record<string, InputMapping>;
 
-  parseDecoratedFields(inputMembers, evaluator, (fieldName, options, decorator) => {
+  parseDecoratedFields(inputMembers, evaluator, (classPropertyName, options, decorator) => {
     let bindingPropertyName: string;
 
     // TODO(required-inputs): parse object-based config.
     if (options === null) {
-      bindingPropertyName = fieldName;
+      bindingPropertyName = classPropertyName;
     } else if (typeof options === 'string') {
       bindingPropertyName = options;
     } else {
@@ -610,11 +610,7 @@ function parseInputFields(
           `@${decorator.name} decorator argument must resolve to a string`);
     }
 
-    inputs[fieldName] = {
-      bindingPropertyName: bindingPropertyName ?? fieldName,
-      classPropertyName: fieldName,
-      required: false
-    };
+    inputs[classPropertyName] = {bindingPropertyName, classPropertyName, required: false};
   });
 
   return inputs;

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/symbol.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/symbol.ts
@@ -7,7 +7,7 @@
  */
 
 import {areTypeParametersEqual, isArrayEqual, isSetEqual, isSymbolEqual, SemanticSymbol, SemanticTypeParameter} from '../../../incremental/semantic_graph';
-import {BindingPropertyName, ClassPropertyMapping, ClassPropertyName, DirectiveTypeCheckMeta, TemplateGuardMeta} from '../../../metadata';
+import {ClassPropertyMapping, DirectiveTypeCheckMeta, InputMapping, InputOrOutput, TemplateGuardMeta} from '../../../metadata';
 import {ClassDeclaration} from '../../../reflection';
 
 /**
@@ -19,8 +19,8 @@ export class DirectiveSymbol extends SemanticSymbol {
 
   constructor(
       decl: ClassDeclaration, public readonly selector: string|null,
-      public readonly inputs: ClassPropertyMapping, public readonly outputs: ClassPropertyMapping,
-      public readonly exportAs: string[]|null,
+      public readonly inputs: ClassPropertyMapping<InputMapping>,
+      public readonly outputs: ClassPropertyMapping, public readonly exportAs: string[]|null,
       public readonly typeCheckMeta: DirectiveTypeCheckMeta,
       public readonly typeParameters: SemanticTypeParameter[]|null) {
     super(decl);
@@ -60,7 +60,7 @@ export class DirectiveSymbol extends SemanticSymbol {
     if (!isArrayEqual(
             Array.from(this.inputs), Array.from(previousSymbol.inputs), isInputMappingEqual) ||
         !isArrayEqual(
-            Array.from(this.outputs), Array.from(previousSymbol.outputs), isInputMappingEqual)) {
+            Array.from(this.outputs), Array.from(previousSymbol.outputs), isInputOrOutputEqual)) {
       return true;
     }
 
@@ -87,10 +87,13 @@ export class DirectiveSymbol extends SemanticSymbol {
   }
 }
 
-function isInputMappingEqual(
-    current: [ClassPropertyName, BindingPropertyName],
-    previous: [ClassPropertyName, BindingPropertyName]): boolean {
-  return current[0] === previous[0] && current[1] === previous[1];
+function isInputMappingEqual(current: InputMapping, previous: InputMapping): boolean {
+  return isInputOrOutputEqual(current, previous) && current.required === previous.required;
+}
+
+function isInputOrOutputEqual(current: InputOrOutput, previous: InputOrOutput): boolean {
+  return current.classPropertyName === previous.classPropertyName &&
+      current.bindingPropertyName === previous.bindingPropertyName;
 }
 
 function isTypeCheckMetaEqual(

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/symbol.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/symbol.ts
@@ -87,6 +87,7 @@ export class DirectiveSymbol extends SemanticSymbol {
   }
 }
 
+// TODO(required-inputs): add a test for this logic in `incremental_semantic_changes_spec.ts`
 function isInputMappingEqual(current: InputMapping, previous: InputMapping): boolean {
   return isInputOrOutputEqual(current, previous) && current.required === previous.required;
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -12,7 +12,7 @@ import ts from 'typescript';
 import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
 
-import {ClassPropertyMapping, ClassPropertyName} from './property_mapping';
+import {ClassPropertyMapping, ClassPropertyName, InputOrOutput} from './property_mapping';
 
 /**
  * Metadata collected for an `NgModule`.
@@ -123,6 +123,9 @@ export enum MatchSource {
   HostDirective,
 }
 
+/** Metadata for a single input mapping. */
+export type InputMapping = InputOrOutput&{required: boolean};
+
 /**
  * Metadata collected for a directive within an NgModule's scope.
  */
@@ -142,7 +145,7 @@ export interface DirectiveMeta extends T2DirectiveMeta, DirectiveTypeCheckMeta {
   /**
    * A mapping of input field names to the property names.
    */
-  inputs: ClassPropertyMapping;
+  inputs: ClassPropertyMapping<InputMapping>;
 
   /**
    * A mapping of output field names to the property names.

--- a/packages/compiler-cli/src/ngtsc/metadata/src/host_directives_resolver.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/host_directives_resolver.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {DirectiveMeta, MatchSource, MetadataReader} from '../../metadata/src/api';
+import {DirectiveMeta, InputMapping, MatchSource, MetadataReader} from '../../metadata/src/api';
 import {ClassDeclaration} from '../../reflection';
-import {BindingPropertyName, ClassPropertyMapping, ClassPropertyName} from '../src/property_mapping';
+import {ClassPropertyMapping, InputOrOutput} from '../src/property_mapping';
 
 import {flattenInheritedDirectiveMetadata} from './inheritance';
 
@@ -55,8 +55,10 @@ export class HostDirectivesResolver {
       results.push({
         ...hostMeta,
         matchSource: MatchSource.HostDirective,
-        inputs: this.filterMappings(hostMeta.inputs, current.inputs),
-        outputs: this.filterMappings(hostMeta.outputs, current.outputs),
+        inputs: ClassPropertyMapping.fromMappedObject(
+            this.filterMappings(hostMeta.inputs, current.inputs, resolveInput)),
+        outputs: ClassPropertyMapping.fromMappedObject(
+            this.filterMappings(hostMeta.outputs, current.outputs, resolveOutput)),
       });
     }
 
@@ -67,11 +69,12 @@ export class HostDirectivesResolver {
    * Filters the class property mappings so that only the allowed ones are present.
    * @param source Property mappings that should be filtered.
    * @param allowedProperties Property mappings that are allowed in the final results.
+   * @param valueResolver Function used to resolve the value that is assigned to the final mapping.
    */
-  private filterMappings(
-      source: ClassPropertyMapping,
-      allowedProperties: {[publicName: string]: string}|null): ClassPropertyMapping {
-    const result: Record<string, BindingPropertyName|[ClassPropertyName, BindingPropertyName]> = {};
+  private filterMappings<T, M extends InputOrOutput>(
+      source: ClassPropertyMapping<M>, allowedProperties: Record<string, string>|null,
+      valueResolver: (binding: string, classPropertyName: string) => T): Record<string, T> {
+    const result: Record<string, T> = {};
 
     if (allowedProperties !== null) {
       for (const publicName in allowedProperties) {
@@ -80,13 +83,23 @@ export class HostDirectivesResolver {
 
           if (bindings !== null) {
             for (const binding of bindings) {
-              result[binding.classPropertyName] = allowedProperties[publicName];
+              result[binding.classPropertyName] =
+                  valueResolver(allowedProperties[publicName], binding.classPropertyName);
             }
           }
         }
       }
     }
 
-    return ClassPropertyMapping.fromMappedObject(result);
+    return result;
   }
+}
+
+function resolveInput(bindingName: string, classPropertyName: string): InputMapping {
+  // TODO(required-inputs): resolve the required value
+  return {bindingPropertyName: bindingName, classPropertyName, required: false};
+}
+
+function resolveOutput(bindingName: string): string {
+  return bindingName;
 }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/inheritance.ts
@@ -9,7 +9,7 @@
 import {Reference} from '../../imports';
 import {ClassDeclaration} from '../../reflection';
 
-import {DirectiveMeta, MetadataReader} from './api';
+import {DirectiveMeta, InputMapping, MetadataReader} from './api';
 import {ClassPropertyMapping, ClassPropertyName} from './property_mapping';
 
 /**
@@ -35,7 +35,7 @@ export function flattenInheritedDirectiveMetadata(
   const restrictedInputFields = new Set<ClassPropertyName>();
   const stringLiteralInputFields = new Set<ClassPropertyName>();
   let isDynamic = false;
-  let inputs = ClassPropertyMapping.empty();
+  let inputs = ClassPropertyMapping.empty<InputMapping>();
   let outputs = ClassPropertyMapping.empty();
   let isStructural: boolean = false;
 

--- a/packages/compiler-cli/src/ngtsc/metadata/src/property_mapping.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/property_mapping.ts
@@ -163,7 +163,6 @@ export class ClassPropertyMapping<T extends InputOrOutput = InputOrOutput> imple
     return obj;
   }
 
-  // TODO: rename this method?
   /**
    * Convert this mapping to a primitive JS object which maps each class property either to itself
    * (for cases where the binding property name is the same) or to an array which contains both
@@ -184,7 +183,7 @@ export class ClassPropertyMapping<T extends InputOrOutput = InputOrOutput> imple
    * property names (and are useful for destructuring).
    */
   * [Symbol.iterator](): IterableIterator<T> {
-    for (const [_classPropertyName, inputOrOutput] of this.forwardMap.entries()) {
+    for (const inputOrOutput of this.forwardMap.values()) {
       yield inputOrOutput;
     }
   }

--- a/packages/compiler-cli/src/ngtsc/metadata/src/property_mapping.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/property_mapping.ts
@@ -50,18 +50,19 @@ export interface InputOrOutput {
  * Allows bidirectional querying of the mapping - looking up all inputs/outputs with a given
  * property name, or mapping from a specific class property to its binding property name.
  */
-export class ClassPropertyMapping implements InputOutputPropertySet {
+export class ClassPropertyMapping<T extends InputOrOutput = InputOrOutput> implements
+    InputOutputPropertySet {
   /**
    * Mapping from class property names to the single `InputOrOutput` for that class property.
    */
-  private forwardMap: Map<ClassPropertyName, InputOrOutput>;
+  private forwardMap: Map<ClassPropertyName, T>;
 
   /**
    * Mapping from property names to one or more `InputOrOutput`s which share that name.
    */
-  private reverseMap: Map<BindingPropertyName, InputOrOutput[]>;
+  private reverseMap: Map<BindingPropertyName, T[]>;
 
-  private constructor(forwardMap: Map<ClassPropertyName, InputOrOutput>) {
+  private constructor(forwardMap: Map<ClassPropertyName, T>) {
     this.forwardMap = forwardMap;
     this.reverseMap = reverseMapFromForwardMap(forwardMap);
   }
@@ -69,7 +70,7 @@ export class ClassPropertyMapping implements InputOutputPropertySet {
   /**
    * Construct a `ClassPropertyMapping` with no entries.
    */
-  static empty(): ClassPropertyMapping {
+  static empty<T extends InputOrOutput>(): ClassPropertyMapping<T> {
     return new ClassPropertyMapping(new Map());
   }
 
@@ -78,15 +79,23 @@ export class ClassPropertyMapping implements InputOutputPropertySet {
    * to either binding property names or an array that contains both names, which is used in on-disk
    * metadata formats (e.g. in .d.ts files).
    */
-  static fromMappedObject(obj: {
-    [classPropertyName: string]: BindingPropertyName|[ClassPropertyName, BindingPropertyName]
-  }): ClassPropertyMapping {
-    const forwardMap = new Map<ClassPropertyName, InputOrOutput>();
+  static fromMappedObject<T extends InputOrOutput>(obj: {
+    [classPropertyName: string]: BindingPropertyName|[ClassPropertyName, BindingPropertyName]|T
+  }): ClassPropertyMapping<T> {
+    const forwardMap = new Map<ClassPropertyName, T>();
 
     for (const classPropertyName of Object.keys(obj)) {
       const value = obj[classPropertyName];
-      const bindingPropertyName = Array.isArray(value) ? value[0] : value;
-      const inputOrOutput: InputOrOutput = {classPropertyName, bindingPropertyName};
+      let inputOrOutput: T;
+
+      if (typeof value === 'string') {
+        inputOrOutput = {classPropertyName, bindingPropertyName: value} as T;
+      } else if (Array.isArray(value)) {
+        inputOrOutput = {classPropertyName, bindingPropertyName: value[0]} as T;
+      } else {
+        inputOrOutput = value;
+      }
+
       forwardMap.set(classPropertyName, inputOrOutput);
     }
 
@@ -97,8 +106,9 @@ export class ClassPropertyMapping implements InputOutputPropertySet {
    * Merge two mappings into one, with class properties from `b` taking precedence over class
    * properties from `a`.
    */
-  static merge(a: ClassPropertyMapping, b: ClassPropertyMapping): ClassPropertyMapping {
-    const forwardMap = new Map<ClassPropertyName, InputOrOutput>(a.forwardMap.entries());
+  static merge<T extends InputOrOutput>(a: ClassPropertyMapping<T>, b: ClassPropertyMapping<T>):
+      ClassPropertyMapping<T> {
+    const forwardMap = new Map<ClassPropertyName, T>(a.forwardMap.entries());
     for (const [classPropertyName, inputOrOutput] of b.forwardMap) {
       forwardMap.set(classPropertyName, inputOrOutput);
     }
@@ -130,14 +140,14 @@ export class ClassPropertyMapping implements InputOutputPropertySet {
   /**
    * Lookup all `InputOrOutput`s that use this `propertyName`.
    */
-  getByBindingPropertyName(propertyName: string): ReadonlyArray<InputOrOutput>|null {
+  getByBindingPropertyName(propertyName: string): ReadonlyArray<T>|null {
     return this.reverseMap.has(propertyName) ? this.reverseMap.get(propertyName)! : null;
   }
 
   /**
    * Lookup the `InputOrOutput` associated with a `classPropertyName`.
    */
-  getByClassPropertyName(classPropertyName: string): InputOrOutput|null {
+  getByClassPropertyName(classPropertyName: string): T|null {
     return this.forwardMap.has(classPropertyName) ? this.forwardMap.get(classPropertyName)! : null;
   }
 
@@ -153,6 +163,7 @@ export class ClassPropertyMapping implements InputOutputPropertySet {
     return obj;
   }
 
+  // TODO: rename this method?
   /**
    * Convert this mapping to a primitive JS object which maps each class property either to itself
    * (for cases where the binding property name is the same) or to an array which contains both
@@ -160,17 +171,10 @@ export class ClassPropertyMapping implements InputOutputPropertySet {
    *
    * This object format is used when mappings are serialized (for example into .d.ts files).
    */
-  toJointMappedObject():
-      {[classPropertyName: string]: BindingPropertyName|[BindingPropertyName, ClassPropertyName]} {
-    const obj: {
-      [classPropertyName: string]: BindingPropertyName|[BindingPropertyName, ClassPropertyName]
-    } = {};
+  toJointMappedObject(): {[classPropertyName: string]: T} {
+    const obj: {[classPropertyName: string]: T} = {};
     for (const [classPropertyName, inputOrOutput] of this.forwardMap) {
-      if (inputOrOutput.bindingPropertyName as string === classPropertyName as string) {
-        obj[classPropertyName] = inputOrOutput.bindingPropertyName;
-      } else {
-        obj[classPropertyName] = [inputOrOutput.bindingPropertyName, classPropertyName];
-      }
+      obj[classPropertyName] = inputOrOutput;
     }
     return obj;
   }
@@ -179,16 +183,16 @@ export class ClassPropertyMapping implements InputOutputPropertySet {
    * Implement the iterator protocol and return entry objects which contain the class and binding
    * property names (and are useful for destructuring).
    */
-  * [Symbol.iterator](): IterableIterator<[ClassPropertyName, BindingPropertyName]> {
-    for (const [classPropertyName, inputOrOutput] of this.forwardMap.entries()) {
-      yield [classPropertyName, inputOrOutput.bindingPropertyName];
+  * [Symbol.iterator](): IterableIterator<T> {
+    for (const [_classPropertyName, inputOrOutput] of this.forwardMap.entries()) {
+      yield inputOrOutput;
     }
   }
 }
 
-function reverseMapFromForwardMap(forwardMap: Map<ClassPropertyName, InputOrOutput>):
-    Map<BindingPropertyName, InputOrOutput[]> {
-  const reverseMap = new Map<BindingPropertyName, InputOrOutput[]>();
+function reverseMapFromForwardMap<T extends InputOrOutput>(forwardMap: Map<ClassPropertyName, T>):
+    Map<BindingPropertyName, T[]> {
+  const reverseMap = new Map<BindingPropertyName, T[]>();
   for (const [_, inputOrOutput] of forwardMap) {
     if (!reverseMap.has(inputOrOutput.bindingPropertyName)) {
       reverseMap.set(inputOrOutput.bindingPropertyName, []);

--- a/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/util.ts
@@ -12,7 +12,7 @@ import {OwningModule, Reference} from '../../imports';
 import {ClassDeclaration, ClassMember, ClassMemberKind, isNamedClassDeclaration, ReflectionHost, reflectTypeEntityToDeclaration} from '../../reflection';
 import {nodeDebugInfo} from '../../util/src/typescript';
 
-import {DirectiveMeta, DirectiveTypeCheckMeta, MetadataReader, NgModuleMeta, PipeMeta, TemplateGuardMeta} from './api';
+import {DirectiveMeta, DirectiveTypeCheckMeta, InputMapping, MetadataReader, NgModuleMeta, PipeMeta, TemplateGuardMeta} from './api';
 import {ClassPropertyMapping, ClassPropertyName} from './property_mapping';
 
 export function extractReferencesFromType(
@@ -112,7 +112,7 @@ export function readStringArrayType(type: ts.TypeNode): string[] {
  * making this metadata invariant to changes of inherited classes.
  */
 export function extractDirectiveTypeCheckMeta(
-    node: ClassDeclaration, inputs: ClassPropertyMapping,
+    node: ClassDeclaration, inputs: ClassPropertyMapping<InputMapping>,
     reflector: ReflectionHost): DirectiveTypeCheckMeta {
   const members = reflector.getMembersOfClass(node);
   const staticMembers = members.filter(member => member.isStatic);

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -9,7 +9,7 @@
 import ts from 'typescript';
 
 import {Reference, ReferenceEmitter} from '../../imports';
-import {ClassPropertyMapping, CompoundMetadataRegistry, DirectiveMeta, DtsMetadataReader, LocalMetadataRegistry, MatchSource, MetadataRegistry, MetaKind, PipeMeta} from '../../metadata';
+import {ClassPropertyMapping, CompoundMetadataRegistry, DirectiveMeta, LocalMetadataRegistry, MatchSource, MetadataRegistry, MetaKind, PipeMeta} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 import {LocalModuleScope, ScopeData} from '../src/api';
 import {DtsModuleScopeResolver} from '../src/dependency';

--- a/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/api.ts
@@ -11,7 +11,7 @@ import ts from 'typescript';
 
 import {ErrorCode} from '../../diagnostics';
 import {Reference} from '../../imports';
-import {ClassPropertyMapping, DirectiveTypeCheckMeta, HostDirectiveMeta} from '../../metadata';
+import {ClassPropertyMapping, DirectiveTypeCheckMeta, HostDirectiveMeta, InputMapping} from '../../metadata';
 import {ClassDeclaration} from '../../reflection';
 
 
@@ -22,7 +22,7 @@ import {ClassDeclaration} from '../../reflection';
 export interface TypeCheckableDirectiveMeta extends DirectiveMeta, DirectiveTypeCheckMeta {
   ref: Reference<ClassDeclaration>;
   queries: string[];
-  inputs: ClassPropertyMapping;
+  inputs: ClassPropertyMapping<InputMapping>;
   outputs: ClassPropertyMapping;
   isStandalone: boolean;
   hostDirectives: HostDirectiveMeta[]|null;

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_check_block.ts
@@ -659,9 +659,9 @@ class TcbDirectiveCtorOp extends TcbOp {
     }
 
     // Add unset directive inputs for each of the remaining unset fields.
-    for (const [fieldName] of this.dir.inputs) {
-      if (!genericInputs.has(fieldName)) {
-        genericInputs.set(fieldName, {type: 'unset', field: fieldName});
+    for (const {classPropertyName} of this.dir.inputs) {
+      if (!genericInputs.has(classPropertyName)) {
+        genericInputs.set(classPropertyName, {type: 'unset', field: classPropertyName});
       }
     }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -11,9 +11,9 @@ import ts from 'typescript';
 
 import {absoluteFrom, AbsoluteFsPath, getSourceFileOrError, LogicalFileSystem} from '../../file_system';
 import {TestFile} from '../../file_system/testing';
-import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, Reexport, Reference, ReferenceEmitter, RelativePathStrategy} from '../../imports';
+import {AbsoluteModuleStrategy, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, Reference, ReferenceEmitter, RelativePathStrategy} from '../../imports';
 import {NOOP_INCREMENTAL_BUILD} from '../../incremental';
-import {ClassPropertyMapping, CompoundMetadataReader, DirectiveMeta, HostDirectivesResolver, MatchSource, MetadataReader, MetadataReaderWithIndex, MetaKind, NgModuleIndex, NgModuleMeta, PipeMeta} from '../../metadata';
+import {ClassPropertyMapping, CompoundMetadataReader, DirectiveMeta, HostDirectivesResolver, InputMapping, MatchSource, MetadataReaderWithIndex, MetaKind, NgModuleIndex} from '../../metadata';
 import {NOOP_PERF_RECORDER} from '../../perf';
 import {TsCreateProgramDriver} from '../../program_driver';
 import {ClassDeclaration, isNamedClassDeclaration, TypeScriptReflectionHost} from '../../reflection';
@@ -233,7 +233,12 @@ export interface TestDirective extends Partial<Pick<
   name: string;
   file?: AbsoluteFsPath;
   type: 'directive';
-  inputs?: {[fieldName: string]: string};
+  inputs?: {
+    [fieldName: string]:
+        string|{
+          classPropertyName: string, bindingPropertyName: string, required: boolean
+        }
+  };
   outputs?: {[fieldName: string]: string};
   coercedInputFields?: string[];
   restrictedInputFields?: string[];
@@ -649,7 +654,7 @@ function getDirectiveMetaFromDeclaration(
     exportAs: decl.exportAs || null,
     selector: decl.selector || null,
     hasNgTemplateContextGuard: decl.hasNgTemplateContextGuard || false,
-    inputs: ClassPropertyMapping.fromMappedObject(decl.inputs || {}),
+    inputs: ClassPropertyMapping.fromMappedObject<InputMapping>(decl.inputs || {}),
     isComponent: decl.isComponent || false,
     ngTemplateGuards: decl.ngTemplateGuards || [],
     coercedInputFields: new Set<string>(decl.coercedInputFields || []),
@@ -699,7 +704,7 @@ function makeScope(program: ts.Program, sf: ts.SourceFile, decls: TestDeclaratio
         name: decl.name,
         selector: decl.selector,
         queries: [],
-        inputs: ClassPropertyMapping.fromMappedObject(decl.inputs || {}),
+        inputs: ClassPropertyMapping.fromMappedObject<InputMapping>(decl.inputs || {}),
         outputs: ClassPropertyMapping.fromMappedObject(decl.outputs || {}),
         isComponent: decl.isComponent ?? false,
         exportAs: decl.exportAs ?? null,
@@ -727,8 +732,8 @@ function makeScope(program: ts.Program, sf: ts.SourceFile, decls: TestDeclaratio
                     hostDecl.directive.name)),
                 origin: sf,
                 isForwardReference: false,
-                inputs: hostDecl.directive.inputs || {},
-                outputs: hostDecl.directive.outputs || {},
+                inputs: hostDecl.inputs || {},
+                outputs: hostDecl.outputs || {},
               };
             }),
       });

--- a/packages/compiler/src/compiler_facade_interface.ts
+++ b/packages/compiler/src/compiler_facade_interface.ts
@@ -79,8 +79,9 @@ export type StringMap = {
   [key: string]: string;
 };
 
-export type StringMapWithRename = {
-  [key: string]: string|[string, string];
+export type InputMap = {
+  // TODO(required-inputs): add required field
+  [key: string]: {bindingPropertyName: string, classPropertyName: string};
 };
 
 export type Provider = unknown;

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -7,7 +7,7 @@
  */
 
 
-import {CompilerFacade, CoreEnvironment, ExportedCompilerFacade, OpaqueValue, R3ComponentMetadataFacade, R3DeclareComponentFacade, R3DeclareDependencyMetadataFacade, R3DeclareDirectiveDependencyFacade, R3DeclareDirectiveFacade, R3DeclareFactoryFacade, R3DeclareInjectableFacade, R3DeclareInjectorFacade, R3DeclareNgModuleFacade, R3DeclarePipeDependencyFacade, R3DeclarePipeFacade, R3DeclareQueryMetadataFacade, R3DependencyMetadataFacade, R3DirectiveMetadataFacade, R3FactoryDefMetadataFacade, R3InjectableMetadataFacade, R3InjectorMetadataFacade, R3NgModuleMetadataFacade, R3PipeMetadataFacade, R3QueryMetadataFacade, R3TemplateDependencyFacade, StringMap, StringMapWithRename} from './compiler_facade_interface';
+import {CompilerFacade, CoreEnvironment, ExportedCompilerFacade, InputMap, OpaqueValue, R3ComponentMetadataFacade, R3DeclareComponentFacade, R3DeclareDependencyMetadataFacade, R3DeclareDirectiveDependencyFacade, R3DeclareDirectiveFacade, R3DeclareFactoryFacade, R3DeclareInjectableFacade, R3DeclareInjectorFacade, R3DeclareNgModuleFacade, R3DeclarePipeDependencyFacade, R3DeclarePipeFacade, R3DeclareQueryMetadataFacade, R3DependencyMetadataFacade, R3DirectiveMetadataFacade, R3FactoryDefMetadataFacade, R3InjectableMetadataFacade, R3InjectorMetadataFacade, R3NgModuleMetadataFacade, R3PipeMetadataFacade, R3QueryMetadataFacade, R3TemplateDependencyFacade} from './compiler_facade_interface';
 import {ConstantPool} from './constant_pool';
 import {ChangeDetectionStrategy, HostBinding, HostListener, Input, Output, ViewEncapsulation} from './core';
 import {compileInjectable} from './injectable_compiler_2';
@@ -325,17 +325,20 @@ function convertQueryPredicate(predicate: OpaqueValue|string[]): MaybeForwardRef
 }
 
 function convertDirectiveFacadeToMetadata(facade: R3DirectiveMetadataFacade): R3DirectiveMetadata {
-  const inputsFromMetadata = parseInputOutputs(facade.inputs || []);
-  const outputsFromMetadata = parseInputOutputs(facade.outputs || []);
+  const inputsFromMetadata = parseInputsArray(facade.inputs || []);
+  const outputsFromMetadata = parseMappingStringArray(facade.outputs || []);
   const propMetadata = facade.propMetadata;
-  const inputsFromType: StringMapWithRename = {};
-  const outputsFromType: StringMap = {};
+  const inputsFromType: InputMap = {};
+  const outputsFromType: Record<string, string> = {};
   for (const field in propMetadata) {
     if (propMetadata.hasOwnProperty(field)) {
       propMetadata[field].forEach(ann => {
         if (isInput(ann)) {
-          inputsFromType[field] =
-              ann.bindingPropertyName ? [ann.bindingPropertyName, field] : field;
+          // TODO(required-inputs): pass required flag
+          inputsFromType[field] = {
+            bindingPropertyName: ann.bindingPropertyName || field,
+            classPropertyName: field
+          };
         } else if (isOutput(ann)) {
           outputsFromType[field] = ann.bindingPropertyName || field;
         }
@@ -369,7 +372,7 @@ function convertDeclareDirectiveFacadeToMetadata(
     typeSourceSpan,
     internalType: new WrappedNodeExpr(declaration.type),
     selector: declaration.selector ?? null,
-    inputs: declaration.inputs ?? {},
+    inputs: declaration.inputs ? inputsMappingToInputMetadata(declaration.inputs) : {},
     outputs: declaration.outputs ?? {},
     host: convertHostDeclarationToMetadata(declaration.host),
     queries: (declaration.queries ?? []).map(convertQueryDeclarationToMetadata),
@@ -414,8 +417,8 @@ function convertHostDirectivesToMetadata(
           {
             directive: wrapReference(hostDirective.directive),
             isForwardReference: false,
-            inputs: hostDirective.inputs ? parseInputOutputs(hostDirective.inputs) : null,
-            outputs: hostDirective.outputs ? parseInputOutputs(hostDirective.outputs) : null,
+            inputs: hostDirective.inputs ? parseMappingStringArray(hostDirective.inputs) : null,
+            outputs: hostDirective.outputs ? parseMappingStringArray(hostDirective.outputs) : null,
           };
     });
   }
@@ -661,12 +664,45 @@ function isOutput(value: any): value is Output {
   return value.ngMetadataName === 'Output';
 }
 
-function parseInputOutputs(values: string[]): StringMap {
+function inputsMappingToInputMetadata(inputs: Record<string, string|[string, string]>) {
+  return Object.keys(inputs).reduce((result, key) => {
+    const value = inputs[key];
+    result[key] = typeof value === 'string' ?
+        {bindingPropertyName: value, classPropertyName: value} :
+        {bindingPropertyName: value[0], classPropertyName: value[1]};
+    return result;
+  }, {} as InputMap);
+}
+
+function parseInputsArray(values: (string|{name: string, alias?: string})[]) {
   return values.reduce((results, value) => {
-    const [field, property] = value.split(':', 2).map(str => str.trim());
-    results[field] = property || field;
+    if (typeof value === 'string') {
+      const [bindingPropertyName, fieldName] = parseMappingString(value);
+      results[fieldName] = {bindingPropertyName, classPropertyName: fieldName};
+    } else {
+      // TODO(required-inputs): pass required flag
+      results[value.name] = {
+        bindingPropertyName: value.alias || value.name,
+        classPropertyName: value.name
+      };
+    }
     return results;
-  }, {} as StringMap);
+  }, {} as InputMap);
+}
+
+function parseMappingStringArray(values: string[]): Record<string, string> {
+  return values.reduce((results, value) => {
+    const [publicName, fieldName] = parseMappingString(value);
+    results[fieldName] = publicName;
+    return results;
+  }, {} as Record<string, string>);
+}
+
+function parseMappingString(value: string): [publicName: string, fieldName: string] {
+  // Either the value is 'field' or 'field: property'. In the first case, `property` will
+  // be undefined, in which case the field name should also be used as the property name.
+  const [fieldName, bindingPropertyName] = value.split(':', 2).map(str => str.trim());
+  return [bindingPropertyName ?? fieldName, fieldName];
 }
 
 function convertDeclarePipeFacadeToMetadata(declaration: R3DeclarePipeFacade): R3PipeMetadata {

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -677,8 +677,8 @@ function inputsMappingToInputMetadata(inputs: Record<string, string|[string, str
 function parseInputsArray(values: (string|{name: string, alias?: string})[]) {
   return values.reduce((results, value) => {
     if (typeof value === 'string') {
-      const [bindingPropertyName, fieldName] = parseMappingString(value);
-      results[fieldName] = {bindingPropertyName, classPropertyName: fieldName};
+      const [bindingPropertyName, classPropertyName] = parseMappingString(value);
+      results[classPropertyName] = {bindingPropertyName, classPropertyName};
     } else {
       // TODO(required-inputs): pass required flag
       results[value.name] = {

--- a/packages/compiler/src/render3/partial/directive.ts
+++ b/packages/compiler/src/render3/partial/directive.ts
@@ -10,7 +10,7 @@ import {Identifiers as R3} from '../r3_identifiers';
 import {convertFromMaybeForwardRefExpression, generateForwardRef, R3CompiledExpression} from '../util';
 import {R3DirectiveMetadata, R3HostMetadata, R3QueryMetadata} from '../view/api';
 import {createDirectiveType, createHostDirectivesMappingArray} from '../view/compiler';
-import {asLiteral, conditionallyCreateMapObjectLiteral, DefinitionMap} from '../view/util';
+import {asLiteral, conditionallyCreateDirectiveBindingLiteral, DefinitionMap} from '../view/util';
 
 import {R3DeclareDirectiveMetadata, R3DeclareQueryMetadata} from './api';
 import {toOptionalLiteralMap} from './util';
@@ -60,8 +60,8 @@ export function createDirectiveDefinitionMap(meta: R3DirectiveMetadata):
     definitionMap.set('selector', o.literal(meta.selector));
   }
 
-  definitionMap.set('inputs', conditionallyCreateMapObjectLiteral(meta.inputs, true));
-  definitionMap.set('outputs', conditionallyCreateMapObjectLiteral(meta.outputs));
+  definitionMap.set('inputs', conditionallyCreateDirectiveBindingLiteral(meta.inputs, true));
+  definitionMap.set('outputs', conditionallyCreateDirectiveBindingLiteral(meta.outputs));
 
   definitionMap.set('host', compileHostMetadata(meta.host));
 

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -85,11 +85,12 @@ export interface R3DirectiveMetadata {
     usesOnChanges: boolean;
   };
 
+  // TODO(required-inputs): add `required` to the `inputs` interface.
   /**
    * A mapping of inputs from class property names to binding property names, or to a tuple of
    * binding property name and class property name if the names are different.
    */
-  inputs: {[field: string]: string|[string, string]};
+  inputs: {[field: string]: {classPropertyName: string, bindingPropertyName: string}};
 
   /**
    * A mapping of outputs from class property names to binding property names, or to a tuple of

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -85,12 +85,11 @@ export interface R3DirectiveMetadata {
     usesOnChanges: boolean;
   };
 
-  // TODO(required-inputs): add `required` to the `inputs` interface.
   /**
    * A mapping of inputs from class property names to binding property names, or to a tuple of
    * binding property name and class property name if the names are different.
    */
-  inputs: {[field: string]: {classPropertyName: string, bindingPropertyName: string}};
+  inputs: {[field: string]: R3InputMetadata};
 
   /**
    * A mapping of outputs from class property names to binding property names, or to a tuple of
@@ -251,6 +250,14 @@ export interface R3ComponentMetadata<DeclarationT extends R3TemplateDependency> 
   changeDetection?: ChangeDetectionStrategy;
 }
 
+/**
+ * Metadata for an individual input on a directive.
+ */
+export interface R3InputMetadata {
+  classPropertyName: string;
+  bindingPropertyName: string;
+  // TODO(required-inputs): add `required` property.
+}
 
 export enum R3TemplateDependencyKind {
   Directive = 0,

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -24,7 +24,7 @@ import {prepareSyntheticListenerFunctionName, prepareSyntheticPropertyName, R3Co
 import {DeclarationListEmitMode, R3ComponentMetadata, R3DirectiveMetadata, R3HostMetadata, R3QueryMetadata, R3TemplateDependency} from './api';
 import {MIN_STYLING_BINDING_SLOTS_REQUIRED, StylingBuilder, StylingInstructionCall} from './styling_builder';
 import {BindingScope, makeBindingParser, prepareEventListenerParameters, renderFlagCheckIfStmt, resolveSanitizationFn, TemplateDefinitionBuilder, ValueConverter} from './template';
-import {asLiteral, conditionallyCreateMapObjectLiteral, CONTEXT_NAME, DefinitionMap, getInstructionStatements, getQueryPredicate, Instruction, RENDER_FLAGS, TEMPORARY_NAME, temporaryAllocator} from './util';
+import {asLiteral, conditionallyCreateDirectiveBindingLiteral, CONTEXT_NAME, DefinitionMap, getInstructionStatements, getQueryPredicate, Instruction, RENDER_FLAGS, TEMPORARY_NAME, temporaryAllocator} from './util';
 
 
 // This regex matches any binding names that contain the "attr." prefix, e.g. "attr.required"
@@ -69,10 +69,10 @@ function baseDirectiveFields(
           meta.name, definitionMap));
 
   // e.g 'inputs: {a: 'a'}`
-  definitionMap.set('inputs', conditionallyCreateMapObjectLiteral(meta.inputs, true));
+  definitionMap.set('inputs', conditionallyCreateDirectiveBindingLiteral(meta.inputs, true));
 
   // e.g 'outputs: {a: 'a'}`
-  definitionMap.set('outputs', conditionallyCreateMapObjectLiteral(meta.outputs));
+  definitionMap.set('outputs', conditionallyCreateDirectiveBindingLiteral(meta.outputs));
 
   if (meta.exportAs !== null) {
     definitionMap.set('exportAs', o.literalArr(meta.exportAs.map(e => o.literal(e))));
@@ -432,12 +432,7 @@ function createBaseDirectiveTypeParams(meta: R3DirectiveMetadata): o.Type[] {
 function getInputsTypeExpression(meta: R3DirectiveMetadata): o.Expression {
   // TODO(required-inputs): expand this to generate the new object literal syntax.
   return o.literalMap(Object.keys(meta.inputs).map(key => {
-    const value = meta.inputs[key];
-    return {
-      key,
-      value: o.literal(typeof value === 'string' ? value : value.bindingPropertyName),
-      quoted: true
-    };
+    return {key, value: o.literal(meta.inputs[key].bindingPropertyName), quoted: true};
   }));
 }
 

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -414,7 +414,7 @@ function stringArrayAsType(arr: ReadonlyArray<string|null>): o.Type {
                           o.NONE_TYPE;
 }
 
-export function createBaseDirectiveTypeParams(meta: R3DirectiveMetadata): o.Type[] {
+function createBaseDirectiveTypeParams(meta: R3DirectiveMetadata): o.Type[] {
   // On the type side, remove newlines from the selector as it will need to fit into a TypeScript
   // string literal, which must be on one line.
   const selectorForType = meta.selector !== null ? meta.selector.replace(/\n/g, '') : null;
@@ -423,10 +423,22 @@ export function createBaseDirectiveTypeParams(meta: R3DirectiveMetadata): o.Type
     typeWithParameters(meta.type.type, meta.typeArgumentCount),
     selectorForType !== null ? stringAsType(selectorForType) : o.NONE_TYPE,
     meta.exportAs !== null ? stringArrayAsType(meta.exportAs) : o.NONE_TYPE,
-    o.expressionType(stringMapAsLiteralExpression(meta.inputs)),
+    o.expressionType(getInputsTypeExpression(meta)),
     o.expressionType(stringMapAsLiteralExpression(meta.outputs)),
     stringArrayAsType(meta.queries.map(q => q.propertyName)),
   ];
+}
+
+function getInputsTypeExpression(meta: R3DirectiveMetadata): o.Expression {
+  // TODO(required-inputs): expand this to generate the new object literal syntax.
+  return o.literalMap(Object.keys(meta.inputs).map(key => {
+    const value = meta.inputs[key];
+    return {
+      key,
+      value: o.literal(typeof value === 'string' ? value : value.bindingPropertyName),
+      quoted: true
+    };
+  }));
 }
 
 /**

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -10,7 +10,6 @@ import {ConstantPool} from '../../constant_pool';
 import {Interpolation} from '../../expression_parser/ast';
 import * as o from '../../output/output_ast';
 import {ParseSourceSpan} from '../../parse_util';
-import {splitAtColon} from '../../util';
 import * as t from '../r3_ast';
 import {Identifiers as R3} from '../r3_identifiers';
 import {ForwardRefHandling} from '../util';
@@ -163,10 +162,11 @@ export function asLiteral(value: any): o.Expression {
   return o.literal(value, o.INFERRED_TYPE);
 }
 
-export function conditionallyCreateMapObjectLiteral(map: Record<string, string|{
-                                                      classPropertyName: string;
-                                                      bindingPropertyName: string;
-                                                    }>, keepDeclared?: boolean): o.Expression|null {
+export function conditionallyCreateDirectiveBindingLiteral(
+    map: Record<string, string|{
+      classPropertyName: string;
+      bindingPropertyName: string;
+    }>, keepDeclared?: boolean): o.Expression|null {
   const keys = Object.getOwnPropertyNames(map);
 
   if (keys.length === 0) {
@@ -174,14 +174,15 @@ export function conditionallyCreateMapObjectLiteral(map: Record<string, string|{
   }
 
   return o.literalMap(keys.map(key => {
-    // canonical syntax: `dirProp: publicProp`
     const value = map[key];
     let declaredName: string;
     let publicName: string;
     let minifiedName: string;
     let needsDeclaredName: boolean;
     if (typeof value === 'string') {
-      minifiedName = declaredName = key;
+      // canonical syntax: `dirProp: publicProp`
+      declaredName = key;
+      minifiedName = key;
       publicName = value;
       needsDeclaredName = false;
     } else {

--- a/packages/core/src/compiler/compiler_facade_interface.ts
+++ b/packages/core/src/compiler/compiler_facade_interface.ts
@@ -79,8 +79,9 @@ export type StringMap = {
   [key: string]: string;
 };
 
-export type StringMapWithRename = {
-  [key: string]: string|[string, string];
+export type InputMap = {
+  // TODO(required-inputs): add required field
+  [key: string]: {bindingPropertyName: string, classPropertyName: string};
 };
 
 export type Provider = unknown;

--- a/packages/core/test/render3/jit/declare_component_spec.ts
+++ b/packages/core/test/render3/jit/declare_component_spec.ts
@@ -525,23 +525,25 @@ function expectComponentDef(
   };
 
   expect(actual.type).toBe(TestClass);
-  expect(actual.selectors).toEqual(expectation.selectors);
-  expect(actual.template).toEqual(expectation.template);
-  expect(actual.inputs).toEqual(expectation.inputs);
-  expect(actual.declaredInputs).toEqual(expectation.declaredInputs);
-  expect(actual.outputs).toEqual(expectation.outputs);
-  expect(actual.features).toEqual(expectation.features);
-  expect(actual.hostAttrs).toEqual(expectation.hostAttrs);
-  expect(actual.hostBindings).toEqual(expectation.hostBindings);
-  expect(actual.hostVars).toEqual(expectation.hostVars);
-  expect(actual.contentQueries).toEqual(expectation.contentQueries);
-  expect(actual.viewQuery).toEqual(expectation.viewQuery);
-  expect(actual.exportAs).toEqual(expectation.exportAs);
-  expect(actual.providersResolver).toEqual(expectation.providersResolver);
-  expect(actual.encapsulation).toEqual(expectation.encapsulation);
-  expect(actual.onPush).toEqual(expectation.onPush);
-  expect(actual.styles).toEqual(expectation.styles);
-  expect(actual.data).toEqual(expectation.data);
+  expect(actual.selectors).withContext('selectors').toEqual(expectation.selectors);
+  expect(actual.template).withContext('template').toEqual(expectation.template);
+  expect(actual.inputs).withContext('inputs').toEqual(expectation.inputs);
+  expect(actual.declaredInputs).withContext('declaredInputs').toEqual(expectation.declaredInputs);
+  expect(actual.outputs).withContext('outputs').toEqual(expectation.outputs);
+  expect(actual.features).withContext('features').toEqual(expectation.features);
+  expect(actual.hostAttrs).withContext('hostAttrs').toEqual(expectation.hostAttrs);
+  expect(actual.hostBindings).withContext('hostBindings').toEqual(expectation.hostBindings);
+  expect(actual.hostVars).withContext('hostVars').toEqual(expectation.hostVars);
+  expect(actual.contentQueries).withContext('contentQueries').toEqual(expectation.contentQueries);
+  expect(actual.viewQuery).withContext('viewQuery').toEqual(expectation.viewQuery);
+  expect(actual.exportAs).withContext('exportAs').toEqual(expectation.exportAs);
+  expect(actual.providersResolver)
+      .withContext('providersResolver')
+      .toEqual(expectation.providersResolver);
+  expect(actual.encapsulation).withContext('encapsulation').toEqual(expectation.encapsulation);
+  expect(actual.onPush).withContext('onPush').toEqual(expectation.onPush);
+  expect(actual.styles).withContext('styles').toEqual(expectation.styles);
+  expect(actual.data).withContext('data').toEqual(expectation.data);
 
   const convertNullToEmptyArray = <T extends Type<any>[]|null>(arr: T): T =>
       arr ?? ([] as unknown as T);

--- a/packages/core/test/render3/jit/declare_directive_spec.ts
+++ b/packages/core/test/render3/jit/declare_directive_spec.ts
@@ -281,18 +281,20 @@ function expectDirectiveDef(
   };
 
   expect(actual.type).toBe(TestClass);
-  expect(actual.selectors).toEqual(expectation.selectors);
-  expect(actual.inputs).toEqual(expectation.inputs);
-  expect(actual.declaredInputs).toEqual(expectation.declaredInputs);
-  expect(actual.outputs).toEqual(expectation.outputs);
-  expect(actual.features).toEqual(expectation.features);
-  expect(actual.hostAttrs).toEqual(expectation.hostAttrs);
-  expect(actual.hostBindings).toEqual(expectation.hostBindings);
-  expect(actual.hostVars).toEqual(expectation.hostVars);
-  expect(actual.contentQueries).toEqual(expectation.contentQueries);
-  expect(actual.viewQuery).toEqual(expectation.viewQuery);
-  expect(actual.exportAs).toEqual(expectation.exportAs);
-  expect(actual.providersResolver).toEqual(expectation.providersResolver);
+  expect(actual.selectors).withContext('selectors').toEqual(expectation.selectors);
+  expect(actual.inputs).withContext('inputs').toEqual(expectation.inputs);
+  expect(actual.declaredInputs).withContext('declaredInputs').toEqual(expectation.declaredInputs);
+  expect(actual.outputs).withContext('outputs').toEqual(expectation.outputs);
+  expect(actual.features).withContext('features').toEqual(expectation.features);
+  expect(actual.hostAttrs).withContext('hostAttrs').toEqual(expectation.hostAttrs);
+  expect(actual.hostBindings).withContext('hostBindings').toEqual(expectation.hostBindings);
+  expect(actual.hostVars).withContext('hostVars').toEqual(expectation.hostVars);
+  expect(actual.contentQueries).withContext('contentQueries').toEqual(expectation.contentQueries);
+  expect(actual.viewQuery).withContext('viewQuery').toEqual(expectation.viewQuery);
+  expect(actual.exportAs).withContext('exportAs').toEqual(expectation.exportAs);
+  expect(actual.providersResolver)
+      .withContext('providersResolver')
+      .toEqual(expectation.providersResolver);
 }
 
 class TestClass {}

--- a/packages/language-service/src/attribute_completions.ts
+++ b/packages/language-service/src/attribute_completions.ts
@@ -220,16 +220,16 @@ export function buildAttributeCompletionTable(
         continue;
       }
 
-      for (const [classPropertyName, rawProperyName] of meta.inputs) {
+      for (const {classPropertyName, bindingPropertyName} of meta.inputs) {
         let propertyName: string;
 
         if (dirSymbol.isHostDirective) {
-          if (!dirSymbol.exposedInputs?.hasOwnProperty(rawProperyName)) {
+          if (!dirSymbol.exposedInputs?.hasOwnProperty(bindingPropertyName)) {
             continue;
           }
-          propertyName = dirSymbol.exposedInputs[rawProperyName];
+          propertyName = dirSymbol.exposedInputs[bindingPropertyName];
         } else {
-          propertyName = rawProperyName;
+          propertyName = bindingPropertyName;
         }
 
         if (table.has(propertyName)) {
@@ -245,16 +245,16 @@ export function buildAttributeCompletionTable(
         });
       }
 
-      for (const [classPropertyName, rawProperyName] of meta.outputs) {
+      for (const {classPropertyName, bindingPropertyName} of meta.outputs) {
         let propertyName: string;
 
         if (dirSymbol.isHostDirective) {
-          if (!dirSymbol.exposedOutputs?.hasOwnProperty(rawProperyName)) {
+          if (!dirSymbol.exposedOutputs?.hasOwnProperty(bindingPropertyName)) {
             continue;
           }
-          propertyName = dirSymbol.exposedOutputs[rawProperyName];
+          propertyName = dirSymbol.exposedOutputs[bindingPropertyName];
         } else {
-          propertyName = rawProperyName;
+          propertyName = bindingPropertyName;
         }
 
         if (table.has(propertyName)) {

--- a/packages/upgrade/src/dynamic/src/upgrade_ng1_adapter.ts
+++ b/packages/upgrade/src/dynamic/src/upgrade_ng1_adapter.ts
@@ -221,9 +221,8 @@ class UpgradeNg1ComponentAdapter implements OnInit, OnChanges, DoCheck {
 
   ngOnChanges(changes: SimpleChanges) {
     const ng1Changes: any = {};
-    Object.keys(changes).forEach(name => {
-      const change: SimpleChange = changes[name];
-      const propertyMapName = getInputPropertyMapName(name);
+    Object.keys(changes).forEach(propertyMapName => {
+      const change: SimpleChange = changes[propertyMapName];
       this.setComponentProperty(propertyMapName, change.currentValue);
       ng1Changes[this.propertyMap[propertyMapName]] = change;
     });


### PR DESCRIPTION
Based on the discussion in https://github.com/angular/angular/pull/49304#discussion_r1124732608. Reworks the compiler internals to allow for additional information about inputs to be stored. This is a prerequisite for required inputs.