### PR TITLE
feat(core): add API to provide CSP nonce for inline stylesheets

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -346,6 +346,9 @@ export function createPlatform(injector: Injector): PlatformRef;
 export function createPlatformFactory(parentPlatformFactory: ((extraProviders?: StaticProvider[]) => PlatformRef) | null, name: string, providers?: StaticProvider[]): (extraProviders?: StaticProvider[]) => PlatformRef;
 
 // @public
+export const CSP_NONCE: InjectionToken<string | null>;
+
+// @public
 export const CUSTOM_ELEMENTS_SCHEMA: SchemaMetadata;
 
 // @public (undocumented)

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -17,7 +17,7 @@ export {TypeDecorator} from './util/decorators';
 export * from './di';
 export {createPlatform, assertPlatform, destroyPlatform, getPlatform, BootstrapOptions, PlatformRef, ApplicationRef, createPlatformFactory, NgProbeToken, APP_BOOTSTRAP_LISTENER} from './application_ref';
 export {enableProdMode, isDevMode} from './util/is_dev_mode';
-export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, PLATFORM_ID, ANIMATION_MODULE_TYPE} from './application_tokens';
+export {APP_ID, PACKAGE_ROOT_URL, PLATFORM_INITIALIZER, PLATFORM_ID, ANIMATION_MODULE_TYPE, CSP_NONCE} from './application_tokens';
 export {APP_INITIALIZER, ApplicationInitStatus} from './application_init';
 export * from './zone';
 export * from './render';

--- a/packages/core/test/acceptance/csp_spec.ts
+++ b/packages/core/test/acceptance/csp_spec.ts
@@ -1,0 +1,150 @@
+/*!
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, CSP_NONCE, destroyPlatform, ElementRef, inject, ViewEncapsulation} from '@angular/core';
+import {bootstrapApplication} from '@angular/platform-browser';
+import {withBody} from '@angular/private/testing';
+
+describe('CSP integration', () => {
+  beforeEach(destroyPlatform);
+  afterEach(destroyPlatform);
+
+  const testStyles = '.a { color: var(--csp-test-var, hotpink); }';
+
+  function findTestNonces(rootNode: ParentNode): string[] {
+    const styles = rootNode.querySelectorAll('style');
+    const nonces: string[] = [];
+
+    for (let i = 0; i < styles.length; i++) {
+      const style = styles[i];
+      if (style.textContent?.includes('--csp-test-var') && style.nonce) {
+        nonces.push(style.nonce);
+      }
+    }
+
+    return nonces;
+  }
+
+  it('should use the predefined ngCspNonce when inserting styles with emulated encapsulation',
+     withBody('<app ngCspNonce="emulated-nonce"></app>', async () => {
+       @Component({
+         selector: 'uses-styles',
+         template: '',
+         styles: [testStyles],
+         standalone: true,
+         encapsulation: ViewEncapsulation.Emulated
+       })
+       class UsesStyles {
+       }
+
+       @Component({
+         selector: 'app',
+         standalone: true,
+         template: '<uses-styles></uses-styles>',
+         imports: [UsesStyles]
+       })
+       class App {
+       }
+
+       const appRef = await bootstrapApplication(App);
+
+       expect(findTestNonces(document)).toEqual(['emulated-nonce']);
+
+       appRef.destroy();
+     }));
+
+  it('should use the predefined ngCspNonce when inserting styles with no encapsulation',
+     withBody('<app ngCspNonce="disabled-nonce"></app>', async () => {
+       @Component({
+         selector: 'uses-styles',
+         template: '',
+         styles: [testStyles],
+         standalone: true,
+         encapsulation: ViewEncapsulation.None
+       })
+       class UsesStyles {
+       }
+
+       @Component({
+         selector: 'app',
+         standalone: true,
+         template: '<uses-styles></uses-styles>',
+         imports: [UsesStyles]
+       })
+       class App {
+       }
+
+       const appRef = await bootstrapApplication(App);
+
+       expect(findTestNonces(document)).toEqual(['disabled-nonce']);
+
+       appRef.destroy();
+     }));
+
+
+  it('should use the predefined ngCspNonce when inserting styles with shadow DOM encapsulation',
+     withBody('<app ngCspNonce="shadow-nonce"></app>', async () => {
+       if (!document.body.attachShadow) {
+         return;
+       }
+
+       let usesStylesRootNode!: HTMLElement;
+
+       @Component({
+         selector: 'uses-styles',
+         template: '',
+         styles: [testStyles],
+         standalone: true,
+         encapsulation: ViewEncapsulation.ShadowDom
+       })
+       class UsesStyles {
+         constructor() {
+           usesStylesRootNode = inject(ElementRef).nativeElement;
+         }
+       }
+
+       @Component({
+         selector: 'app',
+         standalone: true,
+         template: '<uses-styles></uses-styles>',
+         imports: [UsesStyles]
+       })
+       class App {
+       }
+
+       const appRef = await bootstrapApplication(App);
+
+       expect(findTestNonces(usesStylesRootNode.shadowRoot!)).toEqual(['shadow-nonce']);
+
+       appRef.destroy();
+     }));
+
+  it('should prefer nonce provided through DI over one provided in the DOM',
+     withBody('<app ngCspNonce="dom-nonce"></app>', async () => {
+       @Component({selector: 'uses-styles', template: '', styles: [testStyles], standalone: true})
+       class UsesStyles {
+       }
+
+       @Component({
+         selector: 'app',
+         standalone: true,
+         template: '<uses-styles></uses-styles>',
+         imports: [UsesStyles]
+       })
+       class App {
+       }
+
+       const appRef = await bootstrapApplication(App, {
+         providers: [{provide: CSP_NONCE, useValue: 'di-nonce'}],
+       });
+
+       expect(findTestNonces(document)).toEqual(['di-nonce']);
+
+       appRef.destroy();
+     }));
+});

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -126,6 +126,9 @@
     "name": "CONTAINER_HEADER_OFFSET"
   },
   {
+    "name": "CSP_NONCE"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -172,6 +175,9 @@
   },
   {
     "name": "DI_DECORATOR_FLAG"
+  },
+  {
+    "name": "DOCUMENT"
   },
   {
     "name": "DOCUMENT2"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -54,6 +54,9 @@
     "name": "CONTAINER_HEADER_OFFSET"
   },
   {
+    "name": "CSP_NONCE"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -88,6 +91,9 @@
   },
   {
     "name": "DI_DECORATOR_FLAG"
+  },
+  {
+    "name": "DOCUMENT"
   },
   {
     "name": "DOCUMENT2"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -81,6 +81,9 @@
     "name": "CONTAINER_HEADER_OFFSET"
   },
   {
+    "name": "CSP_NONCE"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -124,6 +127,9 @@
   },
   {
     "name": "DI_DECORATOR_FLAG"
+  },
+  {
+    "name": "DOCUMENT"
   },
   {
     "name": "DOCUMENT2"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -84,6 +84,9 @@
     "name": "CONTAINER_HEADER_OFFSET"
   },
   {
+    "name": "CSP_NONCE"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -130,6 +133,9 @@
   },
   {
     "name": "DI_DECORATOR_FLAG"
+  },
+  {
+    "name": "DOCUMENT"
   },
   {
     "name": "DOCUMENT2"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -75,6 +75,9 @@
     "name": "CONTAINER_HEADER_OFFSET"
   },
   {
+    "name": "CSP_NONCE"
+  },
+  {
     "name": "CanActivate"
   },
   {
@@ -151,6 +154,9 @@
   },
   {
     "name": "DI_DECORATOR_FLAG"
+  },
+  {
+    "name": "DOCUMENT"
   },
   {
     "name": "DOCUMENT2"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -42,6 +42,9 @@
     "name": "CONTAINER_HEADER_OFFSET"
   },
   {
+    "name": "CSP_NONCE"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -76,6 +79,9 @@
   },
   {
     "name": "DI_DECORATOR_FLAG"
+  },
+  {
+    "name": "DOCUMENT"
   },
   {
     "name": "DOCUMENT2"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -54,6 +54,9 @@
     "name": "CONTAINER_HEADER_OFFSET"
   },
   {
+    "name": "CSP_NONCE"
+  },
+  {
     "name": "ChangeDetectionStrategy"
   },
   {
@@ -88,6 +91,9 @@
   },
   {
     "name": "DI_DECORATOR_FLAG"
+  },
+  {
+    "name": "DOCUMENT"
   },
   {
     "name": "DOCUMENT2"

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, DOCUMENT, XhrFactory, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {APP_ID, ApplicationConfig as ApplicationConfigFromCore, ApplicationModule, ApplicationRef, createPlatformFactory, ErrorHandler, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalCreateApplication as internalCreateApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
+import {APP_ID, ApplicationConfig as ApplicationConfigFromCore, ApplicationModule, ApplicationRef, createPlatformFactory, CSP_NONCE, ErrorHandler, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalCreateApplication as internalCreateApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
 import {BrowserGetTestability} from './browser/testability';

--- a/packages/platform-browser/src/dom/shared_styles_host.ts
+++ b/packages/platform-browser/src/dom/shared_styles_host.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {APP_ID, Inject, Injectable, OnDestroy} from '@angular/core';
+import {APP_ID, CSP_NONCE, Inject, Injectable, OnDestroy, Optional} from '@angular/core';
 
 /** The style elements attribute name used to set value of `APP_ID` token. */
 const APP_ID_ATTRIBUTE_NAME = 'ng-app-id';
