### PR TITLE
feat(service-worker): Add `hashes` observable to `SwUpdate` to listen for hash changes

### DIFF
--- a/goldens/public-api/service-worker/index.md
+++ b/goldens/public-api/service-worker/index.md
@@ -72,6 +72,10 @@ export class SwUpdate {
     // @deprecated
     readonly available: Observable<UpdateAvailableEvent>;
     checkForUpdate(): Promise<boolean>;
+    readonly hashes: Observable<{
+        latest: string;
+        current: string;
+    }>;
     get isEnabled(): boolean;
     readonly unrecoverable: Observable<UnrecoverableStateEvent>;
     readonly versionUpdates: Observable<VersionEvent>;

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,11 +12,11 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 470131,
+      "main": 470791,
       "polyfills": 33836,
       "styles": 74561,
-      "light-theme": 92890,
-      "dark-theme": 93036
+      "light-theme": 92905,
+      "dark-theme": 93051
     }
   }
 }

--- a/packages/service-worker/src/low_level.ts
+++ b/packages/service-worker/src/low_level.ts
@@ -137,6 +137,10 @@ export interface PushEvent {
 
 export type IncomingEvent = UpdateActivatedEvent|UnrecoverableStateEvent|VersionEvent;
 
+export type HashUpdateEvent = {
+  type: 'HASH_UPDATE'; hash: string;
+};
+
 export interface TypedEvent {
   type: string;
 }

--- a/packages/service-worker/test/comm_spec.ts
+++ b/packages/service-worker/test/comm_spec.ts
@@ -13,6 +13,7 @@ import {ngswCommChannelFactory, SwRegistrationOptions} from '@angular/service-wo
 import {SwPush} from '@angular/service-worker/src/push';
 import {SwUpdate} from '@angular/service-worker/src/update';
 import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockServiceWorkerRegistration, patchDecodeBase64} from '@angular/service-worker/testing/mock';
+import {take} from 'rxjs/operators';
 
 {
   describe('ServiceWorker library', () => {
@@ -517,6 +518,29 @@ import {MockPushManager, MockPushSubscription, MockServiceWorkerContainer, MockS
         });
         expect(() => TestBed.inject(SwUpdate)).not.toThrow();
       });
