### PR TITLE
refactor(router): Remove RouterTestingModule in favor of RouterModule…

### DIFF
--- a/aio/content/examples/testing/src/app/app.component.router.spec.ts
+++ b/aio/content/examples/testing/src/app/app.component.router.spec.ts
@@ -1,29 +1,22 @@
 // For more examples:
 //   https://github.com/angular/angular/blob/main/packages/router/test/integration.spec.ts
 
-import { waitForAsync, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import {Location} from '@angular/common';
+import {provideLocationMocks, SpyLocation} from '@angular/common/testing';
+import {DebugElement, Type} from '@angular/core';
+import {ComponentFixture, fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
+import {By} from '@angular/platform-browser';
+import {provideRouter, Router, RouterLink, RouterModule} from '@angular/router';
 
-import { asyncData } from '../testing';
+import {asyncData, click} from '../testing';
 
-import { RouterTestingModule } from '@angular/router/testing';
-import { SpyLocation } from '@angular/common/testing';
-
-import { Router, RouterLink } from '@angular/router';
-
-import { By } from '@angular/platform-browser';
-import { DebugElement, Type } from '@angular/core';
-import { Location } from '@angular/common';
-
-import { click } from '../testing';
-
-import { routes } from './app-routing.module';
-import { AppModule } from './app.module';
-import { AppComponent } from './app.component';
-import { AboutComponent } from './about/about.component';
-import { DashboardComponent } from './dashboard/dashboard.component';
-
-import { HeroService, TestHeroService } from './model/testing/test-hero.service';
-import { TwainService } from './twain/twain.service';
+import {AboutComponent} from './about/about.component';
+import {routes} from './app-routing.module';
+import {AppComponent} from './app.component';
+import {AppModule} from './app.module';
+import {DashboardComponent} from './dashboard/dashboard.component';
+import {HeroService, TestHeroService} from './model/testing/test-hero.service';
+import {TwainService} from './twain/twain.service';
 
 let comp: AppComponent;
 let fixture: ComponentFixture<AppComponent>;
@@ -31,15 +24,15 @@ let page: Page;
 let router: Router;
 let location: SpyLocation;
 
-describe('AppComponent & RouterTestingModule', () => {
+describe('AppComponent & router testing', () => {
   beforeEach(waitForAsync(() => {
     TestBed
         .configureTestingModule({
           imports: [
             AppModule,
-            RouterTestingModule.withRoutes(routes),
+            RouterModule.forRoot(routes),
           ],
-          providers: [{provide: HeroService, useClass: TestHeroService}]
+          providers: [{provide: HeroService, useClass: TestHeroService}, provideLocationMocks()]
         })
         .compileComponents();
   }));
@@ -64,7 +57,6 @@ describe('AppComponent & RouterTestingModule', () => {
   it('should navigate to "About" w/ browser location URL change', fakeAsync(() => {
        createComponent();
        location.simulateHashChange('/about');
-       // location.go('/about'); // also works ... except, perhaps, in Stackblitz
        advance();
        expectPathToBe('/about');
        expectElementOf(AboutComponent);
@@ -82,8 +74,8 @@ describe('AppComponent & RouterTestingModule', () => {
 
 ///////////////
 
-import { HeroModule } from './hero/hero.module';  // should be lazy loaded
-import { HeroListComponent } from './hero/hero-list.component';
+import {HeroModule} from './hero/hero.module';  // should be lazy loaded
+import {HeroListComponent} from './hero/hero-list.component';
 
 ///////// Can't get lazy loaded Heroes to work yet
 xdescribe('AppComponent & Lazy Loading (not working yet)', () => {
@@ -92,8 +84,10 @@ xdescribe('AppComponent & Lazy Loading (not working yet)', () => {
         .configureTestingModule({
           imports: [
             AppModule,
-            RouterTestingModule.withRoutes(routes),
           ],
+          providers: [
+            provideRouter(routes),
+          ]
         })
         .compileComponents();
   }));
@@ -170,15 +164,11 @@ class Page {
 }
 
 function expectPathToBe(path: string, expectationFailOutput?: any) {
-  expect(location.path())
-  .withContext(expectationFailOutput || 'location.path()')
-  .toEqual(path);
+  expect(location.path()).withContext(expectationFailOutput || 'location.path()').toEqual(path);
 }
 
 function expectElementOf(type: Type<any>): any {
   const el = fixture.debugElement.query(By.directive(type));
-  expect(el)
-    .withContext(`expected an element for ${type.name}`)
-    .toBeTruthy();
+  expect(el).withContext(`expected an element for ${type.name}`).toBeTruthy();
   return el;
 }

--- a/aio/content/examples/toh-pt6/src/app/dashboard/dashboard.component.spec.ts
+++ b/aio/content/examples/toh-pt6/src/app/dashboard/dashboard.component.spec.ts
@@ -1,12 +1,12 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { of } from 'rxjs';
+import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
+import {RouterModule} from '@angular/router';
+import {of} from 'rxjs';
 
-import { HeroSearchComponent } from '../hero-search/hero-search.component';
-import { HeroService } from '../hero.service';
-import { HEROES } from '../mock-heroes';
+import {HeroSearchComponent} from '../hero-search/hero-search.component';
+import {HeroService} from '../hero.service';
+import {HEROES} from '../mock-heroes';
 
-import { DashboardComponent } from './dashboard.component';
+import {DashboardComponent} from './dashboard.component';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -20,8 +20,10 @@ describe('DashboardComponent', () => {
     TestBed
         .configureTestingModule({
           declarations: [DashboardComponent, HeroSearchComponent],
-          imports: [RouterTestingModule.withRoutes([])],
-          providers: [{provide: HeroService, useValue: heroService}]
+          imports: [RouterModule.forRoot([])],
+          providers: [
+            {provide: HeroService, useValue: heroService},
+          ]
         })
         .compileComponents();
 

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -199,7 +199,7 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 |:---                                        |:---                               |:---                   |:---     |
 | [`RouterLinkWithHref` directive](api/router/RouterLinkWithHref) | Use `RouterLink` instead. | v15                   | The `RouterLinkWithHref` directive code was merged into `RouterLink`. Now the `RouterLink` directive can be used for all elements that have `routerLink` attribute. |
 | [`provideRoutes` function](api/router/provideRoutes) | Use `ROUTES` `InjectionToken` instead. | v15                   | The `provideRoutes` helper function is minimally useful and can be unintentionally used instead of `provideRouter` due to similar spelling. |
-| [`setupTestingRouter` function](api/router/testing/setupTestingRouter) | Use `provideRouter` or `RouterTestingModule` instead. | v15.1                   | The `setupTestingRouter` function is not necessary. The `Router` is initialized based on the DI configuration in tests as it would be in production. |
+| [`setupTestingRouter` function](api/router/testing/setupTestingRouter) | Use `provideRouter` or `RouterModule` instead. | v15.1                   | The `setupTestingRouter` function is not necessary. The `Router` is initialized based on the DI configuration in tests as it would be in production. |
 | [class and `InjectionToken` guards and resolvers](api/router/DeprecatedGuard) | Use plain JavaScript functions instead. | v15.2                   | Functional guards are simpler and more powerful than class and token-based guards. |
 
 

--- a/devtools/projects/shell-browser/src/app/app.component.spec.ts
+++ b/devtools/projects/shell-browser/src/app/app.component.spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {TestBed, waitForAsync} from '@angular/core/testing';
-import {RouterTestingModule} from '@angular/router/testing';
+import {RouterModule} from '@angular/router';
 import {ApplicationOperations} from 'ng-devtools';
 
 import {AppComponent} from './app.component';
@@ -18,7 +18,7 @@ describe('AppComponent', () => {
     TestBed
         .configureTestingModule({
           declarations: [AppComponent],
-          imports: [RouterTestingModule],
+          imports: [RouterModule.forRoot([])],
           providers: [
             {
               provide: ApplicationOperations,

--- a/integration/cli-elements-universal/src/app/app.component.spec.ts
+++ b/integration/cli-elements-universal/src/app/app.component.spec.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -12,7 +12,7 @@ describe('AppComponent', () => {
         TestTitleComponent,
       ],
       imports: [
-        RouterTestingModule,
+        RouterModule.forRoot([]),
       ],
     });
     await TestBed.compileComponents();

--- a/integration/cli-hello-world-lazy/src/app/app.component.spec.ts
+++ b/integration/cli-hello-world-lazy/src/app/app.component.spec.ts
@@ -1,5 +1,4 @@
 import {TestBed, waitForAsync} from '@angular/core/testing';
-import {RouterTestingModule} from '@angular/router/testing';
 import {AppComponent} from './app.component';
 
 describe('AppComponent', () => {

--- a/integration/trusted-types/src/app/app.component.spec.ts
+++ b/integration/trusted-types/src/app/app.component.spec.ts
@@ -1,12 +1,12 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule
+        RouterModule.forRoot([])
       ],
       declarations: [
         AppComponent

--- a/packages/core/test/animation/animation_router_integration_spec.ts
+++ b/packages/core/test/animation/animation_router_integration_spec.ts
@@ -12,8 +12,7 @@ import {MockAnimationDriver, MockAnimationPlayer} from '@angular/animations/brow
 import {Component, HostBinding} from '@angular/core';
 import {fakeAsync, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
-import {ActivatedRoute, Router, RouterOutlet} from '@angular/router';
-import {RouterTestingModule} from '@angular/router/testing';
+import {ActivatedRoute, Router, RouterModule, RouterOutlet} from '@angular/router';
 
 (function() {
 // these tests are only meant to be run within the DOM (for now)
@@ -31,7 +30,7 @@ describe('Animation Router Tests', function() {
   beforeEach(() => {
     resetLog();
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule, BrowserAnimationsModule],
+      imports: [RouterModule.forRoot([]), BrowserAnimationsModule],
       providers: [{provide: AnimationDriver, useClass: MockAnimationDriver}]
     });
   });
@@ -108,7 +107,7 @@ describe('Animation Router Tests', function() {
 
        TestBed.configureTestingModule({
          declarations: [Page1Cmp, Page2Cmp, ContainerCmp],
-         imports: [RouterTestingModule.withRoutes([
+         imports: [RouterModule.forRoot([
            {path: 'page1', component: Page1Cmp, data: makeAnimationData('page1')},
            {path: 'page2', component: Page2Cmp, data: makeAnimationData('page2')}
          ])]
@@ -215,7 +214,7 @@ describe('Animation Router Tests', function() {
 
        TestBed.configureTestingModule({
          declarations: [Page1Cmp, Page2Cmp, ContainerCmp],
-         imports: [RouterTestingModule.withRoutes([
+         imports: [RouterModule.forRoot([
            {path: 'page1', component: Page1Cmp, data: makeAnimationData('page1')},
            {path: 'page2', component: Page2Cmp, data: makeAnimationData('page2')}
          ])]
@@ -320,7 +319,7 @@ describe('Animation Router Tests', function() {
 
        TestBed.configureTestingModule({
          declarations: [Page1Cmp, Page2Cmp, ContainerCmp],
-         imports: [RouterTestingModule.withRoutes([
+         imports: [RouterModule.forRoot([
            {path: 'page1', component: Page1Cmp, data: makeAnimationData('page1')},
            {path: 'page2', component: Page2Cmp, data: makeAnimationData('page2')}
          ])]
@@ -414,7 +413,7 @@ describe('Animation Router Tests', function() {
 
        TestBed.configureTestingModule({
          declarations: [Page1Cmp, Page2Cmp, ContainerCmp],
-         imports: [RouterTestingModule.withRoutes([
+         imports: [RouterModule.forRoot([
            {path: 'page1', component: Page1Cmp, data: makeAnimationData('page1')},
            {path: 'page2', component: Page2Cmp, data: makeAnimationData('page2')}
          ])]
@@ -498,7 +497,7 @@ describe('Animation Router Tests', function() {
 
        TestBed.configureTestingModule({
          declarations: [ContainerCmp, RecurPageCmp],
-         imports: [RouterTestingModule.withRoutes([{
+         imports: [RouterModule.forRoot([{
            path: 'recur',
            component: RecurPageCmp,
            outlet: 'recur',

--- a/packages/router/test/create_url_tree.spec.ts
+++ b/packages/router/test/create_url_tree.spec.ts
@@ -17,7 +17,6 @@ import {RouterModule} from '../src/router_module';
 import {ActivatedRoute, ActivatedRouteSnapshot} from '../src/router_state';
 import {Params, PRIMARY_OUTLET} from '../src/shared';
 import {DefaultUrlSerializer, UrlTree} from '../src/url_tree';
-import {RouterTestingModule} from '../testing';
 
 describe('createUrlTree', async () => {
   const serializer = new DefaultUrlSerializer();
@@ -546,7 +545,7 @@ describe('createUrlTreeFromSnapshot', async () => {
          children: [{path: 'innerRoute', component: ChildComponent}]
        }];
 
-       TestBed.configureTestingModule({imports: [RouterTestingModule.withRoutes(routes)]});
+       TestBed.configureTestingModule({imports: [RouterModule.forRoot(routes)]});
        const router = TestBed.inject(Router);
        const fixture = TestBed.createComponent(RootCmp);
 
@@ -602,7 +601,7 @@ describe('createUrlTreeFromSnapshot', async () => {
          },
        ];
 
-       TestBed.configureTestingModule({imports: [RouterTestingModule.withRoutes(routes)]});
+       TestBed.configureTestingModule({imports: [RouterModule.forRoot(routes)]});
        const router = TestBed.inject(Router);
        const fixture = TestBed.createComponent(RootCmp);
 

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -9,9 +9,8 @@
 import {CommonModule, NgForOf} from '@angular/common';
 import {Component, Input, Type} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {provideRouter, Router, RouterOutlet} from '@angular/router/src';
-import {withComponentInputBinding} from '@angular/router/src/provide_router';
-import {RouterTestingHarness, RouterTestingModule} from '@angular/router/testing';
+import {provideRouter, Router, RouterModule, RouterOutlet, withComponentInputBinding} from '@angular/router/src';
+import {RouterTestingHarness} from '@angular/router/testing';
 
 
 describe('router outlet name', () => {
@@ -32,10 +31,8 @@ describe('router outlet name', () => {
        class PopupCmp {
        }
 
-       TestBed.configureTestingModule({
-         imports:
-             [RouterTestingModule.withRoutes([{path: '', outlet: 'popup', component: PopupCmp}])]
-       });
+       TestBed.configureTestingModule(
+           {imports: [RouterModule.forRoot([{path: '', outlet: 'popup', component: PopupCmp}])]});
        const router = TestBed.inject(Router);
        const fixture = createRoot(router, RootCmp);
        expect(fixture.nativeElement.innerHTML).toContain('popup component');
@@ -66,7 +63,7 @@ describe('router outlet name', () => {
        }
 
        TestBed.configureTestingModule({
-         imports: [RouterTestingModule.withRoutes([
+         imports: [RouterModule.forRoot([
            {path: '', outlet: 'greeting', component: GreetingCmp},
            {path: '', outlet: 'farewell', component: FarewellCmp},
          ])]
@@ -124,7 +121,7 @@ describe('router outlet name', () => {
        }
 
        TestBed.configureTestingModule({
-         imports: [RouterTestingModule.withRoutes([
+         imports: [RouterModule.forRoot([
            {path: '1', outlet: 'outlet1', component: Cmp1},
            {path: '2', outlet: 'outlet2', component: Cmp2},
            {path: '3', outlet: 'outlet3', component: Cmp3},
@@ -172,7 +169,7 @@ describe('router outlet name', () => {
        }
 
        TestBed.configureTestingModule({
-         imports: [RouterTestingModule.withRoutes([
+         imports: [RouterModule.forRoot([
            {path: 'parent', component: ParentCmp, children: [{path: 'child', component: ChildCmp}]}
          ])]
        });

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -486,7 +486,7 @@ describe('Integration', () => {
 
       @NgModule({
         declarations: [Parent, NamedOutletHost, Child1, Child2, Child3],
-        imports: [RouterModule]
+        imports: [RouterModule.forRoot([])]
       })
       class TestModule {
       }
@@ -670,7 +670,7 @@ describe('Integration', () => {
 
        @NgModule({
          declarations: [OnPushOutlet, NeedCdCmp],
-         imports: [RouterModule],
+         imports: [RouterModule.forRoot([])],
        })
        class TestModule {
        }
@@ -6084,7 +6084,7 @@ describe('Integration', () => {
       class LoadedModule {
       }
 
-      @NgModule({declarations: [EagerParentComponent], imports: [RouterModule]})
+      @NgModule({declarations: [EagerParentComponent], imports: [RouterModule.forRoot([])]})
       class TestModule {
       }
 

--- a/packages/router/test/operators/prioritized_guard_value.spec.ts
+++ b/packages/router/test/operators/prioritized_guard_value.spec.ts
@@ -8,7 +8,7 @@
 
 
 import {TestBed} from '@angular/core/testing';
-import {RouterTestingModule} from '@angular/router/testing';
+import {RouterModule} from '@angular/router';
 import {TestScheduler} from 'rxjs/testing';
 
 import {prioritizedGuardValue} from '../../src/operators/prioritized_guard_value';
@@ -21,7 +21,7 @@ describe('prioritizedGuardValue operator', () => {
   const TF = {T: true, F: false};
 
   beforeEach(() => {
-    TestBed.configureTestingModule({imports: [RouterTestingModule]});
+    TestBed.configureTestingModule({imports: [RouterModule.forRoot([])]});
   });
   beforeEach(() => {
     testScheduler = new TestScheduler(assertDeepEquals);

--- a/packages/router/test/page_title_strategy_spec.ts
+++ b/packages/router/test/page_title_strategy_spec.ts
@@ -176,7 +176,7 @@ export class RootCmp {
 
 @NgModule({
   declarations: [BlankCmp],
-  imports: [RouterModule],
+  imports: [RouterModule.forRoot([])],
 })
 export class TestModule {
 }

--- a/packages/router/test/regression_integration.spec.ts
+++ b/packages/router/test/regression_integration.spec.ts
@@ -10,8 +10,7 @@ import {CommonModule, HashLocationStrategy, Location, LocationStrategy} from '@a
 import {provideLocationMocks, SpyLocation} from '@angular/common/testing';
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Injectable, NgModule, TemplateRef, Type, ViewChild, ViewContainerRef} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {ChildrenOutletContexts, DefaultUrlSerializer, Router, RouterOutlet, UrlSerializer, UrlTree} from '@angular/router';
-import {RouterTestingModule} from '@angular/router/testing';
+import {ChildrenOutletContexts, DefaultUrlSerializer, Router, RouterModule, RouterOutlet, UrlSerializer, UrlTree} from '@angular/router';
 import {of} from 'rxjs';
 import {delay, mapTo} from 'rxjs/operators';
 
@@ -44,7 +43,7 @@ describe('Integration', () => {
          }
 
          TestBed.configureTestingModule({
-           imports: [RouterTestingModule.withRoutes(
+           imports: [RouterModule.forRoot(
                [{path: 'link-a', component: SimpleCmp}, {path: 'link-b', component: SimpleCmp}])],
            declarations: [LinkComponent, SimpleCmp]
          });
@@ -88,7 +87,7 @@ describe('Integration', () => {
          }
 
          @NgModule({
-           imports: [CommonModule, RouterTestingModule],
+           imports: [CommonModule, RouterModule.forRoot([])],
            declarations: [MyCmp, SimpleCmp],
          })
          class MyModule {
@@ -143,7 +142,7 @@ describe('Integration', () => {
          }
 
          TestBed.configureTestingModule({
-           imports: [RouterTestingModule.withRoutes([{path: 'simple', component: SimpleCmp}])],
+           imports: [RouterModule.forRoot([{path: 'simple', component: SimpleCmp}])],
            declarations: [ComponentWithRouterLink, SimpleCmp]
          });
 
@@ -179,7 +178,7 @@ describe('Integration', () => {
          }
 
          TestBed.configureTestingModule({
-           imports: [RouterTestingModule.withRoutes([{path: 'simple', component: SimpleCmp}])],
+           imports: [RouterModule.forRoot([{path: 'simple', component: SimpleCmp}])],
            declarations: [OnPushComponent, SimpleCmp]
          });
 
@@ -204,8 +203,8 @@ describe('Integration', () => {
        }
 
        TestBed.configureTestingModule({
-         imports: [RouterTestingModule.withRoutes(
-             [{path: ':id', component: SimpleComponent, outlet: 'aux'}])],
+         imports:
+             [RouterModule.forRoot([{path: ':id', component: SimpleComponent, outlet: 'aux'}])],
          declarations: [SimpleComponent, AppComponent],
        });
 
@@ -246,12 +245,13 @@ describe('Integration', () => {
          }
 
          TestBed.configureTestingModule({
-           imports: [RouterTestingModule.withRoutes([
+           imports: [RouterModule.forRoot([
              {path: '', component: SimpleCmp},
              {path: 'one', component: OneCmp, canActivate: ['returnRootUrlTree']}
            ])],
            declarations: [SimpleCmp, RootCmp, OneCmp],
            providers: [
+             provideLocationMocks(),
              {
                provide: 'returnRootUrlTree',
                useFactory: (router: Router) => () => {
@@ -278,7 +278,7 @@ describe('Integration', () => {
   });
 
   describe('duplicate navigation handling (#43447, #43446)', () => {
-    let location: SpyLocation;
+    let location: Location;
     let router: Router;
     let fixture: ComponentFixture<{}>;
 
@@ -316,7 +316,7 @@ describe('Integration', () => {
       });
 
       router = TestBed.inject(Router);
-      location = TestBed.inject(Location) as SpyLocation;
+      location = TestBed.inject(Location);
 
       router.navigateByUrl('/');
       // Will setup location change listeners
@@ -324,9 +324,9 @@ describe('Integration', () => {
     }));
 
     it('duplicate navigation to same url', fakeAsync(() => {
-         location.simulateHashChange('/one');
+         location.go('/one');
          tick(100);
-         location.simulateHashChange('/one');
+         location.go('/one');
          tick(1000);
          advance(fixture);
 
@@ -364,7 +364,7 @@ describe('Integration', () => {
     }
 
     TestBed.configureTestingModule({
-      imports: [CommonModule, RouterTestingModule.withRoutes([{path: '**', component: EmptyCmp}])],
+      imports: [CommonModule, RouterModule.forRoot([{path: '**', component: EmptyCmp}])],
       declarations: [TestCmp, EmptyCmp]
     });
     const fixture = TestBed.createComponent(TestCmp);

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -9,7 +9,7 @@
 import {Location} from '@angular/common';
 import {EnvironmentInjector} from '@angular/core';
 import {inject, TestBed} from '@angular/core/testing';
-import {RouterTestingModule} from '@angular/router/testing';
+import {RouterModule} from '@angular/router';
 import {of} from 'rxjs';
 
 import {ChildActivationStart} from '../src/events';
@@ -31,7 +31,7 @@ describe('Router', () => {
     class TestComponent {}
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [RouterTestingModule]});
+      TestBed.configureTestingModule({imports: [RouterModule.forRoot([])]});
     });
 
     it('should copy config to avoid mutations of user-provided objects', () => {
@@ -67,7 +67,7 @@ describe('Router', () => {
     class NewRootComponent {}
 
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [RouterTestingModule]});
+      TestBed.configureTestingModule({imports: [RouterModule.forRoot([])]});
     });
 
     it('should not change root route when updating the root component', () => {
@@ -82,7 +82,7 @@ describe('Router', () => {
 
   describe('setUpLocationChangeListener', () => {
     beforeEach(() => {
-      TestBed.configureTestingModule({imports: [RouterTestingModule]});
+      TestBed.configureTestingModule({imports: [RouterModule.forRoot([])]});
     });
 
     it('should be idempotent', inject([Router, Location], (r: Router, location: Location) => {
@@ -125,7 +125,7 @@ describe('Router', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [RouterTestingModule],
+        imports: [RouterModule],
         providers: [
           Logger, provideTokenLogger(CA_CHILD), provideTokenLogger(CA_CHILD_FALSE, false),
           provideTokenLogger(CA_CHILD_REDIRECT, serializer.parse('/canActivate_child_redirect')),

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -9,8 +9,7 @@
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
-import {Router, RouterLink} from '@angular/router';
-import {RouterTestingModule} from '@angular/router/testing';
+import {Router, RouterLink, RouterModule} from '@angular/router';
 
 describe('RouterLink', () => {
   it('does not modify tabindex if already set on non-anchor element', () => {
@@ -18,7 +17,8 @@ describe('RouterLink', () => {
     class LinkComponent {
       link: string|null|undefined = '/';
     }
-    TestBed.configureTestingModule({imports: [RouterTestingModule], declarations: [LinkComponent]});
+    TestBed.configureTestingModule(
+        {imports: [RouterModule.forRoot([])], declarations: [LinkComponent]});
     const fixture = TestBed.createComponent(LinkComponent);
     fixture.detectChanges();
     const link = fixture.debugElement.query(By.css('div')).nativeElement;
@@ -40,7 +40,7 @@ describe('RouterLink', () => {
 
     beforeEach(() => {
       TestBed.configureTestingModule({
-        imports: [RouterTestingModule],
+        imports: [RouterModule.forRoot([])],
         declarations: [LinkComponent],
       });
       fixture = TestBed.createComponent(LinkComponent);
@@ -106,7 +106,7 @@ describe('RouterLink', () => {
 
       beforeEach(() => {
         TestBed.configureTestingModule({
-          imports: [RouterTestingModule],
+          imports: [RouterModule.forRoot([])],
           declarations: [LinkComponent],
         });
         fixture = TestBed.createComponent(LinkComponent);
@@ -157,7 +157,7 @@ describe('RouterLink', () => {
       }
 
       TestBed.configureTestingModule({
-        imports: [RouterTestingModule],
+        imports: [RouterModule.forRoot([])],
         declarations: [LinkComponent],
       });
       const fixture = TestBed.createComponent(LinkComponent);

--- a/packages/router/test/standalone.spec.ts
+++ b/packages/router/test/standalone.spec.ts
@@ -10,7 +10,6 @@ import {Component, Injectable, NgModule} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {provideRoutes, Router, RouterModule, ROUTES} from '@angular/router';
-import {RouterTestingModule} from '@angular/router/testing';
 
 @Component({template: '<div>simple standalone</div>', standalone: true})
 export class SimpleStandaloneComponent {
@@ -32,7 +31,7 @@ describe('standalone in Router API', () => {
   describe('loadChildren => routes', () => {
     it('can navigate to and render standalone component', fakeAsync(() => {
          TestBed.configureTestingModule({
-           imports: [RouterTestingModule.withRoutes([
+           imports: [RouterModule.forRoot([
              {
                path: 'lazy',
                component: RootCmp,
@@ -52,7 +51,7 @@ describe('standalone in Router API', () => {
     it('throws an error when loadChildren=>routes has a component that is not standalone',
        fakeAsync(() => {
          TestBed.configureTestingModule({
-           imports: [RouterTestingModule.withRoutes([
+           imports: [RouterModule.forRoot([
              {
                path: 'lazy',
                component: RootCmp,
@@ -81,7 +80,7 @@ describe('standalone in Router API', () => {
 
          TestBed.configureTestingModule({
            imports: [
-             RouterTestingModule.withRoutes([{
+             RouterModule.forRoot([{
                path: 'simple',
                providers: [ConfigurableGuard],
                canActivate: [ConfigurableGuard],
@@ -118,8 +117,7 @@ describe('standalone in Router API', () => {
 
          TestBed.configureTestingModule({
            imports: [
-             RouterTestingModule.withRoutes(
-                 [{path: 'home', providers: [Service], component: MyComponent}]),
+             RouterModule.forRoot([{path: 'home', providers: [Service], component: MyComponent}]),
            ],
            declarations: [MyComponent],
          });
@@ -150,7 +148,7 @@ describe('standalone in Router API', () => {
 
          TestBed.configureTestingModule({
            imports: [
-             RouterTestingModule.withRoutes(
+             RouterModule.forRoot(
                  [{path: 'home', loadChildren: () => LazyModule, component: MyComponent}]),
            ],
            declarations: [MyComponent],
@@ -183,7 +181,7 @@ describe('standalone in Router API', () => {
 
          TestBed.configureTestingModule({
            imports: [
-             RouterTestingModule.withRoutes([{path: 'home', loadChildren: () => LazyModule}]),
+             RouterModule.forRoot([{path: 'home', loadChildren: () => LazyModule}]),
            ],
          });
          const root = TestBed.createComponent(RootCmp);
@@ -258,7 +256,7 @@ describe('standalone in Router API', () => {
 
          TestBed.configureTestingModule({
            imports: [
-             RouterTestingModule.withRoutes([{
+             RouterModule.forRoot([{
                path: 'home',
                // This component and guard should get Service1 since it's provided on this route
                component: ParentCmp,
@@ -299,7 +297,7 @@ describe('standalone in Router API', () => {
          }
 
          TestBed.configureTestingModule({
-           imports: [RouterTestingModule.withRoutes([{
+           imports: [RouterModule.forRoot([{
              path: 'home',
              loadComponent: loadComponentSpy,
              canActivate: [Guard],
@@ -313,7 +311,7 @@ describe('standalone in Router API', () => {
 
     it('loads and renders lazy component', fakeAsync(() => {
          TestBed.configureTestingModule({
-           imports: [RouterTestingModule.withRoutes([{
+           imports: [RouterModule.forRoot([{
              path: 'home',
              loadComponent: () => SimpleStandaloneComponent,
            }])],
@@ -327,7 +325,7 @@ describe('standalone in Router API', () => {
 
     it('throws error when loadComponent is not standalone', fakeAsync(() => {
          TestBed.configureTestingModule({
-           imports: [RouterTestingModule.withRoutes([{
+           imports: [RouterModule.forRoot([{
              path: 'home',
              loadComponent: () => NotStandaloneComponent,
            }])],
@@ -344,7 +342,7 @@ describe('standalone in Router API', () => {
          }
 
          TestBed.configureTestingModule({
-           imports: [RouterTestingModule.withRoutes([{
+           imports: [RouterModule.forRoot([{
              path: 'home',
              loadComponent: () => LazyModule,
            }])],
@@ -358,7 +356,7 @@ describe('standalone in Router API', () => {
   describe('default export unwrapping', () => {
     it('should work for loadComponent', async () => {
       TestBed.configureTestingModule({
-        imports: [RouterTestingModule.withRoutes([{
+        imports: [RouterModule.forRoot([{
           path: 'home',
           loadComponent: () => import('./default_export_component'),
         }])],
@@ -373,7 +371,7 @@ describe('standalone in Router API', () => {
 
     it('should work for loadChildren', async () => {
       TestBed.configureTestingModule({
-        imports: [RouterTestingModule.withRoutes([{
+        imports: [RouterModule.forRoot([{
           path: 'home',
           loadChildren: () => import('./default_export_routes'),
         }])],
@@ -389,7 +387,7 @@ describe('standalone in Router API', () => {
 });
 
 describe('provideRoutes', () => {
-  it('warns if provideRoutes is used without provideRouter, RouterTestingModule, or RouterModule.forRoot',
+  it('warns if provideRoutes is used without provideRouter, RouterModule, or RouterModule.forRoot',
      () => {
        spyOn(console, 'warn');
        TestBed.configureTestingModule({providers: [provideRoutes([])]});

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -28,7 +28,7 @@ function throwInvalidConfigError(parameter: string): never {
  * Router setup factory function used for testing.
  *
  * @publicApi
- * @deprecated Use `provideRouter` or `RouterTestingModule` instead.
+ * @deprecated Use `provideRouter` or `RouterModule` instead.
  */
 export function setupTestingRouter(
     urlSerializer: UrlSerializer, contexts: ChildrenOutletContexts, location: Location,
@@ -101,7 +101,7 @@ export function setupTestingRouter(
  * beforeEach(() => {
  *   TestBed.configureTestingModule({
  *     imports: [
- *       RouterTestingModule.withRoutes(
+ *       RouterModule.forRoot(
  *         [{path: '', component: BlankCmp}, {path: 'simple', component: SimpleCmp}]
  *       )
  *     ]

--- a/packages/router/upgrade/test/upgrade.spec.ts
+++ b/packages/router/upgrade/test/upgrade.spec.ts
@@ -9,8 +9,7 @@
 import {Location} from '@angular/common';
 import {$locationShim, UrlCodec} from '@angular/common/upgrade';
 import {fakeAsync, flush, TestBed} from '@angular/core/testing';
-import {Router} from '@angular/router';
-import {RouterTestingModule} from '@angular/router/testing';
+import {Router, RouterModule} from '@angular/router';
 import {setUpLocationSync} from '@angular/router/upgrade';
 import {UpgradeModule} from '@angular/upgrade/static';
 
@@ -76,7 +75,7 @@ describe('setUpLocationSync', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule.withRoutes([{path: '1', children: []}, {path: '2', children: []}]),
+        RouterModule.forRoot([{path: '1', children: []}, {path: '2', children: []}]),
         UpgradeModule,
         LocationUpgradeTestModule.config(),
       ],


### PR DESCRIPTION
….forRoot

`RouterTestingModule` is not needed as of v16. Instead, TestBed automatically provides `MockPlatformLocation` in order to help test navigations in the application. The location mocks in the RouterTestingModule aren't necessary anymore.

There doesn't appear to be any real documentation around `RouterTestingModule` other than the API docs.