### PR TITLE
feat(core): support Provider type in Injector.create

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -795,7 +795,7 @@ export abstract class Injector {
     // @deprecated (undocumented)
     static create(providers: StaticProvider[], parent?: Injector): Injector;
     static create(options: {
-        providers: StaticProvider[];
+        providers: Array<Provider | StaticProvider>;
         parent?: Injector;
         name?: string;
     }): Injector;

--- a/packages/core/src/di/create_injector.ts
+++ b/packages/core/src/di/create_injector.ts
@@ -10,7 +10,7 @@ import {EMPTY_ARRAY} from '../util/empty';
 import {stringify} from '../util/stringify';
 
 import {Injector} from './injector';
-import {StaticProvider} from './interface/provider';
+import {Provider, StaticProvider} from './interface/provider';
 import {importProvidersFrom} from './provider_collection';
 import {getNullInjector, R3Injector} from './r3_injector';
 import {InjectorScope} from './scope';
@@ -22,7 +22,7 @@ import {InjectorScope} from './scope';
  */
 export function createInjector(
     defType: /* InjectorType<any> */ any, parent: Injector|null = null,
-    additionalProviders: StaticProvider[]|null = null, name?: string): Injector {
+    additionalProviders: Array<Provider|StaticProvider>|null = null, name?: string): Injector {
   const injector =
       createInjectorWithoutInjectorInstances(defType, parent, additionalProviders, name);
   injector.resolveInjectorInitializers();
@@ -36,7 +36,7 @@ export function createInjector(
  */
 export function createInjectorWithoutInjectorInstances(
     defType: /* InjectorType<any> */ any, parent: Injector|null = null,
-    additionalProviders: StaticProvider[]|null = null, name?: string,
+    additionalProviders: Array<Provider|StaticProvider>|null = null, name?: string,
     scopes = new Set<InjectorScope>()): R3Injector {
   const providers = [
     additionalProviders || EMPTY_ARRAY,

--- a/packages/core/src/di/injector.ts
+++ b/packages/core/src/di/injector.ts
@@ -13,7 +13,7 @@ import {InjectorMarkers} from './injector_marker';
 import {INJECTOR} from './injector_token';
 import {ɵɵdefineInjectable} from './interface/defs';
 import {InjectFlags, InjectOptions} from './interface/injector';
-import {StaticProvider} from './interface/provider';
+import {Provider, StaticProvider} from './interface/provider';
 import {NullInjector} from './null_injector';
 import {ProviderToken} from './provider_token';
 
@@ -104,11 +104,14 @@ export abstract class Injector {
    * @returns The new injector instance.
    *
    */
-  static create(options: {providers: StaticProvider[], parent?: Injector, name?: string}): Injector;
+  static create(options:
+                    {providers: Array<Provider|StaticProvider>, parent?: Injector, name?: string}):
+      Injector;
 
 
   static create(
-      options: StaticProvider[]|{providers: StaticProvider[], parent?: Injector, name?: string},
+      options: StaticProvider[]|
+      {providers: Array<Provider|StaticProvider>, parent?: Injector, name?: string},
       parent?: Injector): Injector {
     if (Array.isArray(options)) {
       return createInjector({name: ''}, parent, options, '');


### PR DESCRIPTION
This commit updates the Injector.create function to accept the `Provider` type in addition to the `StaticProvider` type. This should make it easier to work with the Injector.create function and have less type casts if you have a list of `Provider`s available.

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No