### PR TITLE
fix(core): ensure takeUntilDestroyed unregisters onDestroy listener on unsubscribe

### DIFF
--- a/packages/core/rxjs-interop/src/take_until_destroyed.ts
+++ b/packages/core/rxjs-interop/src/take_until_destroyed.ts
@@ -27,7 +27,8 @@ export function takeUntilDestroyed<T>(destroyRef?: DestroyRef): MonoTypeOperator
   }
 
   const destroyed$ = new Observable<void>(observer => {
-    destroyRef!.onDestroy(observer.next.bind(observer));
+    const unregisterFn = destroyRef!.onDestroy(observer.next.bind(observer));
+    return unregisterFn;
   });
 
   return <T>(source: Observable<T>) => {

--- a/packages/core/rxjs-interop/test/take_until_destroyed_spec.ts
+++ b/packages/core/rxjs-interop/test/take_until_destroyed_spec.ts
@@ -63,4 +63,17 @@ describe('takeUntilDestroyed', () => {
     source$.next(2);
     expect(last).toBe(1);
   });
+
+  it('should unregister listener if observable is unsubscribed', () => {
+    const injector = Injector.create({providers: []}) as EnvironmentInjector;
+    const destroyRef = injector.get(DestroyRef);
+    const unregisterFn = jasmine.createSpy();
+    spyOn(destroyRef, 'onDestroy').and.returnValue(unregisterFn);
+
+    const subscription = new BehaviorSubject(0).pipe(takeUntilDestroyed(destroyRef)).subscribe();
+
+    subscription.unsubscribe();
+
+    expect(unregisterFn).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The takeUntilDestroyed function does not remove onDestroy listener on unsubscribe.


## What is the new behavior?
The takeUntilDestroyed function removes onDestroy listener on unsubscribe.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
