### PR TITLE
fix(core): typing of TestBed Common token.

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -49,10 +49,10 @@ export class ComponentFixture<T> {
 }
 
 // @public (undocumented)
-export const ComponentFixtureAutoDetect: InjectionToken<boolean[]>;
+export const ComponentFixtureAutoDetect: InjectionToken<boolean>;
 
 // @public (undocumented)
-export const ComponentFixtureNoNgZone: InjectionToken<boolean[]>;
+export const ComponentFixtureNoNgZone: InjectionToken<boolean>;
 
 // @public
 export function discardPeriodicTasks(): void;

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -598,11 +598,8 @@ export class TestBedImpl implements TestBed {
       throw new Error(`It looks like '${stringify(type)}' has not been compiled.`);
     }
 
-    // TODO: Don't cast as `InjectionToken<boolean>`, proper type is boolean[]
-    const noNgZone = this.inject(ComponentFixtureNoNgZone as InjectionToken<boolean>, false);
-    // TODO: Don't cast as `InjectionToken<boolean>`, proper type is boolean[]
-    const autoDetect: boolean =
-        this.inject(ComponentFixtureAutoDetect as InjectionToken<boolean>, false);
+    const noNgZone = this.inject(ComponentFixtureNoNgZone, false);
+    const autoDetect: boolean = this.inject(ComponentFixtureAutoDetect, false);
     const ngZone: NgZone|null = noNgZone ? null : this.inject(NgZone, null);
     const componentFactory = new ComponentFactory(componentDef);
     const initComponent = () => {

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -31,13 +31,12 @@ export class TestComponentRenderer {
 /**
  * @publicApi
  */
-export const ComponentFixtureAutoDetect =
-    new InjectionToken<boolean[]>('ComponentFixtureAutoDetect');
+export const ComponentFixtureAutoDetect = new InjectionToken<boolean>('ComponentFixtureAutoDetect');
 
 /**
  * @publicApi
  */
-export const ComponentFixtureNoNgZone = new InjectionToken<boolean[]>('ComponentFixtureNoNgZone');
+export const ComponentFixtureNoNgZone = new InjectionToken<boolean>('ComponentFixtureNoNgZone');
 
 /**
  * @publicApi


### PR DESCRIPTION
Both `ComponentFixtureAutoDetect`  and `ComponentFixtureNoNgZone` are mistyped. Tokens are only instantiated with booleans.

The documentation also only mentions `boolean` as value ! 

I mostly see this as a bugfix as the typing is wrong. But is that breaking change acceptable ? 

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] Yes (but how breaking) ? 