### PR TITLE
refactor(core): internal tracker of pending tasks during initial rendering

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -20,6 +20,7 @@ export {provideHydrationSupport as ɵprovideHydrationSupport} from './hydration/
 export {IS_HYDRATION_FEATURE_ENABLED as ɵIS_HYDRATION_FEATURE_ENABLED} from './hydration/tokens';
 export {CurrencyIndex as ɵCurrencyIndex, ExtraLocaleDataIndex as ɵExtraLocaleDataIndex, findLocaleData as ɵfindLocaleData, getLocaleCurrencyCode as ɵgetLocaleCurrencyCode, getLocalePluralCase as ɵgetLocalePluralCase, LocaleDataIndex as ɵLocaleDataIndex, registerLocaleData as ɵregisterLocaleData, unregisterAllLocaleData as ɵunregisterLocaleData} from './i18n/locale_data_api';
 export {DEFAULT_LOCALE_ID as ɵDEFAULT_LOCALE_ID} from './i18n/localization';
+export {InitialRenderPendingTasks as ɵInitialRenderPendingTasks} from './initial_render_pending_tasks';
 export {ComponentFactory as ɵComponentFactory} from './linker/component_factory';
 export {clearResolutionOfComponentResourcesQueue as ɵclearResolutionOfComponentResourcesQueue, resolveComponentResources as ɵresolveComponentResources} from './metadata/resource_loading';
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -10,6 +10,7 @@ import {APP_BOOTSTRAP_LISTENER, ApplicationRef} from '../application_ref';
 import {PLATFORM_ID} from '../application_tokens';
 import {ENVIRONMENT_INITIALIZER, EnvironmentProviders, makeEnvironmentProviders} from '../di';
 import {inject} from '../di/injector_compatibility';
+import {InitialRenderPendingTasks} from '../initial_render_pending_tasks';
 import {enableLocateOrCreateContainerRefImpl} from '../linker/view_container_ref';
 import {enableLocateOrCreateElementNodeImpl} from '../render3/instructions/element';
 import {enableLocateOrCreateElementContainerNodeImpl} from '../render3/instructions/element_container';
