### PR TITLE
fix(compiler): handle trailing comma in object literal

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -949,7 +949,8 @@ export class _ParseAST {
           values.push(new PropertyRead(
               span, sourceSpan, sourceSpan, new ImplicitReceiver(span, sourceSpan), key));
         }
-      } while (this.consumeOptionalCharacter(chars.$COMMA));
+      } while (this.consumeOptionalCharacter(chars.$COMMA) &&
+               !this.next.isCharacter(chars.$RBRACE));
       this.rbracesExpected--;
       this.expectCharacter(chars.$RBRACE);
     }

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -116,6 +116,7 @@ describe('parser', () => {
         checkAction('{}');
         checkAction('{a: 1, "b": 2}[2]');
         checkAction('{}["a"]');
+        checkAction('{a: 1, b: 2,}', '{a: 1, b: 2}');
       });
 
       it('should only allow identifier, string, or keyword as map key', () => {


### PR DESCRIPTION
Fixes that the compiler wasn't parsing an object literal with a trailing comma correctly.

Fixes #49534.