### PR TITLE
refactor(core): adjust signature of the EffectRef

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -495,14 +495,12 @@ export interface DoCheck {
 }
 
 // @public
-export interface Effect {
-    readonly consumer: Consumer;
-    destroy(): void;
-    schedule(): void;
-}
+export function effect(effectFn: () => void): EffectRef;
 
 // @public
-export function effect(effectFn: () => void): Effect;
+export interface EffectRef {
+    destroy(): void;
+}
 
 // @public
 export class ElementRef<T = any> {

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -6,4 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {computed, effect, Effect, isSignal, SettableSignal, Signal, signal, untracked, ValueEqualityFn} from './signals';
+export {computed, effect, EffectRef, isSignal, SettableSignal, Signal, signal, untracked, ValueEqualityFn} from './signals';

--- a/packages/core/src/signals/index.ts
+++ b/packages/core/src/signals/index.ts
@@ -8,7 +8,7 @@
 
 export {isSignal, Signal, ValueEqualityFn} from './src/api';
 export {computed} from './src/computed';
-export {effect, Effect} from './src/effect';
+export {effect, EffectRef} from './src/effect';
 export {setActiveConsumer} from './src/graph';
 export {SettableSignal, signal} from './src/signal';
 export {untracked} from './src/untracked';

--- a/packages/core/src/signals/src/effect.ts
+++ b/packages/core/src/signals/src/effect.ts
@@ -6,29 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Consumer} from './graph';
 import {Watch} from './watch';
 
 /**
- * A global reactive effect, which can be manually scheduled or destroyed.
+ * A global reactive effect, which can be manually destroyed.
  *
  * @developerPreview
  */
-export interface Effect {
-  /**
-   * Schedule the effect for manual execution, if it's not already.
-   */
-  schedule(): void;
-
+export interface EffectRef {
   /**
    * Shut down the effect, removing it from any upcoming scheduled executions.
    */
   destroy(): void;
-
-  /**
-   * Direct access to the effect's `Consumer` for advanced use cases.
-   */
-  readonly consumer: Consumer;
 }
 
 /**
@@ -36,7 +25,7 @@ export interface Effect {
  *
  * @developerPreview
  */
-export function effect(effectFn: () => void): Effect {
+export function effect(effectFn: () => void): EffectRef {
   const watch = new Watch(effectFn, queueWatch);
   globalWatches.add(watch);
 
@@ -44,8 +33,6 @@ export function effect(effectFn: () => void): Effect {
   watch.notify();
 
   return {
-    consumer: watch,
-    schedule: watch.notify.bind(watch),
     destroy: () => {
       queuedWatches.delete(watch);
       globalWatches.delete(watch);


### PR DESCRIPTION
Before this change the effect creation function was returning an instance of the Effect interface with explicit destroy and schedule operations. This commit makes the following changes to the return type of effect:
- the interface is renamed from Effect to EffectRef;
- the only available method on this interface is destroy.

We want to tighten the interface in question so only a minimal set of useful operations is initially exposed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
