### PR TITLE
refactor(docs-infra): remove `semi` rule from eslintrc.

### DIFF
--- a/aio/.eslintrc.json
+++ b/aio/.eslintrc.json
@@ -65,8 +65,7 @@
         "no-use-before-define": "off",
         "prefer-arrow/prefer-arrow-functions": "off",
         "quotes": "off",
-        "@typescript-eslint/quotes": ["error", "single", {"avoidEscape": true}],
-        "semi": "error"
+        "@typescript-eslint/quotes": ["error", "single", {"avoidEscape": true}]
       }
     },
     {


### PR DESCRIPTION
The `semi` rule throws duplicate errors since `plugin:@angular-eslint/ng-cli-compat--formatting-add-on` already includes `@typescript-eslint/semi` as error.