### PR TITLE
refactor(core): remove webworker related checks on `assertDomNode`

### DIFF
--- a/packages/core/src/util/assert.ts
+++ b/packages/core/src/util/assert.ts
@@ -107,14 +107,10 @@ export function throwError(msg: string, actual?: any, expected?: any, comparison
 }
 
 export function assertDomNode(node: any): asserts node is Node {
-  // If we're in a worker, `Node` will not be defined.
-  if (!(typeof Node !== 'undefined' && node instanceof Node) &&
-      !(typeof node === 'object' && node != null &&
-        node.constructor.name === 'WebWorkerRenderNode')) {
+  if (!(node instanceof Node)) {
     throwError(`The provided value must be an instance of a DOM Node but got ${stringify(node)}`);
   }
 }
-
 
 export function assertIndexInRange(arr: any[], index: number) {
   assertDefined(arr, 'Array must be defined.');
@@ -123,7 +119,6 @@ export function assertIndexInRange(arr: any[], index: number) {
     throwError(`Index expected to be less than ${maxLen} but got ${index}`);
   }
 }
-
 
 export function assertOneOf(value: any, ...validValues: any[]) {
   if (validValues.indexOf(value) !== -1) return true;


### PR DESCRIPTION
Since the drop of the webworker platform the node can't be a `WebWorkerRenderNode`. 

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)