### PR TITLE
refactor(core): avoid `ngSkipHydration` on nodes other than component host ones

### DIFF
--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -62,3 +62,11 @@ export function unsupportedProjectionOfDomNodes(): Error {
       'Hydration is not supported for such cases, consider refactoring the code to avoid ' +
       'this pattern or using `ngSkipHydration` on the host element of the component.');
 }
+
+export function invalidSkipHydrationHost() {
+  // TODO: improve error message and use RuntimeError instead.
+  return new Error(
+      'The `ngSkipHydration` flag is applied on a node ' +
+      'that doesn\'t act as a component host. Hydration can be ' +
+      'skipped only on per-component basis.');
+}


### PR DESCRIPTION
Angular Hydration uses Components as hydration boundaries, i.e. you can enable/disable hydration on per-component basis. This commit enforces that the `ngSkipHydration` can only be applied on component host nodes (an error if thrown otherwise).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No