### PR TITLE
docs: release notes for the v13.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="13.4.0"></a>
+# 13.4.0 (2023-04-06)
+### common
+| Commit | Type | Description |
+| -- | -- | -- |
+| [ae34dbca1b](https://github.com/angular/angular/commit/ae34dbca1be10b0245a751bb0596599e95d7b4aa) | feat | Backport NgOptimizedImage to v13 |
+## Special Thanks
+Alex Castle and Paul Gschwendtner
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.0.0-next.7"></a>
 # 16.0.0-next.7 (2023-04-05)
 ## Breaking Changes


### PR DESCRIPTION
Cherry-picks the changelog from the "13.4.x" branch to the next branch (main).