@@ -137,7 +138,8 @@ export function provideHydrationSupport(): EnvironmentProviders {
       useFactory: () => {
         if (isBrowser()) {
           const appRef = inject(ApplicationRef);
-          return () => cleanupDehydratedViews(appRef);
+          const pendingTasks = inject(InitialRenderPendingTasks);
+          return () => cleanupDehydratedViews(appRef, pendingTasks);
         }
         return () => {};  // noop
       },

--- a/packages/core/src/hydration/cleanup.ts
+++ b/packages/core/src/hydration/cleanup.ts
@@ -9,6 +9,7 @@
 import {first} from 'rxjs/operators';
 
 import {ApplicationRef} from '../application_ref';
+import {InitialRenderPendingTasks} from '../initial_render_pending_tasks';
 import {CONTAINER_HEADER_OFFSET, DEHYDRATED_VIEWS, LContainer} from '../render3/interfaces/container';
 import {Renderer} from '../render3/interfaces/renderer';
 import {RNode} from '../render3/interfaces/renderer_dom';
@@ -91,11 +92,14 @@ function cleanupLView(lView: LView) {
  * Walks over all views registered within the ApplicationRef and removes
  * all dehydrated views from all `LContainer`s along the way.
  */
-export function cleanupDehydratedViews(appRef: ApplicationRef) {
+export function cleanupDehydratedViews(
+    appRef: ApplicationRef, pendingTasks: InitialRenderPendingTasks) {
   // Wait once an app becomes stable and cleanup all views that
   // were not claimed during the application bootstrap process.
   // The timing is similar to when we kick off serialization on the server.
-  return appRef.isStable.pipe(first((isStable: boolean) => isStable)).toPromise().then(() => {
+  const isStablePromise = appRef.isStable.pipe(first((isStable: boolean) => isStable)).toPromise();
+  const pendingTasksPromise = pendingTasks.whenAllTasksComplete;
+  return Promise.allSettled([isStablePromise, pendingTasksPromise]).then(() => {
     const viewRefs = appRef._views;
     for (const viewRef of viewRefs) {
       const lView = getComponentLViewForHydration(viewRef);

--- a/packages/core/src/initial_render_pending_tasks.ts
+++ b/packages/core/src/initial_render_pending_tasks.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Injectable} from './di';
+import {inject} from './di/injector_compatibility';
+import {OnDestroy} from './interface/lifecycle_hooks';
+import {NgZone} from './zone/ng_zone';
+
+/**
+ * *Internal* service that keeps track of pending tasks happening in the system
+ * during the initial rendering. No tasks are tracked after an initial
+ * rendering.
+ *
+ * This information is needed to make sure that the serialization on the server
+ * is delayed until all tasks in the queue (such as an initial navigation or a
+ * pending HTTP request) are completed.
+ */
+@Injectable({providedIn: 'root'})
+export class InitialRenderPendingTasks implements OnDestroy {
+  private taskId = 0;
+  private collection = new Set<number>();
+  private ngZone = inject(NgZone);
+
+  private resolve!: VoidFunction;
+  private promise!: Promise<void>;
+
+  get whenAllTasksComplete(): Promise<void> {
+    if (this.collection.size > 0) {
+      return this.promise;
+    }
+    return Promise.resolve().then(() => {
+      this.completed = true;
+    });
+  }
+
+  completed = false;
+
+  constructor() {
+    // Run outside of the Angular zone to avoid triggering
+    // extra change detection cycles.
+    this.ngZone.runOutsideAngular(() => {
+      this.promise = new Promise<void>((resolve) => {
+        this.resolve = resolve;
+      });
+    });
+  }
+
+  add(): number {
+    if (this.completed) {
+      // Indicates that the task was added after
+      // the task queue completion, so it's a noop.
+      return -1;
+    }
+    const taskId = this.taskId++;
+    this.collection.add(taskId);
+    return taskId;
+  }
+
+  remove(taskId: number) {
+    if (this.completed) return;
+
+    this.collection.delete(taskId);
+    if (this.collection.size === 0) {
+      // We've removed the last task, resolve the promise.
+      this.completed = true;
+      this.resolve();
+    }
+  }
+
+  ngOnDestroy() {
+    this.completed = true;
+    this.collection.clear();
+  }
+}

--- a/packages/core/test/acceptance/initial_render_pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/initial_render_pending_tasks_spec.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {TestBed} from '@angular/core/testing';
+
+import {InitialRenderPendingTasks} from '../../src/initial_render_pending_tasks';
+
+describe('InitialRenderPendingTasks', () => {
+  it('should resolve a promise even if there are no tasks', async () => {
+    const pendingTasks = TestBed.inject(InitialRenderPendingTasks);
+    expect(pendingTasks.completed).toBe(false);
+    await pendingTasks.whenAllTasksComplete;
+    expect(pendingTasks.completed).toBe(true);
+  });
+
+  it('should wait until all tasks are completed', async () => {
+    const pendingTasks = TestBed.inject(InitialRenderPendingTasks);
+    expect(pendingTasks.completed).toBe(false);
+
+    const taskA = pendingTasks.add();
+    const taskB = pendingTasks.add();
+    const taskC = pendingTasks.add();
+    expect(pendingTasks.completed).toBe(false);
+
+    pendingTasks.remove(taskA);
+    pendingTasks.remove(taskB);
+    pendingTasks.remove(taskC);
+    await pendingTasks.whenAllTasksComplete;
+    expect(pendingTasks.completed).toBe(true);
+  });
+
+  it('should allow calls to remove the same task multiple times', async () => {
+    const pendingTasks = TestBed.inject(InitialRenderPendingTasks);
+    expect(pendingTasks.completed).toBe(false);
+
+    const taskA = pendingTasks.add();
+
+    expect(pendingTasks.completed).toBe(false);
+
+    pendingTasks.remove(taskA);
+    pendingTasks.remove(taskA);
+    pendingTasks.remove(taskA);
+
+    await pendingTasks.whenAllTasksComplete;
+    expect(pendingTasks.completed).toBe(true);
+  });
+
+  it('should be tolerant to removal of non-existent ids', async () => {
+    const pendingTasks = TestBed.inject(InitialRenderPendingTasks);
+    expect(pendingTasks.completed).toBe(false);
+
+    pendingTasks.remove(Math.random());
+    pendingTasks.remove(Math.random());
+    pendingTasks.remove(Math.random());
+
+    await pendingTasks.whenAllTasksComplete;
+    expect(pendingTasks.completed).toBe(true);
+  });
+});

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -282,6 +282,9 @@
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
   },
   {
+    "name": "InitialRenderPendingTasks"
+  },
+  {
     "name": "InjectFlags"
   },
   {
@@ -436,6 +439,9 @@
   },
   {
     "name": "NavigationError"
+  },
+  {
+    "name": "NavigationResult"
   },
   {
     "name": "NavigationSkipped"

--- a/packages/platform-server/test/BUILD.bazel
+++ b/packages/platform-server/test/BUILD.bazel
@@ -23,6 +23,7 @@ ts_library(
         "//packages/common",
         "//packages/common/http",
         "//packages/common/http/testing",
+        "//packages/common/testing",
         "//packages/compiler",
         "//packages/core",
         "//packages/core/testing",
@@ -30,6 +31,7 @@ ts_library(
         "//packages/platform-browser",
         "//packages/platform-server",
         "//packages/private/testing",
+        "//packages/router",
         "@npm//rxjs",
     ],
 )

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -8,12 +8,15 @@
 
 import '@angular/localize/init';
 
-import {CommonModule, DOCUMENT, isPlatformServer, NgComponentOutlet, NgFor, NgIf, NgTemplateOutlet} from '@angular/common';
-import {ApplicationRef, Component, ComponentRef, createComponent, destroyPlatform, Directive, ElementRef, EnvironmentInjector, ErrorHandler, getPlatform, inject, Input, PLATFORM_ID, Provider, TemplateRef, Type, ViewChild, ViewContainerRef, ɵprovideHydrationSupport as provideHydrationSupport, ɵsetDocument} from '@angular/core';
+import {CommonModule, DOCUMENT, isPlatformServer, NgComponentOutlet, NgFor, NgIf, NgTemplateOutlet, PlatformLocation} from '@angular/common';
+import {MockPlatformLocation} from '@angular/common/testing';
+import {ApplicationRef, Component, ComponentRef, createComponent, destroyPlatform, Directive, ElementRef, EnvironmentInjector, ErrorHandler, getPlatform, inject, Input, NgZone, PLATFORM_ID, Provider, TemplateRef, Type, ViewChild, ViewContainerRef, ɵprovideHydrationSupport as provideHydrationSupport, ɵsetDocument} from '@angular/core';
+import {InitialRenderPendingTasks} from '@angular/core/src/initial_render_pending_tasks';
 import {getComponentDef} from '@angular/core/src/render3/definition';
 import {unescapeTransferStateContent} from '@angular/core/src/transfer_state';
 import {TestBed} from '@angular/core/testing';
 import {bootstrapApplication} from '@angular/platform-browser';
+import {provideRouter, RouterOutlet, Routes} from '@angular/router';
 import {first} from 'rxjs/operators';
 
 import {provideServerSupport} from '../public_api';
@@ -91,7 +94,9 @@ function stripExcessiveSpaces(html: string): string {
 
 /** Returns a Promise that resolves when the ApplicationRef becomes stable. */
 function whenStable(appRef: ApplicationRef): Promise<unknown> {
-  return appRef.isStable.pipe(first((isStable: boolean) => isStable)).toPromise();
+  const isStablePromise = appRef.isStable.pipe(first((isStable: boolean) => isStable)).toPromise();
+  const pendingTasksPromise = appRef.injector.get(InitialRenderPendingTasks).whenAllTasksComplete;
+  return Promise.allSettled([isStablePromise, pendingTasksPromise]);
 }
 
 function verifyClientAndSSRContentsMatch(ssrContents: string, clientAppRootElement: HTMLElement) {
@@ -330,7 +335,7 @@ describe('platform-server integration', () => {
     });
 
     describe('hydration', () => {
-      it('should remove ngh attributes after hydation on the client', async () => {
+      it('should remove ngh attributes after hydration on the client', async () => {
         @Component({
           standalone: true,
           selector: 'app',
@@ -3575,6 +3580,69 @@ describe('platform-server integration', () => {
               'During hydration Angular was unable to locate a node using the "firstChild" path, ' +
               'starting from the <projector-cmp>…</projector-cmp> node');
         });
+      });
+    });
+
+    describe('Router', () => {
+      it('should wait for lazy routes before triggering post-hydration cleanup', async () => {
+        const ngZone = TestBed.inject(NgZone);
+
+        @Component({
+          standalone: true,
+          selector: 'lazy',
+          template: `LazyCmp content`,
+        })
+        class LazyCmp {
+        }
+
+        const routes: Routes = [{
+          path: '',
+          loadComponent: () => {
+            return ngZone.runOutsideAngular(() => {
+              return new Promise(resolve => {
+                setTimeout(() => resolve(LazyCmp), 100);
+              });
+            });
+          },
+        }];
+
+        @Component({
+          standalone: true,
+          selector: 'app',
+          imports: [RouterOutlet],
+          template: `
+            Works!
+            <router-outlet />
+          `,
+        })
+        class SimpleComponent {
+        }
+
+        const providers = [
+          {provide: PlatformLocation, useClass: MockPlatformLocation},
+          provideRouter(routes),
+        ] as unknown as Provider[];
+        const html = await ssr(SimpleComponent, undefined, providers);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+        // Expect serialization to happen once a lazy-loaded route completes loading
+        // and a lazy component is rendered.
+        expect(ssrContents).toContain(`<lazy ${NGH_ATTR_NAME}="0">LazyCmp content</lazy>`);
+
+        resetTViewsFor(SimpleComponent, LazyCmp);
+
+        const appRef = await hydrate(html, SimpleComponent, providers);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+
+        await whenStable(appRef);
+
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
       });
     });
   });

--- a/packages/router/src/utils/navigations.ts
+++ b/packages/router/src/utils/navigations.ts
@@ -6,10 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {Observable} from 'rxjs';
 import {filter, map, take} from 'rxjs/operators';
 
-import {NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped} from '../events';
-import {Router} from '../router';
+import {Event, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped} from '../events';
 
 enum NavigationResult {
   COMPLETE,
@@ -26,7 +26,7 @@ enum NavigationResult {
  * redirecting/superseding navigation must finish.
  * - `NavigationError`, `NavigationEnd`, or `NavigationSkipped` event emits
  */
-export function afterNextNavigation(router: Router, action: () => void) {
+export function afterNextNavigation(router: {events: Observable<Event>}, action: () => void) {
   router.events
       .pipe(
           filter(


### PR DESCRIPTION
This commit implements a simple tracker of pending tasks. The class allows adding and removing tasks from the set. The class also exposes a promise that gets resolved once the last task is removed.

This tracker is needed to keep track of ongoing processes like Router navigation (and potentially HTTP requests) and acts as a signaling mechanism to SSR and hydration that the application is in the "stable" state and a serialization can be performed.

This class would also act as a future replacement for the `ApplicationRef.isStable` for zoneless applications.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No