### PR TITLE
Use `Writable` utility type to improve typings

### DIFF
--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AnimationOptions, AnimationPlayer, AUTO_STYLE, NoopAnimationPlayer, ɵAnimationGroupPlayer as AnimationGroupPlayer, ɵPRE_STYLE as PRE_STYLE, ɵStyleDataMap} from '@angular/animations';
+import {ɵWritable as Writable} from '@angular/core';
 
 import {AnimationTimelineInstruction} from '../dsl/animation_timeline_instruction';
 import {AnimationTransitionFactory} from '../dsl/animation_transition_factory';
@@ -1496,7 +1497,7 @@ export class TransitionAnimationPlayer implements AnimationPlayer {
     this._queuedCallbacks.clear();
     this._containsRealPlayer = true;
     this.overrideTotalTime(player.totalTime);
-    (this as {queued: boolean}).queued = false;
+    (this as Writable<this>).queued = false;
   }
 
   getRealPlayer() {

--- a/packages/core/src/change_detection/differs/default_iterable_differ.ts
+++ b/packages/core/src/change_detection/differs/default_iterable_differ.ts
@@ -7,6 +7,7 @@
  */
 
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
+import {Writable} from '../../interface/type';
 import {isListLikeIterable, iterateListLike} from '../../util/iterable';
 import {stringify} from '../../util/stringify';
 
@@ -178,7 +179,7 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
     let item: V;
     let itemTrackBy: any;
     if (Array.isArray(collection)) {
-      (this as {length: number}).length = collection.length;
+      (this as Writable<this>).length = collection.length;
 
       for (let index = 0; index < this.length; index++) {
         item = collection[index];
@@ -213,12 +214,11 @@ export class DefaultIterableDiffer<V> implements IterableDiffer<V>, IterableChan
         record = record._next;
         index++;
       });
-      (this as {length: number}).length = index;
+      (this as Writable<this>).length = index;
     }
 
     this._truncate(record);
-    // @ts-expect-error overwriting a readonly member
-    this.collection = collection;
+    (this as Writable<this>).collection = collection;
     return this.isDirty;
   }
 

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -23,6 +23,7 @@ export {SSR_CONTENT_INTEGRITY_MARKER as ɵSSR_CONTENT_INTEGRITY_MARKER} from './
 export {CurrencyIndex as ɵCurrencyIndex, ExtraLocaleDataIndex as ɵExtraLocaleDataIndex, findLocaleData as ɵfindLocaleData, getLocaleCurrencyCode as ɵgetLocaleCurrencyCode, getLocalePluralCase as ɵgetLocalePluralCase, LocaleDataIndex as ɵLocaleDataIndex, registerLocaleData as ɵregisterLocaleData, unregisterAllLocaleData as ɵunregisterLocaleData} from './i18n/locale_data_api';
 export {DEFAULT_LOCALE_ID as ɵDEFAULT_LOCALE_ID} from './i18n/localization';
 export {InitialRenderPendingTasks as ɵInitialRenderPendingTasks} from './initial_render_pending_tasks';
+export {Writable as ɵWritable} from './interface/type';
 export {ComponentFactory as ɵComponentFactory} from './linker/component_factory';
 export {clearResolutionOfComponentResourcesQueue as ɵclearResolutionOfComponentResourcesQueue, isComponentDefPendingResolution as ɵisComponentDefPendingResolution, resolveComponentResources as ɵresolveComponentResources, restoreComponentResolutionQueue as ɵrestoreComponentResolutionQueue} from './metadata/resource_loading';
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -14,6 +14,7 @@ import {hasSkipHydrationAttrOnRElement} from '../../hydration/skip_hydration';
 import {PRESERVE_HOST_CONTENT, PRESERVE_HOST_CONTENT_DEFAULT} from '../../hydration/tokens';
 import {processTextNodeMarkersBeforeHydration} from '../../hydration/utils';
 import {DoCheck, OnChanges, OnInit} from '../../interface/lifecycle_hooks';
+import {Writable} from '../../interface/type';
 import {SchemaMetadata} from '../../metadata/schema';
 import {ViewEncapsulation} from '../../metadata/view';
 import {validateAgainstEventAttributes, validateAgainstEventProperties} from '../../sanitization/sanitization';
