### PR TITLE
refactor(core): rename internal DI token that indicates whether hydration is enabled

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -18,7 +18,7 @@ export {XSS_SECURITY_URL as ɵXSS_SECURITY_URL} from './error_details_base_url';
 export {formatRuntimeError as ɵformatRuntimeError, RuntimeError as ɵRuntimeError} from './errors';
 export {annotateForHydration as ɵannotateForHydration} from './hydration/annotate';
 export {withDomHydration as ɵwithDomHydration} from './hydration/api';
-export {IS_HYDRATION_FEATURE_ENABLED as ɵIS_HYDRATION_FEATURE_ENABLED} from './hydration/tokens';
+export {IS_HYDRATION_DOM_REUSE_ENABLED as ɵIS_HYDRATION_DOM_REUSE_ENABLED} from './hydration/tokens';
 export {CurrencyIndex as ɵCurrencyIndex, ExtraLocaleDataIndex as ɵExtraLocaleDataIndex, findLocaleData as ɵfindLocaleData, getLocaleCurrencyCode as ɵgetLocaleCurrencyCode, getLocalePluralCase as ɵgetLocalePluralCase, LocaleDataIndex as ɵLocaleDataIndex, registerLocaleData as ɵregisterLocaleData, unregisterAllLocaleData as ɵunregisterLocaleData} from './i18n/locale_data_api';
 export {DEFAULT_LOCALE_ID as ɵDEFAULT_LOCALE_ID} from './i18n/localization';
 export {InitialRenderPendingTasks as ɵInitialRenderPendingTasks} from './initial_render_pending_tasks';

--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -24,7 +24,7 @@ import {enableLocateOrCreateTextNodeImpl} from '../render3/instructions/text';
 import {TransferState} from '../transfer_state';
 
 import {cleanupDehydratedViews} from './cleanup';
-import {IS_HYDRATION_FEATURE_ENABLED, PRESERVE_HOST_CONTENT} from './tokens';
+import {IS_HYDRATION_DOM_REUSE_ENABLED, PRESERVE_HOST_CONTENT} from './tokens';
 import {enableRetrieveHydrationInfoImpl, NGH_DATA_KEY} from './utils';
 import {enableFindMatchingDehydratedViewImpl} from './views';
 
@@ -107,7 +107,7 @@ function whenStable(
 export function withDomHydration(): EnvironmentProviders {
   return makeEnvironmentProviders([
     {
-      provide: IS_HYDRATION_FEATURE_ENABLED,
+      provide: IS_HYDRATION_DOM_REUSE_ENABLED,
       useFactory: () => {
         let isEnabled = true;
         if (isBrowser()) {
@@ -142,7 +142,7 @@ export function withDomHydration(): EnvironmentProviders {
         // on the client. Moving forward, the `isBrowser` check should
         // be replaced with a tree-shakable alternative (e.g. `isServer`
         // flag).
-        if (isBrowser() && inject(IS_HYDRATION_FEATURE_ENABLED)) {
+        if (isBrowser() && inject(IS_HYDRATION_DOM_REUSE_ENABLED)) {
           enableHydrationRuntimeSupport();
         }
       },
@@ -155,13 +155,13 @@ export function withDomHydration(): EnvironmentProviders {
         // environment and when hydration is configured properly.
         // On a server, an application is rendered from scratch,
         // so the host content needs to be empty.
-        return isBrowser() && inject(IS_HYDRATION_FEATURE_ENABLED);
+        return isBrowser() && inject(IS_HYDRATION_DOM_REUSE_ENABLED);
       }
     },
     {
       provide: APP_BOOTSTRAP_LISTENER,
       useFactory: () => {
-        if (isBrowser() && inject(IS_HYDRATION_FEATURE_ENABLED)) {
+        if (isBrowser() && inject(IS_HYDRATION_DOM_REUSE_ENABLED)) {
           const appRef = inject(ApplicationRef);
           const pendingTasks = inject(InitialRenderPendingTasks);
           const injector = inject(Injector);

--- a/packages/core/src/hydration/tokens.ts
+++ b/packages/core/src/hydration/tokens.ts
@@ -11,10 +11,11 @@ import {InjectionToken} from '../di/injection_token';
 const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
 
 /**
- * Internal token that specifies whether hydration is enabled.
+ * Internal token that specifies whether DOM reuse logic
+ * during hydration is enabled.
  */
-export const IS_HYDRATION_FEATURE_ENABLED =
-    new InjectionToken<boolean>(NG_DEV_MODE ? 'IS_HYDRATION_FEATURE_ENABLED' : '');
+export const IS_HYDRATION_DOM_REUSE_ENABLED =
+    new InjectionToken<boolean>(NG_DEV_MODE ? 'IS_HYDRATION_DOM_REUSE_ENABLED' : '');
 
 // By default (in client rendering mode), we remove all the contents
 // of the host element and render an application after that.

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {ApplicationRef, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵannotateForHydration as annotateForHydration, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵInitialRenderPendingTasks as InitialRenderPendingTasks, ɵIS_HYDRATION_FEATURE_ENABLED as IS_HYDRATION_FEATURE_ENABLED, ɵisPromise} from '@angular/core';
+import {ApplicationRef, InjectionToken, NgModuleRef, PlatformRef, Provider, Renderer2, StaticProvider, Type, ɵannotateForHydration as annotateForHydration, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵInitialRenderPendingTasks as InitialRenderPendingTasks, ɵIS_HYDRATION_DOM_REUSE_ENABLED as IS_HYDRATION_DOM_REUSE_ENABLED, ɵisPromise} from '@angular/core';
 import {first} from 'rxjs/operators';
 
 import {PlatformState} from './platform_state';
@@ -67,7 +67,7 @@ function _render<T>(
 
       const asyncPromises: Promise<any>[] = [];
 
-      if (applicationRef.injector.get(IS_HYDRATION_FEATURE_ENABLED, false)) {
+      if (applicationRef.injector.get(IS_HYDRATION_DOM_REUSE_ENABLED, false)) {
         annotateForHydration(applicationRef, platformState.getDocument());
       }
 


### PR DESCRIPTION
This commit renames an internal token to better align it with the naming of the function (to highlight the fact that it's responsible for DOM part of the hydration).

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No