### PR TITLE
feat(platform-browser): enable HTTP request caching when using `provideClientHydration`

### DIFF
--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -153,7 +153,12 @@ export interface HydrationFeature<FeatureKind extends HydrationFeatureKind> {
 }
 
 // @public
-export type HydrationFeatures = NoDomReuseFeature;
+export const enum HydrationFeatureKind {
+    // (undocumented)
+    NoDomReuseFeature = 0,
+    // (undocumented)
+    NoHttpTransferCache = 1
+}
 
 // @public @deprecated
 export const makeStateKey: typeof makeStateKey_2;
@@ -190,13 +195,10 @@ export type MetaDefinition = {
 };
 
 // @public
-export type NoDomReuseFeature = HydrationFeature<HydrationFeatureKind.NoDomReuseFeature>;
-
-// @public
 export const platformBrowser: (extraProviders?: StaticProvider[]) => PlatformRef;
 
 // @public
-export function provideClientHydration(...features: HydrationFeatures[]): EnvironmentProviders;
+export function provideClientHydration(...features: HydrationFeature<HydrationFeatureKind>[]): EnvironmentProviders;
 
 // @public
 export function provideProtractorTestingSupport(): Provider[];
@@ -251,7 +253,10 @@ export const TransferState: {
 export const VERSION: Version;
 
 // @public
-export function withoutDomReuse(): NoDomReuseFeature;
+export function withNoDomReuse(): HydrationFeature<HydrationFeatureKind.NoDomReuseFeature>;
+
+// @public
+export function withNoHttpTransferCache(): HydrationFeature<HydrationFeatureKind.NoHttpTransferCache>;
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -17,5 +17,6 @@ export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec}
 export {HttpFeature, HttpFeatureKind, provideHttpClient, withInterceptors, withInterceptorsFromDi, withJsonpSupport, withNoXsrfProtection, withRequestsMadeViaParent, withXsrfConfiguration} from './src/provider';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpStatusCode, HttpUploadProgressEvent, HttpUserEvent} from './src/response';
+export {withHttpTransferCache as ɵwithHttpTransferCache} from './src/transfer_cache';
 export {HttpXhrBackend} from './src/xhr';
 export {HttpXsrfTokenExtractor} from './src/xsrf';

--- a/packages/common/http/test/transfer_cache_spec.ts
+++ b/packages/common/http/test/transfer_cache_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {ApplicationRef, Component} from '@angular/core';
+import {ApplicationRef, Component, Injectable} from '@angular/core';
 import {makeStateKey, TransferState} from '@angular/core/src/transfer_state';
 import {fakeAsync, flush, TestBed} from '@angular/core/testing';
 import {withBody} from '@angular/private/testing';
