### PR TITLE
ci: disable size tracking CI job in favor of integration tests size checks

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -1,8 +1,8 @@
 # Configuration for angular-robot
 
-#options for the size plugin
+# options for the size plugin
 size:
-  disabled: false
+  disabled: true
   maxSizeIncrease: 2000
   circleCiStatusName: 'ci/circleci: test'
 
@@ -70,7 +70,6 @@ merge:
     requiredStatuses:
       - 'ci/circleci: build'
       - 'ci/circleci: lint'
-      - 'ci/angular: size'
       - 'google-internal-tests'
       - 'pullapprove'
 


### PR DESCRIPTION
Currently we have multiple integration apps which are instrumented with the payload size checks. In addition to that, there is a separate CI job that performs similar checks. The checks in CI job are redundant, thus this commit disables a separate CI job.

## PR Type
What kind of change does this PR introduce?

- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No