### PR TITLE
refactor(core): avoid incrementing a dev mode counter unnecessarily

### DIFF
--- a/packages/core/src/render3/instructions/element_container.ts
+++ b/packages/core/src/render3/instructions/element_container.ts
@@ -83,8 +83,6 @@ export function ɵɵelementContainerStart(
       tView.data[adjustedIndex] as TElementContainerNode;
   setCurrentTNode(tNode, true);
 
-  ngDevMode && ngDevMode.rendererCreateComment++;
-
   const comment = _locateOrCreateElementContainerNode(tView, lView, tNode, index);
   lView[adjustedIndex] = comment;
 


### PR DESCRIPTION
This commit removes a code that increments the `rendererCreateComment` counter unnecessarily. The counter gets incemented even in hydration scenarios where we do not create a comment node. The counter still gets incemented in the right locations (when we *actually* create a node).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No