### PR TITLE
docs(docs-infra): improve docs for styling precedence and class binding.

### DIFF
--- a/aio/content/guide/class-binding.md
+++ b/aio/content/guide/class-binding.md
@@ -35,7 +35,7 @@ Updating the property without changing object identity has no effect.
 
 </div>
 
-If there are multiple bindings to the same class name, Angular uses [styling precedence](guide/style-precedence) to determine which binding to use.
+If there are multiple bindings to the same class name, Angular uses [styling precedence](guide/style-precedence) to determine which binding to use. These rules specify an order for which class-related bindings have priority.
 
 The following table summarizes class binding syntax.
 
@@ -82,7 +82,7 @@ Updating the property without changing object identity has no effect.
 
 <code-example path="attribute-binding/src/app/single-and-multiple-style-binding.component.ts" header="nav-bar.component.ts"></code-example>
 
-If there are multiple bindings to the same style attribute, Angular uses [styling precedence](guide/style-precedence) to determine which binding to use.
+If there are multiple bindings to the same style attribute, Angular uses [styling precedence](guide/style-precedence) to determine which binding to use. These rules specify an order for which style-related bindings have priority.
 
 The following table summarizes style binding syntax.
 
@@ -93,14 +93,9 @@ The following table summarizes style binding syntax.
 | Multi-style binding             | `[style]="styleExpression"` | `string`                                                                   | `"width: 100px; height: 100px"`     |
 | Multi-style binding             | `[style]="styleExpression"` | <code>Record&lt;string, string &verbar; undefined &verbar; null&gt;</code> | `{width: '100px', height: '100px'}` |
 
-{@a styling-precedence}
-## Styling precedence
-
-A single HTML element can have its CSS class list and style values bound to multiple sources (for example, host bindings from multiple directives).
-
 ## What’s next
 
 * [Component styles](https://angular.io/guide/component-styles)
 * [Introduction to Angular animations](https://angular.io/guide/animations)
 
-@reviewed 2022-05-09
+@reviewed 2023-03-15

--- a/aio/content/guide/style-precedence.md
+++ b/aio/content/guide/style-precedence.md
@@ -12,7 +12,7 @@ This styling precedence is as follows, from the most specific with the highest p
     | Map binding      | <code-example format="html" hideCopy language="html"> &lt;div [class]="classExpression"&gt; </code-example> <code-example format="html" hideCopy language="html"> &lt;div [style]="styleExpression"&gt; </code-example> |
     | Static value     | <code-example format="html" hideCopy language="html"> &lt;div class="foo"&gt; </code-example> <code-example format="html" hideCopy language="html"> &lt;div style="color: blue"&gt; </code-example>                     |
 
-1.  Directive host bindings are less specific because you can use directives in multiple locations, so they have a lower precedence than template bindings.
+1.  Directive host bindings are less specific because you can use directives in multiple locations, so they have lower precedence than template bindings.
 
     | Binding type     | Examples |
     |:---              |:---     |


### PR DESCRIPTION
This PR removes the confusing section - [## Style Precendece](https://angular.io/guide/class-binding#styling-precedence) - from [Class and style binding](https://angular.io/guide/class-binding) docs and adds more clarification to it in the following sections: [## Binding to multiple styles](https://angular.io/guide/class-binding#binding-to-multiple-styles) and [## Binding to multiple CSS classes](https://angular.io/guide/class-binding#binding-to-multiple-css-classes) which already contain references to [Style Precedence](https://angular.io/guide/style-precedence) docs. Hence, there is no need to duplicate it as a separate section.

Fixes #48522.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] `N/A`: Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
