### PR TITLE
refactor(core): throw an error when `APP_INITIALIZER` token is not an array.

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -53,6 +53,7 @@ export interface ApplicationConfig {
 
 // @public
 export class ApplicationInitStatus {
+    constructor();
     // (undocumented)
     readonly done = false;
     // (undocumented)

--- a/packages/core/src/application_init.ts
+++ b/packages/core/src/application_init.ts
@@ -9,6 +9,7 @@
 import {Observable} from 'rxjs';
 
 import {inject, Injectable, InjectionToken} from './di';
+import {RuntimeError, RuntimeErrorCode} from './errors';
 import {isPromise, isSubscribable} from './util/lang';
 
 /**
@@ -104,8 +105,18 @@ export class ApplicationInitStatus {
     this.reject = rej;
   });
 
-  // TODO: Throw RuntimeErrorCode.INVALID_MULTI_PROVIDER if appInits is not an array
   private readonly appInits = inject(APP_INITIALIZER, {optional: true}) ?? [];
+
+  constructor() {
+    if ((typeof ngDevMode === 'undefined' || ngDevMode) && !Array.isArray(this.appInits)) {
+      throw new RuntimeError(
+          RuntimeErrorCode.INVALID_MULTI_PROVIDER,
+          'Unexpected type of the `APP_INITIALIZER` token value ' +
+              `(expected an array, but got ${typeof this.appInits}). ` +
+              'Please check that the `APP_INITIALIZER` token is configured as a ' +
+              '`multi: true` provider.');
+    }
+  }
 
   /** @internal */
   runInitializers() {

--- a/packages/core/test/application_init_spec.ts
+++ b/packages/core/test/application_init_spec.ts
@@ -166,4 +166,23 @@ describe('ApplicationInitStatus', () => {
       }
     });
   });
+
+  describe('wrong initializers', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule(
+          {providers: [{provide: APP_INITIALIZER, useValue: 'notAnArray'}]});
+    });
+
+    it('should throw', () => {
+      try {
+        TestBed.inject(ApplicationInitStatus);
+      } catch (e: any) {
+        expect(e.message).toBe(
+            'NG0209: Unexpected type of the `APP_INITIALIZER` token value ' +
+            `(expected an array, but got string). ` +
+            'Please check that the `APP_INITIALIZER` token is configured as a ' +
+            '`multi: true` provider. Find more at https://angular.io/errors/NG0209');
+      }
+    });
+  });
 });


### PR DESCRIPTION
Providing a non-multi token for `APP_INITIALIZER` now throws `INVALID_MULTI_PROVIDER` (NG209)

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No