### PR TITLE
refactor(core): exclude disconnected nodes from hydration

### DIFF
--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -35,6 +35,7 @@ export const MULTIPLIER = 'x';
 export const NUM_ROOT_NODES = 'r';
 export const TEMPLATE_ID = 'i';  // as it's also an "id"
 export const NODES = 'n';
+export const DISCONNECTED_NODES = 'd';
 
 /**
  * Represents element containers within this view, stored as key-value pairs
@@ -81,6 +82,16 @@ export interface SerializedView {
    * the location of this node (as a set of navigation instructions).
    */
   [NODES]?: Record<number, string>;
+
+  /**
+   * A list of ids which represents a set of nodes disconnected
+   * from the DOM tree at the serialization time, but otherwise
+   * present in the internal data structures.
+   *
+   * This information is used to avoid triggering the hydration
+   * logic for such nodes and instead use a regular "creation mode".
+   */
+  [DISCONNECTED_NODES]?: number[];
 }
 
 /**
@@ -136,6 +147,19 @@ export interface DehydratedView {
    * represent either an <ng-container> or a view container.
    */
   segmentHeads?: {[index: number]: RNode|null};
+
+  /**
+   * An instance of a Set that represents nodes disconnected from
+   * the DOM tree at the serialization time, but otherwise present
+   * in the internal data structures.
+   *
+   * The Set is based on the `SerializedView[DISCONNECTED_NODES]` data
+   * and is needed to have constant-time lookups.
+   *
+   * If the value is `null`, it means that there were no disconnected
+   * nodes detected in this view at serialization time.
+   */
+  disconnectedNodes?: Set<number>|null;
 }
 
 /**

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -16,7 +16,7 @@ import {HEADER_OFFSET, LView, TVIEW, TViewType} from '../render3/interfaces/view
 import {makeStateKey, TransferState} from '../transfer_state';
 import {assertDefined} from '../util/assert';
 
-import {CONTAINERS, DehydratedView, ELEMENT_CONTAINERS, MULTIPLIER, NUM_ROOT_NODES, SerializedContainerView, SerializedView} from './interfaces';
+import {CONTAINERS, DehydratedView, DISCONNECTED_NODES, ELEMENT_CONTAINERS, MULTIPLIER, NUM_ROOT_NODES, SerializedContainerView, SerializedView} from './interfaces';
 
 /**
  * The name of the key used in the TransferState collection,
@@ -263,4 +263,18 @@ export function calcSerializedContainerSize(hydrationInfo: DehydratedView, index
     numNodes += view[NUM_ROOT_NODES] * (view[MULTIPLIER] ?? 1);
   }
   return numNodes;
+}
+
+/**
+ * Checks whether a node is annotated as "disconnected", i.e. not present
+ * in the DOM at serialization time. We should not attempt hydration for
+ * such nodes and instead, use a regular "creation mode".
+ */
+export function isDisconnectedNode(hydrationInfo: DehydratedView, index: number): boolean {
+  // Check if we are processing disconnected info for the first time.
+  if (typeof hydrationInfo.disconnectedNodes === 'undefined') {
+    const nodeIds = hydrationInfo.data[DISCONNECTED_NODES];
+    hydrationInfo.disconnectedNodes = nodeIds ? (new Set(nodeIds)) : null;
+  }
+  return !!hydrationInfo.disconnectedNodes?.has(index);
 }

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -9,7 +9,7 @@
 import {invalidSkipHydrationHost, validateMatchingNode, validateNodeExists} from '../../hydration/error_handling';
 import {locateNextRNode} from '../../hydration/node_lookup_utils';
 import {hasNgSkipHydrationAttr} from '../../hydration/skip_hydration';
-import {getSerializedContainerViews, markRNodeAsClaimedByHydration, setSegmentHead} from '../../hydration/utils';
+import {getSerializedContainerViews, isDisconnectedNode, markRNodeAsClaimedByHydration, setSegmentHead} from '../../hydration/utils';
 import {assertDefined, assertEqual, assertIndexInRange} from '../../util/assert';
 import {assertFirstCreatePass, assertHasParent} from '../assert';
 import {attachPatchData} from '../context_discovery';
