### PR TITLE
refactor(core): Remove VE/Render3 aliases from ViewRef code

### DIFF
--- a/packages/core/src/change_detection/change_detector_ref.ts
+++ b/packages/core/src/change_detection/change_detector_ref.ts
@@ -13,7 +13,7 @@ import {isComponentHost} from '../render3/interfaces/type_checks';
 import {DECLARATION_COMPONENT_VIEW, LView} from '../render3/interfaces/view';
 import {getCurrentTNode, getLView} from '../render3/state';
 import {getComponentLViewByIndex} from '../render3/util/view_utils';
-import {ViewRef as R3_ViewRef} from '../render3/view_ref';
+import {ViewRef} from '../render3/view_ref';
 
 /**
  * Base class that provides change detection functionality.
@@ -146,12 +146,12 @@ function createViewRef(tNode: TNode, lView: LView, isPipe: boolean): ChangeDetec
     // The LView represents the location where the component is declared.
     // Instead we want the LView for the component View and so we need to look it up.
     const componentView = getComponentLViewByIndex(tNode.index, lView);  // look down
-    return new R3_ViewRef(componentView, componentView);
+    return new ViewRef(componentView, componentView);
   } else if (tNode.type & (TNodeType.AnyRNode | TNodeType.AnyContainer | TNodeType.Icu)) {
     // The LView represents the location where the injection is requested from.
     // We need to locate the containing LView (in case where the `lView` is an embedded view)
     const hostComponentView = lView[DECLARATION_COMPONENT_VIEW];  // look up
-    return new R3_ViewRef(hostComponentView, lView);
+    return new ViewRef(hostComponentView, lView);
   }
   return null!;
 }

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -21,8 +21,12 @@ import {destroyLView, detachView, renderDetachView} from './node_manipulation';
 import {storeLViewOnDestroy} from './util/view_utils';
 
 
+// Needed due to tsickle downleveling where multiple `implements` with classes creates
+// multiple @extends in Closure annotations, which is illegal. This workaround fixes
+// the multiple @extends by making the annotation @implements instead
+interface ChangeDetectorRefInterface extends ChangeDetectorRef {}
 
-export class ViewRef<T> implements EmbeddedViewRef<T>, InternalViewRef, ChangeDetectorRef {
+export class ViewRef<T> implements EmbeddedViewRef<T>, InternalViewRef, ChangeDetectorRefInterface {
   private _appRef: ViewRefTracker|null = null;
   private _attachedToViewContainer = false;
 

--- a/packages/core/src/render3/view_ref.ts
+++ b/packages/core/src/render3/view_ref.ts
@@ -6,9 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ChangeDetectorRef as viewEngine_ChangeDetectorRef} from '../change_detection/change_detector_ref';
+import {ChangeDetectorRef} from '../change_detection/change_detector_ref';
 import {RuntimeError, RuntimeErrorCode} from '../errors';
-import {EmbeddedViewRef as viewEngine_EmbeddedViewRef, InternalViewRef as viewEngine_InternalViewRef, ViewRefTracker} from '../linker/view_ref';
+import {EmbeddedViewRef, InternalViewRef, ViewRefTracker} from '../linker/view_ref';
 import {removeFromArray} from '../util/array_utils';
 import {assertEqual} from '../util/assert';
 
@@ -22,13 +22,7 @@ import {storeLViewOnDestroy} from './util/view_utils';
 
 
 
-// Needed due to tsickle downleveling where multiple `implements` with classes creates
-// multiple @extends in Closure annotations, which is illegal. This workaround fixes
-// the multiple @extends by making the annotation @implements instead
-export interface viewEngine_ChangeDetectorRef_interface extends viewEngine_ChangeDetectorRef {}
-
-export class ViewRef<T> implements viewEngine_EmbeddedViewRef<T>, viewEngine_InternalViewRef,
-                                   viewEngine_ChangeDetectorRef_interface {
+export class ViewRef<T> implements EmbeddedViewRef<T>, InternalViewRef, ChangeDetectorRef {
   private _appRef: ViewRefTracker|null = null;
   private _attachedToViewContainer = false;
 


### PR DESCRIPTION
These aliases were used while we needed to maintain compatibility with ViewEngine
