### PR TITLE
refactor(compiler-cli): add back ngcc as a no-op with a warning

### DIFF
--- a/packages/compiler-cli/BUILD.bazel
+++ b/packages/compiler-cli/BUILD.bazel
@@ -7,6 +7,7 @@ package(default_visibility = ["//visibility:public"])
 PUBLIC_TARGETS = [
     ":compiler-cli",
     "//packages/compiler-cli/private",
+    "//packages/compiler-cli/ngcc",
     "//packages/compiler-cli/linker",
     "//packages/compiler-cli/linker/babel",
 ]
@@ -22,6 +23,7 @@ esbuild(
     entry_points = [
         ":index.ts",
         "//packages/compiler-cli:src/bin/ngc.ts",
+        "//packages/compiler-cli/ngcc:index.ts",
         "//packages/compiler-cli:src/bin/ng_xi18n.ts",
         "//packages/compiler-cli/linker:index.ts",
         "//packages/compiler-cli/linker/babel:index.ts",

--- a/packages/compiler-cli/ngcc/BUILD.bazel
+++ b/packages/compiler-cli/ngcc/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//tools:defaults.bzl", "ts_library")
+
+package(default_visibility = ["//visibility:public"])
+
+ts_library(
+    name = "ngcc",
+    srcs = ["index.ts"],
+    tsconfig = "//packages/compiler-cli:tsconfig",
+    deps = [
+        "@npm//@types/node",
+    ],
+)

--- a/packages/compiler-cli/ngcc/index.ts
+++ b/packages/compiler-cli/ngcc/index.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// https://github.com/chalk/chalk/blob/a370f468a43999e4397094ff5c3d17aadcc4860e/source/utilities.js#L21
+function stringEncaseCRLFWithFirstIndex(
+    value: string, prefix: string, postfix: string, index: number): string {
+  let endIndex = 0;
+  let returnValue = '';
+
+  do {
+    const gotCR = value[index - 1] === '\r';
+    returnValue += value.substring(endIndex, gotCR ? index - 1 : index) + prefix +
+        (gotCR ? '\r\n' : '\n') + postfix;
+    endIndex = index + 1;
+    index = value.indexOf('\n', endIndex);
+  } while (index !== -1);
+
+  returnValue += value.substring(endIndex);
+  return returnValue;
+}
+
+// adapted from
+// https://github.com/chalk/chalk/blob/a370f468a43999e4397094ff5c3d17aadcc4860e/source/index.js#L194
+function styleMessage(message: string): string {
+  // red + bold
+  const open = '\x1b[31m\x1b[1m';
+  const close = '\x1b[22m\x1b[39m';
+
+  let styledMessage = message;
+  const lfIndex = styledMessage.indexOf('\n');
+  if (lfIndex !== -1) {
+    styledMessage = stringEncaseCRLFWithFirstIndex(styledMessage, close, open, lfIndex);
+  }
+
+  return open + styledMessage + close;
+}
+
+const warningMsg = `
+
+==========================================
+
+ALERT: As of Angular 16, "ngcc" is no longer required and not invoked during CLI builds. You are seeing this message because the current operation invoked the "ngcc" command directly. This "ngcc" invocation can be safely removed.
+
+A common reason for this is invoking "ngcc" from a "postinstall" hook in package.json.
+
+In Angular 17, this command will be removed. Remove this and any other invocations to prevent errors in later versions.
+
+==========================================
+
+`;
+
+console.warn(styleMessage(warningMsg));
+process.exit(0);

--- a/packages/compiler-cli/package.json
+++ b/packages/compiler-cli/package.json
@@ -4,6 +4,7 @@
   "description": "Angular - the compiler CLI for Node.js",
   "typings": "index.d.ts",
   "bin": {
+    "ngcc": "./bundles/ngcc/index.js",
     "ngc": "./bundles/src/bin/ngc.js",
     "ng-xi18n": "./bundles/src/bin/ng_xi18n.js"
   },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The Angular Compatibility Compiler is removed in Angular 16 and therefore, `ngcc` is no longer available in users' workspaces. In some setups, `ngcc` is invoked in the `postinstall` script of the `package.json`. When updating Angular, in scenarios where `postinstall` is run (e.g. Nx migrations), this throws an error before a migration can remove the `ngcc` invocation. This makes the update process to be more complicated.

## What is the new behavior?

`ngcc` is available as a no-op operation. When invoked, it will warn, providing details about removing `ngcc`. It gives some context at the tool level to folks who haven't caught up with news that `ngcc` was removed.

**Note:** In Angular 17, this will be removed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I chose to inline some slightly modified functionality from chalk for the colors in the console. I did that to avoid adding an extra dependency for this. I'm open to adding the dependency instead or implementing a different way to get colors in the console in a cross-platform way if preferred.