### PR TITLE
refactor(zone.js): remove #9100 todos.

### DIFF
--- a/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
+++ b/packages/zone.js/test/zone-spec/fake-async-test.spec.ts
@@ -1089,21 +1089,15 @@ describe('FakeAsyncTestZoneSpec', () => {
            }, emptyRun));
 });
 
-class Log {
-  logItems: any[];
+class Log<T> {
+  logItems: T[];
 
   constructor() {
     this.logItems = [];
   }
 
-  add(value: any /** TODO #9100 */): void {
+  add(value: T): void {
     this.logItems.push(value);
-  }
-
-  fn(value: any /** TODO #9100 */) {
-    return (a1: any = null, a2: any = null, a3: any = null, a4: any = null, a5: any = null) => {
-      this.logItems.push(value);
-    };
   }
 
   clear(): void {
@@ -1132,7 +1126,7 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
     });
 
     it('should pass arguments to the wrapped function', () => {
-      fakeAsync((foo: any /** TODO #9100 */, bar: any /** TODO #9100 */) => {
+      fakeAsync((foo: string, bar: string) => {
         expect(foo).toEqual('foo');
         expect(bar).toEqual('bar');
       })('foo', 'bar');
@@ -1142,7 +1136,7 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
     it('should throw on nested calls', () => {
       expect(() => {
         fakeAsync(() => {
-          fakeAsync((): any /** TODO #9100 */ => null)();
+          fakeAsync((): null => null)();
         })();
       }).toThrowError('fakeAsync() calls can not be nested');
     });
@@ -1178,7 +1172,7 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
          }));
 
       it('should run chained thens', fakeAsync(() => {
-           const log = new Log();
+           const log = new Log<number>();
 
            resolvedPromise.then((_) => log.add(1)).then((_) => log.add(2));
 
@@ -1189,7 +1183,7 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
          }));
 
       it('should run Promise created in Promise', fakeAsync(() => {
-           const log = new Log();
+           const log = new Log<number>();
 
            resolvedPromise.then((_) => {
              log.add(1);
@@ -1322,7 +1316,7 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
 
       it('should be able to cancel periodic timers from a callback', fakeAsync(() => {
            let cycles = 0;
-           let id: any /** TODO #9100 */;
+           let id: NodeJS.Timer;
 
            id = setInterval(() => {
              cycles++;
@@ -1357,7 +1351,7 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
          }));
 
       it('should process microtasks before timers', fakeAsync(() => {
-           const log = new Log();
+           const log = new Log<string>();
 
            resolvedPromise.then((_) => log.add('microtask'));
 
@@ -1373,7 +1367,7 @@ const {fakeAsync, tick, discardPeriodicTasks, flush, flushMicrotasks} = fakeAsyn
          }));
 
       it('should process micro-tasks created in timers before next timers', fakeAsync(() => {
-           const log = new Log();
+           const log = new Log<string>();
 
            resolvedPromise.then((_) => log.add('microtask'));
 


### PR DESCRIPTION
This commit assigns the correct type instead of `any`.

----
This PR is part of a series of 4 to remove the last remaining todos from #9100

- #49406
- #49407
- #49408
- #49409

