### PR TITLE
fix(compiler): Support `in` operator in *ngIf expressions

### DIFF
--- a/packages/common/test/directives/ng_if_spec.ts
+++ b/packages/common/test/directives/ng_if_spec.ts
@@ -39,6 +39,14 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
          expect(fixture.nativeElement).toHaveText('hello');
        }));
 
+    it('should work in a template attribute with in operator', waitForAsync(() => {
+         const template = '<span *ngIf="\'foo\' in {foo: 3}">hello</span>';
+         fixture = createTestComponent(template);
+         fixture.detectChanges();
+         expect(fixture.debugElement.queryAll(By.css('span')).length).toEqual(1);
+         expect(fixture.nativeElement).toHaveText('hello');
+       }));
+
     it('should work on a template element', waitForAsync(() => {
          const template = '<ng-template [ngIf]="booleanCondition">hello2</ng-template>';
          fixture = createTestComponent(template);

--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -308,6 +308,9 @@ class _AstToIrVisitor implements cdAst.AstVisitor {
       case '>=':
         op = o.BinaryOperator.BiggerEquals;
         break;
+      case 'in':
+        op = o.BinaryOperator.In;
+        break;
       case '??':
         return this.convertNullishCoalesce(ast, mode);
       default:

--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -19,7 +19,8 @@ export enum TokenType {
   Error
 }
 
-const KEYWORDS = ['var', 'let', 'as', 'null', 'undefined', 'true', 'false', 'if', 'else', 'this'];
+const KEYWORDS =
+    ['var', 'let', 'as', 'null', 'in', 'undefined', 'true', 'false', 'if', 'else', 'this'];
 
 export class Lexer {
   tokenize(text: string): Token[] {
@@ -65,6 +66,10 @@ export class Token {
 
   isKeyword(): boolean {
     return this.type == TokenType.Keyword;
+  }
+
+  isKeywordIn(): boolean {
+    return this.type == TokenType.Keyword && this.strValue == 'in';
   }
 
   isKeywordLet(): boolean {

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -780,7 +780,7 @@ export class _ParseAST {
   parseMultiplicative(): AST {
     // '*', '%', '/'
     const start = this.inputIndex;
-    let result = this.parsePrefix();
+    let result = this.parseInOperator();
     while (this.next.type == TokenType.Operator) {
       const operator = this.next.strValue;
       switch (operator) {
@@ -796,6 +796,19 @@ export class _ParseAST {
     }
     return result;
   }
+
+  parseInOperator(): AST {
+    const start = this.inputIndex;
+    let result = this.parsePrefix();
+    if (this.next.isKeywordIn()) {
+      const operator = this.next.strValue;
+      this.advance();
+      let right = this.parsePrefix();
+      result = new Binary(this.span(start), this.sourceSpan(start), operator, result, right);
+    }
+    return result;
+  }
+
 
   parsePrefix(): AST {
     if (this.next.type == TokenType.Operator) {
@@ -1080,7 +1093,6 @@ export class _ParseAST {
    */
   parseTemplateBindings(templateKey: TemplateBindingIdentifier): TemplateBindingParseResult {
     const bindings: TemplateBinding[] = [];
-
     // The first binding is for the template key itself
     // In *ngFor="let item of items", key = "ngFor", value = null
     // In *ngIf="cond | pipe", key = "ngIf", value = "cond | pipe"

--- a/packages/compiler/src/output/abstract_emitter.ts
+++ b/packages/compiler/src/output/abstract_emitter.ts
@@ -436,6 +436,9 @@ export abstract class AbstractEmitterVisitor implements o.StatementVisitor, o.Ex
       case o.BinaryOperator.NullishCoalesce:
         opStr = '??';
         break;
+      case o.BinaryOperator.In:
+        opStr = 'in';
+        break;
       default:
         throw new Error(`Unknown operator ${ast.operator}`);
     }

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -119,6 +119,7 @@ export enum BinaryOperator {
   Bigger,
   BiggerEquals,
   NullishCoalesce,
+  In,
 }
 
 export function nullSafeIsEquivalent<T extends {isEquivalent(other: T): boolean}>(

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -700,6 +700,14 @@ describe('parser', () => {
       ]);
     });
 
+    it('should support usage of ngIf in', () => {
+      const bindings = parseTemplateBindings(`*ngIf="'foo' in a"`);
+      expect(humanize(bindings)).toEqual([
+        // [ key, value, VariableBinding ]
+        ['ngIf', `'foo' in a`, false],
+      ]);
+    });
+
     it('should support common usage of ngFor', () => {
       let bindings: TemplateBinding[];
       bindings = parseTemplateBindings('*ngFor="let person of people"');

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -785,33 +785,33 @@ describe('standalone components, directives, and pipes', () => {
    */
   describe('inheritance', () => {
     it('should allow extending a regular component and turn it into a standalone one', () => {
-      @Component({selector: 'regular', template: 'regular: {{in}}'})
+      @Component({selector: 'regular', template: 'regular: {{input}}'})
       class RegularCmp {
-        @Input() in : string|undefined;
+        @Input() input: string|undefined;
       }
 
-      @Component({selector: 'standalone', template: 'standalone: {{in}}', standalone: true})
+      @Component({selector: 'standalone', template: 'standalone: {{input}}', standalone: true})
       class StandaloneCmp extends RegularCmp {
       }
 
       const fixture = TestBed.createComponent(StandaloneCmp);
-      fixture.componentInstance.in = 'input value';
+      fixture.componentInstance.input = 'input value';
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('standalone: input value');
     });
 
     it('should allow extending a regular component and turn it into a standalone one', () => {
-      @Component({selector: 'standalone', template: 'standalone: {{in}}', standalone: true})
+      @Component({selector: 'standalone', template: 'standalone: {{input}}', standalone: true})
       class StandaloneCmp {
-        @Input() in : string|undefined;
+        @Input() input: string|undefined;
       }
 
-      @Component({selector: 'regular', template: 'regular: {{in}}'})
+      @Component({selector: 'regular', template: 'regular: {{input}}'})
       class RegularCmp extends StandaloneCmp {
       }
 
       const fixture = TestBed.createComponent(RegularCmp);
-      fixture.componentInstance.in = 'input value';
+      fixture.componentInstance.input = 'input value';
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('regular: input value');
     });
@@ -828,11 +828,11 @@ describe('standalone components, directives, and pipes', () => {
       @Component({
         selector: 'standalone',
         standalone: true,
-        template: 'standalone: {{in}}; (<inner></inner>)',
+        template: 'standalone: {{input}}; (<inner></inner>)',
         imports: [InnerCmp]
       })
       class StandaloneCmp {
-        @Input() in : string|undefined;
+        @Input() input: string|undefined;
       }
 
       @Component({selector: 'regular'})
@@ -840,7 +840,7 @@ describe('standalone components, directives, and pipes', () => {
       }
 
       const fixture = TestBed.createComponent(RegularCmp);
-      fixture.componentInstance.in = 'input value';
+      fixture.componentInstance.input = 'input value';
       fixture.detectChanges();
       // the assumption here is that not providing a template is equivalent to providing an empty
       // one

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -313,15 +313,15 @@ describe('ComponentFactory', () => {
     it('should allow setting inputs on the ComponentRef', () => {
       const inputChangesLog: string[] = [];
 
-      @Component({template: `{{in}}`})
+      @Component({template: `{{input}}`})
       class DynamicCmp implements OnChanges {
         ngOnChanges(changes: SimpleChanges): void {
-          const inChange = changes['in'];
+          const inChange = changes['input'];
           inputChangesLog.push(
               `${inChange.previousValue}:${inChange.currentValue}:${inChange.firstChange}`);
         }
 
-        @Input() in : string|undefined;
+        @Input() input: string|undefined;
       }
 
       const fixture = TestBed.createComponent(DynamicCmp);
@@ -330,21 +330,21 @@ describe('ComponentFactory', () => {
       expect(fixture.nativeElement.textContent).toBe('');
       expect(inputChangesLog).toEqual([]);
 
-      fixture.componentRef.setInput('in', 'first');
+      fixture.componentRef.setInput('input', 'first');
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('first');
       expect(inputChangesLog).toEqual(['undefined:first:true']);
 
-      fixture.componentRef.setInput('in', 'second');
+      fixture.componentRef.setInput('input', 'second');
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('second');
       expect(inputChangesLog).toEqual(['undefined:first:true', 'first:second:false']);
     });
 
     it('should allow setting mapped inputs on the ComponentRef', () => {
-      @Component({template: `{{in}}`})
+      @Component({template: `{{input}}`})
       class DynamicCmp {
-        @Input('publicName') in : string|undefined;
+        @Input('publicName') input: string|undefined;
       }
 
       const fixture = TestBed.createComponent(DynamicCmp);
@@ -382,11 +382,11 @@ describe('ComponentFactory', () => {
 
     it('should mark components for check when setting an input on a ComponentRef', () => {
       @Component({
-        template: `{{in}}`,
+        template: `{{input}}`,
         changeDetection: ChangeDetectionStrategy.OnPush,
       })
       class DynamicCmp {
-        @Input() in : string|undefined;
+        @Input() input: string|undefined;
       }
 
       const fixture = TestBed.createComponent(DynamicCmp);
@@ -394,7 +394,7 @@ describe('ComponentFactory', () => {
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('');
 
-      fixture.componentRef.setInput('in', 'pushed');
+      fixture.componentRef.setInput('input', 'pushed');
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('pushed');
     });
@@ -402,7 +402,7 @@ describe('ComponentFactory', () => {
     it('should not set input if value is the same as the previous', () => {
       let log: string[] = [];
       @Component({
-        template: `{{in}}`,
+        template: `{{input}}`,
         standalone: true,
       })
       class DynamicCmp {


### PR DESCRIPTION
This commit adds the support of the `in` operator to the Expression Parser.

Fixes #49612 
Also related to #43485 

Because of #49733, this actually breaks variables named  `in` in templates. It this acceptable ? 

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] Feature

## Does this PR introduce a breaking change?

- [x] No