### PR TITLE
refactor(router): Remove dead code

### DIFF
--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -588,9 +588,6 @@ export class Router {
         this.console.warn(
             `Navigation triggered outside Angular zone, did you forget to call 'ngZone.run()'?`);
       }
-      if (url instanceof UrlTree && url._warnIfUsedForNavigation) {
-        this.console.warn(url._warnIfUsedForNavigation);
-      }
     }
 
     const urlTree = isUrlTree(url) ? url : this.parseUrl(url);

--- a/packages/router/src/url_tree.ts
+++ b/packages/router/src/url_tree.ts
@@ -189,8 +189,6 @@ function matrixParamsMatch(
 export class UrlTree {
   /** @internal */
   _queryParamMap?: ParamMap;
-  /** @internal */
-  _warnIfUsedForNavigation?: string;
 
   constructor(
       /** The root segment group of the URL tree */


### PR DESCRIPTION
This warning is no longer produced because the legacy method of creating URL trees was removed in v16
