### PR TITLE
refactor(core): add a note that hydration for i18n blocks is not yet supported

### DIFF
--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -70,3 +70,12 @@ export function invalidSkipHydrationHost() {
       'that doesn\'t act as a component host. Hydration can be ' +
       'skipped only on per-component basis.');
 }
+
+export function notYetSupportedI18nBlockError() {
+  // TODO: improve error message and use RuntimeError instead.
+  return new Error(
+      'Hydration for nodes marked with `i18n` is not yet supported. ' +
+      'You can opt-out a component that uses `i18n` in a template using ' +
+      'the `ngSkipHydration` attribute or fall back to the previous ' +
+      'hydration logic (which re-creates the application structure).');
+}

--- a/packages/platform-server/test/BUILD.bazel
+++ b/packages/platform-server/test/BUILD.bazel
@@ -26,6 +26,7 @@ ts_library(
         "//packages/compiler",
         "//packages/core",
         "//packages/core/testing",
+        "//packages/localize/init",
         "//packages/platform-browser",
         "//packages/platform-server",
         "//packages/private/testing",


### PR DESCRIPTION
This commit updates the serialization logic to detect a situation when i18n was used for a template and throw an error to indicate that hydration for i18n blocks is not yet supported.

Hydration for i18n blocks will be added in follow up versions.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No