### PR TITLE
feat(devtools): Display getters and setters in devtools property viewer

### DIFF
--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Intentionally do not include all the prototype (Except for getters and setters) 
+// Intentionally do not include all the prototype (Except for getters and setters)
 // because it contains inherited methods (hasOwnProperty, etc.). Also ignore symbols
 // because it is tricky to pass a path to a symbol.
 //
@@ -28,7 +28,7 @@ export const getKeys = (obj: {}): string[] => {
     const targetMethod = prototypeMembers[methodName];
 
     return targetMethod.get || targetMethod.set;
-  })
+  });
 
   return properties.concat(gettersAndSetters);
 };

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts
@@ -27,7 +27,7 @@ export const getKeys = (obj: {}): string[] => {
     }
     const targetMethod = prototypeMembers[methodName];
 
-    return !!targetMethod.get || !!targetMethod.set;
+    return targetMethod.get || targetMethod.set;
   })
 
   return properties.concat(gettersAndSetters);

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/object-utils.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Intentionally do not include the prototype because it contains
-// inherited methods (hasOwnProperty, etc.). Also ignore symbols
+// Intentionally do not include all the prototype (Except for getters and setters) 
+// because it contains inherited methods (hasOwnProperty, etc.). Also ignore symbols
 // because it is tricky to pass a path to a symbol.
 //
 // We'd have to go through a serialization and deserialization logic
@@ -16,5 +16,29 @@ export const getKeys = (obj: {}): string[] => {
   if (!obj) {
     return [];
   }
-  return Object.getOwnPropertyNames(obj);
+  const properties = Object.getOwnPropertyNames(obj);
+
+  const prototypeMembers = Object.getOwnPropertyDescriptors(Object.getPrototypeOf(obj));
+
+  const ignoreList = ['__proto__'];
+  const gettersAndSetters = Object.keys(prototypeMembers).filter(methodName => {
+    if (ignoreList.includes(methodName)) {
+      return false;
+    }
+    const targetMethod = prototypeMembers[methodName];
+
+    return !!targetMethod.get || !!targetMethod.set;
+  })
+
+  return properties.concat(gettersAndSetters);
 };
+
+/**
+ * This helper function covers the common scenario as well as the getters and setters
+ * @param instance The target object
+ * @param propName The string representation of the target property name
+ * @returns The Descriptor object of the property
+ */
+export const getDescriptor = (instance: any, propName: string) =>
+    Object.getOwnPropertyDescriptor(instance, propName) ||
+    Object.getOwnPropertyDescriptor(Object.getPrototypeOf(instance), propName);

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -8,7 +8,7 @@
 
 import {Descriptor, NestedProp, PropType} from 'protocol';
 
-import {getKeys} from './object-utils';
+import {getDescriptor, getKeys} from './object-utils';
 
 // todo(aleksanderbodurri) pull this out of this file
 const METADATA_PROPERTY_NAME = '__ngContext__';
@@ -130,48 +130,48 @@ const shallowPropTypeToTreeMetaData:
       },
     };
 
