### PR TITLE
test(core): add fake impl of WeakRef for older browser tests

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -26,6 +26,7 @@ export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/r
 export {allowSanitizationBypassAndThrow as ɵallowSanitizationBypassAndThrow, BypassType as ɵBypassType, getSanitizationBypassType as ɵgetSanitizationBypassType, SafeHtml as ɵSafeHtml, SafeResourceUrl as ɵSafeResourceUrl, SafeScript as ɵSafeScript, SafeStyle as ɵSafeStyle, SafeUrl as ɵSafeUrl, SafeValue as ɵSafeValue, unwrapSafeValue as ɵunwrapSafeValue} from './sanitization/bypass';
 export {_sanitizeHtml as ɵ_sanitizeHtml} from './sanitization/html_sanitizer';
 export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';
+export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from './signals';
 export {TESTABILITY as ɵTESTABILITY, TESTABILITY_GETTER as ɵTESTABILITY_GETTER} from './testability/testability';
 export {escapeTransferStateContent as ɵescapeTransferStateContent, makeStateKey as ɵmakeStateKey, StateKey as ɵStateKey, TransferState as ɵTransferState, unescapeTransferStateContent as ɵunescapeTransferStateContent} from './transfer_state';
 export {coerceToBoolean as ɵcoerceToBoolean} from './util/coercion';

--- a/packages/core/src/signals/index.ts
+++ b/packages/core/src/signals/index.ts
@@ -13,3 +13,4 @@ export {setActiveConsumer} from './src/graph';
 export {SettableSignal, signal} from './src/signal';
 export {untracked} from './src/untracked';
 export {Watch} from './src/watch';
+export {setAlternateWeakRefImpl} from './src/weak_ref';

--- a/packages/core/src/signals/src/computed.ts
+++ b/packages/core/src/signals/src/computed.ts
@@ -8,7 +8,7 @@
 
 import {createSignalFromFunction, defaultEquals, Signal, ValueEqualityFn} from './api';
 import {Consumer, ConsumerId, consumerPollValueStatus, Edge, nextReactiveId, Producer, producerAccessed, ProducerId, producerNotifyConsumers, setActiveConsumer} from './graph';
-import {WeakRef} from './weak_ref';
+import {newWeakRef} from './weak_ref';
 
 /**
  * Create a computed `Signal` which derives a reactive value from an expression.
@@ -70,7 +70,7 @@ class ComputedImpl<T> implements Producer, Consumer {
   private stale = true;
 
   readonly id = nextReactiveId();
-  readonly ref = new WeakRef(this);
+  readonly ref = newWeakRef(this);
   readonly producers = new Map<ProducerId, Edge>();
   readonly consumers = new Map<ConsumerId, Edge>();
   trackingVersion = 0;

--- a/packages/core/src/signals/src/signal.ts
+++ b/packages/core/src/signals/src/signal.ts
@@ -8,7 +8,7 @@
 
 import {createSignalFromFunction, defaultEquals, Signal, ValueEqualityFn} from './api';
 import {ConsumerId, Edge, nextReactiveId, Producer, producerAccessed, producerNotifyConsumers} from './graph';
-import {WeakRef} from './weak_ref';
+import {newWeakRef, WeakRef} from './weak_ref';
 
 /**
  * A `Signal` with a value that can be mutated via a setter interface.
@@ -41,7 +41,7 @@ class SettableSignalImpl<T> implements Producer {
   constructor(private value: T, private equal: ValueEqualityFn<T>) {}
 
   readonly id = nextReactiveId();
-  readonly ref = new WeakRef(this);
+  readonly ref = newWeakRef(this);
   readonly consumers = new Map<ConsumerId, Edge>();
   valueVersion = 0;
 

--- a/packages/core/src/signals/src/watch.ts
+++ b/packages/core/src/signals/src/watch.ts
@@ -7,7 +7,7 @@
  */
 
 import {Consumer, consumerPollValueStatus, Edge, nextReactiveId, ProducerId, setActiveConsumer} from './graph';
-import {WeakRef} from './weak_ref';
+import {newWeakRef} from './weak_ref';
 
 /**
  * Watches a reactive expression and allows it to be scheduled to re-run
@@ -18,7 +18,7 @@ import {WeakRef} from './weak_ref';
  */
 export class Watch implements Consumer {
   readonly id = nextReactiveId();
-  readonly ref = new WeakRef(this);
+  readonly ref = newWeakRef(this);
   readonly producers = new Map<ProducerId, Edge>();
   trackingVersion = 0;
 


### PR DESCRIPTION
This commit adds the capability to swap the WeakRef implementation in tests to allow testing in browsers that don't support weak references.