### PR TITLE
refactor(core): skip hydration annotation

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,7 +2,7 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 908,
-      "main": 125669,
+      "main": 126280,
       "polyfills": 33792
     }
   },
@@ -19,7 +19,7 @@
   "cli-hello-world-ivy-i18n": {
     "uncompressed": {
       "runtime": 926,
-      "main": 124504,
+      "main": 125031,
       "polyfills": 34676
     }
   },
@@ -34,21 +34,21 @@
   "forms": {
     "uncompressed": {
       "runtime": 888,
-      "main": 158000,
+      "main": 158506,
       "polyfills": 33772
     }
   },
   "animations": {
     "uncompressed": {
       "runtime": 898,
-      "main": 157177,
+      "main": 157747,
       "polyfills": 33782
     }
   },
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 918,
-      "main": 85026,
+      "main": 85542,
       "polyfills": 33802
     }
   },

--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -16,6 +16,7 @@ import {unwrapRNode} from '../render3/util/view_utils';
 import {TransferState} from '../transfer_state';
 
 import {ELEMENT_CONTAINERS, SerializedView} from './interfaces';
+import {SKIP_HYDRATION_ATTR_NAME} from './skip_hydration';
 import {getComponentLViewForHydration, NGH_ATTR_NAME, NGH_DATA_KEY} from './utils';
 
 /**
@@ -123,7 +124,9 @@ function serializeLView(lView: LView, context: HydrationContext): SerializedView
     } else if (Array.isArray(lView[i])) {
       // This is a component, annotate the host node with an `ngh` attribute.
       const targetNode = unwrapRNode(lView[i][HOST]!);
-      annotateHostElementForHydration(targetNode as RElement, lView[i], context);
+      if (!(targetNode as HTMLElement).hasAttribute(SKIP_HYDRATION_ATTR_NAME)) {
+        annotateHostElementForHydration(targetNode as RElement, lView[i], context);
+      }
     } else {
       // <ng-container> case
       if (tNode.type & TNodeType.ElementContainer) {

--- a/packages/core/src/hydration/skip_hydration.ts
+++ b/packages/core/src/hydration/skip_hydration.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {TNode} from '../render3/interfaces/node';
+
+/**
+ * The name of an attribute that can be added to the hydration boundary node
+ * (component host node) to disable hydration for the content within that boundary.
+ */
+export const SKIP_HYDRATION_ATTR_NAME = 'ngSkipHydration';
+
+/**
+ * Helper function to check if a given node has the 'ngSkipHydration' attribute
+ */
+export function hasNgSkipHydrationAttr(tNode: TNode): boolean {
+  const SKIP_HYDRATION_ATTR_NAME_LOWER_CASE = SKIP_HYDRATION_ATTR_NAME.toLowerCase();
+
+  const attrs = tNode.mergedAttrs;
+  if (attrs === null) return false;
+  // only ever look at the attribute name and skip the values
+  for (let i = 0; i < attrs.length; i += 2) {
+    const value = attrs[i];
+    // This is a marker, which means that the static attributes section is over,
+    // so we can exit early.
+    if (typeof value === 'number') return false;
+    if (typeof value === 'string' && value.toLowerCase() === SKIP_HYDRATION_ATTR_NAME_LOWER_CASE) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -18,7 +18,7 @@ import {isContentQueryHost, isDirectiveHost} from '../interfaces/type_checks';
 import {HEADER_OFFSET, HYDRATION, LView, RENDERER, TView} from '../interfaces/view';
 import {assertTNodeType} from '../node_assert';
 import {appendChild, createCommentNode} from '../node_manipulation';
-import {getBindingIndex, getCurrentTNode, getLView, getTView, isCurrentTNodeParent, lastNodeWasCreated, setCurrentTNode, setCurrentTNodeAsNotParent, wasLastNodeCreated} from '../state';
+import {getBindingIndex, getCurrentTNode, getLView, getTView, isCurrentTNodeParent, isInSkipHydrationBlock, lastNodeWasCreated, setCurrentTNode, setCurrentTNodeAsNotParent, wasLastNodeCreated} from '../state';
 import {computeStaticStyling} from '../styling/static_styling';
 import {getConstant} from '../util/view_utils';
 
@@ -166,7 +166,8 @@ function locateOrCreateElementContainerNode(
     tView: TView, lView: LView, tNode: TNode, index: number): RComment {
   let comment: RComment;
   const hydrationInfo = lView[HYDRATION];
-  const isNodeCreationMode = !hydrationInfo;
+  const isNodeCreationMode = !hydrationInfo || isInSkipHydrationBlock();
+
   lastNodeWasCreated(isNodeCreationMode);
 
   // Regular creation mode.

--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -13,7 +13,7 @@ import {TElementNode, TNode, TNodeType} from '../interfaces/node';
 import {RText} from '../interfaces/renderer_dom';
 import {HEADER_OFFSET, HYDRATION, LView, RENDERER, T_HOST, TView} from '../interfaces/view';
 import {appendChild, createTextNode} from '../node_manipulation';
-import {getBindingIndex, getLView, getTView, lastNodeWasCreated, setCurrentTNode, wasLastNodeCreated} from '../state';
+import {getBindingIndex, getLView, getTView, isInSkipHydrationBlock, lastNodeWasCreated, setCurrentTNode, wasLastNodeCreated} from '../state';
 
 import {getOrCreateTNode} from './shared';
 
@@ -66,7 +66,7 @@ let _locateOrCreateTextNode: typeof locateOrCreateTextNodeImpl =
 function locateOrCreateTextNodeImpl(
     tView: TView, lView: LView, tNode: TNode, value: string): RText {
   const hydrationInfo = lView[HYDRATION];
-  const isNodeCreationMode = !hydrationInfo;
+  const isNodeCreationMode = !hydrationInfo || isInSkipHydrationBlock();
   lastNodeWasCreated(isNodeCreationMode);
 
   // Regular creation mode.

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -820,6 +820,18 @@ export function nativeRemoveNode(renderer: Renderer, rNode: RNode, isHostElement
   }
 }
 
+/**
+ * Removes the contents of a given RElement using a given renderer.
+ *
+ * @param renderer A renderer to be used
+ * @param rElement the native RElement to be cleared
+ */
+export function clearElementContents(renderer: Renderer, rElement: RElement): void {
+  while (rElement.firstChild) {
+    nativeRemoveChild(renderer, rElement, rElement.firstChild, false);
+  }
+}
+
 
 /**
  * Performs the operation of `action` on the node. Typically this involves inserting or removing

--- a/packages/core/src/render3/state.ts
+++ b/packages/core/src/render3/state.ts
@@ -172,11 +172,24 @@ interface InstructionState {
    * ```
    */
   bindingsEnabled: boolean;
+
+  /**
+   * Stores the root TNode that has the 'ngSkipHydration' attribute on it for later reference.
+   *
+   * Example:
+   * ```
+   * <my-comp ngSkipHydration>
+   *   Should reference this root node
+   * </my-comp>
+   * ```
+   */
+  skipHydrationRootTNode: TNode|null;
 }
 
 const instructionState: InstructionState = {
   lFrame: createLFrame(null),
   bindingsEnabled: true,
+  skipHydrationRootTNode: null,
 };
 
 /**
@@ -215,6 +228,22 @@ export function getBindingsEnabled(): boolean {
   return instructionState.bindingsEnabled;
 }
 
+/**
+ * Returns true if currently inside a skip hydration block.
+ * @returns boolean
+ */
+export function isInSkipHydrationBlock(): boolean {
+  return instructionState.skipHydrationRootTNode !== null;
+}
+
+/**
+ * Returns true if this is the root TNode of the skip hydration block.
+ * @param tNode the current TNode
+ * @returns boolean
+ */
+export function isSkipHydrationRootTNode(tNode: TNode): boolean {
+  return instructionState.skipHydrationRootTNode === tNode;
+}
 
 /**
  * Enables directive matching on elements.
@@ -240,6 +269,14 @@ export function ɵɵenableBindings(): void {
 }
 
 /**
+ * Sets a flag to specify that the TNode is in a skip hydration block.
+ * @param tNode the current TNode
+ */
+export function enterSkipHydrationBlock(tNode: TNode): void {
+  instructionState.skipHydrationRootTNode = tNode;
+}
+
+/**
  * Disables directive matching on element.
  *
  *  * Example:
@@ -260,6 +297,13 @@ export function ɵɵenableBindings(): void {
  */
 export function ɵɵdisableBindings(): void {
   instructionState.bindingsEnabled = false;
+}
+
+/**
+ * Clears the root skip hydration node when leaving a skip hydration block.
+ */
+export function leaveSkipHydrationBlock(): void {
+  instructionState.skipHydrationRootTNode = null;
 }
 
 /**


### PR DESCRIPTION
This adds the ngSkipHydration annotation, which allows users to opt hydration boundaries out of hydration. This enables incremental adoption of hydration by letting users skip hydration on components that have implementation issues that conflict with hydration.

co-authored-by: @AndrewKushnir

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
