### PR TITLE
feat(platform-browser): Expose EventManagerPlugin in the public api

### DIFF
--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -93,6 +93,15 @@ export class EventManager {
 }
 
 // @public
+export abstract class EventManagerPlugin {
+    constructor(_doc: any);
+    abstract addEventListener(element: HTMLElement, eventName: string, handler: Function): Function;
+    // (undocumented)
+    manager: EventManager;
+    abstract supports(eventName: string): boolean;
+}
+
+// @public
 export const HAMMER_GESTURE_CONFIG: InjectionToken<HammerGestureConfig>;
 
 // @public

--- a/packages/platform-browser/src/dom/events/event_manager.ts
+++ b/packages/platform-browser/src/dom/events/event_manager.ts
@@ -12,7 +12,7 @@ import {Inject, Injectable, InjectionToken, NgZone, ɵRuntimeError as RuntimeErr
 import {RuntimeErrorCode} from '../../errors';
 
 /**
- * The injection token for the event-manager plug-in service.
+ * The injection token for plugins of the `EventManager` service.
  *
  * @publicApi
  */
@@ -82,13 +82,28 @@ export class EventManager {
   }
 }
 
+/**
+ * The plugin definition for the `EventManager` class
+ *
+ * It can be used as a base class to create custom manager plugins, i.e. you can create your own
+ * class that extends the `EventManagerPlugin` one.
+ *
+ * @publicApi
+ */
 export abstract class EventManagerPlugin {
+  // TODO: remove (has some usage in G3)
   constructor(private _doc: any) {}
 
   // Using non-null assertion because it's set by EventManager's constructor
   manager!: EventManager;
 
+  /**
+   * Should return `true` for every event name that should be supported by this plugin
+   */
   abstract supports(eventName: string): boolean;
 
+  /**
+   * Implement the behaviour for the supported events
+   */
   abstract addEventListener(element: HTMLElement, eventName: string, handler: Function): Function;
 }

--- a/packages/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/packages/platform-browser/src/dom/events/hammer_gestures.ts
@@ -272,7 +272,7 @@ export class HammerGesturesPlugin extends EventManagerPlugin {
  * HammerJS to detect gesture events.
  *
  * Note that applications still need to include the HammerJS script itself. This module
- * simply sets up the coordination layer between HammerJS and Angular's EventManager.
+ * simply sets up the coordination layer between HammerJS and Angular's `EventManager`.
  *
  * @publicApi
  */

--- a/packages/platform-browser/src/dom/events/key_events.ts
+++ b/packages/platform-browser/src/dom/events/key_events.ts
@@ -45,7 +45,6 @@ const MODIFIER_KEY_GETTERS: {[key: string]: (event: KeyboardEvent) => boolean} =
 };
 
 /**
- * @publicApi
  * A browser plug-in that provides support for handling of key events in Angular.
  */
 @Injectable()
@@ -188,12 +187,6 @@ export class KeyEventsPlugin extends EventManagerPlugin {
 
   /** @internal */
   static _normalizeKey(keyName: string): string {
-    // TODO: switch to a Map if the mapping grows too much
-    switch (keyName) {
-      case 'esc':
-        return 'escape';
-      default:
-        return keyName;
-    }
+    return keyName === 'esc' ? 'escape' : keyName;
   }
 }

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -75,7 +75,7 @@ export {Title} from './browser/title';
 export {disableDebugTools, enableDebugTools} from './browser/tools/tools';
 export {By} from './dom/debug/by';
 export {REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
-export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
+export {EVENT_MANAGER_PLUGINS, EventManager, EventManagerPlugin} from './dom/events/event_manager';
 export {HAMMER_GESTURE_CONFIG, HAMMER_LOADER, HammerGestureConfig, HammerLoader, HammerModule} from './dom/events/hammer_gestures';
 export {DomSanitizer, SafeHtml, SafeResourceUrl, SafeScript, SafeStyle, SafeUrl, SafeValue} from './security/dom_sanitization_service';
 export {HydrationFeature, provideClientHydration, HydrationFeatureKind, withNoDomReuse, withNoHttpTransferCache} from './hydration';

--- a/packages/platform-server/src/server_events.ts
+++ b/packages/platform-server/src/server_events.ts
@@ -8,17 +8,20 @@
 
 import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
 import {Inject, Injectable} from '@angular/core';
+import {EventManagerPlugin} from '@angular/platform-browser';
 
 @Injectable()
-export class ServerEventManagerPlugin /* extends EventManagerPlugin which is private */ {
-  constructor(@Inject(DOCUMENT) private doc: any) {}
+export class ServerEventManagerPlugin extends EventManagerPlugin {
+  constructor(@Inject(DOCUMENT) private doc: any) {
+    super(doc);
+  }
 
   // Handle all events on the server.
-  supports(eventName: string) {
+  override supports(eventName: string) {
     return true;
   }
 
-  addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
+  override addEventListener(element: HTMLElement, eventName: string, handler: Function): Function {
     return getDOM().onAndCancel(element, eventName, handler);
   }
 }


### PR DESCRIPTION
This commit exposes the `EventManagerPlugin` abstract class to the public API.
It provides a documentation with a usecase and a basic implementation describing the possibilities

Rationale for opening to the public API :

1. The `EVENT_MANAGER_PLUGINS` token is already public
2. The documentation provides a usefull usecase
3. Plugins can already be implemented by following the same API
4. This does not increase the API surface because of 3.
5. This topic gained some visibility in the last few days in the twitter community and seems to be not so widely known, so this helps also for the visibility ! (Also wanted to share the usescases implemented by [@tinkoff/ng-event-plugins](https://github.com/Tinkoff/ng-event-plugins))

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->


- [x] Feature

## Does this PR introduce a breaking change?


- [x] No