### PR TITLE
refactor(common): Remove check for `createShadowRoot`

### DIFF
--- a/packages/common/src/viewport_scroller.ts
+++ b/packages/common/src/viewport_scroller.ts
@@ -209,8 +209,7 @@ function findAnchorFromDocument(document: Document, target: string): HTMLElement
   // `getElementById` and `getElementsByName` won't pierce through the shadow DOM so we
   // have to traverse the DOM manually and do the lookup through the shadow roots.
   if (typeof document.createTreeWalker === 'function' && document.body &&
-      ((document.body as any).createShadowRoot ||
-       typeof document.body.attachShadow === 'function')) {
+      typeof document.body.attachShadow === 'function') {
     const treeWalker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
     let currentNode = treeWalker.currentNode as HTMLElement | null;
 


### PR DESCRIPTION
`createShadowRoot` is not used since the drop of `ViewEncapsulation.Native` in v11 by #38882

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No