@@ -1216,7 +1217,7 @@ export function configureViewWithDirective<T>(
       assertGreaterThanOrEqual(directiveIndex, HEADER_OFFSET, 'Must be in Expando section');
   tView.data[directiveIndex] = def;
   const directiveFactory =
-      def.factory || ((def as {factory: Function}).factory = getFactoryDef(def.type, true));
+      def.factory || ((def as Writable<DirectiveDef<T>>).factory = getFactoryDef(def.type, true));
   // Even though `directiveFactory` will already be using `ɵɵdirectiveInject` in its generated code,
   // we also want to support `inject()` directly from the directive constructor context so we set
   // `ɵɵdirectiveInject` as the inject implementation here too.

--- a/packages/forms/src/directives/ng_control_status.ts
+++ b/packages/forms/src/directives/ng_control_status.ts
@@ -6,11 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, Optional, Self} from '@angular/core';
+import {Directive, Optional, Self, ɵWritable as Writable} from '@angular/core';
 
 import {AbstractControlDirective} from './abstract_control_directive';
 import {ControlContainer} from './control_container';
 import {NgControl} from './ng_control';
+import {type NgForm} from './ng_form';
+import {type FormGroupDirective} from './reactive_directives/form_group_directive';
 
 // DO NOT REFACTOR!
 // Each status is represented by a separate function to make sure that
@@ -54,7 +56,7 @@ export class AbstractControlStatus {
   protected get isSubmitted() {
     // We check for the `submitted` field from `NgForm` and `FormGroupDirective` classes, but
     // we avoid instanceof checks to prevent non-tree-shakable references to those types.
-    return !!(this._cd as unknown as {submitted: boolean} | null)?.submitted;
+    return !!(this._cd as Writable<NgForm|FormGroupDirective>| null)?.submitted;
   }
 }
 

--- a/packages/forms/src/directives/ng_form.ts
+++ b/packages/forms/src/directives/ng_form.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterViewInit, Directive, EventEmitter, forwardRef, Inject, Input, Optional, Provider, Self} from '@angular/core';
+import {AfterViewInit, Directive, EventEmitter, forwardRef, Inject, Input, Optional, Provider, Self, ɵWritable as Writable} from '@angular/core';
 
 import {AbstractControl, FormHooks} from '../model/abstract_model';
 import {FormControl} from '../model/form_control';
