### PR TITLE
feat(zone.js): allow to cancel microTask

### DIFF
--- a/packages/zone.js/test/common/task.spec.ts
+++ b/packages/zone.js/test/common/task.spec.ts
@@ -801,12 +801,12 @@ describe('task lifecycle', () => {
              ]);
        }));
 
-    it('should throw error when try to cancel a microTask', testFnWithLoggedTransitionTo(() => {
+    it('should be able to cancel a microTask', testFnWithLoggedTransitionTo(() => {
          Zone.current.fork({name: 'testMicroTaskZone'}).run(() => {
            const task = Zone.current.scheduleMicroTask('testMicroTask', () => {}, undefined, noop);
            expect(() => {
              Zone.current.cancelTask(task);
-           }).toThrowError('Task is not cancelable');
+           }).not.toThrow();
          });
        }));
 

--- a/packages/zone.js/test/common/zone.spec.ts
+++ b/packages/zone.js/test/common/zone.spec.ts
@@ -379,6 +379,17 @@ describe('Zone', function() {
       macro.invoke();
     });
 
+    it('should be able to cancel microtask from queue', () => {
+      const z = Zone.current;
+
+      z.scheduleMicroTask('test', () => log.push('microTask'));
+      const task1 = z.scheduleMicroTask('test1', () => log.push('microTask1'));
+      task1.zone.cancelTask(task1);
+      setTimeout(() => {
+        expect(log).toEqual(['microTask']);
+      });
+    });
+
     it('should convert task to json without cyclic error', () => {
       const z = Zone.current;
       const event = z.scheduleEventTask('test', () => {}, undefined, noop, noop);


### PR DESCRIPTION
Zone.js keep a microtaskQueue internally, to run microTask such as `Promise.prototype.then`, and currently we can not cancel a microTask, this PR add the ability to cancel a microTask by `task.zone.cancelTask` and remove the task from the microtaskQueue if the task is not executed.