### PR TITLE
docs: Improve documentation about Injection context / inject

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -242,6 +242,7 @@ groups:
           'aio/content/images/guide/dependency-injection-in-action/**/{*,.*}',
           'aio/content/guide/dependency-injection-navtree.md',
           'aio/content/guide/dependency-injection-providers.md',
+          'aio/content/guide/dependency-injection-context.md',
           'aio/content/guide/lightweight-injection-tokens.md',
           'aio/content/guide/displaying-data.md',
           'aio/content/examples/displaying-data/**/{*,.*}',

--- a/aio/content/errors/NG0203.md
+++ b/aio/content/errors/NG0203.md
@@ -1,10 +1,10 @@
 @name `inject()` must be called from an injection context
 @category runtime
-@shortDescription `inject()` must be called from an injection context such as a constructor, a factory function, a field initializer, or a function used with `EnvironmentInjector#runInContext`.
+@shortDescription `inject()` must be called from an injection context such as a constructor, a factory function, a field initializer, or a function used with `runInInjectionContext`.
 
 @description
-You see this error when you try to use the `inject()` function outside of the allowed injection context. The injection context is available during the class creation and initialization. It is also available to functions
-used with `EnvironmentInjector#runInContext`.
+You see this error when you try to use the [`inject`](api/core/inject) function outside of the allowed [injection context](guide/dependency-injection-context). The injection context is available during the class creation and initialization. It is also available to functions
+used with `runInInjectionContext`.
 
 In practice the `inject()` calls are allowed in a constructor, a constructor parameter and a field initializer:
 
