### PR TITLE
fix(platform-browser): export deprecated `TransferState` as type

### DIFF
--- a/goldens/public-api/platform-browser/index.md
+++ b/goldens/public-api/platform-browser/index.md
@@ -235,6 +235,9 @@ export class Title {
 }
 
 // @public @deprecated
+export type TransferState = TransferState_2;
+
+// @public (undocumented)
 export const TransferState: {
     new (): TransferState_2;
 };

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -47,6 +47,8 @@ export const makeStateKey = makeStateKeyFromCore;
  *     instead.
  */
 // The below is a workaround to add a deprecated message.
+export type TransferState = TransferStateFromCore;
+// The below type is needed for G3 due to JSC_CONFORMANCE_VIOLATION.
 export const TransferState: {new (): TransferStateFromCore} = TransferStateFromCore;
 
 /**

--- a/packages/platform-browser/test/testing_public_spec.ts
+++ b/packages/platform-browser/test/testing_public_spec.ts
@@ -11,6 +11,8 @@ import {Compiler, Component, ComponentFactoryResolver, CUSTOM_ELEMENTS_SCHEMA, D
 import {fakeAsync, getTestBed, inject, TestBed, tick, waitForAsync, withModule} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
+import {TransferState} from '../public_api';
+
 // Services, and components for the tests.
 
 @Component({selector: 'child-comp', template: `<span>Original {{childBinding}}</span>`})
@@ -44,18 +46,6 @@ class MyIfComp {
 @Component({selector: 'child-child-comp', template: `<span>ChildChild</span>`})
 @Injectable()
 class ChildChildComp {
-}
-
-@Component({
-  selector: 'child-comp',
-  template: `<span>Original {{childBinding}}(<child-child-comp></child-child-comp>)</span>`,
-})
-@Injectable()
-class ChildWithChildComp {
-  childBinding: string;
-  constructor() {
-    this.childBinding = 'Child';
-  }
 }
 
 class FancyService {
@@ -1056,6 +1046,11 @@ Did you run and wait for 'resolveComponentResources()'?`);
                .toThrowError(
                    /Cannot override template when the test module has already been instantiated/);
          });
+    });
+
+    it('TransferState re-export can be used as a type and contructor', () => {
+      const transferState: TransferState = new TransferState();
+      expect(transferState).toBeDefined();
     });
   });
 }


### PR DESCRIPTION
Prior to this commit `TransferState` re-export could not be used as a type.

Closes #50014
