### PR TITLE
Explicitly set non-reactive context when entering user-written code outside of the template update function

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -536,13 +536,18 @@ function executeTemplate<T>(
 
 export function executeContentQueries(tView: TView, tNode: TNode, lView: LView) {
   if (isContentQueryHost(tNode)) {
-    const start = tNode.directiveStart;
-    const end = tNode.directiveEnd;
-    for (let directiveIndex = start; directiveIndex < end; directiveIndex++) {
-      const def = tView.data[directiveIndex] as DirectiveDef<any>;
-      if (def.contentQueries) {
-        def.contentQueries(RenderFlags.Create, lView[directiveIndex], directiveIndex);
+    const prevConsumer = setActiveConsumer(null);
+    try {
+      const start = tNode.directiveStart;
+      const end = tNode.directiveEnd;
+      for (let directiveIndex = start; directiveIndex < end; directiveIndex++) {
+        const def = tView.data[directiveIndex] as DirectiveDef<any>;
+        if (def.contentQueries) {
+          def.contentQueries(RenderFlags.Create, lView[directiveIndex], directiveIndex);
+        }
       }
+    } finally {
+      setActiveConsumer(prevConsumer);
     }
   }
 }
@@ -1873,7 +1878,12 @@ function executeViewQueryFn<T>(
     flags: RenderFlags, viewQueryFn: ViewQueriesFunction<T>, component: T): void {
   ngDevMode && assertDefined(viewQueryFn, 'View queries function to execute must be defined.');
   setCurrentQueryIndex(0);
-  viewQueryFn(flags, component);
+  const prevConsumer = setActiveConsumer(null);
+  try {
+    viewQueryFn(flags, component);
+  } finally {
+    setActiveConsumer(prevConsumer);
+  }
 }
 
 ///////////////////////////////

--- a/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
+++ b/packages/core/test/acceptance/change_detection_signals_in_zones_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {NgIf} from '@angular/common';
-import {ChangeDetectionStrategy, Component} from '@angular/core';
+import {ChangeDetectionStrategy, Component, Input} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 import {signal} from '../../src/signals';
@@ -139,6 +139,57 @@ describe('OnPush components with signals', () => {
        state.set('new');
        fixture.detectChanges();
        expect(instance.numTemplateExecutions).toBe(1);
+     });
+
+  it('should not mark components as dirty when signal is read in an input of a child component',
+     () => {
+       const state = signal('initial');
+
+       @Component({
+         selector: 'with-input-setter',
+         standalone: true,
+         template: '{{test}}',
+       })
+       class WithInputSetter {
+         test = '';
+
+         @Input()
+         set testInput(newValue: string) {
+           this.test = state() + ':' + newValue;
+         }
+       }
+
+       @Component({
+         template: `
+            {{incrementTemplateExecutions()}}
+            <!-- Template constructed to execute child component constructor in the update pass of a host component -->
+            <ng-template [ngIf]="true"><with-input-setter [testInput]="'input'" /></ng-template>
+          `,
+         changeDetection: ChangeDetectionStrategy.OnPush,
+         standalone: true,
+         imports: [NgIf, WithInputSetter],
+       })
+       class OnPushCmp {
+         numTemplateExecutions = 0;
+         incrementTemplateExecutions() {
+           this.numTemplateExecutions++;
+           return '';
+         }
+       }
+
+       const fixture = TestBed.createComponent(OnPushCmp);
+       const instance = fixture.componentInstance;
+
+       fixture.detectChanges();
+       expect(instance.numTemplateExecutions).toBe(1);
+       expect(fixture.nativeElement.textContent.trim()).toEqual('initial:input');
+
+       // The "state" signal is not accesses in the template's update function anywhere so it
+       // shouldn't mark components as dirty / impact change detection.
+       state.set('new');
+       fixture.detectChanges();
+       expect(instance.numTemplateExecutions).toBe(1);
+       expect(fixture.nativeElement.textContent.trim()).toEqual('initial:input');
      });
 
   it('can read a signal in a host binding', () => {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1533,6 +1533,9 @@
     "name": "writeDirectClass"
   },
   {
+    "name": "writeToDirectiveInput"
+  },
+  {
     "name": "ɵPRE_STYLE"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1215,6 +1215,9 @@
     "name": "writeDirectClass"
   },
   {
+    "name": "writeToDirectiveInput"
+  },
+  {
     "name": "ɵɵdefineComponent"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1710,6 +1710,9 @@
     "name": "writeDirectClass"
   },
   {
+    "name": "writeToDirectiveInput"
+  },
+  {
     "name": "ɵInternalFormsSharedModule"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1686,6 +1686,9 @@
     "name": "writeDirectClass"
   },
   {
+    "name": "writeToDirectiveInput"
+  },
+  {
     "name": "ɵInternalFormsSharedModule"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -957,6 +957,9 @@
     "name": "writeDirectClass"
   },
   {
+    "name": "writeToDirectiveInput"
+  },
+  {
     "name": "ɵɵdefineInjectable"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -2067,6 +2067,9 @@
     "name": "writeDirectClass"
   },
   {
+    "name": "writeToDirectiveInput"
+  },
+  {
     "name": "ɵEmptyOutletComponent"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -1065,6 +1065,9 @@
     "name": "writeDirectClass"
   },
   {
+    "name": "writeToDirectiveInput"
+  },
+  {
     "name": "ɵɵStandaloneFeature"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1464,6 +1464,9 @@
     "name": "writeDirectClass"
   },
   {
+    "name": "writeToDirectiveInput"
+  },
+  {
     "name": "ɵɵadvance"
   },
   {

--- a/packages/core/test/render3/reactivity_spec.ts
+++ b/packages/core/test/render3/reactivity_spec.ts
@@ -276,4 +276,35 @@ describe('effects', () => {
     fixture.detectChanges();
     expect(fixture.nativeElement.textContent).toBe('constructor');
   });
+
+  it('should allow writing to signals in input setters', () => {
+    @Component({
+      selector: 'with-input-setter',
+      standalone: true,
+      template: '{{state()}}',
+    })
+    class WithInputSetter {
+      state = signal('property initializer');
+
+      @Input()
+      set testInput(newValue: string) {
+        this.state.set(newValue);
+      }
+    }
+
+    @Component({
+      selector: 'test-cmp',
+      standalone: true,
+      imports: [WithInputSetter],
+      template: `
+          <with-input-setter [testInput]="'binding'" />|<with-input-setter testInput="static" />
+      `,
+    })
+    class Cmp {
+    }
+
+    const fixture = TestBed.createComponent(Cmp);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toBe('binding|static');
+  });
 });


### PR DESCRIPTION
Explicitly set non-reactive context when entering user-written code outside of the template update function:
* `@Input` setters
* query result setters 
