### PR TITLE
refactor(core): remove DeepReadonly type wrapper for signals

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -419,11 +419,6 @@ export class DebugNode {
 }
 
 // @public
-export type DeepReadonly<T> = T extends (infer R)[] ? ReadonlyArray<DeepReadonly<R>> : (T extends Function ? T : (T extends object ? {
-    readonly [P in keyof T]: DeepReadonly<T[P]>;
-} : T));
-
-// @public
 export const DEFAULT_CURRENCY_CODE: InjectionToken<string>;
 
 // @public @deprecated (undocumented)
@@ -1366,7 +1361,7 @@ export interface SelfDecorator {
 export function setTestabilityGetter(getter: GetTestability): void;
 
 // @public
-export type Signal<T> = (() => DeepReadonly<T>) & {
+export type Signal<T> = (() => T) & {
     [SIGNAL]: unknown;
 };
 

--- a/packages/core/src/core_reactivity_export_internal.ts
+++ b/packages/core/src/core_reactivity_export_internal.ts
@@ -11,7 +11,6 @@ export {
   computed,
   CreateComputedOptions,
   CreateSignalOptions,
-  DeepReadonly,
   isSignal,
   Signal,
   signal,

--- a/packages/core/src/signals/README.md
+++ b/packages/core/src/signals/README.md
@@ -4,7 +4,7 @@ This directory contains the code for Angular's reactive primitive, an implementa
 
 ## Conceptual surface
 
-Angular Signals are zero-argument functions (`() => DeepReadonly<T>`). When executed, they return the current value of the signal. Executing signals does not trigger side effects, though it may lazily recompute intermediate values (lazy memoization).
+Angular Signals are zero-argument functions (`() => T`). When executed, they return the current value of the signal. Executing signals does not trigger side effects, though it may lazily recompute intermediate values (lazy memoization).
 
 Particular contexts (such as template expressions) can be _reactive_. In such contexts, executing a signal will return the value, but also register the signal as a dependency of the context in question. The context's owner will then be notified if any of its signal dependencies produces a new value (usually, this results in the re-execution of those expressions to consume the new values).
 
@@ -38,10 +38,6 @@ The signal creation function one can, optionally, specify an equality comparator
 If the equality function determines that 2 values are equal it will:
 * block update of signal’s value;
 * skip change propagation.
-
-#### `DeepReadonly`
-
-Values read from signals are wrapped in a TypeScript type `DeepReadonly`, which recursively tags all properties and arrays in the inner type as `readonly`, preventing simple mutations. This acts as a safeguard against accidental mutation of signal values outside of the mutation API for `WritableSignal`s.
 
 ### Declarative derived values: `computed()`
 

--- a/packages/core/src/signals/index.ts
+++ b/packages/core/src/signals/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {DeepReadonly, isSignal, Signal, ValueEqualityFn} from './src/api';
+export {isSignal, Signal, ValueEqualityFn} from './src/api';
 export {computed, CreateComputedOptions} from './src/computed';
 export {setActiveConsumer} from './src/graph';
 export {CreateSignalOptions, signal, WritableSignal} from './src/signal';

--- a/packages/core/src/signals/src/api.ts
+++ b/packages/core/src/signals/src/api.ts
@@ -25,7 +25,7 @@ const SIGNAL = Symbol('SIGNAL');
  *
  * @developerPreview
  */
-export type Signal<T> = (() => DeepReadonly<T>)&{
+export type Signal<T> = (() => T)&{
   [SIGNAL]: unknown;
 };
 
@@ -89,18 +89,3 @@ export function defaultEquals<T>(a: T, b: T) {
   // as objects (`typeof null === 'object'`).
   return (a === null || typeof a !== 'object') && Object.is(a, b);
 }
-
-// clang-format off
-/**
- * Makes `T` read-only at the property level.
- *
- * Objects have their properties mapped to `DeepReadonly` types and arrays are converted to
- * `ReadonlyArray`s of `DeepReadonly` values.
- *
- * @developerPreview
- */
-export type DeepReadonly<T> = T extends(infer R)[] ? ReadonlyArray<DeepReadonly<R>> :
-    (T extends Function ? T :
-    (T extends object ? {readonly[P in keyof T]: DeepReadonly<T[P]>} :
-    T));
-// clang-format on

--- a/packages/core/src/signals/src/signal.ts
+++ b/packages/core/src/signals/src/signal.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {createSignalFromFunction, DeepReadonly, defaultEquals, Signal, ValueEqualityFn} from './api';
+import {createSignalFromFunction, defaultEquals, Signal, ValueEqualityFn} from './api';
 import {ReactiveNode} from './graph';
 
 /**
@@ -81,9 +81,9 @@ class WritableSignalImpl<T> extends ReactiveNode {
     this.producerMayHaveChanged();
   }
 
-  signal(): DeepReadonly<T> {
+  signal(): T {
     this.producerAccessed();
-    return this.value as unknown as DeepReadonly<T>;
+    return this.value;
   }
 }
 

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -97,18 +97,4 @@ describe('signals', () => {
     state.set(stateValue);
     expect(derived()).toEqual('object:5');
   });
-
-  it('should prohibit mutable access to properties at a type level', () => {
-    const state = signal({name: 'John'});
-
-    // @ts-expect-error
-    state().name = 'Jacob';
-  });
-
-  it('should prohibit mutable access to arrays at a type level', () => {
-    const state = signal(['John']);
-
-    // @ts-expect-error
-    state().push('Jacob');
-  });
 });


### PR DESCRIPTION
We've been experimenting with the DeepReadonly type that would make signal values deeply read-only and prevent accidental changes without going to the owner of data. What we've found out during the experiments is that additional safety net has more drawbacks than benefits: it just introduces too much friction to be practical for daily usage.
