### PR TITLE
build: update PullApprove config

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -166,6 +166,7 @@ groups:
         - alxhub
         - AndrewKushnir
         - atscott
+        - crisbeto
         - JoostK
 
   # =========================================================
@@ -363,6 +364,7 @@ groups:
         - alxhub
         - AndrewKushnir
         - atscott
+        - crisbeto
         - dylhunn
         - jessicajaniuk
         - pkozlowski-opensource


### PR DESCRIPTION
Updates the PullApprove config to add myself to `fw-compiler` and `fw-core` with the following reasoning:
* We talked about `fw-compiler` some time ago, because it would help with TypeScript updates and because I'm familiar with the compiler.
* Also adding myself to `fw-core` to make it easier with some upcoming features and because I can help with the review load for the runtime changes.