### PR TITLE
refactor(core): handle empty projection slots within `<ng-container>` during hydration

### DIFF
--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -2977,6 +2977,136 @@ describe('platform-server integration', () => {
         verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
       });
 
+      it('should handle empty projection slots within <ng-container>', async () => {
+        @Component({
+          standalone: true,
+          selector: 'projector-cmp',
+          imports: [CommonModule],
+          template: `
+            <ng-container *ngIf="true">
+              <ng-content select="[left]"></ng-content>
+              <div>
+                <ng-content select="[main]"></ng-content>
+              </div>
+              <ng-content select="[right]"></ng-content>
+            </ng-container>
+          `,
+        })
+        class ProjectorCmp {
+        }
+
+        @Component({
+          standalone: true,
+          imports: [ProjectorCmp],
+          selector: 'app',
+          template: `
+            <projector-cmp />
+          `,
+        })
+        class SimpleComponent {
+        }
+
+        const html = await ssr(SimpleComponent);
+        const ssrContents = getAppContents(html);
+
+        expect(ssrContents).toContain('<app ngh');
+
+        resetTViewsFor(SimpleComponent, ProjectorCmp);
+
+        const appRef = await hydrate(html, SimpleComponent);
+        const compRef = getComponentRef<SimpleComponent>(appRef);
+        appRef.tick();
+
+        const clientRootNode = compRef.location.nativeElement;
+        verifyAllNodesClaimedForHydration(clientRootNode);
+        verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+      });
+
+      it('should handle empty projection slots within <ng-container> ' +
+             '(when no other elements are present)',
+         async () => {
+           @Component({
+             standalone: true,
+             selector: 'projector-cmp',
+             imports: [CommonModule],
+             template: `
+              <ng-container *ngIf="true">
+                <ng-content select="[left]"></ng-content>
+                <ng-content select="[right]"></ng-content>
+              </ng-container>
+            `,
+           })
+           class ProjectorCmp {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [ProjectorCmp],
+             selector: 'app',
+             template: `
+              <projector-cmp />
+            `,
+           })
+           class SimpleComponent {
+           }
+
+           const html = await ssr(SimpleComponent);
+           const ssrContents = getAppContents(html);
+
+           expect(ssrContents).toContain('<app ngh');
+
+           resetTViewsFor(SimpleComponent, ProjectorCmp);
+
+           const appRef = await hydrate(html, SimpleComponent);
+           const compRef = getComponentRef<SimpleComponent>(appRef);
+           appRef.tick();
+
+           const clientRootNode = compRef.location.nativeElement;
+           verifyAllNodesClaimedForHydration(clientRootNode);
+           verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+         });
+
+      it('should handle empty projection slots within a template ' +
+             '(when no other elements are present)',
+         async () => {
+           @Component({
+             standalone: true,
+             selector: 'projector-cmp',
+             template: `
+              <ng-content select="[left]"></ng-content>
+              <ng-content select="[right]"></ng-content>
+             `,
+           })
+           class ProjectorCmp {
+           }
+
+           @Component({
+             standalone: true,
+             imports: [ProjectorCmp],
+             selector: 'app',
+             template: `
+              <projector-cmp />
+            `,
+           })
+           class SimpleComponent {
+           }
+
+           const html = await ssr(SimpleComponent);
+           const ssrContents = getAppContents(html);
+
+           expect(ssrContents).toContain('<app ngh');
+
+           resetTViewsFor(SimpleComponent, ProjectorCmp);
+
+           const appRef = await hydrate(html, SimpleComponent);
+           const compRef = getComponentRef<SimpleComponent>(appRef);
+           appRef.tick();
+
+           const clientRootNode = compRef.location.nativeElement;
+           verifyAllNodesClaimedForHydration(clientRootNode);
+           verifyClientAndSSRContentsMatch(ssrContents, clientRootNode);
+         });
+
       it('should project contents into different slots', async () => {
         @Component({
           standalone: true,


### PR DESCRIPTION
This commit updates hydration logic to handle cases when there are projection slots present in a template inside of an `<ng-container>` and when there are regular elements follow an `<ng-content>` slot (see tests for additional information). With this combination, the logic that annotates regular element locations should fallback to calculating a path from a reference node to that node. In case of an `<ng-container>`, the comment node is located *after* the node that needs an annotation. An existing logic was mistakenly returning an empty path, which was represented as a pointer to the reference node. This commit fixes that and triggers a fallback to using a component host node as a reference in this case.

Resolves #49918.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No