### PR TITLE
test: increase size tracking threshold to 5K / 5%

### DIFF
--- a/scripts/ci/payload-size.js
+++ b/scripts/ci/payload-size.js
@@ -15,6 +15,9 @@ const path = require('path');
 // Get limit file, project name and commit SHA from command line arguments.
 const [, , limitFile, project, commit] = process.argv;
 
+const THRESHOLD_BYTES = 5000;
+const THRESHOLD_PERCENT = 5;
+
 // Load sizes.
 const currentSizes = JSON.parse(fs.readFileSync('/tmp/current.log', 'utf8'));
 const allLimitSizes = JSON.parse(fs.readFileSync(limitFile, 'utf8'));
@@ -41,8 +44,9 @@ for (const compressionType in limitSizes) {
             'Maybe the file was renamed or removed.');
       } else {
         const absoluteSizeDiff = Math.abs(actualSize - expectedSize);
-        // If size diff is larger than 1% or 500 bytes...
-        if (absoluteSizeDiff > 500 || absoluteSizeDiff > expectedSize / 100) {
+        // If size diff is larger than THRESHOLD_BYTES or THRESHOLD_PERCENT...
+        if (absoluteSizeDiff > THRESHOLD_BYTES ||
+            absoluteSizeDiff > (expectedSize * THRESHOLD_PERCENT / 100)) {
           failed = true;
           // We must also catch when the size is significantly lower than the payload limit, so
           // we are forced to update the expected payload number when the payload size reduces.
@@ -51,13 +55,14 @@ for (const compressionType in limitSizes) {
           const operator = actualSize > expectedSize ? 'exceeded' : 'fell below';
 
           failureMessages.push(
-              `FAIL: Commit ${commit} ${compressionType} ${filename} ${
-                  operator} expected size by 500 bytes or >1% ` +
+              `FAIL: Commit ${commit} ${compressionType} ${filename} ${operator} expected size by ${
+                  THRESHOLD_BYTES} bytes or >${THRESHOLD_PERCENT}% ` +
               `(expected: ${expectedSize}, actual: ${actualSize}).`);
         } else {
           successMessages.push(
               `SUCCESS: Commit ${commit} ${compressionType} ${
-                  filename} did NOT cross size threshold of 500 bytes or >1% ` +
+                  filename} did NOT cross size threshold of ${THRESHOLD_BYTES} bytes or >${
+                  THRESHOLD_PERCENT} ` +
               `(expected: ${expectedSize}, actual: ${actualSize}).`);
         }
       }
@@ -75,5 +80,6 @@ if (failed) {
       `If this is a desired change, please update the size limits in file '${limitFileRelPath}'.`);
   process.exit(1);
 } else {
-  console.info(`Payload size check passed. All diffs are less than 1% or 500 bytes.`);
+  console.info(`Payload size check passed. All diffs are less than ${THRESHOLD_PERCENT}% or ${
+      THRESHOLD_BYTES} bytes.`);
 }


### PR DESCRIPTION
This commit increases the threshold of payload size tracking tests from 500 bytes to 5,000 bytes, and from 1% to 5%. This is done to minimize merge conflicts while still catching real regressions.