+
+      it('get hashes', async () => {
+        mock.sendMessage({type: 'HASH_UPDATE', hash: 'X'});
+
+        const hashes1 = await update.hashes.pipe(take(1)).toPromise();
+        expect(hashes1.current).toEqual('X');
+        expect(hashes1.latest).toEqual('X');
+
+        mock.sendMessage({
+          type: 'VERSION_READY',
+          currentVersion: {
+            hash: 'A',
+          },
+          latestVersion: {
+            hash: 'B',
+          },
+        });
+
+        const hashes2 = await update.hashes.pipe(take(1)).toPromise();
+        expect(hashes2.current).toEqual('A');
+        expect(hashes2.latest).toEqual('B');
+      });
+
       describe('with no SW', () => {
         beforeEach(() => {
           comm = new NgswCommChannel(undefined);

--- a/packages/service-worker/worker/src/driver.ts
+++ b/packages/service-worker/worker/src/driver.ts
@@ -615,6 +615,9 @@ export class Driver implements Debuggable, UpdateSource {
     // Set the latest version.
     this.latestHash = latest.latest;
 
+    // notify all clients of the latest hash
+    await this.broadcast({type: 'HASH_UPDATE', hash: this.latestHash});
+
     // Finally, assert that the latest version is in fact loaded.
     if (!this.versions.has(latest.latest)) {
       throw new Error(

--- a/packages/service-worker/worker/test/happy_spec.ts
+++ b/packages/service-worker/worker/test/happy_spec.ts
@@ -476,7 +476,9 @@ describe('Driver', () => {
     await driver.initialized;
 
     const client = scope.clients.getMock('default')!;
-    expect(client.messages).toEqual([]);
+    expect(client.messages).toEqual([
+      {type: 'HASH_UPDATE', hash: manifestHash},
+    ]);
 
     scope.updateServerState(serverUpdate);
     expect(await driver.checkForUpdate()).toEqual(true);
@@ -487,6 +489,7 @@ describe('Driver', () => {
     serverUpdate.assertNoOtherRequests();
 
     expect(client.messages).toEqual([
+      {type: 'HASH_UPDATE', hash: manifestHash},
       {
         type: 'VERSION_DETECTED',
         version: {hash: manifestUpdateHash, appData: {version: 'update'}},
@@ -529,7 +532,7 @@ describe('Driver', () => {
     await driver.initialized;
 
     const client = scope.clients.getMock('default')!;
-    expect(client.messages).toEqual([]);
+    expect(client.messages).toEqual([{type: 'HASH_UPDATE', hash: manifestHash}]);
 
     scope.updateServerState(serverUpdate);
     expect(await driver.checkForUpdate()).toEqual(true);
@@ -537,6 +540,7 @@ describe('Driver', () => {
     await driver.updateClient(client as any as Client);
 
     expect(client.messages).toEqual([
+      {type: 'HASH_UPDATE', hash: manifestHash},
       {type: 'VERSION_DETECTED', version: {hash: manifestUpdateHash, appData: {version: 'update'}}},
       {
         type: 'VERSION_READY',
@@ -652,6 +656,10 @@ describe('Driver', () => {
 
     expect(client.messages).toEqual([
       {
+        type: 'HASH_UPDATE',
+        hash: manifestHash,
+      },
+      {
         type: 'VERSION_DETECTED',
         version: {hash: manifestUpdateHash, appData: {version: 'update'}},
       },
@@ -680,6 +688,7 @@ describe('Driver', () => {
        serverUpdate.clearRequests();
 
        expect(client.messages).toEqual([
+         {type: 'HASH_UPDATE', hash: manifestHash},
          {
            type: 'NO_NEW_VERSION_DETECTED',
            version: {hash: manifestHash, appData: {version: 'original'}},
@@ -788,15 +797,17 @@ describe('Driver', () => {
       title: 'This is a test',
       options: {title: 'This is a test', body: 'Test body'},
     }]);
-    expect(scope.clients.getMock('default')!.messages).toEqual([{
-      type: 'PUSH',
-      data: {
-        notification: {
-          title: 'This is a test',
-          body: 'Test body',
+    expect(scope.clients.getMock('default')!.messages).toEqual([
+      {type: 'HASH_UPDATE', hash: manifestHash}, {
+        type: 'PUSH',
+        data: {
+          notification: {
+            title: 'This is a test',
+            body: 'Test body',
+          },
         },
-      },
-    }]);
+      }
+    ]);
   });
 
   describe('notification click events', () => {
@@ -805,7 +816,7 @@ describe('Driver', () => {
       await driver.initialized;
       await scope.handleClick(
           {title: 'This is a test with action', body: 'Test body with action'}, 'button');
-      const message = scope.clients.getMock('default')!.messages[0];
+      const message = scope.clients.getMock('default')!.messages[1];
 
       expect(message.type).toEqual('NOTIFICATION_CLICK');
       expect(message.data.action).toEqual('button');
@@ -820,7 +831,7 @@ describe('Driver', () => {
         title: 'This is a test without action',
         body: 'Test body without action',
       });
-      const message = scope.clients.getMock('default')!.messages[0];
+      const message = scope.clients.getMock('default')!.messages[1];
 
       expect(message.type).toEqual('NOTIFICATION_CLICK');
       expect(message.data.action).toBe('');


### PR DESCRIPTION
To simplify the access of the manifest hashes in apps, `SwUpdate` exposes a new observable : `hashes`

fixes #45414

## PR Type
What kind of change does this PR introduce?

- [x] Feature


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No