### PR TITLE
ci: update link to start google presubmit

### DIFF
--- a/.github/workflows/google-internal-tests.yml
+++ b/.github/workflows/google-internal-tests.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: angular/dev-infra/github-actions/google-internal-tests@070bfccea3fc824c834bbf09ac84835889165878
         with:
-          run-tests-guide-url: http://go/angular/g3sync
+          run-tests-guide-url: http://go/angular-g3sync-start
           github-token: ${{ secrets.GITHUB_TOKEN }}
           sync-config: ./.ng-dev/google-sync-config.json


### PR DESCRIPTION
Updates the golink to start a google presubmit, given that documentation has moved.