### PR TITLE
refactor(compiler-cli): remove unused class decorator downlevel code

### DIFF
--- a/packages/compiler-cli/private/tooling.ts
+++ b/packages/compiler-cli/private/tooling.ts
@@ -45,5 +45,5 @@ export function constructorParametersDownlevelTransform(program: ts.Program):
   const reflectionHost = new TypeScriptReflectionHost(typeChecker);
   return getDownlevelDecoratorsTransform(
       typeChecker, reflectionHost, [], /* isCore */ false,
-      /* enableClosureCompiler */ false, /* skipClassDecorators */ true);
+      /* enableClosureCompiler */ false);
 }

--- a/packages/compiler-cli/src/transformers/downlevel_decorators_transform/downlevel_decorators_transform.ts
+++ b/packages/compiler-cli/src/transformers/downlevel_decorators_transform/downlevel_decorators_transform.ts
@@ -242,23 +242,20 @@ interface ParameterDecorationInfo {
 }
 
 /**
- * Gets a transformer for downleveling Angular decorators.
+ * Gets a transformer for downleveling Angular constructor parameter and property decorators.
+ *
+ * Note that Angular class decorators are never processed as those rely on side effects that
+ * would otherwise no longer be executed. i.e. the creation of a component definition.
+ *
  * @param typeChecker Reference to the program's type checker.
  * @param host Reflection host that is used for determining decorators.
  * @param diagnostics List which will be populated with diagnostics if any.
  * @param isCore Whether the current TypeScript program is for the `@angular/core` package.
  * @param isClosureCompilerEnabled Whether closure annotations need to be added where needed.
- * @param skipClassDecorators Whether class decorators should be skipped from downleveling.
- *   This is useful for JIT mode where class decorators should be preserved as they could rely
- *   on immediate execution. e.g. downleveling `@Injectable` means that the injectable factory
- *   is not created, and injecting the token will not work. If this decorator would not be
- *   downleveled, the `Injectable` decorator will execute immediately on file load, and
- *   Angular will generate the corresponding injectable factory.
  */
 export function getDownlevelDecoratorsTransform(
     typeChecker: ts.TypeChecker, host: ReflectionHost, diagnostics: ts.Diagnostic[],
-    isCore: boolean, isClosureCompilerEnabled: boolean,
-    skipClassDecorators: boolean): ts.TransformerFactory<ts.SourceFile> {
+    isCore: boolean, isClosureCompilerEnabled: boolean): ts.TransformerFactory<ts.SourceFile> {
   function addJSDocTypeAnnotation(node: ts.Node, jsdocType: string): void {
     if (!isClosureCompilerEnabled) {
       return;
@@ -273,26 +270,6 @@ export function getDownlevelDecoratorsTransform(
         hasTrailingNewLine: true,
       },
     ]);
-  }
-
-  /**
-   * Takes a list of decorator metadata object ASTs and produces an AST for a
-   * static class property of an array of those metadata objects.
-   */
-  function createDecoratorClassProperty(decoratorList: ts.ObjectLiteralExpression[]) {
-    const modifier = ts.factory.createToken(ts.SyntaxKind.StaticKeyword);
-    const initializer = ts.factory.createArrayLiteralExpression(decoratorList, true);
-    // NB: the .decorators property does not get a @nocollapse property. There
-    // is no good reason why - it means .decorators is not runtime accessible
-    // if you compile with collapse properties, whereas propDecorators is,
-    // which doesn't follow any stringent logic. However this has been the
-    // case previously, and adding it back in leads to substantial code size
-    // increases as Closure fails to tree shake these props
-    // without @nocollapse.
-    const prop = ts.factory.createPropertyDeclaration(
-        [modifier], 'decorators', undefined, undefined, initializer);
-    addJSDocTypeAnnotation(prop, DECORATOR_INVOCATION_JSDOC_TYPE);
-    return prop;
   }
 
   /**
@@ -523,36 +500,19 @@ export function getDownlevelDecoratorsTransform(
         newMembers.push(ts.visitEachChild(member, decoratorDownlevelVisitor, context));
       }
 
-      // The `ReflectionHost.getDecoratorsOfDeclaration()` method will not return certain kinds of
-      // decorators that will never be Angular decorators. So we cannot rely on it to capture all
-      // the decorators that should be kept. Instead we start off with a set of the raw decorators
-      // on the class, and only remove the ones that have been identified for downleveling.
-      const decoratorsToKeep = new Set<ts.Decorator>(ts.getDecorators(classDecl));
+      // Note: The `ReflectionHost.getDecoratorsOfDeclaration()` method will not
+      // return all decorators, but only ones that could be possible Angular decorators.
       const possibleAngularDecorators = host.getDecoratorsOfDeclaration(classDecl) || [];
 
       let hasAngularDecorator = false;
-      const decoratorsToLower = [];
       for (const decorator of possibleAngularDecorators) {
-        // We only deal with concrete nodes in TypeScript sources, so we don't
-        // need to handle synthetically created decorators.
-        const decoratorNode = decorator.node! as ts.Decorator;
-        const isNgDecorator = isAngularDecorator(decorator, isCore);
-
         // Keep track if we come across an Angular class decorator. This is used
         // to determine whether constructor parameters should be captured or not.
-        if (isNgDecorator) {
+        if (isAngularDecorator(decorator, isCore)) {
           hasAngularDecorator = true;
         }
-
-        if (isNgDecorator && !skipClassDecorators) {
-          decoratorsToLower.push(extractMetadataFromSingleDecorator(decoratorNode, diagnostics));
-          decoratorsToKeep.delete(decoratorNode);
-        }
       }
 
-      if (decoratorsToLower.length) {
-        newMembers.push(createDecoratorClassProperty(decoratorsToLower));
-      }
       if (classParameters) {
         if (hasAngularDecorator || classParameters.some(p => !!p.decorators.length)) {
           // Capture constructor parameters if the class has Angular decorator applied,
@@ -568,16 +528,10 @@ export function getDownlevelDecoratorsTransform(
       const members = ts.setTextRange(
           ts.factory.createNodeArray(newMembers, classDecl.members.hasTrailingComma),
           classDecl.members);
-      const classModifiers = ts.getModifiers(classDecl);
-      let modifiers: ts.ModifierLike[]|undefined;
-
-      if (decoratorsToKeep.size || classModifiers?.length) {
-        modifiers = [...decoratorsToKeep, ...(classModifiers || [])];
-      }
 
       return ts.factory.updateClassDeclaration(
-          classDecl, modifiers, classDecl.name, classDecl.typeParameters, classDecl.heritageClauses,
-          members);
+          classDecl, classDecl.modifiers, classDecl.name, classDecl.typeParameters,
+          classDecl.heritageClauses, members);
     }
 
     /**

--- a/packages/compiler-cli/src/transformers/downlevel_decorators_transform/downlevel_decorators_transform.ts
+++ b/packages/compiler-cli/src/transformers/downlevel_decorators_transform/downlevel_decorators_transform.ts
@@ -504,14 +504,10 @@ export function getDownlevelDecoratorsTransform(
       // return all decorators, but only ones that could be possible Angular decorators.
       const possibleAngularDecorators = host.getDecoratorsOfDeclaration(classDecl) || [];
 
-      let hasAngularDecorator = false;
-      for (const decorator of possibleAngularDecorators) {
-        // Keep track if we come across an Angular class decorator. This is used
-        // to determine whether constructor parameters should be captured or not.
-        if (isAngularDecorator(decorator, isCore)) {
-          hasAngularDecorator = true;
-        }
-      }
+      // Keep track if we come across an Angular class decorator. This is used
+      // to determine whether constructor parameters should be captured or not.
+      const hasAngularDecorator =
+          possibleAngularDecorators.some(d => isAngularDecorator(d, isCore));
 
       if (classParameters) {
         if (hasAngularDecorator || classParameters.some(p => !!p.decorators.length)) {

--- a/tools/legacy-saucelabs/downlevel_decorator_transform.ts
+++ b/tools/legacy-saucelabs/downlevel_decorator_transform.ts
@@ -23,5 +23,5 @@ export function legacyCompilationDownlevelDecoratorTransform(program: ts.Program
   // Note: `isCore` is set to `true` since we also process the core package.
   return getDownlevelDecoratorsTransform(
       typeChecker, reflectionHost, [], /* isCore */ true,
