### PR TITLE
refactor(core): only annotate disconnected nodes in content projection

### DIFF
--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -3173,9 +3173,7 @@ describe('platform-server integration', () => {
         });
       });
 
-      // TODO(akushnir): we should only mark nodes within a content projection block as
-      // "disconnected" (avoid marking other disconnected nodes in a template)
-      xit('should handle element node mismatch', async () => {
+      it('should handle element node mismatch', async () => {
         @Component({
           standalone: true,
           selector: 'app',


### PR DESCRIPTION
Previously, we've annotated all disconnected DOM nodes, even if they are not used in content projection. However, this situation is only possible in content projection and if it happens in other cases (for example, when a node was removed using direct DOM manipulations), this should be a mismatch error.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No