### PR TITLE
fix(docs-infra): add `work-break` to `a` tags in `.cli-option`

### DIFF
--- a/aio/src/styles/2-modules/cli-pages/_cli-pages.scss
+++ b/aio/src/styles/2-modules/cli-pages/_cli-pages.scss
@@ -4,6 +4,12 @@
   .kwd { color: inherit; }  /* override code format */
 }
 
-.cli-option-syntax {
-  white-space: pre;
+.cli-option {
+  a {
+    word-break: break-all;
+  }
+
+  &-syntax {
+    white-space: pre;
+  }
 }


### PR DESCRIPTION
This commit fixes a styling issue were the default values are not being displayed in https://angular.io/cli/build which is because in some cases the option description has a long anchor tag which causes the content to be pushed to the right and gets hidden.

**Before**


<img width="917" alt="Screenshot 2023-04-26 at 15 10 53" src="https://user-images.githubusercontent.com/17563226/234585400-f591c8b8-7f52-4b06-8210-60b24db5fdf8.png">

**After**

<img width="842" alt="Screenshot 2023-04-26 at 14 45 53" src="https://user-images.githubusercontent.com/17563226/234585392-54200f98-f488-49f2-8a4d-e1863f7636cb.png">
