### PR TITLE
fix:(forms) fix boundary symbols insertion in pattern validator

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -536,14 +536,14 @@ export function patternValidator(pattern: string|RegExp): ValidatorFn {
   let regex: RegExp;
   let regexStr: string;
   if (typeof pattern === 'string') {
+    const hasStartBoundary = pattern.charAt(0) === '^';
+    const hasEndBoundary = pattern.charAt(pattern.length - 1) === '$';
     regexStr = '';
-
-    if (pattern.charAt(0) !== '^') regexStr += '^';
-
-    regexStr += pattern;
-
-    if (pattern.charAt(pattern.length - 1) !== '$') regexStr += '$';
-
+    if (!hasStartBoundary || !hasEndBoundary) {
+      regexStr = `${!hasStartBoundary ? '^' : ''}(?:${pattern})${!hasEndBoundary ? '$' : ''}`;
+    } else {
+      regexStr = pattern;
+    }
     regex = new RegExp(regexStr);
   } else {
     regexStr = pattern.toString();

--- a/packages/forms/test/validators_spec.ts
+++ b/packages/forms/test/validators_spec.ts
@@ -356,7 +356,7 @@ describe('Validators', () => {
 
     it('should error on failure to match string', () => {
       expect(Validators.pattern('[a-zA-Z ]*')(new FormControl('aaa0'))).toEqual({
-        'pattern': {'requiredPattern': '^[a-zA-Z ]*$', 'actualValue': 'aaa0'}
+        'pattern': {'requiredPattern': '^(?:[a-zA-Z ]*)$', 'actualValue': 'aaa0'}
       });
     });
 
@@ -389,6 +389,12 @@ describe('Validators', () => {
 
     it('should work with pattern string not containing any boundary symbols',
        () => expect(Validators.pattern('[aA]*')(new FormControl('aaAA'))).toBeNull());
+
+    it('should work with pattern string requiring parenthesis', () => {
+      expect(Validators.pattern('A|B')(new FormControl('Aaaa'))).toEqual({
+        'pattern': {'requiredPattern': '^(?:A|B)$', 'actualValue': 'Aaaa'}
+      });
+    });
   });
 
   describe('compose', () => {


### PR DESCRIPTION
Validators.pattern automatically inserts boundary symbols if the provided regex doesn't already have them.
Before the current fix, the following regex : 'A|B' would be transformed into '^A|B$', which matches /^A.*$/ or /^.*B$/ instead /^A$/ or /^B$/. The fix consists in transforming 'A|B' into '^(?:A|B)$' instead. A more accurate solution would be to use RegExp.prototype.exec() instead of RegExp.prototype.test(), and then ensure indices cover the full string, but that would have a performance impact.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #37501


## What is the new behavior?

Validators.pattern now properly validate the full string for regex that contain several alternatives at root level (eg. A|B|C ).

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
