### PR TITLE
fix(core): ComponentRef.setInput only sets input when not equal to pr…

### DIFF
--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -256,7 +256,7 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
   override hostView: ViewRef<T>;
   override changeDetectorRef: ChangeDetectorRef;
   override componentType: Type<T>;
-  private setInputHistory: {[name: string]: unknown}|null = null;
+  private previousInputValues: Map<string, unknown>|null = null;
 
   constructor(
       componentType: Type<T>, instance: T, public location: ElementRef, private _rootLView: LView,
@@ -271,17 +271,17 @@ export class ComponentRef<T> extends AbstractComponentRef<T> {
     const inputData = this._tNode.inputs;
     let dataValue: PropertyAliasValue|undefined;
     if (inputData !== null && (dataValue = inputData[name])) {
-      this.setInputHistory ??= {};
+      this.previousInputValues ??= new Map();
       // Do not set the input if it is the same as the last value
       // This behavior matches `bindingUpdated` when binding inputs in templates.
-      if (this.setInputHistory.hasOwnProperty(name) &&
-          Object.is(this.setInputHistory[name], value)) {
+      if (this.previousInputValues.has(name) &&
+          Object.is(this.previousInputValues.get(name), value)) {
         return;
       }
 
       const lView = this._rootLView;
       setInputsForProperty(lView[TVIEW], lView, dataValue, name, value);
-      this.setInputHistory[name] = value;
+      this.previousInputValues.set(name, value);
       markDirtyIfOnPush(lView, this._tNode.index);
     } else {
       if (ngDevMode) {

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -369,5 +369,28 @@ describe('ComponentFactory', () => {
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('pushed');
     });
+
+    it('should not set input if value is the same as the previous', () => {
+      let log: string[] = [];
+      @Component({
+        template: `{{in}}`,
+        standalone: true,
+      })
+      class DynamicCmp {
+        @Input()
+            set in(v: string) {
+          log.push(v);
+        }
+      }
+
+      const fixture = TestBed.createComponent(DynamicCmp);
+      fixture.componentRef.setInput('in', '1');
+      fixture.detectChanges();
+      fixture.componentRef.setInput('in', '1');
+      fixture.detectChanges();
+      fixture.componentRef.setInput('in', '2');
+      fixture.detectChanges();
+      expect(log).toEqual(['1', '2']);
+    });
   });
 });


### PR DESCRIPTION
…evious

`ComponentRef.setInput` currently sets the input on the component regardless of the previous value the method was called with. This results in different behavior from bindings in templates, which only set inputs when the value differs in the `Object.is` check from its previous value.

BREAKING CHANGE: ComponentRef.setInput will only set the input on the component if it is different from the previous value (based on `Object.is` equality). If code relies on the input always being set, it should be updated to copy objects or wrap primitives in order to ensure the input value differs from the previous call to `setInput`.
