### PR TITLE
refactor: remove deprecated `EventManager` method `addGlobalEventListener`

### DIFF
--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -94,8 +94,6 @@ export const EVENT_MANAGER_PLUGINS: InjectionToken<EventManagerPlugin[]>;
 export class EventManager {
     constructor(plugins: EventManagerPlugin[], _zone: NgZone);
     addEventListener(element: HTMLElement, eventName: string, handler: Function): Function;
-    // @deprecated
-    addGlobalEventListener(target: string, eventName: string, handler: Function): Function;
     getZone(): NgZone;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<EventManager, never>;

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -858,9 +858,6 @@
     "name": "dashCaseToCamelCase"
   },
   {
-    "name": "decoratePreventDefault"
-  },
-  {
     "name": "deepForEach"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -630,9 +630,6 @@
     "name": "currentConsumer"
   },
   {
-    "name": "decoratePreventDefault"
-  },
-  {
     "name": "deepForEach"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -864,9 +864,6 @@
     "name": "currentConsumer"
   },
   {
-    "name": "decoratePreventDefault"
-  },
-  {
     "name": "deepForEach"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -834,9 +834,6 @@
     "name": "currentConsumer"
   },
   {
-    "name": "decoratePreventDefault"
-  },
-  {
     "name": "deepForEach"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1083,9 +1083,6 @@
     "name": "decodeQuery"
   },
   {
-    "name": "decoratePreventDefault"
-  },
-  {
     "name": "deepForEach"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -570,9 +570,6 @@
     "name": "currentConsumer"
   },
   {
-    "name": "decoratePreventDefault"
-  },
-  {
     "name": "deepForEach"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -750,9 +750,6 @@
     "name": "currentConsumer"
   },
   {
-    "name": "decoratePreventDefault"
-  },
-  {
     "name": "deepForEach"
   },
   {

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ɵgetDOM as getDOM} from '@angular/common';
 import {APP_ID, CSP_NONCE, Inject, Injectable, InjectionToken, OnDestroy, Optional, Renderer2, RendererFactory2, RendererStyleFlags2, RendererType2, ViewEncapsulation} from '@angular/core';
 
 import {EventManager} from './events/event_manager';
