### PR TITLE
refactor(core): Add signal LView flag

### DIFF
--- a/packages/core/src/linker/template_ref.ts
+++ b/packages/core/src/linker/template_ref.ts
@@ -11,7 +11,7 @@ import {DehydratedContainerView} from '../hydration/interfaces';
 import {assertLContainer} from '../render3/assert';
 import {createLView, renderView} from '../render3/instructions/shared';
 import {TContainerNode, TNode, TNodeType} from '../render3/interfaces/node';
-import {DECLARATION_LCONTAINER, LView, LViewFlags, QUERIES, TView} from '../render3/interfaces/view';
+import {DECLARATION_LCONTAINER, FLAGS, LView, LViewFlags, QUERIES, TView} from '../render3/interfaces/view';
 import {getCurrentTNode, getLView} from '../render3/state';
 import {ViewRef as R3_ViewRef} from '../render3/view_ref';
 import {assertDefined} from '../util/assert';
@@ -120,10 +120,13 @@ const R3TemplateRef = class TemplateRef<T> extends ViewEngineTemplateRef<T> {
   override createEmbeddedViewImpl(
       context: T, injector?: Injector,
       hydrationInfo?: DehydratedContainerView|null): EmbeddedViewRef<T> {
+    // Embedded views follow the change detection strategy of the view they're declared in.
+    const isSignalView = this._declarationLView[FLAGS] & LViewFlags.SignalView;
+    const viewFlags = isSignalView ? LViewFlags.SignalView : LViewFlags.CheckAlways;
     const embeddedTView = this._declarationTContainer.tView as TView;
     const embeddedLView = createLView(
-        this._declarationLView, embeddedTView, context, LViewFlags.CheckAlways, null,
-        embeddedTView.declTNode, null, null, null, injector || null, hydrationInfo || null);
+        this._declarationLView, embeddedTView, context, viewFlags, null, embeddedTView.declTNode,
+        null, null, null, injector || null, hydrationInfo || null);
 
     const declarationLContainer = this._declarationLView[this._declarationTContainer.index];
     ngDevMode && assertLContainer(declarationLContainer);

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -184,8 +184,12 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
             hostRenderer, rootSelectorOrNode, this.componentDef.encapsulation, rootViewInjector) :
         createElementNode(hostRenderer, elementName, getNamespace(elementName));
 
-    const rootFlags = this.componentDef.onPush ? LViewFlags.Dirty | LViewFlags.IsRoot :
-                                                 LViewFlags.CheckAlways | LViewFlags.IsRoot;
+    // Signal components use the granular "RefreshView"  for change detection
+    const signalFlags = (LViewFlags.SignalView | LViewFlags.IsRoot);
+    // Non-signal components use the traditional "CheckAlways or OnPush/Dirty" change detection
+    const nonSignalFlags = this.componentDef.onPush ? LViewFlags.Dirty | LViewFlags.IsRoot :
+                                                      LViewFlags.CheckAlways | LViewFlags.IsRoot;
+    const rootFlags = this.componentDef.signals ? signalFlags : nonSignalFlags;
 
     // Create the root view. Uses empty TView and ContentTemplate.
     const rootTView =
@@ -368,10 +372,15 @@ function createRootComponentView(
     hydrationInfo = retrieveHydrationInfo(hostRNode, rootView[INJECTOR]!);
   }
   const viewRenderer = environment.rendererFactory.createRenderer(hostRNode, rootComponentDef);
+  let lViewFlags = LViewFlags.CheckAlways;
+  if (rootComponentDef.signals) {
+    lViewFlags = LViewFlags.SignalView;
+  } else if (rootComponentDef.onPush) {
+    lViewFlags = LViewFlags.Dirty;
+  }
   const componentView = createLView(
-      rootView, getOrCreateComponentTView(rootComponentDef), null,
-      rootComponentDef.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, rootView[tNode.index],
-      tNode, environment, viewRenderer, null, null, hydrationInfo);
+      rootView, getOrCreateComponentTView(rootComponentDef), null, lViewFlags,
+      rootView[tNode.index], tNode, environment, viewRenderer, null, null, hydrationInfo);
 
   if (tView.firstCreatePass) {
     markAsComponentHost(tView, tNode, rootDirectives.length - 1);

--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1472,12 +1472,17 @@ function addComponentLogic<T>(lView: LView, hostTNode: TElementNode, def: Compon
   // Only component views should be added to the view tree directly. Embedded views are
   // accessed through their containers because they may be removed / re-added later.
   const rendererFactory = lView[ENVIRONMENT].rendererFactory;
+  let lViewFlags = LViewFlags.CheckAlways;
+  if (def.signals) {
+    lViewFlags = LViewFlags.SignalView;
+  } else if (def.onPush) {
+    lViewFlags = LViewFlags.Dirty;
+  }
   const componentView = addToViewTree(
       lView,
       createLView(
-          lView, tView, null, def.onPush ? LViewFlags.Dirty : LViewFlags.CheckAlways, native,
-          hostTNode as TElementNode, null, rendererFactory.createRenderer(native, def), null, null,
-          null));
+          lView, tView, null, lViewFlags, native, hostTNode as TElementNode, null,
+          rendererFactory.createRenderer(native, def), null, null, null));
 
   // Component view will always be created before any injected LContainers,
   // so this is a regular element, wrap it with the component view

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -425,18 +425,21 @@ export const enum LViewFlags {
   /** Indicates that the view **or any of its ancestors** have an embedded view injector. */
   HasEmbeddedViewInjector = 1 << 11,
 
+  /** Indicates that the view was created with `signals: true`. */
+  SignalView = 1 << 12,
+
   /**
    * Index of the current init phase on last 21 bits
    */
-  IndexWithinInitPhaseIncrementer = 1 << 12,
+  IndexWithinInitPhaseIncrementer = 1 << 13,
   /**
    * This is the count of the bits the 1 was shifted above (base 10)
    */
-  IndexWithinInitPhaseShift = 12,
+  IndexWithinInitPhaseShift = 13,
 
   // Subtracting 1 gives all 1s to the right of the initial shift
   // So `(1 << 3) - 1` would give 3 1s: 1 << 3 = 0b01000, subtract 1 = 0b00111
-  IndexWithinInitPhaseReset = (1 << 12) - 1,
+  IndexWithinInitPhaseReset = (1 << 13) - 1,
 }
 
 /**


### PR DESCRIPTION
This commit adds an LView flag to indicate that a view is a "signal"
view and updates view creation code to correctly set the flag
based on the declaration component metadata.