### PR TITLE
refactor(core): Rename 'transplanted' view refresh flag and counters …

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -37,7 +37,7 @@ import {Renderer} from '../interfaces/renderer';
 import {RComment, RElement, RNode, RText} from '../interfaces/renderer_dom';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {isComponentDef, isComponentHost, isContentQueryHost} from '../interfaces/type_checks';
-import {CHILD_HEAD, CHILD_TAIL, CHILD_VIEWS_TO_REFRESH, CLEANUP, CONTEXT, DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, EMBEDDED_VIEW_INJECTOR, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, HostBindingOpCodes, HYDRATION, ID, InitPhaseState, INJECTOR, LView, LViewEnvironment, LViewFlags, NEXT, PARENT, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER, RENDERER, T_HOST, TData, TVIEW, TView, TViewType} from '../interfaces/view';
+import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, DESCENDANT_VIEWS_TO_REFRESH, EMBEDDED_VIEW_INJECTOR, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, HostBindingOpCodes, HYDRATION, ID, InitPhaseState, INJECTOR, LView, LViewEnvironment, LViewFlags, NEXT, PARENT, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER, RENDERER, T_HOST, TData, TVIEW, TView, TViewType} from '../interfaces/view';
 import {assertPureTNodeType, assertTNodeType} from '../node_assert';
 import {clearElementContents, updateTextNode} from '../node_manipulation';
 import {isInlineTemplate, isNodeMatchingSelectorList} from '../node_selector_matcher';
@@ -1708,7 +1708,7 @@ function refreshComponent(hostLView: LView, componentHostIdx: number): void {
     const tView = componentView[TVIEW];
     if (componentView[FLAGS] & (LViewFlags.CheckAlways | LViewFlags.Dirty)) {
       refreshView(tView, componentView, tView.template, componentView[CONTEXT]);
-    } else if (componentView[CHILD_VIEWS_TO_REFRESH] > 0) {
+    } else if (componentView[DESCENDANT_VIEWS_TO_REFRESH] > 0) {
       // Only attached components that are CheckAlways or OnPush and dirty should be refreshed
       refreshContainsDirtyView(componentView);
     }
@@ -1733,7 +1733,7 @@ function refreshContainsDirtyView(lView: LView) {
           refreshView(
               embeddedTView, embeddedLView, embeddedTView.template, embeddedLView[CONTEXT]!);
 
-        } else if (embeddedLView[CHILD_VIEWS_TO_REFRESH] > 0) {
+        } else if (embeddedLView[DESCENDANT_VIEWS_TO_REFRESH] > 0) {
           refreshContainsDirtyView(embeddedLView);
         }
       }
@@ -1748,7 +1748,7 @@ function refreshContainsDirtyView(lView: LView) {
       const componentView = getComponentLViewByIndex(components[i], lView);
       // Only attached components that are CheckAlways or OnPush and dirty should be refreshed
       if (viewAttachedToChangeDetector(componentView) &&
-          componentView[CHILD_VIEWS_TO_REFRESH] > 0) {
+          componentView[DESCENDANT_VIEWS_TO_REFRESH] > 0) {
         refreshContainsDirtyView(componentView);
       }
     }

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -10,7 +10,7 @@ import {DehydratedContainerView} from '../../hydration/interfaces';
 
 import {TNode} from './node';
 import {RComment, RElement} from './renderer_dom';
-import {HOST, LView, NEXT, PARENT, T_HOST, TRANSPLANTED_VIEWS_TO_REFRESH} from './view';
+import {CHILD_VIEWS_TO_REFRESH, HOST, LView, NEXT, PARENT, T_HOST} from './view';
 
 
 
@@ -37,7 +37,7 @@ export const TYPE = 1;
  */
 export const HAS_TRANSPLANTED_VIEWS = 2;
 
-// PARENT, NEXT, TRANSPLANTED_VIEWS_TO_REFRESH are indices 3, 4, and 5
+// PARENT, NEXT, CHILD_VIEWS_TO_REFRESH are indices 3, 4, and 5
 // As we already have these constants in LView, we don't need to re-create them.
 
 // T_HOST is index 6
