### PR TITLE
refactor(core): remove unnecessary `reflect-metadata` import.

### DIFF
--- a/packages/core/test/render3/ivy/BUILD.bazel
+++ b/packages/core/test/render3/ivy/BUILD.bazel
@@ -10,7 +10,6 @@ ts_library(
         "//packages:types",
         "//packages/core",
         "//packages/core/src/di/interface",
-        "@npm//reflect-metadata",
     ],
 )
 

--- a/packages/core/test/render3/ivy/jit_spec.ts
+++ b/packages/core/test/render3/ivy/jit_spec.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import 'reflect-metadata';
 
 import {Component, ContentChild, ContentChildren, Directive, ElementRef, forwardRef, getNgModuleById, HostBinding, HostListener, Input, NgModule, Pipe, QueryList, ViewChild, ViewChildren, ɵNgModuleDef as NgModuleDef, ɵɵngDeclareComponent as ngDeclareComponent} from '@angular/core';
 import {Injectable} from '@angular/core/src/di/injectable';


### PR DESCRIPTION
Looks like this import in the JIT unit tests was unnecessary ! Let's remove it. 