### PR TITLE
refactor(core): remove #9100 todos.

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1576,7 +1576,7 @@ export enum ViewEncapsulation {
 export abstract class ViewRef extends ChangeDetectorRef {
     abstract destroy(): void;
     abstract get destroyed(): boolean;
-    abstract onDestroy(callback: Function): any /** TODO #9100, replace by void in a major release*/;
+    abstract onDestroy(callback: Function): void;
 }
 
 // @public

--- a/packages/core/src/linker/view_ref.ts
+++ b/packages/core/src/linker/view_ref.ts
@@ -33,7 +33,7 @@ export abstract class ViewRef extends ChangeDetectorRef {
    * @param callback A handler function that cleans up developer-defined data
    * associated with a view. Called when the `destroy()` method is invoked.
    */
-  abstract onDestroy(callback: Function): any /** TODO #9100, replace by void in a major release*/;
+  abstract onDestroy(callback: Function): void;
 }
 
 /**

--- a/packages/core/test/linker/query_list_spec.ts
+++ b/packages/core/test/linker/query_list_spec.ts
@@ -177,9 +177,9 @@ import {fakeAsync, tick} from '@angular/core/testing';
            }));
 
         it('should provides query list as an argument', fakeAsync(() => {
-             let recorded: any; /** TODO #9100, replace with QueryList when #48004 is merged */
+             let recorded!: QueryList<string>;
              queryList.changes.subscribe({
-               next: (v: any) => {
+               next: (v: QueryList<string>) => {
                  recorded = v;
                }
              });


### PR DESCRIPTION
This commit includes a change on the `ViewRef.onDestroy` signature so this should target v16. 

On #48623, Pawel seemed confident this shouldn't be breaking. 

----
This PR is part of a series of 4 to remove the last remaining todos from #9100

- #49406
- #49407
- #49408
- #49409

