### PR TITLE
fix(compiler-cli): Catch FatalDiagnosticError during template type ch…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -26,7 +26,7 @@ import {TypeCheckableDirectiveMeta, TypeCheckContext} from '../../../typecheck/a
 import {ExtendedTemplateChecker} from '../../../typecheck/extended/api';
 import {getSourceFile} from '../../../util/src/typescript';
 import {Xi18nContext} from '../../../xi18n';
-import {combineResolvers, compileDeclareFactory, compileNgFactoryDefField, compileResults, extractClassMetadata, extractSchemas, findAngularDecorator, forwardRefResolver, getDirectiveDiagnostics, getProviderDiagnostics, InjectableClassRegistry, isExpressionForwardReference, readBaseClass, resolveEnumValue, resolveImportedFile, resolveLiteral, resolveProvidersRequiringFactory, ResourceLoader, toFactoryMetadata, validateHostDirectives, wrapFunctionExpressionsInParens,} from '../../common';
+import {combineResolvers, compileDeclareFactory, compileNgFactoryDefField, compileResults, extractClassMetadata, extractSchemas, findAngularDecorator, forwardRefResolver, getDirectiveDiagnostics, getProviderDiagnostics, InjectableClassRegistry, isExpressionForwardReference, readBaseClass, ReferencesRegistry, resolveEnumValue, resolveImportedFile, resolveLiteral, resolveProvidersRequiringFactory, ResourceLoader, toFactoryMetadata, validateHostDirectives, wrapFunctionExpressionsInParens,} from '../../common';
 import {extractDirectiveMetadata, parseFieldStringArrayValue} from '../../directive';
 import {createModuleWithProvidersResolver, NgModuleSymbol} from '../../ng_module';
 
@@ -56,7 +56,7 @@ export class ComponentDecoratorHandler implements
       private usePoisonedData: boolean, private i18nNormalizeLineEndingsInICUs: boolean,
       private moduleResolver: ModuleResolver, private cycleAnalyzer: CycleAnalyzer,
       private cycleHandlingStrategy: CycleHandlingStrategy, private refEmitter: ReferenceEmitter,
-      private depTracker: DependencyTracker|null,
+      private referencesRegistry: ReferencesRegistry, private depTracker: DependencyTracker|null,
       private injectableRegistry: InjectableClassRegistry,
       private semanticDepGraphUpdater: SemanticDepGraphUpdater|null,
       private annotateForClosureCompiler: boolean, private perf: PerfRecorder,
@@ -194,8 +194,8 @@ export class ComponentDecoratorHandler implements
     // @Component inherits @Directive, so begin by extracting the @Directive metadata and building
     // on it.
     const directiveResult = extractDirectiveMetadata(
-        node, decorator, this.reflector, this.evaluator, this.refEmitter, this.isCore, flags,
-        this.annotateForClosureCompiler,
+        node, decorator, this.reflector, this.evaluator, this.refEmitter, this.referencesRegistry,
+        this.isCore, flags, this.annotateForClosureCompiler,
         this.elementSchemaRegistry.getDefaultComponentElementName());
     if (directiveResult === undefined) {
       // `extractDirectiveMetadata` returns undefined when the @Directive has `jit: true`. In this

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -20,7 +20,7 @@ import {NOOP_PERF_RECORDER} from '../../../perf';
 import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver, TypeCheckScopeRegistry} from '../../../scope';
 import {getDeclaration, makeProgram} from '../../../testing';
