### PR TITLE
changed productId to productID

### DIFF
--- a/aio/content/start/start-routing.md
+++ b/aio/content/start/start-routing.md
@@ -78,14 +78,14 @@ In this section, you'll use the Angular Router to combine the `products` data an
     By injecting `ActivatedRoute`, you are configuring the component to use a service.
     The [Managing Data](start/start-data "Try it: Managing Data") step covers services in more detail.
 
-1.  In the `ngOnInit()` method, extract the `productId` from the route parameters and find the corresponding product in the `products` array.
+1.  In the `ngOnInit()` method, extract the `productID` from the route parameters and find the corresponding product in the `products` array.
 
     <code-example header="src/app/product-details/product-details.component.ts" path="getting-started/src/app/product-details/product-details.component.1.ts" region="get-product"></code-example>
 
     The route parameters correspond to the path variables you define in the route.
     To access the route parameters, we use `route.snapshot`, which is the `ActivatedRouteSnapshot` that contains information about the active route at that particular moment in time.
-    The URL that matches the route provides the `productId` .
-    Angular uses the `productId` to display the details for each unique product.
+    The URL that matches the route provides the `productID` .
+    Angular uses the `productID` to display the details for each unique product.
 
 1.  Update the `ProductDetailsComponent` template to display product details with an `*ngIf`.
     If a product exists, the `<div>` renders with a name, price, and description.


### PR DESCRIPTION
It may be an issue with Chrome or my local repo, but the product Details page would not show when I had Number(routeParams.get('productId'), as indicated in the steps. Through console logging, I determined the issue to be that the route snapshot paramMap listed the property as 'productID'. Upon making that change, the product-details page worked fine.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
