### PR TITLE
Remove target page id from transition

### DIFF
--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -235,7 +235,6 @@ export interface Navigation {
 
 export interface NavigationTransition {
   id: number;
-  targetPageId: number;
   currentUrlTree: UrlTree;
   extractedUrl: UrlTree;
   currentRawUrl: UrlTree;
@@ -323,8 +322,8 @@ export class NavigationTransitions {
   handleNavigationRequest(
       request: Pick<
           NavigationTransition,
-          'targetPageId'|'source'|'restoredState'|'currentUrlTree'|'currentRawUrl'|'rawUrl'|
-          'extras'|'resolve'|'reject'|'promise'|'currentSnapshot'|'currentRouterState'>) {
+          'source'|'restoredState'|'currentUrlTree'|'currentRawUrl'|'rawUrl'|'extras'|'resolve'|
+          'reject'|'promise'|'currentSnapshot'|'currentRouterState'>) {
     const id = ++this.navigationId;
     this.transitions?.next({...this.transitions.value, ...request, id});
   }
@@ -332,7 +331,6 @@ export class NavigationTransitions {
   setupNavigations(router: InternalRouterInterface): Observable<NavigationTransition> {
     this.transitions = new BehaviorSubject<NavigationTransition>({
       id: 0,
-      targetPageId: 0,
       currentUrlTree: router.currentUrlTree,
       currentRawUrl: router.currentUrlTree,
       extractedUrl: router.urlHandlingStrategy.extract(router.currentUrlTree),

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -725,23 +725,6 @@ export class Router {
       });
     }
 
-    let targetPageId: number;
-    if (this.canceledNavigationResolution === 'computed') {
-      // If the `ɵrouterPageId` exist in the state then `targetpageId` should have the value of
-      // `ɵrouterPageId`. This is the case for something like a page refresh where we assign the
-      // target id to the previously set value for that page.
-      if (restoredState && restoredState.ɵrouterPageId) {
-        targetPageId = restoredState.ɵrouterPageId;
-      } else {
-        // Otherwise, targetPageId should be the next number in the event of a `pushState`
-        // navigation.
-        targetPageId = (this.browserPageId ?? 0) + 1;
-      }
-    } else {
-      // This is unused when `canceledNavigationResolution` is not computed.
-      targetPageId = 0;
-    }
-
     // Indicate that the navigation is happening.
     const taskId = this.pendingTasks.add();
     afterNextNavigation(this, () => {
@@ -751,7 +734,6 @@ export class Router {
     });
 
     this.navigationTransitions.handleNavigationRequest({
-      targetPageId,
       source,
       restoredState,
       currentUrlTree: this.currentUrlTree,
@@ -787,7 +769,7 @@ export class Router {
     } else {
       const state = {
         ...transition.extras.state,
-        ...this.generateNgRouterState(transition.id, transition.targetPageId)
+        ...this.generateNgRouterState(transition.id, (this.browserPageId ?? 0) + 1)
       };
       this.location.go(path, '', state);
     }


### PR DESCRIPTION
First commit is in https://github.com/angular/angular/pull/49793

Second commit removes `targetPageId` entirely from the transition. It's no longer necessary because it can be accurately calculated at the time of `setBrowserUrl`.