### PR TITLE
docs: remove ticks in code sample to generate components

### DIFF
--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -195,7 +195,7 @@ This section walks you through creating a child component, `ProductAlertsCompone
 
     <code-example format="shell" language="shell">
 
-    `ng generate component product-alerts`
+    ng generate component product-alerts
   
     </code-example>
 


### PR DESCRIPTION
These ticks appear in the actual documentation and when copied verbatim while following the tutorial, running this command in the terminal simply does nothing.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] **n/a** Tests for the changes have been added (for bug fixes / features)
- [ ] **n/a** Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In https://angular.io/start#pass-data-to-a-child-component, the command `ng generate component product-alerts` contains ticks. Copying this verbatim via the copy button, pasting it into the terminal, and running it, will do nothing.
Issue Number: N/A


## What is the new behavior?

The new version does not contain the ticks anymore.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
n/a