@@ -288,10 +289,13 @@ class DefaultDomRenderer2 implements Renderer2 {
       () => void {
     (typeof ngDevMode === 'undefined' || ngDevMode) && checkNoSyntheticProp(event, 'listener');
     if (typeof target === 'string') {
-      return <() => void>this.eventManager.addGlobalEventListener(
-          target, event, decoratePreventDefault(callback));
+      target = getDOM().getGlobalEventTarget(document, target);
+      if (!target) {
+        throw new Error(`Unsupported event target ${target} for event ${event}`);
+      }
     }
-    return <() => void>this.eventManager.addEventListener(
+
+    return this.eventManager.addEventListener(
                target, event, decoratePreventDefault(callback)) as () => void;
   }
 }

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ɵgetDOM as getDOM} from '@angular/common';
 import {Inject, Injectable, InjectionToken, NgZone} from '@angular/core';
 
 /**
@@ -53,21 +52,6 @@ export class EventManager {
   }
 
   /**
-   * Registers a global handler for an event in a target view.
-   *
-   * @param target A target for global event notifications. One of "window", "document", or "body".
-   * @param eventName The name of the event to listen for.
-   * @param handler A function to call when the notification occurs. Receives the
-   * event object as an argument.
-   * @returns A callback function that can be used to remove the handler.
-   * @deprecated No longer being used in Ivy code. To be removed in version 14.
-   */
-  addGlobalEventListener(target: string, eventName: string, handler: Function): Function {
-    const plugin = this._findPluginFor(eventName);
-    return plugin.addGlobalEventListener(target, eventName, handler);
-  }
-
-  /**
    * Retrieves the compilation zone in which event listeners are registered.
    */
   getZone(): NgZone {
@@ -102,12 +86,4 @@ export abstract class EventManagerPlugin {
   abstract supports(eventName: string): boolean;
 
   abstract addEventListener(element: HTMLElement, eventName: string, handler: Function): Function;
-
-  addGlobalEventListener(element: string, eventName: string, handler: Function): Function {
-    const target: HTMLElement = getDOM().getGlobalEventTarget(this._doc, element);
-    if (!target) {
-      throw new Error(`Unsupported event target ${target} for event ${eventName}`);
-    }
-    return this.addEventListener(target, eventName, handler);
-  }
 }

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -75,26 +75,6 @@ describe('EventManager', () => {
     expect(receivedEvent).toBe(dispatchedEvent);
   });
 
-  it('should add and remove global event listeners', () => {
-    const element = el('<div><div></div></div>');
-    doc.body.appendChild(element);
-    const dispatchedEvent = createMouseEvent('click');
-    let receivedEvent: any /** TODO #9100 */ = null;
-    const handler = (e: any /** TODO #9100 */) => {
-      receivedEvent = e;
-    };
-    const manager = new EventManager([domEventPlugin], new FakeNgZone());
-
-    const remover = manager.addGlobalEventListener('document', 'click', handler);
-    getDOM().dispatchEvent(element, dispatchedEvent);
-    expect(receivedEvent).toBe(dispatchedEvent);
-
-    receivedEvent = null;
-    remover();
-    getDOM().dispatchEvent(element, dispatchedEvent);
-    expect(receivedEvent).toBe(null);
-  });
-
   it('should keep zone when addEventListener', () => {
     const Zone = (window as any)['Zone'];
 

--- a/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
+++ b/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
@@ -30,14 +30,6 @@ import {HammerGestureConfig, HammerGesturesPlugin,} from '@angular/platform-brow
         plugin = new HammerGesturesPlugin(document, new HammerGestureConfig(), fakeConsole);
       });
 
-      it('should implement addGlobalEventListener', () => {
-        spyOn(plugin, 'addEventListener').and.callFake(() => () => {});
-
-        expect(() => {
-          plugin.addGlobalEventListener('document', 'swipe', () => {});
-        }).not.toThrowError();
-      });
-
       it('should warn user and do nothing when Hammer.js not loaded', () => {
         expect(plugin.supports('swipe')).toBe(false);
         expect(fakeConsole.warn)

--- a/packages/platform-browser/test/dom/events/key_events_spec.ts
+++ b/packages/platform-browser/test/dom/events/key_events_spec.ts
@@ -71,17 +71,6 @@ import {KeyEventsPlugin} from '@angular/platform-browser/src/dom/events/key_even
           .toEqual(KeyEventsPlugin.parseEventName('keyup.control.escape'));
     });
 
-    if (!isNode) {
-      it('should implement addGlobalEventListener', () => {
-        const plugin = new KeyEventsPlugin(document);
-
-        spyOn(plugin, 'addEventListener').and.callFake(() => () => {});
-
-        expect(() => plugin.addGlobalEventListener('window', 'keyup.control.esc', () => {}))
-            .not.toThrowError();
-      });
-    }
-
     it('should match key field', () => {
       const baseKeyboardEvent = {
         isTrusted: true,

--- a/packages/platform-server/src/server_events.ts
+++ b/packages/platform-server/src/server_events.ts
@@ -21,13 +21,4 @@ export class ServerEventManagerPlugin /* extends EventManagerPlugin which is pri
   addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
     return getDOM().onAndCancel(element, eventName, handler);
   }
-
-  /** @deprecated No longer being used in Ivy code. To be removed in version 14. */
-  addGlobalEventListener(element: string, eventName: string, handler: Function): Function {
-    const target: HTMLElement = getDOM().getGlobalEventTarget(this.doc, element);
-    if (!target) {
-      throw new Error(`Unsupported event target ${target} for event ${eventName}`);
-    }
-    return this.addEventListener(target, eventName, handler);
-  }
 }

--- a/packages/platform-server/src/server_renderer.ts
+++ b/packages/platform-server/src/server_renderer.ts
@@ -209,11 +209,7 @@ class DefaultServerRenderer2 implements Renderer2 {
       target: 'document'|'window'|'body'|any, eventName: string,
       callback: (event: any) => boolean): () => void {
     checkNoSyntheticProp(eventName, 'listener');
-    if (typeof target === 'string') {
-      return <() => void>this.eventManager.addGlobalEventListener(
-          target, eventName, this.decoratePreventDefault(callback));
-    }
-    return <() => void>this.eventManager.addEventListener(
+    return this.eventManager.addEventListener(
                target, eventName, this.decoratePreventDefault(callback)) as () => void;
   }
 


### PR DESCRIPTION

This commit removes the deprecated `EventManager` method  `addGlobalEventListener`.

BREAKING CHANGE: Deprecated `EventManager` method `addGlobalEventListener` has been removed as it is not used by Ivy.