### PR TITLE
refactor(core): Prevent reads and writes to signals at certain times

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -101,6 +101,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     RENDERER_NOT_FOUND = 407,
     // (undocumented)
+    SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT = 600,
+    // (undocumented)
     TEMPLATE_STRUCTURE_ERROR = 305,
     // (undocumented)
     TYPE_IS_NOT_STANDALONE = 907,

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -336,6 +336,7 @@ export interface CreateComputedOptions<T> {
 
 // @public
 export interface CreateEffectOptions {
+    allowSignalWrites?: boolean;
     injector?: Injector;
     manualCleanup?: boolean;
 }

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -40,6 +40,7 @@ import {setLocaleId} from './render3/i18n/i18n_locale_id';
 import {setJitOptions} from './render3/jit/jit_options';
 import {createEnvironmentInjector, createNgModuleRefWithProviders, NgModuleFactory as R3NgModuleFactory} from './render3/ng_module_ref';
 import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from './render3/util/global_utils';
+import {setThrowInvalidWriteToSignalError} from './signals/src/errors';
 import {TESTABILITY} from './testability/testability';
 import {isPromise} from './util/lang';
 import {stringify} from './util/stringify';
@@ -128,6 +129,19 @@ export function publishDefaultGlobalUtils() {
   ngDevMode && _publishDefaultGlobalUtils();
 }
 
+/**
+ * Sets the error for an invalid write to a signal to be an Angular `RuntimeError`.
+ */
+export function publishSignalConfiguration(): void {
+  setThrowInvalidWriteToSignalError(() => {
+    throw new RuntimeError(
+        RuntimeErrorCode.SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT,
+        ngDevMode &&
+            'Writing to signals is not allowed in a `computed` or an `effect` by default. ' +
+                'Use `allowSignalWrites` in the `CreateEffectOptions` to enable this inside effects.');
+  });
+}
+
 export function isBoundToModule<C>(cf: ComponentFactory<C>): boolean {
   return (cf as R3ComponentFactory<C>).isBoundToModule;
 }
@@ -155,6 +169,7 @@ export function createPlatform(injector: Injector): PlatformRef {
             'There can be only one platform. Destroy the previous one to create a new one.');
   }
   publishDefaultGlobalUtils();
