### PR TITLE
docs: include a note on blocking initial navigation when destructive hydration is used

### DIFF
--- a/packages/platform-browser/src/hydration.ts
+++ b/packages/platform-browser/src/hydration.ts
@@ -44,6 +44,30 @@ function hydrationFeature<FeatureKind extends HydrationFeatureKind>(
  * Disables DOM nodes reuse during hydration. Effectively makes
  * Angular re-render an application from scratch on the client.
  *
+ * When this option is enabled, make sure that the initial navigation
+ * option is configured for the Router as `enabledBlocking` by using the
+ * `withEnabledBlockingInitialNavigation` in the `provideRouter` call:
+ *
+ * ```
+ * bootstrapApplication(RootComponent, {
+ *   providers: [
+ *     provideRouter(
+ *       // ... other features ...
+ *       withEnabledBlockingInitialNavigation()
+ *     ),
+ *     provideClientHydration(withNoDomReuse())
+ *   ]
+ * });
+ * ```
+ *
+ * This would ensure that the application is rerendered after all async
+ * operations in the Router (such as lazy-loading of components,
+ * waiting for async guards and resolvers) are completed to avoid
+ * clearing the DOM on the client too soon, thus causing content flicker.
+ *
+ * @see `provideRouter`
+ * @see `withEnabledBlockingInitialNavigation`
+ *
  * @publicApi
  * @developerPreview
  */


### PR DESCRIPTION
This commit updates the docs for the `withNoDomReuse` function, which lets to opt out of non-destructive hydration. The docs now mention the need to configure an initial navigation option for the Router to be blocking, i.e. use `withEnabledBlockingInitialNavigation()` Router feature.

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No