### PR TITLE
feat(core): expose onDestroy on ApplicationRef

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -87,6 +87,7 @@ export class ApplicationRef {
     detachView(viewRef: ViewRef): void;
     get injector(): EnvironmentInjector;
     readonly isStable: Observable<boolean>;
+    onDestroy(callback: () => void): VoidFunction;
     tick(): void;
     get viewCount(): number;
     // (undocumented)

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -1117,8 +1117,6 @@ export class ApplicationRef {
    *
    * @param callback A callback function to add as a listener.
    * @returns A function which unregisters a listener.
-   *
-   * @internal
    */
   onDestroy(callback: () => void): VoidFunction {
     (typeof ngDevMode === 'undefined' || ngDevMode) && this.warnIfDestroyed();


### PR DESCRIPTION
This change exposes the onDestroy callback on the ApplicationRef as the public API. It is useful for cases where people need to execute cleanup logic on application teardown.

Closes #49087
