### PR TITLE
feat(core): show warning when nested appRef.isStable() is triggered

### DIFF
--- a/packages/core/test/application_ref_spec.ts
+++ b/packages/core/test/application_ref_spec.ts
@@ -808,6 +808,32 @@ class SomeComponent {
          expectStableTexts(MacroMicroTaskComp, ['111']);
        }));
 
+    it('isStable should show warning when nested call detected', (done: DoneFn) => {
+      const fixture = TestBed.createComponent(MicroMacroTaskComp);
+      const appRef: ApplicationRef = TestBed.inject(ApplicationRef);
+      const zone: NgZone = TestBed.inject(NgZone);
+      appRef.attachView(fixture.componentRef.hostView);
+      zone.run(() => appRef.tick());
+
+      const warnSpy = spyOn(console, 'warn');
+      let count = 0;
+      appRef.isStable.subscribe({
+        next: () => {
+          count++;
+          stableCalled = true;
+          if (count > 5) {
+            return;
+          }
+          if (count === 5) {
+            expect(warnSpy).toHaveBeenCalled();
+            done();
+            return;
+          }
+          zone.run(() => {});
+        }
+      });
+    });
+
     describe('unstable', () => {
       let unstableCalled = false;
 

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -820,6 +820,20 @@ function commonTests() {
            done();
          }, resultTimer);
        });
+
+    it('should not cause infinate loop when call zone.run() in onStable subscriber', () => {
+      let x = 0;
+      const sub = _zone.onStable.subscribe(() => {
+        if (x > 0) {
+          fail('should not be here');
+        }
+        _zone.run(() => {
+          x++;
+        });
+      });
+      runNgZoneNoLog(() => {});
+      sub.unsubscribe();
+    });
   });
 
   describe('exceptions', () => {


### PR DESCRIPTION
Close #49275

When we call `ngZone.run()` inside `ApplicationRef.isStable` subscribe callback, it causes an endless loop, since `ngZone.run()` causes `isStable()` to be emitted again. This is by design, and this PR introduces a `console.warn` in `ngDevMode` to let the user know the possible cause.