@@ -106,7 +106,7 @@ export interface LContainer extends Array<any> {
    * change detection we should still descend to find those children to refresh, even if the parents
    * are not `Dirty`/`CheckAlways`.
    */
-  [TRANSPLANTED_VIEWS_TO_REFRESH]: number;
+  [CHILD_VIEWS_TO_REFRESH]: number;
 
   /**
    * A collection of views created based on the underlying `<ng-template>` element but inserted into

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -10,7 +10,7 @@ import {DehydratedContainerView} from '../../hydration/interfaces';
 
 import {TNode} from './node';
 import {RComment, RElement} from './renderer_dom';
-import {CHILD_VIEWS_TO_REFRESH, HOST, LView, NEXT, PARENT, T_HOST} from './view';
+import {DESCENDANT_VIEWS_TO_REFRESH, HOST, LView, NEXT, PARENT, T_HOST} from './view';
 
 
 
@@ -106,7 +106,7 @@ export interface LContainer extends Array<any> {
    * change detection we should still descend to find those children to refresh, even if the parents
    * are not `Dirty`/`CheckAlways`.
    */
-  [CHILD_VIEWS_TO_REFRESH]: number;
+  [DESCENDANT_VIEWS_TO_REFRESH]: number;
 
   /**
    * A collection of views created based on the underlying `<ng-template>` element but inserted into

--- a/packages/core/src/render3/interfaces/container.ts
+++ b/packages/core/src/render3/interfaces/container.ts
@@ -37,7 +37,7 @@ export const TYPE = 1;
  */
 export const HAS_TRANSPLANTED_VIEWS = 2;
 
-// PARENT, NEXT, CHILD_VIEWS_TO_REFRESH are indices 3, 4, and 5
+// PARENT, NEXT, DESCENDANT_VIEWS_TO_REFRESH are indices 3, 4, and 5
 // As we already have these constants in LView, we don't need to re-create them.
 
 // T_HOST is index 6

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -419,7 +419,8 @@ export const enum LViewFlags {
   /**
    * Whether this moved LView was needs to be refreshed. Similar to the Dirty flag, but used for
    * transplanted and signal views where the parent/ancestor views are not marked dirty as well.
-   * i.e. "Refresh just this view". Used in conjunction with the CHILD_VIEWS_TO_REFRESH counter.
+   * i.e. "Refresh just this view". Used in conjunction with the DESCENDANT_VIEWS_TO_REFRESH
+   * counter.
    */
   RefreshView = 1 << 10,
 

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -33,7 +33,7 @@ export const TVIEW = 1;
 export const FLAGS = 2;
 export const PARENT = 3;
 export const NEXT = 4;
-export const CHILD_VIEWS_TO_REFRESH = 5;
+export const DESCENDANT_VIEWS_TO_REFRESH = 5;
 export const T_HOST = 6;
 export const CLEANUP = 7;
 export const CONTEXT = 8;
@@ -322,7 +322,7 @@ export interface LView<T = unknown> extends Array<any> {
    * change detection we should still descend to find those children to refresh, even if the parents
    * are not `Dirty`/`CheckAlways`.
    */
-  [CHILD_VIEWS_TO_REFRESH]: number;
+  [DESCENDANT_VIEWS_TO_REFRESH]: number;
 
   /** Unique ID of the view. Used for `__ngContext__` lookups in the `LView` registry. */
   [ID]: number;

--- a/packages/core/src/render3/interfaces/view.ts
+++ b/packages/core/src/render3/interfaces/view.ts
@@ -33,7 +33,7 @@ export const TVIEW = 1;
 export const FLAGS = 2;
 export const PARENT = 3;
 export const NEXT = 4;
-export const TRANSPLANTED_VIEWS_TO_REFRESH = 5;
+export const CHILD_VIEWS_TO_REFRESH = 5;
 export const T_HOST = 6;
 export const CLEANUP = 7;
 export const CONTEXT = 8;
@@ -322,7 +322,7 @@ export interface LView<T = unknown> extends Array<any> {
    * change detection we should still descend to find those children to refresh, even if the parents
    * are not `Dirty`/`CheckAlways`.
    */
-  [TRANSPLANTED_VIEWS_TO_REFRESH]: number;
+  [CHILD_VIEWS_TO_REFRESH]: number;
 
   /** Unique ID of the view. Used for `__ngContext__` lookups in the `LView` registry. */
   [ID]: number;
@@ -417,10 +417,11 @@ export const enum LViewFlags {
   IsRoot = 1 << 9,
 
   /**
-   * Whether this moved LView was needs to be refreshed at the insertion location because the
-   * declaration was dirty.
+   * Whether this moved LView was needs to be refreshed. Similar to the Dirty flag, but used for
+   * transplanted and signal views where the parent/ancestor views are not marked dirty as well.
+   * i.e. "Refresh just this view". Used in conjunction with the CHILD_VIEWS_TO_REFRESH counter.
    */
-  RefreshTransplantedView = 1 << 10,
+  RefreshView = 1 << 10,
 
   /** Indicates that the view **or any of its ancestors** have an embedded view injector. */
   HasEmbeddedViewInjector = 1 << 11,

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -316,7 +316,7 @@ function detachMovedView(declarationContainer: LContainer, lView: LView) {
 
   // If the view was marked for refresh but then detached before it was checked (where the flag
   // would be cleared and the counter decremented), we need to update the status here.
-  clearViewRefreshFlag(lView)
+  clearViewRefreshFlag(lView);
 
   movedViews.splice(declarationViewIndex, 1);
 }

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -28,7 +28,7 @@ import {assertTNodeType} from './node_assert';
 import {profiler, ProfilerEvent} from './profiler';
 import {setUpAttributes} from './util/attrs_utils';
 import {getLViewParent} from './util/view_traversal_utils';
-import {getNativeByTNode, unwrapRNode, updateTransplantedViewCount} from './util/view_utils';
+import {clearViewRefreshFlag, getNativeByTNode, unwrapRNode} from './util/view_utils';
 
 const enum WalkTNodeTreeAction {
   /** node create in the native environment. Run on initial creation. */
@@ -315,12 +315,8 @@ function detachMovedView(declarationContainer: LContainer, lView: LView) {
   ngDevMode && assertLContainer(insertionLContainer);
 
   // If the view was marked for refresh but then detached before it was checked (where the flag
-  // would be cleared and the counter decremented), we need to decrement the view counter here
-  // instead.
-  if (lView[FLAGS] & LViewFlags.RefreshTransplantedView) {
-    lView[FLAGS] &= ~LViewFlags.RefreshTransplantedView;
-    updateTransplantedViewCount(insertionLContainer, -1);
-  }
+  // would be cleared and the counter decremented), we need to update the status here.
+  clearViewRefreshFlag(lView)
 
   movedViews.splice(declarationViewIndex, 1);
 }

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -13,7 +13,7 @@ import {LContainer, TYPE} from '../interfaces/container';
 import {TConstants, TNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';
 import {isLContainer, isLView} from '../interfaces/type_checks';
-import {FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, TData, TRANSPLANTED_VIEWS_TO_REFRESH, TView} from '../interfaces/view';
+import {CHILD_VIEWS_TO_REFRESH, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, TData, TView} from '../interfaces/view';
 
 
 
@@ -165,20 +165,46 @@ export function resetPreOrderHookFlags(lView: LView) {
 }
 
 /**
- * Updates the `TRANSPLANTED_VIEWS_TO_REFRESH` counter on the `LContainer` as well as the parents
- * whose
+ * Adds the `RefreshView` flag from the lView and updates CHILD_VIEWS_TO_REFRESH counters of
+ * parents.
+ */
+export function markViewForRefresh(lView: LView) {
+  if ((lView[FLAGS] & LViewFlags.RefreshView) === 0) {
+    lView[FLAGS] |= LViewFlags.RefreshView;
+    updateChildViewsToRefresh(lView, 1);
+  }
+}
+
+/**
+ * Removes the `RefreshView` flag from the lView and updates CHILD_VIEWS_TO_REFRESH counters of
+ * parents.
+ */
+export function clearViewRefreshFlag(lView: LView) {
+  if (lView[FLAGS] & LViewFlags.RefreshView) {
+    lView[FLAGS] &= ~LViewFlags.RefreshView;
+    updateChildViewsToRefresh(lView, -1);
+  }
+}
+
+/**
+ * Updates the `CHILD_VIEWS_TO_REFRESH` counter on the parents of the `LView` as well as the parents
+ * above that whose
  *  1. counter goes from 0 to 1, indicating that there is a new child that has a view to refresh
  *  or
  *  2. counter goes from 1 to 0, indicating there are no more descendant views to refresh
  */
-export function updateTransplantedViewCount(lContainer: LContainer, amount: 1|- 1) {
-  lContainer[TRANSPLANTED_VIEWS_TO_REFRESH] += amount;
-  let viewOrContainer: LView|LContainer = lContainer;
-  let parent: LView|LContainer|null = lContainer[PARENT];
+function updateChildViewsToRefresh(lView: LView, amount: 1|- 1) {
+  let parent: LView|LContainer|null = lView[PARENT];
+  if (parent === null) {
+    return;
+  }
+  parent[CHILD_VIEWS_TO_REFRESH] += amount;
+  let viewOrContainer: LView|LContainer = parent;
+  parent = parent[PARENT];
   while (parent !== null &&
-         ((amount === 1 && viewOrContainer[TRANSPLANTED_VIEWS_TO_REFRESH] === 1) ||
-          (amount === -1 && viewOrContainer[TRANSPLANTED_VIEWS_TO_REFRESH] === 0))) {
-    parent[TRANSPLANTED_VIEWS_TO_REFRESH] += amount;
+         ((amount === 1 && viewOrContainer[CHILD_VIEWS_TO_REFRESH] === 1) ||
+          (amount === -1 && viewOrContainer[CHILD_VIEWS_TO_REFRESH] === 0))) {
+    parent[CHILD_VIEWS_TO_REFRESH] += amount;
     viewOrContainer = parent;
     parent = parent[PARENT];
   }

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -13,7 +13,7 @@ import {LContainer, TYPE} from '../interfaces/container';
 import {TConstants, TNode} from '../interfaces/node';
 import {RNode} from '../interfaces/renderer_dom';
 import {isLContainer, isLView} from '../interfaces/type_checks';
-import {CHILD_VIEWS_TO_REFRESH, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, TData, TView} from '../interfaces/view';
+import {DESCENDANT_VIEWS_TO_REFRESH, FLAGS, HEADER_OFFSET, HOST, LView, LViewFlags, ON_DESTROY_HOOKS, PARENT, PREORDER_HOOK_FLAGS, PreOrderHookFlags, TData, TView} from '../interfaces/view';
 
 
 
@@ -171,7 +171,7 @@ export function resetPreOrderHookFlags(lView: LView) {
 export function markViewForRefresh(lView: LView) {
   if ((lView[FLAGS] & LViewFlags.RefreshView) === 0) {
     lView[FLAGS] |= LViewFlags.RefreshView;
-    updateChildViewsToRefresh(lView, 1);
+    updateViewsToRefresh(lView, 1);
   }
 }
 
@@ -182,7 +182,7 @@ export function markViewForRefresh(lView: LView) {
 export function clearViewRefreshFlag(lView: LView) {
   if (lView[FLAGS] & LViewFlags.RefreshView) {
     lView[FLAGS] &= ~LViewFlags.RefreshView;
-    updateChildViewsToRefresh(lView, -1);
+    updateViewsToRefresh(lView, -1);
   }
 }
 
@@ -193,18 +193,18 @@ export function clearViewRefreshFlag(lView: LView) {
  *  or
  *  2. counter goes from 1 to 0, indicating there are no more descendant views to refresh
  */
-function updateChildViewsToRefresh(lView: LView, amount: 1|- 1) {
+function updateViewsToRefresh(lView: LView, amount: 1|- 1) {
   let parent: LView|LContainer|null = lView[PARENT];
   if (parent === null) {
     return;
   }
-  parent[CHILD_VIEWS_TO_REFRESH] += amount;
+  parent[DESCENDANT_VIEWS_TO_REFRESH] += amount;
   let viewOrContainer: LView|LContainer = parent;
   parent = parent[PARENT];
   while (parent !== null &&
-         ((amount === 1 && viewOrContainer[CHILD_VIEWS_TO_REFRESH] === 1) ||
-          (amount === -1 && viewOrContainer[CHILD_VIEWS_TO_REFRESH] === 0))) {
-    parent[CHILD_VIEWS_TO_REFRESH] += amount;
+         ((amount === 1 && viewOrContainer[DESCENDANT_VIEWS_TO_REFRESH] === 1) ||
+          (amount === -1 && viewOrContainer[DESCENDANT_VIEWS_TO_REFRESH] === 0))) {
+    parent[DESCENDANT_VIEWS_TO_REFRESH] += amount;
     viewOrContainer = parent;
     parent = parent[PARENT];
   }

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -165,7 +165,7 @@ export function resetPreOrderHookFlags(lView: LView) {
 }
 
 /**
- * Adds the `RefreshView` flag from the lView and updates CHILD_VIEWS_TO_REFRESH counters of
+ * Adds the `RefreshView` flag from the lView and updates DESCENDANT_VIEWS_TO_REFRESH counters of
  * parents.
  */
 export function markViewForRefresh(lView: LView) {
@@ -176,7 +176,7 @@ export function markViewForRefresh(lView: LView) {
 }
 
 /**
- * Removes the `RefreshView` flag from the lView and updates CHILD_VIEWS_TO_REFRESH counters of
+ * Removes the `RefreshView` flag from the lView and updates DESCENDANT_VIEWS_TO_REFRESH counters of
  * parents.
  */
 export function clearViewRefreshFlag(lView: LView) {
@@ -187,8 +187,8 @@ export function clearViewRefreshFlag(lView: LView) {
 }
 
 /**
- * Updates the `CHILD_VIEWS_TO_REFRESH` counter on the parents of the `LView` as well as the parents
- * above that whose
+ * Updates the `DESCENDANT_VIEWS_TO_REFRESH` counter on the parents of the `LView` as well as the
+ * parents above that whose
  *  1. counter goes from 0 to 1, indicating that there is a new child that has a view to refresh
  *  or
  *  2. counter goes from 1 to 0, indicating there are no more descendant views to refresh

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -774,6 +774,9 @@
     "name": "cleanUpView"
   },
   {
+    "name": "clearViewRefreshFlag"
+  },
+  {
     "name": "cloakAndComputeStyles"
   },
   {
@@ -1260,6 +1263,9 @@
     "name": "markViewDirty"
   },
   {
+    "name": "markViewForRefresh"
+  },
+  {
     "name": "maybeWrapInNotSelector"
   },
   {
@@ -1515,7 +1521,7 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "updateTransplantedViewCount"
+    "name": "updateViewsToRefresh"
   },
   {
     "name": "urlParsingNode"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -588,6 +588,9 @@
     "name": "cleanUpView"
   },
   {
+    "name": "clearViewRefreshFlag"
+  },
+  {
     "name": "collectNativeNodes"
   },
   {
@@ -993,6 +996,9 @@
     "name": "markViewDirty"
   },
   {
+    "name": "markViewForRefresh"
+  },
+  {
     "name": "maybeWrapInNotSelector"
   },
   {
@@ -1197,7 +1203,7 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "updateTransplantedViewCount"
+    "name": "updateViewsToRefresh"
   },
   {
     "name": "urlParsingNode"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -789,6 +789,9 @@
     "name": "cleanUpView"
   },
   {
+    "name": "clearViewRefreshFlag"
+  },
+  {
     "name": "collectNativeNodes"
   },
   {
@@ -1386,6 +1389,9 @@
     "name": "markViewDirty"
   },
   {
+    "name": "markViewForRefresh"
+  },
+  {
     "name": "maybeUnwrapEmpty"
   },
   {
@@ -1686,7 +1692,7 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "updateTransplantedViewCount"
+    "name": "updateViewsToRefresh"
   },
   {
     "name": "urlParsingNode"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -765,6 +765,9 @@
     "name": "cleanUpView"
   },
   {
+    "name": "clearViewRefreshFlag"
+  },
+  {
     "name": "coerceToBoolean"
   },
   {
@@ -1344,6 +1347,9 @@
     "name": "markViewDirty"
   },
   {
+    "name": "markViewForRefresh"
+  },
+  {
     "name": "maybeUnwrapEmpty"
   },
   {
@@ -1662,7 +1668,7 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "updateTransplantedViewCount"
+    "name": "updateViewsToRefresh"
   },
   {
     "name": "urlParsingNode"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -450,6 +450,9 @@
     "name": "cleanUpView"
   },
   {
+    "name": "clearViewRefreshFlag"
+  },
+  {
     "name": "collectNativeNodes"
   },
   {
@@ -774,6 +777,9 @@
     "name": "markViewDirty"
   },
   {
+    "name": "markViewForRefresh"
+  },
+  {
     "name": "maybeWrapInNotSelector"
   },
   {
@@ -942,7 +948,7 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "updateTransplantedViewCount"
+    "name": "updateViewsToRefresh"
   },
   {
     "name": "urlParsingNode"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -657,6 +657,9 @@
     "name": "clearElementContents"
   },
   {
+    "name": "clearViewRefreshFlag"
+  },
+  {
     "name": "collectNativeNodes"
   },
   {
@@ -1068,6 +1071,9 @@
     "name": "markViewDirty"
   },
   {
+    "name": "markViewForRefresh"
+  },
+  {
     "name": "maybeWrapInNotSelector"
   },
   {
@@ -1272,7 +1278,7 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "updateTransplantedViewCount"
+    "name": "updateViewsToRefresh"
   },
   {
     "name": "urlParsingNode"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -972,6 +972,9 @@
     "name": "cleanUpView"
   },
   {
+    "name": "clearViewRefreshFlag"
+  },
+  {
     "name": "coerceToBoolean"
   },
   {
@@ -1677,6 +1680,9 @@
     "name": "markViewDirty"
   },
   {
+    "name": "markViewForRefresh"
+  },
+  {
     "name": "match"
   },
   {
@@ -2043,7 +2049,7 @@
     "name": "updateSegmentGroupChildren"
   },
   {
-    "name": "updateTransplantedViewCount"
+    "name": "updateViewsToRefresh"
   },
   {
     "name": "urlParsingNode"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -534,6 +534,9 @@
     "name": "cleanUpView"
   },
   {
+    "name": "clearViewRefreshFlag"
+  },
+  {
     "name": "collectNativeNodes"
   },
   {
@@ -873,6 +876,9 @@
     "name": "markViewDirty"
   },
   {
+    "name": "markViewForRefresh"
+  },
+  {
     "name": "maybeWrapInNotSelector"
   },
   {
@@ -1050,7 +1056,7 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "updateTransplantedViewCount"
+    "name": "updateViewsToRefresh"
   },
   {
     "name": "urlParsingNode"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -693,6 +693,9 @@
     "name": "cleanUpView"
   },
   {
+    "name": "clearViewRefreshFlag"
+  },
+  {
     "name": "collectNativeNodes"
   },
   {
@@ -1203,6 +1206,9 @@
     "name": "markViewDirty"
   },
   {
+    "name": "markViewForRefresh"
+  },
+  {
     "name": "maybeWrapInNotSelector"
   },
   {
@@ -1440,7 +1446,7 @@
     "name": "updateMicroTaskStatus"
   },
   {
-    "name": "updateTransplantedViewCount"
+    "name": "updateViewsToRefresh"
   },
   {
     "name": "urlParsingNode"


### PR DESCRIPTION
…to be generic

It's likely that the flag and counters used to track transplanted views needing a refresh will be reused to signal views as well. The two follow a similar rule: While the parents might not be "Dirty", there is still a child/descendant view somewhere that needs to be refreshed during change detection.
