### PR TITLE
fix(compiler) support for keyword similar properties in components (i.e. `as`)

### DIFF
--- a/packages/compiler/src/expression_parser/lexer.ts
+++ b/packages/compiler/src/expression_parser/lexer.ts
@@ -12,6 +12,7 @@ export enum TokenType {
   Character,
   Identifier,
   PrivateIdentifier,
+  KeywordyIdentifier,
   Keyword,
   String,
   Operator,
@@ -20,6 +21,9 @@ export enum TokenType {
 }
 
 const KEYWORDS = ['var', 'let', 'as', 'null', 'undefined', 'true', 'false', 'if', 'else', 'this'];
+
+/* This list contains keywords that are valid identifiers is JS */
+const KEYWORDY_IDENTIFIERS = ['as'];
 
 export class Lexer {
   tokenize(text: string): Token[] {
@@ -63,6 +67,10 @@ export class Token {
     return this.type == TokenType.PrivateIdentifier;
   }
 
+  isKeywordyIdentifier(): boolean {
+    return this.type == TokenType.KeywordyIdentifier;
+  }
+
   isKeyword(): boolean {
     return this.type == TokenType.Keyword;
   }
@@ -72,7 +80,7 @@ export class Token {
   }
 
   isKeywordAs(): boolean {
-    return this.type == TokenType.Keyword && this.strValue == 'as';
+    return this.type == TokenType.KeywordyIdentifier && this.strValue == 'as';
   }
 
   isKeywordNull(): boolean {
@@ -107,6 +115,7 @@ export class Token {
     switch (this.type) {
       case TokenType.Character:
       case TokenType.Identifier:
+      case TokenType.KeywordyIdentifier:
       case TokenType.Keyword:
       case TokenType.Operator:
       case TokenType.PrivateIdentifier:
@@ -127,6 +136,10 @@ function newCharacterToken(index: number, end: number, code: number): Token {
 
 function newIdentifierToken(index: number, end: number, text: string): Token {
   return new Token(index, end, TokenType.Identifier, 0, text);
+}
+
+function newKeywordyIdentifierToken(index: number, end: number, text: string): Token {
+  return new Token(index, end, TokenType.KeywordyIdentifier, 0, text);
 }
 
 function newPrivateIdentifierToken(index: number, end: number, text: string): Token {
@@ -286,8 +299,13 @@ class _Scanner {
     this.advance();
     while (isIdentifierPart(this.peek)) this.advance();
     const str: string = this.input.substring(start, this.index);
-    return KEYWORDS.indexOf(str) > -1 ? newKeywordToken(start, this.index, str) :
-                                        newIdentifierToken(start, this.index, str);
+    if (KEYWORDS.indexOf(str) === -1) {
+      return newIdentifierToken(start, this.index, str);
+    } else if (KEYWORDY_IDENTIFIERS.indexOf(str) > -1) {
+      return newKeywordyIdentifierToken(start, this.index, str);
+    } else {
+      return newKeywordToken(start, this.index, str);
+    }
   }
 
   /** Scans an ECMAScript private identifier. */

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -545,7 +545,7 @@ export class _ParseAST {
 
   expectIdentifierOrKeyword(): string|null {
     const n = this.next;
-    if (!n.isIdentifier() && !n.isKeyword()) {
+    if (!n.isIdentifier() && !n.isKeyword() && !n.isKeywordyIdentifier()) {
       if (n.isPrivateIdentifier()) {
         this._reportErrorForPrivateIdentifier(n, 'expected identifier or keyword');
       } else {
@@ -559,7 +559,7 @@ export class _ParseAST {
 
   expectIdentifierOrKeywordOrString(): string {
     const n = this.next;
-    if (!n.isIdentifier() && !n.isKeyword() && !n.isString()) {
+    if (!n.isIdentifier() && !n.isKeyword() && !n.isKeywordyIdentifier() && !n.isString()) {
       if (n.isPrivateIdentifier()) {
         this._reportErrorForPrivateIdentifier(n, 'expected identifier, keyword or string');
       } else {
@@ -885,7 +885,7 @@ export class _ParseAST {
     } else if (this.next.isCharacter(chars.$LBRACE)) {
       return this.parseLiteralMap();
 
-    } else if (this.next.isIdentifier()) {
+    } else if (this.next.isIdentifier() || this.next.isKeywordyIdentifier()) {
       return this.parseAccessMember(
           new ImplicitReceiver(this.span(start), this.sourceSpan(start)), start, false);
     } else if (this.next.isNumber()) {

--- a/packages/compiler/test/integration_spec.ts
+++ b/packages/compiler/test/integration_spec.ts
@@ -39,6 +39,19 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
          }));
     });
 
+    describe('components', () => {
+      it('should support component with keywordy variables', () => {
+        TestBed.configureTestingModule({
+          declarations: [
+            TestComponent,
+          ],
+        });
+
+        const template = `<div>{{as}}</div>`;
+        fixture = createTestComponent(template);
+      });
+    });
+
     describe('ng-container', () => {
       if (browserDetection.isChromeDesktop) {
         it('should work regardless the namespace', waitForAsync(() => {
@@ -66,6 +79,7 @@ import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 @Component({selector: 'test-cmp', template: ''})
 class TestComponent {
+  as: string = 'as';
 }
 
 function createTestComponent(template: string): ComponentFixture<TestComponent> {


### PR DESCRIPTION
At moment, `as` is the only keyword that is also a valid js property identifier. 
The lexer wasn't able to handle this particular case. It always assumed that it was a keyword thus preventing the use of an `as` property in a template.

This fix is required to land #49731. 

fixes #49733

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] No