### PR TITLE
fix(forms): Allow control config to accept `Array<any>`

### DIFF
--- a/packages/forms/src/form_builder.ts
+++ b/packages/forms/src/form_builder.ts
@@ -53,6 +53,20 @@ interface PermissiveAbstractControlOptions extends Omit<AbstractControlOptions, 
 }
 
 /**
+ * Helper type to exclude Validators and ControlsOptions from ControlConfig
+ */
+type ExcludeValidatorsAndControlOptions<U> =
+    Exclude<U, ValidatorConfig|PermissiveAbstractControlOptions>;
+
+/**
+ * Helper type to extract the control value type from a Control Config
+ * The type is need to detect `Array<any>` as `Exclude<Array<any>, string[]> = never`
+ */
+type ExtractTypeFromControlConfig<U> = U extends Array<any>?
+    Array<any> extends U ? U : ExcludeValidatorsAndControlOptions<U>:
+    ExcludeValidatorsAndControlOptions<U>;
+
+/**
  * ControlConfig<T> is a tuple containing a value of type T, plus optional validators and async
  * validators.
  *
@@ -96,7 +110,7 @@ export type ɵElement<T, N extends null> =
   // FormControlState object container, which produces a nullable control.
   [T] extends [FormControlState<infer U>] ? FormControl<U|N> :
   // A ControlConfig tuple, which produces a nullable control.
-  [T] extends [PermissiveControlConfig<infer U>] ? FormControl<Exclude<U, ValidatorConfig| PermissiveAbstractControlOptions>|N> :
+  [T] extends [PermissiveControlConfig<infer U>] ? FormControl<ExtractTypeFromControlConfig<U>|N> :
   FormControl<T|N>;
 
 // clang-format on

--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -10,7 +10,7 @@
 // at compile time.
 
 import {FormBuilder, NonNullableFormBuilder, UntypedFormBuilder} from '../src/form_builder';
-import {AbstractControl, FormArray, FormControl, FormGroup, UntypedFormArray, UntypedFormControl, UntypedFormGroup, Validators} from '../src/forms';
+import {AbstractControl, FormArray, FormControl, FormGroup, UntypedFormArray, UntypedFormControl, UntypedFormGroup, ValidatorFn, Validators} from '../src/forms';
 import {FormRecord} from '../src/model/form_group';
 
 describe('Typed Class', () => {
@@ -1074,6 +1074,17 @@ describe('Typed Class', () => {
         const c = fb.group({foo: [{value: 'bar', disabled: true}, Validators.required]});
         {
           type ControlsType = {foo: FormControl<string|null>};
+          let t: ControlsType = c.controls;
+          let t1 = c.controls;
+          t1 = null as unknown as ControlsType;
+        }
+      });
+
+      it('from objects with any array nested inside ControlConfigs', () => {
+        const anyArr: any[] = [];
+        const c = fb.group({foo: [anyArr, Validators.required]});
+        {
+          type ControlsType = {foo: FormControl<any[]|null>};
           let t: ControlsType = c.controls;
           let t1 = c.controls;
           t1 = null as unknown as ControlsType;


### PR DESCRIPTION
With this commit, controlConfig can accept `Array<any>` as values. Root cause of this issue is `Exclude<Array<any>, string[]> = never`.

Fixes #49622

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?


- [x] No

