### PR TITLE
ci: move error pages outside of the `public-api` group

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -158,7 +158,8 @@ groups:
           'aio/content/guide/angular-compiler-options.md',
           'aio/content/guide/aot-compiler.md',
           'aio/content/guide/aot-metadata-errors.md',
-          'aio/content/guide/template-typecheck.md'
+          'aio/content/guide/template-typecheck.md',
+          'aio/content/extended-diagnostics/*.md'
           ])
     reviewers:
       users:
@@ -241,6 +242,8 @@ groups:
           'aio/content/examples/component-interaction/**/{*,.*}',
           'aio/content/images/guide/component-interaction/**/{*,.*}',
           'aio/content/guide/component-overview.md',
+          'aio/content/errors/*.md',
+          'aio/content/examples/errors/**/{*,.*}',
           'aio/content/examples/component-overview/**/{*,.*}',
           'aio/content/guide/component-styles.md',
           'aio/content/guide/developer-guide-overview.md',
@@ -1204,11 +1207,8 @@ groups:
           'goldens/public-api/**/{*,.*}',
           'docs/NAMING.md',
           'aio/content/guide/angular-package-format.md',
-          'aio/content/errors/*.md',
-          'aio/content/extended-diagnostics/*.md',
           'aio/content/guide/glossary.md',
           'aio/content/guide/styleguide.md',
-          'aio/content/examples/errors/**/{*,.*}',
           'aio/content/examples/styleguide/**/{*,.*}',
           'aio/content/images/guide/styleguide/{*,.*}'
           ])


### PR DESCRIPTION
Currently, a change in an error guide triggers a review for the `public-api` group (requests 3 reviewers and al least 2 must approve). This is overly aggressive and we can relax this by moving the guides under `fw-core` and extended diagnostics under `fw-compiler`. In this case 1 reviewer would be requested.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No