### PR TITLE
fix(compiler): allow trailing commas in object literals expression

### DIFF
--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -932,6 +932,10 @@ export class _ParseAST {
     if (!this.consumeOptionalCharacter(chars.$RBRACE)) {
       this.rbracesExpected++;
       do {
+        if (this.next.isCharacter(chars.$RBRACE)) {
+          break;
+        }
+
         const keyStart = this.inputIndex;
         const quoted = this.next.isString();
         const key = this.expectIdentifierOrKeywordOrString();

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -116,6 +116,9 @@ describe('parser', () => {
         checkAction('{}');
         checkAction('{a: 1, "b": 2}[2]');
         checkAction('{}["a"]');
+        checkAction('{a: 1, b: 2}');
+        checkAction('{a: 1, b: {c: 3}}.b');
+        checkAction('{a: 1, b: 2,}', '{a: 1, b: 2}');
       });
 
       it('should only allow identifier, string, or keyword as map key', () => {


### PR DESCRIPTION
As a follow up to #22277 and as repported by #20773 and #49534



## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix