### PR TITLE
refactor(core): avoid deep links into `@angular/core`

### DIFF
--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -7,9 +7,9 @@
  */
 
 import {assertInInjectionContext, computed, DestroyRef, inject, signal, Signal, WritableSignal} from '@angular/core';
-import {RuntimeError, RuntimeErrorCode} from '@angular/core/src/errors';
 import {Observable} from 'rxjs';
 
+import {RuntimeError, RuntimeErrorCode} from '../../src/errors';
 import {untracked} from '../../src/signals';
 
 /**


### PR DESCRIPTION
This commit updates the code to avoid deep links into the `@angular/core`, which triggers a build issue in apps when a code is referenced.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No