### PR TITLE
docs: remove mention of the webworker platform issues

### DIFF
--- a/packages/common/src/dom_tokens.ts
+++ b/packages/common/src/dom_tokens.ts
@@ -9,10 +9,9 @@
 import {InjectionToken} from '@angular/core';
 
 /**
- * A DI Token representing the main rendering context. In a browser this is the DOM Document.
- *
- * Note: Document might not be available in the Application Context when Application and Rendering
- * Contexts are not the same (e.g. when running the application in a Web Worker).
+ * A DI Token representing the main rendering context.
+ * In a browser and SSR this is the DOM Document.
+ * When using SSR, that document is created by [Domino](https://github.com/angular/domino).
  *
  * @publicApi
  */


### PR DESCRIPTION
The Webworker platform was remove in v10, we can remove this part.

Fixes #49934

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes