### PR TITLE
feat(forms): annotated the this context with void

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -158,7 +158,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static min(min: number): ValidatorFn {
+  static min(min: number, this?: void): ValidatorFn {
     return minValidator(min);
   }
 
@@ -182,7 +182,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static max(max: number): ValidatorFn {
+  static max(max: number, this?: void): ValidatorFn {
     return maxValidator(max);
   }
 
@@ -206,7 +206,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static required(control: AbstractControl): ValidationErrors|null {
+  static required(control: AbstractControl, this?: void): ValidationErrors|null {
     return requiredValidator(control);
   }
 
@@ -231,7 +231,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static requiredTrue(control: AbstractControl): ValidationErrors|null {
+  static requiredTrue(control: AbstractControl, this?: void): ValidationErrors|null {
     return requiredTrueValidator(control);
   }
 
@@ -271,7 +271,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static email(control: AbstractControl): ValidationErrors|null {
+  static email(control: AbstractControl, this?: void): ValidationErrors|null {
     return emailValidator(control);
   }
 
@@ -305,7 +305,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static minLength(minLength: number): ValidatorFn {
+  static minLength(minLength: number, this?: void): ValidatorFn {
     return minLengthValidator(minLength);
   }
 
@@ -336,7 +336,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static maxLength(maxLength: number): ValidatorFn {
+  static maxLength(maxLength: number, this?: void): ValidatorFn {
     return maxLengthValidator(maxLength);
   }
 
@@ -389,7 +389,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static pattern(pattern: string|RegExp): ValidatorFn {
+  static pattern(pattern: string|RegExp, this?: void): ValidatorFn {
     return patternValidator(pattern);
   }
 
@@ -400,7 +400,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static nullValidator(control: AbstractControl): ValidationErrors|null {
+  static nullValidator(control: AbstractControl, this?: void): ValidationErrors|null {
     return nullValidator(control);
   }
 
@@ -415,9 +415,9 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static compose(validators: null): null;
-  static compose(validators: (ValidatorFn|null|undefined)[]): ValidatorFn|null;
-  static compose(validators: (ValidatorFn|null|undefined)[]|null): ValidatorFn|null {
+  static compose(validators: null, this?: void): null;
+  static compose(validators: (ValidatorFn|null|undefined)[], this?: void): ValidatorFn|null;
+  static compose(validators: (ValidatorFn|null|undefined)[]|null, this?: void): ValidatorFn|null {
     return compose(validators);
   }
 
@@ -432,7 +432,7 @@ export class Validators {
    * @see `updateValueAndValidity()`
    *
    */
-  static composeAsync(validators: (AsyncValidatorFn|null)[]): AsyncValidatorFn|null {
+  static composeAsync(validators: (AsyncValidatorFn|null)[], this?: void): AsyncValidatorFn|null {
     return composeAsync(validators);
   }
 }


### PR DESCRIPTION
The typescript eslint rule 'unbound-method' currently flags any validator usage as a violation. Annotating the this context of the static functions fixes the false positive.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The [typescript-eslint/unbound-method rule](https://typescript-eslint.io/rules/unbound-method/) currently flags any usage of the validators as a false positive. See [#1929](https://github.com/typescript-eslint/typescript-eslint/issues/1929) in the typescript-eslint repo. The only solutions currently are to either turn off the rule globally, ignore all static methods, or to disable the rule per file or per line.

Issue Number: N/A


## What is the new behavior?

This change simply adds an optional `this?: void` parameter to each of the Validators static methods to tell eslint that the method does not access the `this` context and therefore the rule doesn't apply. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
