### PR TITLE
refactor: fix typo in windows-chromium-path.js

### DIFF
--- a/aio/tools/windows-chromium-path.js
+++ b/aio/tools/windows-chromium-path.js
@@ -17,7 +17,7 @@ exports.getAdjustedChromeBinPathForWindows = function() {
         const runfilesWorkspaceRoot = path.join(process.env.RUNFILES, 'angular');
 
         // Get the path to chromium from the runfiles base folder. By default, the Bazel make var
-        // $(CHROMIUM) (which CHROME_BIN is set to) has a preceeding '../' to escape the workspace
+        // $(CHROMIUM) (which CHROME_BIN is set to) has a preceding '../' to escape the workspace
         // root within runfiles. Additional '../' may have been prepended to cancel out any chdirs.
         const chromiumPath = process.env.CHROME_BIN.replace(/^(\.\.\/)*/, '');
 


### PR DESCRIPTION
preceeding -> preceding

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
