### PR TITLE
refactor(router): clear pending navigation task in a microtask

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -742,7 +742,11 @@ export class Router {
 
     // Indicate that the navigation is happening.
     const taskId = this.pendingTasks.add();
-    afterNextNavigation(this, () => this.pendingTasks.remove(taskId));
+    afterNextNavigation(this, () => {
+      // Remove pending task in a microtask to allow for cancelled
+      // initial navigations and redirects within the same task.
+      Promise.resolve().then(() => this.pendingTasks.remove(taskId));
+    });
 
     this.navigationTransitions.handleNavigationRequest({
       targetPageId,


### PR DESCRIPTION
This commit updates the logic in the Router that keep track of the initial navigation from being a synchronous to a microtask (Promise.resolve) to allow redirects during the initial navigation.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No