### PR TITLE
fix(core): allow passing value of any type to `isSignal` function

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -838,7 +838,7 @@ export interface InputDecorator {
 export function isDevMode(): boolean;
 
 // @public
-export function isSignal(value: Function): value is Signal<unknown>;
+export function isSignal(value: unknown): value is Signal<unknown>;
 
 // @public
 export function isStandalone(type: Type<unknown>): boolean;

--- a/packages/core/src/signals/src/api.ts
+++ b/packages/core/src/signals/src/api.ts
@@ -30,10 +30,12 @@ export type Signal<T> = (() => T)&{
 };
 
 /**
- * Checks if the given `value` function is a reactive `Signal`.
+ * Checks if the given `value` is a reactive `Signal`.
+ *
+ * @developerPreview
  */
-export function isSignal(value: Function): value is Signal<unknown> {
-  return (value as Signal<unknown>)[SIGNAL] !== undefined;
+export function isSignal(value: unknown): value is Signal<unknown> {
+  return typeof value === 'function' && (value as Signal<unknown>)[SIGNAL] !== undefined;
 }
 
 /**

--- a/packages/core/test/signals/is_signal_spec.ts
+++ b/packages/core/test/signals/is_signal_spec.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {computed, isSignal, signal} from '@angular/core/src/signals';
+
+describe('isSignal', () => {
+  it('should return true for writable signal', () => {
+    const writableSignal = signal('Angular');
+    expect(isSignal(writableSignal)).toBe(true);
+  });
+
+  it('should return true for readonly signal', () => {
+    const readonlySignal = computed(() => 10);
+    expect(isSignal(readonlySignal)).toBe(true);
+  });
+
+  it('should return false for primitive', () => {
+    const primitive = 0;
+    expect(isSignal(primitive)).toBe(false);
+  });
+
+  it('should return false for object', () => {
+    const object = {name: 'Angular'};
+    expect(isSignal(object)).toBe(false);
+  });
+
+  it('should return false for function', () => {
+    const fn = () => {};
+    expect(isSignal(fn)).toBe(false);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

To check if a value of type `unknown` is a Signal, we need to add two conditions:

```ts
import { isSignal } from '@angular/core';

declare const potentialSignal: unknown;

const isSig = typeof potentialSignal === 'function' && isSignal(potentialSignal);
```

## What is the new behavior?

The first condition is not needed anymore, so we can call the `isSignal` function and pass the argument of type `unknown`:

```ts
import { isSignal } from '@angular/core';

declare const potentialSignal: unknown;

const isSig = isSignal(potentialSignal);
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

`isObservable` type guard from the `rxjs` package accepts value of any type as an input argument.
