### PR TITLE
feat(core): effects can optionally return a cleanup function

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -515,7 +515,10 @@ export interface DoCheck {
 }
 
 // @public
-export function effect(effectFn: () => void, options?: CreateEffectOptions): EffectRef;
+export function effect(effectFn: () => EffectCleanupFn | void, options?: CreateEffectOptions): EffectRef;
+
+// @public
+export type EffectCleanupFn = () => void;
 
 // @public
 export interface EffectRef {

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -23,5 +23,6 @@ export {
   CreateEffectOptions,
   effect,
   EffectRef,
+  EffectCleanupFn,
 } from './render3/reactivity/effect';
 // clang-format on    

--- a/packages/core/src/signals/index.ts
+++ b/packages/core/src/signals/index.ts
@@ -11,5 +11,5 @@ export {computed, CreateComputedOptions} from './src/computed';
 export {setActiveConsumer} from './src/graph';
 export {CreateSignalOptions, signal, WritableSignal} from './src/signal';
 export {untracked} from './src/untracked';
-export {Watch} from './src/watch';
+export {Watch, WatchCleanupFn} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';

--- a/packages/core/test/signals/watch_spec.ts
+++ b/packages/core/test/signals/watch_spec.ts
@@ -99,4 +99,32 @@ describe('watchers', () => {
     flushEffects();
     expect(updateCounter).toEqual(3);
   });
+
+  it('should allow returning cleanup function from the watch logic', () => {
+    const source = signal(0);
+
+    const seenCounterValues: number[] = [];
+    testingEffect(() => {
+      seenCounterValues.push(source());
+
+      // return a cleanup function that is executed every time an effect re-runs
+      return () => {
+        if (seenCounterValues.length === 2) {
+          seenCounterValues.length = 0;
+        }
+      };
+    });
+
+    flushEffects();
+    expect(seenCounterValues).toEqual([0]);
+
+    source.update(c => c + 1);
+    flushEffects();
+    expect(seenCounterValues).toEqual([0, 1]);
+
+    source.update(c => c + 1);
+    flushEffects();
+    // cleanup (array trim) should have run before executing effect
+    expect(seenCounterValues).toEqual([2]);
+  });
 });


### PR DESCRIPTION
This change extends the effect API surface so effects can, optionally, return a cleanup function. Such function, if returned, is executed prior to the subsequent effect run.
