### PR TITLE
refactor(core): insert special marker only when text node content is an empty string

### DIFF
--- a/packages/core/src/hydration/annotate.ts
+++ b/packages/core/src/hydration/annotate.ts
@@ -364,7 +364,10 @@ function serializeLView(lView: LView, context: HydrationContext): SerializedView
         //     live DOM has exactly the same state as it was before serialization.
         if (tNode.type & TNodeType.Text) {
           const rNode = unwrapRNode(lView[i]) as HTMLElement;
-          if (rNode.textContent?.replace(/\s/gm, '') === '') {
+          // Collect this node as required special annotation only when its
+          // contents is empty. Otherwise, such text node would be present on
+          // the client after server-side rendering and no special handling needed.
+          if (rNode.textContent === '') {
             context.corruptedTextNodes.set(rNode, TextNodeMarker.EmptyNode);
           } else if (rNode.nextSibling?.nodeType === Node.TEXT_NODE) {
             context.corruptedTextNodes.set(rNode, TextNodeMarker.Separator);

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -498,6 +498,34 @@ describe('platform-server integration', () => {
           verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
         });
 
+        it('should support a single text interpolation', async () => {
+          @Component({
+            standalone: true,
+            selector: 'app',
+            template: `
+              {{ text }}
+            `,
+          })
+          class SimpleComponent {
+            text = 'text';
+          }
+
+          const html = await ssr(SimpleComponent);
+          const ssrContents = getAppContents(html);
+
+          expect(ssrContents).toContain(`<app ${NGH_ATTR_NAME}`);
+
+          resetTViewsFor(SimpleComponent);
+
+          const appRef = await hydrate(html, SimpleComponent);
+          const compRef = getComponentRef<SimpleComponent>(appRef);
+          appRef.tick();
+
+          const clientRootNode = compRef.location.nativeElement;
+          verifyAllNodesClaimedForHydration(clientRootNode);
+          verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+        });
+
         it('should support text and HTML elements', async () => {
           @Component({
             standalone: true,
@@ -2336,6 +2364,85 @@ describe('platform-server integration', () => {
         const ssrContents = getAppContents(html);
 
         expect(ssrContents).toContain('<app ngh');
+
+        resetTViewsFor(SimpleComponent);
+
+        const appRef = await hydrate(html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+      });
+
+      it('should support empty text interpolations within elements ' +
+             '(when interpolation is on a new line)',
+         async () => {
+           @Component({
+             standalone: true,
+             selector: 'app',
+             template: `
+                <div>
+                  {{ text }}
+                </div>
+              `,
+           })
+           class SimpleComponent {
+             text = '';
+           }
+
+           const html = await ssr(SimpleComponent);
+           const ssrContents = getAppContents(html);
+
+           expect(ssrContents).toContain('<app ngh');
+
+           // Expect special markers to not be present, since there
+           // are no corrupted text nodes that require restoring.
+           //
+           // The HTML contents produced by the SSR would look like this:
+           // `<div>  </div>` (1 text node with 2 empty spaces inside of
+           // a <div>), which would result in creating a text node by a
+           // browser.
+           expect(ssrContents).not.toContain(EMPTY_TEXT_NODE_COMMENT);
+           expect(ssrContents).not.toContain(TEXT_NODE_SEPARATOR_COMMENT);
+
+           resetTViewsFor(SimpleComponent);
+
+           const appRef = await hydrate(html, SimpleComponent);
+           const compRef = getComponentRef<SimpleComponent>(appRef);
+           appRef.tick();
+
+           const clientRootNode = compRef.location.nativeElement;
+           verifyAllNodesClaimedForHydration(clientRootNode);
+           verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+         });
+
+      it('should not treat text nodes with `&nbsp`s as empty', async () => {
+        @Component({
+          standalone: true,
+          selector: 'app',
+          template: `
+            <div>&nbsp;{{ text }}&nbsp;</div>
+            &nbsp;&nbsp;&nbsp;
+            <h1>Hello world!</h1>
+            &nbsp;&nbsp;&nbsp;
+            <h2>Hello world!</h2>
+          `,
+        })
+        class SimpleComponent {
+          text = '';
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain('<app ngh');
+
+        // Expect special markers to not be present, since there
+        // are no corrupted text nodes that require restoring.
+        expect(ssrContents).not.toContain(EMPTY_TEXT_NODE_COMMENT);
+        expect(ssrContents).not.toContain(TEXT_NODE_SEPARATOR_COMMENT);
 
         resetTViewsFor(SimpleComponent);
 


### PR DESCRIPTION
Empty text nodes are not present in the server-rendered HTML output, thus we inject a special marker at a text node location to later restore an empty text node at the client. Currently, we treat text nodes with spaces as "empty" as well, however those spaces are present in the HTML and text nodes are created in a browser. Adding extra annotation in this case results in extra text nodes created on the client and may trigger hydration issues. This commit updates the code to avoid treating text nodes with spaces as "empty".

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No