### PR TITLE
fix(router): Ensure routed components inputs are set in OnPush contexts

### DIFF
--- a/packages/router/src/directives/router_outlet.ts
+++ b/packages/router/src/directives/router_outlet.ts
@@ -195,7 +195,8 @@ export class RouterOutlet implements OnDestroy, OnInit, RouterOutletContract {
 
   private parentContexts = inject(ChildrenOutletContexts);
   private location = inject(ViewContainerRef);
-  private changeDetector = inject(ChangeDetectorRef);
+  /** @internal */
+  readonly changeDetector = inject(ChangeDetectorRef);
   private environmentInjector = inject(EnvironmentInjector);
   private inputBinder = inject(INPUT_BINDER, {optional: true});
   /** @nodoc */
@@ -430,6 +431,7 @@ export class RoutedComponentInputBinder {
                 return;
               }
 
+              outlet.changeDetector.markForCheck();
               for (const {templateName} of mirror.inputs) {
                 outlet.activatedComponentRef.setInput(templateName, data[templateName]);
               }


### PR DESCRIPTION
Router input binding is driven by `ComponentRef.setInput`. `ComponentRef.setInput` internally calls `markDirtyIfOnPush` which only marks the given view as dirty but does not mark parents dirty like `ChangeDetectorRef.markForCheck` would.
https://github.com/angular/angular/blob/f071224720f8affb97fd32fb5aeaa13155b13693/packages/core/src/render3/instructions/shared.ts#L1018-L1024

This means that if you are responding to events such as an emit from an `Observable` and call `setInput`, the view of your `ComponentRef` won't necessarily get checked when change detection runs next. If this lives inside some `OnPush` component tree that's not already dirty, it only gets refreshed if you also call `ChangeDetectorRef.markForCheck` in the host component (because it will be "shielded" be a non-dirty parent).
