### PR TITLE
refactor(forms): Add a test that uses ControlConfig with a non-static validator.

### DIFF
--- a/packages/forms/test/typed_integration_spec.ts
+++ b/packages/forms/test/typed_integration_spec.ts
@@ -1105,6 +1105,15 @@ describe('Typed Class', () => {
           let t1 = c3.controls;
           t1 = null as unknown as ControlsType;
         }
+
+        const c4 = fb.group({foo: [[1, 2, 3], Validators.maxLength(4)]});
+        {
+          type ControlsType = {foo: FormControl<number[]|null>};
+          let t: ControlsType = c4.controls;
+          let t1 = c4.controls;
+          t1 = null as unknown as ControlsType;
+        }
+        expect(c4.controls.foo.value).toEqual([1, 2, 3]);
       });
 
       it('from objects with ControlConfigs and validator lists', () => {


### PR DESCRIPTION
Previously, this PR cleaned up a bug introduced by #48679. However, since that PR needed to be rolled back, this PR now just checks in the test, to prevent that issue from re-occurring in the future.