### PR TITLE
refactor(core): drop IE workarounds

### DIFF
--- a/packages/core/src/debug/debug_node.ts
+++ b/packages/core/src/debug/debug_node.ts
@@ -220,17 +220,11 @@ export class DebugElement extends DebugNode {
       }
     }
 
-    const eAttrs = element.attributes;
-    for (let i = 0; i < eAttrs.length; i++) {
-      const attr = eAttrs[i];
-      const lowercaseName = attr.name.toLowerCase();
-
+    for (const attr of element.attributes) {
       // Make sure that we don't assign the same attribute both in its
       // case-sensitive form and the lower-cased one from the browser.
-      if (lowercaseTNodeAttrs.indexOf(lowercaseName) === -1) {
-        // Save the lowercase name to align the behavior between browsers.
-        // IE preserves the case, while all other browser convert it to lower case.
-        attributes[lowercaseName] = attr.value;
+      if (!lowercaseTNodeAttrs.includes(attr.name)) {
+        attributes[attr.name] = attr.value;
       }
     }
 

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -214,33 +214,16 @@ export function getInheritedInjectableDef<T>(type: any): ɵɵInjectableDeclarati
   const def = type && (type[NG_PROV_DEF] || type[NG_INJECTABLE_DEF]);
 
   if (def) {
-    const typeName = getTypeName(type);
     ngDevMode &&
         console.warn(
             `DEPRECATED: DI is instantiating a token "${
-                typeName}" that inherits its @Injectable decorator but does not provide one itself.\n` +
+                type.name}" that inherits its @Injectable decorator but does not provide one itself.\n` +
             `This will become an error in a future version of Angular. Please add @Injectable() to the "${
-                typeName}" class.`);
+                type.name}" class.`);
     return def;
   } else {
     return null;
   }
-}
-
-/** Gets the name of a type, accounting for some cross-browser differences. */
-function getTypeName(type: any): string {
-  // `Function.prototype.name` behaves differently between IE and other browsers. In most browsers
-  // it'll always return the name of the function itself, no matter how many other functions it
-  // inherits from. On IE the function doesn't have its own `name` property, but it takes it from
-  // the lowest level in the prototype chain. E.g. if we have `class Foo extends Parent` most
-  // browsers will evaluate `Foo.name` to `Foo` while IE will return `Parent`. We work around
-  // the issue by converting the function to a string and parsing its name out that way via a regex.
-  if (type.hasOwnProperty('name')) {
-    return type.name;
-  }
-
-  const match = ('' + type).match(/^function\s*([^\s(]+)/);
-  return match === null ? '' : match[1];
 }
 
 /**

--- a/packages/core/src/render3/instructions/element_validation.ts
+++ b/packages/core/src/render3/instructions/element_validation.ts
@@ -86,8 +86,8 @@ export function validateElementIsKnown(
     // as a custom element. Note that unknown elements with a dash in their name won't be instances
     // of HTMLUnknownElement in browsers that support web components.
     const isUnknown =
-        // Note that we can't check for `typeof HTMLUnknownElement === 'function'`,
-        // because while most browsers return 'function', IE returns 'object'.
+        // Note that we can't check for `typeof HTMLUnknownElement === 'function'` because
+        // Domino doesn't expose HTMLUnknownElement globally.
         (typeof HTMLUnknownElement !== 'undefined' && HTMLUnknownElement &&
          element instanceof HTMLUnknownElement) ||
         (typeof customElements !== 'undefined' && tagName.indexOf('-') > -1 &&
@@ -150,8 +150,7 @@ export function isPropertyValid(
     return true;
   }
 
-  // Note: `typeof Node` returns 'function' in most browsers, but on IE it is 'object' so we
-  // need to account for both here, while being careful with `typeof null` also returning 'object'.
+  // Note: `typeof Node` returns 'function' in most browsers, but is undefined with domino.
   return typeof Node === 'undefined' || Node === null || !(element instanceof Node);
 }
 

--- a/packages/core/test/acceptance/styling_spec.ts
+++ b/packages/core/test/acceptance/styling_spec.ts
@@ -2831,6 +2831,43 @@ describe('styling', () => {
     expect(div.classes['my-class']).toBe(true);
   });
 
+  it('should remove styles via Renderer2', () => {
+    let dirInstance: any;
+    @Directive({
+      selector: '[dir]',
+    })
+    class Dir {
+      constructor(public elementRef: ElementRef, public renderer: Renderer2) {
+        dirInstance = this;
+      }
+    }
+
+    @Component({template: `<div dir></div>`})
+    class App {
+    }
+
+    TestBed.configureTestingModule({
+      declarations: [App, Dir],
+    });
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const div = fixture.debugElement.children[0];
+    const nativeEl = dirInstance.elementRef.nativeElement;
+
+    // camel case
+    dirInstance.renderer.setStyle(nativeEl, 'backgroundColor', 'red');
+    expect(div.styles.backgroundColor).toBe('red');
+    dirInstance.renderer.removeStyle(nativeEl, 'backgroundColor');
+    expect(div.styles.backgroundColor).toBe('');
+
+    // kebab case
+    dirInstance.renderer.setStyle(nativeEl, 'background-color', 'red');
+    expect(div.styles.backgroundColor).toBe('red');
+    dirInstance.renderer.removeStyle(nativeEl, 'background-color');
+    expect(div.styles.backgroundColor).toBe('');
+  });
+
   it('should not set classes when falsy value is passed while a sanitizer is present', () => {
     @Component({
       // Note that we use `background` here because it needs to be sanitized.

--- a/packages/core/test/render3/perf/noop_renderer.ts
+++ b/packages/core/test/render3/perf/noop_renderer.ts
@@ -174,8 +174,6 @@ class MicroBenchmarkDomRenderer implements Renderer {
     if (flags & RendererStyleFlags2.DashCase) {
       el.style.removeProperty(style);
     } else {
-      // IE requires '' instead of null
-      // see https://github.com/angular/angular/issues/7916
       el.style[style] = '';
     }
   }

--- a/packages/core/testing/src/styling.ts
+++ b/packages/core/testing/src/styling.ts
@@ -75,7 +75,6 @@ export function getElementStyles(element: Element): {[key: string]: string} {
       const key = style.item(i);
       const value = style.getPropertyValue(key);
       if (value !== '') {
-        // Workaround for IE not clearing properties, instead it just sets them to blank value.
         styles[key] = value;
       }
     }

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -261,10 +261,9 @@ class DefaultDomRenderer2 implements Renderer2 {
 
   removeStyle(el: any, style: string, flags: RendererStyleFlags2): void {
     if (flags & RendererStyleFlags2.DashCase) {
+      // removeProperty has no effect when used on camelCased properties.
       el.style.removeProperty(style);
     } else {
-      // IE requires '' instead of null
-      // see https://github.com/angular/angular/issues/7916
       el.style[style] = '';
     }
   }


### PR DESCRIPTION
Angular doesn't support IE anymore. We can remove the workarounds related to IE.

## PR Type

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No