### PR TITLE
fix(zone.js): fix several behavior diffs when Promise reject unhandled

### DIFF
--- a/packages/zone.js/lib/node/node.ts
+++ b/packages/zone.js/lib/node/node.ts
@@ -96,17 +96,28 @@ Zone.__load_patch(
       function findProcessPromiseRejectionHandler(evtName: string) {
         return function(e: any) {
           const eventTasks = findEventTasks(process, evtName);
+          let found = false;
           eventTasks.forEach(eventTask => {
             // process has added unhandledrejection event listener
             // trigger the event listener
             if (evtName === 'unhandledRejection') {
-              eventTask.invoke(e.rejection, e.promise);
+              eventTask.invoke(e.reason, e.promise);
+              found = true;
             } else if (evtName === 'rejectionHandled') {
               eventTask.invoke(e.promise);
+              found = true;
             }
           });
+          if (!found && evtName === 'unhandledRejection') {
+            api.onUnhandledError(e);
+          }
         };
       }
+
+      // api.onUnhandledError = function(error: any) {
+      //   const NativePromise = global[api.symbol('Promise')];
+      //   NativePromise?.reject(error?.rejection || error);
+      // }
     });
 
 

--- a/packages/zone.js/test/node/process.spec.ts
+++ b/packages/zone.js/test/node/process.spec.ts
@@ -74,7 +74,7 @@ describe('process related test', () => {
       (Zone as any)[zoneSymbol('ignoreConsoleErrorUncaughtError')] = true;
       Zone.current.fork({name: 'promise'}).run(function() {
         const listener = function(reason: any, promise: any) {
-          hookSpy(promise, reason.message);
+          hookSpy(promise, reason?.rejection?.message);
           process.removeListener('unhandledRejection', listener);
         };
         process.on('unhandledRejection', listener);
@@ -124,11 +124,11 @@ describe('process related test', () => {
       let p: any = null;
       Zone.current.fork({name: 'promise'}).run(function() {
         const listener1 = function(reason: any, promise: any) {
-          hookSpy(promise, reason.message);
+          hookSpy(promise, reason.rejection.message);
           process.removeListener('unhandledRejection', listener1);
         };
         const listener2 = function(reason: any, promise: any) {
-          hookSpy(promise, reason.message);
+          hookSpy(promise, reason.rejection.message);
           process.removeListener('unhandledRejection', listener2);
         };
         process.on('unhandledRejection', listener1);

--- a/packages/zone.js/test/zone-spec/long-stack-trace-zone.spec.ts
+++ b/packages/zone.js/test/zone-spec/long-stack-trace-zone.spec.ts
@@ -152,6 +152,7 @@ describe(
               });
               setTimeout(function() {
                 expectElapsed(log[0].stack!, 5);
+                promise.catch(() => {});
                 done();
               }, 0);
             }, 0);


### PR DESCRIPTION
Close #47562

There are several behavior differences between ZoneAwarePromise and Native Promise.

Such as.

```
Promise.reject(new Error("test error")).finally(() => console.log("finally"));
```

1. Native Promise, will console log `finally` and throw a Promise unhandled error also process exit with code 1.
2. ZoneAwarePromise, will console log `finally` but will not output any uncaught error also process exit with code 0.

This PR fix the issue and make Promise rejection behave the same with the native one.


