### PR TITLE
Refactor: Remove remainings of Dart support

### DIFF
--- a/packages/compiler/src/ml_parser/entities.ts
+++ b/packages/compiler/src/ml_parser/entities.ts
@@ -2139,8 +2139,9 @@ export const NAMED_ENTITIES: Record<string, string> = {
 };
 
 
-// The &ngsp; pseudo-entity is denoting a space. see:
-// https://github.com/dart-lang/angular/blob/0bb611387d29d65b5af7f9d2515ab571fd3fbee4/_tests/test/compiler/preserve_whitespace_test.dart
+// The &ngsp; pseudo-entity is denoting a space.
+// 0xE500 is a PUA (Private Use Areas) unicode character
+// This is inspired by the Angular Dart implementation.
 export const NGSP_UNICODE = '\uE500';
 
 NAMED_ENTITIES['ngsp'] = NGSP_UNICODE;

--- a/packages/compiler/src/ml_parser/html_whitespaces.ts
+++ b/packages/compiler/src/ml_parser/html_whitespaces.ts
@@ -26,10 +26,9 @@ function hasPreserveWhitespacesAttr(attrs: html.Attribute[]): boolean {
 }
 
 /**
- * Angular Dart introduced &ngsp; as a placeholder for non-removable space, see:
- * https://github.com/dart-lang/angular/blob/0bb611387d29d65b5af7f9d2515ab571fd3fbee4/_tests/test/compiler/preserve_whitespace_test.dart#L25-L32
- * In Angular Dart &ngsp; is converted to the 0xE500 PUA (Private Use Areas) unicode character
- * and later on replaced by a space. We are re-implementing the same idea here.
+ * &ngsp; is a placeholder for non-removable space
+ * &ngsp; is converted to the 0xE500 PUA (Private Use Areas) unicode character
+ * and later on replaced by a space.
  */
 export function replaceNgsp(value: string): string {
   // lexer is replacing the &ngsp; pseudo-entity with NGSP_UNICODE

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -40,11 +40,10 @@ const SUBTEMPLATE_REGEXP = /�\/?\*(\d+:\d+)�/gi;
 const PH_REGEXP = /�(\/?[#*]\d+):?\d*�/gi;
 
 /**
- * Angular Dart introduced &ngsp; as a placeholder for non-removable space, see:
- * https://github.com/dart-lang/angular/blob/0bb611387d29d65b5af7f9d2515ab571fd3fbee4/_tests/test/compiler/preserve_whitespace_test.dart#L25-L32
- * In Angular Dart &ngsp; is converted to the 0xE500 PUA (Private Use Areas) unicode character
- * and later on replaced by a space. We are re-implementing the same idea here, since translations
- * might contain this special character.
+ * Angular uses the special entity &ngsp; as a placeholder for non-removable space.
+ * It's replaced by the 0xE500 PUA (Private Use Areas) unicode character and later on replaced by a
+ * space.
+ * We are re-implementing the same idea since translations might contain this special character.
  */
 const NGSP_UNICODE_REGEXP = /\uE500/g;
 function replaceNgsp(value: string): string {

--- a/packages/core/test/linker/change_detection_integration_spec.ts
+++ b/packages/core/test/linker/change_detection_integration_spec.ts
@@ -130,8 +130,8 @@ describe(`ChangeDetection`, () => {
        }));
 
     it('should support / operations', fakeAsync(() => {
-         expect(_bindAndCheckSimpleValue('10 / 2')).toEqual([`id=${5.0}`]);
-       }));  // dart exp=5.0, js exp=5
+         expect(_bindAndCheckSimpleValue('10 / 2')).toEqual([`id=5`]);
+       }));
 
     it('should support % operations', fakeAsync(() => {
          expect(_bindAndCheckSimpleValue('11 % 2')).toEqual(['id=1']);

--- a/packages/platform-browser-dynamic/test/resource_loader/resource_loader_impl_spec.ts
+++ b/packages/platform-browser-dynamic/test/resource_loader/resource_loader_impl_spec.ts
@@ -12,12 +12,6 @@ if (isBrowser) {
   describe('ResourceLoaderImpl', () => {
     let resourceLoader: ResourceLoaderImpl;
 
-    // TODO(juliemr): This file currently won't work with dart unit tests run using
-    // exclusive it or describe (iit or ddescribe). This is because when
-    // pub run test is executed against this specific file the relative paths
-    // will be relative to here, so url200 should look like
-    // static_assets/200.html.
-    // We currently have no way of detecting this.
     const url200 = '/base/angular/packages/platform-browser/test/browser/static_assets/200.html';
     const url404 = '/bad/path/404.html';
 

--- a/packages/platform-browser/src/browser/browser_adapter.ts
+++ b/packages/platform-browser/src/browser/browser_adapter.ts
@@ -23,11 +23,9 @@ export class BrowserDomAdapter extends GenericBrowserDomAdapter {
   }
 
   override onAndCancel(el: Node, evt: any, listener: any): Function {
-    el.addEventListener(evt, listener, false);
-    // Needed to follow Dart's subscription semantic, until fix of
-    // https://code.google.com/p/dart/issues/detail?id=17406
+    el.addEventListener(evt, listener);
     return () => {
-      el.removeEventListener(evt, listener, false);
+      el.removeEventListener(evt, listener);
     };
   }
   override dispatchEvent(el: Node, evt: any) {


### PR DESCRIPTION
See individual commits, 

The PR removes remanings of the Dart support in `compiler`, `core` and `platform-browser`. 

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No