### PR TITLE
fix(http): delay accessing pendingTasks.whenAllTasksComplete

### DIFF
--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_BOOTSTRAP_LISTENER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵInitialRenderPendingTasks as InitialRenderPendingTasks} from '@angular/core';
+import {APP_INITIALIZER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵInitialRenderPendingTasks as InitialRenderPendingTasks} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {first, tap} from 'rxjs/operators';
 
@@ -160,7 +160,7 @@ export function withHttpTransferCache(): Provider[] {
       deps: [TransferState, CACHE_STATE]
     },
     {
-      provide: APP_BOOTSTRAP_LISTENER,
+      provide: APP_INITIALIZER,
       multi: true,
       useFactory: () => {
         const appRef = inject(ApplicationRef);
@@ -169,9 +169,7 @@ export function withHttpTransferCache(): Provider[] {
 
         return () => {
           const isStablePromise = appRef.isStable.pipe(first((isStable) => isStable)).toPromise();
-          const pendingTasksPromise = pendingTasks.whenAllTasksComplete;
-
-          Promise.allSettled([isStablePromise, pendingTasksPromise]).then(() => {
+          isStablePromise.then(() => pendingTasks.whenAllTasksComplete).then(() => {
             cacheState.isCacheActive = false;
           });
         };

--- a/packages/core/src/initial_render_pending_tasks.ts
+++ b/packages/core/src/initial_render_pending_tasks.ts
@@ -30,12 +30,11 @@ export class InitialRenderPendingTasks implements OnDestroy {
   private promise!: Promise<void>;
 
   get whenAllTasksComplete(): Promise<void> {
-    if (this.collection.size > 0) {
-      return this.promise;
+    if (this.collection.size === 0) {
+      this.complete();
     }
-    return Promise.resolve().then(() => {
-      this.completed = true;
-    });
+
+    return this.promise;
   }
 
   completed = false;
@@ -66,14 +65,17 @@ export class InitialRenderPendingTasks implements OnDestroy {
 
     this.collection.delete(taskId);
     if (this.collection.size === 0) {
-      // We've removed the last task, resolve the promise.
-      this.completed = true;
-      this.resolve();
+      this.complete();
     }
   }
 
   ngOnDestroy() {
-    this.completed = true;
+    this.complete();
     this.collection.clear();
+  }
+
+  private complete(): void {
+    this.completed = true;
+    this.resolve();
   }
 }


### PR DESCRIPTION
**fix(http): delay accessing `pendingTasks.whenAllTasksComplete`**
    
Accessing `pendingTasks.whenAllTasksComplete` too early causes the `InitialRenderPendingTasks` to return a resolved promise too early. This commit changes the way we access `whenAllTasksComplete` to only happen when the application is stabilized.

---

**fix(core): resolve `InitialRenderPendingTasks` promise on complete**
    
Current in the `InitialRenderPendingTasks` when the `collection` size is 0 a new promise is created a the status is changed to completed. This causes the promise that is created during the class initialization phase to never be resolved which causes SSR to hang indefinitely.