-import {InjectableClassRegistry, ResourceLoader, ResourceLoaderContext} from '../../common';
+import {InjectableClassRegistry, NoopReferencesRegistry, ResourceLoader, ResourceLoaderContext} from '../../common';
 import {ComponentDecoratorHandler} from '../src/handler';
 
 export class StubResourceLoader implements ResourceLoader {
@@ -55,6 +55,7 @@ function setup(program: ts.Program, options: ts.CompilerOptions, host: ts.Compil
   const scopeRegistry = new LocalModuleScopeRegistry(
       metaRegistry, metaReader, dtsResolver, new ReferenceEmitter([]), null);
   const refEmitter = new ReferenceEmitter([]);
+  const referencesRegistry = new NoopReferencesRegistry();
   const injectableRegistry = new InjectableClassRegistry(reflectionHost, /* isCore */ false);
   const resourceRegistry = new ResourceRegistry();
   const hostDirectivesResolver = new HostDirectivesResolver(metaReader);
@@ -85,6 +86,7 @@ function setup(program: ts.Program, options: ts.CompilerOptions, host: ts.Compil
       cycleAnalyzer,
       CycleHandlingStrategy.UseRemoteScoping,
       refEmitter,
+      referencesRegistry,
       /* depTracker */ null,
       injectableRegistry,
       /* semanticDepGraphUpdater */ null,

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -17,7 +17,7 @@ import {PerfEvent, PerfRecorder} from '../../../perf';
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, ReflectionHost} from '../../../reflection';
 import {LocalModuleScopeRegistry} from '../../../scope';
 import {AnalysisOutput, CompileResult, DecoratorHandler, DetectResult, HandlerFlags, HandlerPrecedence, ResolveResult} from '../../../transform';
-import {compileDeclareFactory, compileNgFactoryDefField, compileResults, extractClassMetadata, findAngularDecorator, getDirectiveDiagnostics, getProviderDiagnostics, getUndecoratedClassWithAngularFeaturesDiagnostic, InjectableClassRegistry, isAngularDecorator, readBaseClass, resolveProvidersRequiringFactory, toFactoryMetadata, validateHostDirectives} from '../../common';
+import {compileDeclareFactory, compileNgFactoryDefField, compileResults, extractClassMetadata, findAngularDecorator, getDirectiveDiagnostics, getProviderDiagnostics, getUndecoratedClassWithAngularFeaturesDiagnostic, InjectableClassRegistry, isAngularDecorator, readBaseClass, ReferencesRegistry, resolveProvidersRequiringFactory, toFactoryMetadata, validateHostDirectives} from '../../common';
 
 import {extractDirectiveMetadata} from './shared';
 import {DirectiveSymbol} from './symbol';
@@ -52,8 +52,8 @@ export class DirectiveDecoratorHandler implements
       private reflector: ReflectionHost, private evaluator: PartialEvaluator,
       private metaRegistry: MetadataRegistry, private scopeRegistry: LocalModuleScopeRegistry,
       private metaReader: MetadataReader, private injectableRegistry: InjectableClassRegistry,
-      private refEmitter: ReferenceEmitter, private isCore: boolean,
-      private strictCtorDeps: boolean,
+      private refEmitter: ReferenceEmitter, private referencesRegistry: ReferencesRegistry,
+      private isCore: boolean, private strictCtorDeps: boolean,
       private semanticDepGraphUpdater: SemanticDepGraphUpdater|null,
       private annotateForClosureCompiler: boolean, private perf: PerfRecorder) {}
 
@@ -93,8 +93,8 @@ export class DirectiveDecoratorHandler implements
     this.perf.eventCount(PerfEvent.AnalyzeDirective);
 
     const directiveResult = extractDirectiveMetadata(
-        node, decorator, this.reflector, this.evaluator, this.refEmitter, this.isCore, flags,
-        this.annotateForClosureCompiler);
+        node, decorator, this.reflector, this.evaluator, this.refEmitter, this.referencesRegistry,
+        this.isCore, flags, this.annotateForClosureCompiler);
     if (directiveResult === undefined) {
       return {};
     }

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -15,7 +15,7 @@ import {ClassPropertyMapping, HostDirectiveMeta, InputMapping} from '../../../me
 import {DynamicValue, EnumValue, PartialEvaluator, ResolvedValue} from '../../../partial_evaluator';
 import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, filterToMembersWithDecorator, isNamedClassDeclaration, ReflectionHost, reflectObjectLiteral,} from '../../../reflection';
 import {HandlerFlags} from '../../../transform';
