### PR TITLE
build(elements): remove unecessary filegroup.

### DIFF
--- a/packages/elements/test/BUILD.bazel
+++ b/packages/elements/test/BUILD.bazel
@@ -25,24 +25,8 @@ ts_library(
     ],
 )
 
-filegroup(
-    name = "elements_test_bootstrap_scripts",
-    testonly = True,
-    # do not sort
-    srcs = [
-        # Required for browsers that do not natively support Custom Elements.
-        "@npm//:node_modules/@webcomponents/custom-elements/custom-elements.min.js",
-        "@npm//:node_modules/reflect-metadata/Reflect.js",
-        "//packages/zone.js/bundles:zone.umd.js",
-        "//packages/zone.js/bundles:zone-testing.umd.js",
-    ],
-)
-
 karma_web_test_suite(
     name = "test",
-    bootstrap = [
-        ":elements_test_bootstrap_scripts",
-    ],
     deps = [
         ":test_lib",
     ],


### PR DESCRIPTION
This is uneccessary now. All supported browsers support custom elements.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Build related changes

## Does this PR introduce a breaking change?


- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
