### PR TITLE
fix(http): prevent headers from throwing an error when initializing numerical values

### DIFF
--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -1782,7 +1782,7 @@ export class HttpHeaderResponse extends HttpResponseBase {
 // @public
 export class HttpHeaders {
     constructor(headers?: string | {
-        [name: string]: string | string[];
+        [name: string]: string | number | (string | number)[];
     });
     append(name: string, value: string | string[]): HttpHeaders;
     delete(name: string, value?: string | string[]): HttpHeaders;

--- a/packages/common/http/src/headers.ts
+++ b/packages/common/http/src/headers.ts
@@ -45,7 +45,7 @@ export class HttpHeaders {
 
   /**  Constructs a new HTTP header object with the given values.*/
 
-  constructor(headers?: string|{[name: string]: string | string[]}) {
+  constructor(headers?: string|{[name: string]: string | number | (string | number)[]}) {
     if (!headers) {
       this.headers = new Map<string, string[]>();
     } else if (typeof headers === 'string') {
@@ -72,14 +72,20 @@ export class HttpHeaders {
           assertValidHeaders(headers);
         }
         this.headers = new Map<string, string[]>();
-        Object.keys(headers).forEach(name => {
-          let values: string|string[] = headers[name];
-          const key = name.toLowerCase();
+        Object.entries(headers).forEach(([name, values]) => {
+          let headerValues: string[];
+
           if (typeof values === 'string') {
-            values = [values];
+            headerValues = [values];
+          } else if (typeof values === 'number') {
+            headerValues = [values.toString()];
+          } else {
+            headerValues = values.map((value) => value.toString());
           }
-          if (values.length > 0) {
-            this.headers.set(key, values);
+
+          if (headerValues.length > 0) {
+            const key = name.toLowerCase();
+            this.headers.set(key, headerValues);
             this.maybeSetNormalizedName(name, key);
           }
         });
@@ -264,16 +270,16 @@ export class HttpHeaders {
 
 /**
  * Verifies that the headers object has the right shape: the values
- * must be either strings or arrays. Throws an error if an invalid
+ * must be either strings, numbers or arrays. Throws an error if an invalid
  * header value is present.
  */
 function assertValidHeaders(headers: Record<string, unknown>):
-    asserts headers is Record<string, string|string[]> {
+    asserts headers is Record<string, string|string[]|number|number[]> {
   for (const [key, value] of Object.entries(headers)) {
-    if (typeof value !== 'string' && !Array.isArray(value)) {
+    if (!(typeof value === 'string' || typeof value === 'number') && !Array.isArray(value)) {
       throw new Error(
           `Unexpected value of the \`${key}\` header provided. ` +
-          `Expecting either a string or an array, but got: \`${value}\`.`);
+          `Expecting either a string, a number or an array, but got: \`${value}\`.`);
     }
   }
 }

--- a/packages/common/http/test/client_spec.ts
+++ b/packages/common/http/test/client_spec.ts
@@ -224,7 +224,7 @@ import {toArray} from 'rxjs/operators';
         expect(() => backend.expectOne('/test').request.headers.has('random-header'))
             .toThrowError(
                 'Unexpected value of the `foo` header provided. ' +
-                'Expecting either a string or an array, but got: `null`.');
+                'Expecting either a string, a number or an array, but got: `null`.');
       });
     });
   });

--- a/packages/common/http/test/headers_spec.ts
+++ b/packages/common/http/test/headers_spec.ts
@@ -54,7 +54,7 @@ import {HttpHeaders} from '@angular/common/http/src/headers';
         expect(() => headers.get('foo'))
             .toThrowError(
                 'Unexpected value of the `foo` header provided. ' +
-                'Expecting either a string or an array, but got: `null`.');
+                'Expecting either a string, a number or an array, but got: `null`.');
       });
 
       it('should throw an error when undefined is passed as header', () => {
@@ -64,7 +64,25 @@ import {HttpHeaders} from '@angular/common/http/src/headers';
         expect(() => headers.get('bar'))
             .toThrowError(
                 'Unexpected value of the `bar` header provided. ' +
-                'Expecting either a string or an array, but got: `undefined`.');
+                'Expecting either a string, a number or an array, but got: `undefined`.');
+      });
+
+      it('should not throw an error when a number is passed as header', () => {
+        const headers = new HttpHeaders({'Content-Length': 100});
+        const value = headers.get('Content-Length');
+        expect(value).toEqual('100');
+      });
+
+      it('should not throw an error when a numerical array is passed as header', () => {
+        const headers = new HttpHeaders({'some-key': [123]});
+        const value = headers.get('some-key');
+        expect(value).toEqual('123');
+      });
+
+      it('should not throw an error when an array of strings is passed as header', () => {
+        const headers = new HttpHeaders({'some-key': ['myValue']});
+        const value = headers.get('some-key');
+        expect(value).toEqual('myValue');
       });
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Some libraries could use numbers in headers, but Angular is throwing an error when initializing Headers with numerical values

Issue Number: #49353


## What is the new behavior?
Angular won't throw an error if there's some number in HTTP Headers. It will just cast those values into string.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
