### PR TITLE
refactor(common): deprecate isPlatform functions

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -115,6 +115,7 @@ v16 - v19
 
 | Area                                | API or Feature                                                                                             | Deprecated in | May be removed in |
 |:---                                 |:---                                                                                                        |:---           |:---               |
+| `@angular/common` | `isPlatformWorkerApp` and `isPlatformWorkerUi` | v16 | v18 |
 | `@angular/core` | `EnvironmentInjector.runInContext` | v16 | v18 |
 | `@angular/platform-server`          | [`PlatformConfig.baseUrl` and `PlatformConfig.useAbsoluteUrl` config options](api/platform-server/PlatformConfig) | v16           | v18               |
 | `@angular/platform-browser`         | [`BrowserModule.withServerTransition`](api/platform-browser/BrowserModule#withservertransition)            | v16           | v18         |
@@ -147,6 +148,7 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 |:---                                                                                           |:---                                                 |:---                   |:---     |
 | [`NgComponentOutlet.ngComponentOutletNgModuleFactory`](api/common/NgComponentOutlet)          | `NgComponentOutlet.ngComponentOutletNgModule`       | v14                   | Use the `ngComponentOutletNgModule` input instead. This input doesn't require resolving NgModule factory. |
 | [`DatePipe` - `DATE_PIPE_DEFAULT_TIMEZONE`](api/common/DATE_PIPE_DEFAULT_TIMEZONE) |`{ provide: DATE_PIPE_DEFAULT_OPTIONS, useValue: { timezone: '-1200' }` | v15                    | Use the `DATE_PIPE_DEFAULT_OPTIONS` injection token, which can configure multiple settings at once instead. |
+| `isPlatformWorkerApp` and `isPlatformWorkerUi` | None  | v16 | These two functions have no purpose since the removal of the webworker platform (they only return `false`). They can be safely removed.
 
 <a id="core"></a>
 

--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -340,10 +340,10 @@ export function isPlatformBrowser(platformId: Object): boolean;
 // @public
 export function isPlatformServer(platformId: Object): boolean;
 
-// @public
+// @public @deprecated
 export function isPlatformWorkerApp(platformId: Object): boolean;
 
-// @public
+// @public @deprecated
 export function isPlatformWorkerUi(platformId: Object): boolean;
 
 // @public

--- a/packages/common/src/platform_id.ts
+++ b/packages/common/src/platform_id.ts
@@ -30,6 +30,8 @@ export function isPlatformServer(platformId: Object): boolean {
 /**
  * Returns whether a platform id represents a web worker app platform.
  * @publicApi
+ * @deprecated This function serves no purpose since the removal of the Webworker platform. It will
+ *     always return `false`.
  */
 export function isPlatformWorkerApp(platformId: Object): boolean {
   return platformId === PLATFORM_WORKER_APP_ID;
@@ -38,6 +40,8 @@ export function isPlatformWorkerApp(platformId: Object): boolean {
 /**
  * Returns whether a platform id represents a web worker UI platform.
  * @publicApi
+ * @deprecated This function serves no purpose since the removal of the Webworker platform. It will
+ *     always return `false`.
  */
 export function isPlatformWorkerUi(platformId: Object): boolean {
   return platformId === PLATFORM_WORKER_UI_ID;


### PR DESCRIPTION
The Web worker platform was removed in v11.
`isPlatformWorkerApp` & `isPlatformWorkerUi` have no purpose since, lets deprecate them!

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No. 