+  publishSignalConfiguration();
   _platformInjector = injector;
   const platform = injector.get(PlatformRef);
   runPlatformInitializers(injector);

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -68,6 +68,9 @@ export const enum RuntimeErrorCode {
   // Temporary error code for hydration while i18n is not supported
   HYDRATION_I18N_NOT_YET_SUPPORTED = 518,
 
+  // Signal Errors
+  SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT = 600,
+
   // Styling Errors
 
   // Declarations Errors
@@ -108,7 +111,8 @@ export const enum RuntimeErrorCode {
  *
  * Note: the `message` argument contains a descriptive error message as a string in development
  * mode (when the `ngDevMode` is defined). In production mode (after tree-shaking pass), the
- * `message` argument becomes `false`, thus we account for it in the typings and the runtime logic.
+ * `message` argument becomes `false`, thus we account for it in the typings and the runtime
+ * logic.
  */
 export class RuntimeError<T extends number = RuntimeErrorCode> extends Error {
   constructor(public code: T, message: null|false|string) {

--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -16,6 +16,7 @@ import {LView, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER} from 
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
 
 export class ReactiveLViewConsumer extends ReactiveNode {
+  protected override consumerAllowSignalWrites = false;
   private _lView: LView|null = null;
 
   set lView(lView: LView) {

--- a/packages/core/src/signals/index.ts
+++ b/packages/core/src/signals/index.ts
@@ -8,6 +8,7 @@
 
 export {isSignal, Signal, ValueEqualityFn} from './src/api';
 export {computed, CreateComputedOptions} from './src/computed';
+export {setThrowInvalidWriteToSignalError} from './src/errors';
 export {setActiveConsumer} from './src/graph';
 export {CreateSignalOptions, signal, WritableSignal} from './src/signal';
 export {untracked} from './src/untracked';

--- a/packages/core/src/signals/src/computed.ts
+++ b/packages/core/src/signals/src/computed.ts
@@ -86,6 +86,8 @@ class ComputedImpl<T> extends ReactiveNode {
    */
   private stale = true;
 
+  protected override readonly consumerAllowSignalWrites = false;
+
   protected override onConsumerDependencyMayHaveChanged(): void {
     if (this.stale) {
       // We've already notified consumers that this value has potentially changed.

--- a/packages/core/src/signals/src/errors.ts
+++ b/packages/core/src/signals/src/errors.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+function defaultThrowError(): never {
+  throw new Error();
+}
+
+let throwInvalidWriteToSignalErrorFn = defaultThrowError;
+
+export function throwInvalidWriteToSignalError() {
+  throwInvalidWriteToSignalErrorFn();
+}
+
+export function setThrowInvalidWriteToSignalError(fn: () => never): void {
+  throwInvalidWriteToSignalErrorFn = fn;
+}

--- a/packages/core/src/signals/src/watch.ts
+++ b/packages/core/src/signals/src/watch.ts
@@ -24,11 +24,15 @@ const NOOP_CLEANUP_FN: WatchCleanupFn = () => {};
  * provided scheduling operation to coordinate calling `Watch.run()`.
  */
 export class Watch extends ReactiveNode {
+  protected override readonly consumerAllowSignalWrites: boolean;
   private dirty = false;
   private cleanupFn = NOOP_CLEANUP_FN;
 
-  constructor(private watch: () => void|WatchCleanupFn, private schedule: (watch: Watch) => void) {
+  constructor(
+      private watch: () => void|WatchCleanupFn, private schedule: (watch: Watch) => void,
+      allowSignalWrites: boolean) {
     super();
+    this.consumerAllowSignalWrites = allowSignalWrites;
   }
 
   notify(): void {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1092,6 +1092,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -843,6 +843,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1167,6 +1167,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1128,6 +1128,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -666,6 +666,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1455,6 +1455,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -759,6 +759,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1020,6 +1020,9 @@
     "name": "importProvidersFrom"
   },
   {
+    "name": "inNotificationPhase"
+  },
+  {
     "name": "includeViewProviders"
   },
   {

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -179,4 +179,41 @@ describe('effects', () => {
 
     expect(didRun).toBeTrue();
   });
+  it('should disallow writing to signals within effects by default',
+     withBody('<test-cmp></test-cmp>', async () => {
+       @Component({
+         selector: 'test-cmp',
+         standalone: true,
+         template: '',
+       })
+       class Cmp {
+         counter = signal(0);
+         constructor() {
+           effect(() => {
+             expect(() => this.counter.set(1)).toThrow();
+           });
+         }
+       }
+
+       await bootstrapApplication(Cmp);
+     }));
+
+  it('should allow writing to signals within effects when option set',
+     withBody('<test-cmp></test-cmp>', async () => {
+       @Component({
+         selector: 'test-cmp',
+         standalone: true,
+         template: '',
+       })
+       class Cmp {
+         counter = signal(0);
+         constructor() {
+           effect(() => {
+             expect(() => this.counter.set(1)).not.toThrow();
+           }, {allowSignalWrites: true});
+         }
+       }
+
+       await bootstrapApplication(Cmp);
+     }));
 });

--- a/packages/core/test/signals/computed_spec.ts
+++ b/packages/core/test/signals/computed_spec.ts
@@ -142,7 +142,8 @@ describe('computed', () => {
         },
         () => {
           watchCount++;
-        });
+        },
+        false);
 
     watch.run();
     expect(watchCount).toEqual(0);
@@ -162,5 +163,15 @@ describe('computed', () => {
     // expecting another notification at this point
     source.set('d');
     expect(watchCount).toEqual(2);
+  });
+
+  it('should disallow writing to signals within computeds', () => {
+    const source = signal(0);
+    const illegal = computed(() => {
+      source.set(1);
+      return 0;
+    });
+
+    expect(illegal).toThrow();
   });
 });

--- a/packages/core/test/signals/effect_util.ts
+++ b/packages/core/test/signals/effect_util.ts
@@ -14,7 +14,7 @@ let queue = new Set<Watch>();
  * A wrapper around `Watch` that emulates the `effect` API and allows for more streamlined testing.
  */
 export function testingEffect(effectFn: () => void): void {
-  const watch = new Watch(effectFn, queue.add.bind(queue));
+  const watch = new Watch(effectFn, queue.add.bind(queue), true);
 
   // Effects start dirty.
   watch.notify();


### PR DESCRIPTION
* Prevent reads of signals during the notification process. This shouldn't ever be triggered by user code but is more of a preventative for internal misuse. Reading a signal during notification would/could create glitches where the values being read are not updated to reflect the values being updated by the notification.

* Prevent signal writes inside of computed's. These are meant to be derived values and should not have any side-effects like writing new values to other signals

* Prevent signal writes inside of effects by default. Writing to signal values during the execution of an effect can lead to the `ExpressionChangedAfterItHasBeenCheckedError` if writing to signals that represent global state which is read in a parent component. This is mostly just a problem for `OnPush`/`CheckAlways` components, but with signals being new and pure signal components not even available yet, it will be the majority for a long time.
