### PR TITLE
fix(compiler): fix css keyframes scoping in regards of media queries

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -303,7 +303,7 @@ export class ShadowCss {
   private _scopeAnimationRule(
       rule: CssRule, scopeSelector: string, unscopedKeyframesSet: ReadonlySet<string>): CssRule {
     let content = rule.content.replace(
-        /((?:^|\s+|;)(?:-webkit-)?animation(?:\s*):(?:\s*))([^;]+)/g,
+        /((?:^|\s+|;|\{)(?:-webkit-)?animation(?:\s*):(?:\s*))([^;]+)/g,
         (_, start, animationDeclarations) => start +
             animationDeclarations.replace(
                 this._animationDeclarationKeyframesRe,

--- a/packages/compiler/test/shadow_css/keyframes_spec.ts
+++ b/packages/compiler/test/shadow_css/keyframes_spec.ts
@@ -526,4 +526,24 @@ describe('ShadowCss, keyframes and animations', () => {
         'animation: host-a_foo 0.5s alternate infinite cubic-bezier(.17, .67, .83, .67);');
     expect(result).toContain('animation: calc(2s / 2) host-a_calc;');
   });
+
+  it('should handle animations used inside media queries', () => {
+    const css = `
+      @media (width < 500px) {
+        p {
+          animation: 1s my-mobile-anim;
+        }
+      }
+
+      @media (prefers-reduced-motion: no-preference){div{animation:my-anim 1s 2s ease;}}
+
+      @keyframes my-mobile-anim {}
+      @keyframes my-anim {}
+    `;
+    const result = shim(css, 'host-a');
+    expect(result).toContain('@keyframes host-a_my-mobile-anim {}');
+    expect(result).toContain('animation: 1s host-a_my-mobile-anim;');
+    expect(result).toContain('@keyframes host-a_my-anim {}');
+    expect(result).toContain('animation:host-a_my-anim 1s 2s ease;');
+  });
 });


### PR DESCRIPTION
animations defined inside media queries can start right after opening bracket of its selector, especially when the css is minified, tweak the css keyframes scoping logic to handle such case

resolves #49378

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