@@ -191,7 +191,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
   addControl(dir: NgModel): void {
     resolvedPromise.then(() => {
       const container = this._findContainer(dir.path);
-      (dir as {control: FormControl}).control =
+      (dir as Writable<NgModel>).control =
           <FormControl>container.registerControl(dir.name, dir.control);
       setUpControl(dir.control, dir, this.callSetDisabledState);
       dir.control.updateValueAndValidity({emitEvent: false});
@@ -297,7 +297,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    * @param $event The "submit" event object
    */
   onSubmit($event: Event): boolean {
-    (this as {submitted: boolean}).submitted = true;
+    (this as Writable<this>).submitted = true;
     syncPendingControls(this.form, this._directives);
     this.ngSubmit.emit($event);
     // Forms with `method="dialog"` have some special behavior
@@ -321,7 +321,7 @@ export class NgForm extends ControlContainer implements Form, AfterViewInit {
    */
   resetForm(value: any = undefined): void {
     this.form.reset(value);
-    (this as {submitted: boolean}).submitted = false;
+    (this as Writable<this>).submitted = false;
   }
 
   private _setUpdateStrategy() {

--- a/packages/forms/src/directives/reactive_directives/form_control_name.ts
+++ b/packages/forms/src/directives/reactive_directives/form_control_name.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EventEmitter, forwardRef, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Provider, Self, SimpleChanges, SkipSelf} from '@angular/core';
+import {Directive, EventEmitter, forwardRef, Host, Inject, Input, OnChanges, OnDestroy, Optional, Output, Provider, Self, SimpleChanges, SkipSelf, ɵWritable as Writable} from '@angular/core';
 
 import {FormControl} from '../../model/form_control';
 import {NG_ASYNC_VALIDATORS, NG_VALIDATORS} from '../../validators';
@@ -203,7 +203,7 @@ export class FormControlName extends NgControl implements OnChanges, OnDestroy {
 
   private _setUpControl() {
     this._checkParentType();
-    (this as {control: FormControl}).control = this.formDirective.addControl(this);
+    (this as Writable<this>).control = this.formDirective.addControl(this);
     this._added = true;
   }
 }

--- a/packages/forms/src/directives/reactive_directives/form_group_directive.ts
+++ b/packages/forms/src/directives/reactive_directives/form_group_directive.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Directive, EventEmitter, forwardRef, Inject, Input, OnChanges, OnDestroy, Optional, Output, Provider, Self, SimpleChanges} from '@angular/core';
+import {Directive, EventEmitter, forwardRef, Inject, Input, OnChanges, OnDestroy, Optional, Output, Provider, Self, SimpleChanges, ɵWritable as Writable} from '@angular/core';
 
 import {FormArray} from '../../model/form_array';
 import {FormControl, isFormControl} from '../../model/form_control';
@@ -270,7 +270,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
    * @param $event The "submit" event object
    */
   onSubmit($event: Event): boolean {
-    (this as {submitted: boolean}).submitted = true;
+    (this as Writable<this>).submitted = true;
     syncPendingControls(this.form, this.directives);
     this.ngSubmit.emit($event);
     // Forms with `method="dialog"` have some special behavior that won't reload the page and that
@@ -295,7 +295,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
    */
   resetForm(value: any = undefined): void {
     this.form.reset(value);
-    (this as {submitted: boolean}).submitted = false;
+    (this as Writable<this>).submitted = false;
   }
 
   /** @internal */
@@ -315,7 +315,7 @@ export class FormGroupDirective extends ControlContainer implements Form, OnChan
         // directive instance is being removed (invoked from `FormControlName.ngOnDestroy`).
         if (isFormControl(newCtrl)) {
           setUpControl(newCtrl, dir, this.callSetDisabledState);
-          (dir as {control: FormControl}).control = newCtrl;
+          (dir as Writable<FormControlName>).control = newCtrl;
         }
       }
     });

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EventEmitter, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {EventEmitter, ɵRuntimeError as RuntimeError, ɵWritable as Writable} from '@angular/core';
 import {Observable} from 'rxjs';
 
 import {asyncValidatorsDroppedWithOptsWarning, missingControlError, missingControlValueError, noControlsError} from '../directives/reactive_errors';
@@ -797,7 +797,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * marks all direct ancestors. Default is false.
    */
   markAsTouched(opts: {onlySelf?: boolean} = {}): void {
-    (this as {touched: boolean}).touched = true;
+    (this as Writable<this>).touched = true;
 
     if (this._parent && !opts.onlySelf) {
       this._parent.markAsTouched(opts);
@@ -830,7 +830,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * marks all direct ancestors. Default is false.
    */
   markAsUntouched(opts: {onlySelf?: boolean} = {}): void {
-    (this as {touched: boolean}).touched = false;
+    (this as Writable<this>).touched = false;
     this._pendingTouched = false;
 
     this._forEachChild((control: AbstractControl) => {
@@ -856,7 +856,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * marks all direct ancestors. Default is false.
    */
   markAsDirty(opts: {onlySelf?: boolean} = {}): void {
-    (this as {pristine: boolean}).pristine = false;
+    (this as Writable<this>).pristine = false;
 
     if (this._parent && !opts.onlySelf) {
       this._parent.markAsDirty(opts);
@@ -880,7 +880,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * marks all direct ancestors. Default is false.
    */
   markAsPristine(opts: {onlySelf?: boolean} = {}): void {
-    (this as {pristine: boolean}).pristine = true;
+    (this as Writable<this>).pristine = true;
     this._pendingDirty = false;
 
     this._forEachChild((control: AbstractControl) => {
@@ -909,7 +909,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    *
    */
   markAsPending(opts: {onlySelf?: boolean, emitEvent?: boolean} = {}): void {
-    (this as {status: FormControlStatus}).status = PENDING;
+    (this as Writable<this>).status = PENDING;
 
     if (opts.emitEvent !== false) {
       (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
@@ -942,8 +942,8 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     // parent's dirtiness based on the children.
     const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
 
-    (this as {status: FormControlStatus}).status = DISABLED;
-    (this as {errors: ValidationErrors | null}).errors = null;
+    (this as Writable<this>).status = DISABLED;
+    (this as Writable<this>).errors = null;
     this._forEachChild((control: AbstractControl) => {
       control.disable({...opts, onlySelf: true});
     });
@@ -981,7 +981,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
     // parent's dirtiness based on the children.
     const skipPristineCheck = this._parentMarkedDirty(opts.onlySelf);
 
-    (this as {status: FormControlStatus}).status = VALID;
+    (this as Writable<this>).status = VALID;
     this._forEachChild((control: AbstractControl) => {
       control.enable({...opts, onlySelf: true});
     });
@@ -1054,8 +1054,8 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
 
     if (this.enabled) {
       this._cancelExistingSubscription();
-      (this as {errors: ValidationErrors | null}).errors = this._runValidator();
-      (this as {status: FormControlStatus}).status = this._calculateStatus();
+      (this as Writable<this>).errors = this._runValidator();
+      (this as Writable<this>).status = this._calculateStatus();
 
       if (this.status === VALID || this.status === PENDING) {
         this._runAsyncValidator(opts.emitEvent);
@@ -1079,7 +1079,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   }
 
   private _setInitialStatus() {
-    (this as {status: FormControlStatus}).status = this._allControlsDisabled() ? DISABLED : VALID;
+    (this as Writable<this>).status = this._allControlsDisabled() ? DISABLED : VALID;
   }
 
   private _runValidator(): ValidationErrors|null {
@@ -1088,7 +1088,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
 
   private _runAsyncValidator(emitEvent?: boolean): void {
     if (this.asyncValidator) {
-      (this as {status: FormControlStatus}).status = PENDING;
+      (this as Writable<this>).status = PENDING;
       this._hasOwnPendingAsyncValidator = true;
       const obs = toObservable(this.asyncValidator(this));
       this._asyncValidationSubscription = obs.subscribe((errors: ValidationErrors|null) => {
@@ -1137,7 +1137,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * ```
    */
   setErrors(errors: ValidationErrors|null, opts: {emitEvent?: boolean} = {}): void {
-    (this as {errors: ValidationErrors | null}).errors = errors;
+    (this as Writable<this>).errors = errors;
     this._updateControlsErrors(opts.emitEvent !== false);
   }
 
@@ -1279,7 +1279,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
 
   /** @internal */
   _updateControlsErrors(emitEvent: boolean): void {
-    (this as {status: FormControlStatus}).status = this._calculateStatus();
+    (this as Writable<this>).status = this._calculateStatus();
 
     if (emitEvent) {
       (this.statusChanges as EventEmitter<FormControlStatus>).emit(this.status);
@@ -1292,8 +1292,8 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
 
   /** @internal */
   _initObservables() {
-    (this as {valueChanges: Observable<TValue>}).valueChanges = new EventEmitter();
-    (this as {statusChanges: Observable<FormControlStatus>}).statusChanges = new EventEmitter();
+    (this as Writable<this>).valueChanges = new EventEmitter();
+    (this as Writable<this>).statusChanges = new EventEmitter();
   }
 
 
@@ -1337,7 +1337,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
 
   /** @internal */
   _updatePristine(opts: {onlySelf?: boolean} = {}): void {
-    (this as {pristine: boolean}).pristine = !this._anyControlsDirty();
+    (this as Writable<this>).pristine = !this._anyControlsDirty();
 
     if (this._parent && !opts.onlySelf) {
       this._parent._updatePristine(opts);
@@ -1346,7 +1346,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
 
   /** @internal */
   _updateTouched(opts: {onlySelf?: boolean} = {}): void {
-    (this as {touched: boolean}).touched = this._anyControlsTouched();
+    (this as Writable<this>).touched = this._anyControlsTouched();
 
     if (this._parent && !opts.onlySelf) {
       this._parent._updateTouched(opts);

--- a/packages/forms/src/model/form_array.ts
+++ b/packages/forms/src/model/form_array.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ɵWritable as Writable} from '@angular/core';
+
 import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
 
 import {AbstractControl, AbstractControlOptions, assertAllValuesPresent, assertControlPresent, pickAsyncValidators, pickValidators, ɵRawValue, ɵTypedOrUntyped, ɵValue} from './abstract_model';
@@ -476,7 +478,7 @@ export class FormArray<TControl extends AbstractControl<any> = any> extends Abst
 
   /** @internal */
   override _updateValue(): void {
-    (this as {value: any}).value =
+    (this as Writable<this>).value =
         this.controls.filter((control) => control.enabled || this.disabled)
             .map((control) => control.value);
   }

--- a/packages/forms/src/model/form_control.ts
+++ b/packages/forms/src/model/form_control.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ɵWritable as Writable} from '@angular/core';
+
 import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
 import {removeListItem} from '../util';
 
@@ -456,7 +458,7 @@ export const FormControl: ɵFormControlCtor =
         emitModelToViewChange?: boolean,
         emitViewToModelChange?: boolean
       } = {}): void {
-        (this as {value: TValue}).value = this._pendingValue = value;
+        (this as Writable<this>).value = this._pendingValue = value;
         if (this._onChange.length && options.emitModelToViewChange !== false) {
           this._onChange.forEach(
               (changeFn) => changeFn(this.value, options.emitViewToModelChange !== false));
@@ -532,11 +534,11 @@ export const FormControl: ɵFormControlCtor =
 
       private _applyFormState(formState: FormControlState<TValue>|TValue) {
         if (isFormControlState(formState)) {
-          (this as {value: TValue}).value = this._pendingValue = formState.value;
+          (this as Writable<this>).value = this._pendingValue = formState.value;
           formState.disabled ? this.disable({onlySelf: true, emitEvent: false}) :
                                this.enable({onlySelf: true, emitEvent: false});
         } else {
-          (this as {value: TValue}).value = this._pendingValue = formState;
+          (this as Writable<this>).value = this._pendingValue = formState;
         }
       }
     });

--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -6,6 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ɵWritable as Writable} from '@angular/core';
+
 import {AsyncValidatorFn, ValidatorFn} from '../directives/validators';
 
 import {AbstractControl, AbstractControlOptions, assertAllValuesPresent, assertControlPresent, pickAsyncValidators, pickValidators, ɵRawValue, ɵTypedOrUntyped, ɵValue} from './abstract_model';
@@ -533,7 +535,7 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
 
   /** @internal */
   override _updateValue(): void {
-    (this as {value: any}).value = this._reduceValue();
+    (this as Writable<this>).value = this._reduceValue() as any;
   }
 
   /** @internal */

--- a/packages/forms/test/directives_spec.ts
+++ b/packages/forms/test/directives_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {SimpleChange} from '@angular/core';
+import {SimpleChange, ɵWritable as Writable} from '@angular/core';
 import {fakeAsync, flushMicrotasks, tick} from '@angular/core/testing';
 import {AbstractControl, CheckboxControlValueAccessor, ControlValueAccessor, DefaultValueAccessor, FormArray, FormArrayName, FormControl, FormControlDirective, FormControlName, FormGroup, FormGroupDirective, FormGroupName, NgControl, NgForm, NgModel, NgModelGroup, SelectControlValueAccessor, SelectMultipleControlValueAccessor, ValidationErrors, Validator, Validators} from '@angular/forms';
 import {selectValueAccessor} from '@angular/forms/src/directives/shared';
@@ -658,7 +658,7 @@ class CustomValidatorDirective implements Validator {
         parent.form = new FormGroup({'name': formModel});
         controlNameDir = new FormControlName(parent, [], [], [defaultAccessor], null);
         controlNameDir.name = 'name';
-        (controlNameDir as {control: FormControl}).control = formModel;
+        (controlNameDir as Writable<FormControlName>).control = formModel;
       });
 
       it('should reexport control properties', () => {

--- a/packages/platform-server/src/location.ts
+++ b/packages/platform-server/src/location.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT, LocationChangeEvent, LocationChangeListener, PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
-import {Inject, Injectable, Optional} from '@angular/core';
+import {Inject, Injectable, Optional, ɵWritable as Writable} from '@angular/core';
 import {Subject} from 'rxjs';
 import * as url from 'url';
 
@@ -91,7 +91,7 @@ export class ServerPlatformLocation implements PlatformLocation {
       // Don't fire events if the hash has not changed.
       return;
     }
-    (this as {hash: string}).hash = value;
+    (this as Writable<this>).hash = value;
     const newUrl = this.url;
     queueMicrotask(
         () => this._hashUpdate.next(
@@ -101,8 +101,8 @@ export class ServerPlatformLocation implements PlatformLocation {
   replaceState(state: any, title: string, newUrl: string): void {
     const oldUrl = this.url;
     const parsedUrl = parseUrl(newUrl);
-    (this as {pathname: string}).pathname = parsedUrl.pathname;
-    (this as {search: string}).search = parsedUrl.search;
+    (this as Writable<this>).pathname = parsedUrl.pathname;
+    (this as Writable<this>).search = parsedUrl.search;
     this.setHash(parsedUrl.hash, oldUrl);
   }
 

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -7,7 +7,7 @@
  */
 
 import {Location} from '@angular/common';
-import {inject, Injectable, NgZone, Type, ɵConsole as Console, ɵInitialRenderPendingTasks as InitialRenderPendingTasks, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {inject, Injectable, NgZone, Type, ɵConsole as Console, ɵInitialRenderPendingTasks as InitialRenderPendingTasks, ɵRuntimeError as RuntimeError, ɵWritable as Writable} from '@angular/core';
 import {Observable, Subject, Subscription, SubscriptionLike} from 'rxjs';
 
 import {createSegmentGroupFromRoute, createUrlTreeFromSegmentGroup} from './create_url_tree';


### PR DESCRIPTION
The `Writable` type is usefull when we want overwrite readonly properties and we still want to maintain code navigation/reference. It should be use instead of `any` or `{myPrivateKey: any}` type assertions for example.

See individual commits

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [x] No
