### PR TITLE
docs: Remove `RenderComponentType` from the depreciation list.

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -45,7 +45,6 @@ v15 - v18
 | `@angular/common`                   | [`ReflectiveInjector`](#reflectiveinjector)                                                                |  v8           | v11               |
 | `@angular/core`                     | [`DefaultIterableDiffer`](#core)                                                                           |  v7           | v11         |
 | `@angular/core`                     | [`ReflectiveKey`](#core)                                                                                   |  v8           | v11         |
-| `@angular/core`                     | [`RenderComponentType`](#core)                                                                             |  v7           | v11         |
 | `@angular/core`                     | [`defineInjectable`](#core)                                                                                |  v8           | v11         |
 | `@angular/core`                     | [`entryComponents`](api/core/NgModule#entryComponents)                                                     |  v9           | v11         |
 | `@angular/core`                     | [`ANALYZE_FOR_ENTRY_COMPONENTS`](api/core/ANALYZE_FOR_ENTRY_COMPONENTS)                                    |  v9           | v11         |


### PR DESCRIPTION
`RenderComponentType` was removed by #33019