-const isEditable = (instance: any, propName: string|number, propData: TerminalType) => {
+const isEditable = (descriptor: any, propName: string|number, propData: TerminalType, isGetterOrSetter: boolean) => {
   if (typeof propName === 'symbol') {
     return false;
   }
-  const descriptor = Object.getOwnPropertyDescriptor(instance, propName as string);
+
+  if (isGetterOrSetter) {
+    return false;
+  }
+
   if (descriptor?.writable === false) {
     return false;
   }
-  if (!descriptor?.set && descriptor && !('value' in descriptor)) {
-    return false;
-  }
-  if (descriptor?.set && !descriptor?.get && !('value' in descriptor)) {
-    return false;
-  }
+
   return shallowPropTypeToTreeMetaData[propData.type].editable;
 };
 
-const hasValue = (obj: {}, prop: string|number) => {
-  const descriptor = Object.getOwnPropertyDescriptor(obj, prop);
-  if (!descriptor?.get && descriptor?.set && typeof descriptor?.value === 'undefined') {
-    return false;
+const isGetterOrSetter = (descriptor: any): boolean => {
+  if ((descriptor?.set || descriptor?.get) && !('value' in descriptor)) {
+    return true;
   }
-  return true;
+  return false;
 };
 
 const getPreview =
-    (instance: {}, propName: string|number, propData: TerminalType|CompositeType) => {
-      return hasValue(instance, propName) ? typeToDescriptorPreview[propData.type](propData.prop) :
-                                            SETTER_FIELD_PREVIEW;
+    (propData: TerminalType|CompositeType, isGetterOrSetter: boolean) => {
+      return !isGetterOrSetter ?
+          typeToDescriptorPreview[propData.type](propData.prop) :
+          typeToDescriptorPreview[PropType.Function]({ name: '' });
     };
-
-const SETTER_FIELD_PREVIEW = '[setter]';
 
 export const createShallowSerializedDescriptor =
     (instance: any, propName: string|number, propData: TerminalType): Descriptor => {
       const {type} = propData;
 
+      const descriptor = getDescriptor(instance, propName as string);
+      const getterOrSetter: boolean = isGetterOrSetter(descriptor); 
+
       const shallowSerializedDescriptor: Descriptor = {
         type,
         expandable: shallowPropTypeToTreeMetaData[type].expandable,
-        editable: isEditable(instance, propName, propData),
-        preview: getPreview(instance, propName, propData),
+        editable: isEditable(descriptor, propName, propData, getterOrSetter),
+        preview: getPreview(propData, getterOrSetter),
       };
 
       if (propData.prop !== undefined && serializable[type]) {
@@ -187,11 +187,14 @@ export const createLevelSerializedDescriptor =
         Descriptor => {
           const {type, prop} = propData;
 
+          const descriptor = getDescriptor(instance, propName as string);
+          const getterOrSetter: boolean = isGetterOrSetter(descriptor); 
+
           const levelSerializedDescriptor: Descriptor = {
             type,
             editable: false,
-            expandable: getKeys(prop).length > 0,
-            preview: getPreview(instance, propName, propData),
+            expandable: !getterOrSetter && getKeys(prop).length > 0,
+            preview: getPreview(propData, getterOrSetter),
           };
 
           if (levelOptions.level !== undefined && levelOptions.currentLevel < levelOptions.level) {
@@ -212,11 +215,14 @@ export const createNestedSerializedDescriptor =
          level?: number) => void): Descriptor => {
       const {type, prop} = propData;
 
+      const descriptor = getDescriptor(instance, propName as string);
+      const getterOrSetter: boolean = isGetterOrSetter(descriptor); 
+
       const nestedSerializedDescriptor: Descriptor = {
         type,
         editable: false,
-        expandable: getKeys(prop).length > 0,
-        preview: getPreview(instance, propName, propData),
+        expandable: !getterOrSetter && getKeys(prop).length > 0,
+        preview: getPreview(propData, getterOrSetter),
       };
 
       if (nodes && nodes.length) {

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -130,39 +130,38 @@ const shallowPropTypeToTreeMetaData:
       },
     };
 
-const isEditable = 
-  (descriptor: any, propName: string|number, propData: TerminalType, isGetterOrSetter: boolean) => {
-    if (typeof propName === 'symbol') {
-      return false;
-    }
+const isEditable =
+    (descriptor: any, propName: string|number, propData: TerminalType,
+     isGetterOrSetter: boolean) => {
+      if (typeof propName === 'symbol') {
+        return false;
+      }
 
-    if (isGetterOrSetter) {
-      return false;
-    }
+      if (isGetterOrSetter) {
+        return false;
+      }
 
-    if (descriptor?.writable === false) {
-      return false;
-    }
+      if (descriptor?.writable === false) {
+        return false;
+      }
 
-    return shallowPropTypeToTreeMetaData[propData.type].editable;
-};
-
-const isGetterOrSetter = 
-  (descriptor: any): boolean => (descriptor?.set || descriptor?.get) && !('value' in descriptor);
-
-const getPreview =
-    (propData: TerminalType|CompositeType, isGetterOrSetter: boolean) => {
-      return !isGetterOrSetter ?
-          typeToDescriptorPreview[propData.type](propData.prop) :
-          typeToDescriptorPreview[PropType.Function]({ name: '' });
+      return shallowPropTypeToTreeMetaData[propData.type].editable;
     };
+
+const isGetterOrSetter = (descriptor: any): boolean =>
+    (descriptor?.set || descriptor?.get) && !('value' in descriptor);
+
+const getPreview = (propData: TerminalType|CompositeType, isGetterOrSetter: boolean) => {
+  return !isGetterOrSetter ? typeToDescriptorPreview[propData.type](propData.prop) :
+                             typeToDescriptorPreview[PropType.Function]({name: ''});
+};
 
 export const createShallowSerializedDescriptor =
     (instance: any, propName: string|number, propData: TerminalType): Descriptor => {
       const {type} = propData;
 
       const descriptor = getDescriptor(instance, propName as string);
-      const getterOrSetter: boolean = isGetterOrSetter(descriptor); 
+      const getterOrSetter: boolean = isGetterOrSetter(descriptor);
 
       const shallowSerializedDescriptor: Descriptor = {
         type,
@@ -185,7 +184,7 @@ export const createLevelSerializedDescriptor =
           const {type, prop} = propData;
 
           const descriptor = getDescriptor(instance, propName as string);
-          const getterOrSetter: boolean = isGetterOrSetter(descriptor); 
+          const getterOrSetter: boolean = isGetterOrSetter(descriptor);
 
           const levelSerializedDescriptor: Descriptor = {
             type,
@@ -213,7 +212,7 @@ export const createNestedSerializedDescriptor =
       const {type, prop} = propData;
 
       const descriptor = getDescriptor(instance, propName as string);
-      const getterOrSetter: boolean = isGetterOrSetter(descriptor); 
+      const getterOrSetter: boolean = isGetterOrSetter(descriptor);
 
       const nestedSerializedDescriptor: Descriptor = {
         type,

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/serialized-descriptor-factory.ts
@@ -130,28 +130,25 @@ const shallowPropTypeToTreeMetaData:
       },
     };
 
-const isEditable = (descriptor: any, propName: string|number, propData: TerminalType, isGetterOrSetter: boolean) => {
-  if (typeof propName === 'symbol') {
-    return false;
-  }
+const isEditable = 
+  (descriptor: any, propName: string|number, propData: TerminalType, isGetterOrSetter: boolean) => {
+    if (typeof propName === 'symbol') {
+      return false;
+    }
 
-  if (isGetterOrSetter) {
-    return false;
-  }
+    if (isGetterOrSetter) {
+      return false;
+    }
 
-  if (descriptor?.writable === false) {
-    return false;
-  }
+    if (descriptor?.writable === false) {
+      return false;
+    }
 
-  return shallowPropTypeToTreeMetaData[propData.type].editable;
+    return shallowPropTypeToTreeMetaData[propData.type].editable;
 };
 
-const isGetterOrSetter = (descriptor: any): boolean => {
-  if ((descriptor?.set || descriptor?.get) && !('value' in descriptor)) {
-    return true;
-  }
-  return false;
-};
+const isGetterOrSetter = 
+  (descriptor: any): boolean => (descriptor?.set || descriptor?.get) && !('value' in descriptor);
 
 const getPreview =
     (propData: TerminalType|CompositeType, isGetterOrSetter: boolean) => {

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
@@ -10,6 +10,8 @@ import {PropType} from 'protocol';
 
 import {deeplySerializeSelectedProperties} from './state-serializer';
 
+import {getDescriptor, getKeys} from './object-utils';
+
 const QUERY_1_1 = [];
 
 const QUERY_1_2 = [
@@ -198,7 +200,7 @@ describe('deeplySerializeSelectedProperties', () => {
     });
   });
 
-  it('should work with getters', () => {
+  it('should work with getters with specified query', () => {
     const result = deeplySerializeSelectedProperties(
         {
           get foo(): any {
@@ -224,8 +226,8 @@ describe('deeplySerializeSelectedProperties', () => {
       foo: {
         type: PropType.Object,
         editable: false,
-        expandable: true,
-        preview: '{...}',
+        expandable: false,
+        preview: '(...)',
         value: {
           baz: {
             type: PropType.Object,
@@ -238,7 +240,39 @@ describe('deeplySerializeSelectedProperties', () => {
     });
   });
 
-  it('should getters should be readonly', () => {
+  it('should work with getters without specified query', () => {
+    const result = deeplySerializeSelectedProperties(
+        {
+          get foo(): any {
+            return {
+              baz: {
+                qux: {
+                  cos: 3,
+                },
+              },
+            };
+          },
+        },
+        []);
+    expect(result).toEqual({
+      foo: {
+        type: PropType.Object,
+        editable: false,
+        expandable: false,
+        preview: '(...)',
+        value: {
+          baz: {
+            type: PropType.Object,
+            editable: false,
+            expandable: true,
+            preview: '{...}',
+          },
+        },
+      },
+    });
+  });
+
+  it('both getters and setters should be readonly', () => {
     const result = deeplySerializeSelectedProperties(
         {
           get foo(): number {
@@ -249,22 +283,23 @@ describe('deeplySerializeSelectedProperties', () => {
           },
           set bar(val: number) {},
         },
-        []);
+        []
+    );
+
+    // Neither getter and setter is editable
     expect(result).toEqual({
       foo: {
         type: PropType.Number,
         expandable: false,
-        // Not editable because
-        // we don't have a getter.
         editable: false,
-        preview: '42',
+        preview: '(...)',
         value: 42,
       },
       bar: {
         type: PropType.Number,
         expandable: false,
-        editable: true,
-        preview: '42',
+        editable: false,
+        preview: '(...)',
         value: 42,
       },
     });
@@ -356,7 +391,7 @@ describe('deeplySerializeSelectedProperties', () => {
                 type: PropType.Number,
                 expandable: false,
                 editable: false,
-                preview: '42',
+                preview: '(...)',
                 value: 42,
               },
             },
@@ -366,12 +401,12 @@ describe('deeplySerializeSelectedProperties', () => {
     });
   });
 
-  it('should not show setters at all when associated getters or values are unavailable', () => {
+  it('both setter and getter would get a (...) as preview', () => {
     const result = deeplySerializeSelectedProperties(
         {
           set foo(_: any) {},
-          get bar(): number {
-            return 1;
+          get bar(): Object {
+            return { foo: 1 };
           },
         },
         []);
@@ -380,14 +415,22 @@ describe('deeplySerializeSelectedProperties', () => {
         type: PropType.Undefined,
         editable: false,
         expandable: false,
-        preview: '[setter]',
+        preview: '(...)',
       },
       bar: {
-        type: PropType.Number,
+        type: PropType.Object,
         editable: false,
         expandable: false,
-        preview: '1',
-        value: 1,
+        preview: '(...)',
+        value: {
+          foo: { 
+            type: PropType.Number, 
+            expandable: false, 
+            editable: true, 
+            preview: '1',
+            value: 1,
+          },
+        },
       },
     });
   });
@@ -402,5 +445,76 @@ describe('deeplySerializeSelectedProperties', () => {
         preview: 'undefined',
       }
     });
+  });
+
+  it('getDescriptor should get the descriptors for both getters and setters correctly from the prototype', () => {
+
+    const instance = {
+      __proto__: {
+        get foo(): number {
+          return 42;
+        },
+        set bar(newNum: number) {},
+        get baz(): number {
+          return 42;
+        },
+        set baz(newNum: number) {},
+      }
+    }
+
+    const descriptorFoo = getDescriptor(instance, 'foo');
+    expect(descriptorFoo).not.toBeNull();
+    expect(descriptorFoo!.get).not.toBeNull();
+    expect(descriptorFoo!.set).toBeUndefined();
+    expect(descriptorFoo!.value).toBeUndefined();
+    expect(descriptorFoo!.enumerable).toBe(true);
+    expect(descriptorFoo!.configurable).toBe(true);
+
+    const descriptorBar = getDescriptor(instance, 'bar');
+    expect(descriptorBar).not.toBeNull();
+    expect(descriptorBar!.get).toBeUndefined();
+    expect(descriptorBar!.set).not.toBeNull();
+    expect(descriptorBar!.value).toBeUndefined();
+    expect(descriptorBar!.enumerable).toBe(true);
+    expect(descriptorBar!.configurable).toBe(true);
+
+    const descriptorBaz = getDescriptor(instance, 'baz');
+    expect(descriptorBaz).not.toBeNull();
+    expect(descriptorBaz!.get).not.toBeNull();
+    expect(descriptorBaz!.set).not.toBeNull();
+    expect(descriptorBaz!.value).toBeUndefined();
+    expect(descriptorBaz!.enumerable).toBe(true);
+    expect(descriptorBaz!.configurable).toBe(true);
+  });
+
+  it('getKeys should all keys including getters and setters', () => {
+
+    const instance = {
+      baz: 2,
+      __proto__: {
+        get foo(): number {
+          return 42;
+        },
+        set foo(newNum: number) {},
+        set bar(newNum: number) {}
+      }
+    }
+
+    expect(getKeys(instance)).toEqual(['baz', 'foo', 'bar']);
+  });
+
+  it('getKeys would ignore getters and setters for "__proto__"', () => {
+
+    const instance = {
+      baz: 2,
+      __proto__: {
+        set __proto__(newObj: Object) {},
+        get __proto__(): Object {
+          return {}
+        }
+      }
+    }
+
+    expect(getKeys(instance)).toEqual(['baz']);
   });
 });

--- a/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
+++ b/devtools/projects/ng-devtools-backend/src/lib/state-serializer/state-serializer.spec.ts
@@ -8,9 +8,8 @@
 
 import {PropType} from 'protocol';
 
-import {deeplySerializeSelectedProperties} from './state-serializer';
-
 import {getDescriptor, getKeys} from './object-utils';
+import {deeplySerializeSelectedProperties} from './state-serializer';
 
 const QUERY_1_1 = [];
 
@@ -283,8 +282,7 @@ describe('deeplySerializeSelectedProperties', () => {
           },
           set bar(val: number) {},
         },
-        []
-    );
+        []);
 
     // Neither getter and setter is editable
     expect(result).toEqual({
@@ -406,7 +404,7 @@ describe('deeplySerializeSelectedProperties', () => {
         {
           set foo(_: any) {},
           get bar(): Object {
-            return { foo: 1 };
+            return {foo: 1};
           },
         },
         []);
@@ -423,10 +421,10 @@ describe('deeplySerializeSelectedProperties', () => {
         expandable: false,
         preview: '(...)',
         value: {
-          foo: { 
-            type: PropType.Number, 
-            expandable: false, 
-            editable: true, 
+          foo: {
+            type: PropType.Number,
+            expandable: false,
+            editable: true,
             preview: '1',
             value: 1,
           },
@@ -447,48 +445,47 @@ describe('deeplySerializeSelectedProperties', () => {
     });
   });
 
-  it('getDescriptor should get the descriptors for both getters and setters correctly from the prototype', () => {
+  it('getDescriptor should get the descriptors for both getters and setters correctly from the prototype',
+     () => {
+       const instance = {
+         __proto__: {
+           get foo(): number {
+             return 42;
+           },
+           set bar(newNum: number) {},
+           get baz(): number {
+             return 42;
+           },
+           set baz(newNum: number) {},
+         }
+       };
 
-    const instance = {
-      __proto__: {
-        get foo(): number {
-          return 42;
-        },
-        set bar(newNum: number) {},
-        get baz(): number {
-          return 42;
-        },
-        set baz(newNum: number) {},
-      }
-    }
+       const descriptorFoo = getDescriptor(instance, 'foo');
+       expect(descriptorFoo).not.toBeNull();
+       expect(descriptorFoo!.get).not.toBeNull();
+       expect(descriptorFoo!.set).toBeUndefined();
+       expect(descriptorFoo!.value).toBeUndefined();
+       expect(descriptorFoo!.enumerable).toBe(true);
+       expect(descriptorFoo!.configurable).toBe(true);
 
-    const descriptorFoo = getDescriptor(instance, 'foo');
-    expect(descriptorFoo).not.toBeNull();
-    expect(descriptorFoo!.get).not.toBeNull();
-    expect(descriptorFoo!.set).toBeUndefined();
-    expect(descriptorFoo!.value).toBeUndefined();
-    expect(descriptorFoo!.enumerable).toBe(true);
-    expect(descriptorFoo!.configurable).toBe(true);
+       const descriptorBar = getDescriptor(instance, 'bar');
+       expect(descriptorBar).not.toBeNull();
+       expect(descriptorBar!.get).toBeUndefined();
+       expect(descriptorBar!.set).not.toBeNull();
+       expect(descriptorBar!.value).toBeUndefined();
+       expect(descriptorBar!.enumerable).toBe(true);
+       expect(descriptorBar!.configurable).toBe(true);
 
-    const descriptorBar = getDescriptor(instance, 'bar');
-    expect(descriptorBar).not.toBeNull();
-    expect(descriptorBar!.get).toBeUndefined();
-    expect(descriptorBar!.set).not.toBeNull();
-    expect(descriptorBar!.value).toBeUndefined();
-    expect(descriptorBar!.enumerable).toBe(true);
-    expect(descriptorBar!.configurable).toBe(true);
-
-    const descriptorBaz = getDescriptor(instance, 'baz');
-    expect(descriptorBaz).not.toBeNull();
-    expect(descriptorBaz!.get).not.toBeNull();
-    expect(descriptorBaz!.set).not.toBeNull();
-    expect(descriptorBaz!.value).toBeUndefined();
-    expect(descriptorBaz!.enumerable).toBe(true);
-    expect(descriptorBaz!.configurable).toBe(true);
-  });
+       const descriptorBaz = getDescriptor(instance, 'baz');
+       expect(descriptorBaz).not.toBeNull();
+       expect(descriptorBaz!.get).not.toBeNull();
+       expect(descriptorBaz!.set).not.toBeNull();
+       expect(descriptorBaz!.value).toBeUndefined();
+       expect(descriptorBaz!.enumerable).toBe(true);
+       expect(descriptorBaz!.configurable).toBe(true);
+     });
 
   it('getKeys should all keys including getters and setters', () => {
-
     const instance = {
       baz: 2,
       __proto__: {
@@ -498,22 +495,21 @@ describe('deeplySerializeSelectedProperties', () => {
         set foo(newNum: number) {},
         set bar(newNum: number) {}
       }
-    }
+    };
 
     expect(getKeys(instance)).toEqual(['baz', 'foo', 'bar']);
   });
 
   it('getKeys would ignore getters and setters for "__proto__"', () => {
-
     const instance = {
       baz: 2,
       __proto__: {
         set __proto__(newObj: Object) {},
         get __proto__(): Object {
-          return {}
+          return {};
         }
       }
-    }
+    };
 
     expect(getKeys(instance)).toEqual(['baz']);
   });


### PR DESCRIPTION
Display the function representations of get/set properties in the property viewer just like the existing UI for function properties

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #46047 


## What is the new behavior?
Getters and setters will now show up in "Properties" panel with a function representation "(...)", and they are neither editable nor expandable
<img width="538" alt="image" src="https://user-images.githubusercontent.com/48388101/229662864-95a54f9f-9cb1-47ef-97b4-db84454e29ce.png">

<img width="891" alt="image" src="https://user-images.githubusercontent.com/48388101/229662769-1db496c9-04b3-4790-8db4-4f628fa43540.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
