### PR TITLE
feat(migrations): Add migration for functional Route guards and resolvers

### DIFF
--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -17,6 +17,7 @@ pkg_npm(
     validate = False,
     visibility = ["//packages/core:__pkg__"],
     deps = [
+        "//packages/core/schematics/migrations/functional-guards:bundle",
         "//packages/core/schematics/migrations/relative-link-resolution:bundle",
         "//packages/core/schematics/migrations/router-link-with-href:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration:bundle",

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -9,6 +9,11 @@
       "version": "15.0.0",
       "description": "In Angular version 15, the deprecated `relativeLinkResolution` config parameter of the Router is removed. This migration removes all `relativeLinkResolution` fields from the Router config objects.",
       "factory": "./migrations/relative-link-resolution/bundle"
+    },
+    "migration-v16-functional-guards": {
+      "version": "16.0.0",
+      "description": "In Angular v15.2, class and injection-token guards and resolvers were deprecated at the `Route` definition. This migration update `Route` guards and resolvers to map classes and injection tokens to equivalent functions.",
+      "factory": "./migrations/functional-guards/bundle"
     }
   }
 }

--- a/packages/core/schematics/migrations/functional-guards/BUILD.bazel
+++ b/packages/core/schematics/migrations/functional-guards/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//tools:defaults.bzl", "esbuild", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "functional-guards",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    entry_point = ":index.ts",
+    external = [
+        "@angular-devkit/*",
+        "typescript",
+    ],
+    format = "cjs",
+    platform = "node",
+    deps = [":functional-guards"],
+)

--- a/packages/core/schematics/migrations/functional-guards/README.md
+++ b/packages/core/schematics/migrations/functional-guards/README.md
@@ -1,0 +1,35 @@
+## Class and InjectionToken-based `Router` guards and resolvers
+
+As of Angular v15.2, class-based guards and resolvers were deprecated at the `Route` definition.
+This migration updates guard and resolver properties to use the helper functions to map an injectable
+class to the appropriate guard or resolver function.
+
+#### Before
+```ts
+import { Route } from '@angular/router';
+import { LoggedInGuard } from './logged_in_guard';
+import { ResolveUser } from './user_resolver';
+
+const route: Route = {
+  path: 'user/edit',
+  canActivate: [LoggedInGuard],
+  resolve: {
+    'user': ResolveUser
+  }
+};
+```
+
+#### After
+```ts
+import { Route, mapToCanActivate, mapToResolve } from '@angular/router';
+import { LoggedInGuard } from './logged_in_guard';
+import { ResolveUser } from './user_resolver';
+
+const route: Route = {
+  path: 'user/edit',
+  canActivate: mapToCanActivate([LoggedInGuard]),
+  resolve: {
+    'user': mapToResolve(ResolveUser)
+  }
+};
+```

--- a/packages/core/schematics/migrations/functional-guards/index.ts
+++ b/packages/core/schematics/migrations/functional-guards/index.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicsException, Tree, UpdateRecorder} from '@angular-devkit/schematics';
+import {relative} from 'path';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {canMigrateFile, createMigrationProgram} from '../../utils/typescript/compiler_host';
+
+import {migrateFile} from './util';
+
+export default function(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. ' +
+          'Cannot run a migration to cleanup the deprecated `relativeLinkResolution` config option.');
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runRelativeLinkResolutionMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+function runRelativeLinkResolutionMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const program = createMigrationProgram(tree, tsconfigPath, basePath);
+  const sourceFiles =
+      program.getSourceFiles().filter(sourceFile => canMigrateFile(basePath, sourceFile, program));
+
+  for (const sourceFile of sourceFiles) {
+    let update: UpdateRecorder|null = null;
+
+    const rewriter = (startPos: number, origLength: number, text: string) => {
+      if (update === null) {
+        // Lazily initialize update, because most files will not require migration.
+        update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
+      }
+      update.remove(startPos, origLength);
+      update.insertLeft(startPos, text);
+    };
+
+    migrateFile(sourceFile, rewriter, program.getTypeChecker());
+
+    if (update !== null) {
+      tree.commitUpdate(update);
+    }
+  }
+}

