### PR TITLE
fix(core): allow async functions in effects

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -512,7 +512,7 @@ export interface DoCheck {
 }
 
 // @public
-export function effect(effectFn: () => EffectCleanupFn | void, options?: CreateEffectOptions): EffectRef;
+export function effect(effectFn: (onCleanup: EffectCleanupRegisterFn) => void, options?: CreateEffectOptions): EffectRef;
 
 // @public
 export type EffectCleanupFn = () => void;

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -130,11 +130,11 @@ describe('effects', () => {
     })
     class Cmp {
       counter = signal(0);
-      effectRef = effect(() => {
+      effectRef = effect((onCleanup) => {
         counterLog.push(this.counter());
-        return () => {
+        onCleanup(() => {
           cleanupCount++;
-        };
+        });
       });
     }
 
@@ -179,6 +179,7 @@ describe('effects', () => {
 
     expect(didRun).toBeTrue();
   });
+
   it('should disallow writing to signals within effects by default',
      withBody('<test-cmp></test-cmp>', async () => {
        @Component({

--- a/packages/core/test/signals/effect_util.ts
+++ b/packages/core/test/signals/effect_util.ts
@@ -6,14 +6,15 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Watch} from '@angular/core/src/signals';
+import {Watch, WatchCleanupFn} from '@angular/core/src/signals';
 
 let queue = new Set<Watch>();
 
 /**
  * A wrapper around `Watch` that emulates the `effect` API and allows for more streamlined testing.
  */
-export function testingEffect(effectFn: () => void): void {
+export function testingEffect(effectFn: (onCleanup: (cleanupFn: WatchCleanupFn) => void) => void):
+    void {
   const watch = new Watch(effectFn, queue.add.bind(queue), true);
 
   // Effects start dirty.


### PR DESCRIPTION
This change makes is possible to use async functions (ones returning a promise) as effect run functions.

To make it possible, the signature of the effect function changed: effect cleanup function is registered now (using a dedicated callback passed to the effect creation) instead of being returned from the effect function.
