### PR TITLE
ci: update pullapprove config to reflect current availability

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -56,8 +56,9 @@
 
 version: 3
 
-# availability:
-#   users_unavailable:
+availability:
+  users_unavailable:
+    - devversion
 
 # Meta field that goes unused by PullApprove to allow for defining aliases to be
 # used throughout the config.


### PR DESCRIPTION
Updating PullApprove to reflect current availability. Looks like it cannot be set via UI anymore...