### PR TITLE
feat(platform-browser): add a public API function to enable non-destructive hydration

### DIFF
--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -9,6 +9,7 @@ import { ApplicationRef } from '@angular/core';
 import { ComponentRef } from '@angular/core';
 import { DebugElement } from '@angular/core';
 import { DebugNode } from '@angular/core';
+import { EnvironmentProviders } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/common';
 import { InjectionToken } from '@angular/core';
@@ -143,6 +144,17 @@ export class HammerModule {
     static ɵmod: i0.ɵɵNgModuleDeclaration<HammerModule, never, never, never>;
 }
 
+// @public
+export interface HydrationFeature<FeatureKind extends HydrationFeatureKind> {
+    // (undocumented)
+    ɵkind: FeatureKind;
+    // (undocumented)
+    ɵproviders: Provider[];
+}
+
+// @public
+export type HydrationFeatures = NoDomReuseFeature;
+
 // @public @deprecated
 export const makeStateKey: typeof makeStateKey_2;
 
@@ -178,7 +190,13 @@ export type MetaDefinition = {
 };
 
 // @public
+export type NoDomReuseFeature = HydrationFeature<HydrationFeatureKind.NoDomReuseFeature>;
+
+// @public
 export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef;
+
+// @public
+export function provideClientHydration(...features: HydrationFeatures[]): EnvironmentProviders;
 
 // @public
 export function provideProtractorTestingSupport(): Provider[];
