### PR TITLE
refactor(core): Remove usage of deprecated `Injector.create()`

### DIFF
--- a/packages/benchpress/src/runner.ts
+++ b/packages/benchpress/src/runner.ts
@@ -61,7 +61,7 @@ export class Runner {
       sampleProviders.push(providers);
     }
 
-    const inj = Injector.create(sampleProviders);
+    const inj = Injector.create({providers: sampleProviders});
     const adapter: WebDriverAdapter = inj.get(WebDriverAdapter);
 
     return Promise
@@ -75,11 +75,13 @@ export class Runner {
           // Only WebDriverAdapter is reused.
           // TODO(vsavkin): consider changing it when toAsyncFactory is added back or when child
           // injectors are handled better.
-          const injector = Injector.create([
-            sampleProviders, {provide: Options.CAPABILITIES, useValue: capabilities},
-            {provide: Options.USER_AGENT, useValue: userAgent},
-            {provide: WebDriverAdapter, useValue: adapter}
-          ]);
+          const injector = Injector.create({
+            providers: [
+              sampleProviders, {provide: Options.CAPABILITIES, useValue: capabilities},
+              {provide: Options.USER_AGENT, useValue: userAgent},
+              {provide: WebDriverAdapter, useValue: adapter}
+            ]
+          });
 
           // TODO: With TypeScript 2.5 injector.get does not infer correctly the
           // return type. Remove 'any' and investigate the issue.

--- a/packages/benchpress/test/metric/multi_metric_spec.ts
+++ b/packages/benchpress/test/metric/multi_metric_spec.ts
@@ -11,10 +11,12 @@ import {Injector, Metric, MultiMetric} from '../../index';
 (function() {
 function createMetric(ids: any[]) {
   const m = Injector
-                .create([
-                  ids.map(id => ({provide: id, useValue: new MockMetric(id)})),
-                  MultiMetric.provideWith(ids)
-                ])
+                .create({
+                  providers: [
+                    ids.map(id => ({provide: id, useValue: new MockMetric(id)})),
+                    MultiMetric.provideWith(ids)
+                  ]
+                })
                 .get<MultiMetric>(MultiMetric);
   return Promise.resolve(m);
 }

--- a/packages/benchpress/test/metric/perflog_metric_spec.ts
+++ b/packages/benchpress/test/metric/perflog_metric_spec.ts
@@ -62,7 +62,7 @@ function createMetric(
   if (ignoreNavigation != null) {
     providers.push({provide: PerflogMetric.IGNORE_NAVIGATION, useValue: ignoreNavigation});
   }
-  return Injector.create(providers).get(PerflogMetric);
+  return Injector.create({providers}).get(PerflogMetric);
 }
 
 describe('perflog metric', () => {

--- a/packages/benchpress/test/metric/user_metric_spec.ts
+++ b/packages/benchpress/test/metric/user_metric_spec.ts
@@ -29,7 +29,7 @@ function createMetric(
     {provide: Options.USER_METRICS, useValue: userMetrics},
     {provide: WebDriverAdapter, useValue: wdAdapter}
   ];
-  return Injector.create(providers).get(UserMetric);
+  return Injector.create({providers}).get(UserMetric);
 }
 
 describe('user metric', () => {

--- a/packages/benchpress/test/reporter/json_file_reporter_spec.ts
+++ b/packages/benchpress/test/reporter/json_file_reporter_spec.ts
@@ -32,7 +32,7 @@ import {Injector, JsonFileReporter, MeasureValues, Options, SampleDescription} f
           }
         }
       ];
-      return Injector.create(providers).get<JsonFileReporter>(JsonFileReporter);
+      return Injector.create({providers}).get<JsonFileReporter>(JsonFileReporter);
     }
 
     it('should write all data into a file', done => {

--- a/packages/benchpress/test/reporter/multi_reporter_spec.ts
+++ b/packages/benchpress/test/reporter/multi_reporter_spec.ts
@@ -11,10 +11,12 @@ import {Injector, MeasureValues, MultiReporter, Reporter} from '../../index';
 (function() {
 function createReporters(ids: any[]) {
   const r = Injector
-                .create([
-                  ids.map(id => ({provide: id, useValue: new MockReporter(id)})),
-                  MultiReporter.provideWith(ids)
-                ])
+                .create({
+                  providers: [
+                    ids.map(id => ({provide: id, useValue: new MockReporter(id)})),
+                    MultiReporter.provideWith(ids)
+                  ]
+                })
                 .get<MultiReporter>(MultiReporter);
   return Promise.resolve(r);
 }

--- a/packages/benchpress/test/sampler_spec.ts
+++ b/packages/benchpress/test/sampler_spec.ts
@@ -42,7 +42,7 @@ import {Injector, MeasureValues, Metric, Options, Reporter, Sampler, Validator, 
         providers.push({provide: Options.PREPARE, useValue: prepare});
       }
 
-      sampler = Injector.create(providers).get(Sampler);
+      sampler = Injector.create({providers}).get(Sampler);
     }
 
     it('should call the prepare and execute callbacks using WebDriverAdapter.waitFor', done => {

--- a/packages/benchpress/test/validator/regression_slope_validator_spec.ts
+++ b/packages/benchpress/test/validator/regression_slope_validator_spec.ts
@@ -14,11 +14,13 @@ import {Injector, MeasureValues, RegressionSlopeValidator} from '../../index';
 
     function createValidator({size, metric}: {size: number, metric: string}) {
       validator = Injector
-                      .create([
-                        RegressionSlopeValidator.PROVIDERS,
-                        {provide: RegressionSlopeValidator.METRIC, useValue: metric},
-                        {provide: RegressionSlopeValidator.SAMPLE_SIZE, useValue: size}
-                      ])
+                      .create({
+                        providers: [
+                          RegressionSlopeValidator.PROVIDERS,
+                          {provide: RegressionSlopeValidator.METRIC, useValue: metric},
+                          {provide: RegressionSlopeValidator.SAMPLE_SIZE, useValue: size}
+                        ]
+                      })
                       .get(RegressionSlopeValidator);
     }
 

--- a/packages/benchpress/test/validator/size_validator_spec.ts
+++ b/packages/benchpress/test/validator/size_validator_spec.ts
@@ -15,8 +15,10 @@ import {Injector, MeasureValues, SizeValidator} from '../../index';
     function createValidator(size: number) {
       validator =
           Injector
-              .create(
-                  [SizeValidator.PROVIDERS, {provide: SizeValidator.SAMPLE_SIZE, useValue: size}])
+              .create({
+                providers:
+                    [SizeValidator.PROVIDERS, {provide: SizeValidator.SAMPLE_SIZE, useValue: size}]
+              })
               .get(SizeValidator);
     }
 

--- a/packages/benchpress/test/web_driver_extension_spec.ts
+++ b/packages/benchpress/test/web_driver_extension_spec.ts
@@ -13,11 +13,13 @@ function createExtension(ids: any[], caps: any) {
   return new Promise<any>((res, rej) => {
     try {
       res(Injector
-              .create([
-                ids.map((id) => ({provide: id, useValue: new MockExtension(id)})),
-                {provide: Options.CAPABILITIES, useValue: caps},
-                WebDriverExtension.provideFirstSupported(ids)
-              ])
+              .create({
+                providers: [
+                  ids.map((id) => ({provide: id, useValue: new MockExtension(id)})),
+                  {provide: Options.CAPABILITIES, useValue: caps},
+                  WebDriverExtension.provideFirstSupported(ids)
+                ]
+              })
               .get(WebDriverExtension));
     } catch (e) {
       rej(e);

--- a/packages/benchpress/test/webdriver/chrome_driver_extension_spec.ts
+++ b/packages/benchpress/test/webdriver/chrome_driver_extension_spec.ts
@@ -40,14 +40,16 @@ import {TraceEventFactory} from '../trace_event_factory';
       }
       log = [];
       extension = Injector
-                      .create([
-                        ChromeDriverExtension.PROVIDERS, {
-                          provide: WebDriverAdapter,
-                          useValue: new MockDriverAdapter(log, perfRecords, messageMethod)
-                        },
-                        {provide: Options.USER_AGENT, useValue: userAgent},
-                        {provide: Options.RAW_PERFLOG_PATH, useValue: null}
-                      ])
+                      .create({
+                        providers: [
+                          ChromeDriverExtension.PROVIDERS, {
+                            provide: WebDriverAdapter,
+                            useValue: new MockDriverAdapter(log, perfRecords, messageMethod)
+                          },
+                          {provide: Options.USER_AGENT, useValue: userAgent},
+                          {provide: Options.RAW_PERFLOG_PATH, useValue: null}
+                        ]
+                      })
                       .get(ChromeDriverExtension);
       return extension;
     }

--- a/packages/benchpress/test/webdriver/ios_driver_extension_spec.ts
+++ b/packages/benchpress/test/webdriver/ios_driver_extension_spec.ts
@@ -23,10 +23,12 @@ import {TraceEventFactory} from '../trace_event_factory';
       log = [];
       extension =
           Injector
-              .create([
-                IOsDriverExtension.PROVIDERS,
-                {provide: WebDriverAdapter, useValue: new MockDriverAdapter(log, perfRecords)}
-              ])
+              .create({
+                providers: [
+                  IOsDriverExtension.PROVIDERS,
+                  {provide: WebDriverAdapter, useValue: new MockDriverAdapter(log, perfRecords)}
+                ]
+              })
               .get(IOsDriverExtension);
       return extension;
     }

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -2428,7 +2428,7 @@ describe('di', () => {
       }
 
       const testBedInjector: Injector = TestBed.get(Injector);
-      const childInjector = Injector.create([], testBedInjector);
+      const childInjector = Injector.create({providers: [], parent: testBedInjector});
 
       const anyService = childInjector.get(AnyService);
       expect(anyService.injector).toBe(childInjector);

--- a/packages/core/test/acceptance/providers_spec.ts
+++ b/packages/core/test/acceptance/providers_spec.ts
@@ -666,14 +666,15 @@ describe('providers', () => {
     class OtherService {}
 
     it('should support Optional flag in deps', () => {
-      const injector =
-          Injector.create([{provide: MyService, deps: [[new Optional(), OtherService]]}]);
+      const injector = Injector.create(
+          {providers: [{provide: MyService, deps: [[new Optional(), OtherService]]}]});
 
       expect(injector.get(MyService).value).toBe(null);
     });
 
     it('should support Optional flag in deps without instantiating it', () => {
-      const injector = Injector.create([{provide: MyService, deps: [[Optional, OtherService]]}]);
+      const injector =
+          Injector.create({providers: [{provide: MyService, deps: [[Optional, OtherService]]}]});
 
       expect(injector.get(MyService).value).toBe(null);
     });

--- a/packages/core/test/change_detection/differs/iterable_differs_spec.ts
+++ b/packages/core/test/change_detection/differs/iterable_differs_spec.ts
@@ -50,8 +50,10 @@ import {TestBed} from '@angular/core/testing';
     describe('.extend()', () => {
       it('should extend di-inherited differs', () => {
         const parent = new IterableDiffers([factory1]);
-        const injector = Injector.create([{provide: IterableDiffers, useValue: parent}]);
-        const childInjector = Injector.create([IterableDiffers.extend([factory2])], injector);
+        const injector =
+            Injector.create({providers: [{provide: IterableDiffers, useValue: parent}]});
+        const childInjector =
+            Injector.create({providers: [IterableDiffers.extend([factory2])], parent: injector});
 
         expect(injector.get<IterableDiffers>(IterableDiffers).factories).toEqual([factory1]);
         expect(childInjector.get<IterableDiffers>(IterableDiffers).factories).toEqual([

--- a/packages/core/test/di/static_injector_spec.ts
+++ b/packages/core/test/di/static_injector_spec.ts
@@ -38,8 +38,8 @@ class SportsCar extends Car {
 {
   describe('child', () => {
     it('should load instances from parent injector', () => {
-      const parent = Injector.create([Engine.PROVIDER]);
-      const child = Injector.create([], parent);
+      const parent = Injector.create({providers: [Engine.PROVIDER]});
+      const child = Injector.create({providers: [], parent});
 
       const engineFromParent = parent.get(Engine);
       const engineFromChild = child.get(Engine);
@@ -49,16 +49,16 @@ class SportsCar extends Car {
 
     it('should not use the child providers when resolving the dependencies of a parent provider',
        () => {
-         const parent = Injector.create([Car.PROVIDER, Engine.PROVIDER]);
-         const child = Injector.create([TurboEngine.PROVIDER], parent);
+         const parent = Injector.create({providers: [Car.PROVIDER, Engine.PROVIDER]});
+         const child = Injector.create({providers: [TurboEngine.PROVIDER], parent});
 
          const carFromChild = child.get<Car>(Car);
          expect(carFromChild.engine).toBeAnInstanceOf(Engine);
        });
 
     it('should create new instance in a child injector', () => {
-      const parent = Injector.create([Engine.PROVIDER]);
-      const child = Injector.create([TurboEngine.PROVIDER], parent);
+      const parent = Injector.create({providers: [Engine.PROVIDER]});
+      const child = Injector.create({providers: [TurboEngine.PROVIDER], parent});
 
       const engineFromParent = parent.get(Engine);
       const engineFromChild = child.get(Engine);
@@ -68,8 +68,8 @@ class SportsCar extends Car {
     });
 
     it('should give access to parent', () => {
-      const parent = Injector.create([]);
-      const child = Injector.create([], parent);
+      const parent = Injector.create({providers: []});
+      const child = Injector.create({providers: [], parent});
       expect((child as any).parent).toBe(parent);
     });
   });
@@ -77,8 +77,8 @@ class SportsCar extends Car {
 
   describe('instantiate', () => {
     it('should instantiate an object in the context of the injector', () => {
-      const inj = Injector.create([Engine.PROVIDER]);
-      const childInj = Injector.create([Car.PROVIDER], inj);
+      const inj = Injector.create({providers: [Engine.PROVIDER]});
+      const childInj = Injector.create({providers: [Car.PROVIDER], parent: inj});
       const car = childInj.get<Car>(Car);
       expect(car).toBeAnInstanceOf(Car);
       expect(car.engine).toBe(inj.get(Engine));
@@ -88,19 +88,23 @@ class SportsCar extends Car {
   describe('dependency resolution', () => {
     describe('@Self()', () => {
       it('should return a dependency from self', () => {
-        const inj = Injector.create([
-          Engine.PROVIDER,
-          {provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[Engine, new Self()]]}
-        ]);
+        const inj = Injector.create({
+          providers: [
+            Engine.PROVIDER,
+            {provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[Engine, new Self()]]}
+          ]
+        });
 
         expect(inj.get(Car)).toBeAnInstanceOf(Car);
       });
 
       it('should throw when not requested provider on self', () => {
-        const parent = Injector.create([Engine.PROVIDER]);
-        const child = Injector.create(
-            [{provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[Engine, new Self()]]}],
-            parent);
+        const parent = Injector.create({providers: [Engine.PROVIDER]});
+        const child = Injector.create({
+          providers:
+              [{provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[Engine, new Self()]]}],
+          parent
+        });
 
         expect(() => child.get(Car))
             .toThrowError(
@@ -110,26 +114,26 @@ class SportsCar extends Car {
 
       it('should return a default value when not requested provider on self', () => {
         const car = new SportsCar(new Engine());
-        const injector = Injector.create([]);
+        const injector = Injector.create({providers: []});
         expect(injector.get<Car|null>(Car, null, InjectFlags.Self)).toBeNull();
         expect(injector.get<Car>(Car, car, InjectFlags.Self)).toBe(car);
       });
 
       it('should return a default value when not requested provider on self and optional', () => {
         const flags = InjectFlags.Self | InjectFlags.Optional;
-        const injector = Injector.create([]);
+        const injector = Injector.create({providers: []});
         expect(injector.get<Car|null>(Car, null, InjectFlags.Self)).toBeNull();
         expect(injector.get<Car|number>(Car, 0, flags)).toBe(0);
       });
 
       it(`should return null when not requested provider on self and optional`, () => {
         const flags = InjectFlags.Self | InjectFlags.Optional;
-        const injector = Injector.create([]);
+        const injector = Injector.create({providers: []});
         expect(injector.get<Car|null>(Car, undefined, flags)).toBeNull();
       });
 
       it('should throw error when not requested provider on self', () => {
-        const injector = Injector.create([]);
+        const injector = Injector.create({providers: []});
         expect(() => injector.get(Car, undefined, InjectFlags.Self))
             .toThrowError(
                 `R3InjectorError[${stringify(Car)}]: \n` +
@@ -139,13 +143,14 @@ class SportsCar extends Car {
 
     describe('default', () => {
       it('should skip self', () => {
-        const parent = Injector.create([Engine.PROVIDER]);
-        const child = Injector.create(
-            [
-              TurboEngine.PROVIDER,
-              {provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[SkipSelf, Engine]]}
-            ],
-            parent);
+        const parent = Injector.create({providers: [Engine.PROVIDER]});
+        const child = Injector.create({
+          providers: [
+            TurboEngine.PROVIDER,
+            {provide: Car, useFactory: (e: Engine) => new Car(e), deps: [[SkipSelf, Engine]]}
+          ],
+          parent
+        });
 
         expect(child.get<Car>(Car).engine).toBeAnInstanceOf(Engine);
       });
@@ -166,21 +171,27 @@ class SportsCar extends Car {
     });
 
     it('should resolve forward references', () => {
-      const injector = Injector.create([
-        [{provide: forwardRef(() => BrokenEngine), useClass: forwardRef(() => Engine), deps: []}], {
-          provide: forwardRef(() => String),
-          useFactory: (e: any) => e,
-          deps: [forwardRef(() => BrokenEngine)]
-        }
-      ]);
+      const injector = Injector.create({
+        providers: [
+          [{provide: forwardRef(() => BrokenEngine), useClass: forwardRef(() => Engine), deps: []}],
+          {
+            provide: forwardRef(() => String),
+            useFactory: (e: any) => e,
+            deps: [forwardRef(() => BrokenEngine)]
+          }
+        ]
+      });
       expect(injector.get(String)).toBeAnInstanceOf(Engine);
       expect(injector.get(BrokenEngine)).toBeAnInstanceOf(Engine);
     });
 
     it('should support overriding factory dependencies with dependency annotations', () => {
-      const injector = Injector.create([
-        Engine.PROVIDER, {provide: 'token', useFactory: (e: any) => e, deps: [[new Inject(Engine)]]}
-      ]);
+      const injector = Injector.create({
+        providers: [
+          Engine.PROVIDER,
+          {provide: 'token', useFactory: (e: any) => e, deps: [[new Inject(Engine)]]}
+        ]
+      });
 
       expect(injector.get('token')).toBeAnInstanceOf(Engine);
     });
@@ -188,7 +199,9 @@ class SportsCar extends Car {
 
   describe('displayName', () => {
     it('should work', () => {
-      expect(Injector.create([Engine.PROVIDER, {provide: BrokenEngine, useValue: null}]).toString())
+      expect(
+          Injector.create({providers: [Engine.PROVIDER, {provide: BrokenEngine, useValue: null}]})
+              .toString())
           .toEqual(
               'R3Injector[Engine, BrokenEngine, InjectionToken INJECTOR, InjectionToken INJECTOR_DEF_TYPES, InjectionToken ENVIRONMENT_INITIALIZER]');
     });

--- a/packages/core/test/linker/integration_spec.ts
+++ b/packages/core/test/linker/integration_spec.ts
@@ -2090,7 +2090,8 @@ class DynamicViewport {
     const myService = new MyService();
     myService.greeting = 'dynamic greet';
 
-    this.injector = Injector.create([{provide: MyService, useValue: myService}], vc.injector);
+    this.injector = Injector.create(
+        {providers: [{provide: MyService, useValue: myService}], parent: vc.injector});
     this.componentFactory =
         componentFactoryResolver.resolveComponentFactory(ChildCompUsingService)!;
   }

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -107,9 +107,11 @@ describe('ComponentFactory', () => {
 
     describe('(when `ngModuleRef` is not provided)', () => {
       it('should retrieve `RendererFactory2` from the specified injector', () => {
-        const injector = Injector.create([
-          {provide: RendererFactory2, useValue: rendererFactorySpy},
-        ]);
+        const injector = Injector.create({
+          providers: [
+            {provide: RendererFactory2, useValue: rendererFactorySpy},
+          ]
+        });
 
         cf.create(injector);
 
@@ -118,10 +120,12 @@ describe('ComponentFactory', () => {
 
       it('should retrieve `Sanitizer` from the specified injector', () => {
         const sanitizerFactorySpy = jasmine.createSpy('sanitizerFactory').and.returnValue({});
-        const injector = Injector.create([
-          {provide: RendererFactory2, useValue: rendererFactorySpy},
-          {provide: Sanitizer, useFactory: sanitizerFactorySpy, deps: []},
-        ]);
+        const injector = Injector.create({
+          providers: [
+            {provide: RendererFactory2, useValue: rendererFactorySpy},
+            {provide: Sanitizer, useFactory: sanitizerFactorySpy, deps: []},
+          ]
+        });
 
         cf.create(injector);
 
@@ -131,10 +135,12 @@ describe('ComponentFactory', () => {
 
     describe('(when `ngModuleRef` is provided)', () => {
       it('should retrieve `RendererFactory2` from the specified injector first', () => {
-        const injector = Injector.create([
-          {provide: RendererFactory2, useValue: rendererFactorySpy},
-        ]);
-        const mInjector = Injector.create([THROWING_RENDERER_FACTOR2_PROVIDER]);
+        const injector = Injector.create({
+          providers: [
+            {provide: RendererFactory2, useValue: rendererFactorySpy},
+          ]
+        });
+        const mInjector = Injector.create({providers: [THROWING_RENDERER_FACTOR2_PROVIDER]});
 
         cf.create(injector, undefined, undefined, {injector: mInjector} as NgModuleRef<any>);
 
@@ -143,10 +149,12 @@ describe('ComponentFactory', () => {
 
       it('should retrieve `RendererFactory2` from the `ngModuleRef` if not provided by the injector',
          () => {
-           const injector = Injector.create([]);
-           const mInjector = Injector.create([
-             {provide: RendererFactory2, useValue: rendererFactorySpy},
-           ]);
+           const injector = Injector.create({providers: []});
+           const mInjector = Injector.create({
+             providers: [
+               {provide: RendererFactory2, useValue: rendererFactorySpy},
+             ]
+           });
 
            cf.create(injector, undefined, undefined, {injector: mInjector} as NgModuleRef<any>);
 
@@ -156,16 +164,20 @@ describe('ComponentFactory', () => {
       it('should retrieve `Sanitizer` from the specified injector first', () => {
         const iSanitizerFactorySpy =
             jasmine.createSpy('Injector#sanitizerFactory').and.returnValue({});
-        const injector = Injector.create([
-          {provide: Sanitizer, useFactory: iSanitizerFactorySpy, deps: []},
-        ]);
+        const injector = Injector.create({
+          providers: [
+            {provide: Sanitizer, useFactory: iSanitizerFactorySpy, deps: []},
+          ]
+        });
 
         const mSanitizerFactorySpy =
             jasmine.createSpy('NgModuleRef#sanitizerFactory').and.returnValue({});
-        const mInjector = Injector.create([
-          {provide: RendererFactory2, useValue: rendererFactorySpy},
-          {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
-        ]);
+        const mInjector = Injector.create({
+          providers: [
+            {provide: RendererFactory2, useValue: rendererFactorySpy},
+            {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
+          ]
+        });
 
         cf.create(injector, undefined, undefined, {injector: mInjector} as NgModuleRef<any>);
 
@@ -175,14 +187,16 @@ describe('ComponentFactory', () => {
 
       it('should retrieve `Sanitizer` from the `ngModuleRef` if not provided by the injector',
          () => {
-           const injector = Injector.create([]);
+           const injector = Injector.create({providers: []});
 
            const mSanitizerFactorySpy =
                jasmine.createSpy('NgModuleRef#sanitizerFactory').and.returnValue({});
-           const mInjector = Injector.create([
-             {provide: RendererFactory2, useValue: rendererFactorySpy},
-             {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
-           ]);
+           const mInjector = Injector.create({
+             providers: [
+               {provide: RendererFactory2, useValue: rendererFactorySpy},
+               {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
+             ]
+           });
 
 
            cf.create(injector, undefined, undefined, {injector: mInjector} as NgModuleRef<any>);
@@ -193,10 +207,14 @@ describe('ComponentFactory', () => {
 
     describe('(when the factory is bound to a `ngModuleRef`)', () => {
       it('should retrieve `RendererFactory2` from the specified injector first', () => {
-        const injector = Injector.create([
-          {provide: RendererFactory2, useValue: rendererFactorySpy},
-        ]);
-        (cf as any).ngModule = {injector: Injector.create([THROWING_RENDERER_FACTOR2_PROVIDER])};
+        const injector = Injector.create({
+          providers: [
+            {provide: RendererFactory2, useValue: rendererFactorySpy},
+          ]
+        });
+        (cf as any).ngModule = {
+          injector: Injector.create({providers: [THROWING_RENDERER_FACTOR2_PROVIDER]})
+        };
 
         cf.create(injector);
 
@@ -205,11 +223,13 @@ describe('ComponentFactory', () => {
 
       it('should retrieve `RendererFactory2` from the `ngModuleRef` if not provided by the injector',
          () => {
-           const injector = Injector.create([]);
+           const injector = Injector.create({providers: []});
            (cf as any).ngModule = {
-             injector: Injector.create([
-               {provide: RendererFactory2, useValue: rendererFactorySpy},
-             ])
+             injector: Injector.create({
+               providers: [
+                 {provide: RendererFactory2, useValue: rendererFactorySpy},
+               ]
+             })
            };
 
            cf.create(injector);
@@ -220,17 +240,21 @@ describe('ComponentFactory', () => {
       it('should retrieve `Sanitizer` from the specified injector first', () => {
         const iSanitizerFactorySpy =
             jasmine.createSpy('Injector#sanitizerFactory').and.returnValue({});
-        const injector = Injector.create([
-          {provide: RendererFactory2, useValue: rendererFactorySpy},
-          {provide: Sanitizer, useFactory: iSanitizerFactorySpy, deps: []},
-        ]);
+        const injector = Injector.create({
+          providers: [
+            {provide: RendererFactory2, useValue: rendererFactorySpy},
+            {provide: Sanitizer, useFactory: iSanitizerFactorySpy, deps: []},
+          ]
+        });
 
         const mSanitizerFactorySpy =
             jasmine.createSpy('NgModuleRef#sanitizerFactory').and.returnValue({});
         (cf as any).ngModule = {
-          injector: Injector.create([
-            {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
-          ])
+          injector: Injector.create({
+            providers: [
+              {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
+            ]
+          })
         };
 
         cf.create(injector);
@@ -241,15 +265,17 @@ describe('ComponentFactory', () => {
 
       it('should retrieve `Sanitizer` from the `ngModuleRef` if not provided by the injector',
          () => {
-           const injector = Injector.create([]);
+           const injector = Injector.create({providers: []});
 
            const mSanitizerFactorySpy =
                jasmine.createSpy('NgModuleRef#sanitizerFactory').and.returnValue({});
            (cf as any).ngModule = {
-             injector: Injector.create([
-               {provide: RendererFactory2, useValue: rendererFactorySpy},
-               {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
-             ])
+             injector: Injector.create({
+               providers: [
+                 {provide: RendererFactory2, useValue: rendererFactorySpy},
+                 {provide: Sanitizer, useFactory: mSanitizerFactorySpy, deps: []},
+               ]
+             })
            };
 
 
@@ -270,9 +296,11 @@ describe('ComponentFactory', () => {
         }
       }
 
-      const injector = Injector.create([
-        {provide: RendererFactory2, useFactory: () => new TestMockRendererFactory(), deps: []},
-      ]);
+      const injector = Injector.create({
+        providers: [
+          {provide: RendererFactory2, useFactory: () => new TestMockRendererFactory(), deps: []},
+        ]
+      });
 
       const hostNode = document.createElement('div');
       const componentRef = cf.create(injector, undefined, hostNode);

--- a/packages/platform-browser-dynamic/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/src/compiler_factory.ts
@@ -44,25 +44,27 @@ export class JitCompilerFactory implements CompilerFactory {
   }
   createCompiler(options: CompilerOptions[] = []): Compiler {
     const opts = _mergeOptions(this._defaultOptions.concat(options));
-    const injector = Injector.create([
-      COMPILER_PROVIDERS, {
-        provide: CompilerConfig,
-        useFactory: () => {
-          return new CompilerConfig({
-            // let explicit values from the compiler options overwrite options
-            // from the app providers
-            useJit: opts.useJit,
-            // let explicit values from the compiler options overwrite options
-            // from the app providers
-            defaultEncapsulation: opts.defaultEncapsulation,
-            missingTranslation: opts.missingTranslation,
-            preserveWhitespaces: opts.preserveWhitespaces,
-          });
+    const injector = Injector.create({
+      providers: [
+        COMPILER_PROVIDERS, {
+          provide: CompilerConfig,
+          useFactory: () => {
+            return new CompilerConfig({
+              // let explicit values from the compiler options overwrite options
+              // from the app providers
+              useJit: opts.useJit,
+              // let explicit values from the compiler options overwrite options
+              // from the app providers
+              defaultEncapsulation: opts.defaultEncapsulation,
+              missingTranslation: opts.missingTranslation,
+              preserveWhitespaces: opts.preserveWhitespaces,
+            });
+          },
+          deps: []
         },
-        deps: []
-      },
-      opts.providers!
-    ]);
+        opts.providers!
+      ]
+    });
     return injector.get(Compiler);
   }
 }

--- a/packages/platform-browser/test/browser/tools/tools_spec.ts
+++ b/packages/platform-browser/test/browser/tools/tools_spec.ts
@@ -7,6 +7,7 @@
  */
 
 import {ApplicationRef, Injector, ɵglobal as global} from '@angular/core';
+import {ComponentRef} from '@angular/core/src/render3';
 import {disableDebugTools, enableDebugTools} from '@angular/platform-browser';
 
 {
@@ -19,13 +20,15 @@ import {disableDebugTools, enableDebugTools} from '@angular/platform-browser';
 
     beforeEach(() => {
       enableDebugTools({
-        injector: Injector.create([{
-          provide: ApplicationRef,
-          useValue: jasmine.createSpyObj(
-              'ApplicationRef', ['bootstrap', 'tick', 'attachView', 'detachView']),
-          deps: []
-        }])
-      } as any);
+        injector: Injector.create({
+          providers: [{
+            provide: ApplicationRef,
+            useValue: jasmine.createSpyObj(
+                'ApplicationRef', ['bootstrap', 'tick', 'attachView', 'detachView']),
+            deps: []
+          }]
+        })
+      } as ComponentRef<any>);
     });
 
     afterEach(() => {


### PR DESCRIPTION
This commit removes all usages of the deprecated `Injector.create` method but does not remove the deprecated signature itself.

Question also, would a migration be required to remove the deprecated overload ? 