### PR TITLE
fix(http): HTTP cache was being disabled prematurely

### DIFF
--- a/integration/platform-server/src/http-transferstate-lazy/transfer-state.component.ts
+++ b/integration/platform-server/src/http-transferstate-lazy/transfer-state.component.ts
@@ -7,7 +7,7 @@
  */
 
 import {HttpClient} from '@angular/common/http';
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 
 @Component({
   selector: 'transfer-state-app-http',
@@ -16,18 +16,22 @@ import {Component} from '@angular/core';
     <div class="two">{{ responseTwo }}</div>
   `,
 })
-export class TransferStateComponent {
+export class TransferStateComponent implements OnInit {
   responseOne: string = '';
   responseTwo: string = '';
 
   constructor(
     private readonly httpClient: HttpClient,
   ) {
-    this.httpClient.get<any>(`http://localhost:4206/api`).subscribe((response) => {
+    // Test that HTTP cache works when HTTP call is made in the constructor.
+    this.httpClient.get<any>('http://localhost:4206/api').subscribe((response) => {
       this.responseOne = response.data;
     });
+  }
 
-    this.httpClient.get<any>(`http://localhost:4206/api-2`).subscribe((response) => {
+  ngOnInit(): void {
+    // Test that HTTP cache works when HTTP call is made in a lifecycle hook.
+    this.httpClient.get<any>('http://localhost:4206/api-2').subscribe((response) => {
       this.responseTwo = response.data;
     });
   }

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_INITIALIZER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵInitialRenderPendingTasks as InitialRenderPendingTasks} from '@angular/core';
+import {APP_BOOTSTRAP_LISTENER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵInitialRenderPendingTasks as InitialRenderPendingTasks} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {first, tap} from 'rxjs/operators';
 
@@ -160,7 +160,7 @@ export function withHttpTransferCache(): Provider[] {
       deps: [TransferState, CACHE_STATE]
     },
     {
-      provide: APP_INITIALIZER,
+      provide: APP_BOOTSTRAP_LISTENER,
       multi: true,
       useFactory: () => {
         const appRef = inject(ApplicationRef);


### PR DESCRIPTION
This commit fixes an issue were on the server the HTTP cache was being disabled prematurely which caused HTTP calls performed in `ngOnInit` life cycle hooks not to be cached.
