### PR TITLE
Template Pipeline: Various features (`ng-container`, chains, binary operators, keyed reads, `ng-template` inputs)

### DIFF
--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -49,6 +49,21 @@ export enum OpKind {
   ElementEnd,
 
   /**
+   * An operation to begin an `ng-container`.
+   */
+  ContainerStart,
+
+  /**
+   * An operation for an `ng-container` with no children.
+   */
+  Container,
+
+  /**
+   * An operation to end an `ng-container`.
+   */
+  ContainerEnd,
+
+  /**
    * An operation to render a text node.
    */
   Text,

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -315,6 +315,9 @@ export function transformExpressionsInOp(
     case OpKind.Element:
     case OpKind.ElementStart:
     case OpKind.ElementEnd:
+    case OpKind.Container:
+    case OpKind.ContainerStart:
+    case OpKind.ContainerEnd:
     case OpKind.Template:
     case OpKind.Text:
     case OpKind.Advance:

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -344,6 +344,9 @@ export function transformExpressionsInExpression(
     expr.rhs = transformExpressionsInExpression(expr.rhs, transform, flags);
   } else if (expr instanceof o.ReadPropExpr) {
     expr.receiver = transformExpressionsInExpression(expr.receiver, transform, flags);
+  } else if (expr instanceof o.ReadKeyExpr) {
+    expr.receiver = transformExpressionsInExpression(expr.receiver, transform, flags);
+    expr.index = transformExpressionsInExpression(expr.index, transform, flags);
   } else if (expr instanceof o.InvokeFunctionExpr) {
     expr.fn = transformExpressionsInExpression(expr.fn, transform, flags);
     for (let i = 0; i < expr.args.length; i++) {

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -17,8 +17,9 @@ import type {UpdateOp} from './update';
 /**
  * An operation usable on the creation side of the IR.
  */
-export type CreateOp = ListEndOp<CreateOp>|StatementOp<CreateOp>|ElementOp|ElementStartOp|
-    ElementEndOp|TemplateOp|TextOp|ListenerOp|VariableOp<CreateOp>;
+export type CreateOp =
+    ListEndOp<CreateOp>|StatementOp<CreateOp>|ElementOp|ElementStartOp|ElementEndOp|ContainerOp|
+    ContainerStartOp|ContainerEndOp|TemplateOp|TextOp|ListenerOp|VariableOp<CreateOp>;
 
 /**
  * Representation of a local reference on an element.
@@ -39,8 +40,8 @@ export interface LocalRef {
  * Base interface for `Element`, `ElementStart`, and `Template` operations, containing common fields
  * used to represent their element-like nature.
  */
-export interface ElementOpBase extends Op<CreateOp>, ConsumesSlotOpTrait {
-  kind: OpKind.Element|OpKind.ElementStart|OpKind.Template;
+export interface ElementOrContainerOpBase extends Op<CreateOp>, ConsumesSlotOpTrait {
+  kind: OpKind.Element|OpKind.ElementStart|OpKind.Container|OpKind.ContainerStart|OpKind.Template;
 
   /**
    * `XrefId` allocated for this element.
@@ -48,11 +49,6 @@ export interface ElementOpBase extends Op<CreateOp>, ConsumesSlotOpTrait {
    * This ID is used to reference this element from other IR structures.
    */
   xref: XrefId;
-
-  /**
-   * The HTML tag name for this element.
-   */
-  tag: string;
 
   /**
    * Attributes of various kinds on this element.
@@ -74,6 +70,15 @@ export interface ElementOpBase extends Op<CreateOp>, ConsumesSlotOpTrait {
    * compilation.
    */
   localRefs: LocalRef[]|ConstIndex|null;
+}
+
+export interface ElementOpBase extends ElementOrContainerOpBase {
+  kind: OpKind.Element|OpKind.ElementStart|OpKind.Template;
+
+  /**
+   * The HTML tag name for this element.
+   */
+  tag: string;
 }
 
 /**
@@ -164,6 +169,34 @@ export function createElementEndOp(xref: XrefId): ElementEndOp {
     xref,
     ...NEW_OP,
   };
+}
+
+/**
+ * Logical operation representing the start of a container in the creation IR.
+ */
+export interface ContainerStartOp extends ElementOrContainerOpBase {
+  kind: OpKind.ContainerStart;
+}
+
+/**
+ * Logical operation representing an empty container in the creation IR.
+ */
+export interface ContainerOp extends ElementOrContainerOpBase {
+  kind: OpKind.Container;
+}
+
+/**
+ * Logical operation representing the end of a container structure in the creation IR.
+ *
+ * Pairs with an `ContainerStart` operation.
+ */
+export interface ContainerEndOp extends Op<CreateOp> {
+  kind: OpKind.ContainerEnd;
+
+  /**
+   * The `XrefId` of the element declared via `ContainerStart`.
+   */
+  xref: XrefId;
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/src/conversion.ts
+++ b/packages/compiler/src/template/pipeline/src/conversion.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../output/output_ast';
+
+export const BINARY_OPERATORS = new Map([
+  ['&&', o.BinaryOperator.And],
+  ['>', o.BinaryOperator.Bigger],
+  ['>=', o.BinaryOperator.BiggerEquals],
+  ['&', o.BinaryOperator.BitwiseAnd],
+  ['/', o.BinaryOperator.Divide],
+  ['==', o.BinaryOperator.Equals],
+  ['===', o.BinaryOperator.Identical],
+  ['<', o.BinaryOperator.Lower],
+  ['<=', o.BinaryOperator.LowerEquals],
+  ['-', o.BinaryOperator.Minus],
+  ['%', o.BinaryOperator.Modulo],
+  ['*', o.BinaryOperator.Multiply],
+  ['!=', o.BinaryOperator.NotEquals],
+  ['!==', o.BinaryOperator.NotIdentical],
+  ['??', o.BinaryOperator.NullishCoalesce],
+  ['||', o.BinaryOperator.Or],
+  ['+', o.BinaryOperator.Plus],
+]);

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -27,6 +27,7 @@ import {phaseVariableOptimization} from './phases/variable_optimization';
 import {phaseChaining} from './phases/chaining';
 import {phaseMergeNextContext} from './phases/next_context_merging';
 import {phaseNgContainer} from './phases/ng_container';
+import {phaseSaveRestoreView} from './phases/save_restore_view';
 
 /**
  * Run all transformation phases in the correct order against a `ComponentCompilation`. After this
@@ -34,6 +35,7 @@ import {phaseNgContainer} from './phases/ng_container';
  */
 export function transformTemplate(cpl: ComponentCompilation): void {
   phaseGenerateVariables(cpl);
+  phaseSaveRestoreView(cpl);
   phaseResolveNames(cpl);
   phaseResolveContexts(cpl);
   phaseLocalRefs(cpl);

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -26,6 +26,7 @@ import {phaseResolveContexts} from './phases/resolve_contexts';
 import {phaseVariableOptimization} from './phases/variable_optimization';
 import {phaseChaining} from './phases/chaining';
 import {phaseMergeNextContext} from './phases/next_context_merging';
+import {phaseNgContainer} from './phases/ng_container';
 
 /**
  * Run all transformation phases in the correct order against a `ComponentCompilation`. After this
@@ -36,7 +37,6 @@ export function transformTemplate(cpl: ComponentCompilation): void {
   phaseResolveNames(cpl);
   phaseResolveContexts(cpl);
   phaseLocalRefs(cpl);
-  phaseEmptyElements(cpl);
   phaseConstCollection(cpl);
   phaseSlotAllocation(cpl);
   phaseVarCounting(cpl);
@@ -44,6 +44,8 @@ export function transformTemplate(cpl: ComponentCompilation): void {
   phaseNaming(cpl);
   phaseVariableOptimization(cpl, {conservative: true});
   phaseMergeNextContext(cpl);
+  phaseNgContainer(cpl);
+  phaseEmptyElements(cpl);
   phaseReify(cpl);
   phaseChaining(cpl);
 }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -179,12 +179,15 @@ function ingestAttributes(op: ir.ElementOpBase, element: t.Element|t.Template): 
 function ingestBindings(
     view: ViewCompilation, op: ir.ElementOpBase, element: t.Element|t.Template): void {
   if (element instanceof t.Template) {
-    for (const attr of element.templateAttrs) {
-      if (typeof attr.value === 'string') {
-        // TODO: do we need to handle static attribute bindings here?
-      } else {
-        view.update.push(ir.createPropertyOp(op.xref, attr.name, convertAst(attr.value, view.tpl)));
+    // TODO: Are ng-template inputs handled differently from element inputs?
+    // <ng-template dir [foo]="...">
+    // <item-cmp *ngFor="let item of items" [item]="item">
+    for (const input of [...element.templateAttrs, ...element.inputs]) {
+      if (!(input instanceof t.BoundAttribute)) {
+        continue;
       }
+
+      view.update.push(ir.createPropertyOp(op.xref, input.name, convertAst(input.value, view.tpl)));
     }
   } else {
     for (const input of element.inputs) {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -141,6 +141,8 @@ function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
         operator, convertAst(ast.left, cpl), convertAst(ast.right, cpl));
   } else if (ast instanceof e.ThisReceiver) {
     return new ir.ContextExpr(cpl.root.xref);
+  } else if (ast instanceof e.KeyedRead) {
+    return new o.ReadKeyExpr(convertAst(ast.receiver, cpl), convertAst(ast.key, cpl));
   } else if (ast instanceof e.Chain) {
     throw new Error(`AssertionError: Chain in unknown context`);
   } else {

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -16,22 +16,21 @@ import * as ir from '../ir';
 
 export function element(
     slot: number, tag: string, constIndex: number|null, localRefIndex: number|null): ir.CreateOp {
-  return elementStartBase(Identifiers.element, slot, tag, constIndex, localRefIndex);
+  return elementOrContainerBase(Identifiers.element, slot, tag, constIndex, localRefIndex);
 }
-
 
 export function elementStart(
     slot: number, tag: string, constIndex: number|null, localRefIndex: number|null): ir.CreateOp {
-  return elementStartBase(Identifiers.elementStart, slot, tag, constIndex, localRefIndex);
+  return elementOrContainerBase(Identifiers.elementStart, slot, tag, constIndex, localRefIndex);
 }
 
-function elementStartBase(
-    instruction: o.ExternalReference, slot: number, tag: string, constIndex: number|null,
+function elementOrContainerBase(
+    instruction: o.ExternalReference, slot: number, tag: string|null, constIndex: number|null,
     localRefIndex: number|null): ir.CreateOp {
-  const args: o.Expression[] = [
-    o.literal(slot),
-    o.literal(tag),
-  ];
+  const args: o.Expression[] = [o.literal(slot)];
+  if (tag !== null) {
+    args.push(o.literal(tag));
+  }
   if (localRefIndex !== null) {
     args.push(
         o.literal(constIndex),  // might be null, but that's okay.
@@ -46,6 +45,22 @@ function elementStartBase(
 
 export function elementEnd(): ir.CreateOp {
   return call(Identifiers.elementEnd, []);
+}
+
+export function elementContainerStart(
+    slot: number, constIndex: number|null, localRefIndex: number|null): ir.CreateOp {
+  return elementOrContainerBase(
+      Identifiers.elementContainerStart, slot, /* tag */ null, constIndex, localRefIndex);
+}
+
+export function elementContainer(
+    slot: number, constIndex: number|null, localRefIndex: number|null): ir.CreateOp {
+  return elementOrContainerBase(
+      Identifiers.elementContainer, slot, /* tag */ null, constIndex, localRefIndex);
+}
+
+export function elementContainerEnd(): ir.CreateOp {
+  return call(Identifiers.elementContainerEnd, []);
 }
 
 export function template(

--- a/packages/compiler/src/template/pipeline/src/phases/chaining.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/chaining.ts
@@ -15,6 +15,9 @@ const CHAINABLE = new Set([
   R3.elementStart,
   R3.elementEnd,
   R3.property,
+  R3.elementContainerStart,
+  R3.elementContainerEnd,
+  R3.elementContainer,
 ]);
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/empty_elements.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/empty_elements.ts
@@ -9,20 +9,29 @@
 import * as ir from '../../ir';
 import {ComponentCompilation} from '../compilation';
 
+const REPLACEMENTS = new Map<ir.OpKind, [ir.OpKind, ir.OpKind]>([
+  [ir.OpKind.ElementEnd, [ir.OpKind.ElementStart, ir.OpKind.Element]],
+  [ir.OpKind.ContainerEnd, [ir.OpKind.ContainerStart, ir.OpKind.Container]],
+]);
+
 /**
- * Replace sequences of `ElementStart` followed by `ElementEnd` with a condensed `Element`
- * instruction.
+ * Replace sequences of mergable elements (e.g. `ElementStart` and `ElementEnd`) with a consolidated
+ * element (e.g. `Element`).
  */
 export function phaseEmptyElements(cpl: ComponentCompilation): void {
   for (const [_, view] of cpl.views) {
     for (const op of view.create) {
-      if (op.kind === ir.OpKind.ElementEnd && op.prev !== null &&
-          op.prev.kind === ir.OpKind.ElementStart) {
-        // Transmute the `ElementStart` instruction to `Element`. This is safe as they're designed
+      const opReplacements = REPLACEMENTS.get(op.kind);
+      if (opReplacements === undefined) {
+        continue;
+      }
+      const [startKind, mergedKind] = opReplacements;
+      if (op.prev !== null && op.prev.kind === startKind) {
+        // Transmute the start instruction to the merged version. This is safe as they're designed
         // to be identical apart from the `kind`.
-        (op.prev as unknown as ir.ElementOp).kind = ir.OpKind.Element;
+        (op.prev as ir.Op<ir.CreateOp>).kind = mergedKind;
 
-        // Remove the `ElementEnd` instruction.
+        // Remove the end instruction.
         ir.OpList.remove<ir.CreateOp>(op);
       }
     }

--- a/packages/compiler/src/template/pipeline/src/phases/ng_container.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/ng_container.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as ir from '../../ir';
+import {ComponentCompilation} from '../compilation';
+
+const CONTAINER_TAG = 'ng-container';
+
+/**
+ * Replace an `Element` or `ElementStart` whose tag is `ng-container` with a specific op.
+ */
+export function phaseNgContainer(cpl: ComponentCompilation): void {
+  for (const [_, view] of cpl.views) {
+    const updatedElementXrefs = new Set<ir.XrefId>();
+    for (const op of view.create) {
+      if (op.kind === ir.OpKind.ElementStart && op.tag === CONTAINER_TAG) {
+        // Transmute the `ElementStart` instruction to `ContainerStart`.
+        (op as ir.Op<ir.CreateOp>).kind = ir.OpKind.ContainerStart;
+        updatedElementXrefs.add(op.xref);
+      }
+
+      if (op.kind === ir.OpKind.ElementEnd && updatedElementXrefs.has(op.xref)) {
+        // This `ElementEnd` is associated with an `ElementStart` we already transmuted.
+        (op as ir.Op<ir.CreateOp>).kind = ir.OpKind.ContainerEnd;
+      }
+    }
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -50,6 +50,21 @@ function reifyCreateOperations(view: ViewCompilation, ops: ir.OpList<ir.CreateOp
       case ir.OpKind.ElementEnd:
         ir.OpList.replace(op, ng.elementEnd());
         break;
+      case ir.OpKind.ContainerStart:
+        ir.OpList.replace(
+            op,
+            ng.elementContainerStart(
+                op.slot!, op.attributes as number | null, op.localRefs as number | null));
+        break;
+      case ir.OpKind.Container:
+        ir.OpList.replace(
+            op,
+            ng.elementContainer(
+                op.slot!, op.attributes as number | null, op.localRefs as number | null));
+        break;
+      case ir.OpKind.ContainerEnd:
+        ir.OpList.replace(op, ng.elementContainerEnd());
+        break;
       case ir.OpKind.Template:
         const childView = view.tpl.views.get(op.xref)!;
         ir.OpList.replace(

--- a/packages/compiler/src/template/pipeline/src/phases/save_restore_view.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/save_restore_view.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {ComponentCompilation} from '../compilation';
+
+export function phaseSaveRestoreView(cpl: ComponentCompilation): void {
+  for (const view of cpl.views.values()) {
+    if (view === cpl.root) {
+      // Save/restore operations are not necessary for the root view.
+      continue;
+    }
+
+    view.create.prepend([
+      ir.createVariableOp<ir.CreateOp>(
+          view.tpl.allocateXrefId(), {
+            kind: ir.SemanticVariableKind.SavedView,
+            name: null,
+            view: view.xref,
+          },
+          new ir.GetCurrentViewExpr()),
+    ]);
+
+    for (const op of view.create) {
+      if (op.kind !== ir.OpKind.Listener) {
+        continue;
+      }
+
+      op.handlerOps.prepend([
+        ir.createVariableOp<ir.UpdateOp>(
+            view.tpl.allocateXrefId(), {
+              kind: ir.SemanticVariableKind.Context,
+              name: null,
+              view: view.xref,
+            },
+            new ir.RestoreViewExpr(view.xref)),
+      ]);
+
+      // The "restore view" operation in listeners requires a call to `resetView` to reset the
+      // context prior to returning from the listener operation. Find any `return` statements in
+      // the listener body and wrap them in a call to reset the view.
+      for (const handlerOp of op.handlerOps) {
+        if (handlerOp.kind === ir.OpKind.Statement &&
+            handlerOp.statement instanceof o.ReturnStatement) {
+          handlerOp.statement.value = new ir.ResetViewExpr(handlerOp.statement.value);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implement a couple of missing features in the new template pipeline compiler, to continue bringing it to parity with the old `TemplateDefinitionBuilder`. This commit series especially fixes issues that came up while working on the `ng-template` input tests.

See individual commits for per-feature info.