### PR TITLE
refactor(core): Use (where applicable), `ViewContainer.createComponent` instead of relying on the `ComponentFactoryResolver`.

### DIFF
--- a/packages/core/test/acceptance/change_detection_spec.ts
+++ b/packages/core/test/acceptance/change_detection_spec.ts
@@ -8,7 +8,7 @@
 
 
 import {CommonModule} from '@angular/common';
-import {ApplicationRef, ChangeDetectionStrategy, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, Directive, DoCheck, EmbeddedViewRef, ErrorHandler, EventEmitter, Input, NgModule, OnInit, Output, QueryList, TemplateRef, Type, ViewChild, ViewChildren, ViewContainerRef} from '@angular/core';
+import {ApplicationRef, ChangeDetectionStrategy, ChangeDetectorRef, Component, ComponentRef, Directive, DoCheck, EmbeddedViewRef, ErrorHandler, EventEmitter, Input, NgModule, OnInit, Output, QueryList, TemplateRef, Type, ViewChild, ViewChildren, ViewContainerRef} from '@angular/core';
 import {ComponentFixture, fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 import {BehaviorSubject} from 'rxjs';
@@ -138,8 +138,7 @@ describe('change detection', () => {
       TestBed.configureTestingModule({declarations: [App, ViewManipulation, DynamicComp]});
       const fixture = TestBed.createComponent(App);
       const vm: ViewManipulation = fixture.debugElement.childNodes[0].references['vm'];
-      const factory = TestBed.get(ComponentFactoryResolver).resolveComponentFactory(DynamicComp);
-      const componentRef = vm.vcRef.createComponent(factory);
+      const componentRef = vm.vcRef.createComponent(DynamicComp);
       const button = fixture.nativeElement.querySelector('button');
       fixture.detectChanges();
 
@@ -175,11 +174,10 @@ describe('change detection', () => {
         counter = 0;
         @ViewChild('vc', {read: ViewContainerRef}) vcRef!: ViewContainerRef;
 
-        constructor(private _cfr: ComponentFactoryResolver) {}
+        constructor() {}
 
         createComponentView<T>(cmptType: Type<T>): ComponentRef<T> {
-          const cf = this._cfr.resolveComponentFactory(cmptType);
-          return this.vcRef.createComponent(cf);
+          return this.vcRef.createComponent(cmptType);
         }
       }
 

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {assertInInjectionContext, Attribute, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, createEnvironmentInjector, createNgModule, Directive, ElementRef, ENVIRONMENT_INITIALIZER, EnvironmentInjector, EventEmitter, forwardRef, Host, HostBinding, ImportedNgModuleProviders, importProvidersFrom, ImportProvidersSource, inject, Inject, Injectable, InjectFlags, InjectionToken, InjectOptions, INJECTOR, Injector, Input, LOCALE_ID, makeEnvironmentProviders, ModuleWithProviders, NgModule, NgModuleRef, NgZone, Optional, Output, Pipe, PipeTransform, Provider, runInInjectionContext, Self, SkipSelf, TemplateRef, Type, ViewChild, ViewContainerRef, ViewEncapsulation, ViewRef, ɵcreateInjector as createInjector, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵINJECTOR_SCOPE, ɵInternalEnvironmentProviders as InternalEnvironmentProviders} from '@angular/core';
+import {assertInInjectionContext, Attribute, ChangeDetectorRef, Component, ComponentRef, createEnvironmentInjector, createNgModule, Directive, ElementRef, ENVIRONMENT_INITIALIZER, EnvironmentInjector, EventEmitter, forwardRef, Host, HostBinding, ImportedNgModuleProviders, importProvidersFrom, ImportProvidersSource, inject, Inject, Injectable, InjectFlags, InjectionToken, InjectOptions, INJECTOR, Injector, Input, LOCALE_ID, makeEnvironmentProviders, ModuleWithProviders, NgModule, NgModuleRef, NgZone, Optional, Output, Pipe, PipeTransform, Provider, runInInjectionContext, Self, SkipSelf, TemplateRef, Type, ViewChild, ViewContainerRef, ViewEncapsulation, ViewRef, ɵcreateInjector as createInjector, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵINJECTOR_SCOPE, ɵInternalEnvironmentProviders as InternalEnvironmentProviders} from '@angular/core';
 import {RuntimeError, RuntimeErrorCode} from '@angular/core/src/errors';
 import {ViewRef as ViewRefInternal} from '@angular/core/src/render3/view_ref';
 import {TestBed} from '@angular/core/testing';
@@ -895,15 +895,12 @@ describe('di', () => {
           childOrigin!: ViewContainerRef;
           @ViewChild('childOriginWithDirB', {read: ViewContainerRef, static: true})
           childOriginWithDirB!: ViewContainerRef;
-          childFactory = this.resolver.resolveComponentFactory(Child);
-
-          constructor(readonly resolver: ComponentFactoryResolver, readonly injector: Injector) {}
 
           addChild() {
-            return this.childOrigin.createComponent(this.childFactory);
+            return this.childOrigin.createComponent(Child);
           }
           addChildWithDirB() {
-            return this.childOriginWithDirB.createComponent(this.childFactory);
+            return this.childOriginWithDirB.createComponent(Child);
           }
         }
 
@@ -913,15 +910,18 @@ describe('di', () => {
         const child = fixture.componentInstance.addChild();
         expect(child).toBeDefined();
         expect(child.instance.dirA)
-            .not.toBeNull('dirA should be found. It is on the parent of the viewContainerRef.');
+            .withContext('dirA should be found. It is on the parent of the viewContainerRef.')
+            .not.toBeNull();
         const child2 = fixture.componentInstance.addChildWithDirB();
         expect(child2).toBeDefined();
         expect(child2.instance.dirA)
-            .not.toBeNull('dirA should be found. It is on the parent of the viewContainerRef.');
+            .withContext('dirA should be found. It is on the parent of the viewContainerRef.')
+            .not.toBeNull();
         expect(child2.instance.dirB)
-            .toBeNull(
+            .withContext(
                 'dirB appears on the ng-container and should not be found because the ' +
-                'viewContainerRef.createComponent node is inserted next to the container.');
+                'viewContainerRef.createComponent node is inserted next to the container.')
+            .toBeNull();
       });
     });
 
@@ -2879,12 +2879,10 @@ describe('di', () => {
         class RootComp {
           public childCompRef!: ComponentRef<ChildComp>;
 
-          constructor(
-              public factoryResolver: ComponentFactoryResolver, public vcr: ViewContainerRef) {}
+          constructor(public vcr: ViewContainerRef) {}
 
           create() {
-            const factory = this.factoryResolver.resolveComponentFactory(ChildComp);
-            this.childCompRef = this.vcr.createComponent(factory);
+            this.childCompRef = this.vcr.createComponent(ChildComp);
             this.childCompRef.changeDetectorRef.detectChanges();
           }
         }

--- a/packages/core/test/acceptance/environment_injector_spec.ts
+++ b/packages/core/test/acceptance/environment_injector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ComponentFactoryResolver, createEnvironmentInjector, ENVIRONMENT_INITIALIZER, EnvironmentInjector, inject, InjectFlags, InjectionToken, INJECTOR, Injector, NgModuleRef, ViewContainerRef} from '@angular/core';
+import {Component, createComponent, createEnvironmentInjector, ENVIRONMENT_INITIALIZER, EnvironmentInjector, inject, InjectFlags, InjectionToken, INJECTOR, Injector, NgModuleRef, ViewContainerRef} from '@angular/core';
 import {R3Injector} from '@angular/core/src/di/r3_injector';
 import {RuntimeError, RuntimeErrorCode} from '@angular/core/src/errors';
 import {TestBed} from '@angular/core/testing';
@@ -89,10 +89,8 @@ describe('environment injector', () => {
        }
 
        const parentEnvInjector = TestBed.inject(EnvironmentInjector);
-       const envInjector = createEnvironmentInjector([Service], parentEnvInjector);
-       const cfr = envInjector.get(ComponentFactoryResolver);
-       const cf = cfr.resolveComponentFactory(TestComponent);
-       const cRef = cf.create(Injector.NULL);
+       const environmentInjector = createEnvironmentInjector([Service], parentEnvInjector);
+       const cRef = createComponent(TestComponent, {environmentInjector});
 
        expect(cRef.instance.service).toBeInstanceOf(Service);
      });

--- a/packages/core/test/acceptance/host_binding_spec.ts
+++ b/packages/core/test/acceptance/host_binding_spec.ts
@@ -8,7 +8,7 @@
 
 import {state, style, transition, trigger} from '@angular/animations';
 import {CommonModule} from '@angular/common';
-import {AfterContentInit, Component, ComponentFactoryResolver, ComponentRef, ContentChildren, Directive, DoCheck, HostBinding, HostListener, Injectable, Input, NgModule, OnChanges, OnInit, QueryList, ViewChild, ViewChildren, ViewContainerRef} from '@angular/core';
+import {AfterContentInit, Component, ComponentRef, ContentChildren, Directive, DoCheck, HostBinding, HostListener, Injectable, Input, NgModule, OnChanges, OnInit, QueryList, ViewChild, ViewChildren, ViewContainerRef} from '@angular/core';
 import {bypassSanitizationTrustHtml, bypassSanitizationTrustStyle, bypassSanitizationTrustUrl} from '@angular/core/src/sanitization/bypass';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
@@ -142,11 +142,8 @@ describe('host bindings', () => {
         @Input() prop2 = 0;
 
         ngAfterViewInit() {
-          const factory = this.componentFactoryResolver.resolveComponentFactory(ChildCmp);
-          this.child = this.vcr.createComponent(factory);
+          this.child = this.vcr.createComponent(ChildCmp);
         }
-
-        constructor(private componentFactoryResolver: ComponentFactoryResolver) {}
       }
 
       @Component({

--- a/packages/core/test/acceptance/lifecycle_spec.ts
+++ b/packages/core/test/acceptance/lifecycle_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {AfterViewInit, ChangeDetectorRef, Component, ComponentFactoryResolver, ContentChildren, Directive, DoCheck, Input, NgModule, OnChanges, QueryList, SimpleChange, SimpleChanges, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {AfterViewInit, ChangeDetectorRef, Component, ContentChildren, Directive, DoCheck, Input, NgModule, OnChanges, QueryList, SimpleChange, SimpleChanges, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -1561,11 +1561,8 @@ describe('onInit', () => {
     class App {
       @ViewChild('container', {read: ViewContainerRef}) viewContainerRef!: ViewContainerRef;
 
-      constructor(public compFactoryResolver: ComponentFactoryResolver) {}
-
       createDynamicView() {
-        const dynamicCompFactory = this.compFactoryResolver.resolveComponentFactory(DynamicComp);
-        this.viewContainerRef.createComponent(dynamicCompFactory);
+        this.viewContainerRef.createComponent(DynamicComp);
       }
     }
 

--- a/packages/core/test/acceptance/standalone_injector_spec.ts
+++ b/packages/core/test/acceptance/standalone_injector_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ComponentFactoryResolver, createEnvironmentInjector, EnvironmentInjector, Injector, NgModule, ViewChild, ViewContainerRef} from '@angular/core';
+import {Component, createComponent, createEnvironmentInjector, EnvironmentInjector, NgModule, ViewChild, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 describe('standalone injector', () => {
@@ -85,10 +85,9 @@ describe('standalone injector', () => {
 
     const fixture = TestBed.createComponent(AppComponent);
 
-    const cfr = TestBed.inject(ComponentFactoryResolver);
-    const cf = cfr.resolveComponentFactory(DynamicComponent);
-
-    const componentRef = cf.create(Injector.NULL);
+    const environmentInjector =
+        createEnvironmentInjector([Service], TestBed.inject(EnvironmentInjector));
+    const componentRef = createComponent(DynamicComponent, {environmentInjector});
     componentRef.changeDetectorRef.detectChanges();
 
     expect(componentRef.location.nativeElement.textContent).toBe('Service value');

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {CommonModule} from '@angular/common';
-import {Component, ComponentFactoryResolver, ComponentRef, Directive, ElementRef, HostBinding, Input, NgModule, Renderer2, ViewChild, ViewContainerRef} from '@angular/core';
+import {Component, ComponentRef, Directive, ElementRef, HostBinding, Input, Renderer2, ViewChild, ViewContainerRef} from '@angular/core';
 import {bypassSanitizationTrustStyle} from '@angular/core/src/sanitization/bypass';
 import {ngDevModeResetPerfCounters} from '@angular/core/src/util/ng_dev_mode';
 import {TestBed} from '@angular/core/testing';
@@ -2660,11 +2660,8 @@ describe('styling', () => {
          }
 
          ngAfterViewInit() {
-           const factory = this.componentFactoryResolver.resolveComponentFactory(ChildCmp);
-           this.child = this.vcr.createComponent(factory);
+           this.child = this.vcr.createComponent(ChildCmp);
          }
-
-         constructor(private componentFactoryResolver: ComponentFactoryResolver) {}
        }
 
        @Component({
@@ -2732,11 +2729,8 @@ describe('styling', () => {
          }
 
          ngAfterViewInit() {
-           const factory = this.componentFactoryResolver.resolveComponentFactory(ChildCmp);
-           this.child = this.vcr.createComponent(factory);
+           this.child = this.vcr.createComponent(ChildCmp);
          }
-
-         constructor(private componentFactoryResolver: ComponentFactoryResolver) {}
        }
 
        @Component({

--- a/packages/core/test/acceptance/template_ref_spec.ts
+++ b/packages/core/test/acceptance/template_ref_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Component, ComponentFactoryResolver, Injector, NgModule, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {Component, Injector, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
@@ -188,7 +188,7 @@ describe('TemplateRef', () => {
 
       @Component({selector: 'test', template: ''})
       class TestCmp {
-        constructor(public cfr: ComponentFactoryResolver) {}
+        constructor(public vcr: ViewContainerRef) {}
       }
 
       beforeEach(() => {
@@ -200,12 +200,12 @@ describe('TemplateRef', () => {
             DynamicCmp, `<ng-template #templateRef><ng-content></ng-content></ng-template>`);
 
         const fixture = TestBed.createComponent(TestCmp);
-        const dynamicCmptFactory =
-            fixture.componentInstance.cfr.resolveComponentFactory(DynamicCmp);
-
         // Number of projectable nodes matches the number of slots - all nodes should be returned
         const projectableNodes = [[document.createTextNode('textNode')]];
-        const cmptRef = dynamicCmptFactory.create(Injector.NULL, projectableNodes);
+
+        const cmptRef = fixture.componentInstance.vcr.createComponent(
+            DynamicCmp, {injector: Injector.NULL, projectableNodes});
+
         const viewRef = cmptRef.instance.templateRef.createEmbeddedView({});
         expect(viewRef.rootNodes.length).toBe(1);
       });
@@ -215,11 +215,10 @@ describe('TemplateRef', () => {
             DynamicCmp, `<ng-template #templateRef><ng-content></ng-content></ng-template>`);
 
         const fixture = TestBed.createComponent(TestCmp);
-        const dynamicCmptFactory =
-            fixture.componentInstance.cfr.resolveComponentFactory(DynamicCmp);
 
         // There are slots but projectable nodes were not provided - nothing should be returned
-        const cmptRef = dynamicCmptFactory.create(Injector.NULL, []);
+        const cmptRef = fixture.componentInstance.vcr.createComponent(
+            DynamicCmp, {injector: Injector.NULL, projectableNodes: []});
         const viewRef = cmptRef.instance.templateRef.createEmbeddedView({});
         expect(viewRef.rootNodes.length).toBe(0);
       });
@@ -229,12 +228,12 @@ describe('TemplateRef', () => {
            TestBed.overrideTemplate(DynamicCmp, `<ng-template #templateRef></ng-template>`);
 
            const fixture = TestBed.createComponent(TestCmp);
-           const dynamicCmptFactory =
-               fixture.componentInstance.cfr.resolveComponentFactory(DynamicCmp);
 
            // There are no slots but projectable were provided - nothing should be returned
            const projectableNodes = [[document.createTextNode('textNode')]];
-           const cmptRef = dynamicCmptFactory.create(Injector.NULL, projectableNodes);
+
+           const cmptRef = fixture.componentInstance.vcr.createComponent(
+               DynamicCmp, {injector: Injector.NULL, projectableNodes});
            const viewRef = cmptRef.instance.templateRef.createEmbeddedView({});
            expect(viewRef.rootNodes.length).toBe(0);
          });

--- a/packages/core/test/acceptance/view_insertion_spec.ts
+++ b/packages/core/test/acceptance/view_insertion_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {CommonModule} from '@angular/common';
-import {ChangeDetectorRef, Component, ComponentFactoryResolver, Directive, EmbeddedViewRef, Injectable, Injector, Input, NgModule, TemplateRef, ViewChild, ViewContainerRef, ViewRef} from '@angular/core';
+import {ChangeDetectorRef, Component, Directive, EmbeddedViewRef, Injectable, Injector, Input, TemplateRef, ViewChild, ViewContainerRef, ViewRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 
@@ -491,12 +491,12 @@ describe('view insertion', () => {
           @ViewChild('insert', {static: true}) insertTpl!: TemplateRef<{}>;
           @ViewChild('vi', {static: true}) viewInsertingDir!: ViewInsertingDir;
 
-          constructor(private _cfr: ComponentFactoryResolver, private _injector: Injector) {}
+          constructor(private _vcr: ViewContainerRef, private _injector: Injector) {}
 
           insert() {
             // create a dynamic component view to act as an "insert before" view
-            const componentFactory = this._cfr.resolveComponentFactory(DynamicComponent);
-            const beforeView = componentFactory.create(this._injector).hostView;
+            const beforeView =
+                this._vcr.createComponent(DynamicComponent, {injector: this._injector}).hostView;
             // change-detect the "before view" to create all child views
             beforeView.detectChanges();
             this.viewInsertingDir.insert(beforeView, this.insertTpl);
@@ -539,10 +539,8 @@ describe('view insertion', () => {
          class AppComponent {
            @ViewChild('container', {read: ViewContainerRef, static: true}) vcr!: ViewContainerRef;
 
-           constructor(private _cfr: ComponentFactoryResolver) {}
-
            click() {
-             this.vcr.createComponent(this._cfr.resolveComponentFactory(DynamicComponent));
+             this.vcr.createComponent(DynamicComponent);
            }
          }
 

--- a/packages/core/test/acceptance/view_ref_spec.ts
+++ b/packages/core/test/acceptance/view_ref_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, ChangeDetectorRef, Component, ComponentFactoryResolver, ComponentRef, ElementRef, EmbeddedViewRef, Injector, NgModule, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
+import {ApplicationRef, ChangeDetectorRef, Component, ComponentRef, createComponent, ElementRef, EmbeddedViewRef, EnvironmentInjector, Injector, TemplateRef, ViewChild, ViewContainerRef} from '@angular/core';
 import {InternalViewRef} from '@angular/core/src/linker/view_ref';
 import {TestBed} from '@angular/core/testing';
 
@@ -21,13 +21,10 @@ describe('ViewRef', () => {
     @Component({template: `<span></span>`})
     class App {
       componentRef!: ComponentRef<DynamicComponent>;
-      constructor(
-          public appRef: ApplicationRef, private cfr: ComponentFactoryResolver,
-          private injector: Injector) {}
+      constructor(public appRef: ApplicationRef, private injector: EnvironmentInjector) {}
 
       create() {
-        const componentFactory = this.cfr.resolveComponentFactory(DynamicComponent);
-        this.componentRef = componentFactory.create(this.injector);
+        this.componentRef = createComponent(DynamicComponent, {environmentInjector: this.injector});
         (this.componentRef.hostView as InternalViewRef).attachToAppRef(this.appRef);
         document.body.appendChild(this.componentRef.instance.elRef.nativeElement);
       }
@@ -80,14 +77,11 @@ describe('ViewRef', () => {
       @ViewChild(TemplateRef) templateRef!: TemplateRef<any>;
       componentRef!: ComponentRef<DynamicComponent>;
       viewRef!: EmbeddedViewRef<any>;
-      constructor(
-          private _viewContainerRef: ViewContainerRef,
-          private _componentFactoryResolver: ComponentFactoryResolver) {}
+      constructor(private _viewContainerRef: ViewContainerRef) {}
 
       create() {
-        const factory = this._componentFactoryResolver.resolveComponentFactory(DynamicComponent);
         this.viewRef = this.templateRef.createEmbeddedView(null);
-        this.componentRef = this._viewContainerRef.createComponent(factory);
+        this.componentRef = this._viewContainerRef.createComponent(DynamicComponent);
         this.componentRef.instance.viewContainerRef.insert(this.viewRef);
       }
     }
@@ -114,14 +108,11 @@ describe('ViewRef', () => {
       @ViewChild(TemplateRef) templateRef!: TemplateRef<any>;
       componentRef!: ComponentRef<DynamicComponent>;
       viewRef!: EmbeddedViewRef<any>;
-      constructor(
-          private _viewContainerRef: ViewContainerRef,
-          private _componentFactoryResolver: ComponentFactoryResolver) {}
+      constructor(private _viewContainerRef: ViewContainerRef) {}
 
       create() {
-        const factory = this._componentFactoryResolver.resolveComponentFactory(DynamicComponent);
         this.viewRef = this.templateRef.createEmbeddedView(null);
-        this.componentRef = this._viewContainerRef.createComponent(factory);
+        this.componentRef = this._viewContainerRef.createComponent(DynamicComponent);
         this.componentRef.instance.viewContainerRef.insert(this.viewRef);
       }
     }

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
-import {ApplicationRef, Component, ComponentRef, ContentChild, destroyPlatform, Directive, ErrorHandler, EventEmitter, HostListener, InjectionToken, Injector, Input, NgModule, NgModuleRef, NgZone, Output, Pipe, PipeTransform, Provider, QueryList, Renderer2, SimpleChanges, TemplateRef, ViewChildren, ViewContainerRef} from '@angular/core';
+import {ApplicationRef, Component, ComponentRef, ContentChild, createComponent, destroyPlatform, Directive, EnvironmentInjector, ErrorHandler, EventEmitter, HostListener, InjectionToken, Injector, Input, NgModule, NgZone, Output, Pipe, PipeTransform, Provider, QueryList, Renderer2, SimpleChanges, TemplateRef, ViewChildren, ViewContainerRef} from '@angular/core';
 import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
 import {BrowserModule, By} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
@@ -334,9 +334,8 @@ describe('regressions', () => {
     class App {
     }
 
-    const modRef = TestBed.configureTestingModule({declarations: [App]}).inject(NgModuleRef);
     const compRef =
-        modRef.componentFactoryResolver.resolveComponentFactory(App).create(Injector.NULL);
+        createComponent(App, {environmentInjector: TestBed.inject(EnvironmentInjector)});
 
     expect(compRef.location.nativeElement.hasAttribute('ng-version')).toBe(false);
   });


### PR DESCRIPTION
This PR is merely a suggestion, is it welcome to reduce the usage of `ComponentFactoryResolver` in unit test to only where it's relevant ?

Also, since its internal usage isn't deprecated as there is no alternative to several cases, has it been discussed to move it to a private API ? 