### PR TITLE
refactor(core): Handle corrupted text nodes during serialization and hydration process

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -18,7 +18,7 @@ import {TransferState} from '../transfer_state';
 
 import {CONTAINERS, ELEMENT_CONTAINERS, NUM_ROOT_NODES, SerializedContainerView, SerializedView, TEMPLATE_ID, TEMPLATES} from './interfaces';
 import {SKIP_HYDRATION_ATTR_NAME} from './skip_hydration';
-import {getComponentLViewForHydration, NGH_ATTR_NAME, NGH_DATA_KEY} from './utils';
+import {getComponentLViewForHydration, NGH_ATTR_NAME, NGH_DATA_KEY, TextNodeMarker} from './utils';
 
 /**
  * A collection that tracks all serialized views (`ngh` DOM annotations)
@@ -74,6 +74,7 @@ function getSsrId(tView: TView): string {
  */
 interface HydrationContext {
   serializedViewCollection: SerializedViewCollection;
+  corruptedTextNodes: Map<HTMLElement, TextNodeMarker>;
 }
 
 /**
@@ -95,6 +96,7 @@ function calcNumRootNodes(tView: TView, lView: LView, tNode: TNode|null): number
  */
 export function annotateForHydration(appRef: ApplicationRef, doc: Document) {
   const serializedViewCollection = new SerializedViewCollection();
+  const corruptedTextNodes = new Map<HTMLElement, TextNodeMarker>();
   const viewRefs = appRef._views;
   for (const viewRef of viewRefs) {
     const lView = getComponentLViewForHydration(viewRef);
@@ -105,8 +107,10 @@ export function annotateForHydration(appRef: ApplicationRef, doc: Document) {
       if (hostElement) {
         const context: HydrationContext = {
           serializedViewCollection,
+          corruptedTextNodes,
         };
         annotateHostElementForHydration(hostElement as HTMLElement, lView, context);
+        insertCorruptedTextNodeMarkers(corruptedTextNodes, doc);
       }
     }
   }
@@ -223,6 +227,26 @@ function serializeLView(lView: LView, context: HydrationContext): SerializedView
         // those nodes to reach a corresponding anchor node (comment node).
         ngh[ELEMENT_CONTAINERS] ??= {};
         ngh[ELEMENT_CONTAINERS][noOffsetIndex] = calcNumRootNodes(tView, lView, tNode.child);
+      } else {
+        // Handle case where text nodes can be lost after DOM serialization:
+        //     When there is an *empty text node* in DOM: in this case, this
+        //     node would not make it into the serialized string and as a result,
+        //     this node wouldn't be created in a browser. This would result in
+        //     a mismatch during the hydration, where the runtime logic would expect
+        //     a text node to be present in live DOM, but no text node would exist.
+        //     Example: `<span>{{ name }}</span>` when the `name` is an empty string.
+        //     This would result in `<span></span>` string after serialization and
+        //     in a browser only the `span` element would be created. To resolve that,
+        //     an extra comment node is appended in place of an empty text node and
+        //     that special comment node is replaced with an empty text node *before*
+        //     hydration.
+
+        if (tNode.type & TNodeType.Text) {
+          const rNode = unwrapRNode(lView[i]) as HTMLElement;
+          if (rNode.textContent?.replace(/\s/gm, '') === '') {
+            context.corruptedTextNodes.set(rNode, TextNodeMarker.EmptyNode);
+          }
+        }
       }
     }
   }
@@ -242,4 +266,20 @@ function annotateHostElementForHydration(
   const index = context.serializedViewCollection.add(ngh);
   const renderer = lView[RENDERER];
   renderer.setAttribute(element, NGH_ATTR_NAME, index.toString());
+}
+
+/**
+ * Physically inserts the comment nodes to ensure empty text nodes and adjacent
+ * text node separators are preserved after server serialization of the DOM.
+ * These get swapped back for empty text nodes or separators once hydration happens
+ * on the client.
+ *
+ * @param corruptedTextNodes The Map of text nodes to be replaced with comments
+ * @param doc The document
+ */
+function insertCorruptedTextNodeMarkers(
+    corruptedTextNodes: Map<HTMLElement, string>, doc: Document) {
+  for (let [textNode, marker] of corruptedTextNodes) {
+    textNode.after(doc.createComment(marker));
+  }
 }

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -12,6 +12,7 @@ import {inject} from '../di/injector_compatibility';
 import {enableLocateOrCreateContainerRefImpl} from '../linker/view_container_ref';
 import {enableLocateOrCreateElementNodeImpl} from '../render3/instructions/element';
 import {enableLocateOrCreateElementContainerNodeImpl} from '../render3/instructions/element_container';
