### PR TITLE
refactor(platform-server): remove `renderApplication` overload that accepts a component

### DIFF
--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -59,15 +59,6 @@ export function renderApplication<T>(bootstrap: () => Promise<ApplicationRef>, o
 }): Promise<string>;
 
 // @public
-export function renderApplication<T>(rootComponent: Type<T>, options: {
-    appId: string;
-    document?: string | Document;
-    url?: string;
-    providers?: Array<Provider | EnvironmentProviders>;
-    platformProviders?: Provider[];
-}): Promise<string>;
-
-// @public
 export function renderModule<T>(moduleType: Type<T>, options: {
     document?: string | Document;
     url?: string;

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -219,7 +219,6 @@ export {
 export {
   setDocument as ɵsetDocument
 } from './render3/interfaces/document';
-export { getComponentDef as ɵgetComponentDef} from './render3/definition';
 export {
   compileComponent as ɵcompileComponent,
   compileDirective as ɵcompileDirective,

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -176,8 +176,7 @@ export function renderApplication<T>(bootstrap: () => Promise<ApplicationRef>, o
   url?: string,
   platformProviders?: Provider[],
 }): Promise<string> {
-  const {document, url, platformProviders} = options;
-  const platform = _getPlatform(platformDynamicServer, {document, url, platformProviders});
+  const platform = _getPlatform(platformDynamicServer, options);
 
   return _render(platform, bootstrap());
 }

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -6,12 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, EnvironmentProviders, importProvidersFrom, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵannotateForHydration as annotateForHydration, ɵgetComponentDef as getComponentDef, ɵinternalCreateApplication as internalCreateApplication, ɵIS_HYDRATION_FEATURE_ENABLED as IS_HYDRATION_FEATURE_ENABLED, ɵisPromise} from '@angular/core';
-import {BrowserModule} from '@angular/platform-browser';
+import {ApplicationRef, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵannotateForHydration as annotateForHydration, ɵIS_HYDRATION_FEATURE_ENABLED as IS_HYDRATION_FEATURE_ENABLED, ɵisPromise} from '@angular/core';
 import {first} from 'rxjs/operators';
 
 import {PlatformState} from './platform_state';
-import {platformDynamicServer, ServerModule} from './server';
+import {platformDynamicServer} from './server';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG} from './tokens';
 
 interface PlatformOptions {
@@ -176,74 +175,9 @@ export function renderApplication<T>(bootstrap: () => Promise<ApplicationRef>, o
   document?: string|Document,
   url?: string,
   platformProviders?: Provider[],
-}): Promise<string>;
-/**
- * Bootstraps an instance of an Angular application and renders it to a string.
- *
- * Note: the root component passed into this function *must* be a standalone one (should have
- * the `standalone: true` flag in the `@Component` decorator config).
- *
- * ```typescript
- * @Component({
- *   standalone: true,
- *   template: 'Hello world!'
- * })
- * class RootComponent {}
- *
- * const output: string = await renderApplication(RootComponent, {appId: 'server-app'});
- * ```
- *
- * @param rootComponent A reference to a Standalone Component that should be rendered.
- * @param options Additional configuration for the render operation:
- *  - `appId` - a string identifier of this application. The appId is used to prefix all
- *              server-generated stylings and state keys of the application in TransferState
- *              use-cases.
- *  - `document` - the document of the page to render, either as an HTML string or
- *                 as a reference to the `document` instance.
- *  - `url` - the URL for the current render request.
- *  - `providers` - set of application level providers for the current render request.
- *  - `platformProviders` - the platform level providers for the current render request.
- *
- * @returns A Promise, that returns serialized (to a string) rendered page, once resolved.
- *
- * @publicApi
- * @developerPreview
- */
-export function renderApplication<T>(rootComponent: Type<T>, options: {
-  /** @deprecated use `APP_ID` token to set the application ID. */
-  appId: string,
-  document?: string|Document,
-  url?: string,
-  providers?: Array<Provider|EnvironmentProviders>,
-  platformProviders?: Provider[],
-}): Promise<string>;
-export function renderApplication<T>(
-    rootComponentOrBootstrapFn: Type<T>|(() => Promise<ApplicationRef>), options: {
-      appId?: string,
-      document?: string|Document,
-      url?: string,
-      providers?: Array<Provider|EnvironmentProviders>,
-      platformProviders?: Provider[],
-    }): Promise<string> {
-  const {document, url, platformProviders, appId = ''} = options;
+}): Promise<string> {
+  const {document, url, platformProviders} = options;
   const platform = _getPlatform(platformDynamicServer, {document, url, platformProviders});
 
-  if (isBootstrapFn(rootComponentOrBootstrapFn)) {
-    return _render(platform, rootComponentOrBootstrapFn());
-  }
-
-  const appProviders = [
-    importProvidersFrom(BrowserModule.withServerTransition({appId})),
-    importProvidersFrom(ServerModule),
-    ...(options.providers ?? []),
-  ];
-
-  return _render(
-      platform,
-      internalCreateApplication({rootComponent: rootComponentOrBootstrapFn, appProviders}));
-}
-
-function isBootstrapFn(value: unknown): value is() => Promise<ApplicationRef> {
-  // We can differentiate between a component and a bootstrap function by reading `cmp`:
-  return typeof value === 'function' && !getComponentDef(value);
+  return _render(platform, bootstrap());
 }

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -9,11 +9,14 @@
 import '@angular/localize/init';
 
 import {CommonModule, DOCUMENT, isPlatformServer, NgComponentOutlet, NgFor, NgIf, NgTemplateOutlet} from '@angular/common';
