### PR TITLE
refactor(animations): remove circular deps

### DIFF
--- a/goldens/circular-deps/packages.json
+++ b/goldens/circular-deps/packages.json
@@ -1,9 +1,5 @@
 [
   [
-    "packages/animations/browser/src/render/animation_driver.ts",
-    "packages/animations/browser/src/render/shared.ts"
-  ],
-  [
     "packages/compiler-cli/src/ngtsc/partial_evaluator/src/interface.ts",
     "packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts"
   ],

--- a/packages/animations/browser/src/render/shared.ts
+++ b/packages/animations/browser/src/render/shared.ts
@@ -8,7 +8,6 @@
 import {AnimationEvent, AnimationPlayer, AUTO_STYLE, NoopAnimationPlayer, ɵAnimationGroupPlayer, ɵPRE_STYLE as PRE_STYLE, ɵStyleDataMap} from '@angular/animations';
 
 import {AnimationStyleNormalizer} from '../../src/dsl/style_normalization/animation_style_normalizer';
-import {AnimationDriver} from '../../src/render/animation_driver';
 import {animationFailed} from '../error_helpers';
 
 import {ANIMATABLE_PROP_SET} from './web_animations/animatable_props_set';
@@ -25,8 +24,8 @@ export function optimizeGroupPlayer(players: AnimationPlayer[]): AnimationPlayer
 }
 
 export function normalizeKeyframes(
-    driver: AnimationDriver, normalizer: AnimationStyleNormalizer, element: any,
-    keyframes: Array<ɵStyleDataMap>, preStyles: ɵStyleDataMap = new Map(),
+    normalizer: AnimationStyleNormalizer, keyframes: Array<ɵStyleDataMap>,
+    preStyles: ɵStyleDataMap = new Map(),
     postStyles: ɵStyleDataMap = new Map()): Array<ɵStyleDataMap> {
   const errors: Error[] = [];
   const normalizedKeyframes: Array<ɵStyleDataMap> = [];

--- a/packages/animations/browser/src/render/timeline_animation_engine.ts
+++ b/packages/animations/browser/src/render/timeline_animation_engine.ts
@@ -49,8 +49,7 @@ export class TimelineAnimationEngine {
       i: AnimationTimelineInstruction, preStyles: ɵStyleDataMap,
       postStyles?: ɵStyleDataMap): AnimationPlayer {
     const element = i.element;
-    const keyframes = normalizeKeyframes(
-        this._driver, this._normalizer, element, i.keyframes, preStyles, postStyles);
+    const keyframes = normalizeKeyframes(this._normalizer, i.keyframes, preStyles, postStyles);
     return this._driver.animate(element, keyframes, i.duration, i.delay, i.easing, [], true);
   }
 

--- a/packages/animations/browser/src/render/transition_animation_engine.ts
+++ b/packages/animations/browser/src/render/transition_animation_engine.ts
@@ -1438,8 +1438,7 @@ export class TransitionAnimationEngine {
       const postStyles = postStylesMap.get(element);
 
       const keyframes = normalizeKeyframes(
-          this.driver, this._normalizer, element, timelineInstruction.keyframes, preStyles,
-          postStyles);
+          this._normalizer, timelineInstruction.keyframes, preStyles, postStyles);
       const player = this._buildPlayer(timelineInstruction, keyframes, previousPlayers);
 
       // this means that this particular player belongs to a sub trigger. It is


### PR DESCRIPTION
`AnimationDriver` was not used in shared.ts.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?


- [x] No