@@ -25,7 +25,8 @@ export class SharedStylesHost implements OnDestroy {
 
   constructor(
       @Inject(DOCUMENT) private readonly doc: Document,
-      @Inject(APP_ID) private readonly appId: string) {
+      @Inject(APP_ID) private readonly appId: string,
+      @Inject(CSP_NONCE) @Optional() private nonce?: string|null) {
     this.styleNodesInDOM = this.collectServerRenderedStyles();
     this.resetHostNodes();
   }
@@ -139,9 +140,14 @@ export class SharedStylesHost implements OnDestroy {
       return styleEl;
     } else {
       const styleEl = this.doc.createElement('style');
+
+      if (this.nonce) {
+        // Uses a keyed write to avoid issues with property minification.
+        styleEl['nonce'] = this.nonce;
+      }
+
       styleEl.textContent = style;
       styleEl.setAttribute(APP_ID_ATTRIBUTE_NAME, this.appId);
-
       return styleEl;
     }
   }


### PR DESCRIPTION
Angular uses inline styles to insert the styles associated with a component. This violates the strict styles [Content Security Policy](https://web.dev/strict-csp/) which doesn't allow inline styles by default. One way to allow the styles to be applied is to set a `nonce` attribute on them, but because the code for inserting the stylesheets is deep inside the framework, users weren't able to provide it without accessing private APIs.

These changes add a new `CSP_NONCE` injection token that will allow users to provide a nonce, if their app is using CSP. If the token isn't provided, the framework will look for an `ngCspNonce` attribute on the app's root node instead. The latter approach is provided as a convenience for apps that render the `index.html` through a server, e.g. `<app ngCspNonce="{% randomNonceAddedByTheServer %}"></app>`.

This PR addresses adding the nonce to framework-generated styles. There will be follow-up PRs that add support for it in critical CSS tags in the CLI, and in Angular Material.

Fixes #6361.