-import {APP_ID, ApplicationRef, Component, ComponentRef, createComponent, destroyPlatform, Directive, ElementRef, EnvironmentInjector, getPlatform, inject, Input, PLATFORM_ID, Provider, TemplateRef, Type, ViewChild, ViewContainerRef, ɵgetComponentDef as getComponentDef, ɵprovideHydrationSupport as provideHydrationSupport, ɵsetDocument, ɵunescapeTransferStateContent as unescapeTransferStateContent} from '@angular/core';
+import {ApplicationRef, Component, ComponentRef, createComponent, destroyPlatform, Directive, ElementRef, EnvironmentInjector, getPlatform, inject, Input, PLATFORM_ID, Provider, TemplateRef, Type, ViewChild, ViewContainerRef, ɵprovideHydrationSupport as provideHydrationSupport, ɵsetDocument} from '@angular/core';
+import {getComponentDef} from '@angular/core/src/render3/definition';
+import {unescapeTransferStateContent} from '@angular/core/src/transfer_state';
 import {TestBed} from '@angular/core/testing';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {first} from 'rxjs/operators';
 
+import {provideServerSupport} from '../public_api';
 import {renderApplication} from '../src/utils';
 
 /**
@@ -143,8 +146,6 @@ describe('platform-server integration', () => {
   afterAll(() => destroyPlatform());
 
   describe('hydration', () => {
-    const appId = 'simple-cmp';
-
     let doc: Document;
 
     beforeEach(() => {
@@ -168,13 +169,14 @@ describe('platform-server integration', () => {
       const defaultHtml = '<html><head></head><body><app></app></body></html>';
       const providers = [
         ...(envProviders ?? []),
-        {provide: APP_ID, useValue: appId},
+        provideServerSupport(),
         provideHydrationSupport(),
       ];
-      return renderApplication(component, {
+
+      const bootstrap = () => bootstrapApplication(component, {providers});
+
+      return renderApplication(bootstrap, {
         document: doc ?? defaultHtml,
-        appId,
-        providers,
       });
     }
 
@@ -204,10 +206,10 @@ describe('platform-server integration', () => {
 
       const providers = [
         ...(envProviders ?? []),
-        {provide: APP_ID, useValue: appId},
         {provide: DOCUMENT, useFactory: _document, deps: []},
         provideHydrationSupport(),
       ];
+
       return bootstrapApplication(component, {providers});
     }
 


### PR DESCRIPTION
This commit removes the `renderApplication` overload that accepts a root component as the first parameter.

BREAKING CHANGE:

`renderApplication` method no longer accepts a root component as first argument. Instead, provide a bootstrapping function that returns a `Promise<ApplicationRef>`.

Before
```ts
const output: string = await renderApplication(RootComponent, options);
```

Now
```ts
const bootstrap = () => bootstrapApplication(RootComponent, appConfig);
const output: string = await renderApplication(bootstrap, options);
```