### PR TITLE
refactor(compiler-cli): remove `MethodIdentifier` type

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/api.ts
@@ -15,7 +15,6 @@ import {ClassDeclaration, DeclarationNode} from '../../reflection';
  */
 export enum IdentifierKind {
   Property,
-  Method,  // TODO: No longer being used. To be removed together with `MethodIdentifier`.
   Element,
   Template,
   Attribute,
@@ -45,14 +44,6 @@ interface ExpressionIdentifier extends TemplateIdentifier {
 /** Describes a property accessed in a template. */
 export interface PropertyIdentifier extends ExpressionIdentifier {
   kind: IdentifierKind.Property;
-}
-
-/**
- * Describes a method accessed in a template.
- * @deprecated No longer being used. To be removed.
- */
-export interface MethodIdentifier extends ExpressionIdentifier {
-  kind: IdentifierKind.Method;
 }
 
 /** Describes an element attribute in a template. */
@@ -114,7 +105,7 @@ export interface VariableIdentifier extends TemplateIdentifier {
  * they were discovered in.
  */
 export type TopLevelIdentifier = PropertyIdentifier|ElementIdentifier|TemplateNodeIdentifier|
-    ReferenceIdentifier|VariableIdentifier|MethodIdentifier;
+    ReferenceIdentifier|VariableIdentifier;
 
 /**
  * Describes the absolute byte offsets of a text anchor in a source code.

--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -9,7 +9,7 @@ import {AST, ASTWithSource, BoundTarget, ImplicitReceiver, ParseSourceSpan, Prop
 
 import {ClassDeclaration, DeclarationNode} from '../../reflection';
 
-import {AbsoluteSourceSpan, AttributeIdentifier, ElementIdentifier, IdentifierKind, MethodIdentifier, PropertyIdentifier, ReferenceIdentifier, TemplateNodeIdentifier, TopLevelIdentifier, VariableIdentifier} from './api';
+import {AbsoluteSourceSpan, AttributeIdentifier, ElementIdentifier, IdentifierKind, PropertyIdentifier, ReferenceIdentifier, TemplateNodeIdentifier, TopLevelIdentifier, VariableIdentifier} from './api';
 import {ComponentMeta} from './context';
 
 /**
@@ -21,7 +21,7 @@ interface HTMLNode extends TmplAstNode {
   name?: string;
 }
 
-type ExpressionIdentifier = PropertyIdentifier|MethodIdentifier;
+type ExpressionIdentifier = PropertyIdentifier;
 type TmplTarget = TmplAstReference|TmplAstVariable;
 type TargetIdentifier = ReferenceIdentifier|VariableIdentifier;
 type TargetIdentifierMap = Map<TmplTarget, TargetIdentifier>;


### PR DESCRIPTION
`MethodIdentifier` is unused as is `IdentifierKind.Method`. They both can be removed.