### PR TITLE
fix(platform-browser): only add `ng-app-id` to style on server side

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,7 +2,7 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 908,
-      "main": 128561,
+      "main": 129184,
       "polyfills": 33792
     }
   },
@@ -41,14 +41,14 @@
   "animations": {
     "uncompressed": {
       "runtime": 898,
-      "main": 159415,
+      "main": 159979,
       "polyfills": 33782
     }
   },
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 918,
-      "main": 86975,
+      "main": 87601,
       "polyfills": 33802
     }
   },

--- a/integration/platform-server/e2e/helloworld-spec.ts
+++ b/integration/platform-server/e2e/helloworld-spec.ts
@@ -28,7 +28,7 @@ describe('Hello world E2E Tests', function() {
     expect(element(by.css('div')).getText()).toEqual('Hello world!');
 
     // Make sure the server styles get reused by the client.
-    expect(element(by.css('style[ng-app-id="ng"]')).isPresent()).toBeTruthy();
+    expect(element(by.css('style[ng-app-id="ng"]')).isPresent()).toBeFalsy();
     expect(element(by.css('style[ng-style-reused]')).isPresent()).toBeTruthy();
     expect(element(by.css('style')).getText()).toBe('');
 

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -25,20 +25,20 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
     it('should add existing styles to new hosts', () => {
       ssh.addStyles(['a {};']);
       ssh.addHost(someHost);
-      expect(someHost.innerHTML).toEqual('<style ng-app-id="app-id">a {};</style>');
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
     });
 
     it('should add new styles to hosts', () => {
       ssh.addHost(someHost);
       ssh.addStyles(['a {};']);
-      expect(someHost.innerHTML).toEqual('<style ng-app-id="app-id">a {};</style>');
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
     });
 
     it('should add styles only once to hosts', () => {
       ssh.addStyles(['a {};']);
       ssh.addHost(someHost);
       ssh.addStyles(['a {};']);
-      expect(someHost.innerHTML).toEqual('<style ng-app-id="app-id">a {};</style>');
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
     });
 
     it('should use the document head as default host', () => {
@@ -49,7 +49,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
     it('should remove style nodes on destroy', () => {
       ssh.addStyles(['a {};']);
       ssh.addHost(someHost);
-      expect(someHost.innerHTML).toEqual('<style ng-app-id="app-id">a {};</style>');
+      expect(someHost.innerHTML).toEqual('<style>a {};</style>');
 
       ssh.ngOnDestroy();
       expect(someHost.innerHTML).toEqual('');


### PR DESCRIPTION
This commit fixes an issue where it causes issues in G3 when we add `ng-app-id` on browser apps.
