### PR TITLE
feat(core): allow removal of previously registered DestroyRef callbacks

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -445,7 +445,7 @@ export function destroyPlatform(): void;
 
 // @public
 export abstract class DestroyRef {
-    abstract onDestroy(callback: () => void): void;
+    abstract onDestroy(callback: () => void): () => void;
 }
 
 // @public

--- a/goldens/size-tracking/aio-payloads.json
+++ b/goldens/size-tracking/aio-payloads.json
@@ -12,7 +12,7 @@
   "aio-local": {
     "uncompressed": {
       "runtime": 4325,
-      "main": 470131,
+      "main": 469779,
       "polyfills": 33836,
       "styles": 74561,
       "light-theme": 92890,

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -127,7 +127,7 @@ export abstract class EnvironmentInjector implements Injector {
   /**
    * @internal
    */
-  abstract onDestroy(callback: () => void): void;
+  abstract onDestroy(callback: () => void): () => void;
 }
 
 export class R3Injector extends EnvironmentInjector {
@@ -211,8 +211,9 @@ export class R3Injector extends EnvironmentInjector {
     }
   }
 
-  override onDestroy(callback: () => void): void {
+  override onDestroy(callback: () => void): () => void {
     this._onDestroyHooks.push(callback);
+    return () => this.removeOnDestroy(callback);
   }
 
   override runInContext<ReturnT>(fn: () => ReturnT): ReturnT {
@@ -396,6 +397,13 @@ export class R3Injector extends EnvironmentInjector {
       return providedIn === 'any' || (this.scopes.has(providedIn));
     } else {
       return this.injectorDefTypes.has(providedIn);
+    }
+  }
+
+  private removeOnDestroy(callback: () => void): void {
+    const destroyCBIdx = this._onDestroyHooks.indexOf(callback);
+    if (destroyCBIdx !== -1) {
+      this._onDestroyHooks.splice(destroyCBIdx, 1);
     }
   }
 }

--- a/packages/core/src/linker/destroy_ref.ts
+++ b/packages/core/src/linker/destroy_ref.ts
@@ -9,13 +9,15 @@
 import {EnvironmentInjector} from '../di';
 import {LView} from '../render3/interfaces/view';
 import {getLView} from '../render3/state';
-import {storeLViewOnDestroy} from '../render3/util/view_utils';
+import {removeLViewOnDestroy, storeLViewOnDestroy} from '../render3/util/view_utils';
 
 /**
  * `DestroyRef` lets you set callbacks to run for any cleanup or destruction behavior.
  * The scope of this destruction depends on where `DestroyRef` is injected. If `DestroyRef`
  * is injected in a component or directive, the callbacks run when that component or
  * directive is destroyed. Otherwise the callbacks run when a corresponding injector is destroyed.
+ *
+ * @publicApi
  */
 export abstract class DestroyRef {
   // Here the `DestroyRef` acts primarily as a DI token. There are (currently) types of objects that
@@ -24,9 +26,22 @@ export abstract class DestroyRef {
   // - `EnvironmentInjector` when retrieved from an environment injector
 
   /**
-   * Registers a destroy callback in a given lifecycle scope.
+   * Registers a destroy callback in a given lifecycle scope.  Returns a cleanup function that can
+   * be invoked to unregister the callback.
+   *
+   * @usageNotes
+   * ### Example
+   * ```typescript
+   * const destroyRef = inject(DestroyRef);
+   *
+   * // register a destroy callback
+   * const unregisterFn = destroyRef.onDestroy(() => doSomethingOnDestroy());
+   *
+   * // stop the destroy callback from executing if needed
+   * unregisterFn();
+   * ```
    */
-  abstract onDestroy(callback: () => void): void;
+  abstract onDestroy(callback: () => void): () => void;
 
   /**
    * @internal
@@ -46,8 +61,9 @@ class NodeInjectorDestroyRef extends DestroyRef {
     super();
   }
 
-  override onDestroy(callback: () => void): void {
+  override onDestroy(callback: () => void): () => void {
     storeLViewOnDestroy(this._lView, callback);
+    return () => removeLViewOnDestroy(this._lView, callback);
   }
 }
 

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -192,3 +192,15 @@ export function storeLViewOnDestroy(lView: LView, onDestroyCallback: () => void)
   }
   lView[ON_DESTROY_HOOKS].push(onDestroyCallback);
 }
+
+/**
+ * Removes previously registered LView-specific destroy callback.
+ */
+export function removeLViewOnDestroy(lView: LView, onDestroyCallback: () => void) {
+  if (lView[ON_DESTROY_HOOKS] === null) return;
+
+  const destroyCBIdx = lView[ON_DESTROY_HOOKS].indexOf(onDestroyCallback);
+  if (destroyCBIdx !== -1) {
+    lView[ON_DESTROY_HOOKS].splice(destroyCBIdx, 1);
+  }
+}


### PR DESCRIPTION
This change makes it possible to remove a previously registered destroy callback - to do so it is enough to call the unregistration function returned from the onDestroy method call.
