### PR TITLE
docs(common): mark lifecycle methods as nodoc

### DIFF
--- a/packages/common/testing/src/location_mock.ts
+++ b/packages/common/testing/src/location_mock.ts
@@ -33,6 +33,7 @@ export class SpyLocation implements Location {
   /** @internal */
   _urlChangeSubscription: SubscriptionLike|null = null;
 
+  /** @nodoc */
   ngOnDestroy(): void {
     this._urlChangeSubscription?.unsubscribe();
     this._urlChangeListeners = [];

--- a/packages/upgrade/static/src/upgrade_component.ts
+++ b/packages/upgrade/static/src/upgrade_component.ts
@@ -116,6 +116,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     this.initializeOutputs();
   }
 
+  /** @nodoc */
   ngOnInit() {
     // Collect contents, insert and compile template
     const attachChildNodes: ILinkFn|undefined = this.helper.prepareTransclusion();
@@ -187,6 +188,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     }
   }
 
+  /** @nodoc */
   ngOnChanges(changes: SimpleChanges) {
     if (!this.bindingDestination) {
       this.pendingChanges = changes;
@@ -195,6 +197,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     }
   }
 
+  /** @nodoc */
   ngDoCheck() {
     const twoWayBoundProperties = this.bindings.twoWayBoundProperties;
     const twoWayBoundLastValues = this.bindings.twoWayBoundLastValues;
@@ -214,6 +217,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     });
   }
 
+  /** @nodoc */
   ngOnDestroy() {
     if (isFunction(this.unregisterDoCheckWatcher)) {
       this.unregisterDoCheckWatcher();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The lifecycle method `ngOnDestroy()` is listed in the docs: https://angular.io/api/common/testing/SpyLocation#ngondestroy

Issue Number: N/A


## What is the new behavior?
the lifecycle methods are marked as `@nodoc` and thus should not appear in the public docs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
