### PR TITLE
refactor(core): update the link in hydration stats message

### DIFF
--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -75,7 +75,7 @@ function printHydrationStats(console: Console) {
       `and ${ngDevMode!.hydratedNodes} node(s), ` +
       `${ngDevMode!.componentsSkippedHydration} component(s) were skipped. ` +
       `Note: this feature is in Developer Preview mode. ` +
-      `Learn more at https://angular.io/guides/hydration.`;
+      `Learn more at https://next.angular.io/guide/hydration.`;
   // tslint:disable-next-line:no-console
   console.log(message);
 }


### PR DESCRIPTION
Currently, the link points to https://angular.io/guides/hydration and there are 2 issues with it: the `guides/hydration` should actually be `guide/hydration` and the guide is only available at https://next.angular.io, but not at https://angular.io. It will be available at https://angular.io once v16 final is released. For now, we can point to https://next.angular.io, so that developers testing hydration during the pre-release period can follow the link.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No