### PR TITLE
refactor(router): create outlet injector using Injector.create()

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -315,7 +315,7 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     const snapshot = activatedRoute.snapshot;
     const component = snapshot.component!;
     const childContexts = this.parentContexts.getOrCreateContext(this.name).children;
-    const injector = new OutletInjector(activatedRoute, childContexts, location.injector);
+    const injector = createOutletInjector(activatedRoute, childContexts, location.injector);
 
     this.activated = location.createComponent(component, {
       index: location.length,
@@ -329,20 +329,13 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
   }
 }
 
-class OutletInjector implements Injector {
-  constructor(
-      private route: ActivatedRoute, private childContexts: ChildrenOutletContexts,
-      private parent: Injector) {}
-
-  get(token: any, notFoundValue?: any): any {
-    if (token === ActivatedRoute) {
-      return this.route;
-    }
-
-    if (token === ChildrenOutletContexts) {
-      return this.childContexts;
-    }
-
-    return this.parent.get(token, notFoundValue);
-  }
+function createOutletInjector(
+    route: ActivatedRoute, childContexts: ChildrenOutletContexts, parent: Injector) {
+  return Injector.create({
+    providers: [
+      {provide: ActivatedRoute, useValue: route},
+      {provide: ChildrenOutletContexts, useValue: childContexts}
+    ],
+    parent
+  });
 }


### PR DESCRIPTION
Use Injector.create() to create an outlet injector instead of creating a class that implements the Injector interface, which simplifies the logic.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