+import {enableApplyRootElementTransformImpl} from '../render3/instructions/shared';
 import {enableLocateOrCreateContainerAnchorImpl} from '../render3/instructions/template';
 import {enableLocateOrCreateTextNodeImpl} from '../render3/instructions/text';
 
@@ -47,6 +48,7 @@ function enableHydrationRuntimeSupport() {
     enableLocateOrCreateContainerAnchorImpl();
     enableLocateOrCreateContainerRefImpl();
     enableFindMatchingDehydratedViewImpl();
+    enableApplyRootElementTransformImpl();
   }
 }
 

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -9,13 +9,14 @@
 
 import {Injector} from '../di/injector';
 import {ViewRef} from '../linker/view_ref';
+import {getDocument} from '../render3/interfaces/document';
 import {RElement, RNode} from '../render3/interfaces/renderer_dom';
 import {isRootView} from '../render3/interfaces/type_checks';
 import {HEADER_OFFSET, LView, TVIEW, TViewType} from '../render3/interfaces/view';
 import {makeStateKey, TransferState} from '../transfer_state';
 import {assertDefined} from '../util/assert';
 
-import {CONTAINERS, DehydratedContainerView, DehydratedView, ELEMENT_CONTAINERS, NUM_ROOT_NODES, SerializedContainerView, SerializedView} from './interfaces';
+import {CONTAINERS, DehydratedView, ELEMENT_CONTAINERS, NUM_ROOT_NODES, SerializedContainerView, SerializedView} from './interfaces';
 
 /**
  * The name of the key used in the TransferState collection,
@@ -34,6 +35,18 @@ export const NGH_DATA_KEY = makeStateKey<Array<SerializedView>>(TRANSFER_STATE_T
  * state that contains the necessary hydration info for this component.
  */
 export const NGH_ATTR_NAME = 'ngh';
