### PR TITLE
refactor(router): Remove internal use of guard and resolve interfaces

### DIFF
--- a/packages/router/src/operators/check_guards.ts
+++ b/packages/router/src/operators/check_guards.ts
@@ -11,7 +11,7 @@ import {concat, defer, from, MonoTypeOperatorFunction, Observable, of, OperatorF
 import {concatMap, first, map, mergeMap, tap} from 'rxjs/operators';
 
 import {ActivationStart, ChildActivationStart, Event} from '../events';
-import {CanActivateChild, CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanLoadFn, CanMatchFn, Route} from '../models';
+import {CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanLoadFn, CanMatchFn, Route} from '../models';
 import {redirectingNavigationError} from '../navigation_canceling_error';
 import {NavigationTransition} from '../navigation_transition';
 import {ActivatedRouteSnapshot, RouterStateSnapshot} from '../router_state';
@@ -138,8 +138,8 @@ function runCanActivateChild(
       const guardsMapped =
           d.guards.map((canActivateChild: CanActivateChildFn|ProviderToken<unknown>) => {
             const closestInjector = getClosestRouteInjector(d.node) ?? injector;
-            const guard =
-                getTokenOrFunctionIdentity<CanActivateChild>(canActivateChild, closestInjector);
+            const guard = getTokenOrFunctionIdentity<{canActivateChild: CanActivateChildFn}>(
+                canActivateChild, closestInjector);
             const guardVal = isCanActivateChild(guard) ?
                 guard.canActivateChild(futureARS, futureRSS) :
                 closestInjector.runInContext(

--- a/packages/router/src/utils/type_guards.ts
+++ b/packages/router/src/utils/type_guards.ts
@@ -8,7 +8,7 @@
 
 import {EmptyError} from 'rxjs';
 
-import {CanActivate, CanActivateChild, CanDeactivate, CanLoad, CanMatch} from '../models';
+import {CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanLoadFn, CanMatchFn} from '../models';
 import {NAVIGATION_CANCELING_ERROR, NavigationCancelingError, RedirectingNavigationCancelingError} from '../navigation_canceling_error';
 import {isUrlTree} from '../url_tree';
 
@@ -33,23 +33,23 @@ export function isBoolean(v: any): v is boolean {
   return typeof v === 'boolean';
 }
 
-export function isCanLoad(guard: any): guard is CanLoad {
-  return guard && isFunction<CanLoad>(guard.canLoad);
+export function isCanLoad(guard: any): guard is {canLoad: CanLoadFn} {
+  return guard && isFunction<CanLoadFn>(guard.canLoad);
 }
 
-export function isCanActivate(guard: any): guard is CanActivate {
-  return guard && isFunction<CanActivate>(guard.canActivate);
+export function isCanActivate(guard: any): guard is {canActivate: CanActivateFn} {
+  return guard && isFunction<CanActivateFn>(guard.canActivate);
 }
 
-export function isCanActivateChild(guard: any): guard is CanActivateChild {
-  return guard && isFunction<CanActivateChild>(guard.canActivateChild);
+export function isCanActivateChild(guard: any): guard is {canActivateChild: CanActivateChildFn} {
+  return guard && isFunction<CanActivateChildFn>(guard.canActivateChild);
 }
 
-export function isCanDeactivate<T>(guard: any): guard is CanDeactivate<T> {
-  return guard && isFunction<CanDeactivate<T>>(guard.canDeactivate);
+export function isCanDeactivate<T>(guard: any): guard is {canDeactivate: CanDeactivateFn<T>} {
+  return guard && isFunction<CanDeactivateFn<T>>(guard.canDeactivate);
 }
-export function isCanMatch(guard: any): guard is CanMatch {
-  return guard && isFunction<CanMatch>(guard.canMatch);
+export function isCanMatch(guard: any): guard is {canMatch: CanMatchFn} {
+  return guard && isFunction<CanMatchFn>(guard.canMatch);
 }
 
 export function isRedirectingNavigationCancelingError(

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -13,7 +13,7 @@ import {ApplicationRef, Component, CUSTOM_ELEMENTS_SCHEMA, destroyPlatform, ENVI
 import {TestBed} from '@angular/core/testing';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
-import {NavigationEnd, provideRouter, Resolve, Router, RouterModule, RouterOutlet, withEnabledBlockingInitialNavigation} from '@angular/router';
+import {NavigationEnd, provideRouter, Router, RouterModule, RouterOutlet, withEnabledBlockingInitialNavigation} from '@angular/router';
 
 // This is needed, because all files under `packages/` are compiled together as part of the
 // [legacy-unit-tests-saucelabs][1] CI job, including the `lib.webworker.d.ts` typings brought in by
@@ -51,7 +51,7 @@ describe('bootstrap', () => {
   }
 
   @Injectable({providedIn: 'root'})
-  class TestResolver implements Resolve<unknown> {
+  class TestResolver {
     resolve() {
       let resolve: (value: unknown) => void;
       const res = new Promise(r => resolve = r);

--- a/packages/router/test/computed_state_restoration.spec.ts
+++ b/packages/router/test/computed_state_restoration.spec.ts
@@ -11,15 +11,15 @@ import {provideLocationMocks, SpyLocation} from '@angular/common/testing';
 import {Component, Injectable, NgModule, Type} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {CanActivate, CanDeactivate, Resolve, Router, RouterModule, RouterOutlet, UrlTree, withRouterConfig} from '@angular/router';
-import {EMPTY, Observable, of} from 'rxjs';
+import {Router, RouterModule, RouterOutlet, UrlTree, withRouterConfig} from '@angular/router';
+import {EMPTY, of} from 'rxjs';
 
 import {provideRouter} from '../src/provide_router';
 import {isUrlTree} from '../src/url_tree';
 
 describe('`restoredState#ɵrouterPageId`', () => {
   @Injectable({providedIn: 'root'})
-  class MyCanDeactivateGuard implements CanDeactivate<unknown> {
+  class MyCanDeactivateGuard {
     allow: boolean = true;
     canDeactivate(): boolean {
       return this.allow;
@@ -27,7 +27,7 @@ describe('`restoredState#ɵrouterPageId`', () => {
   }
 
   @Injectable({providedIn: 'root'})
-  class ThrowingCanActivateGuard implements CanActivate {
+  class ThrowingCanActivateGuard {
     throw = false;
 
     constructor(private router: Router) {}
@@ -41,7 +41,7 @@ describe('`restoredState#ɵrouterPageId`', () => {
   }
 
   @Injectable({providedIn: 'root'})
-  class MyCanActivateGuard implements CanActivate {
+  class MyCanActivateGuard {
     allow: boolean = true;
     redirectTo: string|null|UrlTree = null;
 
@@ -57,7 +57,7 @@ describe('`restoredState#ɵrouterPageId`', () => {
     }
   }
   @Injectable({providedIn: 'root'})
-  class MyResolve implements Resolve<Observable<unknown>> {
+  class MyResolve {
     myresolve = of(2);
     resolve() {
       return this.myresolve;

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -12,11 +12,11 @@ import {ChangeDetectionStrategy, Component, EnvironmentInjector, inject as coreI
 import {ComponentFixture, fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {By} from '@angular/platform-browser/src/dom/debug/by';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
-import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, CanActivate, CanDeactivate, ChildActivationEnd, ChildActivationStart, DefaultUrlSerializer, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, Navigation, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped, NavigationStart, ParamMap, Params, PreloadAllModules, PreloadingStrategy, PRIMARY_OUTLET, Resolve, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouteReuseStrategy, RouterEvent, RouterLink, RouterLinkActive, RouterModule, RouterOutlet, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
+import {ActivatedRoute, ActivatedRouteSnapshot, ActivationEnd, ActivationStart, ChildActivationEnd, ChildActivationStart, DefaultUrlSerializer, DetachedRouteHandle, Event, GuardsCheckEnd, GuardsCheckStart, Navigation, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped, NavigationStart, ParamMap, Params, PreloadAllModules, PreloadingStrategy, PRIMARY_OUTLET, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, Router, RouteReuseStrategy, RouterEvent, RouterLink, RouterLinkActive, RouterModule, RouterOutlet, RouterPreloader, RouterStateSnapshot, RoutesRecognized, RunGuardsAndResolvers, UrlHandlingStrategy, UrlSegment, UrlSegmentGroup, UrlSerializer, UrlTree} from '@angular/router';
 import {concat, EMPTY, Observable, Observer, of, Subscription} from 'rxjs';
 import {delay, filter, first, last, map, mapTo, takeWhile, tap} from 'rxjs/operators';
 
-import {CanActivateChildFn, CanActivateFn, CanMatch, CanMatchFn, Data, ResolveFn} from '../src/models';
+import {CanActivateChildFn, CanActivateFn, CanMatchFn, Data, ResolveFn} from '../src/models';
 import {provideRouter, withNavigationErrorHandler, withRouterConfig} from '../src/provide_router';
 import {wrapIntoObservable} from '../src/utils/collection';
 import {getLoadedRoutes} from '../src/utils/config';
@@ -865,7 +865,7 @@ describe('Integration', () => {
 
   describe('"eager" urlUpdateStrategy', () => {
     @Injectable()
-    class AuthGuard implements CanActivate {
+    class AuthGuard {
       canActivateResult = true;
 
       canActivate() {
@@ -873,7 +873,7 @@ describe('Integration', () => {
       }
     }
     @Injectable()
-    class DelayedGuard implements CanActivate {
+    class DelayedGuard {
       canActivate() {
         return of('').pipe(delay(1000), mapTo(true));
       }
@@ -2055,7 +2055,7 @@ describe('Integration', () => {
 
 
   describe('data', () => {
-    class ResolveSix implements Resolve<number> {
+    class ResolveSix {
       resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): number {
         return 6;
       }
@@ -3242,7 +3242,7 @@ describe('Integration', () => {
       });
 
       describe('should work when given a class', () => {
-        class AlwaysTrue implements CanActivate {
+        class AlwaysTrue {
           canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
             return true;
           }
@@ -4215,7 +4215,7 @@ describe('Integration', () => {
       describe('next state', () => {
         let log: string[];
 
-        class ClassWithNextState implements CanDeactivate<TeamCmp> {
+        class ClassWithNextState {
           canDeactivate(
               component: TeamCmp, currentRoute: ActivatedRouteSnapshot,
               currentState: RouterStateSnapshot, nextState: RouterStateSnapshot): boolean {
@@ -4285,7 +4285,7 @@ describe('Integration', () => {
       });
 
       describe('should work when given a class', () => {
-        class AlwaysTrue implements CanDeactivate<TeamCmp> {
+        class AlwaysTrue {
           canDeactivate(): boolean {
             return true;
           }
@@ -4912,7 +4912,7 @@ describe('Integration', () => {
 
     describe('canMatch', () => {
       @Injectable({providedIn: 'root'})
-      class ConfigurableGuard implements CanMatch {
+      class ConfigurableGuard {
         result: Promise<boolean|UrlTree>|Observable<boolean|UrlTree>|boolean|UrlTree = false;
         canMatch() {
           return this.result;
@@ -5008,7 +5008,7 @@ describe('Integration', () => {
            class ChildLazyLoadedComponent {
            }
            @Injectable()
-           class LazyCanMatchFalse implements CanMatch {
+           class LazyCanMatchFalse {
              canMatch() {
                return false;
              }
@@ -5775,7 +5775,7 @@ describe('Integration', () => {
          }
 
          @Injectable()
-         class Resolver implements Resolve<Service> {
+         class Resolver {
            constructor(public service: Service) {}
            resolve() {
              return this.service;

--- a/packages/router/test/regression_integration.spec.ts
+++ b/packages/router/test/regression_integration.spec.ts
@@ -10,7 +10,7 @@ import {CommonModule, HashLocationStrategy, Location, LocationStrategy} from '@a
 import {provideLocationMocks, SpyLocation} from '@angular/common/testing';
 import {ChangeDetectionStrategy, ChangeDetectorRef, Component, Injectable, NgModule, TemplateRef, Type, ViewChild, ViewContainerRef} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
-import {ChildrenOutletContexts, DefaultUrlSerializer, Resolve, Router, RouterOutlet, UrlSerializer, UrlTree} from '@angular/router';
+import {ChildrenOutletContexts, DefaultUrlSerializer, Router, RouterOutlet, UrlSerializer, UrlTree} from '@angular/router';
 import {RouterTestingModule} from '@angular/router/testing';
 import {of} from 'rxjs';
 import {delay, mapTo} from 'rxjs/operators';
@@ -284,7 +284,7 @@ describe('Integration', () => {
 
     beforeEach(fakeAsync(() => {
       @Injectable()
-      class DelayedResolve implements Resolve<{}> {
+      class DelayedResolve {
         resolve() {
           return of('').pipe(delay(1000), mapTo(true));
         }


### PR DESCRIPTION
These interfaces are deprecated and should not be used internally.