### PR TITLE
refactor(core): log hydration setup warning in dev mode only

### DIFF
--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -115,7 +115,7 @@ export function withDomHydration(): EnvironmentProviders {
           // hydration annotations. Otherwise, keep hydration disabled.
           const transferState = inject(TransferState, {optional: true});
           isEnabled = !!transferState?.get(NGH_DATA_KEY, null);
-          if (!isEnabled) {
+          if (!isEnabled && (typeof ngDevMode !== 'undefined' && ngDevMode)) {
             const console = inject(Console);
             const message = formatRuntimeError(
                 RuntimeErrorCode.MISSING_HYDRATION_ANNOTATIONS,


### PR DESCRIPTION
This commit updates the code to log hydration setup warning in dev mode only. Previously, the warning was retained in the code even after optimization, thus making it into production bundles. The warning is meant to let developers know that hydration was enabled, but wasn't activated, so it's safe to tree-shake it away from production bundles.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No