### PR TITLE
fix(router): Ensure Router preloading works with lazy component and s…

### DIFF
--- a/packages/router/src/router_preloader.ts
+++ b/packages/router/src/router_preloader.ts
@@ -121,7 +121,8 @@ export class RouterPreloader implements OnDestroy {
       if ((route.loadChildren && !route._loadedRoutes && route.canLoad === undefined) ||
           (route.loadComponent && !route._loadedComponent)) {
         res.push(this.preloadConfig(injectorForCurrentRoute, route));
-      } else if (route.children || route._loadedRoutes) {
+      }
+      if (route.children || route._loadedRoutes) {
         res.push(this.processRoutes(injectorForChildren, (route.children ?? route._loadedRoutes)!));
       }
     }

--- a/packages/router/test/router_preloader.spec.ts
+++ b/packages/router/test/router_preloader.spec.ts
@@ -818,5 +818,35 @@ describe('RouterPreloader', () => {
          tick(3);
          expect(getLoadedComponent(baseRoute)).toBeDefined();
        }));
+
+    it('loads nested components', () => {
+      @Component({template: '', standalone: true})
+      class LoadedComponent {
+      }
+      lazyComponentSpy.and.returnValue(LoadedComponent);
+
+      TestBed.inject(Router).resetConfig([
+        {
+          path: 'a',
+          loadComponent: lazyComponentSpy,
+          children: [{
+            path: 'b',
+            loadComponent: lazyComponentSpy,
+            children: [{
+              path: 'c',
+              loadComponent: lazyComponentSpy,
+              children: [{
+                path: 'd',
+                loadComponent: lazyComponentSpy,
+              }]
+            }]
+          }]
+        },
+      ]);
+
+      const preloader = TestBed.inject(RouterPreloader);
+      preloader.preload().subscribe(() => {});
+      expect(lazyComponentSpy).toHaveBeenCalledTimes(4);
+    });
   });
 });


### PR DESCRIPTION
…tatic children

The preloading strategy did not handle a `loadComponent` on a route with a static `children`. It only preloaded children if they were also `loadChildren` or both were not lazy loaded.

fixes #49558