-      /* enableClosureCompiler */ false, /* skipClassDecorators */ true);
+      /* enableClosureCompiler */ false);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11518,13 +11518,6 @@ madge@^6.0.0:
     typescript "^3.9.5"
     walkdir "^0.4.1"
 
-magic-string@0.27.0, magic-string@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
-  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
-  dependencies:
-    "@jridgewell/sourcemap-codec" "^1.4.13"
-
 magic-string@0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.0.tgz#fd58a4748c5c4547338a424e90fa5dd17f4de529"
@@ -11538,6 +11531,13 @@ magic-string@^0.25.7:
   integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
   dependencies:
     sourcemap-codec "^1.4.8"
+
+magic-string@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.27.0.tgz#e4a3413b4bab6d98d2becffd48b4a257effdbbf3"
+  integrity sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.13"
 
 make-dir@^1.0.0:
   version "1.3.0"


### PR DESCRIPTION
The decorator downlevel transform is never used for actual class decorators because Angular class decorators rely on immediate execution for JIT. Initially we also supported downleveling of class decorators for View Engine library output, but libraries are shipped using partial compilation output and are not using this transform anymore.

All usages of the transform explicitly set `skipClassDecorators = true`, so this PR is in practice removing
unused/dead code.

Note that the transform is exclusively used for JIT processing, commonly for test files to help ease temporal dead-zone/forward-ref issues. We can remove the class decorator downlevel logic to remove technical debt.