### PR TITLE
refactor(core): Remove `NG_DEV_MODE` const

### DIFF
--- a/packages/core/src/hydration/tokens.ts
+++ b/packages/core/src/hydration/tokens.ts
@@ -8,14 +8,12 @@
 
 import {InjectionToken} from '../di/injection_token';
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || !!ngDevMode;
-
 /**
  * Internal token that specifies whether DOM reuse logic
  * during hydration is enabled.
  */
-export const IS_HYDRATION_DOM_REUSE_ENABLED =
-    new InjectionToken<boolean>(NG_DEV_MODE ? 'IS_HYDRATION_DOM_REUSE_ENABLED' : '');
+export const IS_HYDRATION_DOM_REUSE_ENABLED = new InjectionToken<boolean>(
+    (typeof ngDevMode === 'undefined' || !!ngDevMode) ? 'IS_HYDRATION_DOM_REUSE_ENABLED' : '');
 
 // By default (in client rendering mode), we remove all the contents
 // of the host element and render an application after that.
@@ -25,8 +23,8 @@ export const PRESERVE_HOST_CONTENT_DEFAULT = false;
  * Internal token that indicates whether host element content should be
  * retained during the bootstrap.
  */
-export const PRESERVE_HOST_CONTENT =
-    new InjectionToken<boolean>(NG_DEV_MODE ? 'PRESERVE_HOST_CONTENT' : '', {
+export const PRESERVE_HOST_CONTENT = new InjectionToken<boolean>(
+    (typeof ngDevMode === 'undefined' || !!ngDevMode) ? 'PRESERVE_HOST_CONTENT' : '', {
       providedIn: 'root',
       factory: () => PRESERVE_HOST_CONTENT_DEFAULT,
     });

--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -13,19 +13,18 @@ import {markViewDirty} from './instructions/mark_view_dirty';
 import {ComponentTemplate, HostBindingsFunction, RenderFlags} from './interfaces/definition';
 import {LView, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER} from './interfaces/view';
 
-const NG_DEV_MODE = typeof ngDevMode === 'undefined' || ngDevMode;
-
 export class ReactiveLViewConsumer extends ReactiveNode {
   protected override consumerAllowSignalWrites = false;
   private _lView: LView|null = null;
 
   set lView(lView: LView) {
-    NG_DEV_MODE && assertEqual(this._lView, null, 'Consumer already associated with a view.');
+    (typeof ngDevMode === 'undefined' || ngDevMode) &&
+        assertEqual(this._lView, null, 'Consumer already associated with a view.');
     this._lView = lView;
   }
 
   protected override onConsumerDependencyMayHaveChanged() {
-    NG_DEV_MODE &&
+    (typeof ngDevMode === 'undefined' || ngDevMode) &&
         assertDefined(
             this._lView,
             'Updating a signal during template or host binding execution is not allowed.');

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -735,9 +735,6 @@
     "name": "applyView"
   },
   {
-    "name": "assertDefined"
-  },
-  {
     "name": "attachPatchData"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -561,9 +561,6 @@
     "name": "applyView"
   },
   {
-    "name": "assertDefined"
-  },
-  {
     "name": "attachPatchData"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -753,9 +753,6 @@
     "name": "assertControlPresent"
   },
   {
-    "name": "assertDefined"
-  },
-  {
     "name": "attachInjectFlag"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -735,9 +735,6 @@
     "name": "applyViewChange"
   },
   {
-    "name": "assertDefined"
-  },
-  {
     "name": "attachInjectFlag"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -426,9 +426,6 @@
     "name": "applyView"
   },
   {
-    "name": "assertDefined"
-  },
-  {
     "name": "attachPatchData"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -939,9 +939,6 @@
     "name": "applyView"
   },
   {
-    "name": "assertDefined"
-  },
-  {
     "name": "attachPatchData"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -510,9 +510,6 @@
     "name": "applyView"
   },
   {
-    "name": "assertDefined"
-  },
-  {
     "name": "attachPatchData"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -660,9 +660,6 @@
     "name": "applyViewChange"
   },
   {
-    "name": "assertDefined"
-  },
-  {
     "name": "assertTemplate"
   },
   {


### PR DESCRIPTION
Follow up to #49530, removing the last remaining `NG_DEV_MODE`


## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)



## Does this PR introduce a breaking change?


- [x] No