### PR TITLE
refactor(core): post-hydration cleanup of unclaimed views

### DIFF
--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -186,10 +186,7 @@ function locateOrCreateElementContainerNode(
           'Unexpected state: hydrating an <ng-container>, ' +
               'but no hydration info is available.');
 
-  // If this container is non-empty, store the first node as a segment head,
-  // otherwise, this node is an anchor and segment head doesn't exist (thus `null`).
-  const segmentHead = ngContainerSize > 0 ? currentRNode : null;
-  setSegmentHead(hydrationInfo, index, segmentHead);
+  setSegmentHead(hydrationInfo, index, currentRNode);
   comment = siblingAfter<RComment>(ngContainerSize, currentRNode)!;
 
   if (ngDevMode) {

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -140,11 +140,8 @@ function locateOrCreateContainerAnchorImpl(
   const currentRNode = locateNextRNode(hydrationInfo, tView, lView, tNode)!;
   ngDevMode && validateNodeExists(currentRNode);
 
+  setSegmentHead(hydrationInfo, index, currentRNode);
   const viewContainerSize = calcSerializedContainerSize(hydrationInfo, index);
-  // If this container is non-empty, store the first node as a segment head,
-  // otherwise, this node is an anchor and segment head doesn't exist (thus `null`).
-  const segmentHead = viewContainerSize > 0 ? currentRNode : null;
-  setSegmentHead(hydrationInfo, index, segmentHead);
   const comment = siblingAfter<RComment>(viewContainerSize, currentRNode)!;
 
   if (ngDevMode) {

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -51,6 +51,7 @@ declare global {
     hydratedNodes: number;
     hydratedComponents: number;
     dehydratedViewsRemoved: number;
+    dehydratedViewsCleanupRuns: number;
   }
 }
 
@@ -83,6 +84,7 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
     hydratedNodes: 0,
     hydratedComponents: 0,
     dehydratedViewsRemoved: 0,
+    dehydratedViewsCleanupRuns: 0,
   };
 
   // Make sure to refer to ngDevMode as ['ngDevMode'] for closure.


### PR DESCRIPTION
This PR adds a logic to remove all dehydrated views that were not claimed during the hydration. The process is started once the ApplicationRef becomes stable on the client (which matches the timing of serialization on the server).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No