### PR TITLE
refactor(core): avoid repeated views in serialized data

### DIFF
--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -31,6 +31,7 @@ export enum NodeNavigationStep {
 export const ELEMENT_CONTAINERS = 'e';
 export const TEMPLATES = 't';
 export const CONTAINERS = 'c';
+export const MULTIPLIER = 'x';
 export const NUM_ROOT_NODES = 'r';
 export const TEMPLATE_ID = 'i';  // as it's also an "id"
 export const NODES = 'n';
@@ -103,6 +104,13 @@ export interface SerializedContainerView extends SerializedView {
    * and identify segments that belong to different views.
    */
   [NUM_ROOT_NODES]: number;
+
+  /**
+   * Number of times this view is repeated.
+   * This is used to avoid serializing and sending the same hydration
+   * information about similar views (for example, produced by *ngFor).
+   */
+  [MULTIPLIER]?: number;
 }
 
 /**

--- a/packages/core/src/hydration/utils.ts
+++ b/packages/core/src/hydration/utils.ts
@@ -16,7 +16,7 @@ import {HEADER_OFFSET, LView, TVIEW, TViewType} from '../render3/interfaces/view
 import {makeStateKey, TransferState} from '../transfer_state';
 import {assertDefined} from '../util/assert';
 
-import {CONTAINERS, DehydratedView, ELEMENT_CONTAINERS, NUM_ROOT_NODES, SerializedContainerView, SerializedView} from './interfaces';
+import {CONTAINERS, DehydratedView, ELEMENT_CONTAINERS, MULTIPLIER, NUM_ROOT_NODES, SerializedContainerView, SerializedView} from './interfaces';
 
 /**
  * The name of the key used in the TransferState collection,
@@ -260,7 +260,7 @@ export function calcSerializedContainerSize(hydrationInfo: DehydratedView, index
   const views = getSerializedContainerViews(hydrationInfo, index) ?? [];
   let numNodes = 0;
   for (let view of views) {
-    numNodes += view[NUM_ROOT_NODES];
+    numNodes += view[NUM_ROOT_NODES] * (view[MULTIPLIER] ?? 1);
   }
   return numNodes;
 }


### PR DESCRIPTION
This commit updates the serialization logic to recognized similar repeated views and instead of including the same info over and over again, a special field is added to the serialized view object with a number of repetitions. The hydration logic also recognizes the flag and creates the necessary number of dehydrated views in a container.

This optimization should help minimize the amount of extra annotations required for cases like `*ngFor` with large number of items.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No