### PR TITLE
refactor(animations): remove #9100 todos.

### DIFF
--- a/goldens/public-api/animations/index.md
+++ b/goldens/public-api/animations/index.md
@@ -123,7 +123,7 @@ export interface AnimationPlayer {
     play(): void;
     reset(): void;
     restart(): void;
-    setPosition(position: any /** TODO #9100 */): void;
+    setPosition(position: number): void;
     readonly totalTime: number;
 }
 

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -1598,7 +1598,7 @@ export class TransitionAnimationPlayer implements AnimationPlayer {
     !this.queued && this._player.reset();
   }
 
-  setPosition(p: any): void {
+  setPosition(p: number): void {
     if (!this.queued) {
       this._player.setPosition(p);
     }

--- a/packages/animations/src/players/animation_player.ts
+++ b/packages/animations/src/players/animation_player.ts
@@ -78,7 +78,7 @@ export interface AnimationPlayer {
    * Sets the position of the animation.
    * @param position A 0-based offset into the duration, in milliseconds.
    */
-  setPosition(position: any /** TODO #9100 */): void;
+  setPosition(position: number): void;
   /**
    * Reports the current position of the animation.
    * @returns A 0-based offset into the duration, in milliseconds.


### PR DESCRIPTION
Minor breaking change: On `AnimationPlayer.setPosition` the argument is now of type `number`

----
This PR is part of a series of 4 to remove the last remaining todos from #9100

- #49406
- #49407
- #49408
- #49409

