### PR TITLE
perf(compiler-cli): optimize NgModule emit for standalone components

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -503,6 +503,7 @@ export class ComponentDecoratorHandler implements
       animationTriggerNames: analysis.animationTriggerNames,
       schemas: analysis.schemas,
       decorator: analysis.decorator,
+      assumedToExportProviders: false,
     });
 
     this.resourceRegistry.registerResources(analysis.resources, node);

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -158,6 +158,9 @@ export class DirectiveDecoratorHandler implements
       imports: null,
       schemas: null,
       decorator: analysis.decorator,
+      // Directives analyzed within our own compilation are not _assumed_ to export providers.
+      // Instead, we statically analyze their imports to make a direct determination.
+      assumedToExportProviders: false,
     });
 
     this.injectableRegistry.registerInjectable(node, {

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/test/ng_module_spec.ts
@@ -12,7 +12,7 @@ import ts from 'typescript';
 import {absoluteFrom} from '../../../file_system';
 import {runInEachFileSystem} from '../../../file_system/testing';
 import {LocalIdentifierStrategy, ReferenceEmitter} from '../../../imports';
-import {CompoundMetadataReader, DtsMetadataReader, LocalMetadataRegistry} from '../../../metadata';
+import {CompoundMetadataReader, DtsMetadataReader, ExportedProviderStatusResolver, LocalMetadataRegistry} from '../../../metadata';
 import {PartialEvaluator} from '../../../partial_evaluator';
 import {NOOP_PERF_RECORDER} from '../../../perf';
 import {isNamedClassDeclaration, TypeScriptReflectionHost} from '../../../reflection';
@@ -68,11 +68,12 @@ runInEachFileSystem(() => {
           new ReferenceEmitter([]), null);
       const refEmitter = new ReferenceEmitter([new LocalIdentifierStrategy()]);
       const injectableRegistry = new InjectableClassRegistry(reflectionHost, /* isCore */ false);
+      const exportedProviderStatusResolver = new ExportedProviderStatusResolver(metaReader);
 
       const handler = new NgModuleDecoratorHandler(
           reflectionHost, evaluator, metaReader, metaRegistry, scopeRegistry, referencesRegistry,
-          /* isCore */ false, refEmitter,
-          /* annotateForClosureCompiler */ false, /* onlyPublishPublicTypings */ false,
+          exportedProviderStatusResolver, /* semanticDepGraphUpdater */ null, /* isCore */ false,
+          refEmitter, /* annotateForClosureCompiler */ false, /* onlyPublishPublicTypings */ false,
           injectableRegistry, NOOP_PERF_RECORDER);
       const TestModule =
           getDeclaration(program, _('/entry.ts'), 'TestModule', isNamedClassDeclaration);

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -18,7 +18,7 @@ import {AbsoluteModuleStrategy, AliasingHost, AliasStrategy, DefaultImportTracke
 import {IncrementalBuildStrategy, IncrementalCompilation, IncrementalState} from '../../incremental';
 import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {generateAnalysis, IndexedComponent, IndexingContext} from '../../indexer';
-import {ComponentResources, CompoundMetadataReader, CompoundMetadataRegistry, DirectiveMeta, DtsMetadataReader, HostDirectivesResolver, LocalMetadataRegistry, MetadataReader, MetadataReaderWithIndex, PipeMeta, ResourceRegistry} from '../../metadata';
+import {ComponentResources, CompoundMetadataReader, CompoundMetadataRegistry, DirectiveMeta, DtsMetadataReader, ExportedProviderStatusResolver, HostDirectivesResolver, LocalMetadataRegistry, MetadataReader, MetadataReaderWithIndex, PipeMeta, ResourceRegistry} from '../../metadata';
 import {NgModuleIndexImpl} from '../../metadata/src/ng_module_index';
 import {PartialEvaluator} from '../../partial_evaluator';
 import {ActivePerfRecorder, DelegatingPerfRecorder, PerfCheckpoint, PerfEvent, PerfPhase} from '../../perf';
@@ -991,6 +991,7 @@ export class NgCompiler {
     const metaRegistry = new CompoundMetadataRegistry([localMetaRegistry, ngModuleScopeRegistry]);
     const injectableRegistry = new InjectableClassRegistry(reflector, isCore);
     const hostDirectivesResolver = new HostDirectivesResolver(metaReader);
+    const exportedProviderStatusResolver = new ExportedProviderStatusResolver(metaReader);
 
     const typeCheckScopeRegistry =
         new TypeCheckScopeRegistry(scopeReader, metaReader, hostDirectivesResolver);
@@ -1061,9 +1062,9 @@ export class NgCompiler {
           this.delegatingPerfRecorder),
       new NgModuleDecoratorHandler(
           reflector, evaluator, metaReader, metaRegistry, ngModuleScopeRegistry, referencesRegistry,
-          isCore, refEmitter, this.closureCompilerEnabled,
-          this.options.onlyPublishPublicTypingsForNgModules ?? false, injectableRegistry,
-          this.delegatingPerfRecorder),
+          exportedProviderStatusResolver, semanticDepGraphUpdater, isCore, refEmitter,
+          this.closureCompilerEnabled, this.options.onlyPublishPublicTypingsForNgModules ?? false,
+          injectableRegistry, this.delegatingPerfRecorder),
     ];
 
     const traitCompiler = new TraitCompiler(

--- a/packages/compiler-cli/src/ngtsc/metadata/index.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/index.ts
@@ -13,4 +13,5 @@ export {CompoundMetadataRegistry, LocalMetadataRegistry} from './src/registry';
 export {ResourceRegistry, Resource, ComponentResources, isExternalResource, ExternalResource} from './src/resource_registry';
 export {extractDirectiveTypeCheckMeta, hasInjectableFields, CompoundMetadataReader} from './src/util';
 export {BindingPropertyName, ClassPropertyMapping, ClassPropertyName, InputOrOutput} from './src/property_mapping';
+export {ExportedProviderStatusResolver} from './src/providers';
 export {HostDirectivesResolver} from './src/host_directives_resolver';

--- a/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/api.ts
@@ -55,6 +55,14 @@ export interface NgModuleMeta {
    * If this is `null`, no decorator exists, meaning it's probably from a .d.ts file.
    */
   decorator: ts.Decorator|null;
+
+  /**
+   * Whether this NgModule may declare providers.
+   *
+   * If the compiler does not know if the NgModule may declare providers, this will be `true` (for
+   * example, NgModules declared outside the current compilation are assumed to declare providers).
+   */
+  mayDeclareProviders: boolean;
 }
 
 /**
@@ -195,6 +203,11 @@ export interface DirectiveMeta extends T2DirectiveMeta, DirectiveTypeCheckMeta {
 
   /** Additional directives applied to the directive host. */
   hostDirectives: HostDirectiveMeta[]|null;
+
+  /**
+   * Whether the directive should be assumed to export providers if imported as a standalone type.
+   */
+  assumedToExportProviders: boolean;
 }
 
 /** Metadata collected about an additional directive that is being applied to a directive host. */

--- a/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/dts.ts
@@ -60,6 +60,9 @@ export class DtsMetadataReader implements MetadataReader {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      // NgModules declared outside the current compilation are assumed to contain providers, as it
+      // would be a non-breaking change for a library to introduce providers at any point.
+      mayDeclareProviders: true,
     };
   }
 
@@ -128,6 +131,8 @@ export class DtsMetadataReader implements MetadataReader {
       // The same goes for schemas.
       schemas: null,
       decorator: null,
+      // Assume that standalone components from .d.ts files may export providers.
+      assumedToExportProviders: isComponent && isStandalone,
     };
   }
 

--- a/packages/compiler-cli/src/ngtsc/metadata/src/providers.ts
+++ b/packages/compiler-cli/src/ngtsc/metadata/src/providers.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Reference} from '../../imports';
+import {ClassDeclaration} from '../../reflection';
+
+import {MetadataReader} from './api';
+
+/**
+ * Determines whether types may or may not export providers to NgModules, by transitively walking
+ * the NgModule & standalone import graph.
+ */
+export class ExportedProviderStatusResolver {
+  /**
+   * `ClassDeclaration`s that we are in the process of determining the provider status for.
+   *
+   * This is used to detect cycles in the import graph and avoid getting stuck in them.
+   */
+  private calculating = new Set<ClassDeclaration>();
+
+  constructor(private metaReader: MetadataReader) {}
+
+  /**
+   * Determines whether `ref` may or may not export providers to NgModules which import it.
+   *
+   * NgModules export providers if any are declared, and standalone components export providers from
+   * their `imports` array (if any).
+   *
+   * If `true`, then `ref` should be assumed to export providers. In practice, this could mean
+   * either that `ref` is a local type that we _know_ exports providers, or it's imported from a
+   * .d.ts library and is declared in a way where the compiler cannot prove that it doesn't.
+   *
+   * If `false`, then `ref` is guaranteed not to export providers.
+   *
+   * @param `ref` the class for which the provider status should be determined
+   * @param `dependencyCallback` a callback that, if provided, will be called for every type
+   *     which is used in the determination of provider status for `ref`
+   * @returns `true` if `ref` should be assumed to export providers, or `false` if the compiler can
+   *     prove that it does not
+   */
+  mayExportProviders(
+      ref: Reference<ClassDeclaration>,
+      dependencyCallback?: (importRef: Reference<ClassDeclaration>) => void): boolean {
+    if (this.calculating.has(ref.node)) {
+      // For cycles, we treat the cyclic edge as not having providers.
+      return false;
+    }
+    this.calculating.add(ref.node);
+
+    if (dependencyCallback !== undefined) {
+      dependencyCallback(ref);
+    }
+
+    try {
+      const dirMeta = this.metaReader.getDirectiveMetadata(ref);
+      if (dirMeta !== null) {
+        if (!dirMeta.isComponent || !dirMeta.isStandalone) {
+          return false;
+        }
+
+        if (dirMeta.assumedToExportProviders) {
+          return true;
+        }
+
+        // If one of the imports contains providers, then so does this component.
+        return (dirMeta.imports ?? [])
+            .some(importRef => this.mayExportProviders(importRef, dependencyCallback));
+      }
+
+      const pipeMeta = this.metaReader.getPipeMetadata(ref);
+      if (pipeMeta !== null) {
+        return false;
+      }
+
+      const ngModuleMeta = this.metaReader.getNgModuleMetadata(ref);
+      if (ngModuleMeta !== null) {
+        if (ngModuleMeta.mayDeclareProviders) {
+          return true;
+        }
+
+        // If one of the NgModule's imports may contain providers, then so does this NgModule.
+        return ngModuleMeta.imports.some(
+            importRef => this.mayExportProviders(importRef, dependencyCallback));
+      }
+
+      return false;
+    } finally {
+      this.calculating.delete(ref.node);
+    }
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/scope/test/local_spec.ts
@@ -58,6 +58,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
 
     const scope = scopeRegistry.getScopeOfModule(Module.node) as LocalModuleScope;
@@ -79,6 +80,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -91,6 +93,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -103,6 +106,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -124,6 +128,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -136,6 +141,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -157,6 +163,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -169,6 +176,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -181,6 +189,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
 
     const scope = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -209,6 +218,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
 
     const scope = scopeRegistry.getScopeOfModule(Module.node) as LocalModuleScope;
@@ -229,6 +239,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -241,6 +252,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
 
     const scopeA = scopeRegistry.getScopeOfModule(ModuleA.node) as LocalModuleScope;
@@ -261,6 +273,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
     metaRegistry.registerNgModuleMetadata({
       kind: MetaKind.NgModule,
@@ -273,6 +286,7 @@ describe('LocalModuleScopeRegistry', () => {
       rawImports: null,
       rawExports: null,
       decorator: null,
+      mayDeclareProviders: false,
     });
 
     expect(scopeRegistry.getScopeOfModule(ModuleA.node)!.compilation.isPoisoned).toBeTrue();
@@ -314,6 +328,7 @@ function fakeDirective(ref: Reference<ClassDeclaration>): DirectiveMeta {
     schemas: null,
     decorator: null,
     hostDirectives: null,
+    assumedToExportProviders: false,
   };
 }
 

--- a/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/testing/index.ts
@@ -722,6 +722,7 @@ function makeScope(program: ts.Program, sf: ts.SourceFile, decls: TestDeclaratio
         imports: null,
         schemas: null,
         decorator: null,
+        assumedToExportProviders: false,
         hostDirectives:
             decl.hostDirectives === undefined ? null : decl.hostDirectives.map(hostDecl => {
               return {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/GOLDEN_PARTIAL.js
@@ -331,7 +331,7 @@ class Module {
 }
 Module.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Module, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
 Module.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Module, imports: [StandaloneCmp, StandaloneDir] });
-Module.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Module, imports: [StandaloneCmp] });
+Module.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Module });
 export { Module };
 i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: Module, decorators: [{
             type: NgModule,

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/module_optimization.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/standalone/module_optimization.js
@@ -1,1 +1,1 @@
-Module.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({ imports: [StandaloneCmp] });
+Module.ɵinj = /*@__PURE__*/ i0.ɵɵdefineInjector({});

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -8219,11 +8219,20 @@ function allTests(os: string) {
     describe('InjectorDef emit optimizations for standalone', () => {
       it('should not filter components out of NgModule.imports', () => {
         env.write('test.ts', `
-          import {Component, NgModule} from '@angular/core';
+          import {Component, Injectable, NgModule} from '@angular/core';
+
+          @Injectable()
+          export class Service {}
+
+          @NgModule({
+            providers: [Service]
+          })
+          export class DepModule {}
 
           @Component({
             standalone: true,
             selector: 'standalone-cmp',
+            imports: [DepModule],
             template: '',
           })
           export class StandaloneCmp {}

--- a/packages/compiler-cli/test/ngtsc/standalone_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/standalone_spec.ts
@@ -902,13 +902,22 @@ runInEachFileSystem(() => {
     });
 
     describe('optimizations', () => {
-      it('does emit standalone components in injector imports', () => {
+      it('does emit standalone components in injector imports if they contain providers', () => {
         env.write('test.ts', `
-          import {Component, NgModule} from '@angular/core';
+          import {Component, Injectable, NgModule} from '@angular/core';
+
+          @Injectable()
+          export class Service {}
+
+          @NgModule({
+            providers: [Service],
+          })
+          export class DepModule {}
 
           @Component({
             standalone: true,
             selector: 'standalone-cmp',
+            imports: [DepModule],
             template: '',
           })
           export class StandaloneCmp {}
@@ -924,6 +933,74 @@ runInEachFileSystem(() => {
         const jsCode = env.getContents('test.js');
         expect(jsCode).toContain('i0.ɵɵdefineInjector({ imports: [StandaloneCmp] });');
       });
+
+      it('does emit standalone components in injector imports if they import a NgModule from .d.ts',
+         () => {
+           env.write('dep.d.ts', `
+            import {ɵɵNgModuleDeclaration} from '@angular/core';
+
+            declare class DepModule {
+              static ɵmod: ɵɵNgModuleDeclaration<DepModule, never, never, never>;
+            }
+          `);
+
+           env.write('test.ts', `
+            import {Component, Injectable, NgModule} from '@angular/core';
+            import {DepModule} from './dep';
+
+            @Component({
+              standalone: true,
+              selector: 'standalone-cmp',
+              imports: [DepModule],
+              template: '',
+            })
+            export class StandaloneCmp {}
+
+            @NgModule({
+              imports: [StandaloneCmp],
+              exports: [StandaloneCmp],
+            })
+            export class Module {}
+          `);
+           env.driveMain();
+
+           const jsCode = env.getContents('test.js');
+           expect(jsCode).toContain('i0.ɵɵdefineInjector({ imports: [StandaloneCmp] });');
+         });
+
+      it('does emit standalone components in injector imports if they import a component from .d.ts',
+         () => {
+           env.write('dep.d.ts', `
+              import {ɵɵComponentDeclaration} from '@angular/core';
+
+              export declare class DepCmp {
+                static ɵcmp: ɵɵComponentDeclaration<DepCmp, "dep-cmp", never, {}, {}, never, never, true>
+              }
+            `);
+
+           env.write('test.ts', `
+              import {Component, Injectable, NgModule} from '@angular/core';
+              import {DepCmp} from './dep';
+
+              @Component({
+                standalone: true,
+                selector: 'standalone-cmp',
+                imports: [DepCmp],
+                template: '',
+              })
+              export class StandaloneCmp {}
+
+              @NgModule({
+                imports: [StandaloneCmp],
+                exports: [StandaloneCmp],
+              })
+              export class Module {}
+            `);
+           env.driveMain();
+
+           const jsCode = env.getContents('test.js');
+           expect(jsCode).toContain('i0.ɵɵdefineInjector({ imports: [StandaloneCmp] });');
+         });
 
       it('does not emit standalone directives or pipes in injector imports', () => {
         env.write('test.ts', `
@@ -951,6 +1028,33 @@ runInEachFileSystem(() => {
         `);
         env.driveMain();
 
+        const jsCode = env.getContents('test.js');
+        expect(jsCode).toContain('i0.ɵɵdefineInjector({});');
+      });
+
+      it('should exclude directives from NgModule imports if they expose no providers', () => {
+        env.write('test.ts', `
+            import {Component, NgModule} from '@angular/core';
+
+            @NgModule({})
+            export class DepModule {}
+
+            @Component({
+              standalone: true,
+              selector: 'test-cmp',
+              imports: [DepModule],
+              template: '',
+            })
+            export class TestCmp {}
+
+            @NgModule({
+              imports: [TestCmp],
+              exports: [TestCmp],
+            })
+            export class TestModule {}
+          `);
+
+        env.driveMain();
         const jsCode = env.getContents('test.js');
         expect(jsCode).toContain('i0.ɵɵdefineInjector({});');
       });


### PR DESCRIPTION
NgModules which import standalone components currently list those components in their injector definitions, because we assume that any standalone component may export providers from its own imports.

This commit adds an optimization for that emit, which attempts to statically analyze the NgModule imports and determine which standalone components, if any are present, do not export providers and thus can be omitted.

This analysis is imperfect, because some imported components may be declared outside of the current compilation, or transitively import types which are declared outside the compilation. These types are therefore _assumed_ to carry providers and so the optimization isn't applied to them.