### PR TITLE
Feature to bind `Router` information to component inputs

### DIFF
--- a/aio/content/examples/router/src/app/app-routing.module.11.ts
+++ b/aio/content/examples/router/src/app/app-routing.module.11.ts
@@ -1,0 +1,32 @@
+import {NgModule} from '@angular/core';
+import {provideRouter, Routes, withComponentInputBinding} from '@angular/router';
+
+import {authGuard} from './auth/auth.guard';
+import {ComposeMessageComponent} from './compose-message/compose-message.component';
+import {PageNotFoundComponent} from './page-not-found/page-not-found.component';
+
+const appRoutes: Routes = [
+  {path: 'compose', component: ComposeMessageComponent, outlet: 'popup'}, {
+    path: 'admin',
+    loadChildren: () => import('./admin/admin.module').then(m => m.AdminModule),
+    canMatch: [authGuard]
+  },
+  {
+    path: 'crisis-center',
+    loadChildren: () =>
+        import('./crisis-center/crisis-center.module').then(m => m.CrisisCenterModule),
+    data: {preload: true}
+  },
+  {path: '', redirectTo: '/superheroes', pathMatch: 'full'},
+  {path: '**', component: PageNotFoundComponent}
+];
+
+@NgModule({
+  // #docregion withComponentInputBinding
+  providers: [
+    provideRouter(appRoutes, withComponentInputBinding()),
+  ]
+  // #enddocregion withComponentInputBinding
+})
+export class AppRoutingModule {
+}

--- a/aio/content/examples/router/src/app/heroes/hero-detail/hero-detail.component.4.ts
+++ b/aio/content/examples/router/src/app/heroes/hero-detail/hero-detail.component.4.ts
@@ -1,0 +1,34 @@
+// #docplaster
+// #docregion
+import {Component, Input, OnInit} from '@angular/core';
+import {Router} from '@angular/router';
+import {Observable} from 'rxjs';
+
+import {Hero} from '../hero';
+import {HeroService} from '../hero.service';
+
+@Component({
+  selector: 'app-hero-detail',
+  templateUrl: './hero-detail.component.html',
+  styleUrls: ['./hero-detail.component.css']
+})
+export class HeroDetailComponent {
+  hero$!: Observable<Hero>;
+
+  constructor(private router: Router, private service: HeroService) {}
+
+  // #docregion id-input
+  @Input()
+  set id(heroId: string) {
+    this.hero$ = this.service.getHero(heroId);
+  }
+  // #enddocregion id-input
+
+  gotoHeroes(hero: Hero) {
+    const heroId = hero ? hero.id : null;
+    // Pass along the hero id if available
+    // so that the HeroList component can select that hero.
+    // Include a junk 'foo' property for fun.
+    this.router.navigate(['/superheroes', {id: heroId, foo: 'foo'}]);
+  }
+}

--- a/aio/content/examples/router/src/app/heroes/hero-detail/hero-detail.component.ts
+++ b/aio/content/examples/router/src/app/heroes/hero-detail/hero-detail.component.ts
@@ -1,14 +1,12 @@
 // #docplaster
 // #docregion
-import { switchMap } from 'rxjs/operators';
-import { Component, OnInit } from '@angular/core';
-// #docregion imports-route-info
-import { Router, ActivatedRoute, ParamMap } from '@angular/router';
-// #enddocregion imports-route-info
-import { Observable } from 'rxjs';
+import {Component, OnInit} from '@angular/core';
+import {ActivatedRoute, ParamMap, Router} from '@angular/router';
+import {Observable} from 'rxjs';
+import {switchMap} from 'rxjs/operators';
 