+
+export const enum TextNodeMarker {
+
+  /**
+   * The contents of the text comment added to nodes that would otherwise be
+   * empty when serialized by the server and passed to the client. The empty
+   * node is lost when the browser parses it otherwise. This comment node will
+   * be replaced during hydration in the client to restore the lost empty text
+   * node.
+   */
+  EmptyNode = 'ngetn',
+}
 
 /**
  * Reference to a function that reads `ngh` attribute value from a given RNode
@@ -88,7 +101,7 @@ export function retrieveHydrationInfoImpl(rNode: RElement, injector: Injector): 
 }
 
 /**
- * Sets the implementation for the `retrieveNghInfo` function.
+ * Sets the implementation for the `retrieveHydrationInfo` function.
  */
 export function enableRetrieveHydrationInfoImpl() {
   _retrieveHydrationInfoImpl = retrieveHydrationInfoImpl;
@@ -121,6 +134,44 @@ export function getComponentLViewForHydration(viewRef: ViewRef): LView|null {
     lView = lView[HEADER_OFFSET];
   }
   return lView;
+}
+
+function getTextNodeContent(node: Node): string|undefined {
+  return node.textContent?.replace(/\s/gm, '');
+}
+
+/**
+ * Restores text nodes into the DOM that were lost during SSR
+ * serialization. The hydration process replaces empty text nodes and text
+ * nodes that are immediately adjacent to other text nodes with comment nodes
+ * that this method filters on to restore those missing nodes that the
+ * hydration process is expecting to be present.
+ *
+ * @param node The app's root HTML Element
+ */
+export function processTextNodeMarkersBeforeHydration(node: HTMLElement) {
+  const doc = getDocument();
+  const commenNodestIterator = doc.createNodeIterator(node, NodeFilter.SHOW_COMMENT, {
+    acceptNode(node) {
+      const content = getTextNodeContent(node);
+      const isTextNodeMarker = content === TextNodeMarker.EmptyNode;
+      return isTextNodeMarker ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+    }
+  });
+  let currentNode: Comment;
+  // We cannot modify the DOM while using the commentIterator,
+  // because it throws off the iterator state.
+  // So we collect all marker nodes first and then follow up with
+  // applying the changes to the DOM: inserting an empty node.
+  const nodes = [];
+  while (currentNode = commenNodestIterator.nextNode() as Comment) {
+    nodes.push(currentNode);
+  }
+  for (let node of nodes) {
+    if (node.textContent === TextNodeMarker.EmptyNode) {
+      node.replaceWith(doc.createTextNode(''));
+    }
+  }
 }
 
 /**

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -719,7 +719,7 @@ export function applyRootElementTransformImpl(rootElement: HTMLElement) {
 }
 
 /**
- * Sets the implementation for the `applyRootElementInfo` function.
+ * Sets the implementation for the `applyRootElementTransform` function.
  */
 export function enableApplyRootElementTransformImpl() {
   _applyRootElementTransformImpl = applyRootElementTransformImpl;

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -11,7 +11,7 @@ import {ErrorHandler} from '../../error_handler';
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {DehydratedView} from '../../hydration/interfaces';
 import {PRESERVE_HOST_CONTENT, PRESERVE_HOST_CONTENT_DEFAULT} from '../../hydration/tokens';
-import {retrieveHydrationInfo} from '../../hydration/utils';
+import {processTextNodeMarkersBeforeHydration, retrieveHydrationInfo} from '../../hydration/utils';
 import {DoCheck, OnChanges, OnInit} from '../../interface/lifecycle_hooks';
 import {SchemaMetadata} from '../../metadata/schema';
 import {ViewEncapsulation} from '../../metadata/view';
@@ -663,7 +663,7 @@ function createViewBlueprint(bindingStartIndex: number, initialViewLength: numbe
 /**
  * Locates the host native element, used for bootstrapping existing nodes into rendering pipeline.
  *
- * @param rendererFactory Factory function to create renderer instance.
+ * @param renderer the renderer used to locate the element.
  * @param elementOrSelector Render element or CSS selector to locate the element.
  * @param encapsulation View Encapsulation defined for component that requests host element.
  * @param injector Root view injector instance.
@@ -672,17 +672,57 @@ export function locateHostElement(
     renderer: Renderer, elementOrSelector: RElement|string, encapsulation: ViewEncapsulation,
     injector: Injector): RElement {
   // Note: we use default value for the `PRESERVE_HOST_CONTENT` here even though it's a
-  // tree-shakable one (providedIn:'root'). This code path can be triggered during dynamic component
-  // creation (after calling ViewContainerRef.createComponent) when an injector instance can be
-  // provided. The injector instance might be disconnected from the main DI tree, thus the
-  // `PRESERVE_HOST_CONTENT` woild not be able to instantiate. In this case, the default value will
-  // be used.
+  // tree-shakable one (providedIn:'root'). This code path can be triggered during dynamic
+  // component creation (after calling ViewContainerRef.createComponent) when an injector
+  // instance can be provided. The injector instance might be disconnected from the main DI
+  // tree, thus the `PRESERVE_HOST_CONTENT` woild not be able to instantiate. In this case, the
+  // default value will be used.
   const preserveHostContent = injector.get(PRESERVE_HOST_CONTENT, PRESERVE_HOST_CONTENT_DEFAULT);
 
   // When using native Shadow DOM, do not clear host element to allow native slot
   // projection.
   const preserveContent = preserveHostContent || encapsulation === ViewEncapsulation.ShadowDom;
-  return renderer.selectRootElement(elementOrSelector, preserveContent);
+  const rootElement = renderer.selectRootElement(elementOrSelector, preserveContent);
+  applyRootElementTransform(rootElement as HTMLElement);
+  return rootElement;
+}
+
+/**
+ * Applies any root element transformations that are needed. If hydration is enabled,
+ * this will process corrupted text nodes.
+ *
+ * @param rootElement the app root HTML Element
+ */
+export function applyRootElementTransform(rootElement: HTMLElement) {
+  _applyRootElementTransformImpl(rootElement as HTMLElement);
+}
+
+/**
+ * Reference to a function that applies transformations to the root HTML element
+ * of an app. When hydration is enabled, this processes any corrupt text nodes
+ * so they are properly hydratable on the client.
+ *
+ * @param rootElement the app root HTML Element
+ */
+let _applyRootElementTransformImpl: typeof applyRootElementTransformImpl =
+    (rootElement: HTMLElement) => null;
+
+/**
+ * Processes text node markers before hydration begins. This replaces any special comment
+ * nodes that were added prior to serialization are swapped out to restore proper text
+ * nodes before hydration.
+ *
+ * @param rootElement the app root HTML Element
+ */
+export function applyRootElementTransformImpl(rootElement: HTMLElement) {
+  processTextNodeMarkersBeforeHydration(rootElement);
+}
+
+/**
+ * Sets the implementation for the `applyRootElementInfo` function.
+ */
+export function enableApplyRootElementTransformImpl() {
+  _applyRootElementTransformImpl = applyRootElementTransformImpl;
 }
 
 /**
@@ -697,9 +737,9 @@ export function storeCleanupWithContext(
   const lCleanup = getOrCreateLViewCleanup(lView);
 
   // Historically the `storeCleanupWithContext` was used to register both framework-level and
-  // user-defined cleanup callbacks, but over time those two types of cleanups were separated. This
-  // dev mode checks assures that user-level cleanup callbacks are _not_ stored in data structures
-  // reserved for framework-specific hooks.
+  // user-defined cleanup callbacks, but over time those two types of cleanups were separated.
+  // This dev mode checks assures that user-level cleanup callbacks are _not_ stored in data
+  // structures reserved for framework-specific hooks.
   ngDevMode &&
       assertDefined(
           context, 'Cleanup context is mandatory when registering framework-level destroy hooks');

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -447,6 +447,9 @@
     "name": "PRESERVE_HOST_CONTENT"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT_DEFAULT"
+  },
+  {
     "name": "PlatformRef"
   },
   {
@@ -610,6 +613,9 @@
   },
   {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "_applyRootElementTransformImpl"
   },
   {
     "name": "_contains"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -330,6 +330,9 @@
     "name": "PRESERVE_HOST_CONTENT"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT_DEFAULT"
+  },
+  {
     "name": "PlatformRef"
   },
   {
@@ -451,6 +454,9 @@
   },
   {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "_applyRootElementTransformImpl"
   },
   {
     "name": "_currentInjector"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -447,6 +447,9 @@
     "name": "PRESERVE_HOST_CONTENT"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT_DEFAULT"
+  },
+  {
     "name": "PlatformRef"
   },
   {
@@ -619,6 +622,9 @@
   },
   {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "_applyRootElementTransformImpl"
   },
   {
     "name": "_currentInjector"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -438,6 +438,9 @@
     "name": "PRESERVE_HOST_CONTENT"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT_DEFAULT"
+  },
+  {
     "name": "PlatformRef"
   },
   {
@@ -610,6 +613,9 @@
   },
   {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "_applyRootElementTransformImpl"
   },
   {
     "name": "_currentInjector"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -261,6 +261,9 @@
     "name": "PRESERVE_HOST_CONTENT"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT_DEFAULT"
+  },
+  {
     "name": "PlatformRef"
   },
   {
@@ -355,6 +358,9 @@
   },
   {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "_applyRootElementTransformImpl"
   },
   {
     "name": "_currentInjector"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -519,6 +519,9 @@
     "name": "PRESERVE_HOST_CONTENT"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT_DEFAULT"
+  },
+  {
     "name": "PRIMARY_OUTLET"
   },
   {
@@ -817,6 +820,9 @@
   },
   {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "_applyRootElementTransformImpl"
   },
   {
     "name": "_currentInjector"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -306,6 +306,9 @@
     "name": "PRESERVE_HOST_CONTENT"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT_DEFAULT"
+  },
+  {
     "name": "R3Injector"
   },
   {
@@ -412,6 +415,9 @@
   },
   {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "_applyRootElementTransformImpl"
   },
   {
     "name": "_currentInjector"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -351,6 +351,9 @@
     "name": "PRESERVE_HOST_CONTENT"
   },
   {
+    "name": "PRESERVE_HOST_CONTENT_DEFAULT"
+  },
+  {
     "name": "PlatformRef"
   },
   {
@@ -532,6 +535,9 @@
   },
   {
     "name": "__forward_ref__"
+  },
+  {
+    "name": "_applyRootElementTransformImpl"
   },
   {
     "name": "_currentInjector"

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -20,12 +20,14 @@ import {renderApplication} from '../src/utils';
  */
 const NGH_ATTR_NAME = 'ngh';
 const EMPTY_TEXT_NODE_COMMENT = 'ngetn';
+const TEXT_NODE_SEPARATOR_COMMENT = 'ngtns';
 
 const SKIP_HYDRATION_ATTR_NAME = 'ngSkipHydration';
 const SKIP_HYDRATION_ATTR_NAME_LOWER_CASE = SKIP_HYDRATION_ATTR_NAME.toLowerCase();
 
 const NGH_ATTR_REGEXP = new RegExp(` ${NGH_ATTR_NAME}=".*?"`, 'g');
 const EMPTY_TEXT_NODE_REGEXP = new RegExp(`<!--${EMPTY_TEXT_NODE_COMMENT}-->`, 'g');
+const TEXT_NODE_SEPARATOR_REGEXP = new RegExp(`<!--${TEXT_NODE_SEPARATOR_COMMENT}-->`, 'g');
 
 /**
  * Drop utility attributes such as `ng-version`, `ng-server-context` and `ngh`,
@@ -35,7 +37,9 @@ function stripUtilAttributes(html: string, keepNgh: boolean): string {
   html = html.replace(/ ng-version=".*?"/g, '')  //
              .replace(/ ng-server-context=".*?"/g, '');
   if (!keepNgh) {
-    html = html.replace(NGH_ATTR_REGEXP, '').replace(EMPTY_TEXT_NODE_REGEXP, '');
+    html = html.replace(NGH_ATTR_REGEXP, '')
+               .replace(EMPTY_TEXT_NODE_REGEXP, '')
+               .replace(TEXT_NODE_SEPARATOR_REGEXP, '');
   }
   return html;
 }
@@ -1680,6 +1684,74 @@ describe('platform-server integration', () => {
         const html = await ssr(SimpleComponent);
         const ssrContents = getAppContents(html);
 
+        expect(ssrContents).toContain('<app ngh');
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await hydrate(html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+      });
+
+      it('should support restoration of multiple text nodes in a row', async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          template: `
+            This is hydrated content.<span>{{emptyText}}{{moreText}}{{andMoreText}}</span>.
+            <p>{{secondEmptyText}}{{secondMoreText}}</p>
+          `,
+        })
+        class SimpleComponent {
+          emptyText = '';
+          moreText = '';
+          andMoreText = '';
+          secondEmptyText = '';
+          secondMoreText = '';
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        // TODO: properly assert `ngh` attribute value once the `ngh`
+        // format stabilizes, for now we just check that it's present.
+        expect(ssrContents).toContain('<app ngh');
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await hydrate(html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+      });
+
+      it('should support projected text node content with plain text nodes', async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          imports: [NgIf],
+          template: `
+            <div>
+              Hello
+              <ng-container *ngIf="true">Angular</ng-container>
+              <ng-container *ngIf="true">World</ng-container>
+            </div>
+          `,
+        })
+        class SimpleComponent {
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+        // TODO: properly assert `ngh` attribute value once the `ngh`
+        // format stabilizes, for now we just check that it's present.
         expect(ssrContents).toContain('<app ngh');
 
         resetTViewsFor(SimpleComponent);

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -19,9 +19,13 @@ import {renderApplication} from '../src/utils';
  * could be found.
  */
 const NGH_ATTR_NAME = 'ngh';
+const EMPTY_TEXT_NODE_COMMENT = 'ngetn';
+
 const SKIP_HYDRATION_ATTR_NAME = 'ngSkipHydration';
 const SKIP_HYDRATION_ATTR_NAME_LOWER_CASE = SKIP_HYDRATION_ATTR_NAME.toLowerCase();
+
 const NGH_ATTR_REGEXP = new RegExp(` ${NGH_ATTR_NAME}=".*?"`, 'g');
+const EMPTY_TEXT_NODE_REGEXP = new RegExp(`<!--${EMPTY_TEXT_NODE_COMMENT}-->`, 'g');
 
 /**
  * Drop utility attributes such as `ng-version`, `ng-server-context` and `ngh`,
@@ -31,7 +35,7 @@ function stripUtilAttributes(html: string, keepNgh: boolean): string {
   html = html.replace(/ ng-version=".*?"/g, '')  //
              .replace(/ ng-server-context=".*?"/g, '');
   if (!keepNgh) {
-    html = html.replace(NGH_ATTR_REGEXP, '');
+    html = html.replace(NGH_ATTR_REGEXP, '').replace(EMPTY_TEXT_NODE_REGEXP, '');
   }
   return html;
 }
@@ -1653,6 +1657,41 @@ describe('platform-server integration', () => {
            verifyAllNodesClaimedForHydration(clientRootNode);
            verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
          });
+    });
+
+    describe('corrupted text nodes restoration', () => {
+      it('should support empty text nodes', async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          template: `
+            This is hydrated content.
+            <span>{{spanText}}</span>.
+            <p>{{pText}}</p>
+            <div>{{anotherText}}</div>
+          `,
+        })
+        class SimpleComponent {
+          spanText = '';
+          pText = '';
+          anotherText = '';
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain('<app ngh');
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await hydrate(html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR handles two cases:
- Restoring empty text nodes that were lost during serialization
- Preserving text nodes in the case that a text node is immediately adjacent to another text node

Both are cases in which information about those nodes / separators being present is lost when serialized and transferred to the browser. We handle this with special comment nodes that are added just prior to SSR DOM serialization. Those comment nodes are found and replaced with their respective empty text nodes or separations during the hydration process.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No