### PR TITLE
refactor(platform-browser-dynamic): Drop IE related workarounds.

### DIFF
--- a/packages/platform-browser-dynamic/src/platform-browser-dynamic.ts
+++ b/packages/platform-browser-dynamic/src/platform-browser-dynamic.ts
@@ -7,7 +7,7 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
-import {CompilerFactory, createPlatformFactory, platformCore, PlatformRef, Provider, StaticProvider} from '@angular/core';
+import {createPlatformFactory, Provider} from '@angular/core';
 
 import {platformCoreDynamic} from './platform_core_dynamic';
 import {INTERNAL_BROWSER_DYNAMIC_PLATFORM_PROVIDERS} from './platform_providers';

--- a/packages/platform-browser-dynamic/src/resource_loader/resource_loader_impl.ts
+++ b/packages/platform-browser-dynamic/src/resource_loader/resource_loader_impl.ts
@@ -23,13 +23,9 @@ export class ResourceLoaderImpl extends ResourceLoader {
     xhr.responseType = 'text';
 
     xhr.onload = function() {
-      // responseText is the old-school way of retrieving response (supported by IE8 & 9)
-      // response/responseType properties were introduced in ResourceLoader Level2 spec (supported
-      // by IE10)
-      const response = xhr.response || xhr.responseText;
+      const response = xhr.response;
 
-      // normalize IE9 bug (https://bugs.jquery.com/ticket/1450)
-      let status = xhr.status === 1223 ? 204 : xhr.status;
+      let status = xhr.status;
 
       // fix status code when it is 0 (0 status is undocumented).
       // Occurs when accessing file resources or on Android 4.1 stock browser


### PR DESCRIPTION
IE is not supported by Angular anymore, we can drop IE specific code !

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No