### PR TITLE
docs-infra: remove dart support & mentions

### DIFF
--- a/aio/src/app/custom-elements/code/code.component.ts
+++ b/aio/src/app/custom-elements/code/code.component.ts
@@ -68,7 +68,7 @@ export class CodeComponent implements OnChanges {
   /** Whether the copy button should be shown. */
   @Input() hideCopy: boolean;
 
-  /** Language to render the code (e.g. javascript, dart, typescript). */
+  /** Language to render the code (e.g. javascript, typescript). */
   @Input() language: string | undefined;
 
   /**

--- a/aio/tools/transforms/angular-api-package/tag-defs/Annotation.js
+++ b/aio/tools/transforms/angular-api-package/tag-defs/Annotation.js
@@ -1,5 +1,0 @@
-// A ts2dart compiler annotation that we don't care about for API docs.
-// But, if we don't have a tag-def for it the doc-gen will error.
-module.exports = function() {
-  return {name: 'Annotation'};
-};

--- a/aio/tools/transforms/angular-api-package/tag-defs/ts2dart_const.js
+++ b/aio/tools/transforms/angular-api-package/tag-defs/ts2dart_const.js
@@ -1,4 +1,0 @@
-// A ts2dart compiler annotation that can be ignored in API docs.
-module.exports = function() {
-  return {name: 'ts2dart_const', ignore: true};
-};

--- a/aio/tools/transforms/angular-base-package/index.js
+++ b/aio/tools/transforms/angular-base-package/index.js
@@ -77,7 +77,7 @@ module.exports = new Package('angular-base', [
 
   // Target environments
   .config(function(targetEnvironments) {
-    const ALLOWED_LANGUAGES = ['ts', 'js', 'dart'];
+    const ALLOWED_LANGUAGES = ['ts', 'js'];
     const TARGET_LANGUAGE = 'ts';
 
     ALLOWED_LANGUAGES.forEach(target => targetEnvironments.addAllowed(target));

--- a/aio/tools/transforms/examples-package/services/region-matchers/inline-c.js
+++ b/aio/tools/transforms/examples-package/services/region-matchers/inline-c.js
@@ -1,4 +1,4 @@
-// This comment type is used in C like languages such as JS, TS, Dart, etc
+// This comment type is used in C like languages such as JS, TS, etc
 module.exports = {
   regionStartMatcher: /^\s*\/\/\s*#docregion\s*(.*)\s*$/,
   regionEndMatcher: /^\s*\/\/\s*#enddocregion\s*(.*)\s*$/,

--- a/aio/tools/transforms/examples-package/services/region-parser.js
+++ b/aio/tools/transforms/examples-package/services/region-parser.js
@@ -13,7 +13,6 @@ module.exports = function regionParser() {
     js: inlineC,
     mjs: inlineCOnly,
     es6: inlineC,
-    dart: inlineC,
     html: html,
     svg: html,
     css: blockC,


### PR DESCRIPTION
There is no need to keep the support for Dart here.