--- a/packages/core/schematics/migrations/functional-guards/util.ts
+++ b/packages/core/schematics/migrations/functional-guards/util.ts
@@ -1,0 +1,220 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {ChangeTracker} from '../../utils/change_tracker';
+
+const requiredRouteProperties = new Set(['path', 'matcher']);
+const guardPropertyNames =
+    new Set(['canActivate', 'canMatch', 'canDeactivate', 'canActivateChild']);
+
+export interface RewriteEntity {
+  startPos: number;
+  width: number;
+  replacement: string;
+}
+
+export interface MigratableRoute {
+  guards?: ts.PropertyAssignment[];
+  title?: ts.PropertyAssignment;
+  resolvedData?: ts.PropertyAssignment[];
+}
+
+export type RewriteFn = (startPos: number, origLength: number, text: string) => void;
+
+export function migrateFile(
+    sourceFile: ts.SourceFile, rewriteFn: RewriteFn, typeChecker: ts.TypeChecker) {
+  const printer = ts.createPrinter();
+  const changeTracker = new ChangeTracker(printer);
+  const usages = getMigratableRoutes(sourceFile);
+  for (const migratableRoute of usages) {
+    const {title, resolvedData, guards} = migratableRoute;
+    if (title) {
+      migrateResolveProperty(title, typeChecker, changeTracker, sourceFile);
+    }
+    if (resolvedData) {
+      for (const property of resolvedData) {
+        migrateResolveProperty(property, typeChecker, changeTracker, sourceFile);
+      }
+    }
+    if (guards) {
+      for (const property of guards) {
+        if (!ts.isArrayLiteralExpression(property.initializer)) {
+          continue;
+        }
+
+        const classGuards: ts.Expression[] = [];
+        const injectionTokenGuards: ts.Expression[] = [];
+        const nonClassGuards: ts.Expression[] = [];
+
+        for (const element of property.initializer.elements) {
+          if (isInjectionToken(element, typeChecker)) {
+            injectionTokenGuards.push(element);
+          } else if (isClass(element, typeChecker)) {
+            classGuards.push(element);
+          } else {
+            nonClassGuards.push(element);
+          }
+        }
+
+        if ((classGuards.length === 0 && injectionTokenGuards.length === 0) ||
+            !ts.isIdentifier(property.name)) {
+          // nothing to migrate if there are no class-based guards
+          continue;
+        }
+
+        const guardName = property.name.text;
+        const mapperFunctionName = `mapTo${guardName.charAt(0).toUpperCase()}${guardName.slice(1)}`;
+        const mappedClassGuards = ts.factory.createCallExpression(
+            ts.factory.createIdentifier(mapperFunctionName), undefined,
+            [ts.factory.createArrayLiteralExpression(classGuards)]);
+
+        if (classGuards.length > 0) {
+          changeTracker.addImport(sourceFile, mapperFunctionName, '@angular/router');
+        }
+
+        if (nonClassGuards.length === 0 && injectionTokenGuards.length === 0) {
+          // All we have is class guards so we just use the mapped function
+          const replacementNode =
+              ts.factory.updatePropertyAssignment(property, property.name, mappedClassGuards);
+          changeTracker.replaceNode(property, replacementNode, ts.EmitHint.Unspecified);
+        } else {
+          const elements: ts.Expression[] = [...nonClassGuards];
+          if (classGuards.length > 0) {
+            elements.push(ts.factory.createSpreadElement(mappedClassGuards));
+          }
+          if (injectionTokenGuards.length > 0) {
+            elements.push(...injectionTokenGuards.map(g => {
+              return injectionTokenToFunction(changeTracker, sourceFile, g);
+            }));
+          }
+          const concatenatedGuards = ts.factory.createArrayLiteralExpression(elements);
+          const replacementNode =
+              ts.factory.updatePropertyAssignment(property, property.name, concatenatedGuards);
+          changeTracker.replaceNode(property, replacementNode, ts.EmitHint.Unspecified);
+        }
+      }
+    }
+  }
+
+  for (const changesInFile of changeTracker.recordChanges().values()) {
+    for (const change of changesInFile) {
+      rewriteFn(change.start, change.removeLength ?? 0, change.text);
+    }
+  }
+}
+
+function injectionTokenToFunction(
+    changeTracker: ChangeTracker, sourceFile: ts.SourceFile,
+    token: ts.Expression): ts.ArrowFunction {
+  changeTracker.addImport(sourceFile, 'inject', '@angular/core');
+
+  // Inject the token and call it with the guard or resolver params
+  // inject(token)(...params)
+  const functionBody = ts.factory.createCallExpression(
+      ts.factory.createCallExpression(ts.factory.createIdentifier('inject'), undefined, [token]),
+      undefined,
+      [ts.factory.createSpreadElement(ts.factory.createIdentifier('params'))],
+  );
+
+  // (...params)
+  const genericSpreadParams = ts.factory.createParameterDeclaration(
+      undefined,
+      ts.factory.createToken(ts.SyntaxKind.DotDotDotToken),
+      ts.factory.createIdentifier('params'),
+  );
+
+  // (...params) => inject(token)(...params)
+  return ts.factory.createArrowFunction(
+      undefined,
+      undefined,
+      [genericSpreadParams],
+      undefined,
+      ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+      functionBody,
+  );
+}
+
+function migrateResolveProperty(
+    title: ts.PropertyAssignment, typeChecker: ts.TypeChecker, changeTracker: ChangeTracker,
+    sourceFile: ts.SourceFile) {
+  if (!isClass(title.initializer, typeChecker)) {
+    return;
+  }
+
+  let migratedInitializer: ts.Expression;
+  if (isInjectionToken(title.initializer, typeChecker)) {
+    migratedInitializer = injectionTokenToFunction(changeTracker, sourceFile, title.initializer);
+  } else {
+    const mapperFunctionName = 'mapToResolve';
+    changeTracker.addImport(sourceFile, mapperFunctionName, '@angular/router');
+    // mapToResolve(Resolver)
+    migratedInitializer = ts.factory.createCallExpression(
+        ts.factory.createIdentifier(mapperFunctionName), undefined, [title.initializer]);
+  }
+  const replacementNode =
+      ts.factory.updatePropertyAssignment(title, title.name, migratedInitializer);
+  changeTracker.replaceNode(title, replacementNode, ts.EmitHint.Unspecified);
+}
+
+function getMigratableRoutes(sourceFile: ts.SourceFile): MigratableRoute[] {
+  const routesToMigrate: MigratableRoute[] = [];
+  const visitNode = (node: ts.Node) => {
+    if (ts.isObjectLiteralExpression(node)) {
+      const hasRequiredRouteProperty =
+          node.properties.some(prop => isPropertyAssignmentWithName(prop, requiredRouteProperties));
+      if (hasRequiredRouteProperty) {
+        const route: MigratableRoute = {};
+
+        route.guards = node.properties.filter(
+            (prop): prop is ts.PropertyAssignment =>
+                isPropertyAssignmentWithName(prop, guardPropertyNames));
+
+        route.title = node.properties.find(
+            (prop): prop is ts.PropertyAssignment => isPropertyAssignmentWithName(prop, 'title'));
+
+        const resolve = node.properties.find(
+            (prop): prop is ts.PropertyAssignment => isPropertyAssignmentWithName(prop, 'resolve'));
+        if (resolve && ts.isObjectLiteralExpression(resolve.initializer)) {
+          route.resolvedData = resolve.initializer.properties.filter(
+              (p): p is ts.PropertyAssignment => ts.isPropertyAssignment(p));
+        }
+
+        if (route.guards?.length || route.title || route.resolvedData?.length) {
+          routesToMigrate.push(route);
+        }
+      }
+    }
+    ts.forEachChild(node, visitNode);
+  };
+  ts.forEachChild(sourceFile, visitNode);
+  return routesToMigrate;
+}
+
+function isPropertyAssignmentWithName(
+    property: ts.ObjectLiteralElementLike,
+    nameOrNames: string|Set<string>): property is ts.PropertyAssignment {
+  return ts.isPropertyAssignment(property) && ts.isIdentifier(property.name) &&
+      (nameOrNames instanceof Set ? nameOrNames.has(property.name.text) :
+                                    nameOrNames === property.name.text);
+}
+
+function isClass(node: ts.Node, typeChecker: ts.TypeChecker): boolean {
+  const symbol = typeChecker.getSymbolAtLocation(node);
+  const type = typeChecker.getTypeAtLocation(node);
+  function isClassDeclaration(symbol?: ts.Symbol): boolean {
+    return !!symbol?.valueDeclaration && ts.isClassDeclaration(symbol.valueDeclaration);
+  }
+  return isClassDeclaration(type.getSymbol()) || isClassDeclaration(symbol);
+}
+
+function isInjectionToken(node: ts.Node, typeChecker: ts.TypeChecker): boolean {
+  const type = typeChecker.getTypeAtLocation(node);
+  return type.getSymbol()?.escapedName === 'InjectionToken';
+}

