### PR TITLE
refactor(core): skip hydration for components that use i18n (instead of throwing an error)

### DIFF
--- a/aio/content/guide/hydration.md
+++ b/aio/content/guide/hydration.md
@@ -114,7 +114,9 @@ class ExampleCmp {}
 The `ngSkipHydration` attribute will force Angular to skip hydrating the entire component and its children. Using this attribute means that the component will behave as if hydration is not enabled, meaning it will destroy and re-render itself.
 
 <div class="alert is-helpful">
-  This will fix rendering issues, but it means that for this component (and its children), you don't get the benefits of hydration. You will need to adjust your component's implementation to avoid hydration-breaking patterns (i.e. Direct DOM Manipulation) to be able to remove the skip hydration annotation.
+
+This will fix rendering issues, but it means that for this component (and its children), you don't get the benefits of hydration. You will need to adjust your component's implementation to avoid hydration-breaking patterns (i.e. Direct DOM Manipulation) to be able to remove the skip hydration annotation.
+
 </div>
 
 The `ngSkipHydration` attribute can only be used on component host nodes. Angular throws an error if this attribute is added to other nodes.
@@ -124,7 +126,10 @@ Keep in mind that adding the `ngSkipHydration` attribute to your root applicatio
 <a id="i18n"></a>
 
 ## I18N
-We don't yet support internationalization with hydration, but support is coming. If you attempt to enable hydration on an application with internationalization, you will receive an error NG518, which states that I18N is not yet supported.
+
+We don't yet support internationalization with hydration, but support is coming.
+Currently, Angular would skip hydration for components that use i18n blocks, effectively
+re-rendering those components from scratch.
 
 ## Third Party Libraries with DOM Manipulation
 

--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -41,8 +41,6 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     HOST_DIRECTIVE_UNRESOLVABLE = 307,
     // (undocumented)
