### PR TITLE
refactor(elements): `ComponentNgElementStrategyFactory` and `ComponentNgElementStrategy` are not part of the public API.

### DIFF
--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -20,8 +20,6 @@ const DESTROY_DELAY = 10;
 /**
  * Factory that creates new ComponentNgElementStrategy instance. Gets the component factory with the
  * constructor's injector's factory resolver and passes that factory to each strategy.
- *
- * @publicApi
  */
 export class ComponentNgElementStrategyFactory implements NgElementStrategyFactory {
   componentFactory: ComponentFactory<any>;
@@ -39,8 +37,6 @@ export class ComponentNgElementStrategyFactory implements NgElementStrategyFacto
 /**
  * Creates and destroys a component ref using a component factory and handles change detection
  * in response to input changes.
- *
- * @publicApi
  */
 export class ComponentNgElementStrategy implements NgElementStrategy {
   // Subject of `NgElementStrategyEvent` observables corresponding to the component's outputs.


### PR DESCRIPTION
Per #37416, it has been chosen to not make them public.


## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [x] No
