### PR TITLE
refactor(core): add hydration logic for view containers

### DIFF
--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 469002,
+      "main": 470131,
       "polyfills": 33836,
       "styles": 74561,
       "light-theme": 92890,

--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,7 +2,7 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 908,
-      "main": 128010,
+      "main": 128561,
       "polyfills": 33792
     }
   },
@@ -26,7 +26,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2734,
-      "main": 231317,
+      "main": 232018,
       "polyfills": 33810,
       "src_app_lazy_lazy_routes_ts": 487
     }
@@ -34,7 +34,7 @@
   "forms": {
     "uncompressed": {
       "runtime": 888,
-      "main": 160227,
+      "main": 160778,
       "polyfills": 33772
     }
   },

--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -203,10 +203,10 @@ function serializeLView(lView: LView, context: HydrationContext): SerializedView
       // - or an array that represents an LView of a component
       if (Array.isArray(hostNode)) {
         // This is a component, serialize info about it.
-        // TODO: we should *not* serialize if a component is opted-out
-        // (i.e. `ngSkipHydration` is applied).
         const targetNode = unwrapRNode(hostNode as LView) as RElement;
-        annotateHostElementForHydration(targetNode, hostNode as LView, context);
+        if (!(targetNode as HTMLElement).hasAttribute(SKIP_HYDRATION_ATTR_NAME)) {
+          annotateHostElementForHydration(targetNode, hostNode as LView, context);
+        }
       }
       ngh[CONTAINERS] ??= {};
       ngh[CONTAINERS][noOffsetIndex] = serializeLContainer(lView[i], context);

--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -16,7 +16,7 @@ import {HEADER_OFFSET, HOST, LView, RENDERER, TView, TVIEW, TViewType} from '../
 import {unwrapRNode} from '../render3/util/view_utils';
 import {TransferState} from '../transfer_state';
 
-import {CONTAINERS, ELEMENT_CONTAINERS, NUM_ROOT_NODES, SerializedContainerView, SerializedView, TEMPLATE, TEMPLATES} from './interfaces';
+import {CONTAINERS, ELEMENT_CONTAINERS, NUM_ROOT_NODES, SerializedContainerView, SerializedView, TEMPLATE_ID, TEMPLATES} from './interfaces';
 import {SKIP_HYDRATION_ATTR_NAME} from './skip_hydration';
 import {getComponentLViewForHydration, NGH_ATTR_NAME, NGH_DATA_KEY} from './utils';
 
@@ -47,22 +47,24 @@ class SerializedViewCollection {
 }
 
 /**
- * Registry that keeps track of unique TView ids throughout
- * the entire serialization process. This is needed to uniquely
- * identify dehydrated views at runtime: pick up dehydrated
- * views that represent an instance of a view created based
- * on a particular TView.
+ * Global counter that is used to generate a unique id for TViews
+ * during the serialization process.
  */
