### PR TITLE
feat(platform-server): add `provideServerSupport` function to provide server capabilities to an application

### DIFF
--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -49,6 +49,9 @@ export class PlatformState {
 }
 
 // @public
+export function provideServerSupport(): EnvironmentProviders;
+
+// @public
 export function renderApplication<T>(bootstrap: () => Promise<ApplicationRef>, options: {
     document?: string | Document;
     url?: string;

--- a/packages/platform-server/src/platform-server.ts
+++ b/packages/platform-server/src/platform-server.ts
@@ -7,6 +7,7 @@
  */
 
 export {PlatformState} from './platform_state';
+export {provideServerSupport} from './provide_server';
 export {platformDynamicServer, platformServer, ServerModule} from './server';
 export {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, PlatformConfig} from './tokens';
 export {ServerTransferStateModule} from './transfer_state';

--- a/packages/platform-server/src/provide_server.ts
+++ b/packages/platform-server/src/provide_server.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HttpClientModule} from '@angular/common/http';
+import {EnvironmentProviders, importProvidersFrom, makeEnvironmentProviders} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+
+import {PLATFORM_SERVER_PROVIDERS} from './server';
+
+/**
+ * Sets up providers necessary to enable server rendering functionality for the application.
+ *
+ * @usageNotes
+ *
+ * Basic example of how you can add server support to your application:
+ * ```ts
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideServerSupport()]
+ * });
+ * ```
+ *
+ * @publicApi
+ * @returns A set of providers to setup the server.
+ */
+export function provideServerSupport(): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    importProvidersFrom(BrowserModule),
+    importProvidersFrom(HttpClientModule),
+    importProvidersFrom(NoopAnimationsModule),
+    ...PLATFORM_SERVER_PROVIDERS,
+  ]);
+}

--- a/packages/platform-server/src/provide_server.ts
+++ b/packages/platform-server/src/provide_server.ts
@@ -6,10 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {HttpClientModule} from '@angular/common/http';
-import {EnvironmentProviders, importProvidersFrom, makeEnvironmentProviders} from '@angular/core';
-import {BrowserModule} from '@angular/platform-browser';
-import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {provideHttpClient, withInterceptorsFromDi} from '@angular/common/http';
+import {EnvironmentProviders, makeEnvironmentProviders} from '@angular/core';
+import {provideNoopAnimations} from '@angular/platform-browser/animations';
 
 import {PLATFORM_SERVER_PROVIDERS} from './server';
 
@@ -30,9 +29,8 @@ import {PLATFORM_SERVER_PROVIDERS} from './server';
  */
 export function provideServerSupport(): EnvironmentProviders {
   return makeEnvironmentProviders([
-    importProvidersFrom(BrowserModule),
-    importProvidersFrom(HttpClientModule),
-    importProvidersFrom(NoopAnimationsModule),
+    provideHttpClient(withInterceptorsFromDi()),
+    provideNoopAnimations(),
     ...PLATFORM_SERVER_PROVIDERS,
   ]);
 }

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -60,6 +60,15 @@ export const SERVER_RENDER_PROVIDERS: Provider[] = [
   {provide: EVENT_MANAGER_PLUGINS, multi: true, useClass: ServerEventManagerPlugin},
 ];
 
+export const PLATFORM_SERVER_PROVIDERS: Provider[] = [
+  TRANSFER_STATE_SERIALIZATION_PROVIDERS,
+  SERVER_RENDER_PROVIDERS,
+  SERVER_HTTP_PROVIDERS,
+  {provide: Testability, useValue: null},  // Keep for backwards-compatibility.
+  {provide: TESTABILITY, useValue: null},
+  {provide: ViewportScroller, useClass: NullViewportScroller},
+];
+
 /**
  * The ng module for the server.
  *
@@ -68,14 +77,7 @@ export const SERVER_RENDER_PROVIDERS: Provider[] = [
 @NgModule({
   exports: [BrowserModule],
   imports: [HttpClientModule, NoopAnimationsModule],
-  providers: [
-    TRANSFER_STATE_SERIALIZATION_PROVIDERS,
-    SERVER_RENDER_PROVIDERS,
-    SERVER_HTTP_PROVIDERS,
-    {provide: Testability, useValue: null},  // Keep for backwards-compatibility.
-    {provide: TESTABILITY, useValue: null},
-    {provide: ViewportScroller, useClass: NullViewportScroller},
-  ],
+  providers: PLATFORM_SERVER_PROVIDERS,
 })
 export class ServerModule {
 }

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -13,7 +13,7 @@ import {HttpClientTestingModule, HttpTestingController} from '@angular/common/ht
 import {ApplicationRef, Component, destroyPlatform, getPlatform, HostListener, importProvidersFrom, Inject, inject as coreInject, Injectable, Input, NgModule, NgZone, PLATFORM_ID, ViewEncapsulation} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {bootstrapApplication, BrowserModule, makeStateKey, Title, TransferState} from '@angular/platform-browser';
-import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformDynamicServer, PlatformState, renderModule, ServerModule} from '@angular/platform-server';
+import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformDynamicServer, PlatformState, provideServerSupport, renderModule, ServerModule} from '@angular/platform-server';
 import {Observable} from 'rxjs';
 import {first} from 'rxjs/operators';
 
@@ -206,7 +206,7 @@ const MyAsyncServerAppStandalone = createMyAsyncServerApp(true);
 const boostrapMyAsyncServerAppStandalone = () => bootstrapApplication(MyAsyncServerAppStandalone, {
   providers: [
     importProvidersFrom(BrowserModule.withServerTransition({appId: 'simple-cmp'})),
-    importProvidersFrom(ServerModule),
+    provideServerSupport(),
   ]
 });
 


### PR DESCRIPTION


This commit adds the `provideServerSupport()` function that returns the `EnvironmentProviders` needed to setup server rendering without NgModules.
