### PR TITLE
refactor(platform-browser): remove private `DomSharedStylesHost` workaround

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,7 +2,7 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 908,
-      "main": 129184,
+      "main": 128657,
       "polyfills": 33792
     }
   },
@@ -41,14 +41,14 @@
   "animations": {
     "uncompressed": {
       "runtime": 898,
-      "main": 159979,
+      "main": 159461,
       "polyfills": 33782
     }
   },
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 918,
-      "main": 87601,
+      "main": 87081,
       "polyfills": 33802
     }
   },

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -195,9 +195,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "DomSharedStylesHost"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -951,9 +948,6 @@
     "name": "getFactoryDef"
   },
   {
-    "name": "getFactoryOf"
-  },
-  {
     "name": "getFirstLContainer"
   },
   {
@@ -1147,9 +1141,6 @@
   },
   {
     "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isForwardRef"
   },
   {
     "name": "isFunction"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -114,9 +114,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "DomSharedStylesHost"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -714,9 +711,6 @@
     "name": "getFactoryDef"
   },
   {
-    "name": "getFactoryOf"
-  },
-  {
     "name": "getFirstLContainer"
   },
   {
@@ -883,9 +877,6 @@
   },
   {
     "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isForwardRef"
   },
   {
     "name": "isFunction"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -156,9 +156,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "DomSharedStylesHost"
-  },
-  {
     "name": "EMAIL_REGEXP"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -162,9 +162,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "DomSharedStylesHost"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -192,9 +192,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "DomSharedStylesHost"
-  },
-  {
     "name": "EMPTY"
   },
   {
@@ -2080,9 +2077,6 @@
   },
   {
     "name": "ɵɵelementStart"
-  },
-  {
-    "name": "ɵɵgetInheritedFactory"
   },
   {
     "name": "ɵɵinject"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -96,9 +96,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "DomSharedStylesHost"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -645,9 +642,6 @@
     "name": "getFactoryDef"
   },
   {
-    "name": "getFactoryOf"
-  },
-  {
     "name": "getFirstLContainer"
   },
   {
@@ -786,9 +780,6 @@
     "name": "isEnvironmentProviders"
   },
   {
-    "name": "isForwardRef"
-  },
-  {
     "name": "isFunction"
   },
   {
@@ -874,9 +865,6 @@
   },
   {
     "name": "ngZoneApplicationErrorHandlerFactory"
-  },
-  {
-    "name": "noSideEffects"
   },
   {
     "name": "nonNull"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -117,9 +117,6 @@
     "name": "DomRendererFactory2"
   },
   {
-    "name": "DomSharedStylesHost"
-  },
-  {
     "name": "EMPTY_ARRAY"
   },
   {
@@ -855,9 +852,6 @@
     "name": "getFactoryDef"
   },
   {
-    "name": "getFactoryOf"
-  },
-  {
     "name": "getFirstLContainer"
   },
   {
@@ -1072,9 +1066,6 @@
   },
   {
     "name": "isEnvironmentProviders"
-  },
-  {
-    "name": "isForwardRef"
   },
   {
     "name": "isFunction"

--- a/packages/platform-browser/src/browser.ts
+++ b/packages/platform-browser/src/browser.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule, DOCUMENT, XhrFactory, ɵPLATFORM_BROWSER_ID as PLATFORM_BROWSER_ID} from '@angular/common';
-import {APP_ID, ApplicationConfig as ApplicationConfigFromCore, ApplicationModule, ApplicationRef, createPlatformFactory, CSP_NONCE, ErrorHandler, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalCreateApplication as internalCreateApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
+import {APP_ID, ApplicationConfig as ApplicationConfigFromCore, ApplicationModule, ApplicationRef, createPlatformFactory, ErrorHandler, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, RendererFactory2, SkipSelf, StaticProvider, Testability, TestabilityRegistry, Type, ɵINJECTOR_SCOPE as INJECTOR_SCOPE, ɵinternalCreateApplication as internalCreateApplication, ɵsetDocument, ɵTESTABILITY as TESTABILITY, ɵTESTABILITY_GETTER as TESTABILITY_GETTER} from '@angular/core';
 
 import {BrowserDomAdapter} from './browser/browser_adapter';
 import {BrowserGetTestability} from './browser/testability';
@@ -16,7 +16,7 @@ import {DomRendererFactory2} from './dom/dom_renderer';
 import {DomEventsPlugin} from './dom/events/dom_events';
 import {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 import {KeyEventsPlugin} from './dom/events/key_events';
-import {DomSharedStylesHost, SharedStylesHost} from './dom/shared_styles_host';
+import {SharedStylesHost} from './dom/shared_styles_host';
 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 
@@ -207,7 +207,6 @@ const BROWSER_MODULE_PROVIDERS: Provider[] = [
   {provide: EVENT_MANAGER_PLUGINS, useClass: KeyEventsPlugin, multi: true, deps: [DOCUMENT]},
   DomRendererFactory2, SharedStylesHost, EventManager,
   {provide: RendererFactory2, useExisting: DomRendererFactory2},
-  {provide: DomSharedStylesHost, useExisting: SharedStylesHost},
   {provide: XhrFactory, useClass: BrowserXhr, deps: []},
   NG_DEV_MODE ? {provide: BROWSER_MODULE_PROVIDERS_MARKER, useValue: true} : []
 ];

--- a/packages/platform-browser/src/dom/shared_styles_host.ts
+++ b/packages/platform-browser/src/dom/shared_styles_host.ts
@@ -182,11 +182,3 @@ export class SharedStylesHost implements OnDestroy {
     hostNodes.add(this.doc.head);
   }
 }
-
-/**
- * Interm G3 workaround for usages of private `DomSharedStylesHost`.
- * TODO(alanagius): delete once all usages in G3 are removed.
- */
-@Injectable()
-export class DomSharedStylesHost extends SharedStylesHost {
-}

--- a/packages/platform-browser/src/private_export.ts
+++ b/packages/platform-browser/src/private_export.ts
@@ -14,5 +14,5 @@ export {DomRendererFactory2 as ɵDomRendererFactory2, NAMESPACE_URIS as ɵNAMESP
 export {DomEventsPlugin as ɵDomEventsPlugin} from './dom/events/dom_events';
 export {HammerGesturesPlugin as ɵHammerGesturesPlugin} from './dom/events/hammer_gestures';
 export {KeyEventsPlugin as ɵKeyEventsPlugin} from './dom/events/key_events';
-export {DomSharedStylesHost as ɵDomSharedStylesHost, SharedStylesHost as ɵSharedStylesHost} from './dom/shared_styles_host';
+export {SharedStylesHost as ɵSharedStylesHost} from './dom/shared_styles_host';
 export {DomSanitizerImpl as ɵDomSanitizerImpl} from './security/dom_sanitization_service';


### PR DESCRIPTION
This workaround is no longer needed as all usage of `DomSharedStylesHost` have been removed from Google3.

---

TGP 🟢 http://test/OCL:517894589:BASE:517999275:1679331618640:bafead94