### PR TITLE
refactor(core): handle a case when ngSkipHydration is applied to the root node of an application

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -107,7 +107,9 @@ export function annotateForHydration(appRef: ApplicationRef, doc: Document) {
     // an embedded view (not a component view).
     if (lView !== null) {
       const hostElement = lView[HOST];
-      if (hostElement) {
+      // Root elements might also be annotated with the `ngSkipHydration` attribute,
+      // check if it's present before starting the serialization process.
+      if (hostElement && !(hostElement as HTMLElement).hasAttribute(SKIP_HYDRATION_ATTR_NAME)) {
         const context: HydrationContext = {
           serializedViewCollection,
           corruptedTextNodes,


### PR DESCRIPTION
This commit updates the logic to handle a case when the `ngSkipHydration` attribute is applied to the root node of an app. In this case, the hydration info should not be serialized and the contents of the app on the client should be cleared up before initial rendering.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No