### PR TITLE
Deprecate `withServerTransition` call and generate static `APP_ID`

### DIFF
--- a/aio/content/examples/universal/src/app/app.module.ts
+++ b/aio/content/examples/universal/src/app/app.module.ts
@@ -21,7 +21,7 @@ import { isPlatformBrowser } from '@angular/common';
 
 @NgModule({
   imports: [
-    BrowserModule.withServerTransition({ appId: 'tour-of-heroes' }),
+    BrowserModule,
     FormsModule,
     AppRoutingModule,
     HttpClientModule,

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -100,6 +100,7 @@ v16 - v19
 | `@angular/platform-server`          | [`ServerTransferStateModule`](#platform-server)                                                            | v14           | v16         |
 | `@angular/service-worker`           | [`SwUpdate#activated`](api/service-worker/SwUpdate#activated)                                              | v13           | v16         |
 | `@angular/service-worker`           | [`SwUpdate#available`](api/service-worker/SwUpdate#available)                                              | v13           | v16         |
+| `@angular/platform-browser`         | [`BrowserModule.withServerTransition`](api/platform-browser/BrowserModule#withservertransition)                                                          | v16           | v18         |
 
 ### Deprecated features that can be removed in v17 or later
 
@@ -204,6 +205,7 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 | API                                                              | Replacement                                        | Deprecation announced | Details |
 |:---                                                              |:---                                                |:---                   |:---     |
 | [`BrowserTransferStateModule`](api/platform-browser/BrowserTransferStateModule) | No replacement needed.  | v14.1                   | The `TransferState` class is available for injection without importing additional modules on the client side of a server-rendered application. |
+| [`BrowserModule.withServerTransition`](api/platform-browser/BrowserModule#withservertransition) | No replacement needed.  | v16.0                   | The `APP_ID`token should be used instead to set the application ID. |
 
 <a id="platform-browser-dynamic"></a>
 

--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -35,6 +35,7 @@ export function bootstrapApplication(rootComponent: Type<unknown>, options?: App
 // @public
 export class BrowserModule {
     constructor(providersAlreadyPresent: boolean | null);
+    // @deprecated
     static withServerTransition(params: {
         appId: string;
     }): ModuleWithProviders<BrowserModule>;

--- a/integration/cli-elements-universal/src/app/app.module.ts
+++ b/integration/cli-elements-universal/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { CUSTOM_ELEMENTS_SCHEMA, Inject, Injector, NgModule, PLATFORM_ID } from '@angular/core';
+import { APP_ID, CUSTOM_ELEMENTS_SCHEMA, Inject, Injector, NgModule, PLATFORM_ID } from '@angular/core';
 import { createCustomElement } from '@angular/elements';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
@@ -16,7 +16,7 @@ import { TitleComponent } from './title.component';
     TitleComponent,
   ],
   imports: [
-    BrowserModule.withServerTransition({ appId: 'serverApp' }),
+    BrowserModule,
     RouterModule.forRoot([]),
   ],
   schemas: [

--- a/integration/injectable-def/src/app.ts
+++ b/integration/injectable-def/src/app.ts
@@ -14,7 +14,7 @@ export class TestApp {}
   bootstrap: [TestApp],
   imports: [
     Lib2Module,
-    BrowserModule.withServerTransition({appId: 'appId'}),
+    BrowserModule,
     ServerModule,
   ],
 })

--- a/integration/platform-server/e2e/helloworld-spec.ts
+++ b/integration/platform-server/e2e/helloworld-spec.ts
@@ -15,7 +15,7 @@ describe('Hello world E2E Tests', function() {
     // Load the page without waiting for Angular since it is not bootstrapped automatically.
     browser.driver.get(browser.baseUrl + 'helloworld');
 
-    const style = browser.driver.findElement(by.css('style[ng-app="hlw"]'));
+    const style = browser.driver.findElement(by.css('style[ng-app="ng"]'));
     expect(style.getText()).not.toBeNull();
 
     // Test the contents from the server.
@@ -28,7 +28,7 @@ describe('Hello world E2E Tests', function() {
     expect(element(by.css('div')).getText()).toEqual('Hello world!');
 
     // Make sure the server styles get reused by the client.
-    expect(element(by.css('style[ng-app="hlw"]')).isPresent()).toBeFalsy();
+    expect(element(by.css('style[ng-app="ng"]')).isPresent()).toBeFalsy();
     expect(element(by.css('style[ng-style-reused]')).isPresent()).toBeTruthy()
     expect(element(by.css('style')).getText()).toBe('');
 

--- a/integration/platform-server/src/helloworld/app.ts
+++ b/integration/platform-server/src/helloworld/app.ts
@@ -14,7 +14,7 @@ import {HelloWorldComponent} from './hello-world.component';
 @NgModule({
   declarations: [HelloWorldComponent],
   bootstrap: [HelloWorldComponent],
-  imports: [BrowserModule.withServerTransition({appId: 'hlw'})],
+  imports: [BrowserModule],
 })
 export class HelloWorldModule {
 }

--- a/integration/platform-server/src/transferstate/app.ts
+++ b/integration/platform-server/src/transferstate/app.ts
@@ -15,7 +15,7 @@ import {TransferStateComponent} from './transfer-state.component';
   declarations: [TransferStateComponent],
   bootstrap: [TransferStateComponent],
   imports: [
-    BrowserModule.withServerTransition({appId: 'ts'}),
+    BrowserModule,
   ],
 })
 export class TransferStateModule {

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/basic.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/basic.ts
@@ -21,7 +21,7 @@ export class AppComponent {
 @NgModule({
   imports: [
     Lib2Module,
-    BrowserModule.withServerTransition({appId: 'id-app'}),
+    BrowserModule,
     ServerModule,
   ],
   declarations: [AppComponent],

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/dep.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/dep.ts
@@ -27,7 +27,7 @@ export class AppComponent {
 
 @NgModule({
   imports: [
-    BrowserModule.withServerTransition({appId: 'id-app'}),
+    BrowserModule,
     ServerModule,
   ],
   declarations: [AppComponent],

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/hierarchy.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/hierarchy.ts
@@ -36,7 +36,7 @@ export class ChildComponent {
 
 @NgModule({
   imports: [
-    BrowserModule.withServerTransition({appId: 'hierarchy-app'}),
+    BrowserModule,
     ServerModule,
   ],
   declarations: [AppComponent, ChildComponent],

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/root.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/root.ts
@@ -28,7 +28,7 @@ export function children(): any {
 
 @NgModule({
   imports: [
-    BrowserModule.withServerTransition({appId: 'id-app'}),
+    BrowserModule,
     ServerModule,
     RouterModule.forRoot(
         [

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/self.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/self.ts
@@ -28,7 +28,7 @@ export class AppComponent {
 
 @NgModule({
   imports: [
-    BrowserModule.withServerTransition({appId: 'id-app'}),
+    BrowserModule,
     ServerModule,
   ],
   declarations: [AppComponent],

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/string.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/string.ts
@@ -24,7 +24,7 @@ export class AppComponent {
 
 @NgModule({
   imports: [
-    BrowserModule.withServerTransition({appId: 'id-app'}),
+    BrowserModule,
     ServerModule,
   ],
   declarations: [AppComponent],

--- a/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/token.ts
+++ b/packages/compiler-cli/integrationtest/bazel/injectable_def/app/src/token.ts
@@ -37,7 +37,7 @@ export class AppComponent {
 
 @NgModule({
   imports: [
-    BrowserModule.withServerTransition({appId: 'id-app'}),
+    BrowserModule,
     ServerModule,
     TokenModule,
   ],

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -9,13 +9,10 @@
 import {InjectionToken} from './di/injection_token';
 
 /**
- * A [DI token](guide/glossary#di-token "DI token definition") representing a unique string ID, used
+ * A [DI token](guide/glossary#di-token "DI token definition") representing a string ID, used
  * primarily for prefixing application attributes and CSS styles when
  * {@link ViewEncapsulation#Emulated ViewEncapsulation.Emulated} is being used.
  *
- * BY default, the value is randomly generated and assigned to the application by Angular.
- * To provide a custom ID value, use a DI provider <!-- TODO: provider --> to configure
- * the root {@link Injector} that uses this token.
  * The token is needed in cases when multiple applications are bootstrapped on a page
  * (for example, using `bootstrapApplication` calls). In this case, ensure that those applications
  * have different `APP_ID` value setup. For example:
@@ -23,21 +20,21 @@ import {InjectionToken} from './di/injection_token';
  * ```
  * bootstrapApplication(ComponentA, {
  *   providers: [
- *     {provide: APP_ID, useValue: 'app-a'},
+ *     { provide: APP_ID, useValue: 'app-a' },
  *     // ... other providers ...
  *   ]
  * });
  *
  * bootstrapApplication(ComponentB, {
  *   providers: [
- *     {provide: APP_ID, useValue: 'app-b'},
+ *     { provide: APP_ID, useValue: 'app-b' },
  *     // ... other providers ...
  *   ]
  * });
  * ```
  *
- * By default, when there is only 1 application bootstrapped, you don't need to provide the `APP_ID`
- * token (the `ng` will be used as an app ID).
+ * By default, when there is only one application bootstrapped, you don't need to provide the
+ * `APP_ID` token (the `ng` will be used as an app ID).
  *
  * @publicApi
  */

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -16,31 +16,38 @@ import {InjectionToken} from './di/injection_token';
  * BY default, the value is randomly generated and assigned to the application by Angular.
  * To provide a custom ID value, use a DI provider <!-- TODO: provider --> to configure
  * the root {@link Injector} that uses this token.
+ * The token is needed in cases when multiple applications are bootstrapped on a page
+ * (for example, using `bootstrapApplication` calls). In this case, ensure that those applications
+ * have different `APP_ID` value setup. For example:
+ *
+ * ```
+ * bootstrapApplication(ComponentA, {
+ *   providers: [
+ *     {provide: APP_ID, useValue: 'app-a'},
+ *     // ... other providers ...
+ *   ]
+ * });
+ *
+ * bootstrapApplication(ComponentB, {
+ *   providers: [
+ *     {provide: APP_ID, useValue: 'app-b'},
+ *     // ... other providers ...
+ *   ]
+ * });
+ * ```
+ *
+ * By default, when there is only 1 application bootstrapped, you don't need to provide the `APP_ID`
+ * token (the `ng` will be used as an app ID).
  *
  * @publicApi
  */
 export const APP_ID = new InjectionToken<string>('AppId', {
   providedIn: 'root',
-  factory: _appIdRandomProviderFactory,
+  factory: () => DEFAULT_APP_ID,
 });
 
-export function _appIdRandomProviderFactory() {
-  return `${_randomChar()}${_randomChar()}${_randomChar()}`;
-}
-
-/**
- * Providers that generate a random `APP_ID_TOKEN`.
- * @publicApi
- */
-export const APP_ID_RANDOM_PROVIDER = {
-  provide: APP_ID,
-  useFactory: _appIdRandomProviderFactory,
-  deps: <any[]>[],
-};
-
-function _randomChar(): string {
-  return String.fromCharCode(97 + Math.floor(Math.random() * 25));
-}
+/** Default value of the `APP_ID` token. */
+const DEFAULT_APP_ID = 'ng';
 
 /**
  * A function that is executed when a platform is initialized.

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -7,7 +7,6 @@
  */
 
 export {ALLOW_MULTIPLE_PLATFORMS as ɵALLOW_MULTIPLE_PLATFORMS, internalCreateApplication as ɵinternalCreateApplication, provideNgZoneChangeDetection as ɵprovideNgZoneChangeDetection} from './application_ref';
-export {APP_ID_RANDOM_PROVIDER as ɵAPP_ID_RANDOM_PROVIDER} from './application_tokens';
 export {defaultIterableDiffers as ɵdefaultIterableDiffers, defaultKeyValueDiffers as ɵdefaultKeyValueDiffers} from './change_detection/change_detection';
 export {Console as ɵConsole} from './console';
 export {convertToBitFlags as ɵconvertToBitFlags, setCurrentInjector as ɵsetCurrentInjector} from './di/injector_compatibility';

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -159,6 +159,9 @@
     "name": "DASH_CASE_REGEXP"
   },
   {
+    "name": "DEFAULT_APP_ID"
+  },
+  {
     "name": "DEFAULT_NOOP_PREVIOUS_NODE"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -660,9 +660,6 @@
     "name": "_query"
   },
   {
-    "name": "_randomChar"
-  },
-  {
     "name": "_retrieveHydrationInfoImpl"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -84,6 +84,9 @@
     "name": "ConnectableSubscriber"
   },
   {
+    "name": "DEFAULT_APP_ID"
+  },
+  {
     "name": "DI_DECORATOR_FLAG"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -486,9 +486,6 @@
     "name": "_processI18nInsertBefore"
   },
   {
-    "name": "_randomChar"
-  },
-  {
     "name": "_retrieveHydrationInfoImpl"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -669,9 +669,6 @@
     "name": "_processI18nInsertBefore"
   },
   {
-    "name": "_randomChar"
-  },
-  {
     "name": "_retrieveHydrationInfoImpl"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -117,6 +117,9 @@
     "name": "ControlContainer"
   },
   {
+    "name": "DEFAULT_APP_ID"
+  },
+  {
     "name": "DEFAULT_VALUE_ACCESSOR"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -123,6 +123,9 @@
     "name": "ControlContainer"
   },
   {
+    "name": "DEFAULT_APP_ID"
+  },
+  {
     "name": "DEFAULT_VALUE_ACCESSOR"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -657,9 +657,6 @@
     "name": "_processI18nInsertBefore"
   },
   {
-    "name": "_randomChar"
-  },
-  {
     "name": "_retrieveHydrationInfoImpl"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -141,6 +141,9 @@
     "name": "CreateUrlTreeUsingSnapshot"
   },
   {
+    "name": "DEFAULT_APP_ID"
+  },
+  {
     "name": "DEFAULT_LOCALE_ID"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -861,9 +861,6 @@
     "name": "_processI18nInsertBefore"
   },
   {
-    "name": "_randomChar"
-  },
-  {
     "name": "_retrieveHydrationInfoImpl"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -69,6 +69,9 @@
     "name": "ConnectableSubscriber"
   },
   {
+    "name": "DEFAULT_APP_ID"
+  },
+  {
     "name": "DEFAULT_LOCALE_ID"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -447,9 +447,6 @@
     "name": "_processI18nInsertBefore"
   },
   {
-    "name": "_randomChar"
-  },
-  {
     "name": "_retrieveHydrationInfoImpl"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -579,9 +579,6 @@
     "name": "_processI18nInsertBefore"
   },
   {
-    "name": "_randomChar"
-  },
-  {
     "name": "_retrieveHydrationInfoImpl"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -84,6 +84,9 @@
     "name": "ConnectableSubscriber"
   },
   {
+    "name": "DEFAULT_APP_ID"
+  },
+  {
     "name": "DI_DECORATOR_FLAG"
   },
   {

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -245,6 +245,8 @@ export class BrowserModule {
    * @param params An object containing an identifier for the app to transition.
    * The ID must match between the client and server versions of the app.
    * @returns The reconfigured `BrowserModule` to import into the app's root `AppModule`.
+   *
+   * @deprecated Use {@link APP_ID} instead to set the application ID.
    */
   static withServerTransition(params: {appId: string}): ModuleWithProviders<BrowserModule> {
     return {

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_ID, ApplicationRef, EnvironmentProviders, importProvidersFrom, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵannotateForHydration as annotateForHydration, ɵgetComponentDef as getComponentDef, ɵinternalCreateApplication as internalCreateApplication, ɵIS_HYDRATION_FEATURE_ENABLED as IS_HYDRATION_FEATURE_ENABLED, ɵisPromise} from '@angular/core';
+import {ApplicationRef, EnvironmentProviders, importProvidersFrom, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵannotateForHydration as annotateForHydration, ɵgetComponentDef as getComponentDef, ɵinternalCreateApplication as internalCreateApplication, ɵIS_HYDRATION_FEATURE_ENABLED as IS_HYDRATION_FEATURE_ENABLED, ɵisPromise} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {first} from 'rxjs/operators';
 
@@ -49,12 +49,6 @@ function _render<T>(
     bootstrapPromise: Promise<NgModuleRef<T>|ApplicationRef>): Promise<string> {
   return bootstrapPromise.then((moduleOrApplicationRef) => {
     const environmentInjector = moduleOrApplicationRef.injector;
-    const transitionId = environmentInjector.get(APP_ID, null);
-    if (!transitionId) {
-      throw new Error(
-          `renderModule[Factory]() requires the use of BrowserModule.withServerTransition() to ensure
-the server-rendered app can be properly bootstrapped into a client app.`);
-    }
     const applicationRef: ApplicationRef = moduleOrApplicationRef instanceof ApplicationRef ?
         moduleOrApplicationRef :
         environmentInjector.get(ApplicationRef);

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -10,7 +10,7 @@ import {animate, AnimationBuilder, state, style, transition, trigger} from '@ang
 import {DOCUMENT, isPlatformServer, PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
 import {HTTP_INTERCEPTORS, HttpClient, HttpClientModule, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
-import {ApplicationRef, Component, destroyPlatform, getPlatform, HostListener, importProvidersFrom, Inject, inject as coreInject, Injectable, Input, NgModule, NgZone, PLATFORM_ID, ViewEncapsulation} from '@angular/core';
+import {ApplicationRef, Component, destroyPlatform, getPlatform, HostListener, Inject, inject as coreInject, Injectable, Input, NgModule, NgZone, PLATFORM_ID, ViewEncapsulation} from '@angular/core';
 import {TestBed, waitForAsync} from '@angular/core/testing';
 import {bootstrapApplication, BrowserModule, makeStateKey, Title, TransferState} from '@angular/platform-browser';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformDynamicServer, PlatformState, provideServerSupport, renderModule, ServerModule} from '@angular/platform-server';
@@ -95,8 +95,7 @@ const RenderHookProviders = [
 
 @NgModule({
   bootstrap: [MyServerApp],
-  imports:
-      [MyServerAppModule, BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
+  imports: [MyServerAppModule, BrowserModule, ServerModule],
   providers: [...RenderHookProviders],
 })
 class RenderHookModule {
@@ -110,8 +109,7 @@ const MultiRenderHookProviders = [
 
 @NgModule({
   bootstrap: [MyServerApp],
-  imports:
-      [MyServerAppModule, BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
+  imports: [MyServerAppModule, BrowserModule, ServerModule],
   providers: [...MultiRenderHookProviders],
 })
 class MultiRenderHookModule {
@@ -128,8 +126,7 @@ const AsyncRenderHookProviders = [
 
 @NgModule({
   bootstrap: [MyServerApp],
-  imports:
-      [MyServerAppModule, BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
+  imports: [MyServerAppModule, BrowserModule, ServerModule],
   providers: [...AsyncRenderHookProviders],
 })
 class AsyncRenderHookModule {
@@ -148,8 +145,7 @@ const AsyncMultiRenderHookProviders = [
 
 @NgModule({
   bootstrap: [MyServerApp],
-  imports:
-      [MyServerAppModule, BrowserModule.withServerTransition({appId: 'render-hook'}), ServerModule],
+  imports: [MyServerAppModule, BrowserModule, ServerModule],
   providers: [...AsyncMultiRenderHookProviders],
 })
 class AsyncMultiRenderHookModule {
@@ -205,14 +201,13 @@ const MyAsyncServerAppStandalone = createMyAsyncServerApp(true);
 
 const boostrapMyAsyncServerAppStandalone = () => bootstrapApplication(MyAsyncServerAppStandalone, {
   providers: [
-    importProvidersFrom(BrowserModule.withServerTransition({appId: 'simple-cmp'})),
     provideServerSupport(),
   ]
 });
 
 @NgModule({
   declarations: [MyAsyncServerApp],
-  imports: [BrowserModule.withServerTransition({appId: 'async-server'}), ServerModule],
+  imports: [BrowserModule, ServerModule],
   bootstrap: [MyAsyncServerApp]
 })
 class AsyncServerModule {
@@ -234,7 +229,7 @@ const SVGComponentStandalone = createSVGComponent(true);
 
 @NgModule({
   declarations: [SVGComponent],
-  imports: [BrowserModule.withServerTransition({appId: 'svg-server'}), ServerModule],
+  imports: [BrowserModule, ServerModule],
   bootstrap: [SVGComponent]
 })
 class SVGServerModule {
@@ -276,7 +271,7 @@ const MyAnimationAppStandalone = createMyAnimationApp(true);
 
 @NgModule({
   declarations: [MyAnimationApp],
-  imports: [BrowserModule.withServerTransition({appId: 'anim-server'}), ServerModule],
+  imports: [BrowserModule, ServerModule],
   bootstrap: [MyAnimationApp]
 })
 class AnimationServerModule {
@@ -297,11 +292,8 @@ function createMyStylesApp(standalone: boolean) {
 const MyStylesApp = createMyStylesApp(false);
 const MyStylesAppStandalone = createMyStylesApp(true);
 
-@NgModule({
-  declarations: [MyStylesApp],
-  imports: [BrowserModule.withServerTransition({appId: 'example-styles'}), ServerModule],
-  bootstrap: [MyStylesApp]
-})
+@NgModule(
+    {declarations: [MyStylesApp], imports: [BrowserModule, ServerModule], bootstrap: [MyStylesApp]})
 class ExampleStylesModule {
 }
 
@@ -326,7 +318,7 @@ const MyTransferStateAppStandalone = createMyTransferStateApp(true);
 
 @NgModule({
   declarations: [MyTransferStateApp],
-  imports: [BrowserModule.withServerTransition({appId: 'transfer-state-app'}), ServerModule],
+  imports: [BrowserModule, ServerModule],
   bootstrap: [MyTransferStateApp]
 })
 class MyTransferStateModule {
@@ -384,7 +376,7 @@ const ShadowDomEncapsulationAppStandalone = createShadowDomEncapsulationApp(true
 
 @NgModule({
   declarations: [ShadowDomEncapsulationApp],
-  imports: [BrowserModule.withServerTransition({appId: 'test'}), ServerModule],
+  imports: [BrowserModule, ServerModule],
   bootstrap: [ShadowDomEncapsulationApp]
 })
 class ShadowDomExampleModule {
@@ -417,7 +409,7 @@ const [MyHostComponentStandalone, _] = createFalseAttributesComponents(true);
 @NgModule({
   declarations: [MyHostComponent, MyChildComponent],
   bootstrap: [MyHostComponent],
-  imports: [ServerModule, BrowserModule.withServerTransition({appId: 'false-attributes'})]
+  imports: [ServerModule, BrowserModule]
 })
 class FalseAttributesModule {
 }
@@ -440,7 +432,7 @@ const MyInputComponentStandalone = createMyInputComponent(true);
 @NgModule({
   declarations: [MyInputComponent],
   bootstrap: [MyInputComponent],
-  imports: [ServerModule, BrowserModule.withServerTransition({appId: 'name-attributes'})]
+  imports: [ServerModule, BrowserModule]
 })
 class NameModule {
 }
@@ -463,7 +455,7 @@ const HTMLTypesAppStandalone = createHTMLTypesApp(true);
 
 @NgModule({
   declarations: [HTMLTypesApp],
-  imports: [BrowserModule.withServerTransition({appId: 'inner-html'}), ServerModule],
+  imports: [BrowserModule, ServerModule],
   bootstrap: [HTMLTypesApp]
 })
 class HTMLTypesModule {
@@ -487,7 +479,7 @@ const MyHiddenComponentStandalone = createMyHiddenComponent(true);
 @NgModule({
   declarations: [MyHiddenComponent],
   bootstrap: [MyHiddenComponent],
-  imports: [ServerModule, BrowserModule.withServerTransition({appId: 'hidden-attributes'})]
+  imports: [ServerModule, BrowserModule]
 })
 class HiddenModule {
 }
@@ -575,7 +567,7 @@ describe('platform-server integration', () => {
          const styles: any[] = head.children as any;
          expect(styles.length).toBe(1);
          expect(styles[0].textContent).toContain('color: red');
-         expect(styles[0].getAttribute('ng-app')).toBe('example-styles');
+         expect(styles[0].getAttribute('ng-app')).toBe('ng');
        });
      }));
 
@@ -842,12 +834,11 @@ describe('platform-server integration', () => {
            }];
            const bootstrap = isStandalone ?
                renderApplication(
-                   MyStylesAppStandalone,
-                   {...options, platformProviders: providers, appId: 'example-styles'}) :
+                   MyStylesAppStandalone, {...options, platformProviders: providers, appId: 'ng'}) :
                renderModule(ExampleStylesModule, {...options, extraProviders: providers});
            bootstrap.then(output => {
              expect(output).toMatch(
-                 /<app _nghost-example-styles-c\d+="" ng-version="0.0.0-PLACEHOLDER" ng-server-context="ssg">/);
+                 /<app _nghost-ng-c\d+="" ng-version="0.0.0-PLACEHOLDER" ng-server-context="ssg">/);
              called = true;
            });
          }));
@@ -877,13 +868,12 @@ describe('platform-server integration', () => {
          waitForAsync(() => {
            const options = {document: doc};
            const bootstrap = isStandalone ?
-               renderApplication(
-                   MyTransferStateAppStandalone, {...options, appId: 'transfer-state-app'}) :
+               renderApplication(MyTransferStateAppStandalone, {...options, appId: 'ng'}) :
                renderModule(MyTransferStateModule, {...options});
            bootstrap.then(output => {
              const expectedOutput =
                  '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other"><div>Works!</div></app>' +
-                 '<script id="transfer-state-app-state" type="application/json">{&q;some-key&q;:&q;some-value&q;}</script></body></html>';
+                 '<script id="ng-state" type="application/json">{&q;some-key&q;:&q;some-value&q;}</script></body></html>';
              expect(output).toEqual(expectedOutput);
              called = true;
            });

--- a/packages/platform-server/test/transfer_state_spec.ts
+++ b/packages/platform-server/test/transfer_state_spec.ts
@@ -12,7 +12,7 @@ import {renderModule, ServerModule} from '@angular/platform-server';
 
 describe('transfer_state', () => {
   const defaultExpectedOutput =
-      '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other">Works!</app><script id="transfer-state" type="application/json">{&q;test&q;:10}</script></body></html>';
+      '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other">Works!</app><script id="ng-state" type="application/json">{&q;test&q;:10}</script></body></html>';
 
   it('adds transfer script tag when using renderModule', async () => {
     const STATE_KEY = makeStateKey<number>('test');
@@ -27,7 +27,7 @@ describe('transfer_state', () => {
     @NgModule({
       bootstrap: [TransferComponent],
       declarations: [TransferComponent],
-      imports: [BrowserModule.withServerTransition({appId: 'transfer'}), ServerModule],
+      imports: [BrowserModule, ServerModule],
     })
     class TransferStoreModule {
     }
@@ -48,7 +48,7 @@ describe('transfer_state', () => {
     @NgModule({
       bootstrap: [EscapedComponent],
       declarations: [EscapedComponent],
-      imports: [BrowserModule.withServerTransition({appId: 'transfer'}), ServerModule],
+      imports: [BrowserModule, ServerModule],
     })
     class EscapedTransferStoreModule {
     }
@@ -57,7 +57,7 @@ describe('transfer_state', () => {
         await renderModule(EscapedTransferStoreModule, {document: '<esc-app></esc-app>'});
     expect(output).toBe(
         '<html><head></head><body><esc-app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other">Works!</esc-app>' +
-        '<script id="transfer-state" type="application/json">' +
+        '<script id="ng-state" type="application/json">' +
         '{&q;testString&q;:&q;&l;/script&g;&l;script&g;' +
         'alert(&s;Hello&a;&s; + \\&q;World\\&q;);&q;}</script></body></html>');
   });
@@ -75,7 +75,7 @@ describe('transfer_state', () => {
     @NgModule({
       bootstrap: [TransferComponent],
       declarations: [TransferComponent],
-      imports: [BrowserModule.withServerTransition({appId: 'transfer'}), ServerModule],
+      imports: [BrowserModule, ServerModule],
     })
     class TransferStoreModule {
     }


### PR DESCRIPTION
**feat(platform-browser): deprecate `withServerTransition` call**
This commit deprecated ` BrowserModule.withServerTransition` instead `APP_ID` should be used instead to configure the app id.

DEPRECATED: `BrowserModule.withServerTransition` has been deprecated. `APP_ID` should be used instead to set the application ID.
NB: Unless, you render multiple Angular applications on the same page, setting an application ID is not necessary.

Before:
```ts
imports: [
  BrowserModule.withServerTransition({ appId: 'serverApp' }),
  ...
]
```

After:
```ts
imports: [
  BrowserModule,
  { provide: APP_ID, useValue: 'serverApp' },
  ...
],
```

---
**refactor(core): generate a static application ID.**
Prior to this change, a random application ID was generated each time which forced users using server rendering to provide an application ID themselves. This was needed to handle rare cases when multiple Angular applications are rendered on the same page.
  
  With this change the application ID is no longer generated randomly and instead it is hard coded.
  
  BREAKING CHANGE:
  
  The `APP_ID` token value is no longer randomly generated. If you are bootstrapping multiple application on the same page you will need to set to provide the `APP_ID` yourself.
  
  ```ts
  bootstrapApplication(ComponentA, {
    providers: [
     { provide: APP_ID, useValue: 'app-a' },
     // ... other providers ...
    ]
  });
  ```
