### PR TITLE
docs(docs-infra): improve docs for @angular/localize package.

### DIFF
--- a/aio/content/guide/i18n-common-add-package.md
+++ b/aio/content/guide/i18n-common-add-package.md
@@ -2,22 +2,31 @@
 
 To take advantage of the localization features of Angular, use the [Angular CLI][AioCliMain] to add the `@angular/localize` package to your project.
 
-To add the `@angular/localize` package, use the following command to update the `package.json` and `polyfills.ts` files in your project.
+To add the `@angular/localize` package, use the following command to update the `package.json` and TypeScript configuration files in your project.
 
 <code-example path="i18n/doc-files/commands.sh" region="add-localize"></code-example>
 
+It adds `types: ["@angular/localize"]` in the TypeScript configuration files as well as the reference to the type definition of `@angular/localize` at the top of the `main.ts` file.
+
 <div class="alert is-helpful">
 
-For more information about `package.json` and `polyfill.ts` files, see [Workspace npm dependencies][AioGuideNpmPackages].
+For more information about `package.json` and `tsconfig.json` files, see [Workspace npm dependencies][AioGuideNpmPackages] and [TypeScript Configuraiton][AioGuideTsConfig].
 
 </div>
 
-If `@angular/localize` is not installed and you try to build a localized version of your project, the [Angular CLI][AioCliMain] generates an error.
+If `@angular/localize` is not installed and you try to build a localized version of your project (for example, while using the `i18n` attributes in templates), the [Angular CLI][AioCliMain] will generate an error, which would contain the steps that you can take to enable i18n for your project.
 
-<!--todo: add example error -->
+## Options
 
+| OPTION           | DESCRIPTION | VALUE TYPE | DEFAULT VALUE
+|:---              |:---    |:------     |:------
+| `--project`      | The name of the project. | `string` |
+| `--use-at-runtime` | If set, then `$localize` can be used at runtime. Also `@angular/localize` gets included in the `dependencies` section of `package.json`, rather than `devDependencies`, which is the default.  | `boolean` | `false`
+
+For more available options, see [ng add][AioCliAdd] in [Angular CLI][AioCliMain].
 ## What's next
 
+*   [@angular/localize API][AioApiLocalize]
 *   [Refer to locales by ID][AioGuideI18nCommonLocaleId]
 
 <!-- links -->
@@ -28,8 +37,14 @@ If `@angular/localize` is not installed and you try to build a localized version
 
 [AioGuideNpmPackages]: guide/npm-packages "Workspace npm dependencies | Angular"
 
+[AioGuideTsConfig]: guide/typescript-configuration "TypeScript Configuration | Angular"
+
+[AioCliAdd]: cli/add "ng add | CLI | Angular"
+
+[AioApiLocalize]: api/localize "$localize | @angular/localize - API | Angular"
+
 <!-- external links -->
 
 <!-- end links -->
 
-@reviewed 2021-10-07
+@reviewed 2023-03-10

--- a/packages/localize/schematics/ng-add/README.md
+++ b/packages/localize/schematics/ng-add/README.md
@@ -6,5 +6,5 @@ It will search their `angular.json` file, and add `types: ["@angular/localize"]`
 configuration files of the project.
 
 If the user specifies that they want to use `$localize` at runtime then the dependency will be
-added to the `depdendencies` section of `package.json` rather than in the `devDependencies` which
+added to the `dependencies` section of `package.json` rather than in the `devDependencies` which
 is the default.


### PR DESCRIPTION
This PR adds missing documentation for `@angular/localize` package and fixes a tiny one-word typo in the `README.md` file for `@angular/localize schematic`.

Fixes #49219.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