--- a/packages/core/schematics/migrations/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/google3/BUILD.bazel
@@ -5,6 +5,7 @@ ts_library(
     srcs = glob(["**/*.ts"]),
     tsconfig = "//packages/core/schematics:tsconfig.json",
     deps = [
+        "//packages/core/schematics/migrations/functional-guards",
         "//packages/core/schematics/migrations/relative-link-resolution",
         "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tslint",
@@ -31,9 +32,19 @@ esbuild(
     deps = [":google3"],
 )
 
+esbuild(
+    name = "functional_gaurds_rule_cjs",
+    entry_point = ":functionalGuardsRule.ts",
+    format = "cjs",
+    output = "functionalGuardsCjsRule.js",
+    platform = "node",
+    deps = [":google3"],
+)
+
 filegroup(
     name = "google3_cjs",
     srcs = [
+        ":functional_gaurds_rule_cjs",
         ":relative_link_resolution_cjs",
         ":wait_for_async_rule_cjs",
     ],

--- a/packages/core/schematics/migrations/google3/functionalGuardsRule.ts
+++ b/packages/core/schematics/migrations/google3/functionalGuardsRule.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Replacement, RuleFailure, Rules} from 'tslint';
+
+import {migrateFile} from '../functional-guards/util';
+
+/** TSLint rule for the `relativeLinkResolution` migration. */
+export class Rule extends Rules.TypedRule {
+  override applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[] {
+    const failures: RuleFailure[] = [];
+
+    const rewriter = (startPos: number, origLength: number, text: string) => {
+      const failure = new RuleFailure(
+          sourceFile, startPos, startPos + origLength,
+          'The `relativeLinkResolution` Router config option is removed and should not be used.',
+          this.ruleName, new Replacement(startPos, origLength, text));
+      failures.push(failure);
+    };
+
+    migrateFile(sourceFile, rewriter, program.getTypeChecker());
+
+    return failures;
+  }
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -19,6 +19,8 @@ jasmine_node_test(
     data = [
         "//packages/core/schematics:collection.json",
         "//packages/core/schematics:migrations.json",
+        "//packages/core/schematics/migrations/functional-guards",
+        "//packages/core/schematics/migrations/functional-guards:bundle",
         "//packages/core/schematics/migrations/relative-link-resolution",
         "//packages/core/schematics/migrations/relative-link-resolution:bundle",
         "//packages/core/schematics/migrations/router-link-with-href",

--- a/packages/core/schematics/test/functional_guards_spec.ts
+++ b/packages/core/schematics/test/functional_guards_spec.ts
@@ -1,0 +1,242 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('functional guards migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('migration-v16-functional-guards', {}, tree);
+  }
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+        strictNullChecks: true,
+      },
+    }));
+
+    writeFile('/angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('/node_modules/@angular/core/index.d.ts', `
+    export declare class InjectionToken<T> {
+      protected _desc: string;
+      readonly ɵprov: unknown;
+      constructor(_desc: string, options?: {
+          providedIn?: Type<any> | 'root' | 'platform' | 'any' | null;
+          factory: () => T;
+      });
+      toString(): string;
+    }
+   `);
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  it('should migrate canActivate with only class-based guards', async () => {
+    writeFile('/index.ts', `
+          export class MyGuard {
+          }
+
+          const route = {
+            path: '',
+            canActivate: [MyGuard],
+          };
+        `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain('canActivate: mapToCanActivate([MyGuard])');
+  });
+
+  it('should migrate not canActivate with only functional guards', async () => {
+    writeFile('/index.ts', `
+          const route = {
+            path: '',
+            canActivate: [() => true],
+          };
+        `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).not.toContain('mapToCanActivate');
+  });
+
+  it('should migrate when using a matcher instead of path on the route', async () => {
+    writeFile('/index.ts', `
+          export class MyGuard { }
+
+          const route = {
+            matcher: () => {},
+            canActivate: [MyGuard],
+          };
+        `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain('mapToCanActivate([MyGuard])');
+  });
+
+  it('should not migrate when there is no path or matcher (these are required on the route)',
+     async () => {
+       writeFile('/index.ts', `
+          export class MyGuard { }
+
+          const route = {
+            canActivate: [MyGuard],
+          };
+        `);
+
+       await runMigration();
+
+       const content = tree.readContent('/index.ts');
+       expect(content).not.toContain('mapToCanActivate');
+     });
+
+  it('should migrate canActivate with mixed guards', async () => {
+    writeFile('/index.ts', `
+          export class MyGuard {}
+
+          const route = {
+            path: '',
+            canActivate: [() => true, MyGuard],
+          };
+        `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain('canActivate: [() => true, ...mapToCanActivate([MyGuard])]');
+  });
+
+  it('should migrate resolve properties', async () => {
+    writeFile('/index.ts', `
+          export class ResolveMyData2 {}
+          export class ResolveMyData3 {}
+
+          const route = {
+            path: '',
+            resolve: {
+              'data1': () => 'data1',
+              'data2': ResolveMyData2,
+              data3: ResolveMyData3,
+            }
+          };
+        `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`'data1': () => 'data1'`);
+    expect(content).toContain(`'data2': mapToResolve(ResolveMyData2)`);
+    expect(content).toContain(`data3: mapToResolve(ResolveMyData3)`);
+  });
+
+  it('should migrate title resolvers', async () => {
+    writeFile('/index.ts', `
+          export class ResolveTitle {}
+
+          const route = {
+            path: '',
+            title: ResolveTitle,
+          };
+        `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`title: mapToResolve(ResolveTitle)`);
+  });
+
+  it('should migrate all properties at once', async () => {
+    writeFile('/index.ts', `
+          export class MyClass {}
+
+          const route = {
+            path: '',
+            title: MyClass,
+            resolve: {
+              data: MyClass
+            },
+            canActivate: [MyClass],
+            canActivateChild: [MyClass],
+            canDeactivate: [MyClass],
+            canMatch: [MyClass],
+          };
+        `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`title: mapToResolve(MyClass)`);
+    expect(content).toContain(`data: mapToResolve(MyClass)`);
+    expect(content).toContain(`canActivate: mapToCanActivate([MyClass])`);
+    expect(content).toContain(`canActivateChild: mapToCanActivateChild([MyClass])`);
+    expect(content).toContain(`canDeactivate: mapToCanDeactivate([MyClass])`);
+    expect(content).toContain(`canMatch: mapToCanMatch([MyClass])`);
+  });
+
+  it('migrates injection token guards and resolvers', async () => {
+    writeFile('/index.ts', `
+    import {InjectionToken} from '@angular/core';
+
+    const resolveTitleToken = new InjectionToken<() => string>('');
+    const canActivateToken = new InjectionToken<() => boolean>('');
+
+    const route = {
+      path: '',
+      title: resolveTitleToken,
+      canActivate: [canActivateToken],
+    };
+  `);
+
+    await runMigration();
+
+    const content = tree.readContent('/index.ts');
+    expect(content).toContain(`title: (...params) => inject(resolveTitleToken)(...params)`);
+    expect(content).toContain(`canActivate: [(...params) => inject(canActivateToken)(...params)]`);
+  });
+
+  // TODO: test imported classes
+});


### PR DESCRIPTION
This migration updates `Route` definitions to use functions instead of class and `InjectionToken` references in the guard and resolver properties. This is accomplished by using the recently added mapper functions.