### PR TITLE
refactor(docs-infra): cleanup deprecated code

### DIFF
--- a/aio/scripts/deploy-to-firebase/pre-deploy-actions.spec.mjs
+++ b/aio/scripts/deploy-to-firebase/pre-deploy-actions.spec.mjs
@@ -164,6 +164,7 @@ describe('deploy-to-firebase/pre-deploy-actions:', () => {
 
   describe('undo.checkPayloadSize()', () => {
     // This method is a no-op, so there is nothing to test.
+    // eslint-disable-next-line jasmine/expect-single-argument
     it('does not need tests', () => expect().nothing());
   });
 

--- a/aio/src/app/app.component.spec.ts
+++ b/aio/src/app/app.component.spec.ts
@@ -22,7 +22,7 @@ import { SearchResultsComponent } from 'app/shared/search-results/search-results
 import { TocItem, TocService } from 'app/shared/toc.service';
 import { SwUpdatesService } from 'app/sw-updates/sw-updates.service';
 import { of, Subject, timer } from 'rxjs';
-import { first, mapTo } from 'rxjs/operators';
+import { first, map } from 'rxjs/operators';
 import { MockLocationService } from 'testing/location.service';
 import { MockLogger } from 'testing/logger.service';
 import { MockSearchService } from 'testing/search.service';
@@ -1431,7 +1431,7 @@ class TestHttpClient {
   };
 
   get(url: string) {
-    let data;
+    let data: any;
     if (/navigation\.json/.test(url)) {
       data = this.navJson;
     } else {
@@ -1445,7 +1445,7 @@ class TestHttpClient {
     }
 
     // Preserve async nature of `HttpClient`.
-    return timer(1).pipe(mapTo(data));
+    return timer(1).pipe(map(() => data));
   }
 }
 

--- a/aio/src/app/app.component.ts
+++ b/aio/src/app/app.component.ts
@@ -414,7 +414,7 @@ export class AppComponent implements OnInit {
       }
     }
 
-    this.tocMaxHeight = (document.body.scrollHeight - window.pageYOffset - this.tocMaxHeightOffset).toFixed(2);
+    this.tocMaxHeight = (document.body.scrollHeight - window.scrollY - this.tocMaxHeightOffset).toFixed(2);
   }
 
   // Restrain scrolling inside an element, when the cursor is over it

