### PR TITLE
refactor(core): Synchronously emit the current signal value in toObservable

### DIFF
--- a/packages/core/test/render3/BUILD.bazel
+++ b/packages/core/test/render3/BUILD.bazel
@@ -25,6 +25,7 @@ ts_library(
         "//packages/common",
         "//packages/compiler",
         "//packages/core",
+        "//packages/core/rxjs-interop",
         "//packages/core/src/di/interface",
         "//packages/core/src/interface",
         "//packages/core/src/util",

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -6,7 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {AsyncPipe} from '@angular/common';
 import {AfterViewInit, Component, ContentChildren, createComponent, destroyPlatform, effect, EnvironmentInjector, inject, Injector, Input, NgZone, OnChanges, QueryList, signal, SimpleChanges, ViewChild} from '@angular/core';
+import {toObservable} from '@angular/core/rxjs-interop';
 import {TestBed} from '@angular/core/testing';
 import {bootstrapApplication} from '@angular/platform-browser';
 import {withBody} from '@angular/private/testing';
@@ -385,5 +387,22 @@ describe('effects', () => {
     state.set('changed');
     fixture.detectChanges();
     expect(fixture.componentInstance.noOfCmpCreated).toBe(1);
+  });
+
+  it('should allow toObservable subscription in template (with async pipe)', () => {
+    @Component({
+      selector: 'test-cmp',
+      standalone: true,
+      imports: [AsyncPipe],
+      template: '{{counter$ | async}}',
+    })
+    class Cmp {
+      counter$ = toObservable(signal(0));
+    }
+
+    const fixture = TestBed.createComponent(Cmp);
+    expect(() => fixture.detectChanges(true)).not.toThrow();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('0');
   });
 });


### PR DESCRIPTION

As described in
https://github.com/angular/angular/discussions/49681#discussioncomment-5628930, if an `Observable` created from a signal with `toObservable` is subscribed to in a template, it will initially have `null` as the value. Immediately after the template is done executing, effects are flushed and this results in the `AsyncPipe` getting a new value before the `checkNoChanges` pass, resulting in `ExpressionChanged` error.

```
template: '{{obs$ | async}}'
...
obs$ = toObservable(signal(0));
```

Instead, this commit updates the inner effect of `toObservable` to not be created until the next microtask.
