### PR TITLE
docs(docs-infra): Split Errors by categories & sort by code.

### DIFF
--- a/aio/tools/transforms/angular-errors-package/processors/processErrorsContainerDoc.js
+++ b/aio/tools/transforms/angular-errors-package/processors/processErrorsContainerDoc.js
@@ -3,9 +3,32 @@ module.exports = function processErrorsContainerDoc() {
     $runAfter: ['extra-docs-added'],
     $runBefore: ['rendering-docs'],
     $process(docs) {
-      const errorsDoc = docs.find(doc => doc.id === 'errors/index');
+      const errorsDoc = docs.find((doc) => doc.id === 'errors/index');
       errorsDoc.id = 'errors-container';
-      errorsDoc.errors = docs.filter(doc => doc.docType === 'error');
-    }
+      errorsDoc.errors = [
+        {
+          title: 'Runtime',
+          errors: docs
+            .filter((doc) => doc.docType === 'error' && doc.category === 'runtime')
+            .sort(byCode),
+        },
+        {
+          title: 'Compiler',
+          errors: docs
+            .filter((doc) => doc.docType === 'error' && doc.category === 'compiler')
+            .sort(byCode),
+        },
+      ];
+    },
   };
 };
+
+/**
+ * Helper function to sort documents by error codes (NG0100 will come before NG0200)
+ */
+function byCode(doc1, doc2) {
+  // slice to drop the 'NG' part of the code.
+  const code1 = +doc1.code.slice(2);
+  const code2 = +doc2.code.slice(2);
+  return code1 > code2 ? 1 : -1;
+}

--- a/aio/tools/transforms/templates/error/errors-container.template.html
+++ b/aio/tools/transforms/templates/error/errors-container.template.html
@@ -1,18 +1,17 @@
-{% extends 'content.template.html' -%}
+{% extends 'content.template.html' -%} {% block content %}
+<div class="content">{$ doc.description | marked $}</div>
 
-{% block content %}
-<div class="content">
-  {$ doc.description | marked $}
-</div>
-
-<ul class="error-list">
-  {% for error in doc.errors %}
-  <li>
-    <a class="code-anchor" href="{$ error.path $}">
-      <span class="symbol {$ error.category $}"></span>
-      <code class="no-auto-link">{$ error.code $}: {$ error.name $}</code>
-    </a>
-  </li>
+  {% for section in doc.errors %}
+  <h2 id="description">{$ section.title $} errors</h2>
+  <ul class="error-list">
+    {% for error in section.errors %}
+    <li>
+      <a class="code-anchor" href="{$ error.path $}">
+        <span class="symbol {$ error.category $}"></span>
+        <code class="no-auto-link">{$ error.code $}: {$ error.name $}</code>
+      </a>
+    </li>
+    {% endfor %}
+  </ul>
   {% endfor %}
-</ul>
 {% endblock %}


### PR DESCRIPTION
* 2 categories : Runtime errors and Compiler Errors.
* Numeric sort on error code.
![Screenshot 2023-03-06 at 22 18 26](https://user-images.githubusercontent.com/1300985/223233083-e968374f-aea6-43af-a4e0-6901db938173.png)
