### PR TITLE
CSS parsing fixes

### DIFF
--- a/packages/compiler/test/render3/style_parser_spec.ts
+++ b/packages/compiler/test/render3/style_parser_spec.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {hyphenate, parse as parseStyle, stripUnnecessaryQuotes} from '../../src/render3/view/style_parser';
+import {hyphenate, parse as parseStyle} from '../../src/render3/view/style_parser';
 
 describe('style parsing', () => {
   it('should parse empty or blank strings', () => {
@@ -31,18 +31,6 @@ describe('style parsing', () => {
     expect(result).toEqual(['width', '333px', 'height', '666px', 'opacity', '0.5']);
   });
 
-  it('should chomp out start/end quotes', () => {
-    const result = parseStyle(
-        'content: "foo"; opacity: \'0.5\'; font-family: "Verdana", Helvetica, "sans-serif"');
-    expect(result).toEqual(
-        ['content', 'foo', 'opacity', '0.5', 'font-family', '"Verdana", Helvetica, "sans-serif"']);
-  });
-
-  it('should not mess up with quoted strings that contain [:;] values', () => {
-    const result = parseStyle('content: "foo; man: guy"; width: 100px');
-    expect(result).toEqual(['content', 'foo; man: guy', 'width', '100px']);
-  });
-
   it('should not mess up with quoted strings that contain inner quote values', () => {
     const quoteStr = '"one \'two\' three \"four\" five"';
     const result = parseStyle(`content: ${quoteStr}; width: 123px`);
@@ -62,25 +50,6 @@ describe('style parsing', () => {
   it('should hyphenate style properties from camel case', () => {
     const result = parseStyle('borderWidth: 200px');
     expect(result).toEqual(['border-width', '200px']);
-  });
-
-  describe('quote chomping', () => {
-    it('should remove the start and end quotes', () => {
-      expect(stripUnnecessaryQuotes('\'foo bar\'')).toEqual('foo bar');
-      expect(stripUnnecessaryQuotes('"foo bar"')).toEqual('foo bar');
-    });
-
-    it('should not remove quotes if the quotes are not at the start and end', () => {
-      expect(stripUnnecessaryQuotes('foo bar')).toEqual('foo bar');
-      expect(stripUnnecessaryQuotes('   foo bar   ')).toEqual('   foo bar   ');
-      expect(stripUnnecessaryQuotes('\'foo\' bar')).toEqual('\'foo\' bar');
-      expect(stripUnnecessaryQuotes('foo "bar"')).toEqual('foo "bar"');
-    });
-
-    it('should not remove quotes if there are inner quotes', () => {
-      const str = '"Verdana", "Helvetica"';
-      expect(stripUnnecessaryQuotes(str)).toEqual(str);
-    });
   });
 
   describe('camelCasing => hyphenation', () => {

--- a/packages/compiler/test/render3/style_parser_spec.ts
+++ b/packages/compiler/test/render3/style_parser_spec.ts
@@ -57,6 +57,18 @@ describe('style parsing', () => {
     expect(result).toEqual(['border-width', '200px']);
   });
 
+  describe('should not remove quotes', () => {
+    it('from string data types', () => {
+      const result = parseStyle('content: "foo"');
+      expect(result).toEqual(['content', '"foo"']);
+    });
+
+    it('that changes the value context from invalid to valid', () => {
+      const result = parseStyle('width: "1px"');
+      expect(result).toEqual(['width', '"1px"']);
+    });
+  });
+
   describe('camelCasing => hyphenation', () => {
     it('should convert a camel-cased value to a hyphenated value', () => {
       expect(hyphenate('fooBar')).toEqual('foo-bar');

--- a/packages/compiler/test/render3/style_parser_spec.ts
+++ b/packages/compiler/test/render3/style_parser_spec.ts
@@ -31,6 +31,11 @@ describe('style parsing', () => {
     expect(result).toEqual(['width', '333px', 'height', '666px', 'opacity', '0.5']);
   });
 
+  it('should not mess up with quoted strings that contain [:;] values', () => {
+    const result = parseStyle('content: "foo; man: guy"; width: 100px');
+    expect(result).toEqual(['content', '"foo; man: guy"', 'width', '100px']);
+  });
+
   it('should not mess up with quoted strings that contain inner quote values', () => {
     const quoteStr = '"one \'two\' three \"four\" five"';
     const result = parseStyle(`content: ${quoteStr}; width: 123px`);

--- a/packages/core/src/render3/instructions/styling.ts
+++ b/packages/core/src/render3/instructions/styling.ts
@@ -833,8 +833,11 @@ function isStylingValuePresent(value: any): boolean {
  * @param suffix
  */
 function normalizeSuffix(value: any, suffix: string|undefined|null): string|null|undefined|boolean {
-  if (value == null /** || value === undefined */) {
+  if (value == null || value === '') {
     // do nothing
+    // Do not add the suffix if the value is going to be empty.
+    // As it produce invalid CSS, which the browsers will automatically omit but Domino will not.
+    // Example: `"left": "px;"` instead of `"left": ""`.
   } else if (typeof suffix === 'string') {
     value = value + suffix;
   } else if (typeof value === 'object') {

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -158,6 +158,8 @@ describe('styling', () => {
         selector: 'test-style-quoting',
         template: `
           <div style="content: &quot;foo&quot;"></div>
+          <div style='content: "foo"'></div>
+          <div style="content: 'foo'"></div>
         `
       })
       class Cmp {
@@ -167,8 +169,10 @@ describe('styling', () => {
       const fixture = TestBed.createComponent(Cmp);
       fixture.detectChanges();
 
-      const div = fixture.nativeElement.querySelector('div');
-      expect(getSortedStyle(div)).toBe('content: "foo";');
+      const divElements = fixture.nativeElement.querySelectorAll('div');
+      expect(getSortedStyle(divElements[0])).toBe('content: "foo";');
+      expect(getSortedStyle(divElements[1])).toBe('content: "foo";');
+      expect(getSortedStyle(divElements[2])).toMatch(/content: ["']foo["'];/);
     });
 
     it('should apply template classes in correct order', () => {

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -123,14 +123,15 @@ describe('styling', () => {
 
       const div = fixture.nativeElement.querySelector('div');
       expect(getSortedClassName(div)).toEqual('HOST_STATIC_1 HOST_STATIC_2 STATIC');
-      expect(getSortedStyle(div)).toEqual('color: blue; font-family: c2;');
+      // Chrome will remove quotes but Firefox and Domino do not.
+      expect(getSortedStyle(div)).toMatch(/color: blue; font-family: "?c2"?;/);
     });
 
     it('should support hostBindings inheritance', () => {
       @Component({template: `<div my-host-bindings class="STATIC" style="color: blue;"></div>`})
       class Cmp {
       }
-      @Directive({host: {'class': 'SUPER_STATIC', 'style': 'font-family: "super"; width: "1px";'}})
+      @Directive({host: {'class': 'SUPER_STATIC', 'style': 'font-family: "super";'}})
       class SuperDir {
       }
       @Directive({
@@ -149,7 +150,25 @@ describe('styling', () => {
       // Browsers keep the '"' around the font name, but Domino removes it some we do search and
       // replace. Yes we could do `replace(/"/g, '')` but that fails on android.
       expect(getSortedStyle(div).replace('"', '').replace('"', ''))
-          .toEqual('color: blue; font-family: host font; width: 1px;');
+          .toEqual('color: blue; font-family: host font;');
+    });
+
+    it('should apply style properties that require quote wrapping', () => {
+      @Component({
+        selector: 'test-style-quoting',
+        template: `
+          <div style="content: &quot;foo&quot;"></div>
+        `
+      })
+      class Cmp {
+      }
+
+      TestBed.configureTestingModule({declarations: [Cmp]});
+      const fixture = TestBed.createComponent(Cmp);
+      fixture.detectChanges();
+
+      const div = fixture.nativeElement.querySelector('div');
+      expect(getSortedStyle(div)).toBe('content: "foo";');
     });
 
     it('should apply template classes in correct order', () => {


### PR DESCRIPTION
**fix(compiler): do not unquote CSS values**

Currently we are unsafely unquoting CSS values which in some cases causes valid values to become invalid and invalid values to become valid.

Example:
```html
<div style="width:&quot;1px;&quot;"></div>
```

In the above case, `width` has an invalid value of `"1px"`, however the compiler will transform it to `1px` which makes it valid.

On the other hand,  in the below case
```html
<div style="content:&quot;foo&quot;"></div>
```

`content` has a valid value of `"foo"`, but since the compiler unwraps it to `foo` it becomes invalid. For correctness, we should not remove quotes.

```js
const div = document.createElement('div');
div.style.width='"1px"';
div.style.content='foo';

div.style.width; // ''
div.style.content; // ''


div.style.width='1px';
div.style.content='"foo"';

div.style.width; // '1px'
div.style.content; // '"foo"'
```

More information about values can be found https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier

----

**fix(core): set style property value to empty string instead of an invalid value**

Currently when the value of a styling property that has a unit is empty string a invalid value is generated.

Example:
`[style.width.px] = ""` will generate a value of `"px"`, when instead it should be `""`.

This causes browser to reset the value to an empty string. This is however not the case in Domino with changes in https://github.com/angular/domino/commit/bfc9114d1eb5b7591c43a7c6aef6ad50d24e369f.

---
Related to https://github.com/angular/angular/pull/49445
TGP 🟢 : http://test/OCL:517391008:BASE:517903049:1679305336599:6def8c79
~Failing target CL: http://cl/517411522~