### PR TITLE
refactor(core): drop a reference to `enableProdMode()` in a console.log

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -1009,8 +1009,7 @@ export class ApplicationRef {
     this._loadComponent(compRef);
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       const _console = this._injector.get(Console);
-      _console.log(
-          `Angular is running in development mode. Call enableProdMode() to enable production mode.`);
+      _console.log(`Angular is running in development mode.`);
     }
     return compRef;
   }


### PR DESCRIPTION
New `ng new` apps no longer generate `enableProdMode` calls when an app is created. The prod mode is enabled via CLI flags (and configuration in the `angular.json` if needed).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No