### PR TITLE
refactor(dev-infra): remove obsolete todos

### DIFF
--- a/integration/hello_world__closure/e2e/tsconfig.json
+++ b/integration/hello_world__closure/e2e/tsconfig.json
@@ -2,7 +2,5 @@
   "compilerOptions": {
     "outDir": "../built/e2e",
     "types": ["jasmine", "jasminewd2"],
-    // TODO(alexeagle): was required for Protractor 4.0.11
-    "skipLibCheck": true
   }
 }

--- a/integration/hello_world__closure/tsconfig.json
+++ b/integration/hello_world__closure/tsconfig.json
@@ -6,8 +6,6 @@
   "compilerOptions": {
     "module": "es2015",
     "moduleResolution": "node",
-    // TODO(i): strictNullChecks should turned on but are temporarily disabled due to #15432
-    "strictNullChecks": false,
     "target": "es6",
     "noImplicitAny": false,
     "sourceMap": false,

--- a/integration/i18n/e2e/tsconfig.json
+++ b/integration/i18n/e2e/tsconfig.json
@@ -2,7 +2,5 @@
   "compilerOptions": {
     "outDir": "../built/e2e",
     "types": ["jasmine", "jasminewd2"],
-    // TODO(alexeagle): was required for Protractor 4.0.11
-    "skipLibCheck": true
   }
 }

--- a/integration/i18n/tsconfig.json
+++ b/integration/i18n/tsconfig.json
@@ -6,8 +6,6 @@
   "compilerOptions": {
     "module": "es2020",
     "moduleResolution": "node",
-    // TODO(i): strictNullChecks should turned on but are temporarily disabled due to #15432
-    "strictNullChecks": false,
     "target": "es2020",
     "noImplicitAny": false,
     "sourceMap": false,

--- a/integration/ng_elements/e2e/tsconfig.json
+++ b/integration/ng_elements/e2e/tsconfig.json
@@ -2,7 +2,5 @@
   "compilerOptions": {
     "outDir": "../built/e2e",
     "types": ["jasmine", "jasminewd2"],
-    // TODO(alexeagle): was required for Protractor 4.0.11
-    "skipLibCheck": true
   }
 }

--- a/integration/platform-server/e2e/tsconfig.json
+++ b/integration/platform-server/e2e/tsconfig.json
@@ -2,7 +2,5 @@
   "compilerOptions": {
     "outDir": "../built/e2e",
     "types": ["jasmine", "jasminewd2"],
-    // TODO(alexeagle): was required for Protractor 4.0.11
-    "skipLibCheck": true
   }
 }

--- a/integration/platform-server/tsconfig.json
+++ b/integration/platform-server/tsconfig.json
@@ -2,8 +2,6 @@
   "compilerOptions": {
     "module": "es2020",
     "moduleResolution": "node",
-    // TODO(i): strictNullChecks should turned on but are temporarily disabled due to #15432
-    "strictNullChecks": false,
     "target": "es2020",
     "noImplicitAny": false,
     "sourceMap": false,


### PR DESCRIPTION
Both  `skipLibCheck: true` and `strictNullChecks: false`  are not needed anymore in the integration tests. 