### PR TITLE
refactor(core): add asReadonly helper to writable signals

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1591,6 +1591,7 @@ export abstract class ViewRef extends ChangeDetectorRef {
 
 // @public
 export interface WritableSignal<T> extends Signal<T> {
+    asReadonly(): Signal<T>;
     mutate(mutatorFn: (value: T) => void): void;
     set(value: T): void;
     update(updateFn: (value: T) => T): void;

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -98,6 +98,24 @@ describe('signals', () => {
     expect(derived()).toEqual('object:5');
   });
 
+  it('should allow converting writable signals to their readonly counterpart', () => {
+    const counter = signal(0);
+    const readOnlyCounter = counter.asReadonly();
+
+    // @ts-expect-error
+    expect(readOnlyCounter.set).toBeUndefined();
+    // @ts-expect-error
+    expect(readOnlyCounter.update).toBeUndefined();
+    // @ts-expect-error
+    expect(readOnlyCounter.mutate).toBeUndefined();
+
+    const double = computed(() => readOnlyCounter() * 2);
+    expect(double()).toBe(0);
+
+    counter.set(2);
+    expect(double()).toBe(4);
+  });
+
   describe('post-signal-set functions', () => {
     let prevPostSignalSetFn: (() => void)|null = null;
     let log: number;


### PR DESCRIPTION
The new asReadonly method on the WritableSignal interface makes it possible to create readonly instance of a writable signal.

Readonly signals can be accessed to read their value, but can't be changed using set, update or mutate methods.
