### PR TITLE
refactor(core): output hydration stats into a console in dev mode

### DIFF
--- a/packages/core/src/hydration/cleanup.ts
+++ b/packages/core/src/hydration/cleanup.ts
@@ -6,10 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {first} from 'rxjs/operators';
-
 import {ApplicationRef} from '../application_ref';
-import {InitialRenderPendingTasks} from '../initial_render_pending_tasks';
 import {CONTAINER_HEADER_OFFSET, DEHYDRATED_VIEWS, LContainer} from '../render3/interfaces/container';
 import {Renderer} from '../render3/interfaces/renderer';
 import {RNode} from '../render3/interfaces/renderer_dom';
@@ -92,23 +89,15 @@ function cleanupLView(lView: LView) {
  * Walks over all views registered within the ApplicationRef and removes
  * all dehydrated views from all `LContainer`s along the way.
  */
-export function cleanupDehydratedViews(
-    appRef: ApplicationRef, pendingTasks: InitialRenderPendingTasks) {
-  // Wait once an app becomes stable and cleanup all views that
-  // were not claimed during the application bootstrap process.
-  // The timing is similar to when we kick off serialization on the server.
-  const isStablePromise = appRef.isStable.pipe(first((isStable: boolean) => isStable)).toPromise();
-  const pendingTasksPromise = pendingTasks.whenAllTasksComplete;
-  return Promise.allSettled([isStablePromise, pendingTasksPromise]).then(() => {
-    const viewRefs = appRef._views;
-    for (const viewRef of viewRefs) {
-      const lView = getComponentLViewForHydration(viewRef);
-      // An `lView` might be `null` if a `ViewRef` represents
-      // an embedded view (not a component view).
-      if (lView !== null && lView[HOST] !== null) {
-        cleanupLView(lView);
-        ngDevMode && ngDevMode.dehydratedViewsCleanupRuns++;
-      }
+export function cleanupDehydratedViews(appRef: ApplicationRef) {
+  const viewRefs = appRef._views;
+  for (const viewRef of viewRefs) {
+    const lView = getComponentLViewForHydration(viewRef);
+    // An `lView` might be `null` if a `ViewRef` represents
+    // an embedded view (not a component view).
+    if (lView !== null && lView[HOST] !== null) {
+      cleanupLView(lView);
+      ngDevMode && ngDevMode.dehydratedViewsCleanupRuns++;
     }
-  });
+  }
 }

--- a/packages/core/src/render3/instructions/element.ts
+++ b/packages/core/src/render3/instructions/element.ts
@@ -238,6 +238,8 @@ function locateOrCreateElementNodeImpl(
       // Since this isn't hydratable, we need to empty the node
       // so there's no duplicate content after render
       clearElementContents(native);
+
+      ngDevMode && ngDevMode.componentsSkippedHydration++;
     } else if (ngDevMode) {
       // If this is not a component host, throw an error.
       // Hydration can be skipped on per-component basis only.

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -24,6 +24,7 @@ declare global {
    * Finally, ngDevMode may not have been defined at all.
    */
   const ngDevMode: null|NgDevModePerfCounters;
+
   interface NgDevModePerfCounters {
     namedConstructors: boolean;
     firstCreatePass: number;

--- a/packages/core/src/util/ng_dev_mode.ts
+++ b/packages/core/src/util/ng_dev_mode.ts
@@ -52,6 +52,7 @@ declare global {
     hydratedComponents: number;
     dehydratedViewsRemoved: number;
     dehydratedViewsCleanupRuns: number;
+    componentsSkippedHydration: number;
   }
 }
 
@@ -85,6 +86,7 @@ export function ngDevModeResetPerfCounters(): NgDevModePerfCounters {
     hydratedComponents: 0,
     dehydratedViewsRemoved: 0,
     dehydratedViewsCleanupRuns: 0,
+    componentsSkippedHydration: 0,
   };
 
   // Make sure to refer to ngDevMode as ['ngDevMode'] for closure.


### PR DESCRIPTION
This commit adds a logic to output basic hydration stats into a console. This is also helpful to ensure that hydration is enabled and works.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No