### PR TITLE
refactor(compiler-cli): remove `incrementalDriver` on the compiler

### DIFF
--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -145,7 +145,7 @@ export function incrementalFromCompilerTicket(
   const oldProgram = oldCompiler.getCurrentProgram();
   const oldState = oldCompiler.incrementalStrategy.getIncrementalState(oldProgram);
   if (oldState === null) {
-    // No incremental step is possible here, since no IncrementalDriver was found for the old
+    // No incremental step is possible here, since no IncrementalState was found for the old
     // program.
     return freshCompilationTicket(
         newProgram, oldCompiler.options, incrementalBuildStrategy, programDriver, perfRecorder,
@@ -364,16 +364,6 @@ export class NgCompiler {
 
   get perfRecorder(): ActivePerfRecorder {
     return this.livePerfRecorder;
-  }
-
-  /**
-   * Exposes the `IncrementalCompilation` under an old property name that the CLI uses, avoiding a
-   * chicken-and-egg problem with the rename to `incrementalCompilation`.
-   *
-   * TODO(alxhub): remove when the CLI uses the new name.
-   */
-  get incrementalDriver(): IncrementalCompilation {
-    return this.incrementalCompilation;
   }
 
   private updateWithChangedResources(

--- a/packages/compiler-cli/src/ngtsc/incremental/src/strategy.ts
+++ b/packages/compiler-cli/src/ngtsc/incremental/src/strategy.ts
@@ -7,20 +7,21 @@
  */
 
 import ts from 'typescript';
+
 import {IncrementalState} from './state';
 
 /**
- * Strategy used to manage the association between a `ts.Program` and the `IncrementalDriver` which
+ * Strategy used to manage the association between a `ts.Program` and the `IncrementalState` which
  * represents the reusable Angular part of its compilation.
  */
 export interface IncrementalBuildStrategy {
   /**
-   * Determine the Angular `IncrementalDriver` for the given `ts.Program`, if one is available.
+   * Determine the Angular `IncrementalState` for the given `ts.Program`, if one is available.
    */
   getIncrementalState(program: ts.Program): IncrementalState|null;
 
   /**
-   * Associate the given `IncrementalDriver` with the given `ts.Program` and make it available to
+   * Associate the given `IncrementalState` with the given `ts.Program` and make it available to
    * future compilations.
    */
   setIncrementalState(driver: IncrementalState, program: ts.Program): void;
@@ -49,7 +50,7 @@ export class NoopIncrementalBuildStrategy implements IncrementalBuildStrategy {
 }
 
 /**
- * Tracks an `IncrementalDriver` within the strategy itself.
+ * Tracks an `IncrementalState` within the strategy itself.
  */
 export class TrackedIncrementalBuildStrategy implements IncrementalBuildStrategy {
   private state: IncrementalState|null = null;
@@ -73,8 +74,8 @@ export class TrackedIncrementalBuildStrategy implements IncrementalBuildStrategy
 }
 
 /**
- * Manages the `IncrementalDriver` associated with a `ts.Program` by monkey-patching it onto the
- * program under `SYM_INCREMENTAL_DRIVER`.
+ * Manages the `IncrementalState` associated with a `ts.Program` by monkey-patching it onto the
+ * program under `SYM_INCREMENTAL_STATE`.
  */
 export class PatchedProgramIncrementalBuildStrategy implements IncrementalBuildStrategy {
   getIncrementalState(program: ts.Program): IncrementalState|null {
@@ -96,7 +97,7 @@ export class PatchedProgramIncrementalBuildStrategy implements IncrementalBuildS
 
 
 /**
- * Symbol under which the `IncrementalDriver` is stored on a `ts.Program`.
+ * Symbol under which the `IncrementalState` is stored on a `ts.Program`.
  *
  * The TS model of incremental compilation is based around reuse of a previous `ts.Program` in the
  * construction of a new one. The `NgCompiler` follows this abstraction - passing in a previous
@@ -104,8 +105,8 @@ export class PatchedProgramIncrementalBuildStrategy implements IncrementalBuildS
  * not be from an Angular compilation (that is, it need not have been created from `NgCompiler`).
  *
  * If it is, though, Angular can benefit from reusing previous analysis work. This reuse is managed
- * by the `IncrementalDriver`, which is inherited from the old program to the new program. To
- * support this behind the API of passing an old `ts.Program`, the `IncrementalDriver` is stored on
+ * by the `IncrementalState`, which is inherited from the old program to the new program. To
+ * support this behind the API of passing an old `ts.Program`, the `IncrementalState` is stored on
  * the `ts.Program` under this symbol.
  */
 const SYM_INCREMENTAL_STATE = Symbol('NgIncrementalState');


### PR DESCRIPTION
The CLI now only uses the `incrementalDriver` property.

## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [x] No