### PR TITLE
fix(zone.js): onbeforeunload should check return value

### DIFF
--- a/packages/zone.js/lib/common/utils.ts
+++ b/packages/zone.js/lib/common/utils.ts
@@ -150,7 +150,11 @@ const wrapFn = function(this: unknown, event: Event) {
     }
   } else {
     result = listener && listener.apply(this, arguments);
-    if (result != undefined && !result) {
+    if (event.type === 'beforeunload') {
+      // For beforeunload event, we need to set returnValue
+      // so the browser can prompt
+      event.returnValue = result;
+    } else if (result != undefined && !result) {
       event.preventDefault();
     }
   }


### PR DESCRIPTION
Close #47579

onbeforeunload handler return value is used to show confirm or not.

```
window.onbeforeunload = function (e) {
  return 'something';
}
```

But

```
window.addEventListener('beforeunload', function() {
  return 'something';
});
```
Doesn't work.

And currently, zone.js patch all `onProperty` such as `onbeforeunload` to `addEventListener` call, so `onbeforeunload` not working.

So this PR revert the original behavior for `onbeforeunload` event.