@@ -203,7 +203,8 @@ function locateOrCreateElementNodeImpl(
     tView: TView, lView: LView, tNode: TNode, renderer: Renderer, name: string,
     index: number): RElement {
   const hydrationInfo = lView[HYDRATION];
-  const isNodeCreationMode = !hydrationInfo || isInSkipHydrationBlock();
+  const isNodeCreationMode =
+      !hydrationInfo || isInSkipHydrationBlock() || isDisconnectedNode(hydrationInfo, index);
   lastNodeWasCreated(isNodeCreationMode);
 
   // Regular creation mode.

--- a/packages/core/src/render3/instructions/template.ts
+++ b/packages/core/src/render3/instructions/template.ts
@@ -8,7 +8,7 @@
 import {validateMatchingNode, validateNodeExists} from '../../hydration/error_handling';
 import {TEMPLATES} from '../../hydration/interfaces';
 import {locateNextRNode, siblingAfter} from '../../hydration/node_lookup_utils';
-import {calcSerializedContainerSize, markRNodeAsClaimedByHydration, setSegmentHead} from '../../hydration/utils';
+import {calcSerializedContainerSize, isDisconnectedNode, markRNodeAsClaimedByHydration, setSegmentHead} from '../../hydration/utils';
 import {assertFirstCreatePass} from '../assert';
 import {attachPatchData} from '../context_discovery';
 import {registerPostOrderHooks} from '../hooks';
@@ -128,7 +128,8 @@ function createContainerAnchorImpl(
 function locateOrCreateContainerAnchorImpl(
     tView: TView, lView: LView, tNode: TNode, index: number): RComment {
   const hydrationInfo = lView[HYDRATION];
-  const isNodeCreationMode = !hydrationInfo || isInSkipHydrationBlock();
+  const isNodeCreationMode =
+      !hydrationInfo || isInSkipHydrationBlock() || isDisconnectedNode(hydrationInfo, index);
   lastNodeWasCreated(isNodeCreationMode);
 
   // Regular creation mode.

--- a/packages/core/src/render3/instructions/text.ts
+++ b/packages/core/src/render3/instructions/text.ts
@@ -7,7 +7,7 @@
  */
 import {validateMatchingNode} from '../../hydration/error_handling';
 import {locateNextRNode} from '../../hydration/node_lookup_utils';
-import {markRNodeAsClaimedByHydration} from '../../hydration/utils';
+import {isDisconnectedNode, markRNodeAsClaimedByHydration} from '../../hydration/utils';
 import {assertEqual, assertIndexInRange} from '../../util/assert';
 import {TElementNode, TNode, TNodeType} from '../interfaces/node';
 import {RText} from '../interfaces/renderer_dom';
@@ -42,7 +42,7 @@ export function ɵɵtext(index: number, value: string = ''): void {
       getOrCreateTNode(tView, adjustedIndex, TNodeType.Text, value, null) :
       tView.data[adjustedIndex] as TElementNode;
 
-  const textNative = _locateOrCreateTextNode(tView, lView, tNode, value);
+  const textNative = _locateOrCreateTextNode(tView, lView, tNode, value, index);
   lView[adjustedIndex] = textNative;
 
   if (wasLastNodeCreated()) {
@@ -54,7 +54,7 @@ export function ɵɵtext(index: number, value: string = ''): void {
 }
 
 let _locateOrCreateTextNode: typeof locateOrCreateTextNodeImpl =
-    (tView: TView, lView: LView, tNode: TNode, value: string) => {
+    (tView: TView, lView: LView, tNode: TNode, value: string, index: number) => {
       lastNodeWasCreated(true);
       return createTextNode(lView[RENDERER], value);
     };
@@ -64,9 +64,10 @@ let _locateOrCreateTextNode: typeof locateOrCreateTextNodeImpl =
  * in addition to the regular creation mode of text nodes.
  */
 function locateOrCreateTextNodeImpl(
-    tView: TView, lView: LView, tNode: TNode, value: string): RText {
+    tView: TView, lView: LView, tNode: TNode, value: string, index: number): RText {
   const hydrationInfo = lView[HYDRATION];
-  const isNodeCreationMode = !hydrationInfo || isInSkipHydrationBlock();
+  const isNodeCreationMode =
+      !hydrationInfo || isInSkipHydrationBlock() || isDisconnectedNode(hydrationInfo, index);
   lastNodeWasCreated(isNodeCreationMode);
 
   // Regular creation mode.

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -2540,57 +2540,202 @@ describe('platform-server integration', () => {
         verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
       });
 
-      // FIXME(akushnir): this is a special use-case that will be covered in a followup PR.
-      // This would require some extra logic to detect if some nodes were "dropped" during the
-      // content projection operation.
-      xit('should support partial projection (when some nodes are not projected)', async () => {
-        @Component({
-          standalone: true,
-          selector: 'projector-cmp',
-          template: `
-            <div>
-              Header slot: <ng-content select="header"></ng-content>
-              Main slot: <ng-content select="main"></ng-content>
-              Footer slot: <ng-content select="footer"></ng-content>
-              <!-- no "default" projection bucket -->
-            </div>
-          `,
-        })
-        class ProjectorCmp {
-        }
+      describe('partial projection', () => {
+        it('should support cases when some element nodes are not projected', async () => {
+          @Component({
+            standalone: true,
+            selector: 'projector-cmp',
+            template: `
+              <div>
+                Header slot: <ng-content select="header" />
+                Main slot: <ng-content select="main" />
+                Footer slot: <ng-content select="footer" />
+                <!-- no "default" projection bucket -->
+              </div>
+            `,
+          })
+          class ProjectorCmp {
+          }
 
-        @Component({
-          standalone: true,
-          imports: [ProjectorCmp],
-          selector: 'app',
-          template: `
-            <projector-cmp>
-              <!-- contents is intentionally randomly ordered -->
-              <h1>This node is not projected.</h1>
-              <footer>Footer</footer>
-              <header>Header</header>
-              <main>Main</main>
-              <h2>This node is not projected as well.</h2>
-            </projector-cmp>
-          `,
-        })
-        class SimpleComponent {
-        }
+          @Component({
+            standalone: true,
+            imports: [ProjectorCmp],
+            selector: 'app',
+            template: `
+              <projector-cmp>
+                <!-- contents is randomly ordered for testing -->
+                <h1>This node is not projected.</h1>
+                <footer>Footer</footer>
+                <header>Header</header>
+                <main>Main</main>
+                <h2>This node is not projected as well.</h2>
+              </projector-cmp>
+            `,
+          })
+          class SimpleComponent {
+          }
 
-        const html = await ssr(SimpleComponent);
-        const ssrContents = getAppContents(html);
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
 
-        expect(ssrContents).toContain('<app ngh');
+          expect(ssrContents).toContain('<app ngh');
 
-        resetTViewsFor(SimpleComponent, ProjectorCmp);
+          resetTViewsFor(SimpleComponent, ProjectorCmp);
 
-        const appRef = await hydrate(html, SimpleComponent);
-        const compRef = getComponentRef<SimpleComponent>(appRef);
-        appRef.tick();
+          const appRef = await hydrate(html, SimpleComponent);
+          const compRef = getComponentRef<SimpleComponent>(appRef);
+          appRef.tick();
 
-        const clientRootNode = compRef.location.nativeElement;
-        verifyAllNodesClaimedForHydration(clientRootNode);
-        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+          const clientRootNode = compRef.location.nativeElement;
+          verifyAllNodesClaimedForHydration(clientRootNode);
+          verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+        });
+
+        it('should support cases when view containers are not projected', async () => {
+          @Component({
+            standalone: true,
+            selector: 'projector-cmp',
+            template: `No content projection slots.`,
+          })
+          class ProjectorCmp {
+          }
+
+          @Component({
+            standalone: true,
+            imports: [ProjectorCmp],
+            selector: 'app',
+            template: `
+              <projector-cmp>
+                <ng-container *ngIf="true">
+                  <h1>This node is not projected.</h1>
+                  <h2>This node is not projected as well.</h2>
+                </ng-container>
+              </projector-cmp>
+            `,
+          })
+          class SimpleComponent {
+          }
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain('<app ngh');
+
+          resetTViewsFor(SimpleComponent, ProjectorCmp);
+
+          const appRef = await hydrate(html, SimpleComponent);
+          const compRef = getComponentRef<SimpleComponent>(appRef);
+          appRef.tick();
+
+          const clientRootNode = compRef.location.nativeElement;
+          verifyAllNodesClaimedForHydration(clientRootNode);
+          verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+        });
+
+        it('should support cases when component nodes are not projected', async () => {
+          @Component({
+            standalone: true,
+            selector: 'projector-cmp',
+            template: `No content projection slots.`,
+          })
+          class ProjectorCmp {
+          }
+
+          @Component({
+            standalone: true,
+            selector: 'nested',
+            template: 'This is a nested component.',
+          })
+          class NestedComponent {
+          }
+
+
+          @Component({
+            standalone: true,
+            imports: [ProjectorCmp, NestedComponent],
+            selector: 'app',
+            template: `
+              <projector-cmp>
+                <nested>
+                  <h1>This node is not projected.</h1>
+                  <h2>This node is not projected as well.</h2>
+                </nested>
+              </projector-cmp>
+            `,
+          })
+          class SimpleComponent {
+          }
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain('<app ngh');
+
+          resetTViewsFor(SimpleComponent, ProjectorCmp, NestedComponent);
+
+          const appRef = await hydrate(html, SimpleComponent);
+          const compRef = getComponentRef<SimpleComponent>(appRef);
+          appRef.tick();
+
+          const clientRootNode = compRef.location.nativeElement;
+          verifyAllNodesClaimedForHydration(clientRootNode);
+          verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+        });
+
+        it('should support cases when component nodes are not projected in nested components',
+           async () => {
+             @Component({
+               standalone: true,
+               selector: 'projector-cmp',
+               template: `
+                <main>
+                  <ng-content />
+                </main>
+              `,
+             })
+             class ProjectorCmp {
+             }
+
+             @Component({
+               standalone: true,
+               selector: 'nested',
+               template: 'No content projection slots.',
+             })
+             class NestedComponent {
+             }
+
+
+             @Component({
+               standalone: true,
+               imports: [ProjectorCmp, NestedComponent],
+               selector: 'app',
+               template: `
+                <projector-cmp>
+                  <nested>
+                    <h1>This node is not projected.</h1>
+                    <h2>This node is not projected as well.</h2>
+                  </nested>
+                </projector-cmp>
+              `,
+             })
+             class SimpleComponent {
+             }
+
+             const html = await ssr(SimpleComponent);
+             const ssrContents = getAppContents(html);
+
+             expect(ssrContents).toContain('<app ngh');
+
+             resetTViewsFor(SimpleComponent, ProjectorCmp, NestedComponent);
+
+             const appRef = await hydrate(html, SimpleComponent);
+             const compRef = getComponentRef<SimpleComponent>(appRef);
+             appRef.tick();
+
+             const clientRootNode = compRef.location.nativeElement;
+             verifyAllNodesClaimedForHydration(clientRootNode);
+             verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+           });
       });
 
       it('should project contents with *ngIf\'s', async () => {


### PR DESCRIPTION
This commit updates the hydration logic to handle situations where DOM nodes might end up
being disconnected from the DOM tree. We serialize ids of those nodes into the hydration
state transfer data and use the information to switch from hydration to the regular "creation
mode" at runtime.

This situation may happen during the content projection, when some nodes don't make it
into one of the content projection slots (for example, when there is no default
`<ng-content />` slot in projector component's template).

Note: we leverage the fact that we have this information available in the DOM emulation
layer (in Domino) for now. Longer-term solution should not rely on the DOM emulation and
only use internal data structures and state to compute this information.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No