@@ -39,7 +39,8 @@ describe('TransferCache', () => {
       TestBed.resetTestingModule();
       isStable = new BehaviorSubject<boolean>(false);
 
-      class ApplicationRefPathed extends ApplicationRef {
+      @Injectable()
+      class ApplicationRefPatched extends ApplicationRef {
         override isStable = new BehaviorSubject<boolean>(false);
       }
 
@@ -47,8 +48,7 @@ describe('TransferCache', () => {
         declarations: [SomeComponent],
         providers: [
           {provide: DOCUMENT, useFactory: () => document},
-          {provide: ApplicationRef, useClass: ApplicationRefPathed},
-          {provide: ApplicationRef, useClass: ApplicationRefPathed},
+          {provide: ApplicationRef, useClass: ApplicationRefPatched},
           withHttpTransferCache(),
           provideHttpClient(),
           provideHttpClientTesting(),

--- a/packages/platform-browser/BUILD.bazel
+++ b/packages/platform-browser/BUILD.bazel
@@ -14,6 +14,7 @@ ng_module(
     deps = [
         "//packages:types",
         "//packages/common",
+        "//packages/common/http",
         "//packages/core",
         "//packages/zone.js/lib:zone_d_ts",
         "@npm//@types/hammerjs",

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -77,7 +77,7 @@ export {REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
 export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerLoader, HammerModule} from './dom/events/hammer_gestures';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
-export {HydrationFeature, provideClientHydration, NoDomReuseFeature, HydrationFeatures, withoutDomReuse} from './hydration';
+export {HydrationFeature, provideClientHydration, HydrationFeatureKind, withNoDomReuse, withNoHttpTransferCache} from './hydration';
 
 export * from './private_export';
 export {VERSION} from './version';

--- a/packages/platform-browser/test/BUILD.bazel
+++ b/packages/platform-browser/test/BUILD.bazel
@@ -29,6 +29,8 @@ ts_library(
         "//packages/animations/browser",
         "//packages/animations/browser/testing",
         "//packages/common",
+        "//packages/common/http",
+        "//packages/common/http/testing",
         "//packages/compiler",
         "//packages/core",
         "//packages/core/testing",

--- a/packages/platform-browser/test/hydration_spec.ts
+++ b/packages/platform-browser/test/hydration_spec.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {HttpClient, provideHttpClient} from '@angular/common/http';
+import {HttpTestingController, provideHttpClientTesting} from '@angular/common/http/testing';
+import {ApplicationRef, Component, Injectable} from '@angular/core';
+import {TestBed} from '@angular/core/testing';
+import {withBody} from '@angular/private/testing';
+import {BehaviorSubject} from 'rxjs';
+
+import {provideClientHydration, withNoHttpTransferCache} from '../public_api';
+
+describe('provideClientHydration', () => {
+  @Component({selector: 'test-hydrate-app', template: ''})
+  class SomeComponent {
+  }
+
+  function makeRequestAndExpectOne(url: string, body: string): void {
+    TestBed.inject(HttpClient).get(url).subscribe();
+    TestBed.inject(HttpTestingController).expectOne(url).flush(body);
+  }
+
+  function makeRequestAndExpectNone(url: string): void {
+    TestBed.inject(HttpClient).get(url).subscribe();
+    TestBed.inject(HttpTestingController).expectNone(url);
+  }
+
+  @Injectable()
+  class ApplicationRefPatched extends ApplicationRef {
+    override isStable = new BehaviorSubject<boolean>(false);
+  }
+
+  describe('default', () => {
+    beforeEach(withBody('<test-hydrate-app></test-hydrate-app>', () => {
+      TestBed.resetTestingModule();
+
+      TestBed.configureTestingModule({
+        declarations: [SomeComponent],
+        providers: [
+          {provide: DOCUMENT, useFactory: () => document},
+          {provide: ApplicationRef, useClass: ApplicationRefPatched},
+          provideClientHydration(),
+          provideHttpClient(),
+          provideHttpClientTesting(),
+        ],
+      });
+
+      const appRef = TestBed.inject(ApplicationRef);
+      appRef.bootstrap(SomeComponent);
+    }));
+
+    it(`should use cached HTTP calls`, () => {
+      makeRequestAndExpectOne('/test-1', 'foo');
+      // Do the same call, this time it should served from cache.
+      makeRequestAndExpectNone('/test-1');
+    });
+  });
+
+  describe('withNoHttpTransferCache', () => {
+    beforeEach(withBody('<test-hydrate-app></test-hydrate-app>', () => {
+      TestBed.resetTestingModule();
+
+      TestBed.configureTestingModule({
+        declarations: [SomeComponent],
+        providers: [
+          {provide: DOCUMENT, useFactory: () => document},
+          {provide: ApplicationRef, useClass: ApplicationRefPatched},
+          provideClientHydration(withNoHttpTransferCache()),
+          provideHttpClient(),
+          provideHttpClientTesting(),
+        ],
+      });
+
+      const appRef = TestBed.inject(ApplicationRef);
+      appRef.bootstrap(SomeComponent);
+    }));
+
+    it(`should not cached HTTP calls`, () => {
+      makeRequestAndExpectOne('/test-1', 'foo');
+      // Do the same call, this time should pass through as cache is disabled.
+      makeRequestAndExpectOne('/test-1', 'foo');
+    });
+  });
+});


### PR DESCRIPTION
This commit adds support by default for HTTP caching when using `provideClientHydration`. Users can opt-out of this behaviour by using the `withoutHttpTransferCache` feature.

```ts
import {
  bootstrapApplication,
  provideClientHydration,
  withNoHttpTransferCache,
} from '@angular/platform-browser';
// ...
bootstrapApplication(RootCmp, {
  providers: [provideClientHydration(withNoHttpTransferCache())]
});
```