-    HYDRATION_I18N_NOT_YET_SUPPORTED = 518,
-    // (undocumented)
     HYDRATION_MISSING_NODE = -502,
     // (undocumented)
     HYDRATION_MISSING_SIBLINGS = -501,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -65,8 +65,6 @@ export const enum RuntimeErrorCode {
   HYDRATION_MISSING_NODE = -502,
   UNSUPPORTED_PROJECTION_DOM_NODES = -503,
   INVALID_SKIP_HYDRATION_HOST = -504,
-  // Temporary error code for hydration while i18n is not supported
-  HYDRATION_I18N_NOT_YET_SUPPORTED = 518,
 
   // Signal Errors
   SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT = 600,

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -35,7 +35,7 @@ let isHydrationSupportEnabled = false;
 
 /**
  * Brings the necessary hydration code in tree-shakable manner.
- * The code is only present when the `provideHydrationSupport` is
+ * The code is only present when the `provideClientHydration` is
  * invoked. Otherwise, this code is tree-shaken away during the
  * build optimization step.
  *

--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -174,23 +174,6 @@ export function invalidSkipHydrationHost(rNode: RNode): Error {
   return new RuntimeError(RuntimeErrorCode.INVALID_SKIP_HYDRATION_HOST, message);
 }
 
-/**
- * Builds the hydration error message in the case that a user is attempting to enable
- * hydration on internationalized nodes, which is not yet supported.
- *
- * @param rNode the HTML Element
- * @returns an error
- */
-export function notYetSupportedI18nBlockError(rNode: RNode): Error {
-  const header = 'Hydration for nodes marked with `i18n` is not yet supported. ' +
-      'You can opt-out a component that uses `i18n` in a template using ' +
-      'the `ngSkipHydration` attribute or fall back to the previous ' +
-      'hydration logic (which re-creates the application structure).\n\n';
-  const actual = `${describeDomFromNode(rNode)}\n\n`;
-  const message = header + actual;
-  return new RuntimeError(RuntimeErrorCode.HYDRATION_I18N_NOT_YET_SUPPORTED, message);
-}
-
 // Stringification methods
 
 /**

--- a/packages/core/src/render3/instructions/i18n.ts
+++ b/packages/core/src/render3/instructions/i18n.ts
@@ -15,7 +15,7 @@ import {i18nAttributesFirstPass, i18nStartFirstCreatePass} from '../i18n/i18n_pa
 import {i18nPostprocess} from '../i18n/i18n_postprocess';
 import {TI18n} from '../interfaces/i18n';
 import {TElementNode, TNodeType} from '../interfaces/node';
-import {HEADER_OFFSET, T_HOST} from '../interfaces/view';
+import {DECLARATION_COMPONENT_VIEW, FLAGS, HEADER_OFFSET, LViewFlags, T_HOST, TViewType} from '../interfaces/view';
 import {getClosestRElement} from '../node_manipulation';
 import {getCurrentParentTNode, getLView, getTView, nextBindingIndex, setInI18nBlock} from '../state';
 import {getConstant} from '../util/view_utils';
@@ -58,6 +58,19 @@ export function ɵɵi18nStart(
         tView, parentTNode === null ? 0 : parentTNode.index, lView, adjustedIndex, message,
         subTemplateIndex);
   }
+
+  // Set a flag that this LView has i18n blocks.
+  // The flag is later used to determine whether this component should
+  // be hydrated (currently hydration is not supported for i18n blocks).
+  if (tView.type === TViewType.Embedded) {
+    // Annotate host component's LView (not embedded view's LView),
+    // since hydration can be skipped on per-component basis only.
+    const componentLView = lView[DECLARATION_COMPONENT_VIEW];
+    componentLView[FLAGS] |= LViewFlags.HasI18n;
+  } else {
+    lView[FLAGS] |= LViewFlags.HasI18n;
+  }
+
   const tI18n = tView.data[adjustedIndex] as TI18n;
   const sameViewParentTNode = parentTNode === lView[T_HOST] ? null : parentTNode;
   const parentRNode = getClosestRElement(tView, sameViewParentTNode, lView);

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -401,33 +401,36 @@ export const enum LViewFlags {
   /** Whether this view has default change detection strategy (checks always) or onPush */
   CheckAlways = 0b00000010000,
 
+  /** Whether there are any i18n blocks inside this LView. */
+  HasI18n = 0b00000100000,
+
   /** Whether or not this view is currently dirty (needing check) */
-  Dirty = 0b00000100000,
+  Dirty = 0b000001000000,
 
   /** Whether or not this view is currently attached to change detection tree. */
-  Attached = 0b000001000000,
+  Attached = 0b000010000000,
 
   /** Whether or not this view is destroyed. */
-  Destroyed = 0b000010000000,
+  Destroyed = 0b000100000000,
 
   /** Whether or not this view is the root view */
-  IsRoot = 0b000100000000,
+  IsRoot = 0b001000000000,
 
   /**
    * Whether this moved LView was needs to be refreshed at the insertion location because the
    * declaration was dirty.
    */
-  RefreshTransplantedView = 0b001000000000,
+  RefreshTransplantedView = 0b0010000000000,
 
   /** Indicates that the view **or any of its ancestors** have an embedded view injector. */
-  HasEmbeddedViewInjector = 0b0010000000000,
+  HasEmbeddedViewInjector = 0b0100000000000,
 
   /**
    * Index of the current init phase on last 21 bits
    */
-  IndexWithinInitPhaseIncrementer = 0b0100000000000,
-  IndexWithinInitPhaseShift = 11,
-  IndexWithinInitPhaseReset = 0b0011111111111,
+  IndexWithinInitPhaseIncrementer = 0b01000000000000,
+  IndexWithinInitPhaseShift = 12,
+  IndexWithinInitPhaseReset = 0b00111111111111,
 }
 
 /**


### PR DESCRIPTION
Currently, non-destructive hydration for i18n blocks is not supported (but support is coming!). This commit updates the serialization logic from throwing an error when it comes across an i18n block to annotating a component with a skip hydration flag.

The second commit applies the same changes for components that use `ViewEncapsulation.ShadowDom`. The Domino DOM emulation library doesn't support shadow DOM. For such components we can not guarantee that client and server representations would match perfectly. To avoid hydration mismatch errors, such components are opted out of hydration.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No