### PR TITLE
refactor(core): remove duplicate call to `getComponentId`

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -312,8 +312,6 @@ export function ɵɵdefineComponent<T>(componentDefinition: ComponentDefinition<
       id: '',
     };
 
-    def.id = getComponentId(def);
-
     initFeatures(def);
     const dependencies = componentDefinition.dependencies;
     def.directiveDefs = extractDefListOrFactory(dependencies, /* pipeDef */ false);

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -903,9 +903,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getComponentId"
-  },
-  {
     "name": "getComponentLViewByIndex"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -666,9 +666,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getComponentId"
-  },
-  {
     "name": "getComponentLViewByIndex"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -936,9 +936,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getComponentId"
-  },
-  {
     "name": "getComponentLViewByIndex"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -903,9 +903,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getComponentId"
-  },
-  {
     "name": "getComponentLViewByIndex"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1212,9 +1212,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getComponentId"
-  },
-  {
     "name": "getComponentLViewByIndex"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -603,9 +603,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getComponentId"
-  },
-  {
     "name": "getComponentLViewByIndex"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -792,9 +792,6 @@
     "name": "getComponentDef"
   },
   {
-    "name": "getComponentId"
-  },
-  {
     "name": "getComponentLViewByIndex"
   },
   {


### PR DESCRIPTION
`getComponentId` is called twice by mistake.

https://github.com/angular/angular/blob/f7c266c4e61663691d49d72dd0db8174563c7694/packages/core/src/render3/definition.ts#L319