-class TViewSsrIdRegistry {
-  private registry = new WeakMap<TView, string>();
-  private currentId = 0;
+let tViewSsrId = 0;
 
-  get(tView: TView): string {
-    if (!this.registry.has(tView)) {
-      this.registry.set(tView, `t${this.currentId++}`);
-    }
-    return this.registry.get(tView)!;
+/**
+ * Generates a unique id for a given TView and returns this id.
+ * The id is also stored on this instance of a TView and reused in
+ * subsequent calls.
+ *
+ * This id is needed to uniquely identify and pick up dehydrated views
+ * at runtime.
+ */
+function getSsrId(tView: TView): string {
+  if (!tView.ssrId) {
+    tView.ssrId = `t${tViewSsrId++}`;
   }
+  return tView.ssrId;
 }
 
 /**
@@ -72,7 +74,6 @@ class TViewSsrIdRegistry {
  */
 interface HydrationContext {
   serializedViewCollection: SerializedViewCollection;
-  ssrIdRegistry: TViewSsrIdRegistry;
 }
 
 /**
@@ -94,7 +95,6 @@ function calcNumRootNodes(tView: TView, lView: LView, tNode: TNode|null): number
  */
 export function annotateForHydration(appRef: ApplicationRef, doc: Document) {
   const serializedViewCollection = new SerializedViewCollection();
-  const ssrIdRegistry = new TViewSsrIdRegistry();
   const viewRefs = appRef._views;
   for (const viewRef of viewRefs) {
     const lView = getComponentLViewForHydration(viewRef);
@@ -105,7 +105,6 @@ export function annotateForHydration(appRef: ApplicationRef, doc: Document) {
       if (hostElement) {
         const context: HydrationContext = {
           serializedViewCollection,
-          ssrIdRegistry,
         };
         annotateHostElementForHydration(hostElement as HTMLElement, lView, context);
       }
@@ -119,12 +118,12 @@ export function annotateForHydration(appRef: ApplicationRef, doc: Document) {
 }
 
 /**
- * Serializes the lContainer data into a list of Serializedview objects,
+ * Serializes the lContainer data into a list of SerializedView objects,
  * that represent views within this lContainer.
  *
  * @param lContainer the lContainer we are serializing
  * @param context the hydration context
- * @returns an array of the `Serializedview` objects
+ * @returns an array of the `SerializedView` objects
  */
 function serializeLContainer(
     lContainer: LContainer, context: HydrationContext): SerializedContainerView[] {
@@ -133,7 +132,7 @@ function serializeLContainer(
   for (let i = CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
     let childLView = lContainer[i] as LView;
 
-    // If this is a root view, get an LView for te underlying component,
+    // If this is a root view, get an LView for the underlying component,
     // because it contains information about the view to serialize.
     if (isRootView(childLView)) {
       childLView = childLView[HEADER_OFFSET];
@@ -149,12 +148,12 @@ function serializeLContainer(
       // host node itself (other nodes would be inside that host node).
       numRootNodes = 1;
     } else {
-      template = context.ssrIdRegistry.get(childTView);
+      template = getSsrId(childTView);
       numRootNodes = calcNumRootNodes(childTView, childLView, childTView.firstChild);
     }
 
     const view: SerializedContainerView = {
-      [TEMPLATE]: template,
+      [TEMPLATE_ID]: template,
       [NUM_ROOT_NODES]: numRootNodes,
       ...serializeLView(lContainer[i] as LView, context),
     };
@@ -192,7 +191,7 @@ function serializeLView(lView: LView, context: HydrationContext): SerializedView
       const embeddedTView = tNode.tView;
       if (embeddedTView !== null) {
         ngh[TEMPLATES] ??= {};
-        ngh[TEMPLATES][noOffsetIndex] = context.ssrIdRegistry.get(embeddedTView);
+        ngh[TEMPLATES][noOffsetIndex] = getSsrId(embeddedTView);
       }
 
       // Serialize views within this LContainer.

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -9,12 +9,15 @@
 import {PLATFORM_ID} from '../application_tokens';
 import {ENVIRONMENT_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders} from '../di';
 import {inject} from '../di/injector_compatibility';
+import {enableLocateOrCreateContainerRefImpl} from '../linker/view_container_ref';
 import {enableLocateOrCreateElementNodeImpl} from '../render3/instructions/element';
 import {enableLocateOrCreateElementContainerNodeImpl} from '../render3/instructions/element_container';
+import {enableLocateOrCreateContainerAnchorImpl} from '../render3/instructions/template';
 import {enableLocateOrCreateTextNodeImpl} from '../render3/instructions/text';
 
 import {IS_HYDRATION_FEATURE_ENABLED, PRESERVE_HOST_CONTENT} from './tokens';
 import {enableRetrieveHydrationInfoImpl} from './utils';
+import {enableFindMatchingDehydratedViewImpl} from './views';
 
 
 /**
@@ -41,6 +44,9 @@ function enableHydrationRuntimeSupport() {
     enableLocateOrCreateElementNodeImpl();
     enableLocateOrCreateTextNodeImpl();
     enableLocateOrCreateElementContainerNodeImpl();
+    enableLocateOrCreateContainerAnchorImpl();
+    enableLocateOrCreateContainerRefImpl();
+    enableFindMatchingDehydratedViewImpl();
   }
 }
 

--- a/packages/core/src/hydration/cleanup.ts
+++ b/packages/core/src/hydration/cleanup.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DEHYDRATED_VIEWS, LContainer} from '../render3/interfaces/container';
+import {Renderer} from '../render3/interfaces/renderer';
+import {RNode} from '../render3/interfaces/renderer_dom';
+import {PARENT, RENDERER} from '../render3/interfaces/view';
+import {nativeRemoveNode} from '../render3/node_manipulation';
+import {EMPTY_ARRAY} from '../util/empty';
+
+import {validateSiblingNodeExists} from './error_handling';
+import {DehydratedContainerView, NUM_ROOT_NODES} from './interfaces';
+
+/**
+ * Removes all dehydrated views from a given LContainer:
+ * both in internal data structure, as well as removing
+ * corresponding DOM nodes that belong to that dehydrated view.
+ */
+export function removeDehydratedViews(lContainer: LContainer) {
+  const views = lContainer[DEHYDRATED_VIEWS] ?? [];
+  const parentLView = lContainer[PARENT];
+  const renderer = parentLView[RENDERER];
+  for (const view of views) {
+    removeDehydratedView(view, renderer);
+    ngDevMode && ngDevMode.dehydratedViewsRemoved++;
+  }
+  // Reset the value to an empty array to indicate that no
+  // further processing of dehydrated views is needed for
+  // this view container (i.e. do not trigger the lookup process
+  // once again in case a `ViewContainerRef` is created later).
+  lContainer[DEHYDRATED_VIEWS] = EMPTY_ARRAY;
+}
+
+/**
+ * Helper function to remove all nodes from a dehydrated view.
+ */
+function removeDehydratedView(dehydratedView: DehydratedContainerView, renderer: Renderer) {
+  let nodesRemoved = 0;
+  let currentRNode = dehydratedView.firstChild;
+  if (currentRNode) {
+    const numNodes = dehydratedView.data[NUM_ROOT_NODES];
+    while (nodesRemoved < numNodes) {
+      ngDevMode && validateSiblingNodeExists(currentRNode);
+      const nextSibling: RNode = currentRNode.nextSibling!;
+      nativeRemoveNode(renderer, currentRNode, false);
+      currentRNode = nextSibling;
+      nodesRemoved++;
+    }
+  }
+}

--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -7,6 +7,7 @@
  */
 
 import {TNode} from '../render3/interfaces/node';
+import {RNode} from '../render3/interfaces/renderer_dom';
 import {LView} from '../render3/interfaces/view';
 
 /**
@@ -14,10 +15,11 @@ import {LView} from '../render3/interfaces/view';
  * based on internal data structure state.
  */
 export function validateMatchingNode(
-    node: Node, nodeType: number, tagName: string|null, lView: LView, tNode: TNode): void {
-  if (node.nodeType !== nodeType ||
-      (node.nodeType === Node.ELEMENT_NODE &&
-       (node as HTMLElement).tagName.toLowerCase() !== tagName?.toLowerCase())) {
+    node: RNode, nodeType: number, tagName: string|null, lView: LView, tNode: TNode): void {
+  validateNodeExists(node);
+  if ((node as Node).nodeType !== nodeType ||
+      (node as Node).nodeType === Node.ELEMENT_NODE &&
+          (node as HTMLElement).tagName.toLowerCase() !== tagName?.toLowerCase()) {
     // TODO: improve error message and use RuntimeError instead.
     throw new Error(`Unexpected node found during hydration.`);
   }
@@ -26,9 +28,16 @@ export function validateMatchingNode(
 /**
  * Verifies whether next sibling node exists.
  */
-export function validateSiblingNodeExists(node: Node): void {
+export function validateSiblingNodeExists(node: RNode): void {
   if (!node.nextSibling) {
     // TODO: improve error message and use RuntimeError instead.
     throw new Error(`Unexpected state: insufficient number of sibling nodes.`);
+  }
+}
+
+export function validateNodeExists(node: RNode|null): void {
+  if (!node) {
+    // TODO: improve error message and use RuntimeError instead.
+    throw new Error(`Hydration expected an element to be present at this location.`);
   }
 }

--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -28,8 +28,9 @@ export function validateMatchingNode(
 /**
  * Verifies whether next sibling node exists.
  */
-export function validateSiblingNodeExists(node: RNode): void {
-  if (!node.nextSibling) {
+export function validateSiblingNodeExists(node: RNode|null): void {
+  validateNodeExists(node);
+  if (!(node as RNode).nextSibling) {
     // TODO: improve error message and use RuntimeError instead.
     throw new Error(`Unexpected state: insufficient number of sibling nodes.`);
   }

--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -8,8 +8,11 @@
 
 import {RNode} from '../render3/interfaces/renderer_dom';
 
-/* Represents a key in NghDom that holds information about <ng-container>s. */
+/* Serialized view key that holds information about <ng-container>s. */
 export const ELEMENT_CONTAINERS = 'e';
+
+/* Serialized view key that holds information about templates. */
+export const TEMPLATES = 't';
 
 /**
  * Represents element containers within this view, stored as key-value pairs
@@ -32,6 +35,14 @@ export interface SerializedView {
    * Serialized information about <ng-container>s.
    */
   [ELEMENT_CONTAINERS]?: SerializedElementContainers;
+
+  /**
+   * Serialized information about templates.
+   * Key-value pairs where a key is an index of the corresponding
+   * `template` instruction and the value is a unique id that can
+   * be used during hydration to identify that template.
+   */
+  [TEMPLATES]?: Record<number, string>;
 }
 
 /**

--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -8,11 +8,15 @@
 
 import {RNode} from '../render3/interfaces/renderer_dom';
 
-/* Serialized view key that holds information about <ng-container>s. */
+/**
+ * Keys within serialized view data structure to represent various
+ * parts. See the `SerializedView` interface below for additional information.
+ */
 export const ELEMENT_CONTAINERS = 'e';
-
-/* Serialized view key that holds information about templates. */
 export const TEMPLATES = 't';
+export const CONTAINERS = 'c';
+export const NUM_ROOT_NODES = 'r';
+export const TEMPLATE = 'i';  // as it's also an "id"
 
 /**
  * Represents element containers within this view, stored as key-value pairs
@@ -43,6 +47,37 @@ export interface SerializedView {
    * be used during hydration to identify that template.
    */
   [TEMPLATES]?: Record<number, string>;
+
+  /**
+   * Serialized information about view containers.
+   * Key-value pairs where a key is an index of the corresponding
+   * LContainer entry within an LView, and the value is a list
+   * of serialized information about views within this container.
+   */
+  [CONTAINERS]?: Record<number, SerializedContainerView[]>;
+}
+
+/**
+ * Serialized data structure that contains relevant hydration
+ * annotation information about a view that is a part of a
+ * ViewContainer collection.
+ */
+export interface SerializedContainerView extends SerializedView {
+  /**
+   * Unique id that represents a TView that was used to create
+   * a given instance of a view:
+   *  - TViewType.Embedded: a unique id generated during serialization on the server
+   *  - TViewType.Component: an id generated based on component properties
+   *                        (see `getComponentId` function for details)
+   */
+  [TEMPLATE]: string;
+
+  /**
+   * Number of root nodes that belong to this view.
+   * This information is needed to effectively traverse the DOM tree
+   * and identify segments that belong to different views.
+   */
+  [NUM_ROOT_NODES]: number;
 }
 
 /**

--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -119,3 +119,14 @@ export interface DehydratedView {
    */
   ngContainers?: {[index: number]: DehydratedElementContainer};
 }
+
+/**
+ * An object that contains hydration-related information serialized
+ * on the server, as well as the necessary references to segments of
+ * the DOM, to facilitate the hydration process for a given view
+ * inside a view container (either an embedded view or a view created
+ * for a component).
+ */
+export interface DehydratedContainerView extends DehydratedView {
+  data: Readonly<SerializedContainerView>;
+}

--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -81,19 +81,6 @@ export interface SerializedContainerView extends SerializedView {
 }
 
 /**
- * Represents a hydration-related element container structure
- * at runtime, which includes a reference to a first node in
- * a DOM segment that corresponds to a given element container.
- */
-export interface DehydratedElementContainer {
-  /**
-   * A reference to the first child in a DOM segment associated
-   * with a first child in a given <ng-container>.
-   */
-  firstChild: RNode|null;
-}
-
-/**
  * An object that contains hydration-related information serialized
  * on the server, as well as the necessary references to segments of
  * the DOM, to facilitate the hydration process for a given hydration
@@ -112,12 +99,10 @@ export interface DehydratedView {
   firstChild: RNode|null;
 
   /**
-   * Collection of <ng-container>s in a given view,
-   * used as a set of pointers to first children in each
-   * <ng-container>, so that those pointers are reused by
-   * subsequent instructions.
+   * Stores references to first nodes in DOM segments that
+   * represent either an <ng-container> or a view container.
    */
-  ngContainers?: {[index: number]: DehydratedElementContainer};
+  segmentHeads?: {[index: number]: RNode|null};
 }
 
 /**

--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -16,7 +16,7 @@ export const ELEMENT_CONTAINERS = 'e';
 export const TEMPLATES = 't';
 export const CONTAINERS = 'c';
 export const NUM_ROOT_NODES = 'r';
-export const TEMPLATE = 'i';  // as it's also an "id"
+export const TEMPLATE_ID = 'i';  // as it's also an "id"
 
 /**
  * Represents element containers within this view, stored as key-value pairs
@@ -70,7 +70,7 @@ export interface SerializedContainerView extends SerializedView {
    *  - TViewType.Component: an id generated based on component properties
    *                        (see `getComponentId` function for details)
    */
-  [TEMPLATE]: string;
+  [TEMPLATE_ID]: string;
 
   /**
    * Number of root nodes that belong to this view.

--- a/packages/core/src/hydration/node_lookup_utils.ts
+++ b/packages/core/src/hydration/node_lookup_utils.ts
@@ -59,11 +59,11 @@ export function locateNextRNode<T extends RNode>(
         // represented in the DOM as `<div></div>...<!--container-->`.
         // In this case, there are nodes *after* this element and we need to skip
         // all of them to reach an element that we are looking for.
-        const previousSiblingIndex = previousTNode.index - HEADER_OFFSET;
-        const segmentHead = getSegmentHead(hydrationInfo, previousSiblingIndex);
+        const noOffsetPrevSiblingIndex = previousTNode.index - HEADER_OFFSET;
+        const segmentHead = getSegmentHead(hydrationInfo, noOffsetPrevSiblingIndex);
         if (previousTNode.type === TNodeType.Element && segmentHead) {
           const numRootNodesToSkip =
-              calcSerializedContainerSize(hydrationInfo, previousSiblingIndex);
+              calcSerializedContainerSize(hydrationInfo, noOffsetPrevSiblingIndex);
           // `+1` stands for an anchor comment node after all the views in this container.
           const nodesToSkip = numRootNodesToSkip + 1;
           // First node after this segment.
@@ -83,7 +83,7 @@ export function locateNextRNode<T extends RNode>(
 export function siblingAfter<T extends RNode>(skip: number, from: RNode): T|null {
   let currentNode = from;
   for (let i = 0; i < skip; i++) {
-    ngDevMode && validateSiblingNodeExists(currentNode as Node);
+    ngDevMode && validateSiblingNodeExists(currentNode);
     currentNode = currentNode.nextSibling!;
   }
   return currentNode as T;

--- a/packages/core/src/hydration/skip_hydration.ts
+++ b/packages/core/src/hydration/skip_hydration.ts
@@ -7,6 +7,7 @@
  */
 
 import {TNode} from '../render3/interfaces/node';
+import {LView} from '../render3/interfaces/view';
 
 /**
  * The name of an attribute that can be added to the hydration boundary node
@@ -31,6 +32,22 @@ export function hasNgSkipHydrationAttr(tNode: TNode): boolean {
     if (typeof value === 'string' && value.toLowerCase() === SKIP_HYDRATION_ATTR_NAME_LOWER_CASE) {
       return true;
     }
+  }
+  return false;
+}
+
+/**
+ * Helper function that determines if a given node is within a skip hydration block
+ * by navigating up the TNode tree to see if any parent nodes have skip hydration
+ * attribute.
+ */
+export function isInSkipHydrationBlock(tNode: TNode): boolean {
+  let currentTNode: TNode|null = tNode.parent;
+  while (currentTNode) {
+    if (hasNgSkipHydrationAttr(currentTNode)) {
+      return true;
+    }
+    currentTNode = currentTNode.parent;
   }
   return false;
 }

--- a/packages/core/src/hydration/views.ts
+++ b/packages/core/src/hydration/views.ts
@@ -1,0 +1,82 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DEHYDRATED_VIEWS, LContainer} from '../render3/interfaces/container';
+import {RNode} from '../render3/interfaces/renderer_dom';
+
+import {DehydratedContainerView, NUM_ROOT_NODES, SerializedContainerView, TEMPLATE} from './interfaces';
+import {siblingAfter} from './node_lookup_utils';
+
+
+/**
+ * Given a current DOM node and a serialized information about the views
+ * in a container, walks over the DOM structure, collecting the list of
+ * dehydrated views.
+ */
+export function locateDehydratedViewsInContainer(
+    currentRNode: RNode,
+    serializedViews: SerializedContainerView[]): [RNode, DehydratedContainerView[]] {
+  const dehydratedViews: DehydratedContainerView[] = [];
+  for (const serializedView of serializedViews) {
+    const view: DehydratedContainerView = {
+      data: serializedView,
+      firstChild: null,
+    };
+    if (serializedView[NUM_ROOT_NODES] > 0) {
+      // Keep reference to the first node in this view,
+      // so it can be accessed while invoking template instructions.
+      view.firstChild = currentRNode as HTMLElement;
+
+      // Move over to the next node after this view, which can
+      // either be a first node of the next view or an anchor comment
+      // node after the last view in a container.
+      currentRNode = siblingAfter(serializedView[NUM_ROOT_NODES], currentRNode)!;
+    }
+    dehydratedViews.push(view);
+  }
+
+  return [currentRNode, dehydratedViews];
+}
+
+/**
+ * Reference to a function that searches for a matching dehydrated views
+ * stored on a given lContainer.
+ * Returns `null` by default, when hydration is not enabled.
+ */
+let _findMatchingDehydratedViewImpl: typeof findMatchingDehydratedViewImpl =
+    (lContainer: LContainer, template: string|null) => null;
+
+function findMatchingDehydratedViewImpl(
+    lContainer: LContainer, template: string|null): DehydratedContainerView|null {
+  if (!lContainer || !template || !lContainer[DEHYDRATED_VIEWS]) {
+    return null;
+  }
+  let view: DehydratedContainerView|null = null;
+  // Does the target container have any dehydrated views?
+  const views = lContainer[DEHYDRATED_VIEWS];
+  if (views.length > 0) {
+    const viewIndex = views.findIndex(view => view.data[TEMPLATE] === template);
+
+    if (viewIndex > -1) {
+      view = views[viewIndex];
+
+      // Drop this view from the list of de-hydrated ones.
+      views.splice(viewIndex, 1);
+    }
+  }
+  return view;
+}
+
+export function enableFindMatchingDehydratedViewImpl() {
+  _findMatchingDehydratedViewImpl = findMatchingDehydratedViewImpl;
+}
+
+export function findMatchingDehydratedView(
+    lContainer: LContainer, template: string|null): DehydratedContainerView|null {
+  return _findMatchingDehydratedViewImpl(lContainer, template);
+}

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -38,7 +38,7 @@ import {ComponentDef, DirectiveDef, HostDirectiveDefs} from './interfaces/defini
 import {PropertyAliasValue, TContainerNode, TElementContainerNode, TElementNode, TNode, TNodeType} from './interfaces/node';
 import {Renderer, RendererFactory} from './interfaces/renderer';
 import {RElement, RNode} from './interfaces/renderer_dom';
-import {CONTEXT, HEADER_OFFSET, HYDRATION, INJECTOR, LView, LViewFlags, TVIEW, TViewType} from './interfaces/view';
+import {CONTEXT, HEADER_OFFSET, INJECTOR, LView, LViewFlags, TVIEW, TViewType} from './interfaces/view';
 import {MATH_ML_NAMESPACE, SVG_NAMESPACE} from './namespaces';
 import {createElementNode, setupStaticAttributes, writeDirectClass} from './node_manipulation';
 import {extractAttrsAndClassesFromSelector, stringifyCSSSelectorList} from './node_selector_matcher';
@@ -178,7 +178,8 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
                                                  LViewFlags.CheckAlways | LViewFlags.IsRoot;
 
     // Create the root view. Uses empty TView and ContentTemplate.
-    const rootTView = createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, null);
+    const rootTView =
+        createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, null, null);
     const rootLView = createLView(
         null, rootTView, null, rootFlags, null, null, rendererFactory, hostRenderer, sanitizer,
         rootViewInjector, null, null);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -10,7 +10,7 @@ import {Injector} from '../../di/injector';
 import {ErrorHandler} from '../../error_handler';
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {DehydratedView} from '../../hydration/interfaces';
-import {IS_HYDRATION_FEATURE_ENABLED, PRESERVE_HOST_CONTENT, PRESERVE_HOST_CONTENT_DEFAULT} from '../../hydration/tokens';
+import {PRESERVE_HOST_CONTENT, PRESERVE_HOST_CONTENT_DEFAULT} from '../../hydration/tokens';
 import {retrieveHydrationInfo} from '../../hydration/utils';
 import {DoCheck, OnChanges, OnInit} from '../../interface/lifecycle_hooks';
 import {SchemaMetadata} from '../../metadata/schema';
@@ -558,44 +558,6 @@ export function saveResolvedLocalsInData(
 }
 
 /**
- * A method can returns a component ID from the component definition using a variant of DJB2 hash
- * algorithm.
- *
- * TODO: remove this method once https://github.com/angular/angular/pull/48253 lands.
- */
-function getComponentId(componentDef: Partial<ComponentDef<unknown>>): string {
-  let hash = 0;
-
-  // We cannot rely solely on the component selector as the same selector can be used in different
-  // modules.
-  // Example:
-  // https://github.com/angular/components/blob/d9f82c8f95309e77a6d82fd574c65871e91354c2/src/material/core/option/option.ts#L248
-  // https://github.com/angular/components/blob/285f46dc2b4c5b127d356cb7c4714b221f03ce50/src/material/legacy-core/option/option.ts#L32
-
-  const hashSelectors = [
-    componentDef.selectors,
-    componentDef.ngContentSelectors,
-    componentDef.hostVars,
-    componentDef.hostAttrs,
-    componentDef.consts,
-    componentDef.vars,
-    componentDef.decls,
-    componentDef.encapsulation,
-    componentDef.standalone,
-  ].join('|');
-
-  for (const char of hashSelectors) {
-    hash = Math.imul(31, hash) + char.charCodeAt(0) << 0;
-  }
-
-  // Force positive number hash.
-  // 2147483647 = equivalent of Integer.MAX_VALUE.
-  hash += 2147483647 + 1;
-
-  return `c${hash}`;
-}
-
-/**
  * Gets TView from a template function or creates a new TView
  * if it doesn't already exist.
  *
@@ -611,11 +573,9 @@ export function getOrCreateComponentTView(def: ComponentDef<any>): TView {
     // Declaration node here is null since this function is called when we dynamically create a
     // component and hence there is no declaration.
     const declTNode = null;
-    // TODO: replace with `def.id` once https://github.com/angular/angular/pull/48253 lands.
-    const componentId = getComponentId(def);
     return def.tView = createTView(
                TViewType.Component, declTNode, def.template, def.decls, def.vars, def.directiveDefs,
-               def.pipeDefs, def.viewQuery, def.schemas, def.consts, componentId);
+               def.pipeDefs, def.viewQuery, def.schemas, def.consts, def.id);
   }
 
   return tView;
@@ -1597,6 +1557,7 @@ export function createLContainer(
     native,       // native,
     null,         // view refs
     null,         // moved views
+    null,         // dehydrated views
   ];
   ngDevMode &&
       assertEqual(

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -5,16 +5,20 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {validateMatchingNode, validateNodeExists} from '../../hydration/error_handling';
 import {TEMPLATES} from '../../hydration/interfaces';
+import {locateNextRNode, siblingAfter} from '../../hydration/node_lookup_utils';
+import {calcSerializedContainerSize, markRNodeAsClaimedByHydration, setSegmentHead} from '../../hydration/utils';
 import {assertFirstCreatePass} from '../assert';
 import {attachPatchData} from '../context_discovery';
 import {registerPostOrderHooks} from '../hooks';
 import {ComponentTemplate} from '../interfaces/definition';
-import {LocalRefExtractor, TAttributes, TContainerNode, TNodeType} from '../interfaces/node';
+import {LocalRefExtractor, TAttributes, TContainerNode, TNode, TNodeType} from '../interfaces/node';
+import {RComment} from '../interfaces/renderer_dom';
 import {isDirectiveHost} from '../interfaces/type_checks';
 import {HEADER_OFFSET, HYDRATION, LView, RENDERER, TView, TViewType} from '../interfaces/view';
 import {appendChild} from '../node_manipulation';
-import {getLView, getTView, setCurrentTNode} from '../state';
+import {getLView, getTView, isInSkipHydrationBlock, lastNodeWasCreated, setCurrentTNode, wasLastNodeCreated} from '../state';
 import {getConstant} from '../util/view_utils';
 
 import {addToViewTree, createDirectivesInstances, createLContainer, createTView, getOrCreateTNode, resolveDirectives, saveResolvedLocalsInData} from './shared';
@@ -87,8 +91,11 @@ export function ɵɵtemplate(
                                         tView.data[adjustedIndex] as TContainerNode;
   setCurrentTNode(tNode, false);
 
-  const comment = lView[RENDERER].createComment(ngDevMode ? 'container' : '');
-  appendChild(tView, lView, comment, tNode);
+  const comment = _locateOrCreateContainerAnchor(tView, lView, tNode, index) as RComment;
+
+  if (wasLastNodeCreated()) {
+    appendChild(tView, lView, comment, tNode);
+  }
   attachPatchData(comment, lView);
 
   addToViewTree(lView, lView[adjustedIndex] = createLContainer(comment, lView, comment, tNode));
@@ -100,4 +107,54 @@ export function ɵɵtemplate(
   if (localRefsIndex != null) {
     saveResolvedLocalsInData(lView, tNode, localRefExtractor);
   }
+}
+
+let _locateOrCreateContainerAnchor = createContainerAnchorImpl;
+
+/**
+ * Regular creation mode for LContainers and their anchor (comment) nodes.
+ */
+function createContainerAnchorImpl(
+    tView: TView, lView: LView, tNode: TNode, index: number): RComment {
+  lastNodeWasCreated(true);
+  return lView[RENDERER].createComment(ngDevMode ? 'container' : '');
+}
+
+/**
+ * Enables hydration code path (to lookup existing elements in DOM)
+ * in addition to the regular creation mode for LContainers and their
+ * anchor (comment) nodes.
+ */
+function locateOrCreateContainerAnchorImpl(
+    tView: TView, lView: LView, tNode: TNode, index: number): RComment {
+  const hydrationInfo = lView[HYDRATION];
+  const isNodeCreationMode = !hydrationInfo || isInSkipHydrationBlock();
+  lastNodeWasCreated(isNodeCreationMode);
+
+  // Regular creation mode.
+  if (isNodeCreationMode) {
+    return createContainerAnchorImpl(tView, lView, tNode, index);
+  }
+
+  // Hydration mode, looking up existing elements in DOM.
+  const currentRNode = locateNextRNode(hydrationInfo, tView, lView, tNode)!;
+  ngDevMode && validateNodeExists(currentRNode);
+
+  const viewContainerSize = calcSerializedContainerSize(hydrationInfo, index);
+  // If this container is non-empty, store the first node as a segment head,
+  // otherwise, this node is an anchor and segment head doesn't exist (thus `null`).
+  const segmentHead = viewContainerSize > 0 ? currentRNode : null;
+  setSegmentHead(hydrationInfo, index, segmentHead);
+  const comment = siblingAfter<RComment>(viewContainerSize, currentRNode)!;
+
+  if (ngDevMode) {
+    validateMatchingNode(comment, Node.COMMENT_NODE, null, lView, tNode);
+    markRNodeAsClaimedByHydration(comment);
+  }
+
+  return comment;
+}
+
+export function enableLocateOrCreateContainerAnchorImpl() {
+  _locateOrCreateContainerAnchor = locateOrCreateContainerAnchorImpl;
 }

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -36,7 +36,7 @@ function templateFirstCreatePass(
   const hydrationInfo = lView[HYDRATION];
   if (hydrationInfo) {
     const noOffsetIndex = index - HEADER_OFFSET;
-    ssrId = (hydrationInfo && hydrationInfo.data[TEMPLATES]?.[noOffsetIndex]) || null;
+    ssrId = (hydrationInfo && hydrationInfo.data[TEMPLATES]?.[noOffsetIndex]) ?? null;
   }
   // TODO(pk): refactor getOrCreateTNode to have the "create" only version
   const tNode = getOrCreateTNode(

--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -77,7 +77,7 @@ function locateOrCreateTextNodeImpl(
   // Hydration mode, looking up an existing element in DOM.
   const textNative = locateNextRNode(hydrationInfo, tView, lView, tNode) as RText;
 
-  ngDevMode && validateMatchingNode(textNative as Node, Node.TEXT_NODE, null, lView, tNode);
+  ngDevMode && validateMatchingNode(textNative, Node.TEXT_NODE, null, lView, tNode);
   ngDevMode && markRNodeAsClaimedByHydration(textNative);
 
   return textNative;

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {DehydratedContainerView} from '../../hydration/interfaces';
+
 import {TNode} from './node';
 import {RComment, RElement} from './renderer_dom';
 import {HOST, LView, NEXT, PARENT, T_HOST, TRANSPLANTED_VIEWS_TO_REFRESH} from './view';
@@ -44,6 +46,7 @@ export const HAS_TRANSPLANTED_VIEWS = 2;
 export const NATIVE = 7;
 export const VIEW_REFS = 8;
 export const MOVED_VIEWS = 9;
+export const DEHYDRATED_VIEWS = 10;
 
 
 /**
@@ -52,7 +55,7 @@ export const MOVED_VIEWS = 9;
  * which views are already in the DOM (and don't need to be re-added) and so we can
  * remove views from the DOM when they are no longer required.
  */
-export const CONTAINER_HEADER_OFFSET = 10;
+export const CONTAINER_HEADER_OFFSET = 11;
 
 /**
  * The state associated with a container.
@@ -130,6 +133,18 @@ export interface LContainer extends Array<any> {
    * doing so creates circular dependency.
    */
   [VIEW_REFS]: unknown[]|null;
+
+  /**
+   * Array of dehydrated views within this container.
+   *
+   * This information is used during the hydration process on the client.
+   * The hydration logic tries to find a matching dehydrated view, "claim" it
+   * and use this information to do further matching. After that this "claimed"
+   * view is removed from the list. The remaining "unclaimed" views are later
+   * on "garbage-collected", i.e. removed from the DOM once the hydration
+   * logic finishes.
+   */
+  [DEHYDRATED_VIEWS]: DehydratedContainerView[]|null;
 }
 
 // Note: This hack is necessary so we don't erroneously get a circular dependency

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -138,9 +138,9 @@ export interface LContainer extends Array<any> {
    *
    * This information is used during the hydration process on the client.
    * The hydration logic tries to find a matching dehydrated view, "claim" it
-   * and use this information to do further matching. After that this "claimed"
-   * view is removed from the list. The remaining "unclaimed" views are later
-   * on "garbage-collected", i.e. removed from the DOM once the hydration
+   * and use this information to do further matching. After that, this "claimed"
+   * view is removed from the list. The remaining "unclaimed" views are
+   * "garbage-collected" later on, i.e. removed from the DOM once the hydration
    * logic finishes.
    */
   [DEHYDRATED_VIEWS]: DehydratedContainerView[]|null;

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -121,8 +121,7 @@ export interface LContainer extends Array<any> {
   [T_HOST]: TNode;
 
   /** The comment element that serves as an anchor for this LContainer. */
-  readonly[NATIVE]:
-      RComment;  // TODO(misko): remove as this value can be gotten by unwrapping `[HOST]`
+  [NATIVE]: RComment;
 
   /**
    * Array of `ViewRef`s used by any `ViewContainerRef`s that point to this container.

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -782,6 +782,14 @@ export interface TView {
    * view. This means that the view is likely corrupted and we should try to recover it.
    */
   incompleteFirstPass: boolean;
+
+  /**
+   * Unique id of this TView for hydration purposes:
+   * - TViewType.Embedded: a unique id generated during serialization on the server
+   * - TViewType.Component: an id generated based on component properties
+   *                        (see `getComponentId` function for details)
+   */
+  ssrId: string|null;
 }
 
 /** Single hook callback function. */

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -50,6 +50,7 @@ declare global {
     rendererCreateComment: number;
     hydratedNodes: number;
     hydratedComponents: number;
+    dehydratedViewsRemoved: number;
   }
 }
 
@@ -81,6 +82,7 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
     rendererCreateComment: 0,
     hydratedNodes: 0,
     hydratedComponents: 0,
+    dehydratedViewsRemoved: 0,
   };
 
   // Make sure to refer to ngDevMode as ['ngDevMode'] for closure.

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -546,6 +546,9 @@
     "name": "Subscription"
   },
   {
+    "name": "TEMPLATES"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -624,6 +627,9 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_findMatchingDehydratedViewImpl"
+  },
+  {
     "name": "_getInsertInFrontOfRNodeWithI18n"
   },
   {
@@ -640,6 +646,12 @@
   },
   {
     "name": "_keyMap"
+  },
+  {
+    "name": "_locateOrCreateAnchorNode"
+  },
+  {
+    "name": "_locateOrCreateContainerAnchor"
   },
   {
     "name": "_locateOrCreateElementNode"
@@ -898,6 +910,9 @@
   },
   {
     "name": "findAttrIndexInNode"
+  },
+  {
+    "name": "findMatchingDehydratedView"
   },
   {
     "name": "findStylingValue"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -534,6 +534,9 @@
     "name": "Subscription"
   },
   {
+    "name": "TEMPLATES"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -615,6 +618,9 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_findMatchingDehydratedViewImpl"
+  },
+  {
     "name": "_getInsertInFrontOfRNodeWithI18n"
   },
   {
@@ -628,6 +634,12 @@
   },
   {
     "name": "_keyMap"
+  },
+  {
+    "name": "_locateOrCreateAnchorNode"
+  },
+  {
+    "name": "_locateOrCreateContainerAnchor"
   },
   {
     "name": "_locateOrCreateElementNode"
@@ -868,6 +880,9 @@
   },
   {
     "name": "findAttrIndexInNode"
+  },
+  {
+    "name": "findMatchingDehydratedView"
   },
   {
     "name": "findStylingValue"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -825,6 +825,9 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_findMatchingDehydratedViewImpl"
+  },
+  {
     "name": "_getInsertInFrontOfRNodeWithI18n"
   },
   {
@@ -838,6 +841,9 @@
   },
   {
     "name": "_keyMap"
+  },
+  {
+    "name": "_locateOrCreateAnchorNode"
   },
   {
     "name": "_locateOrCreateElementNode"
@@ -1162,6 +1168,9 @@
   },
   {
     "name": "findAttrIndexInNode"
+  },
+  {
+    "name": "findMatchingDehydratedView"
   },
   {
     "name": "findNode"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -432,6 +432,9 @@
     "name": "Subscription"
   },
   {
+    "name": "TEMPLATES"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -537,6 +540,9 @@
     "name": "_enable_super_gross_mode_that_will_cause_bad_things"
   },
   {
+    "name": "_findMatchingDehydratedViewImpl"
+  },
+  {
     "name": "_getInsertInFrontOfRNodeWithI18n"
   },
   {
@@ -550,6 +556,12 @@
   },
   {
     "name": "_keyMap"
+  },
+  {
+    "name": "_locateOrCreateAnchorNode"
+  },
+  {
+    "name": "_locateOrCreateContainerAnchor"
   },
   {
     "name": "_locateOrCreateElementNode"
@@ -769,6 +781,9 @@
   },
   {
     "name": "findAttrIndexInNode"
+  },
+  {
+    "name": "findMatchingDehydratedView"
   },
   {
     "name": "findStylingValue"

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -140,7 +140,8 @@ describe('di', () => {
   describe('getOrCreateNodeInjector', () => {
     it('should handle initial undefined state', () => {
       const contentView = createLView(
-          null, createTView(TViewType.Component, null, null, 1, 0, null, null, null, null, null),
+          null,
+          createTView(TViewType.Component, null, null, 1, 0, null, null, null, null, null, null),
           {}, LViewFlags.CheckAlways, null, null, {} as any, {} as any, null, null, null, null);
       enterView(contentView);
       try {

--- a/packages/core/test/render3/instructions/shared_spec.ts
+++ b/packages/core/test/render3/instructions/shared_spec.ts
@@ -37,7 +37,7 @@ export function enterViewWithOneDiv() {
   const vars = 60;  // Space for directive expando,  template, component + 3 directives if we assume
                     // that each consume 10 slots.
   const tView = createTView(
-      TViewType.Component, null, emptyTemplate, consts, vars, null, null, null, null, null);
+      TViewType.Component, null, emptyTemplate, consts, vars, null, null, null, null, null, null);
   // Just assume that the expando starts after 10 initial bindings.
   tView.expandoStartIndex = HEADER_OFFSET + 10;
   const tNode = tView.firstChild = createTNode(tView, null!, TNodeType.Element, 0, 'div', null);

--- a/packages/core/test/render3/is_shape_of.ts
+++ b/packages/core/test/render3/is_shape_of.ts
@@ -136,6 +136,7 @@ const ShapeOfTView: ShapeOf<TView> = {
   schemas: true,
   consts: true,
   incompleteFirstPass: true,
+  ssrId: true,
 };
 
 

--- a/packages/core/test/render3/matchers_spec.ts
+++ b/packages/core/test/render3/matchers_spec.ts
@@ -47,7 +47,7 @@ describe('render3 matchers', () => {
   });
 
   describe('matchTView', () => {
-    const tView = createTView(TViewType.Root, null, null, 2, 3, null, null, null, null, null);
+    const tView = createTView(TViewType.Root, null, null, 2, 3, null, null, null, null, null, null);
     it('should match', () => {
       expect(tView).toEqual(matchTView());
       expect(tView).toEqual(matchTView({type: TViewType.Root}));
@@ -55,7 +55,7 @@ describe('render3 matchers', () => {
     });
   });
   describe('matchTNode', () => {
-    const tView = createTView(TViewType.Root, null, null, 2, 3, null, null, null, null, null);
+    const tView = createTView(TViewType.Root, null, null, 2, 3, null, null, null, null, null, null);
     const tNode = createTNode(tView, null, TNodeType.Element, 0, 'tagName', []);
 
     it('should match', () => {

--- a/packages/core/test/render3/perf/directive_instantiate/index.ts
+++ b/packages/core/test/render3/perf/directive_instantiate/index.ts
@@ -75,13 +75,13 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 }
 
 const rootLView = createLView(
-    null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
+    null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null, null), {},
     LViewFlags.IsRoot, null, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(
     TViewType.Embedded, null, testTemplate, 21, 10, [Tooltip.ɵdir], null, null, null,
-    [['position', 'top', 3, 'tooltip']]);
+    [['position', 'top', 3, 'tooltip']], null);
 
 // create view once so we don't profile the first create pass
 createAndRenderLView(rootLView, embeddedTView, viewTNode);

--- a/packages/core/test/render3/perf/element_text_create/index.ts
+++ b/packages/core/test/render3/perf/element_text_create/index.ts
@@ -64,14 +64,15 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 }
 
 const rootLView = createLView(
-    null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
+    null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null, null), {},
     LViewFlags.IsRoot, null, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(
     TViewType.Embedded, null, testTemplate, 21, 0, null, null, null, null, [[
       'name1', 'value1', 'name2', 'value2', 'name3', 'value3', 'name4', 'value4', 'name5', 'value5'
-    ]]);
+    ]],
+    null);
 
 // create view once so we don't profile the first create pass
 createAndRenderLView(rootLView, embeddedTView, viewTNode);

--- a/packages/core/test/render3/perf/listeners/index.ts
+++ b/packages/core/test/render3/perf/listeners/index.ts
@@ -66,12 +66,13 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 }
 
 const rootLView = createLView(
-    null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
+    null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null, null), {},
     LViewFlags.IsRoot, null, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(
-    TViewType.Embedded, null, testTemplate, 11, 0, null, null, null, null, [[3, 'click', 'input']]);
+    TViewType.Embedded, null, testTemplate, 11, 0, null, null, null, null, [[3, 'click', 'input']],
+    null);
 
 // create view once so we don't profile the first create pass
 createAndRenderLView(rootLView, embeddedTView, viewTNode);

--- a/packages/core/test/render3/perf/ng_template/index.ts
+++ b/packages/core/test/render3/perf/ng_template/index.ts
@@ -63,13 +63,13 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 }
 
 const rootLView = createLView(
-    null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
+    null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null, null), {},
     LViewFlags.IsRoot, null, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(
     TViewType.Root, null, testTemplate, 2, 0, [NgIfLike.ɵdir], null, null, null,
-    [['viewManipulation', '']]);
+    [['viewManipulation', '']], null);
 
 // create view once so we don't profile first template pass
 createAndRenderLView(rootLView, embeddedTView, viewTNode);

--- a/packages/core/test/render3/perf/setup.ts
+++ b/packages/core/test/render3/perf/setup.ts
@@ -50,7 +50,8 @@ export function setupTestHarness(
     embeddedViewContext: any = {}, consts: TAttributes[]|null = null,
     directiveRegistry: DirectiveDefList|null = null): TestHarness {
   // Create a root view with a container
-  const hostTView = createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, consts);
+  const hostTView =
+      createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, consts, null);
   const tContainerNode = getOrCreateTNode(hostTView, 0, TNodeType.Container, null, null);
   const hostNode = renderer.createElement('div');
   const hostLView = createLView(
@@ -65,7 +66,7 @@ export function setupTestHarness(
   // create test embedded views
   const embeddedTView = createTView(
       TViewType.Embedded, null, templateFn, decls, vars, directiveRegistry, null, null, null,
-      consts);
+      consts, null);
   const viewTNode = createTNode(hostTView, null, TNodeType.Element, -1, null, null);
 
   function createEmbeddedLView(): LView {

--- a/packages/core/test/render3/perf/view_destroy_hook/index.ts
+++ b/packages/core/test/render3/perf/view_destroy_hook/index.ts
@@ -52,13 +52,13 @@ function testTemplate(rf: RenderFlags, ctx: any) {
 }
 
 const rootLView = createLView(
-    null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null), {},
+    null, createTView(TViewType.Root, null, null, 0, 0, null, null, null, null, null, null), {},
     LViewFlags.IsRoot, null, null, null, null, null, null, null, null);
 
 const viewTNode = createTNode(null!, null, TNodeType.Element, -1, null, null);
 const embeddedTView = createTView(
     TViewType.Embedded, null, testTemplate, 21, 10, [ToDestroy.ɵdir], null, null, null,
-    [['to-destroy']]);
+    [['to-destroy']], null);
 
 // create view once so we don't profile the first create pass
 createAndRenderLView(rootLView, embeddedTView, viewTNode);

--- a/packages/core/test/render3/view_fixture.ts
+++ b/packages/core/test/render3/view_fixture.ts
@@ -66,7 +66,8 @@ export class ViewFixture {
 
     const hostRenderer = rendererFactory.createRenderer(null, null);
     this.host = hostRenderer.createElement('host-element') as HTMLElement;
-    const hostTView = createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, null);
+    const hostTView =
+        createTView(TViewType.Root, null, null, 1, 0, null, null, null, null, null, null);
     const hostLView = createLView(
         null, hostTView, {}, LViewFlags.CheckAlways | LViewFlags.IsRoot, null, null,
         rendererFactory, hostRenderer, sanitizer || null, null, null, null);
@@ -87,7 +88,7 @@ export class ViewFixture {
     this.tView = createTView(
         TViewType.Component, null, template, decls || 0, vars || 0,
         directives ? toDefs(directives, dir => extractDirectiveDef(dir)!) : null, null, null, null,
-        consts || null);
+        consts || null, null);
     const hostTNode =
         createTNode(hostTView, null, TNodeType.Element, 0, 'host-element', null) as TElementNode;
     this.lView = createLView(


### PR DESCRIPTION
This commit implements hydration support for view containers, which should make `*ngIf`, `*ngFor` and other structural directive work with hydration.

The logic also respects the `ngSkipHydration` flag and skips hydration in such cases.

See individual commits for additional information.

## PR Type
What kind of change does this PR introduce?
- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No