### PR TITLE
fix(router): Ensure initial navigation clears current navigation when…

### DIFF
--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -645,6 +645,11 @@ export class NavigationTransitions {
                              this.rootContexts, router.routeReuseStrategy,
                              (evt: Event) => this.events.next(evt), this.inputBindingEnabled),
 
+                         // Ensure that if some observable used to drive the transition doesn't
+                         // complete, the navigation still finalizes This should never happen, but
+                         // this is done as a safety measure to avoid surfacing this error (#49567).
+                         take(1),
+
                          tap({
                            next: (t: NavigationTransition) => {
                              completed = true;

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -211,6 +211,7 @@ export function getBootstrapListener() {
     router.resetRootComponentType(ref.componentTypes[0]);
     if (!bootstrapDone.closed) {
       bootstrapDone.next();
+      bootstrapDone.complete();
       bootstrapDone.unsubscribe();
     }
   };

--- a/packages/router/test/bootstrap.spec.ts
+++ b/packages/router/test/bootstrap.spec.ts
@@ -257,6 +257,9 @@ describe('bootstrap', () => {
       const router = ref.injector.get(Router);
       const data = router.routerState.snapshot.root.firstChild!.data;
       expect(data['test']).toEqual('test-data');
+      // Also ensure that the navigation completed. The navigation transition clears the
+      // current navigation in its `finalize` operator.
+      expect(router.getCurrentNavigation()).toBeNull();
     });
     await Promise.all([bootstrapPromise, navigationEndPromise]);
   });


### PR DESCRIPTION
… blocking

The navigation transition clears the current navigation in the finalize operator of the current navigation Observer. This commit both completes the `bootstrapDone` observable and updates the transition to only take 1 emit from the completed navigation. Either of these changes on their own would fix the issue. The latter is a preventative measure in case a mistake like the former is made again.

fixes #49567
