### PR TITLE
fix(core): add newline to hydration mismatch errors

### DIFF
--- a/packages/core/src/hydration/error_handling.ts
+++ b/packages/core/src/hydration/error_handling.ts
@@ -169,7 +169,7 @@ export function invalidSkipHydrationHost(rNode: RNode): Error {
       'that doesn\'t act as a component host. Hydration can be ' +
       'skipped only on per-component basis.\n\n';
   const actual = `${describeDomFromNode(rNode)}\n\n`;
-  const footer = 'Please move the `ngSkipHydration` attribute to the component host element.';
+  const footer = 'Please move the `ngSkipHydration` attribute to the component host element.\n\n';
   const message = header + actual + footer;
   return new RuntimeError(RuntimeErrorCode.INVALID_SKIP_HYDRATION_HOST, message);
 }
@@ -366,7 +366,7 @@ function getHydrationErrorFooter(componentClassName?: string): string {
   return `To fix this problem:\n` +
       `  * check ${componentInfo} component for hydration-related issues\n` +
       `  * or skip hydration by adding the \`ngSkipHydration\` attribute ` +
-      `to its host node in a template`;
+      `to its host node in a template\n\n`;
 }
 
 /**


### PR DESCRIPTION
This adds a newline after the hydration mismatch errors to provide more separation and readability.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