-import { HeroService } from '../hero.service';
-import { Hero } from '../hero';
+import {Hero} from '../hero';
+import {HeroService} from '../hero.service';
 
 @Component({
   selector: 'app-hero-detail',
@@ -18,22 +16,13 @@ import { Hero } from '../hero';
 export class HeroDetailComponent implements OnInit {
   hero$!: Observable<Hero>;
 
-  // #docregion activated-route
-  constructor(
-    private route: ActivatedRoute,
-  // #enddocregion activated-route
-    private router: Router,
-    private service: HeroService
-  // #docregion activated-route
-  ) {}
-  // #enddocregion activated-route
+  constructor(private route: ActivatedRoute, private router: Router, private service: HeroService) {
+  }
 
 
   ngOnInit() {
     this.hero$ = this.route.paramMap.pipe(
-      switchMap((params: ParamMap) =>
-        this.service.getHero(params.get('id')!))
-    );
+        switchMap((params: ParamMap) => this.service.getHero(params.get('id')!)));
   }
 
   // #docregion redirect
@@ -42,7 +31,7 @@ export class HeroDetailComponent implements OnInit {
     // Pass along the hero id if available
     // so that the HeroList component can select that hero.
     // Include a junk 'foo' property for fun.
-    this.router.navigate(['/superheroes', { id: heroId, foo: 'foo' }]);
+    this.router.navigate(['/superheroes', {id: heroId, foo: 'foo'}]);
   }
   // #enddocregion redirect
 }

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -119,41 +119,22 @@ To edit an item, users click an Edit button, which opens an `EditGroceryItem` co
 You want that component to retrieve the `id` for the grocery item so it can display the right information to the user.
 
 Use a route to pass this type of information to your application components.
-To do so, you use the [ActivatedRoute](api/router/ActivatedRoute) interface.
+To do so, you use the [withComponentInputBinding](api/router/withComponentInputBinding) feature with `provideRouter` or the `bindToComponentInputs` option of `RouterModule.forRoot`.
 
 To get information from a route:
 
-1.  Import `ActivatedRoute` and `ParamMap` to your component.
+1.  Add the `withComponentInputBinding` feature to the `provideRouter` method.
 
-    <code-example header="In the component class (excerpt)" path="router/src/app/heroes/hero-detail/hero-detail.component.ts" region="imports-route-info"></code-example>
+    <code-example header="provideRouter feature" path="router/src/app/app-routing.module.11.ts" region="withComponentInputBinding"></code-example>
 
-    These `import` statements add several important elements that your component needs.
-    To learn more about each, see the following API pages:
+1.  Update the component to have an `Input` matching the name of the parameter.
 
-    *   [`Router`](api/router)
-    *   [`ActivatedRoute`](api/router/ActivatedRoute)
-    *   [`ParamMap`](api/router/ParamMap)
-
-1.  Inject an instance of `ActivatedRoute` by adding it to your component's constructor:
-
-    <code-example header="In the component class (excerpt)" path="router/src/app/heroes/hero-detail/hero-detail.component.ts" region="activated-route"></code-example>
-
-1.  Update the `ngOnInit()` method to access the `ActivatedRoute` and track the `name` parameter:
-
-    <code-example header="In the component (excerpt)">
-
-    ngOnInit() {
-      this.route.queryParams.subscribe(params =&gt; {
-        this.name = params['name'];
-      });
-    }
-
-    </code-example>
+    <code-example header="The component input (excerpt)" path="router/src/app/heroes/hero-detail/hero-detail.component.4.ts" region="id-input"></code-example>
 
     <div class="alert is-helpful">
 
-    **NOTE**: <br />
-    The preceding example uses a variable, `name`, and assigns it the value based on the `name` parameter.
+    **NOTE:** <br>
+    You can bind all route data with key, value pairs to component inputs: static or resolved route data, path parameters, matrix parameters, and query parameters.
 
     </div>
 

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -1098,6 +1098,9 @@ export class UrlTree {
 export const VERSION: Version;
 
 // @public
+export function withComponentInputBinding(): ComponentInputBindingFeature;
+
+// @public
 export function withDebugTracing(): DebugTracingFeature;
 
 // @public

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -293,6 +293,7 @@ export const enum EventType {
 
 // @public
 export interface ExtraOptions extends InMemoryScrollingOptions, RouterConfigOptions {
+    bindToComponentInputs?: boolean;
     enableTracing?: boolean;
     // @deprecated
     errorHandler?: (error: any) => any;
@@ -688,6 +689,7 @@ export class Router {
     constructor();
     // @deprecated
     canceledNavigationResolution: 'replace' | 'computed';
+    readonly componentInputBindingEnabled: boolean;
     // (undocumented)
     config: Routes;
     createUrlTree(commands: any[], navigationExtras?: UrlCreationOptions): UrlTree;
@@ -780,7 +782,7 @@ export interface RouterFeature<FeatureKind extends RouterFeatureKind> {
 }
 
 // @public
-export type RouterFeatures = PreloadingFeature | DebugTracingFeature | InitialNavigationFeature | InMemoryScrollingFeature | RouterConfigurationFeature | NavigationErrorHandlerFeature;
+export type RouterFeatures = PreloadingFeature | DebugTracingFeature | InitialNavigationFeature | InMemoryScrollingFeature | RouterConfigurationFeature | NavigationErrorHandlerFeature | ComponentInputBindingFeature;
 
 // @public
 export type RouterHashLocationFeature = RouterFeature<RouterFeatureKind.RouterHashLocationFeature>;
@@ -911,6 +913,7 @@ export interface RouterOutletContract {
     detach(): ComponentRef<unknown>;
     detachEvents?: EventEmitter<unknown>;
     isActivated: boolean;
+    supportsBindingToComponentInputs?: boolean;
 }
 
 // @public

--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -894,6 +894,8 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)
+    readonly supportsBindingToComponentInputs = true;
+    // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<RouterOutlet, "router-outlet", ["outlet"], { "name": { "alias": "name"; "required": false; }; }, { "activateEvents": "activate"; "deactivateEvents": "deactivate"; "attachEvents": "attach"; "detachEvents": "detach"; }, never, never, true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<RouterOutlet, never>;
@@ -913,7 +915,7 @@ export interface RouterOutletContract {
     detach(): ComponentRef<unknown>;
     detachEvents?: EventEmitter<unknown>;
     isActivated: boolean;
-    supportsBindingToComponentInputs?: boolean;
+    readonly supportsBindingToComponentInputs?: true;
 }
 
 // @public

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -276,6 +276,9 @@
     "name": "INJECTOR_SCOPE"
   },
   {
+    "name": "INPUT_BINDER"
+  },
+  {
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
   },
   {

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -16,7 +16,7 @@ export {CanActivateChildFn, CanActivateFn, CanDeactivateFn, CanLoadFn, CanMatchF
 export * from './models_deprecated';
 export {Navigation, NavigationExtras, UrlCreationOptions} from './navigation_transition';
 export {DefaultTitleStrategy, TitleStrategy} from './page_title_strategy';
-export {DebugTracingFeature, DisabledInitialNavigationFeature, EnabledBlockingInitialNavigationFeature, InitialNavigationFeature, InMemoryScrollingFeature, NavigationErrorHandlerFeature, PreloadingFeature, provideRouter, provideRoutes, RouterConfigurationFeature, RouterFeature, RouterFeatures, RouterHashLocationFeature, withDebugTracing, withDisabledInitialNavigation, withEnabledBlockingInitialNavigation, withHashLocation, withInMemoryScrolling, withNavigationErrorHandler, withPreloading, withRouterConfig} from './provide_router';
+export {DebugTracingFeature, DisabledInitialNavigationFeature, EnabledBlockingInitialNavigationFeature, InitialNavigationFeature, InMemoryScrollingFeature, NavigationErrorHandlerFeature, PreloadingFeature, provideRouter, provideRoutes, RouterConfigurationFeature, RouterFeature, RouterFeatures, RouterHashLocationFeature, withComponentInputBinding, withDebugTracing, withDisabledInitialNavigation, withEnabledBlockingInitialNavigation, withHashLocation, withInMemoryScrolling, withNavigationErrorHandler, withPreloading, withRouterConfig} from './provide_router';
 export {BaseRouteReuseStrategy, DetachedRouteHandle, RouteReuseStrategy} from './route_reuse_strategy';
 export {Router} from './router';
 export {ExtraOptions, InitialNavigation, InMemoryScrollingOptions, ROUTER_CONFIGURATION, RouterConfigOptions} from './router_config';

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -11,6 +11,7 @@ import {BehaviorSubject, combineLatest, EMPTY, Observable, of, Subject} from 'rx
 import {catchError, defaultIfEmpty, filter, finalize, map, switchMap, take, tap} from 'rxjs/operators';
 
 import {createRouterState} from './create_router_state';
+import {INPUT_BINDER} from './directives/router_outlet';
 import {Event, GuardsCheckEnd, GuardsCheckStart, IMPERATIVE_NAVIGATION, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, NavigationSkipped, NavigationSkippedCode, NavigationStart, NavigationTrigger, ResolveEnd, ResolveStart, RouteConfigLoadEnd, RouteConfigLoadStart, RoutesRecognized} from './events';
 import {NavigationBehaviorOptions, QueryParamsHandling, Route, Routes} from './models';
 import {isNavigationCancelingError, isRedirectingNavigationCancelingError, redirectingNavigationError} from './navigation_canceling_error';
@@ -292,6 +293,7 @@ export class NavigationTransitions {
   private readonly environmentInjector = inject(EnvironmentInjector);
   private readonly urlSerializer = inject(UrlSerializer);
   private readonly rootContexts = inject(ChildrenOutletContexts);
+  private readonly inputBindingEnabled = inject(INPUT_BINDER, {optional: true}) !== null;
   navigationId = 0;
   get hasRequestedNavigation() {
     return this.navigationId !== 0;
@@ -641,7 +643,7 @@ export class NavigationTransitions {
 
                          activateRoutes(
                              this.rootContexts, router.routeReuseStrategy,
-                             (evt: Event) => this.events.next(evt)),
+                             (evt: Event) => this.events.next(evt), this.inputBindingEnabled),
 
                          tap({
                            next: (t: NavigationTransition) => {

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -7,11 +7,11 @@
  */
 
 import {HashLocationStrategy, LOCATION_INITIALIZED, LocationStrategy, ViewportScroller} from '@angular/common';
-import {APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, ApplicationRef, ComponentRef, ENVIRONMENT_INITIALIZER, EnvironmentInjector, EnvironmentProviders, inject, InjectFlags, InjectionToken, Injector, makeEnvironmentProviders, NgZone, Provider, Type} from '@angular/core';
+import {APP_BOOTSTRAP_LISTENER, APP_INITIALIZER, ApplicationRef, Component, ComponentRef, ENVIRONMENT_INITIALIZER, EnvironmentInjector, EnvironmentProviders, inject, InjectFlags, InjectionToken, Injector, makeEnvironmentProviders, NgZone, Provider, Type} from '@angular/core';
 import {of, Subject} from 'rxjs';
-import {filter, map, take} from 'rxjs/operators';
 
-import {Event, NavigationCancel, NavigationCancellationCode, NavigationEnd, NavigationError, stringifyEvent} from './events';
+import {INPUT_BINDER, RoutedComponentInputBinder} from './directives/router_outlet';
+import {Event, NavigationError, stringifyEvent} from './events';
 import {Routes} from './models';
 import {NavigationTransitions} from './navigation_transition';
 import {Router} from './router';
@@ -649,6 +649,46 @@ export function withNavigationErrorHandler(fn: (error: NavigationError) => void)
 }
 
 /**
+ * A type alias for providers returned by `withComponentInputBinding` for use with `provideRouter`.
+ *
+ * @see `withComponentInputBinding`
+ * @see `provideRouter`
+ *
+ * @publicApi
+ */
+export type ComponentInputBindingFeature =
+    RouterFeature<RouterFeatureKind.ComponentInputBindingFeature>;
+
+/**
+ * Enables binding information from the `Router` state directly to the inputs of the component in
+ * `Route` configurations.
+ *
+ * @usageNotes
+ *
+ * Basic example of how you can enable the feature:
+ * ```
+ * const appRoutes: Routes = [];
+ * bootstrapApplication(AppComponent,
+ *   {
+ *     providers: [
+ *       provideRouter(appRoutes, withComponentInputBinding())
+ *     ]
+ *   }
+ * );
+ * ```
+ *
+ * @returns A set of providers for use with `provideRouter`.
+ */
+export function withComponentInputBinding(): ComponentInputBindingFeature {
+  const providers = [
+    RoutedComponentInputBinder,
+    {provide: INPUT_BINDER, useExisting: RoutedComponentInputBinder},
+  ];
+
+  return routerFeature(RouterFeatureKind.ComponentInputBindingFeature, providers);
+}
+
+/**
  * A type alias that represents all Router features available for use with `provideRouter`.
  * Features can be enabled by adding special functions to the `provideRouter` call.
  * See documentation for each symbol to find corresponding function name. See also `provideRouter`
@@ -658,8 +698,9 @@ export function withNavigationErrorHandler(fn: (error: NavigationError) => void)
  *
  * @publicApi
  */
-export type RouterFeatures = PreloadingFeature|DebugTracingFeature|InitialNavigationFeature|
-    InMemoryScrollingFeature|RouterConfigurationFeature|NavigationErrorHandlerFeature;
+export type RouterFeatures =
+    PreloadingFeature|DebugTracingFeature|InitialNavigationFeature|InMemoryScrollingFeature|
+    RouterConfigurationFeature|NavigationErrorHandlerFeature|ComponentInputBindingFeature;
 
 /**
  * The list of features as an enum to uniquely type each feature.
@@ -673,4 +714,5 @@ export const enum RouterFeatureKind {
   RouterConfigurationFeature,
   RouterHashLocationFeature,
   NavigationErrorHandlerFeature,
+  ComponentInputBindingFeature,
 }

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -11,6 +11,7 @@ import {inject, Injectable, NgZone, Type, ɵConsole as Console, ɵInitialRenderP
 import {Observable, of, SubscriptionLike} from 'rxjs';
 
 import {createSegmentGroupFromRoute, createUrlTreeFromSegmentGroup} from './create_url_tree';
+import {INPUT_BINDER} from './directives/router_outlet';
 import {RuntimeErrorCode} from './errors';
 import {Event, IMPERATIVE_NAVIGATION, NavigationTrigger} from './events';
 import {NavigationBehaviorOptions, OnSameUrlNavigation, Routes} from './models';
@@ -306,6 +307,14 @@ export class Router {
   private readonly navigationTransitions = inject(NavigationTransitions);
   private readonly urlSerializer = inject(UrlSerializer);
   private readonly location = inject(Location);
+
+  /**
+   * Indicates whether the the application has opted in to binding Router data to component inputs.
+   *
+   * This option is enabled by the `withComponentInputBinding` feature of `provideRouter` or
+   * `bindToComponentInputs` in the `ExtraOptions` of `RouterModule.forRoot`.
+   */
+  readonly componentInputBindingEnabled = !!inject(INPUT_BINDER, {optional: true});
 
   constructor() {
     this.isNgZoneEnabled = inject(NgZone) instanceof NgZone && NgZone.isInAngularZone();

--- a/packages/router/src/router_config.ts
+++ b/packages/router/src/router_config.ts
@@ -198,6 +198,12 @@ export interface ExtraOptions extends InMemoryScrollingOptions, RouterConfigOpti
   initialNavigation?: InitialNavigation;
 
   /**
+   * When true, enables binding information from the `Router` state directly to the inputs of the
+   * component in `Route` configurations.
+   */
+  bindToComponentInputs?: boolean;
+
+  /**
    * A custom error handler for failed navigations.
    * If the handler returns a value, the navigation Promise is resolved with this value.
    * If the handler throws an exception, the navigation Promise is rejected with the exception.

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -16,7 +16,7 @@ import {RouterOutlet} from './directives/router_outlet';
 import {RuntimeErrorCode} from './errors';
 import {Routes} from './models';
 import {NavigationTransitions} from './navigation_transition';
-import {getBootstrapListener, rootRoute, ROUTER_IS_PROVIDED, withDebugTracing, withDisabledInitialNavigation, withEnabledBlockingInitialNavigation, withPreloading} from './provide_router';
+import {getBootstrapListener, rootRoute, ROUTER_IS_PROVIDED, withComponentInputBinding, withDebugTracing, withDisabledInitialNavigation, withEnabledBlockingInitialNavigation, withPreloading} from './provide_router';
 import {Router} from './router';
 import {ExtraOptions, ROUTER_CONFIGURATION} from './router_config';
 import {RouterConfigLoader, ROUTES} from './router_config_loader';
@@ -125,6 +125,7 @@ export class RouterModule {
         config?.preloadingStrategy ? withPreloading(config.preloadingStrategy).ɵproviders : [],
         {provide: NgProbeToken, multi: true, useFactory: routerNgProbeToken},
         config?.initialNavigation ? provideInitialNavigation(config) : [],
+        config?.bindToComponentInputs ? withComponentInputBinding().ɵproviders : [],
         provideRouterInitializer(),
       ],
     };

--- a/packages/router/test/directives/router_outlet.spec.ts
+++ b/packages/router/test/directives/router_outlet.spec.ts
@@ -264,27 +264,6 @@ describe('component input binding', () => {
     const instance = await harness.navigateByUrl('/x;language=english', MyComponent);
     expect(instance.language).toEqual('english');
   });
-  it('sets component inputs from path params', async () => {
-    @Component({
-      template: '',
-    })
-    class MyComponent {
-      @Input() language?: string;
-    }
-
-    TestBed.configureTestingModule({
-      providers: [provideRouter(
-          [{
-            path: '**',
-            component: MyComponent,
-          }],
-          withComponentInputBinding())]
-    });
-    const harness = await RouterTestingHarness.create();
-
-    const instance = await harness.navigateByUrl('/x;language=english', MyComponent);
-    expect(instance.language).toEqual('english');
-  });
 
   it('when keys conflict, sets inputs based on priority: data > path params > query params',
      async () => {


### PR DESCRIPTION
Adds ability for `RouterOutlet` to bind `Router` information to the routed
component's inputs. This commit also exposes some helpers for
implementers of custom outlets to do their own input binding if desired.

Resolves https://github.com/angular/angular/issues/18967

Edit to add some more color to the "required inputs" / no references / no compiler warning for the inputs:

- Some router data lives entirely in userspace and isn't known until runtime. This includes path parameters and query parameters. Only static `data` or `resolve` items can be known at compilation time.
- We considered requiring that bindings be defined in the `data` or `resolve` of the `Route` definitions. However, this would require developers to set the [runGuardsAndResolvers](https://angular.io/api/router/RunGuardsAndResolvers) option at least to `'pathParamsOrQueryParamsChange'`. This was undesirable from a usability and discoverability standpoint.
- Required inputs are checked by the template type checking. Because these components are created dynamically by the `RouterOutlet`, required inputs cannot be checked by the compiler. This is also true of any other component created dynamically.
- We also considered yet another property on `Route` to define what bindings to set on the component. Similar to the point above, this was much more verbose than desired.
- There might be some compiler magic we could add to do some level of type checking. However, I feel the Router package should be developed in a way that isn't "special". That is, it's a library that doesn't use any private APIs or integrations that aren't available to any library author. This ensures that the capabilities in the Router can always be replicated in an alternate Routing library driven by the community; I think this is an important property to at least have as a goal for the health of community projects.