### PR TITLE
refactor(core): Add hydration for components that were lazy loaded

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1554,9 +1554,10 @@ export abstract class ViewContainerRef {
         ngModuleRef?: NgModuleRef<unknown>;
         environmentInjector?: EnvironmentInjector | NgModuleRef<unknown>;
         projectableNodes?: Node[][];
+        wasLazyLoaded?: boolean;
     }): ComponentRef<C>;
     // @deprecated
-    abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], environmentInjector?: EnvironmentInjector | NgModuleRef<any>): ComponentRef<C>;
+    abstract createComponent<C>(componentFactory: ComponentFactory<C>, index?: number, injector?: Injector, projectableNodes?: any[][], environmentInjector?: EnvironmentInjector | NgModuleRef<any>, wasLazyLoaded?: boolean): ComponentRef<C>;
     abstract createEmbeddedView<C>(templateRef: TemplateRef<C>, context?: C, options?: {
         index?: number;
         injector?: Injector;

--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -13,12 +13,12 @@ import {TI18n} from '../render3/interfaces/i18n';
 import {TNode, TNodeType} from '../render3/interfaces/node';
 import {RElement} from '../render3/interfaces/renderer_dom';
 import {isLContainer, isProjectionTNode, isRootView} from '../render3/interfaces/type_checks';
-import {HEADER_OFFSET, HOST, LView, RENDERER, TView, TVIEW, TViewType} from '../render3/interfaces/view';
+import {FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, RENDERER, TView, TVIEW, TViewType} from '../render3/interfaces/view';
 import {unwrapRNode} from '../render3/util/view_utils';
 import {TransferState} from '../transfer_state';
 
 import {notYetSupportedI18nBlockError, unsupportedProjectionOfDomNodes} from './error_handling';
-import {CONTAINERS, ELEMENT_CONTAINERS, MULTIPLIER, NODES, NUM_ROOT_NODES, SerializedContainerView, SerializedView, TEMPLATE_ID, TEMPLATES} from './interfaces';
+import {CONTAINERS, ELEMENT_CONTAINERS, LAZY, MULTIPLIER, NODES, NUM_ROOT_NODES, SerializedContainerView, SerializedView, TEMPLATE_ID, TEMPLATES} from './interfaces';
 import {calcPathForNode} from './node_lookup_utils';
 import {isInSkipHydrationBlock, SKIP_HYDRATION_ATTR_NAME} from './skip_hydration';
 import {getComponentLViewForHydration, NGH_ATTR_NAME, NGH_DATA_KEY, TextNodeMarker} from './utils';
@@ -177,6 +177,14 @@ function serializeLContainer(
     } else {
       // Record this view as most recently added.
       lastViewAsString = currentViewAsString;
+
+      // Add an annotation if a view was created for a component that was lazy-loaded.
+      // This will prevent the post-hydration cleanup from removing the dehydrated view,
+      // so that it can later be picked up during hydration (once component's code is loaded).
+      if ((childLView[FLAGS] & LViewFlags.WasLazyLoaded) === LViewFlags.WasLazyLoaded) {
+        view[LAZY] = 1;  // use number instead of true, because it's shorter
+      }
+
       views.push(view);
     }
   }

--- a/packages/core/src/hydration/interfaces.ts
+++ b/packages/core/src/hydration/interfaces.ts
@@ -35,6 +35,7 @@ export const MULTIPLIER = 'x';
 export const NUM_ROOT_NODES = 'r';
 export const TEMPLATE_ID = 'i';  // as it's also an "id"
 export const NODES = 'n';
+export const LAZY = 'l';
 
 /**
  * Represents element containers within this view, stored as key-value pairs
@@ -111,6 +112,14 @@ export interface SerializedContainerView extends SerializedView {
    * information about similar views (for example, produced by *ngFor).
    */
   [MULTIPLIER]?: number;
+
+  /**
+   * A flag that indicates that the view was created lazily, thus the post-hydration
+   * cleanup needs to retain the view. Examples: components created as a result of
+   * lazy-loading of a route or components created via `ViewContainerRef.createComponent`,
+   * after loading component code using dynamic imports.
+   */
+  [LAZY]?: number;  // we use `1` as a flag, thus type is a number
 }
 
 /**

--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -117,4 +117,18 @@ export abstract class ComponentFactory<C> {
   abstract create(
       injector: Injector, projectableNodes?: any[][], rootSelectorOrNode?: string|any,
       environmentInjector?: EnvironmentInjector|NgModuleRef<any>): ComponentRef<C>;
+
+  /**
+   * Create function implementation.
+   *
+   * This implementation is internal and allows framework code
+   * to invoke it with extra parameters (e.g. for hydration) without
+   * affecting public API.
+   *
+   * @internal
+   */
+  abstract createImpl(
+      injector: Injector, projectableNodes?: any[][], rootSelectorOrNode?: string|any,
+      environmentInjector?: EnvironmentInjector|NgModuleRef<any>,
+      wasLazyLoaded?: boolean): ComponentRef<C>;
 }

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -373,33 +373,41 @@ export const enum LViewFlags {
   /** Whether this view has default change detection strategy (checks always) or onPush */
   CheckAlways = 0b00000010000,
 
+  /**
+   * Whether this view was created after lazy-loading a component.
+   * This information is needed for hydration, to retain dehydrated
+   * view after initial rendering pass. Otherwise, such a view would
+   * be removed up by the post-hydration cleanup operation.
+   */
+  WasLazyLoaded = 0b00000100000,
+
   /** Whether or not this view is currently dirty (needing check) */
-  Dirty = 0b00000100000,
+  Dirty = 0b000001000000,
 
   /** Whether or not this view is currently attached to change detection tree. */
-  Attached = 0b000001000000,
+  Attached = 0b000010000000,
 
   /** Whether or not this view is destroyed. */
-  Destroyed = 0b000010000000,
+  Destroyed = 0b000100000000,
 
   /** Whether or not this view is the root view */
-  IsRoot = 0b000100000000,
+  IsRoot = 0b001000000000,
 
   /**
    * Whether this moved LView was needs to be refreshed at the insertion location because the
    * declaration was dirty.
    */
-  RefreshTransplantedView = 0b001000000000,
+  RefreshTransplantedView = 0b0010000000000,
 
   /** Indicates that the view **or any of its ancestors** have an embedded view injector. */
-  HasEmbeddedViewInjector = 0b0010000000000,
+  HasEmbeddedViewInjector = 0b0100000000000,
 
   /**
    * Index of the current init phase on last 21 bits
    */
-  IndexWithinInitPhaseIncrementer = 0b0100000000000,
-  IndexWithinInitPhaseShift = 11,
-  IndexWithinInitPhaseReset = 0b0011111111111,
+  IndexWithinInitPhaseIncrementer = 0b01000000000000,
+  IndexWithinInitPhaseShift = 12,
+  IndexWithinInitPhaseReset = 0b00111111111111,
 }
 
 /**

--- a/packages/elements/test/component-factory-strategy_spec.ts
+++ b/packages/elements/test/component-factory-strategy_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ChangeDetectorRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, Injector, NgModuleRef, NgZone, SimpleChange, SimpleChanges, Type} from '@angular/core';
+import {ApplicationRef, ChangeDetectorRef, ComponentFactory, ComponentFactoryResolver, ComponentRef, EnvironmentInjector, Injector, NgModuleRef, NgZone, SimpleChange, SimpleChanges, Type} from '@angular/core';
 import {fakeAsync, tick} from '@angular/core/testing';
 import {Subject} from 'rxjs';
 
@@ -485,6 +485,13 @@ export class FakeComponentFactory<T extends Type<any>> extends ComponentFactory<
   override create(
       injector: Injector, projectableNodes?: any[][], rootSelectorOrNode?: string|any,
       ngModule?: NgModuleRef<any>): ComponentRef<any> {
+    return this.createImpl(injector, projectableNodes, rootSelectorOrNode, ngModule);
+  }
+
+  createImpl(
+      injector: Injector, projectableNodes?: any[][]|undefined, rootSelectorOrNode?: any,
+      environmentInjector?: EnvironmentInjector|NgModuleRef<any>|undefined,
+      wasLazyLoaded?: boolean|undefined): ComponentRef<T> {
     return this.componentRef;
   }
 }

--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -317,10 +317,17 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     const childContexts = this.parentContexts.getOrCreateContext(this.name).children;
     const injector = new OutletInjector(activatedRoute, childContexts, location.injector);
 
+    const routeConfig = activatedRoute.routeConfig;
+    // If a route has any lazy-loading behavior, annotate corersponding views
+    // as "lazy", so that they are retained during the post-hydration cleanup
+    // and hydrated later once the code is loaded.
+    const wasLazyLoaded = !!routeConfig?.loadComponent || !!routeConfig?.loadChildren;
+
     this.activated = location.createComponent(component, {
       index: location.length,
       injector,
-      environmentInjector: environmentInjector ?? this.environmentInjector
+      environmentInjector: environmentInjector ?? this.environmentInjector,
+      wasLazyLoaded,
     });
     // Calling `markForCheck` to make sure we will run the change detection when the
     // `RouterOutlet` is inside a `ChangeDetectionStrategy.OnPush` component.


### PR DESCRIPTION
This ensures that hydration still happens on components that were set up to lazy load through the router. Hydration will happen after the component has finished loading.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
