### PR TITLE
fix(core): `ComponentMirror` exposes hostdirectives inputs/outputs

### DIFF
--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -11,8 +11,8 @@ import {EnvironmentInjector, getNullInjector} from '../di/r3_injector';
 import {Type} from '../interface/type';
 import {ComponentRef} from '../linker/component_factory';
 
-import {ComponentFactory} from './component_ref';
-import {getComponentDef} from './definition';
+import {ComponentFactory, toRefArray} from './component_ref';
+import {getComponentDef, getDirectiveDef} from './definition';
 import {assertComponentDef} from './errors';
 
 /**
@@ -115,7 +115,8 @@ export interface ComponentMirror<C> {
   /**
    * The outputs of the component.
    */
-  get outputs(): ReadonlyArray<{readonly propName: string, readonly templateName: string}>;
+  get outputs(): ReadonlyArray<{readonly propName: string; readonly templateName: string}>;
+
   /**
    * Selector for all <ng-content> elements in the component.
    */
@@ -174,8 +175,8 @@ export interface ComponentMirror<C> {
 export function reflectComponentType<C>(component: Type<C>): ComponentMirror<C>|null {
   const componentDef = getComponentDef(component);
   if (!componentDef) return null;
-
   const factory = new ComponentFactory<C>(componentDef);
+
   return {
     get selector(): string {
       return factory.selector;
@@ -184,14 +185,25 @@ export function reflectComponentType<C>(component: Type<C>): ComponentMirror<C>|
       return factory.componentType;
     },
     get inputs(): ReadonlyArray<{
-      propName: string,
-      templateName: string,
+      propName: string; templateName: string;
       transform?: (value: any) => any,
     }> {
-      return factory.inputs;
+      return [
+        ...factory.inputs,
+        ...(componentDef.hostDirectives ?? []).flatMap((directiveRef) => {
+          // the directiveRef returns no inputs, a call the getDirectiveDef is required
+          return toRefArray(getDirectiveDef(directiveRef.directive)?.inputs ?? {});
+        }),
+      ];
     },
-    get outputs(): ReadonlyArray<{propName: string, templateName: string}> {
-      return factory.outputs;
+    get outputs(): ReadonlyArray<{propName: string; templateName: string}> {
+      return [
+        ...factory.outputs,
+        ...(componentDef.hostDirectives ?? []).flatMap((directiveRef) => {
+          // the directiveRef returns no inputs, a call the getDirectiveDef is required
+          return toRefArray(getDirectiveDef(directiveRef.directive)?.outputs ?? {});
+        }),
+      ];
     },
     get ngContentSelectors(): ReadonlyArray<string> {
       return factory.ngContentSelectors;

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -68,7 +68,8 @@ export class ComponentFactoryResolver extends AbstractComponentFactoryResolver {
   }
 }
 
-function toRefArray<T>(map: {[P in keyof T]?: string|[minifiedName: string, flags: InputFlags]}):
+export function toRefArray<T>(
+    map: {[P in keyof T]?: string|[minifiedName: string, flags: InputFlags]}):
     {propName: string; templateName: string}[] {
   const array: {propName: string; templateName: string;}[] = [];
   for (const publicName in map) {

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -923,6 +923,17 @@ describe('component', () => {
   });
 
   describe('reflectComponentType', () => {
+    @Directive({selector: '[dir1]', inputs: ['input-1a', 'input-1b'], outputs: ['output-1']})
+    class Dir1 {
+    }
+    @Directive({
+      selector: '[dir2]',
+      inputs: ['input-2a', 'input-2b:input-alias-2b'],
+      outputs: ['output-2']
+    })
+    class Dir2 {
+    }
+
     it('should create an ComponentMirror for a standalone component', () => {
       function transformFn() {}
 
@@ -937,13 +948,14 @@ describe('component', () => {
         `,
         inputs: ['input-a', 'input-b:input-alias-b'],
         outputs: ['output-a', 'output-b:output-alias-b'],
+        imports: [Dir1, Dir2],
+        hostDirectives: [Dir1, Dir2],
       })
       class StandaloneComponent {
         @Input({alias: 'input-alias-c', transform: transformFn}) inputC: unknown;
       }
 
       const mirror = reflectComponentType(StandaloneComponent)!;
-
       expect(mirror.selector).toBe('standalone-component');
       expect(mirror.type).toBe(StandaloneComponent);
       expect(mirror.isStandalone).toEqual(true);
@@ -951,10 +963,16 @@ describe('component', () => {
         {propName: 'input-a', templateName: 'input-a'},
         {propName: 'input-b', templateName: 'input-alias-b'},
         {propName: 'inputC', templateName: 'input-alias-c', transform: transformFn},
+        {propName: 'input-1a', templateName: 'input-1a'},
+        {propName: 'input-1b', templateName: 'input-1b'},
+        {propName: 'input-2a', templateName: 'input-2a'},
+        {propName: 'input-2b', templateName: 'input-alias-2b'},
       ]);
       expect(mirror.outputs).toEqual([
         {propName: 'output-a', templateName: 'output-a'},
-        {propName: 'output-b', templateName: 'output-alias-b'}
+        {propName: 'output-b', templateName: 'output-alias-b'},
+        {propName: 'output-1', templateName: 'output-1'},
+        {propName: 'output-2', templateName: 'output-2'},
       ]);
       expect(mirror.ngContentSelectors).toEqual([
         '*', 'content-selector-a', 'content-selector-b', '*'
@@ -974,6 +992,7 @@ describe('component', () => {
         `,
         inputs: ['input-a', 'input-b:input-alias-b'],
         outputs: ['output-a', 'output-b:output-alias-b'],
+        hostDirectives: [Dir1, Dir2],
       })
       class NonStandaloneComponent {
         @Input({alias: 'input-alias-c', transform: transformFn}) inputC: unknown;
@@ -988,10 +1007,16 @@ describe('component', () => {
         {propName: 'input-a', templateName: 'input-a'},
         {propName: 'input-b', templateName: 'input-alias-b'},
         {propName: 'inputC', templateName: 'input-alias-c', transform: transformFn},
+        {propName: 'input-1a', templateName: 'input-1a'},
+        {propName: 'input-1b', templateName: 'input-1b'},
+        {propName: 'input-2a', templateName: 'input-2a'},
+        {propName: 'input-2b', templateName: 'input-alias-2b'},
       ]);
       expect(mirror.outputs).toEqual([
         {propName: 'output-a', templateName: 'output-a'},
-        {propName: 'output-b', templateName: 'output-alias-b'}
+        {propName: 'output-b', templateName: 'output-alias-b'},
+        {propName: 'output-1', templateName: 'output-1'},
+        {propName: 'output-2', templateName: 'output-2'},
       ]);
       expect(mirror.ngContentSelectors).toEqual([
         '*', 'content-selector-a', 'content-selector-b', '*'


### PR DESCRIPTION
This commits increases the api surface for `ComponentMirror` by exposings a Map of HostDirectives' inputs/outputs.

See #49734

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [x] No