### PR TITLE
fix(platform-browser): set nonce attribute in a platform compatible way

### DIFF
--- a/packages/core/test/acceptance/csp_spec.ts
+++ b/packages/core/test/acceptance/csp_spec.ts
@@ -22,8 +22,9 @@ describe('CSP integration', () => {
 
     for (let i = 0; i < styles.length; i++) {
       const style = styles[i];
-      if (style.textContent?.includes('--csp-test-var') && style.nonce) {
-        nonces.push(style.nonce);
+      const nonce = style.getAttribute('nonce');
+      if (nonce && style.textContent?.includes('--csp-test-var')) {
+        nonces.push(nonce);
       }
     }
 

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -327,8 +327,7 @@ class ShadowDomRenderer extends DefaultDomRenderer2 {
       const styleEl = document.createElement('style');
 
       if (nonce) {
-        // Uses a keyed write to avoid issues with property minification.
-        styleEl['nonce'] = nonce;
+        styleEl.setAttribute('nonce', nonce);
       }
 
       styleEl.textContent = style;

--- a/packages/platform-browser/src/dom/shared_styles_host.ts
+++ b/packages/platform-browser/src/dom/shared_styles_host.ts
@@ -147,8 +147,7 @@ export class SharedStylesHost implements OnDestroy {
       const styleEl = this.doc.createElement('style');
 
       if (this.nonce) {
-        // Uses a keyed write to avoid issues with property minification.
-        styleEl['nonce'] = this.nonce;
+        styleEl.setAttribute('nonce', this.nonce);
       }
 
       styleEl.textContent = style;

--- a/packages/platform-browser/test/dom/shared_styles_host_spec.ts
+++ b/packages/platform-browser/test/dom/shared_styles_host_spec.ts
@@ -54,5 +54,12 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
       ssh.ngOnDestroy();
       expect(someHost.innerHTML).toEqual('');
     });
+
+    it(`should add 'nonce' attribute when a nonce value is provided`, () => {
+      ssh = new SharedStylesHost(doc, 'app-id', '{% nonce %}');
+      ssh.addStyles(['a {};']);
+      ssh.addHost(someHost);
+      expect(someHost.innerHTML).toEqual('<style nonce="{% nonce %}">a {};</style>');
+    });
   });
 }


### PR DESCRIPTION
Setting the `nonce` attribute using the property is not supported by Domino. This change update the usage to use `setAttribute` and also add a test to verify that the `nonce` is set when it should.

//cc @crisbeto 