### PR TITLE
feat(core): support usage of non-experimental decorators with TypeScript 5.0

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1512,6 +1512,8 @@ export interface TypeDecorator {
     <T extends Type<any>>(type: T): T;
     // (undocumented)
     (target: Object, propertyKey?: string | symbol, parameterIndex?: number): void;
+    // (undocumented)
+    (target: unknown, context: unknown): void;
 }
 
 // @public

--- a/packages/core/src/util/decorators.ts
+++ b/packages/core/src/util/decorators.ts
@@ -34,6 +34,9 @@ export interface TypeDecorator {
   // so we cannot declare this interface as a subtype.
   // see https://github.com/angular/angular/issues/3379#issuecomment-126169417
   (target: Object, propertyKey?: string|symbol, parameterIndex?: number): void;
+  // Standard (non-experimental) Decorator signature that avoids direct usage of
+  // any TS 5.0+ specific types.
+  (target: unknown, context: unknown): void;
 }
 
 export const ANNOTATIONS = '__annotations__';
@@ -152,6 +155,12 @@ export function makePropDecorator(
       const decoratorInstance = new (<any>PropDecoratorFactory)(...args);
 
       function PropDecorator(target: any, name: string) {
+        // target is undefined with standard decorators. This case is not supported and will throw
+        // if this decorator is used in JIT mode with standard decorators.
+        if (target === undefined) {
+          throw new Error('Standard Angular field decorators are not supported in JIT mode.');
+        }
+
         const constructor = target.constructor;
         // Use of Object.defineProperty is important because it creates a non-enumerable property
         // which prevents the property from being copied during subclassing.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Previously, attempting to turn off the `experimentalDecorators` TypeScript configuration option within an Angular project would result in build time errors. These errors were due to an exposed Decorator signature from `@angular/core` that TypeScript thought was incompatible with standard decorators. However, Angular's class decorators (`Component`, `Directive`, `Pipe`, `Injectable`, `NgModule`) are actually already compatible with standard decorators. The export types for the decorators only needed to be updated to reflect that compatibility. With the updated exported types, applications will now successfully compile and execute in AOT mode with one important dependency injection caveat explained in the note below.
For JIT mode applications that are built with the Angular CLI, `@ngtools/webpack`, or use `tsickle`, there were also no additional changes required with the same dependency injection caveat. These tools automatically convert property decorators (now called field decorators) at build time to store Angular property metadata directly on the relevant class. Building with these tools is the overwhelmingly common method of building an application. Any applications that do not use one of these tools will not function at runtime in JIT mode if using standard decorators. The behavior and code for when experimental decorators is enabled has been left intact.

NOTE: Angular constructor dependency injection that requires parameter decorators is not supported. The standard decorator specification does not support parameter decorators. The `inject` function must be used for all cases that previously required a parameter decorator. This includes such decorators as `Inject`, `Optional`, `Self`, `SkipSelf`, `Host`, and `Attribute`. Constructor dependency injection that relies only on the supplied parameter type will continue to function as expected if using AOT; as well as in JIT mode if using the Angular CLI, `@ngtools/webpack` directly, or `tsickle`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Documentation for the `inject` function can be found at: https://angular.io/api/core/inject
The decorator specification proposal can be found at: https://github.com/tc39/proposal-decorators

An initial CLI E2E test that uses these changes is available here: https://github.com/angular/angular-cli/pull/24886