-import {createSourceSpan, createValueHasWrongTypeError, forwardRefResolver, getConstructorDependencies, toR3Reference, tryUnwrapForwardRef, unwrapConstructorDependencies, unwrapExpression, validateConstructorDependencies, wrapFunctionExpressionsInParens, wrapTypeReference,} from '../../common';
+import {createSourceSpan, createValueHasWrongTypeError, forwardRefResolver, getConstructorDependencies, ReferencesRegistry, toR3Reference, tryUnwrapForwardRef, unwrapConstructorDependencies, unwrapExpression, validateConstructorDependencies, wrapFunctionExpressionsInParens, wrapTypeReference,} from '../../common';
 
 const EMPTY_OBJECT: {[key: string]: string} = {};
 const QUERY_TYPES = new Set([
@@ -33,7 +33,8 @@ const QUERY_TYPES = new Set([
  */
 export function extractDirectiveMetadata(
     clazz: ClassDeclaration, decorator: Readonly<Decorator|null>, reflector: ReflectionHost,
-    evaluator: PartialEvaluator, refEmitter: ReferenceEmitter, isCore: boolean, flags: HandlerFlags,
+    evaluator: PartialEvaluator, refEmitter: ReferenceEmitter,
+    referencesRegistry: ReferencesRegistry, isCore: boolean, flags: HandlerFlags,
     annotateForClosureCompiler: boolean, defaultSelector: string|null = null): {
   decorator: Map<string, ts.Expression>,
   metadata: R3DirectiveMetadata,
@@ -186,6 +187,10 @@ export function extractDirectiveMetadata(
   const rawHostDirectives = directive.get('hostDirectives') || null;
   const hostDirectives =
       rawHostDirectives === null ? null : extractHostDirectives(rawHostDirectives, evaluator);
+
+  if (hostDirectives !== null) {
+    referencesRegistry.add(clazz, ...hostDirectives.map(hostDir => hostDir.directive));
+  }
 
   const metadata: R3DirectiveMetadata = {
     name: clazz.name.text,

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -189,6 +189,9 @@ export function extractDirectiveMetadata(
       rawHostDirectives === null ? null : extractHostDirectives(rawHostDirectives, evaluator);
 
   if (hostDirectives !== null) {
+    // The template type-checker will need to import host directive types, so add them
+    // as referenced by `clazz`. This will ensure that libraries are required to export
+    // host directives which are visible from publicly exported components.
     referencesRegistry.add(clazz, ...hostDirectives.map(hostDir => hostDir.directive));
   }
 

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/test/directive_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/test/directive_spec.ts
@@ -17,7 +17,7 @@ import {NOOP_PERF_RECORDER} from '../../../perf';
 import {ClassDeclaration, isNamedClassDeclaration, TypeScriptReflectionHost} from '../../../reflection';
 import {LocalModuleScopeRegistry, MetadataDtsModuleScopeResolver} from '../../../scope';
 import {getDeclaration, makeProgram} from '../../../testing';
-import {InjectableClassRegistry} from '../../common';
+import {InjectableClassRegistry, NoopReferencesRegistry} from '../../common';
 import {DirectiveDecoratorHandler} from '../index';
 
 runInEachFileSystem(() => {
@@ -166,13 +166,14 @@ runInEachFileSystem(() => {
     const metaReader = new LocalMetadataRegistry();
     const dtsReader = new DtsMetadataReader(checker, reflectionHost);
     const refEmitter = new ReferenceEmitter([]);
+    const referenceRegistry = new NoopReferencesRegistry();
     const scopeRegistry = new LocalModuleScopeRegistry(
         metaReader, new CompoundMetadataReader([metaReader, dtsReader]),
         new MetadataDtsModuleScopeResolver(dtsReader, null), refEmitter, null);
     const injectableRegistry = new InjectableClassRegistry(reflectionHost, /* isCore */ false);
     const handler = new DirectiveDecoratorHandler(
         reflectionHost, evaluator, scopeRegistry, scopeRegistry, metaReader, injectableRegistry,
-        refEmitter,
+        refEmitter, referenceRegistry,
         /*isCore*/ false,
         /*strictCtorDeps*/ false,
         /*semanticDepGraphUpdater*/ null,

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1037,7 +1037,7 @@ export class NgCompiler {
           this.options.i18nUseExternalIds !== false,
           this.options.enableI18nLegacyMessageIdFormat !== false, this.usePoisonedData,
           this.options.i18nNormalizeLineEndingsInICUs === true, this.moduleResolver,
-          this.cycleAnalyzer, cycleHandlingStrategy, refEmitter,
+          this.cycleAnalyzer, cycleHandlingStrategy, refEmitter, referencesRegistry,
           this.incrementalCompilation.depGraph, injectableRegistry, semanticDepGraphUpdater,
           this.closureCompilerEnabled, this.delegatingPerfRecorder, hostDirectivesResolver),
 
@@ -1046,7 +1046,7 @@ export class NgCompiler {
       // clang-format off
         new DirectiveDecoratorHandler(
             reflector, evaluator, metaRegistry, ngModuleScopeRegistry, metaReader,
-            injectableRegistry, refEmitter, isCore, strictCtorDeps, semanticDepGraphUpdater,
+            injectableRegistry, refEmitter, referencesRegistry, isCore, strictCtorDeps, semanticDepGraphUpdater,
           this.closureCompilerEnabled,
           this.delegatingPerfRecorder,
         ) as Readonly<DecoratorHandler<unknown, unknown, SemanticSymbol | null,unknown>>,

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -99,6 +99,7 @@ export class DtsMetadataReader implements MetadataReader {
     const inputs = ClassPropertyMapping.fromMappedObject(readInputsType(def.type.typeArguments[3]));
     const outputs = ClassPropertyMapping.fromMappedObject(
         readMapType(def.type.typeArguments[4], readStringType));
+
     const hostDirectives = def.type.typeArguments.length > 8 ?
         readHostDirectivesType(this.checker, def.type.typeArguments[8], ref.bestGuessOwningModule) :
         null;

--- a/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
+++ b/packages/compiler-cli/src/ngtsc/testing/fake_core/index.ts
@@ -71,8 +71,9 @@ export interface SimpleChanges {
 }
 
 export type ɵɵNgModuleDeclaration<ModuleT, DeclarationsT, ImportsT, ExportsT> = unknown;
-export type ɵɵDirectiveDeclaration<DirT, SelectorT, ExportAsT, InputsT, OutputsT, QueriesT> =
-    unknown;
+export type ɵɵDirectiveDeclaration<
+    DirT, SelectorT, ExportAsT, InputsT, OutputsT, QueriesT, A = never, B = never,
+    HostDirectivesT = never> = unknown;
 export type ɵɵPipeDeclaration<PipeT, NameT> = unknown;
 
 export enum ViewEncapsulation {

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -654,8 +654,8 @@ export class TraitCompiler implements ProgramTypeCheckAdapter {
             trait.analysisDiagnostics !== null) {
           diagnostics.push(...trait.analysisDiagnostics);
         }
-        if (trait.state === TraitState.Resolved && trait.resolveDiagnostics !== null) {
-          diagnostics.push(...trait.resolveDiagnostics);
+        if (trait.state === TraitState.Resolved) {
+          diagnostics.push(...(trait.resolveDiagnostics ?? []));
         }
       }
     }

--- a/packages/compiler-cli/src/ngtsc/transform/src/trait.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/trait.ts
@@ -7,7 +7,9 @@
  */
 
 import ts from 'typescript';
+
 import {SemanticSymbol} from '../../incremental/semantic_graph';
+
 import {DecoratorHandler, DetectResult} from './api';
 
 export enum TraitState {
@@ -194,6 +196,7 @@ class TraitImpl<D, A, S extends SemanticSymbol|null, R> {
   resolution: Readonly<R>|null = null;
   analysisDiagnostics: ts.Diagnostic[]|null = null;
   resolveDiagnostics: ts.Diagnostic[]|null = null;
+  typeCheckDiagnostics: ts.Diagnostic[]|null = null;
 
   constructor(handler: DecoratorHandler<D, A, S, R>, detected: DetectResult<D>) {
     this.handler = handler;
@@ -220,6 +223,7 @@ class TraitImpl<D, A, S extends SemanticSymbol|null, R> {
     this.resolution = resolution;
     this.state = TraitState.Resolved;
     this.resolveDiagnostics = diagnostics;
+    this.typeCheckDiagnostics = null;
     return this as ResolvedTrait<D, A, S, R>;
   }
 

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -5861,6 +5861,26 @@ function allTests(os: string) {
         expect(ts.isClassDeclaration(id.parent)).toBe(true);
       });
 
+      it('should report an error when a visible host directive is not exported', () => {
+        env.tsconfig({'flatModuleOutFile': 'flat.js'});
+        env.write('test.ts', `
+        import {Directive, NgModule} from '@angular/core';
+
+        @Directive({
+          standalone: true,
+        })
+        class HostDir {}
+
+        // The directive is not exported.
+        @Directive({selector: 'test', hostDirectives: [HostDir]})
+        export class Dir {}
+      `);
+
+        const errors = env.driveDiagnostics();
+        expect(errors.length).toBe(1);
+        expect(errors[0].code).toBe(ngErrorCode(ErrorCode.SYMBOL_NOT_EXPORTED));
+      });
+
       it('should report an error when a deeply visible directive is not exported', () => {
         env.tsconfig({'flatModuleOutFile': 'flat.js'});
         env.write('test.ts', `


### PR DESCRIPTION
…ecking

This commit updates the type checking step of the compilation to catch `FatalDiagnosticError` and surface them as diagnostics rather than crashing.

Fixes https://github.com/angular/vscode-ng-language-service/issues/1881
