### PR TITLE
refactor(core): remove duplicate call to `getComponentId`

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -312,8 +312,6 @@ export function ɵɵdefineComponent<T>(componentDefinition: ComponentDefinition<
       id: '',
     };
 
-    def.id = getComponentId(def);
-
     initFeatures(def);
     const dependencies = componentDefinition.dependencies;
     def.directiveDefs = extractDefListOrFactory(dependencies, /* pipeDef */ false);


### PR DESCRIPTION
`getComponentId` is called twice by mistake.

https://github.com/angular/angular/blob/f7c266c4e61663691d49d72dd0db8174563c7694/packages/core/src/render3/definition.ts#L319
