### PR TITLE
build: exclude draft PRs from triage queue

### DIFF
--- a/.ng-dev/caretaker.mts
+++ b/.ng-dev/caretaker.mts
@@ -14,7 +14,7 @@ export const caretaker: CaretakerConfig = {
     },
     {
       name: 'Initial Triage Queue',
-      query: `is:open no:milestone`,
+      query: `is:open no:milestone -draft:true`,
     },
   ],
   caretakerGroup: 'angular-caretaker',


### PR DESCRIPTION
Excludes draft PRs from triage queue. Note that we cannot use `draft:false` as otherwise
all issues would be filtered. Rather we need to negate `draft:true` which matches
non-draft PRs and normal issues.

https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-for-draft-pull-requests