### PR TITLE
refactor(core): Use intersections on branded types.

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -213,7 +213,7 @@ export function getParentInjectorLocation(tNode: TNode, lView: LView): RelativeI
   if (tNode.parent && tNode.parent.injectorIndex !== -1) {
     // If we have a parent `TNode` and there is an injector associated with it we are done, because
     // the parent injector is within the current `LView`.
-    return tNode.parent.injectorIndex as any;  // ViewOffset is 0
+    return tNode.parent.injectorIndex as RelativeInjectorLocation;  // ViewOffset is 0
   }
 
   // When parent injector location is computed it may be outside of the current view. (ie it could
@@ -242,7 +242,8 @@ export function getParentInjectorLocation(tNode: TNode, lView: LView): RelativeI
     if (parentTNode.injectorIndex !== -1) {
       // We found a NodeInjector which points to something.
       return (parentTNode.injectorIndex |
-              (declarationViewOffset << RelativeInjectorLocationFlags.ViewOffsetShift)) as any;
+              (declarationViewOffset << RelativeInjectorLocationFlags.ViewOffsetShift)) as
+          RelativeInjectorLocation;
     }
   }
   return NO_PARENT_INJECTOR;
@@ -477,7 +478,7 @@ function lookupTokenUsingNodeInjector<T>(
     // injector.
     let previousTView: TView|null = null;
     let injectorIndex = getInjectorIndex(tNode, lView);
-    let parentLocation: RelativeInjectorLocation = NO_PARENT_INJECTOR;
+    let parentLocation = NO_PARENT_INJECTOR;
     let hostTElementNode: TNode|null =
         flags & InjectFlags.Host ? lView[DECLARATION_COMPONENT_VIEW][T_HOST] : null;
 

--- a/packages/core/src/render3/interfaces/injector.ts
+++ b/packages/core/src/render3/interfaces/injector.ts
@@ -64,9 +64,9 @@ export const enum NodeInjectorOffset {
  * The interfaces encodes number of parents `LView`s to traverse and index in the `LView`
  * pointing to the parent injector.
  */
-export interface RelativeInjectorLocation {
+export type RelativeInjectorLocation = number&{
   __brand__: 'RelativeInjectorLocationFlags';
-}
+};
 
 export const enum RelativeInjectorLocationFlags {
   InjectorIndexMask = 0b111111111111111,
@@ -74,7 +74,7 @@ export const enum RelativeInjectorLocationFlags {
   NO_PARENT = -1,
 }
 
-export const NO_PARENT_INJECTOR: RelativeInjectorLocation = -1 as any;
+export const NO_PARENT_INJECTOR = -1 as RelativeInjectorLocation;
 
 /**
  * Each injector is saved in 9 contiguous slots in `LView` and 9 contiguous slots in

--- a/packages/core/src/render3/interfaces/styling.ts
+++ b/packages/core/src/render3/interfaces/styling.ts
@@ -119,9 +119,9 @@ export interface TStylingStatic extends KeyValueArray<any> {}
  *
  * NOTE: `0` has special significance and represents `null` as in no additional pointer.
  */
-export interface TStylingRange {
+export type TStylingRange = number&{
   __brand__: 'TStylingRange';
-}
+};
 
 /**
  * Shift and masks constants for encoding two numbers into and duplicate info into a single number.
@@ -161,54 +161,52 @@ export const enum StylingRange {
 export function toTStylingRange(prev: number, next: number): TStylingRange {
   ngDevMode && assertNumberInRange(prev, 0, StylingRange.UNSIGNED_MASK);
   ngDevMode && assertNumberInRange(next, 0, StylingRange.UNSIGNED_MASK);
-  return (prev << StylingRange.PREV_SHIFT | next << StylingRange.NEXT_SHIFT) as any;
+  return (prev << StylingRange.PREV_SHIFT | next << StylingRange.NEXT_SHIFT) as TStylingRange;
 }
 
 export function getTStylingRangePrev(tStylingRange: TStylingRange): number {
   ngDevMode && assertNumber(tStylingRange, 'expected number');
-  return ((tStylingRange as any as number) >> StylingRange.PREV_SHIFT) & StylingRange.UNSIGNED_MASK;
+  return (tStylingRange >> StylingRange.PREV_SHIFT) & StylingRange.UNSIGNED_MASK;
 }
 
 export function getTStylingRangePrevDuplicate(tStylingRange: TStylingRange): boolean {
   ngDevMode && assertNumber(tStylingRange, 'expected number');
-  return ((tStylingRange as any as number) & StylingRange.PREV_DUPLICATE) ==
-      StylingRange.PREV_DUPLICATE;
+  return (tStylingRange & StylingRange.PREV_DUPLICATE) == StylingRange.PREV_DUPLICATE;
 }
 
 export function setTStylingRangePrev(
     tStylingRange: TStylingRange, previous: number): TStylingRange {
   ngDevMode && assertNumber(tStylingRange, 'expected number');
   ngDevMode && assertNumberInRange(previous, 0, StylingRange.UNSIGNED_MASK);
-  return (((tStylingRange as any as number) & ~StylingRange.PREV_MASK) |
-          (previous << StylingRange.PREV_SHIFT)) as any;
+  return ((tStylingRange & ~StylingRange.PREV_MASK) | (previous << StylingRange.PREV_SHIFT)) as
+      TStylingRange;
 }
 
 export function setTStylingRangePrevDuplicate(tStylingRange: TStylingRange): TStylingRange {
   ngDevMode && assertNumber(tStylingRange, 'expected number');
-  return ((tStylingRange as any as number) | StylingRange.PREV_DUPLICATE) as any;
+  return (tStylingRange | StylingRange.PREV_DUPLICATE) as TStylingRange;
 }
 
 export function getTStylingRangeNext(tStylingRange: TStylingRange): number {
   ngDevMode && assertNumber(tStylingRange, 'expected number');
-  return ((tStylingRange as any as number) & StylingRange.NEXT_MASK) >> StylingRange.NEXT_SHIFT;
+  return (tStylingRange & StylingRange.NEXT_MASK) >> StylingRange.NEXT_SHIFT;
 }
 
 export function setTStylingRangeNext(tStylingRange: TStylingRange, next: number): TStylingRange {
   ngDevMode && assertNumber(tStylingRange, 'expected number');
   ngDevMode && assertNumberInRange(next, 0, StylingRange.UNSIGNED_MASK);
-  return (((tStylingRange as any as number) & ~StylingRange.NEXT_MASK) |  //
-          next << StylingRange.NEXT_SHIFT) as any;
+  return ((tStylingRange & ~StylingRange.NEXT_MASK) |  //
+          next << StylingRange.NEXT_SHIFT) as TStylingRange;
 }
 
 export function getTStylingRangeNextDuplicate(tStylingRange: TStylingRange): boolean {
   ngDevMode && assertNumber(tStylingRange, 'expected number');
-  return ((tStylingRange as any as number) & StylingRange.NEXT_DUPLICATE) ===
-      StylingRange.NEXT_DUPLICATE;
+  return ((tStylingRange) & StylingRange.NEXT_DUPLICATE) === StylingRange.NEXT_DUPLICATE;
 }
 
 export function setTStylingRangeNextDuplicate(tStylingRange: TStylingRange): TStylingRange {
   ngDevMode && assertNumber(tStylingRange, 'expected number');
-  return ((tStylingRange as any as number) | StylingRange.NEXT_DUPLICATE) as any;
+  return (tStylingRange | StylingRange.NEXT_DUPLICATE) as TStylingRange;
 }
 
 export function getTStylingRangeTail(tStylingRange: TStylingRange): number {

--- a/packages/core/src/render3/util/injector_utils.ts
+++ b/packages/core/src/render3/util/injector_utils.ts
@@ -19,17 +19,16 @@ export function hasParentInjector(parentLocation: RelativeInjectorLocation): boo
 export function getParentInjectorIndex(parentLocation: RelativeInjectorLocation): number {
   ngDevMode && assertNumber(parentLocation, 'Number expected');
   ngDevMode && assertNotEqual(parentLocation as any, -1, 'Not a valid state.');
-  const parentInjectorIndex =
-      (parentLocation as any as number) & RelativeInjectorLocationFlags.InjectorIndexMask;
+  const parentInjectorIndex = parentLocation & RelativeInjectorLocationFlags.InjectorIndexMask;
   ngDevMode &&
       assertGreaterThan(
           parentInjectorIndex, HEADER_OFFSET,
           'Parent injector must be pointing past HEADER_OFFSET.');
-  return (parentLocation as any as number) & RelativeInjectorLocationFlags.InjectorIndexMask;
+  return parentLocation & RelativeInjectorLocationFlags.InjectorIndexMask;
 }
 
 export function getParentInjectorViewOffset(parentLocation: RelativeInjectorLocation): number {
-  return (parentLocation as any as number) >> RelativeInjectorLocationFlags.ViewOffsetShift;
+  return parentLocation >> RelativeInjectorLocationFlags.ViewOffsetShift;
 }
 
 /**

--- a/packages/core/src/util/security/trusted_type_defs.ts
+++ b/packages/core/src/util/security/trusted_type_defs.ts
@@ -25,17 +25,17 @@
  * but restricted to the API surface used within Angular.
  */
 
-export declare interface TrustedHTML {
+export type TrustedHTML = string&{
   __brand__: 'TrustedHTML';
-}
-export declare interface TrustedScript {
+};
+export type TrustedScript = string&{
   __brand__: 'TrustedScript';
-}
-export declare interface TrustedScriptURL {
+};
+export type TrustedScriptURL = string&{
   __brand__: 'TrustedScriptURL';
-}
+};
 
-export declare interface TrustedTypePolicyFactory {
+export interface TrustedTypePolicyFactory {
   createPolicy(policyName: string, policyOptions: {
     createHTML?: (input: string) => string,
     createScript?: (input: string) => string,
@@ -44,7 +44,7 @@ export declare interface TrustedTypePolicyFactory {
   getAttributeType(tagName: string, attribute: string): string|null;
 }
 
-export declare interface TrustedTypePolicy {
+export interface TrustedTypePolicy {
   createHTML(input: string): TrustedHTML;
   createScript(input: string): TrustedScript;
   createScriptURL(input: string): TrustedScriptURL;

--- a/packages/core/src/util/security/trusted_types.ts
+++ b/packages/core/src/util/security/trusted_types.ts
@@ -17,6 +17,7 @@
  */
 
 import {global} from '../global';
+
 import {TrustedHTML, TrustedScript, TrustedScriptURL, TrustedTypePolicy, TrustedTypePolicyFactory} from './trusted_type_defs';
 
 /**
@@ -119,7 +120,7 @@ export function newTrustedFunctionForDev(...args: string[]): Function {
   // Using eval directly confuses the compiler and prevents this module from
   // being stripped out of JS binaries even if not used. The global['eval']
   // indirection fixes that.
-  const fn = global['eval'](trustedScriptFromString(body) as string) as Function;
+  const fn = global['eval'](trustedScriptFromString(body)) as Function;
   if (fn.bind === undefined) {
     // Workaround for a browser bug that only exists in Chrome 83, where passing
     // a TrustedScript to eval just returns the TrustedScript back without


### PR DESCRIPTION
An Intersection on a branded type allows us to remove some unecessary type assertions.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No