### PR TITLE
fix(migrations): preserve trailing commas in code generated by standalone migration

### DIFF
--- a/packages/core/schematics/ng-generate/standalone-migration/prune-modules.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/prune-modules.ts
@@ -152,7 +152,10 @@ function removeArrayReferences(
     tracker: ChangeTracker): void {
   for (const [array, toRemove] of locations.getEntries()) {
     const newElements = filterRemovedElements(array.elements, toRemove);
-    tracker.replaceNode(array, ts.factory.updateArrayLiteralExpression(array, newElements));
+    tracker.replaceNode(
+        array,
+        ts.factory.updateArrayLiteralExpression(
+            array, ts.factory.createNodeArray(newElements, array.elements.hasTrailingComma)));
   }
 }
 

--- a/packages/core/schematics/ng-generate/standalone-migration/standalone-bootstrap.ts
+++ b/packages/core/schematics/ng-generate/standalone-migration/standalone-bootstrap.ts
@@ -244,9 +244,13 @@ function replaceBootstrapCallExpression(
 
     // Push the providers after `importProvidersFrom` call for better readability.
     combinedProviders.push(...providers);
+
+    const providersArray = ts.factory.createNodeArray(
+        combinedProviders,
+        analysis.metadata.properties.hasTrailingComma && combinedProviders.length > 2);
     const initializer = remapDynamicImports(
         sourceFile.fileName,
-        ts.factory.createArrayLiteralExpression(combinedProviders, combinedProviders.length > 1));
+        ts.factory.createArrayLiteralExpression(providersArray, combinedProviders.length > 1));
 
     args.push(ts.factory.createObjectLiteralExpression(
         [ts.factory.createPropertyAssignment('providers', initializer)], true));


### PR DESCRIPTION
This is based on some internal feedback. Adds logic to the standalone migration that attempts to preserve trailing commas when updating existing AST nodes. When creating new ones, it tries to infer whether to generate the trailing comma based on the surrounding code.