### PR TITLE
refactor(core): remove store from instructions

### DIFF
--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -16,24 +16,23 @@ export {
   isBoundToModule as ɵisBoundToModule
 } from './application_ref';
 export {
-  injectChangeDetectorRef as ɵinjectChangeDetectorRef,
+  injectChangeDetectorRef as ɵinjectChangeDetectorRef
 } from './change_detection/change_detector_ref';
 export {
-  getDebugNode as ɵgetDebugNode,
+  getDebugNode as ɵgetDebugNode
 } from './debug/debug_node';
+export { createInjector as ɵcreateInjector } from './di/create_injector';
 export {
   NG_INJ_DEF as ɵNG_INJ_DEF,
   NG_PROV_DEF as ɵNG_PROV_DEF,
-  isInjectable as ɵisInjectable,
+  isInjectable as ɵisInjectable
 } from './di/interface/defs';
-export {createInjector as ɵcreateInjector} from './di/create_injector';
 export {
-  registerNgModuleType as ɵɵregisterNgModuleType,
-  setAllowDuplicateNgModuleIdsForTest as ɵsetAllowDuplicateNgModuleIdsForTest,
+  setAllowDuplicateNgModuleIdsForTest as ɵsetAllowDuplicateNgModuleIdsForTest, registerNgModuleType as ɵɵregisterNgModuleType
 } from './linker/ng_module_registration';
 export {
   NgModuleDef as ɵNgModuleDef,
-  NgModuleTransitiveScopes as ɵNgModuleTransitiveScopes,
+  NgModuleTransitiveScopes as ɵNgModuleTransitiveScopes
 } from './metadata/ng_module_def';
 export {
   getLContext as ɵgetLContext
@@ -43,31 +42,17 @@ export {
   NG_DIR_DEF as ɵNG_DIR_DEF,
   NG_ELEMENT_ID as ɵNG_ELEMENT_ID,
   NG_MOD_DEF as ɵNG_MOD_DEF,
-  NG_PIPE_DEF as ɵNG_PIPE_DEF,
+  NG_PIPE_DEF as ɵNG_PIPE_DEF
 } from './render3/fields';
 export {
   AttributeMarker as ɵAttributeMarker,
-  ComponentDef as ɵComponentDef,
-  ComponentFactory as ɵRender3ComponentFactory,
-  ComponentRef as ɵRender3ComponentRef,
-  ComponentType as ɵComponentType,
-  CssSelectorList as ɵCssSelectorList,
-  detectChanges as ɵdetectChanges,
-  DirectiveDef as ɵDirectiveDef,
-  DirectiveType as ɵDirectiveType,
-  getDirectives as ɵgetDirectives,
-  getHostElement as ɵgetHostElement,
-  LifecycleHooksFeature as ɵLifecycleHooksFeature,
-  NgModuleFactory as ɵNgModuleFactory,
-  NgModuleRef as ɵRender3NgModuleRef,
-  NgModuleType as ɵNgModuleType,
-  NO_CHANGE as ɵNO_CHANGE,
-  PipeDef as ɵPipeDef,
-  RenderFlags as ɵRenderFlags,
-  setClassMetadata as ɵsetClassMetadata,
-  setLocaleId as ɵsetLocaleId,
-  store as ɵstore,
-  ɵɵadvance,
+  ComponentDef as ɵComponentDef, ComponentType as ɵComponentType,
+  CssSelectorList as ɵCssSelectorList, DirectiveDef as ɵDirectiveDef,
+  DirectiveType as ɵDirectiveType, LifecycleHooksFeature as ɵLifecycleHooksFeature, NO_CHANGE as ɵNO_CHANGE, NgModuleFactory as ɵNgModuleFactory, NgModuleType as ɵNgModuleType, PipeDef as ɵPipeDef, ComponentFactory as ɵRender3ComponentFactory,
+  ComponentRef as ɵRender3ComponentRef, NgModuleRef as ɵRender3NgModuleRef, RenderFlags as ɵRenderFlags, detectChanges as ɵdetectChanges, getDirectives as ɵgetDirectives,
+  getHostElement as ɵgetHostElement, ɵgetUnknownElementStrictMode, ɵgetUnknownPropertyStrictMode, setClassMetadata as ɵsetClassMetadata,
+  setLocaleId as ɵsetLocaleId, ɵsetUnknownElementStrictMode, ɵsetUnknownPropertyStrictMode, ɵɵComponentDeclaration, ɵɵCopyDefinitionFeature, ɵɵDirectiveDeclaration, ɵɵFactoryDeclaration, ɵɵHostDirectivesFeature, ɵɵInheritDefinitionFeature, ɵɵInjectorDeclaration, ɵɵNgModuleDeclaration,
+  ɵɵNgOnChangesFeature, ɵɵPipeDeclaration, ɵɵProvidersFeature, ɵɵStandaloneFeature, ɵɵadvance,
   ɵɵattribute,
   ɵɵattributeInterpolate1,
   ɵɵattributeInterpolate2,
@@ -88,16 +73,10 @@ export {
   ɵɵclassMapInterpolate7,
   ɵɵclassMapInterpolate8,
   ɵɵclassMapInterpolateV,
-  ɵɵclassProp,
-  ɵɵComponentDeclaration,
-  ɵɵcontentQuery,
-  ɵɵCopyDefinitionFeature,
-  ɵɵdefineComponent,
+  ɵɵclassProp, ɵɵcontentQuery, ɵɵdefineComponent,
   ɵɵdefineDirective,
   ɵɵdefineNgModule,
-  ɵɵdefinePipe,
-  ɵɵDirectiveDeclaration,
-  ɵɵdirectiveInject,
+  ɵɵdefinePipe, ɵɵdirectiveInject,
   ɵɵdisableBindings,
   ɵɵelement,
   ɵɵelementContainer,
@@ -105,9 +84,7 @@ export {
   ɵɵelementContainerStart,
   ɵɵelementEnd,
   ɵɵelementStart,
-  ɵɵenableBindings,
-  ɵɵFactoryDeclaration,
-  ɵɵgetCurrentView,
+  ɵɵenableBindings, ɵɵgetCurrentView,
   ɵɵgetInheritedFactory,
   ɵɵhostProperty,
   ɵɵi18n,
@@ -116,27 +93,18 @@ export {
   ɵɵi18nEnd,
   ɵɵi18nExp,
   ɵɵi18nPostprocess,
-  ɵɵi18nStart,
-  ɵɵInheritDefinitionFeature,
-  ɵɵinjectAttribute,
-  ɵɵInjectorDeclaration,
-  ɵɵinvalidFactory,
+  ɵɵi18nStart, ɵɵinjectAttribute, ɵɵinvalidFactory,
   ɵɵlistener,
   ɵɵloadQuery,
   ɵɵnamespaceHTML,
   ɵɵnamespaceMathML,
   ɵɵnamespaceSVG,
-  ɵɵnextContext,
-  ɵɵNgModuleDeclaration,
-  ɵɵNgOnChangesFeature,
-  ɵɵpipe,
+  ɵɵnextContext, ɵɵpipe,
   ɵɵpipeBind1,
   ɵɵpipeBind2,
   ɵɵpipeBind3,
   ɵɵpipeBind4,
-  ɵɵpipeBindV,
-  ɵɵPipeDeclaration,
-  ɵɵprojection,
+  ɵɵpipeBindV, ɵɵprojection,
   ɵɵprojectionDef,
   ɵɵproperty,
   ɵɵpropertyInterpolate,
@@ -148,10 +116,7 @@ export {
   ɵɵpropertyInterpolate6,
   ɵɵpropertyInterpolate7,
   ɵɵpropertyInterpolate8,
-  ɵɵpropertyInterpolateV,
-  ɵɵProvidersFeature,
-  ɵɵHostDirectivesFeature,
-  ɵɵpureFunction0,
+  ɵɵpropertyInterpolateV, ɵɵpureFunction0,
   ɵɵpureFunction1,
   ɵɵpureFunction2,
   ɵɵpureFunction3,
@@ -170,9 +135,7 @@ export {
   ɵɵrestoreView,
 
   ɵɵsetComponentScope,
-  ɵɵsetNgModuleScope,
-  ɵɵStandaloneFeature,
-  ɵɵstyleMap,
+  ɵɵsetNgModuleScope, ɵɵstyleMap,
   ɵɵstyleMapInterpolate1,
   ɵɵstyleMapInterpolate2,
   ɵɵstyleMapInterpolate3,
@@ -207,24 +170,20 @@ export {
   ɵɵtextInterpolate7,
   ɵɵtextInterpolate8,
   ɵɵtextInterpolateV,
-  ɵɵviewQuery,
-  ɵgetUnknownElementStrictMode,
-  ɵsetUnknownElementStrictMode,
-  ɵgetUnknownPropertyStrictMode,
-  ɵsetUnknownPropertyStrictMode
+  ɵɵviewQuery
 } from './render3/index';
 export {
-  LContext as ɵLContext,
+  LContext as ɵLContext
 } from './render3/interfaces/context';
 export {
   setDocument as ɵsetDocument
 } from './render3/interfaces/document';
 export {
   compileComponent as ɵcompileComponent,
-  compileDirective as ɵcompileDirective,
+  compileDirective as ɵcompileDirective
 } from './render3/jit/directive';
 export {
-  resetJitOptions as ɵresetJitOptions,
+  resetJitOptions as ɵresetJitOptions
 } from './render3/jit/jit_options';
 export {
   compileNgModule as ɵcompileNgModule,
@@ -232,7 +191,7 @@ export {
   flushModuleScopingQueueAsMuchAsPossible as ɵflushModuleScopingQueueAsMuchAsPossible,
   patchComponentDefWithScope as ɵpatchComponentDefWithScope,
   resetCompiledComponents as ɵresetCompiledComponents,
-  transitiveScopesFor as ɵtransitiveScopesFor,
+  transitiveScopesFor as ɵtransitiveScopesFor
 } from './render3/jit/module';
 export {
   FactoryTarget as ɵɵFactoryTarget,
@@ -243,27 +202,31 @@ export {
   ɵɵngDeclareInjectable,
   ɵɵngDeclareInjector,
   ɵɵngDeclareNgModule,
-  ɵɵngDeclarePipe,
+  ɵɵngDeclarePipe
 } from './render3/jit/partial';
 export {
-  compilePipe as ɵcompilePipe,
+  compilePipe as ɵcompilePipe
 } from './render3/jit/pipe';
 export {
   isNgModule as ɵisNgModule
 } from './render3/jit/util';
 export { Profiler as ɵProfiler, ProfilerEvent as ɵProfilerEvent } from './render3/profiler';
 export {
-  publishDefaultGlobalUtils as ɵpublishDefaultGlobalUtils
-,
-  publishGlobalUtil as ɵpublishGlobalUtil} from './render3/util/global_utils';
-export {ViewRef as ɵViewRef} from './render3/view_ref';
+  publishDefaultGlobalUtils as ɵpublishDefaultGlobalUtils,
+
+  publishGlobalUtil as ɵpublishGlobalUtil
+} from './render3/util/global_utils';
+export { ViewRef as ɵViewRef } from './render3/view_ref';
 export {
   bypassSanitizationTrustHtml as ɵbypassSanitizationTrustHtml,
   bypassSanitizationTrustResourceUrl as ɵbypassSanitizationTrustResourceUrl,
   bypassSanitizationTrustScript as ɵbypassSanitizationTrustScript,
   bypassSanitizationTrustStyle as ɵbypassSanitizationTrustStyle,
-  bypassSanitizationTrustUrl as ɵbypassSanitizationTrustUrl,
+  bypassSanitizationTrustUrl as ɵbypassSanitizationTrustUrl
 } from './sanitization/bypass';
+export {
+  ɵɵvalidateIframeAttribute
+} from './sanitization/iframe_attrs_validation';
 export {
   ɵɵsanitizeHtml,
   ɵɵsanitizeResourceUrl,
@@ -272,13 +235,10 @@ export {
   ɵɵsanitizeUrl,
   ɵɵsanitizeUrlOrResourceUrl,
   ɵɵtrustConstantHtml,
-  ɵɵtrustConstantResourceUrl,
+  ɵɵtrustConstantResourceUrl
 } from './sanitization/sanitization';
 export {
-  ɵɵvalidateIframeAttribute,
-} from './sanitization/iframe_attrs_validation';
-export {
-  noSideEffects as ɵnoSideEffects,
+  noSideEffects as ɵnoSideEffects
 } from './util/closure';
 
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -23,9 +23,7 @@ export {ɵɵgetInheritedFactory} from './di';
 export {getLocaleId, setLocaleId} from './i18n/i18n_locale_id';
 // clang-format off
 export {
-  detectChanges,
-  store,
-  ɵɵadvance,
+  detectChanges, ɵgetUnknownElementStrictMode, ɵgetUnknownPropertyStrictMode, ɵsetUnknownElementStrictMode, ɵsetUnknownPropertyStrictMode, ɵɵadvance,
 
   ɵɵattribute,
   ɵɵattributeInterpolate1,
@@ -127,29 +125,25 @@ export {
   ɵɵtextInterpolate6,
   ɵɵtextInterpolate7,
   ɵɵtextInterpolate8,
-  ɵɵtextInterpolateV,
-  ɵgetUnknownElementStrictMode,
-  ɵsetUnknownElementStrictMode,
-  ɵgetUnknownPropertyStrictMode,
-  ɵsetUnknownPropertyStrictMode
+  ɵɵtextInterpolateV
 } from './instructions/all';
-export {ɵɵi18n, ɵɵi18nApply, ɵɵi18nAttributes, ɵɵi18nEnd, ɵɵi18nExp,ɵɵi18nPostprocess, ɵɵi18nStart} from './instructions/i18n';
-export {RenderFlags} from './interfaces/definition';
+export { ɵɵi18n, ɵɵi18nApply, ɵɵi18nAttributes, ɵɵi18nEnd, ɵɵi18nExp, ɵɵi18nPostprocess, ɵɵi18nStart } from './instructions/i18n';
+export { RenderFlags } from './interfaces/definition';
 export {
   AttributeMarker
 } from './interfaces/node';
-export {CssSelectorList, ProjectionSlots} from './interfaces/projection';
+export { CssSelectorList, ProjectionSlots } from './interfaces/projection';
 export {
-  setClassMetadata,
+  setClassMetadata
 } from './metadata';
-export {NgModuleFactory, NgModuleRef, createEnvironmentInjector} from './ng_module_ref';
+export { NgModuleFactory, NgModuleRef, createEnvironmentInjector } from './ng_module_ref';
 export {
   ɵɵpipe,
   ɵɵpipeBind1,
   ɵɵpipeBind2,
   ɵɵpipeBind3,
   ɵɵpipeBind4,
-  ɵɵpipeBindV,
+  ɵɵpipeBindV
 } from './pipe';
 export {
   ɵɵpureFunction0,
@@ -161,25 +155,25 @@ export {
   ɵɵpureFunction6,
   ɵɵpureFunction7,
   ɵɵpureFunction8,
-  ɵɵpureFunctionV,
+  ɵɵpureFunctionV
 } from './pure_function';
 export {
   ɵɵcontentQuery,
   ɵɵloadQuery,
   ɵɵqueryRefresh,
-  ɵɵviewQuery} from './query';
+  ɵɵviewQuery
+} from './query';
 export {
   ɵɵdisableBindings,
 
   ɵɵenableBindings,
   ɵɵresetView,
-  ɵɵrestoreView,
+  ɵɵrestoreView
 } from './state';
-export {NO_CHANGE} from './tokens';
-export { ɵɵresolveBody, ɵɵresolveDocument,ɵɵresolveWindow} from './util/misc_utils';
-export { ɵɵtemplateRefExtractor} from './view_engine_compatibility_prebound';
+export { NO_CHANGE } from './tokens';
+export { ɵɵresolveBody, ɵɵresolveDocument, ɵɵresolveWindow } from './util/misc_utils';
+export { ɵɵtemplateRefExtractor } from './view_engine_compatibility_prebound';
 // clang-format on
-
 export {
   ComponentDebugMetadata,
   ComponentDef,

--- a/packages/core/src/render3/instructions/storage.ts
+++ b/packages/core/src/render3/instructions/storage.ts
@@ -5,21 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {HEADER_OFFSET, LView, TView} from '../interfaces/view';
+import {HEADER_OFFSET} from '../interfaces/view';
 import {getContextLView} from '../state';
 import {load} from '../util/view_utils';
 
-
-/** Store a value in the `data` at a given `index`. */
-export function store<T>(tView: TView, lView: LView, index: number, value: T): void {
-  // We don't store any static data for local variables, so the first time
-  // we see the template, we should store as null to avoid a sparse array
-  if (index >= tView.data.length) {
-    tView.data[index] = null;
-    tView.blueprint[index] = null;
-  }
-  lView[index] = value;
-}
 
 /**
  * Retrieves a local reference from the current contextViewData.

--- a/packages/core/src/render3/pipe.ts
+++ b/packages/core/src/render3/pipe.ts
@@ -13,14 +13,24 @@ import {Type} from '../interface/type';
 
 import {getFactoryDef} from './definition_factory';
 import {setIncludeViewProviders} from './di';
-import {store, ɵɵdirectiveInject} from './instructions/all';
+import {ɵɵdirectiveInject} from './instructions/all';
 import {isHostComponentStandalone} from './instructions/element_validation';
 import {PipeDef, PipeDefList} from './interfaces/definition';
-import {CONTEXT, DECLARATION_COMPONENT_VIEW, HEADER_OFFSET, LView, TVIEW} from './interfaces/view';
+import {CONTEXT, DECLARATION_COMPONENT_VIEW, HEADER_OFFSET, LView, TVIEW, TView} from './interfaces/view';
 import {pureFunction1Internal, pureFunction2Internal, pureFunction3Internal, pureFunction4Internal, pureFunctionVInternal} from './pure_function';
 import {getBindingRoot, getLView, getTView} from './state';
 import {load} from './util/view_utils';
 
+/** Store a value in the `data` at a given `index`. */
+function store<T>(tView: TView, lView: LView, index: number, value: T): void {
+  // We don't store any static data for local variables, so the first time
+  // we see the template, we should store as null to avoid a sparse array
+  if (index >= tView.data.length) {
+    tView.data[index] = null;
+    tView.blueprint[index] = null;
+  }
+  lView[index] = value;
+}
 
 
 /**


### PR DESCRIPTION
The store function is only used in pipe implementation and should not be exposed as an instruction.
