### PR TITLE
test: improve testing of HTTP and transfer state cache

### DIFF
--- a/integration/platform-server/e2e/http-transferstate-lazy-spec.ts
+++ b/integration/platform-server/e2e/http-transferstate-lazy-spec.ts
@@ -10,8 +10,8 @@ import {browser, by, element} from 'protractor';
 
 import {verifyNoBrowserErrors} from './util';
 
-describe('Http TransferState Lazy', function() {
-  it('should transfer http state in lazy component', function() {
+describe('Http TransferState Lazy', () => {
+  it('should transfer http state in lazy component', async () => {
     // Load the page without waiting for Angular since it is not bootstrapped automatically.
     browser.driver.get(browser.baseUrl + 'http-transferstate-lazy');
 
@@ -26,6 +26,16 @@ describe('Http TransferState Lazy', function() {
     browser.executeScript('doBootstrap()');
     expect(element(by.css('div.one')).getText()).toBe('API 1 response');
     expect(element(by.css('div.two')).getText()).toBe('API 2 response');
+
+    // Validate that there were no HTTP calls to '/api'.
+    const requests = await browser.driver.executeScript(() => {
+      return window.performance.getEntriesByType('resource');
+    });
+    const apiRequests = (requests as any)
+      .filter(({name}) => name.includes('/api'))
+      .map(({name}) => name);
+
+    expect(apiRequests).toEqual([]);
 
     // Make sure there were no client side errors.
     verifyNoBrowserErrors();

--- a/integration/platform-server/e2e/util.ts
+++ b/integration/platform-server/e2e/util.ts
@@ -11,15 +11,19 @@ declare var browser: any;
 declare var expect: any;
 
 export function verifyNoBrowserErrors() {
-  browser.manage().logs().get('browser').then(function(browserLog: any[]) {
-    const errors: any[] = [];
-    browserLog.filter(logEntry => {
-      const msg = logEntry.message;
-      console.log('>> ' + msg);
-      if (logEntry.level.value >= webdriver.logging.Level.INFO.value) {
-        errors.push(msg);
-      }
+  browser
+    .manage()
+    .logs()
+    .get('browser')
+    .then((browserLog: any[]) => {
+      const errors: any[] = [];
+      browserLog.forEach((logEntry) => {
+        const msg = logEntry.message;
+        console.log('>> ' + msg);
+        if (logEntry.level.value >= webdriver.logging.Level.INFO.value) {
+          errors.push(msg);
+        }
+      });
+      expect(errors).toEqual([]);
     });
-    expect(errors).toEqual([]);
-  });
 }

--- a/integration/platform-server/src/http-transferstate-lazy/app.ts
+++ b/integration/platform-server/src/http-transferstate-lazy/app.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgModule} from '@angular/core';
-import {BrowserModule} from '@angular/platform-browser';
+import {BrowserModule, provideClientHydration} from '@angular/platform-browser';
 import {RouterModule, Routes} from '@angular/router';
 import {AppComponent} from './app.component';
 
@@ -25,6 +25,7 @@ const routes: Routes = [
     BrowserModule,
     RouterModule.forRoot(routes),
   ],
+  providers: [provideClientHydration()]
 })
 export class HttpLazyTransferStateModule {
 }

--- a/integration/platform-server/src/http-transferstate-lazy/transfer-state.component.ts
+++ b/integration/platform-server/src/http-transferstate-lazy/transfer-state.component.ts
@@ -6,12 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {isPlatformServer} from '@angular/common';
 import {HttpClient} from '@angular/common/http';
-import {Component, Inject, PLATFORM_ID, TransferState, makeStateKey} from '@angular/core';
-
-const httpCacheKeyOne = makeStateKey<string>('http-one');
-const httpCacheKeyTwo = makeStateKey<string>('http-two');
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'transfer-state-app-http',
@@ -25,25 +21,14 @@ export class TransferStateComponent {
   responseTwo: string = '';
 
   constructor(
-    @Inject(PLATFORM_ID) private platformId: {},
     private readonly httpClient: HttpClient,
-    private readonly transferState: TransferState
-  ) {}
+  ) {
+    this.httpClient.get<any>(`http://localhost:4206/api`).subscribe((response) => {
+      this.responseOne = response.data;
+    });
 
-  ngOnInit() {
-    if (isPlatformServer(this.platformId)) {
-      this.httpClient.get<any>(`http://localhost:4206/api`).subscribe((response) => {
-        this.transferState.set(httpCacheKeyOne, response.data);
-        this.responseOne = response.data;
-      });
-
-      this.httpClient.get<any>(`http://localhost:4206/api-2`).subscribe((response) => {
-        this.transferState.set(httpCacheKeyTwo, response.data);
-        this.responseTwo = response.data;
-      });
-    } else {
-      this.responseOne = this.transferState.get(httpCacheKeyOne, '');
-      this.responseTwo = this.transferState.get(httpCacheKeyTwo, '');
-    }
+    this.httpClient.get<any>(`http://localhost:4206/api-2`).subscribe((response) => {
+      this.responseTwo = response.data;
+    });
   }
 }


### PR DESCRIPTION
This commit improves the HTTP transfer state integration test by using `provideClientHydration` method and validates that no HTTP calls are performed during the client bootstrapping.
