### PR TITLE
refactor(core): hydrate components of the same type used with and without ngSkipHydration

### DIFF
--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -564,9 +564,6 @@
     "name": "Subscription"
   },
   {
-    "name": "TEMPLATES"
-  },
-  {
     "name": "TESTABILITY"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -552,9 +552,6 @@
     "name": "Subscription"
   },
   {
-    "name": "TEMPLATES"
-  },
-  {
     "name": "TESTABILITY"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -456,9 +456,6 @@
     "name": "Subscription"
   },
   {
-    "name": "TEMPLATES"
-  },
-  {
     "name": "TESTABILITY"
   },
   {


### PR DESCRIPTION
This commit updates hydration logic to handle a case when the same component is used multiple times in a template and in some of those cases, component is opted-out of hydration, for example:

```
<cmp ngSkipHydration />
<cmp />
```

Previously, the first occurrence of the `<cmp>` would result in storing the `ssrId` on a TView as `null` (since hydration is disabled for the component) and the second component instance reused the `null` as a value, thus also skipping hydration.

With the changes from this commit, the `ssrId` would be set when we come across a hydratable instance. We also make sure that the `ssrId` value never changes after we first set it to a non-`null` value.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No