### PR TITLE
refactor(common): add missing `override` to satisfy the linter

### DIFF
--- a/packages/common/test/directives/ng_plural_spec.ts
+++ b/packages/common/test/directives/ng_plural_spec.ts
@@ -162,7 +162,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 @Injectable()
 class TestLocalization extends NgLocalization {
-  getPluralCategory(value: number): string {
+  override getPluralCategory(value: number): string {
     if (value > 1 && value < 4) {
       return 'few';
     }

--- a/packages/common/test/pipes/i18n_plural_pipe_spec.ts
+++ b/packages/common/test/pipes/i18n_plural_pipe_spec.ts
@@ -85,7 +85,7 @@ import {TestBed} from '@angular/core/testing';
 }
 
 class TestLocalization extends NgLocalization {
-  getPluralCategory(value: number): string {
+  override getPluralCategory(value: number): string {
     return value > 1 && value < 6 ? 'many' : 'other';
   }
 }

--- a/packages/common/testing/src/mock_location_strategy.ts
+++ b/packages/common/testing/src/mock_location_strategy.ts
@@ -35,18 +35,18 @@ export class MockLocationStrategy extends LocationStrategy {
     this._subject.emit(new _MockPopStateEvent(this.path()));
   }
 
-  path(includeHash: boolean = false): string {
+  override path(includeHash: boolean = false): string {
     return this.internalPath;
   }
 
-  prepareExternalUrl(internal: string): string {
+  override prepareExternalUrl(internal: string): string {
     if (internal.startsWith('/') && this.internalBaseHref.endsWith('/')) {
       return this.internalBaseHref + internal.substring(1);
     }
     return this.internalBaseHref + internal;
   }
 
-  pushState(ctx: any, title: string, path: string, query: string): void {
+  override pushState(ctx: any, title: string, path: string, query: string): void {
     // Add state change to changes array
     this.stateChanges.push(ctx);
 
@@ -59,7 +59,7 @@ export class MockLocationStrategy extends LocationStrategy {
     this.urlChanges.push(externalUrl);
   }
 
-  replaceState(ctx: any, title: string, path: string, query: string): void {
+  override replaceState(ctx: any, title: string, path: string, query: string): void {
     // Reset the last index of stateChanges to the ctx (state) object
     this.stateChanges[(this.stateChanges.length || 1) - 1] = ctx;
 
@@ -72,15 +72,15 @@ export class MockLocationStrategy extends LocationStrategy {
     this.urlChanges.push('replace: ' + externalUrl);
   }
 
-  onPopState(fn: (value: any) => void): void {
+  override onPopState(fn: (value: any) => void): void {
     this._subject.subscribe({next: fn});
   }
 
-  getBaseHref(): string {
+  override getBaseHref(): string {
     return this.internalBaseHref;
   }
 
-  back(): void {
+  override back(): void {
     if (this.urlChanges.length > 0) {
       this.urlChanges.pop();
       this.stateChanges.pop();
@@ -89,11 +89,11 @@ export class MockLocationStrategy extends LocationStrategy {
     }
   }
 
-  forward(): void {
+  override forward(): void {
     throw 'not implemented';
   }
 
-  getState(): unknown {
+  override getState(): unknown {
     return this.stateChanges[(this.stateChanges.length || 1) - 1];
   }
 }

--- a/packages/compiler/test/i18n/integration_common.ts
+++ b/packages/compiler/test/i18n/integration_common.ts
@@ -31,7 +31,7 @@ export class I18nComponent {
 
 export class FrLocalization extends NgLocalization {
   public static PROVIDE = {provide: NgLocalization, useClass: FrLocalization, deps: []};
-  getPluralCategory(value: number): string {
+  override getPluralCategory(value: number): string {
     switch (value) {
       case 0:
       case 1:

--- a/packages/platform-browser/animations/src/animation_builder.ts
+++ b/packages/platform-browser/animations/src/animation_builder.ts
@@ -24,7 +24,7 @@ export class BrowserAnimationBuilder extends AnimationBuilder {
     this._renderer = rootRenderer.createRenderer(doc.body, typeData) as AnimationRenderer;
   }
 
-  build(animation: AnimationMetadata|AnimationMetadata[]): AnimationFactory {
+  override build(animation: AnimationMetadata|AnimationMetadata[]): AnimationFactory {
     const id = this._nextAnimationId.toString();
     this._nextAnimationId++;
     const entry = Array.isArray(animation) ? sequence(animation) : animation;
@@ -38,7 +38,7 @@ export class BrowserAnimationFactory extends AnimationFactory {
     super();
   }
 
-  create(element: any, options?: AnimationOptions): AnimationPlayer {
+  override create(element: any, options?: AnimationOptions): AnimationPlayer {
     return new RendererAnimationPlayer(this._id, element, options || {}, this._renderer);
   }
 }

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -22,7 +22,7 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     setRootDomAdapter(new BrowserDomAdapter());
   }
 
-  onAndCancel(el: Node, evt: any, listener: any): Function {
+  override onAndCancel(el: Node, evt: any, listener: any): Function {
     el.addEventListener(evt, listener, false);
     // Needed to follow Dart's subscription semantic, until fix of
     // https://code.google.com/p/dart/issues/detail?id=17406
@@ -30,35 +30,35 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
       el.removeEventListener(evt, listener, false);
     };
   }
-  dispatchEvent(el: Node, evt: any) {
+  override dispatchEvent(el: Node, evt: any) {
     el.dispatchEvent(evt);
   }
-  remove(node: Node): void {
+  override remove(node: Node): void {
     if (node.parentNode) {
       node.parentNode.removeChild(node);
     }
   }
-  createElement(tagName: string, doc?: Document): HTMLElement {
+  override createElement(tagName: string, doc?: Document): HTMLElement {
     doc = doc || this.getDefaultDocument();
     return doc.createElement(tagName);
   }
-  createHtmlDocument(): Document {
+  override createHtmlDocument(): Document {
     return document.implementation.createHTMLDocument('fakeTitle');
   }
-  getDefaultDocument(): Document {
+  override getDefaultDocument(): Document {
     return document;
   }
 
-  isElementNode(node: Node): boolean {
+  override isElementNode(node: Node): boolean {
     return node.nodeType === Node.ELEMENT_NODE;
   }
 
-  isShadowRoot(node: any): boolean {
+  override isShadowRoot(node: any): boolean {
     return node instanceof DocumentFragment;
   }
 
   /** @deprecated No longer being used in Ivy code. To be removed in version 14. */
-  getGlobalEventTarget(doc: Document, target: string): EventTarget|null {
+  override getGlobalEventTarget(doc: Document, target: string): EventTarget|null {
     if (target === 'window') {
       return window;
     }
@@ -70,17 +70,17 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
     }
     return null;
   }
-  getBaseHref(doc: Document): string|null {
+  override getBaseHref(doc: Document): string|null {
     const href = getBaseElementHref();
     return href == null ? null : relativePath(href);
   }
-  resetBaseElement(): void {
+  override resetBaseElement(): void {
     baseElement = null;
   }
-  getUserAgent(): string {
+  override getUserAgent(): string {
     return window.navigator.userAgent;
   }
-  getCookie(name: string): string|null {
+  override getCookie(name: string): string|null {
     return parseCookieValue(document.cookie, name);
   }
 }

--- a/packages/platform-browser/src/browser/generic_browser_adapter.ts
+++ b/packages/platform-browser/src/browser/generic_browser_adapter.ts
@@ -17,5 +17,5 @@ import {ɵDomAdapter as DomAdapter} from '@angular/common';
  * can introduce XSS risks.
  */
 export abstract class GenericBrowserDomAdapter extends DomAdapter {
-  readonly supportsDOMEvents: boolean = true;
+  override readonly supportsDOMEvents: boolean = true;
 }


### PR DESCRIPTION
When running `yarn lint` locally, the linter was complaining for several missing `override` Any idea why ? 

Anyway, here are the fixes for the complaints, they were in common, compiler and platform-browser. 