--- a/aio/src/app/custom-elements/announcement-bar/announcement-bar.component.spec.ts
+++ b/aio/src/app/custom-elements/announcement-bar/announcement-bar.component.spec.ts
@@ -76,7 +76,7 @@ describe('AnnouncementBarComponent', () => {
     it('should handle a failed request for `announcements.json`', () => {
       component.ngOnInit();
       const request = httpMock.expectOne('generated/announcements.json');
-      request.error(new ErrorEvent('404'));
+      request.error(new ProgressEvent('404'));
       expect(component.announcement).toBeUndefined();
       expect(mockLogger.output.error).toEqual([
         [jasmine.any(Error)]

--- a/aio/src/app/custom-elements/elements-loader.ts
+++ b/aio/src/app/custom-elements/elements-loader.ts
@@ -1,4 +1,4 @@
-import { createNgModuleRef, Inject, Injectable, NgModuleRef, Type } from '@angular/core';
+import { createNgModule, Inject, Injectable, NgModuleRef, Type } from '@angular/core';
 import { ELEMENT_MODULE_LOAD_CALLBACKS_TOKEN, WithCustomElementComponent } from './element-registry';
 import { from, Observable, of } from 'rxjs';
 import { createCustomElement } from '@angular/elements';
@@ -46,7 +46,7 @@ export class ElementsLoader {
       const loadedAndRegistered =
         (modulePathLoader() as Promise<Type<WithCustomElementComponent>>)
           .then(elementModule => {
-            const elementModuleRef = createNgModuleRef(elementModule, this.moduleRef.injector);
+            const elementModuleRef = createNgModule(elementModule, this.moduleRef.injector);
             const injector = elementModuleRef.injector;
             const CustomElementComponent = elementModuleRef.instance.customElementComponent;
             const CustomElement = createCustomElement(CustomElementComponent, {injector});

--- a/aio/src/app/custom-elements/events/events.service.spec.ts
+++ b/aio/src/app/custom-elements/events/events.service.spec.ts
@@ -38,7 +38,7 @@ describe('EventsService', () => {
 
   it('should handle a failed request for `events.json`', () => {
     const request = httpMock.expectOne('generated/events.json');
-    request.error(new ErrorEvent('404'));
+    request.error(new ProgressEvent('404'));
     expect(mockLogger.output.error).toEqual([
       [jasmine.any(Error)]
     ]);
@@ -47,7 +47,7 @@ describe('EventsService', () => {
 
   it('should return an empty array on a failed request for `events.json`', done => {
     const request = httpMock.expectOne('generated/events.json');
-    request.error(new ErrorEvent('404'));
+    request.error(new ProgressEvent('404'));
     eventsService.events.subscribe(results => {
       expect(results).toEqual([]);
       done();

--- a/aio/src/app/shared/scroll-spy.service.ts
+++ b/aio/src/app/shared/scroll-spy.service.ts
@@ -166,7 +166,7 @@ export class ScrollSpyService {
   }
 
   private getScrollTop() {
-    return window && window.pageYOffset || 0;
+    return window && window.scrollY || 0;
   }
 
   private getTopOffset() {

--- a/aio/src/app/shared/scroll.service.spec.ts
+++ b/aio/src/app/shared/scroll.service.spec.ts
@@ -192,7 +192,7 @@ describe('ScrollService', () => {
 
     it('should return `<body>` if unable to find the top-of-page element', () => {
       (document.getElementById as jasmine.Spy).and.returnValue(null);
-      expect(scrollService.topOfPageElement).toBe(document.body as any);
+      expect(scrollService.topOfPageElement).toBe(document.body);
     });
   });
 
@@ -274,14 +274,14 @@ describe('ScrollService', () => {
     it('should scroll all the way to the top if close enough', () => {
       const element: HTMLElement = new MockElement() as any;
 
-      (window as any).pageYOffset = 25;
+      window.scrollY = 25;
       scrollService.scrollToElement(element);
 
       expect(element.scrollIntoView).toHaveBeenCalled();
       expect(window.scrollBy).toHaveBeenCalledWith(0, -scrollService.topOffset);
       (window.scrollBy as jasmine.Spy).calls.reset();
 
-      (window as any).pageYOffset = 15;
+      window.scrollY = 15;
       scrollService.scrollToElement(element);
 
       expect(element.scrollIntoView).toHaveBeenCalled();
@@ -297,7 +297,7 @@ describe('ScrollService', () => {
 
   describe('#scrollToTop', () => {
     it('should scroll to top', () => {
-      const topOfPageElement = new MockElement() as any as Element;
+      const topOfPageElement = new MockElement();
       document.getElementById.and.callFake(
           (id: string) => id === 'top-of-page' ? topOfPageElement : null);
 

--- a/aio/src/app/shared/scroll.service.ts
+++ b/aio/src/app/shared/scroll.service.ts
@@ -161,8 +161,8 @@ export class ScrollService implements OnDestroy {
 
         // If we are very close to the top (<20px), then scroll all the way up.
         // (This can happen if `element` is at the top of the page, but has a small top-margin.)
-        if (window.pageYOffset < 20) {
-          window.scrollBy(0, -window.pageYOffset);
+        if (window.scrollY < 20) {
+          window.scrollBy(0, -window.scrollY);
         }
       }
     }


### PR DESCRIPTION
This commit replaces (non material-related) deprecated code present in the aio app.

* `pageYOffset` can be replaced by `scrollY`
*  RxJs' `mapTo()` is just a `map()`
* `createNgModuleRef` can be replaced by `createNgModule`
* HttpEmits `ProgressEvent` not `ErrorEvent`  (see #34748)
* `SwUpdate.available` is replaced by  `versionUpdates` with a `filter`
* `SwUpdate.activated` is replaced by the returned promised of `SwUpdate.activateUpdate`.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] angular.io application / infrastructure changes

## Does this PR introduce a breaking change?


- [x] No