@@ -23,7 +23,7 @@ export class Car {
 }
 ```
 
-It is also legal to call `inject` from a provider's factory:
+It is also legal to call [`inject`](api/core/inject) from a provider's factory:
 
 ```typescript
 providers: [
@@ -35,7 +35,7 @@ providers: [
 ]
 ```
 
-Calls to the `inject()` function outside of the class creation or `runInContext` will result in error. Most notably, calls to `inject()` are disallowed after a class instance was created, in methods (including lifecycle hooks):
+Calls to the [`inject`](api/core/inject) function outside of the class creation or `runInInjectionContext` will result in error. Most notably, calls to `inject()` are disallowed after a class instance was created, in methods (including lifecycle hooks):
 
 ```typescript
 @Component({ ... })
@@ -52,7 +52,7 @@ export class CarComponent {
 
 Work backwards from the stack trace of the error to identify a place where the disallowed call to `inject()` is located. 
 
-To fix the error move the `inject()` call to an allowed place (usually a class constructor or a field initializer).
+To fix the error move the [`inject`](api/core/inject) call to an allowed place (usually a class constructor or a field initializer).
 
 **Note:** If you are running in a test context, `TestBed.runInInjectionContext` will enable `inject()` to succeed.
 
@@ -68,4 +68,4 @@ TestBed.runInInjectionContext(() => {
 
 <!-- end links -->
 
-@reviewed 2022-05-27
+@reviewed 2023-04-11

--- a/aio/content/examples/dependency-injection/src/app/heroes/hero.service.5.ts
+++ b/aio/content/examples/dependency-injection/src/app/heroes/hero.service.5.ts
@@ -1,0 +1,22 @@
+// #docregion
+import { EnvironmentInjector, inject, Injectable, runInInjectionContext } from '@angular/core';
+
+@Injectable({providedIn:
+  'root'
+})
+export class SomeService {}
+
+  // #docregion run-in-context
+@Injectable({
+  providedIn: 'root',
+})
+export class HeroService {
+  private environmentInjector = inject(EnvironmentInjector);
+
+  someMethod() {
+    runInInjectionContext(this.environmentInjector, () => {
+      inject(SomeService); // Do what you need with the injected service
+    });
+  }
+}
+// #enddocregion run-in-context

--- a/aio/content/guide/dependency-injection-context.md
+++ b/aio/content/guide/dependency-injection-context.md
@@ -1,0 +1,63 @@
+# Injection context
+
+The dependency injection (DI) system relies internaly on a runtime context where the current injector is available. 
+This means that injectors can only work when code is executed in this context. 
+
+The injection context is available in these situations: 
+
+* Construction (via the `constructor`) of a class being instantiated by the DI system, such as an `@Injectable` or `@Component`.
+* In the initializer for fields of such classes.
+* In the factory function specified for `useFactory` of a `Provider` or an `@Injectable`.
+* In the `factory` function specified for an `InjectionToken`.
+* Within a stack frame that is run in a injection context.
+
+Knowing when your are in an injection context, will allow you to use the [`inject`](api/core/inject) function to inject instances.
+
+## Class constructors
+
+Everytime the DI system instantiates a class, this is done in an injection context. This is being handled by the framework itself. The constructor of the class is executed in that runtime context thus allowing to inject a token using the [`inject`](api/core/inject) function. 
+
+<code-example language="typescript">
+class MyComponent  {
+  private service1: Service1;
+  private service2: Service2 = inject(Service2); // In context
+
+  constructor() {
+    this.service1 = inject(HeroService) // In context
+  }
+}
+</code-example>
+
+## Stack frame in context
+
+Some APIs are designed to be run in an injection context. This is the case, for example, of the router guards. It allows the use of [`inject`](api/core/inject) to access a service within the guard function. 
+
+Here is an example for `CanActivateFn`
+<code-example format="typescript" language="typescript">
+const canActivateTeam: CanActivateFn =
+    (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+      return inject(PermissionsService).canActivate(inject(UserToken), route.params.id);
+    };
+</code-example>
+
+## Run within an injection context
+
+When you want to run a given function in an injection context without being in one, you can do it with `runInInjectionContext`. 
+This requires to have access to a given injector like the `EnvironmentInjector` for example.  
+
+<code-example path="dependency-injection/src/app/heroes/hero.service.5.ts" region="run-in-context" header="src/app/heroes/hero.service.ts">
+</code-example>
+
+Note that `inject` will return an instance only if the injector can resolve the required token. 
+
+## Asserts the context 
+
+Angular provides `assertInInjectionContext` helper function to assert that the current context is an injection context.
+
+## Using DI outside of a context
+
+Calling [`inject`](api/core/inject) or calling `assertInInjectionContext` outside of an injection context will throw [error NG0203](/errors/NG0203).
+
+
+
+@reviewed 2023-04-11

--- a/aio/content/guide/dependency-injection-overview.md
+++ b/aio/content/guide/dependency-injection-overview.md
@@ -34,11 +34,17 @@ You should be familiar with the Angular apps in general, and have the fundamenta
     <p>Describes how to configure dependencies using the providers field on the @Component and @NgModule decorators. Also describes how to use InjectionToken to provide and inject values in DI, which can be helpful when you want to use a value other than classes as dependencies.</p>
     <p class="card-footer">Configuring dependency providers</p>
   </a>
+    <a href="guide/dependency-injection-context" class="docs-card" title="Injection context">
+    <section>Injection context</section>
+    <p>Describes what an injection context is and how to use the DI system where you need it.</p>
+    <p class="card-footer">Injection context</p>
+  </a>
   <a href="guide/hierarchical-dependency-injection" class="docs-card" title="Hierarchical injectors">
     <section>Hierarchical injectors</section>
     <p>Hierarchical DI enables you to share dependencies between different parts of the application only when and if you need to. This is an advanced topic.</p>
     <p class="card-footer">Hierarchical injectors</p>
   </a>
+
 </div>
 
 @reviewed 2022-08-02

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -294,6 +294,11 @@
               "tooltip": "A provider factory function is a plain function that Angular can call to create a dependency."
             },
             {
+              "url": "guide/dependency-injection-context",
+              "title": "Injection context",
+              "tooltip": "Dependency injection depends on a runtime context to work."
+            },
+            {
               "url": "guide/hierarchical-dependency-injection",
               "title": "Hierarchical injectors",
               "tooltip": "Hierarchical dependency injection enables you to share dependencies between different parts of the application only when and if you need to."

--- a/packages/core/rxjs-interop/src/take_until_destroyed.ts
+++ b/packages/core/rxjs-interop/src/take_until_destroyed.ts
@@ -15,8 +15,8 @@ import {takeUntil} from 'rxjs/operators';
  * etc) is destroyed.
  *
  * @param destroyRef optionally, the `DestroyRef` representing the current context. This can be
- *     passed explicitly to use `takeUntilDestroyed` outside of an injection context. Otherwise, the
- * current `DestroyRef` is injected.
+ *     passed explicitly to use `takeUntilDestroyed` outside of an [injection
+ * context](guide/dependency-injection-context). Otherwise, the current `DestroyRef` is injected.
  *
  * @developerPreview
  */

--- a/packages/core/rxjs-interop/src/to_observable.ts
+++ b/packages/core/rxjs-interop/src/to_observable.ts
@@ -18,7 +18,8 @@ export interface ToObservableOptions {
   /**
    * The `Injector` to use when creating the underlying `effect` which watches the signal.
    *
-   * If this isn't specified, the current injection context will be used.
+   * If this isn't specified, the current [injection context](guide/dependency-injection-context)
+   * will be used.
    */
   injector?: Injector;
 }

--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -64,10 +64,11 @@ export interface ToSignalOptions<T> {
  * Before the `Observable` emits its first value, the `Signal` will return `undefined`. To avoid
  * this, either an `initialValue` can be passed or the `requireSync` option enabled.
  *
- * By default, the subscription will be automatically cleaned up when the current injection context
- * is destroyed. For example, when `toObservable` is called during the construction of a component,
- * the subscription will be cleaned up when the component is destroyed. If an injection context is
- * not available, an explicit `Injector` can be passed instead.
+ * By default, the subscription will be automatically cleaned up when the current [injection
+ * context](guide/dependency-injection-context) is destroyed. For example, when `toObservable` is
+ * called during the construction of a component, the subscription will be cleaned up when the
+ * component is destroyed. If an injection context is not available, an explicit `Injector` can be
+ * passed instead.
  *
  * If the subscription should persist until the `Observable` itself completes, the `manualCleanup`
  * option can be specified instead, which disables the automatic subscription teardown. No injection
@@ -115,10 +116,11 @@ export function toSignal<T>(
  * `initialValue`. If the `Observable` is guaranteed to emit synchronously, then the `requireSync`
  * option can be passed instead.
  *
- * By default, the subscription will be automatically cleaned up when the current injection context
- * is destroyed. For example, when `toObservable` is called during the construction of a component,
- * the subscription will be cleaned up when the component is destroyed. If an injection context is
- * not available, an explicit `Injector` can be passed instead.
+ * By default, the subscription will be automatically cleaned up when the current [injection
+ * context](guide/dependency-injection-context) is destroyed. For example, when `toObservable` is
+ * called during the construction of a component, the subscription will be cleaned up when the
+ * component is destroyed. If an injection context is not available, an explicit `Injector` can be
+ * passed instead.
  *
  * If the subscription should persist until the `Observable` itself completes, the `manualCleanup`
  * option can be specified instead, which disables the automatic subscription teardown. No injection

--- a/packages/core/src/di/contextual.ts
+++ b/packages/core/src/di/contextual.ts
@@ -13,13 +13,15 @@ import {getInjectImplementation, setInjectImplementation} from './inject_switch'
 import {R3Injector} from './r3_injector';
 
 /**
- * Runs the given function in the context of the given `Injector`.
+ * Runs the given function in the [context](guide/dependency-injection-context) of the given
+ * `Injector`.
  *
- * Within the function's stack frame, `inject` can be used to inject dependencies from the given
- * `Injector`. Note that `inject` is only usable synchronously, and cannot be used in any
- * asynchronous callbacks or after any `await` points.
+ * Within the function's stack frame, [`inject`](api/core/inject) can be used to inject dependencies
+ * from the given `Injector`. Note that `inject` is only usable synchronously, and cannot be used in
+ * any asynchronous callbacks or after any `await` points.
  *
- * @param injector the injector which will satisfy calls to `inject` while `fn` is executing
+ * @param injector the injector which will satisfy calls to [`inject`](api/core/inject) while `fn`
+ *     is executing
  * @param fn the closure to be run in the context of `injector`
  * @returns the return value of the function, if any
  * @publicApi
@@ -40,7 +42,8 @@ export function runInInjectionContext<ReturnT>(injector: Injector, fn: () => Ret
 }
 
 /**
- * Asserts that the current stack frame is within an injection context and has access to `inject`.
+ * Asserts that the current stack frame is within an [injection
+ * context](guide/dependency-injection-context) and has access to `inject`.
  *
  * @param debugFn a reference to the function making the assertion (used for the error message).
  *

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -31,7 +31,7 @@ import {ɵɵdefineInjectable} from './interface/defs';
  * (possibly by creating) a default value of the parameterized type `T`. This sets up the
  * `InjectionToken` using this factory as a provider as if it was defined explicitly in the
  * application's root injector. If the factory function, which takes zero arguments, needs to inject
- * dependencies, it can do so using the `inject` function.
+ * dependencies, it can do so using the [`inject`](api/core/inject) function.
  * As you can see in the Tree-shakable InjectionToken example below.
  *
  * Additionally, if a `factory` is specified you can also specify the `providedIn` option, which

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -151,13 +151,14 @@ export function inject<T>(token: ProviderToken<T>, options: InjectOptions&{optio
 export function inject<T>(token: ProviderToken<T>, options: InjectOptions): T|null;
 /**
  * Injects a token from the currently active injector.
- * `inject` is only supported during instantiation of a dependency by the DI system. It can be used
- * during:
+ * `inject` is only supported in a [injection context](/guide/dependency-injection-context). It can
+ * be used during:
  * - Construction (via the `constructor`) of a class being instantiated by the DI system, such
  * as an `@Injectable` or `@Component`.
  * - In the initializer for fields of such classes.
  * - In the factory function specified for `useFactory` of a `Provider` or an `@Injectable`.
  * - In the `factory` function specified for an `InjectionToken`.
+ * - In a stackframe of a function call in a DI context
  *
  * @param token A token that represents a dependency that should be injected.
  * @param flags Optional flags that control how injection is executed.

--- a/packages/core/src/di/interface/defs.ts
+++ b/packages/core/src/di/interface/defs.ts
@@ -135,7 +135,8 @@ export interface InjectorTypeWithProviders<T> {
  *   with an `@NgModule` or other `InjectorType`, or by specifying that this injectable should be
  *   provided in the `'root'` injector, which will be the application-level injector in most apps.
  * * `factory` gives the zero argument function which will create an instance of the injectable.
- *   The factory can call `inject` to access the `Injector` and request injection of dependencies.
+ *   The factory can call [`inject`](api/core/inject) to access the `Injector` and request injection
+ * of dependencies.
  *
  * @codeGenApi
  * @publicApi This instruction has been emitted by ViewEngine for some time and is deployed to npm.

--- a/packages/core/src/di/interface/injector.ts
+++ b/packages/core/src/di/interface/injector.ts
@@ -20,7 +20,7 @@ export const enum DecoratorFlags {
  * Injection flags for DI.
  *
  * @publicApi
- * @deprecated use an options object for `inject` instead.
+ * @deprecated use an options object for [`inject`](api/core/inject) instead.
  */
 export enum InjectFlags {
   // TODO(alxhub): make this 'const' (and remove `InternalInjectFlags` enum) when ngc no longer
@@ -82,7 +82,7 @@ export const enum InternalInjectFlags {
 }
 
 /**
- * Type of the options argument to `inject`.
+ * Type of the options argument to [`inject`](api/core/inject).
  *
  * @publicApi
  */

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -112,9 +112,9 @@ export abstract class EnvironmentInjector implements Injector {
   /**
    * Runs the given function in the context of this `EnvironmentInjector`.
    *
-   * Within the function's stack frame, `inject` can be used to inject dependencies from this
-   * injector. Note that `inject` is only usable synchronously, and cannot be used in any
-   * asynchronous callbacks or after any `await` points.
+   * Within the function's stack frame, [`inject`](api/core/inject) can be used to inject
+   * dependencies from this injector. Note that `inject` is only usable synchronously, and cannot be
+   * used in any asynchronous callbacks or after any `await` points.
    *
    * @param fn the closure to be run in the context of this injector
    * @returns the return value of the function, if any

--- a/packages/core/src/linker/template_ref.ts
+++ b/packages/core/src/linker/template_ref.ts
@@ -42,8 +42,8 @@ export abstract class TemplateRef<C> {
   /**
    * The anchor element in the parent view for this embedded view.
    *
-   * The data-binding and injection contexts of embedded views created from this `TemplateRef`
-   * inherit from the contexts of this location.
+   * The data-binding and [injection contexts](guide/dependency-injection-context) of embedded views
+   * created from this `TemplateRef` inherit from the contexts of this location.
    *
    * Typically new embedded views are attached to the view container of this location, but in
    * advanced use-cases, the view can be attached to a different container while keeping the

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -115,7 +115,8 @@ export interface CreateEffectOptions {
   /**
    * The `Injector` in which to create the effect.
    *
-   * If this is not provided, the current injection context will be used instead (via `inject`).
+   * If this is not provided, the current [injection context](guide/dependency-injection-context)
+   * will be used instead (via `inject`).
    */
   injector?: Injector;
 

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -41,8 +41,9 @@ export type OnSameUrlNavigation = 'reload'|'ignore';
 /**
  * The `InjectionToken` and `@Injectable` classes for guards and resolvers are deprecated in favor
  * of plain JavaScript functions instead.. Dependency injection can still be achieved using the
- * `inject` function from `@angular/core` and an injectable class can be used as a functional guard
- * using `inject`: `canActivate: [() => inject(myGuard).canActivate()]`.
+ * [`inject`](api/core/inject) function from `@angular/core` and an injectable class can be used as
+ * a functional guard using [`inject`](api/core/inject): `canActivate: [() =>
+ * inject(myGuard).canActivate()]`.
  *
  * @deprecated
  * @see {@link CanMatchFn}
@@ -699,8 +700,8 @@ export interface LoadedRouterConfig {
  *
  * @publicApi
  * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
- *     injectable class can be used as a functional guard using the `inject` function:
- *     `canActivate: [() => inject(myGuard).canActivate()]`.
+ *     injectable class can be used as a functional guard using the [`inject`](api/core/inject)
+ * function: `canActivate: [() => inject(myGuard).canActivate()]`.
  * @see {@link CanActivateFn}
  */
 export interface CanActivate {
@@ -789,8 +790,8 @@ export type CanActivateFn = (route: ActivatedRouteSnapshot, state: RouterStateSn
  *
  * @publicApi
  * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
- *     injectable class can be used as a functional guard using the `inject` function:
- *     `canActivateChild: [() => inject(myGuard).canActivateChild()]`.
+ *     injectable class can be used as a functional guard using the [`inject`](api/core/inject)
+ * function: `canActivateChild: [() => inject(myGuard).canActivateChild()]`.
  * @see {@link CanActivateChildFn}
  */
 export interface CanActivateChild {
@@ -872,8 +873,8 @@ export type CanActivateChildFn = (childRoute: ActivatedRouteSnapshot, state: Rou
  *
  * @publicApi
  * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
- *     injectable class can be used as a functional guard using the `inject` function:
- *     `canDeactivate: [() => inject(myGuard).canDeactivate()]`.
+ *     injectable class can be used as a functional guard using the [`inject`](api/core/inject)
+ * function: `canDeactivate: [() => inject(myGuard).canDeactivate()]`.
  * @see {@link CanDeactivateFn}
  */
 export interface CanDeactivate<T> {
@@ -964,8 +965,8 @@ export type CanDeactivateFn<T> =
  *
  * @publicApi
  * @deprecated Class-based `Route` guards are deprecated in favor of functional guards. An
- *     injectable class can be used as a functional guard using the `inject` function:
- *     `canMatch: [() => inject(myGuard).canMatch()]`.
+ *     injectable class can be used as a functional guard using the [`inject`](api/core/inject)
+ * function: `canMatch: [() => inject(myGuard).canMatch()]`.
  * @see {@link CanMatchFn}
  */
 export interface CanMatch {
@@ -1083,7 +1084,8 @@ export type CanMatchFn = (route: Route, segments: UrlSegment[]) =>
  *
  * @publicApi
  * @deprecated Class-based `Route` resolvers are deprecated in favor of functional resolvers. An
- * injectable class can be used as a functional guard using the `inject` function: `resolve:
+ * injectable class can be used as a functional guard using the [`inject`](api/core/inject)
+ function: `resolve:
  * {'user': () => inject(UserResolver).resolve()}`.
  * @see {@link ResolveFn}
  */

--- a/packages/router/src/provide_router.ts
+++ b/packages/router/src/provide_router.ts
@@ -607,7 +607,8 @@ export type NavigationErrorHandlerFeature =
  * Subscribes to the Router's navigation events and calls the given function when a
  * `NavigationError` happens.
  *
- * This function is run inside application's injection context so you can use the `inject` function.
+ * This function is run inside application's [injection context](guide/dependency-injection-context)
+ * so you can use the [`inject`](api/core/inject) function.
  *
  * @usageNotes
  *
@@ -626,7 +627,7 @@ export type NavigationErrorHandlerFeature =
  *
  * @see {@link NavigationError}
  * @see {@link core/inject}
- * @see {@link EnvironmentInjector#runInContext}
+ * @see {@link runInInjectionContext}
  *
  * @returns A set of providers for use with `provideRouter`.
  *


### PR DESCRIPTION
Injection context has gain public visibility with the exposure of `inject`. Lets provide some insights : 

* A detailed page about the concept of injection context
* Improve linking to `inject` (not resolved automaticaly because there is `core/inject` and `core/testing/inject`
* links to `runInInjectionContext` instead of the deprecated `EnvironmentInjector#runInContext`. 


Fixes #49774


## PR Type
What kind of change does this PR introduce?


- [x] Documentation content changes