### PR TITLE
refactor(core): call `publishSignalConfiguration` when bootstraping a standalone component

### DIFF
--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -190,6 +190,7 @@ function createOrReusePlatformInjector(providers: StaticProvider[] = []): Inject
   const injector = createPlatformInjector(providers);
   _platformInjector = injector;
   publishDefaultGlobalUtils();
+  publishSignalConfiguration();
   runPlatformInitializers(injector);
   return injector;
 }


### PR DESCRIPTION
`publishSignalConfiguration` was not called when bootstraping an app using `boostrapApplication()`

## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No