### PR TITLE
feat(core): expose `makeStateKey`, `StateKey` and  `TransferState`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -100,7 +100,6 @@ v16 - v19
 | `@angular/platform-server`          | [`ServerTransferStateModule`](#platform-server)                                                            | v14           | v16         |
 | `@angular/service-worker`           | [`SwUpdate#activated`](api/service-worker/SwUpdate#activated)                                              | v13           | v16         |
 | `@angular/service-worker`           | [`SwUpdate#available`](api/service-worker/SwUpdate#available)                                              | v13           | v16         |
-| `@angular/platform-browser`         | [`BrowserModule.withServerTransition`](api/platform-browser/BrowserModule#withservertransition)                                                          | v16           | v18         |
 
 ### Deprecated features that can be removed in v17 or later
 
@@ -121,6 +120,8 @@ v16 - v19
 |:---                                 |:---                                                                                                        |:---           |:---               |
 | `@angular/core` | `EnvironmentInjector.runInContext` | v16 | v18 |
 | `@angular/platform-server`          | [`PlatformConfig.baseUrl` and `PlatformConfig.useAbsoluteUrl` config options](api/platform-server/PlatformConfig) | v16           | v18               |
+| `@angular/platform-browser`         | [`BrowserModule.withServerTransition`](api/platform-browser/BrowserModule#withservertransition)            | v16           | v18         |
+| `@angular/platform-browser`         | [`makeStateKey`, `StateKey` and `TransferState`](#platform-browser)                                        | v16           | v18         |
 
 ### Deprecated features with no planned removal version
 
@@ -210,7 +211,7 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 |:---                                                              |:---                                                |:---                   |:---     |
 | [`BrowserTransferStateModule`](api/platform-browser/BrowserTransferStateModule) | No replacement needed.  | v14.1                   | The `TransferState` class is available for injection without importing additional modules on the client side of a server-rendered application. |
 | [`BrowserModule.withServerTransition`](api/platform-browser/BrowserModule#withservertransition) | No replacement needed.  | v16.0                   | The `APP_ID`token should be used instead to set the application ID. |
-
+| `makeStateKey`, `StateKey` and `TransferState` | Import from `@angular/core`.  | v16.0                   | Same behavior, but exported from a different package. |
 <a id="platform-browser-dynamic"></a>
 
 ### &commat;angular/platform-browser-dynamic

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -121,7 +121,7 @@ v16 - v19
 | `@angular/core` | `EnvironmentInjector.runInContext` | v16 | v18 |
 | `@angular/platform-server`          | [`PlatformConfig.baseUrl` and `PlatformConfig.useAbsoluteUrl` config options](api/platform-server/PlatformConfig) | v16           | v18               |
 | `@angular/platform-browser`         | [`BrowserModule.withServerTransition`](api/platform-browser/BrowserModule#withservertransition)            | v16           | v18         |
-| `@angular/platform-browser`         | [`makeStateKey`, `StateKey` and `TransferState`](#platform-browser)                                        | v16           | v18         |
+| `@angular/platform-browser`         | [`makeStateKey`, `StateKey` and `TransferState`](#platform-browser), symbols were moved to `@angular/core`                                        | v16           | v18         |
 
 ### Deprecated features with no planned removal version
 

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -939,6 +939,9 @@ export const LOCALE_ID: InjectionToken<string>;
 export function makeEnvironmentProviders(providers: (Provider | EnvironmentProviders)[]): EnvironmentProviders;
 
 // @public
+export function makeStateKey<T = void>(key: string): StateKey<T>;
+
+// @public
 export function mergeApplicationConfig(...configs: ApplicationConfig[]): ApplicationConfig;
 
 // @public
@@ -1400,6 +1403,12 @@ export interface SkipSelfDecorator {
 }
 
 // @public
+export type StateKey<T> = string & {
+    __not_a_string: never;
+    __value_type?: T;
+};
+
+// @public
 export interface StaticClassProvider extends StaticClassSansProvider {
     multi?: boolean;
     provide: any;
@@ -1457,6 +1466,19 @@ export class TestabilityRegistry {
 export interface TrackByFunction<T> {
     // (undocumented)
     <U extends T>(index: number, item: T & U): any;
+}
+
+// @public
+export class TransferState {
+    get<T>(key: StateKey<T>, defaultValue: T): T;
+    hasKey<T>(key: StateKey<T>): boolean;
+    get isEmpty(): boolean;
+    onSerialize<T>(key: StateKey<T>, callback: () => T): void;
+    remove<T>(key: StateKey<T>): void;
+    set<T>(key: StateKey<T>, value: T): void;
+    toJson(): string;
+    // (undocumented)
+    static ɵprov: unknown;
 }
 
 // @public

--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -12,7 +12,7 @@ import { DebugNode } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/common';
 import { InjectionToken } from '@angular/core';
-import { ɵmakeStateKey as makeStateKey } from '@angular/core';
+import { makeStateKey as makeStateKey_2 } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
 import { NgZone } from '@angular/core';
 import { PlatformRef } from '@angular/core';
@@ -20,9 +20,9 @@ import { Predicate } from '@angular/core';
 import { Provider } from '@angular/core';
 import { Sanitizer } from '@angular/core';
 import { SecurityContext } from '@angular/core';
-import { ɵStateKey as StateKey } from '@angular/core';
+import { StateKey as StateKey_2 } from '@angular/core';
 import { StaticProvider } from '@angular/core';
-import { ɵTransferState as TransferState } from '@angular/core';
+import { TransferState as TransferState_2 } from '@angular/core';
 import { Type } from '@angular/core';
 import { Version } from '@angular/core';
 
@@ -145,7 +145,8 @@ export class HammerModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<HammerModule, never, never, never>;
 }
 
-export { makeStateKey }
+// @public @deprecated
+export const makeStateKey: typeof makeStateKey_2;
 
 // @public
 export class Meta {
@@ -211,7 +212,8 @@ export interface SafeUrl extends SafeValue {
 export interface SafeValue {
 }
 
-export { StateKey }
+// @public @deprecated
+export type StateKey<T> = StateKey_2<T>;
 
 // @public
 export class Title {
@@ -224,7 +226,10 @@ export class Title {
     static ɵprov: i0.ɵɵInjectableDeclaration<Title>;
 }
 
-export { TransferState }
+// @public @deprecated
+export const TransferState: {
+    new (): TransferState_2;
+};
 
 // @public (undocumented)
 export const VERSION: Version;

--- a/integration/platform-server/src/http-transferstate-lazy/transfer-state.component.ts
+++ b/integration/platform-server/src/http-transferstate-lazy/transfer-state.component.ts
@@ -8,8 +8,7 @@
 
 import {isPlatformServer} from '@angular/common';
 import {HttpClient} from '@angular/common/http';
-import {Component, Inject, PLATFORM_ID} from '@angular/core';
-import {TransferState, makeStateKey} from '@angular/platform-browser';
+import {Component, Inject, PLATFORM_ID, TransferState, makeStateKey} from '@angular/core';
 
 const httpCacheKey = makeStateKey<string>('http');
 

--- a/integration/platform-server/src/transferstate/transfer-state.component.ts
+++ b/integration/platform-server/src/transferstate/transfer-state.component.ts
@@ -7,8 +7,7 @@
  */
 
 import {isPlatformServer} from '@angular/common';
-import {Component, Inject, PLATFORM_ID} from '@angular/core';
-import {StateKey, TransferState, makeStateKey} from '@angular/platform-browser';
+import {Component, Inject, PLATFORM_ID, TransferState, makeStateKey} from '@angular/core';
 
 const COUNTER_KEY = makeStateKey<number>('counter');
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -41,6 +41,7 @@ export {createNgModule, createNgModuleRef, createEnvironmentInjector} from './re
 export {createComponent, reflectComponentType, ComponentMirror} from './render3/component';
 export {isStandalone} from './render3/definition';
 export {ApplicationConfig, mergeApplicationConfig} from './application_config';
+export {makeStateKey, StateKey, TransferState} from './transfer_state';
 
 import {global} from './util/global';
 if (typeof ngDevMode !== 'undefined' && ngDevMode) {

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -29,7 +29,7 @@ export {_sanitizeHtml as ɵ_sanitizeHtml} from './sanitization/html_sanitizer';
 export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from './signals';
 export {TESTABILITY as ɵTESTABILITY, TESTABILITY_GETTER as ɵTESTABILITY_GETTER} from './testability/testability';
-export {escapeTransferStateContent as ɵescapeTransferStateContent, makeStateKey as ɵmakeStateKey, StateKey as ɵStateKey, TransferState as ɵTransferState, unescapeTransferStateContent as ɵunescapeTransferStateContent} from './transfer_state';
+export {escapeTransferStateContent as ɵescapeTransferStateContent, unescapeTransferStateContent as ɵunescapeTransferStateContent} from './transfer_state';
 export {coerceToBoolean as ɵcoerceToBoolean} from './util/coercion';
 export {devModeEqual as ɵdevModeEqual} from './util/comparison';
 export {makeDecorator as ɵmakeDecorator} from './util/decorators';

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -7,7 +7,66 @@
  */
 
 // Re-export TransferState to the public API of the `platform-browser` for backwards-compatibility.
-export {ɵmakeStateKey as makeStateKey, ɵStateKey as StateKey, ɵTransferState as TransferState} from '@angular/core';
+import {makeStateKey as makeStateKeyFromCore, StateKey as StateKeyFromCore, TransferState as TransferStateFromCore} from '@angular/core';
+
+/**
+ * Create a `StateKey<T>` that can be used to store value of type T with `TransferState`.
+ *
+ * Example:
+ *
+ * ```
+ * const COUNTER_KEY = makeStateKey<number>('counter');
+ * let value = 10;
+ *
+ * transferState.set(COUNTER_KEY, value);
+ * ```
+ *
+ * @publicApi
+ * @deprecated `makeStateKey` has moved, please import `makeStateKey` from `@angular/core` instead.
+ */
+// The below is a workaround to add a deprecated message.
+export const makeStateKey = makeStateKeyFromCore;
+
+/**
+ *
+ * A key value store that is transferred from the application on the server side to the application
+ * on the client side.
+ *
+ * The `TransferState` is available as an injectable token.
+ * On the client, just inject this token using DI and use it, it will be lazily initialized.
+ * On the server it's already included if `renderApplication` function is used. Otherwise, import
+ * the `ServerTransferStateModule` module to make the `TransferState` available.
+ *
+ * The values in the store are serialized/deserialized using JSON.stringify/JSON.parse. So only
+ * boolean, number, string, null and non-class objects will be serialized and deserialized in a
+ * non-lossy manner.
+ *
+ * @publicApi
+ *
+ * @deprecated `TransferState` has moved, please import `TransferState` from `@angular/core`
+ *     instead.
+ */
+// The below is a workaround to add a deprecated message.
+export const TransferState: {new (): TransferStateFromCore} = TransferStateFromCore;
+
+/**
+ * A type-safe key to use with `TransferState`.
+ *
+ * Example:
+ *
+ * ```
+ * const COUNTER_KEY = makeStateKey<number>('counter');
+ * let value = 10;
+ *
+ * transferState.set(COUNTER_KEY, value);
+ * ```
+ * @publicApi
+ *
+ * @deprecated `StateKey` has moved, please import `StateKey` from `@angular/core` instead.
+ */
+// The below is a workaround to add a deprecated message.
+export type StateKey<T> = StateKeyFromCore<T>;
+
 export {ApplicationConfig, bootstrapApplication, BrowserModule, createApplication, platformBrowser, provideProtractorTestingSupport} from './browser';
 export {Meta, MetaDefinition} from './browser/meta';
 export {Title} from './browser/title';

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -6,15 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {animate, state, style, transition, trigger} from '@angular/animations';
+import {animate, style, transition, trigger} from '@angular/animations';
 import {DOCUMENT, isPlatformBrowser, ɵgetDOM as getDOM} from '@angular/common';
-import {ANIMATION_MODULE_TYPE, APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, Inject, inject as _inject, InjectionToken, Injector, Input, LOCALE_ID, NgModule, NgModuleRef, OnDestroy, Pipe, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Testability, TestabilityRegistry, Type, VERSION} from '@angular/core';
+import {ANIMATION_MODULE_TYPE, APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, Inject, inject as _inject, InjectionToken, Injector, LOCALE_ID, NgModule, NgModuleRef, OnDestroy, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Testability, TestabilityRegistry, TransferState, Type, VERSION} from '@angular/core';
 import {ApplicationRef, destroyPlatform} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
 import {inject, TestBed} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
-import {BrowserModule, TransferState} from '@angular/platform-browser';
+import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {provideAnimations, provideNoopAnimations} from '@angular/platform-browser/animations';
 import {expect} from '@angular/platform-browser/testing/src/matchers';

--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -7,8 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {APP_ID, NgModule, Provider, ɵescapeTransferStateContent as escapeTransferStateContent} from '@angular/core';
-import {TransferState} from '@angular/platform-browser';
+import {APP_ID, NgModule, Provider, TransferState, ɵescapeTransferStateContent as escapeTransferStateContent} from '@angular/core';
 
 import {BEFORE_APP_SERIALIZED} from './tokens';
 

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -10,9 +10,10 @@ import {animate, AnimationBuilder, state, style, transition, trigger} from '@ang
 import {DOCUMENT, isPlatformServer, PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
 import {HTTP_INTERCEPTORS, HttpClient, HttpClientModule, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {HttpClientTestingModule, HttpTestingController} from '@angular/common/http/testing';
-import {ApplicationConfig, ApplicationRef, Component, destroyPlatform, EnvironmentProviders, getPlatform, HostListener, Inject, inject as coreInject, Injectable, Input, mergeApplicationConfig, NgModule, NgZone, PLATFORM_ID, Provider, Type, ViewEncapsulation, ɵInitialRenderPendingTasks as InitialRenderPendingTasks} from '@angular/core';
+import {ApplicationConfig, ApplicationRef, Component, destroyPlatform, EnvironmentProviders, getPlatform, HostListener, Inject, inject as coreInject, Injectable, Input, makeStateKey, mergeApplicationConfig, NgModule, NgZone, PLATFORM_ID, Provider, TransferState, Type, ViewEncapsulation} from '@angular/core';
+import {InitialRenderPendingTasks} from '@angular/core/src/initial_render_pending_tasks';
 import {TestBed, waitForAsync} from '@angular/core/testing';
-import {bootstrapApplication, BrowserModule, makeStateKey, Title, TransferState} from '@angular/platform-browser';
+import {bootstrapApplication, BrowserModule, Title} from '@angular/platform-browser';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformDynamicServer, PlatformState, provideServerSupport, renderModule, ServerModule} from '@angular/platform-server';
 import {provideRouter, RouterOutlet, Routes} from '@angular/router';
 import {Observable} from 'rxjs';

--- a/packages/platform-server/test/transfer_state_spec.ts
+++ b/packages/platform-server/test/transfer_state_spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, NgModule,} from '@angular/core';
-import {BrowserModule, makeStateKey, TransferState} from '@angular/platform-browser';
+import {Component, makeStateKey, NgModule, TransferState} from '@angular/core';
+import {BrowserModule} from '@angular/platform-browser';
 import {renderModule, ServerModule} from '@angular/platform-server';
 
 describe('transfer_state', () => {


### PR DESCRIPTION
This commits adds `makeStateKey`, `StateKey` and  `TransferState` methods in `@angular/core` as public API and deprecated the same exported symbols in `@angular/platform-browser`.

DEPRECATED:  `makeStateKey`, `StateKey` and  `TransferState` exports have been moved from `@angular/platform-browser` to `@angular/core`. Please update the imports.


```diff
- import {makeStateKey, StateKey, TransferState} from '@angular/platform-browser';
+ import {makeStateKey, StateKey, TransferState} from '@angular/core';
```
