### PR TITLE
fix(core): onStable() call ngZone() should not cause infinite loop

### DIFF
--- a/packages/core/src/zone/ng_zone.ts
+++ b/packages/core/src/zone/ng_zone.ts
@@ -324,27 +324,11 @@ interface NgZonePrivate extends NgZone {
 }
 
 function checkStable(zone: NgZonePrivate) {
-  // TODO: @JiaLiPassion, should check zone.isCheckStableRunning to prevent
-  // re-entry. The case is:
-  //
-  // @Component({...})
-  // export class AppComponent {
-  // constructor(private ngZone: NgZone) {
-  //   this.ngZone.onStable.subscribe(() => {
-  //     this.ngZone.run(() => console.log('stable'););
-  //   });
-  // }
-  //
-  // The onStable subscriber run another function inside ngZone
-  // which causes `checkStable()` re-entry.
-  // But this fix causes some issues in g3, so this fix will be
-  // launched in another PR.
   if (zone._nesting == 0 && !zone.hasPendingMicrotasks && !zone.isStable) {
     try {
       zone._nesting++;
       zone.onMicrotaskEmpty.emit(null);
     } finally {
-      zone._nesting--;
       if (!zone.hasPendingMicrotasks) {
         try {
           zone.runOutsideAngular(() => zone.onStable.emit(null));
@@ -352,6 +336,7 @@ function checkStable(zone: NgZonePrivate) {
           zone.isStable = true;
         }
       }
+      zone._nesting--;
     }
   }
 }

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -820,6 +820,20 @@ function commonTests() {
            done();
          }, resultTimer);
        });
+
+    it('should throw error when call zone.run() in onStable subscriber', () => {
+      let x = 0;
+      const sub = _zone.onStable.subscribe(() => {
+        if (x > 0) {
+          fail('should not be here');
+        }
+        _zone.run(() => {
+          x++;
+        });
+      });
+      runNgZoneNoLog(() => {});
+      sub.unsubscribe();
+    });
   });
 
   describe('exceptions', () => {


### PR DESCRIPTION
Now if we do something like

```
ngZone.onStable.subscribe(() => {
  ngZone.run(() => {});
});
```

It causes infinite loop since ngZone.run() trigger another onStable emit.

We already have the mechanism to avoid such kind of nested call. This PR just move the nested check position to fix this issue.
