### PR TITLE
feat(core): Drop public `factories` property for `IterableDiffers`

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -880,8 +880,6 @@ export class IterableDiffers {
     // (undocumented)
     static create(factories: IterableDifferFactory[], parent?: IterableDiffers): IterableDiffers;
     static extend(factories: IterableDifferFactory[]): StaticProvider;
-    // @deprecated (undocumented)
-    factories: IterableDifferFactory[];
     // (undocumented)
     find(iterable: any): IterableDifferFactory;
     // (undocumented)

--- a/packages/core/src/change_detection/differs/iterable_differs.ts
+++ b/packages/core/src/change_detection/differs/iterable_differs.ts
@@ -195,13 +195,7 @@ export class IterableDiffers {
   static ɵprov = /** @pureOrBreakMyCode */ ɵɵdefineInjectable(
       {token: IterableDiffers, providedIn: 'root', factory: defaultIterableDiffersFactory});
 
-  /**
-   * @deprecated v4.0.0 - Should be private
-   */
-  factories: IterableDifferFactory[];
-  constructor(factories: IterableDifferFactory[]) {
-    this.factories = factories;
-  }
+  constructor(private factories: IterableDifferFactory[]) {}
 
   static create(factories: IterableDifferFactory[], parent?: IterableDiffers): IterableDiffers {
     if (parent != null) {

--- a/packages/core/test/change_detection/differs/iterable_differs_spec.ts
+++ b/packages/core/test/change_detection/differs/iterable_differs_spec.ts
@@ -44,6 +44,7 @@ import {TestBed} from '@angular/core/testing';
       const parent = IterableDiffers.create(<any>[factory1]);
       const child = IterableDiffers.create(<any>[factory2], parent);
 
+      // @ts-expect-error private member
       expect(child.factories).toEqual([factory2, factory1]);
     });
 
@@ -55,7 +56,10 @@ import {TestBed} from '@angular/core/testing';
         const childInjector =
             Injector.create({providers: [IterableDiffers.extend([factory2])], parent: injector});
 
+        // @ts-expect-error factories is a private member
         expect(injector.get<IterableDiffers>(IterableDiffers).factories).toEqual([factory1]);
+
+        // @ts-expect-error factories is a private member
         expect(childInjector.get<IterableDiffers>(IterableDiffers).factories).toEqual([
           factory2, factory1
         ]);

--- a/packages/core/test/change_detection/differs/iterable_differs_spec.ts
+++ b/packages/core/test/change_detection/differs/iterable_differs_spec.ts
@@ -11,9 +11,9 @@ import {TestBed} from '@angular/core/testing';
 
 {
   describe('IterableDiffers', function() {
-    let factory1: any;
-    let factory2: any;
-    let factory3: any;
+    let factory1: jasmine.SpyObj<IterableDifferFactory>;
+    let factory2: jasmine.SpyObj<IterableDifferFactory>;
+    let factory3: jasmine.SpyObj<IterableDifferFactory>;
 
     beforeEach(() => {
       const getFactory = () => jasmine.createSpyObj('IterableDifferFactory', ['supports']);
@@ -33,7 +33,7 @@ import {TestBed} from '@angular/core/testing';
       factory2.supports.and.returnValue(true);
       factory3.supports.and.returnValue(true);
 
-      const differs = IterableDiffers.create(<any>[factory1, factory2, factory3]);
+      const differs = IterableDiffers.create([factory1, factory2, factory3]);
       expect(differs.find('some object')).toBe(factory2);
     });
 
@@ -41,8 +41,8 @@ import {TestBed} from '@angular/core/testing';
       factory1.supports.and.returnValue(true);
       factory2.supports.and.returnValue(false);
 
-      const parent = IterableDiffers.create(<any>[factory1]);
-      const child = IterableDiffers.create(<any>[factory2], parent);
+      const parent = IterableDiffers.create([factory1]);
+      const child = IterableDiffers.create([factory2], parent);
 
       // @ts-expect-error private member
       expect(child.factories).toEqual([factory2, factory1]);
@@ -50,9 +50,9 @@ import {TestBed} from '@angular/core/testing';
 
     describe('.extend()', () => {
       it('should extend di-inherited differs', () => {
-        const parent = new IterableDiffers([factory1]);
+        const differ = new IterableDiffers([factory1]);
         const injector =
-            Injector.create({providers: [{provide: IterableDiffers, useValue: parent}]});
+            Injector.create({providers: [{provide: IterableDiffers, useValue: differ}]});
         const childInjector =
             Injector.create({providers: [IterableDiffers.extend([factory2])], parent: injector});
 


### PR DESCRIPTION
Removing the public from `IterableDiffers`'s `factories` which was deprecated long time ago. Also there is a quick cleanup of the related tests. 

Let me know if the breaking change requires some work.  

## Does this PR introduce a breaking change?

- [x] Yes