@@ -231,6 +249,9 @@ export const TransferState: {
 
 // @public (undocumented)
 export const VERSION: Version;
+
+// @public
+export function withoutDomReuse(): NoDomReuseFeature;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -16,7 +16,7 @@ export {INJECTOR_SCOPE as ɵINJECTOR_SCOPE} from './di/scope';
 export {XSS_SECURITY_URL as ɵXSS_SECURITY_URL} from './error_details_base_url';
 export {formatRuntimeError as ɵformatRuntimeError, RuntimeError as ɵRuntimeError} from './errors';
 export {annotateForHydration as ɵannotateForHydration} from './hydration/annotate';
-export {provideHydrationSupport as ɵprovideHydrationSupport} from './hydration/api';
+export {withDomHydration as ɵwithDomHydration} from './hydration/api';
 export {IS_HYDRATION_FEATURE_ENABLED as ɵIS_HYDRATION_FEATURE_ENABLED} from './hydration/tokens';
 export {CurrencyIndex as ɵCurrencyIndex, ExtraLocaleDataIndex as ɵExtraLocaleDataIndex, findLocaleData as ɵfindLocaleData, getLocaleCurrencyCode as ɵgetLocaleCurrencyCode, getLocalePluralCase as ɵgetLocalePluralCase, LocaleDataIndex as ɵLocaleDataIndex, registerLocaleData as ɵregisterLocaleData, unregisterAllLocaleData as ɵunregisterLocaleData} from './i18n/locale_data_api';
 export {DEFAULT_LOCALE_ID as ɵDEFAULT_LOCALE_ID} from './i18n/localization';

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -74,6 +74,7 @@ function printHydrationStats(console: Console) {
   const message = `Angular hydrated ${ngDevMode!.hydratedComponents} component(s) ` +
       `and ${ngDevMode!.hydratedNodes} node(s), ` +
       `${ngDevMode!.componentsSkippedHydration} component(s) were skipped. ` +
+      `Note: this feature is in Developer Preview mode. ` +
       `Learn more at https://angular.io/guides/hydration.`;
   // tslint:disable-next-line:no-console
   console.log(message);
@@ -92,47 +93,15 @@ function whenStable(
 
 /**
  * Returns a set of providers required to setup hydration support
- * for an application that is server side rendered.
- *
- * ## NgModule-based bootstrap
- *
- * You can add the function call to the root AppModule of an application:
- * ```
- * import {provideHydrationSupport} from '@angular/core';
- *
- * @NgModule({
- *   providers: [
- *     // ... other providers ...
- *     provideHydrationSupport()
- *   ],
- *   declarations: [AppComponent],
- *   bootstrap: [AppComponent]
- * })
- * class AppModule {}
- * ```
- *
- * ## Standalone-based bootstrap
- *
- * Add the function to the `bootstrapApplication` call:
- * ```
- * import {provideHydrationSupport} from '@angular/core';
- *
- * bootstrapApplication(RootComponent, {
- *   providers: [
- *     // ... other providers ...
- *     provideHydrationSupport()
- *   ]
- * });
- * ```
+ * for an application that is server side rendered. This function is
+ * included into the `provideClientHydration` public API function from
+ * the `platform-browser` package.
  *
  * The function sets up an internal flag that would be recognized during
  * the server side rendering time as well, so there is no need to
  * configure or change anything in NgUniversal to enable the feature.
- *
- * @publicApi
- * @developerPreview
  */
-export function provideHydrationSupport(): EnvironmentProviders {
+export function withDomHydration(): EnvironmentProviders {
   return makeEnvironmentProviders([
     {
       provide: ENVIRONMENT_INITIALIZER,

--- a/packages/platform-browser/src/hydration.ts
+++ b/packages/platform-browser/src/hydration.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {EnvironmentProviders, makeEnvironmentProviders, Provider, ɵwithDomHydration as withDomHydration} from '@angular/core';
+
+/**
+ * The list of features as an enum to uniquely type each feature.
+ */
+export const enum HydrationFeatureKind {
+  NoDomReuseFeature
+}
+
+/**
+ * Helper type to represent a Hydration feature.
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export interface HydrationFeature<FeatureKind extends HydrationFeatureKind> {
+  ɵkind: FeatureKind;
+  ɵproviders: Provider[];
+}
+
+/**
+ * Helper function to create an object that represents a Hydration feature.
+ */
+function hydrationFeature<FeatureKind extends HydrationFeatureKind>(
+    kind: FeatureKind, providers: Provider[]): HydrationFeature<FeatureKind> {
+  return {ɵkind: kind, ɵproviders: providers};
+}
+
+/**
+ * A type alias that represents a feature which disables DOM reuse during hydration
+ * (effectively making Angular re-render the whole application from scratch).
+ * The type is used to describe the return value of the `withoutDomReuse` function.
+ *
+ * @see `withoutDomReuse`
+ * @see `provideClientHydration`
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export type NoDomReuseFeature = HydrationFeature<HydrationFeatureKind.NoDomReuseFeature>;
+
+/**
+ * Disables DOM nodes reuse during hydration. Effectively makes
+ * Angular re-render an application from scratch on the client.
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export function withoutDomReuse(): NoDomReuseFeature {
+  // This feature has no providers and acts as a flag that turns off
+  // non-destructive hydration (which otherwise is turned on by default).
+  const providers: Provider[] = [];
+  return hydrationFeature(HydrationFeatureKind.NoDomReuseFeature, providers);
+}
+
+/**
+ * A type alias that represents all Hydration features available for use with
+ * `provideClientHydration`. Features can be enabled by adding special functions to the
+ * `provideClientHydration` call. See documentation for each symbol to find corresponding
+ * function name. See also `provideClientHydration` documentation on how to use those functions.
+ *
+ * @see `provideClientHydration`
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export type HydrationFeatures = NoDomReuseFeature;
+
+/**
+ * Sets up providers necessary to enable hydration functionality for the application.
+ * By default, the function enables the recommended set of features for the optimal
+ * performance for most of the applications. You can enable/disable features by
+ * passing special functions (from the `HydrationFeatures` set) as arguments to the
+ * `provideClientHydration` function.
+ *
+ * @usageNotes
+ *
+ * Basic example of how you can enable hydration in your application when
+ * `bootstrapApplication` function is used:
+ * ```
+ * bootstrapApplication(AppComponent, {
+ *   providers: [provideClientHydration()]
+ * });
+ * ```
+ *
+ * Alternatively if you are using NgModules, you would add `provideClientHydration`
+ * to your root app module's provider list.
+ * ```
+ * @NgModule({
+ *   declarations: [RootCmp],
+ *   bootstrap: [RootCmp],
+ *   providers: [provideClientHydration()],
+ * })
+ * export class AppModule {}
+ * ```
+ *
+ * @see `HydrationFeatures`
+ *
+ * @param features Optional features to configure additional router behaviors.
+ * @returns A set of providers to enable hydration.
+ *
+ * @publicApi
+ * @developerPreview
+ */
+export function provideClientHydration(...features: HydrationFeatures[]): EnvironmentProviders {
+  const shouldUseDomHydration =
+      !features.find(feature => feature.ɵkind === HydrationFeatureKind.NoDomReuseFeature);
+  return makeEnvironmentProviders([
+    (shouldUseDomHydration ? withDomHydration() : []),
+    features.map(feature => feature.ɵproviders),
+  ]);
+}

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -77,6 +77,7 @@ export {REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
 export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerLoader, HammerModule} from './dom/events/hammer_gestures';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
+export {HydrationFeature, provideClientHydration, NoDomReuseFeature, HydrationFeatures, withoutDomReuse} from './hydration';
 
 export * from './private_export';
 export {VERSION} from './version';


### PR DESCRIPTION
This commit adds the `provideClientHydration` function to the public API. This function can be used to enable the non-destructive Angular hydration.

Important note: the non-destructive hydration feature is in Developer Preview mode, learn more about it at https://angular.io/guide/releases#developer-preview.

Before you can get started with hydration, you must have a server side rendered (SSR) application. Follow the [Angular Universal Guide](https://angular.io/guide/universal) to enable server side rendering first. Once you have SSR working with your application, you can enable hydration by visiting your main app component or module and importing `provideClientHydration` from `@angular/platform-browser`. You'll then add that provider to your app's bootstrapping providers list.

```typescript
import {
  bootstrapApplication,
  provideClientHydration,
} from '@angular/platform-browser';
// ...
bootstrapApplication(RootCmp, {
  providers: [provideClientHydration()]
});
```

Alternatively if you are using NgModules, you would add `provideClientHydration` to your root app module's provider list.

```typescript
import {provideClientHydration} from '@angular/platform-browser';
import {NgModule} from '@angular/core';

@NgModule({
  declarations: [RootCmp],
  exports: [RootCmp],
  bootstrap: [RootCmp],
  providers: [provideClientHydration()],
})
export class AppModule {}
```

You can confirm hydration is enabled by opening Developer Tools in your browser and viewing the console. You should see a message that includes hydration-related stats, such as the number of components and nodes hydrated.

Co-authored-by: @jessicajaniuk @alan-agius4

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
