### PR TITLE
fix(platform-server): remove dependency on `@angular/platform-browser-dynamic`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -117,6 +117,7 @@ v16 - v19
 |:---                                 |:---                                                                                                        |:---           |:---               |
 | `@angular/core` | `EnvironmentInjector.runInContext` | v16 | v18 |
 | `@angular/platform-server`          | [`PlatformConfig.baseUrl` and `PlatformConfig.useAbsoluteUrl` config options](api/platform-server/PlatformConfig) | v16           | v18               |
+| `@angular/platform-server`          | [`platformDynamicServer`](api/platform-server/platformDynamicServer) | v16           | v18               |
 | `@angular/platform-browser`         | [`BrowserModule.withServerTransition`](api/platform-browser/BrowserModule#withservertransition)            | v16           | v18         |
 | `@angular/platform-browser`         | [`makeStateKey`, `StateKey` and `TransferState`](#platform-browser), symbols were moved to `@angular/core`                                        | v16           | v18         |
 
@@ -223,6 +224,9 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 |:---                                                              |:---                                                |:---                   |:---     |
 | [`ServerTransferStateModule`](api/platform-server/ServerTransferStateModule) | No replacement needed.  | v14.1                   | The `TransferState` class is available for injection without importing additional modules during server side rendering, when `ServerModule` is imported or `renderApplication` function is used for bootstrap. |
 | [`PlatformConfig.baseUrl` and `PlatformConfig.useAbsoluteUrl` config options](api/platform-server/PlatformConfig) | none                    | v16                   | This was previously unused.                   |
+| [`platformDynamicServer`](api/platform-server/platformDynamicServer) | Import `@angular/compiler` and replace the usage with `platformServer` instead. | v16                   | This is done to decrease the server bundle size for AOT builds.                   |
+
+
 <a id="forms"></a>
 
 ### &commat;angular/forms

--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -33,7 +33,7 @@ export interface PlatformConfig {
     useAbsoluteUrl?: boolean;
 }
 
-// @public
+// @public @deprecated
 export const platformDynamicServer: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;
 
 // @public (undocumented)

--- a/packages/platform-server/BUILD.bazel
+++ b/packages/platform-server/BUILD.bazel
@@ -21,7 +21,6 @@ ng_module(
         "//packages/compiler",
         "//packages/core",
         "//packages/platform-browser",
-        "//packages/platform-browser-dynamic",
         "//packages/platform-browser/animations",
         "//packages/zone.js/lib:zone_d_ts",
         "@npm//@types/node",

--- a/packages/platform-server/package.json
+++ b/packages/platform-server/package.json
@@ -12,8 +12,7 @@
     "@angular/common": "0.0.0-PLACEHOLDER",
     "@angular/compiler": "0.0.0-PLACEHOLDER",
     "@angular/core": "0.0.0-PLACEHOLDER",
-    "@angular/platform-browser": "0.0.0-PLACEHOLDER",
-    "@angular/platform-browser-dynamic": "0.0.0-PLACEHOLDER"
+    "@angular/platform-browser": "0.0.0-PLACEHOLDER"
   },
   "dependencies": {
     "tslib": "^2.3.0",

--- a/packages/platform-server/src/server.ts
+++ b/packages/platform-server/src/server.ts
@@ -10,7 +10,6 @@ import {DOCUMENT, PlatformLocation, ViewportScroller, ɵgetDOM as getDOM, ɵNull
 import {HttpClientModule} from '@angular/common/http';
 import {createPlatformFactory, Injector, NgModule, Optional, PLATFORM_ID, PLATFORM_INITIALIZER, platformCore, PlatformRef, Provider, StaticProvider, Testability, ɵALLOW_MULTIPLE_PLATFORMS as ALLOW_MULTIPLE_PLATFORMS, ɵsetDocument, ɵTESTABILITY as TESTABILITY} from '@angular/core';
 import {BrowserModule, EVENT_MANAGER_PLUGINS} from '@angular/platform-browser';
-import {ɵplatformCoreDynamic as platformCoreDynamic} from '@angular/platform-browser-dynamic';
 import {NoopAnimationsModule} from '@angular/platform-browser/animations';
 
 import {DominoAdapter, parseDocument} from './domino_adapter';
@@ -89,7 +88,9 @@ export const platformServer: (extraProviders?: StaticProvider[]|undefined) => Pl
 /**
  * The server platform that supports the runtime compiler.
  *
+ * @see `platformServer`
+ * @deprecated add an `import @angular/compiler` and replace the usage with `platformServer`
+ *     instead.
  * @publicApi
  */
-export const platformDynamicServer =
-    createPlatformFactory(platformCoreDynamic, 'serverDynamic', INTERNAL_SERVER_PLATFORM_PROVIDERS);
+export const platformDynamicServer = platformServer;

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -10,7 +10,7 @@ import {ApplicationRef, InjectionToken, PlatformRef, Provider, Renderer2, Static
 import {first} from 'rxjs/operators';
 
 import {PlatformState} from './platform_state';
-import {platformDynamicServer, platformServer} from './server';
+import {platformServer} from './server';
 import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG} from './tokens';
 
 interface PlatformOptions {
@@ -25,9 +25,7 @@ interface PlatformOptions {
  */
 function createServerPlatform(options: PlatformOptions): PlatformRef {
   const extraProviders = options.platformProviders ?? [];
-  const platformFactory =
-      (typeof ngJitMode === 'undefined' || ngJitMode) ? platformDynamicServer : platformServer;
-  return platformFactory([
+  return platformServer([
     {provide: INITIAL_CONFIG, useValue: {document: options.document, url: options.url}},
     extraProviders
   ]);

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import '@angular/compiler';
 
 import {animate, AnimationBuilder, state, style, transition, trigger} from '@angular/animations';
 import {DOCUMENT, isPlatformServer, PlatformLocation, ɵgetDOM as getDOM} from '@angular/common';
@@ -14,7 +15,7 @@ import {ApplicationConfig, ApplicationRef, Component, destroyPlatform, Environme
 import {InitialRenderPendingTasks} from '@angular/core/src/initial_render_pending_tasks';
 import {TestBed} from '@angular/core/testing';
 import {bootstrapApplication, BrowserModule, provideClientHydration, Title, withNoDomReuse, withNoHttpTransferCache} from '@angular/platform-browser';
-import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformDynamicServer, PlatformState, provideServerRendering, renderModule, ServerModule} from '@angular/platform-server';
+import {BEFORE_APP_SERIALIZED, INITIAL_CONFIG, platformServer, PlatformState, provideServerRendering, renderModule, ServerModule} from '@angular/platform-server';
 import {provideRouter, RouterOutlet, Routes} from '@angular/router';
 import {Observable} from 'rxjs';
 import {first} from 'rxjs/operators';
@@ -536,7 +537,7 @@ describe('platform-server integration', () => {
 
   it('should bootstrap', async () => {
     const platform =
-        platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+        platformServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
 
     const moduleRef = await platform.bootstrapModule(ExampleModule);
     expect(isPlatformServer(moduleRef.injector.get(PLATFORM_ID))).toBe(true);
@@ -552,10 +553,10 @@ describe('platform-server integration', () => {
 
   it('should allow multiple platform instances', async () => {
     const platform =
-        platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+        platformServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
 
     const platform2 =
-        platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+        platformServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
 
 
     await platform.bootstrapModule(ExampleModule).then((moduleRef) => {
@@ -572,7 +573,7 @@ describe('platform-server integration', () => {
   });
 
   it('adds title to the document using Title service', async () => {
-    const platform = platformDynamicServer([{
+    const platform = platformServer([{
       provide: INITIAL_CONFIG,
       useValue: {document: '<html><head><title></title></head><body><app></app></body></html>'}
     }]);
@@ -586,7 +587,7 @@ describe('platform-server integration', () => {
   });
 
   it('should get base href from document', async () => {
-    const platform = platformDynamicServer([{
+    const platform = platformServer([{
       provide: INITIAL_CONFIG,
       useValue: {document: '<html><head><base href="/"></head><body><app></app></body></html>'}
     }]);
@@ -597,7 +598,7 @@ describe('platform-server integration', () => {
   });
 
   it('adds styles with ng-app-id attribute', async () => {
-    const platform = platformDynamicServer([{
+    const platform = platformServer([{
       provide: INITIAL_CONFIG,
       useValue: {document: '<html><head></head><body><app></app></body></html>'}
     }]);
@@ -612,7 +613,7 @@ describe('platform-server integration', () => {
 
   it('copies known properties to attributes', async () => {
     const platform =
-        platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+        platformServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
     const ref = await platform.bootstrapModule(ImageExampleModule);
     const appRef: ApplicationRef = ref.injector.get(ApplicationRef);
     const app = appRef.components[0].location.nativeElement;
@@ -623,14 +624,14 @@ describe('platform-server integration', () => {
   describe('PlatformLocation', () => {
     it('is injectable', async () => {
       const platform =
-          platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+          platformServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
       const appRef = await platform.bootstrapModule(ExampleModule);
       const location = appRef.injector.get(PlatformLocation);
       expect(location.pathname).toBe('/');
       platform.destroy();
     });
     it('is configurable via INITIAL_CONFIG', async () => {
-      const platform = platformDynamicServer([{
+      const platform = platformServer([{
         provide: INITIAL_CONFIG,
         useValue: {document: '<app></app>', url: 'http://test.com/deep/path?query#hash'}
       }]);
@@ -644,7 +645,7 @@ describe('platform-server integration', () => {
     });
 
     it('parses component pieces of a URL', async () => {
-      const platform = platformDynamicServer([{
+      const platform = platformServer([{
         provide: INITIAL_CONFIG,
         useValue: {document: '<app></app>', url: 'http://test.com:80/deep/path?query#hash'}
       }]);
@@ -661,7 +662,7 @@ describe('platform-server integration', () => {
     });
 
     it('handles empty search and hash portions of the url', async () => {
-      const platform = platformDynamicServer([{
+      const platform = platformServer([{
         provide: INITIAL_CONFIG,
         useValue: {document: '<app></app>', url: 'http://test.com/deep/path'}
       }]);
@@ -676,7 +677,7 @@ describe('platform-server integration', () => {
 
     it('pushState causes the URL to update', async () => {
       const platform =
-          platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+          platformServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
 
       const appRef = await platform.bootstrapModule(ExampleModule);
       const location = appRef.injector.get(PlatformLocation);
@@ -688,7 +689,7 @@ describe('platform-server integration', () => {
 
     it('allows subscription to the hash state', done => {
       const platform =
-          platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+          platformServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
       platform.bootstrapModule(ExampleModule).then(appRef => {
         const location: PlatformLocation = appRef.injector.get(PlatformLocation);
         expect(location.pathname).toBe('/');
@@ -715,8 +716,7 @@ describe('platform-server integration', () => {
     });
 
     it('using long form should work', async () => {
-      const platform =
-          platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: doc}}]);
+      const platform = platformServer([{provide: INITIAL_CONFIG, useValue: {document: doc}}]);
 
       const moduleRef = await platform.bootstrapModule(AsyncServerModule);
       const applicationRef = moduleRef.injector.get(ApplicationRef);
@@ -1118,14 +1118,14 @@ describe('platform-server integration', () => {
   describe('HttpClient', () => {
     it('can inject HttpClient', async () => {
       const platform =
-          platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+          platformServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
       const ref = await platform.bootstrapModule(HttpClientExampleModule);
       expect(ref.injector.get(HttpClient) instanceof HttpClient).toBeTruthy();
     });
 
     it('can make HttpClient requests', async () => {
       const platform =
-          platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+          platformServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
       await platform.bootstrapModule(HttpClientExampleModule).then(ref => {
         const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
         const http = ref.injector.get(HttpClient);
@@ -1141,7 +1141,7 @@ describe('platform-server integration', () => {
 
     it('can use HttpInterceptor that injects HttpClient', async () => {
       const platform =
-          platformDynamicServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
+          platformServer([{provide: INITIAL_CONFIG, useValue: {document: '<app></app>'}}]);
       await platform.bootstrapModule(HttpInterceptorExampleModule).then(ref => {
         const mock = ref.injector.get(HttpTestingController) as HttpTestingController;
         const http = ref.injector.get(HttpClient);


### PR DESCRIPTION


Using `@angular/platform-browser-dynamic` is no longer required for JIT scenarios with Ivy. Instead `@angular/compiler` should be imported instead.

This change is part of the effort to reduce the server bundles sizes, which is needed to support cloud workers.

BREAKING CHANGE:
Users that are using SSR with JIT mode will now need to add  `import to @angular/compiler` before bootstrapping the application.

**NOTE:** this does not effect users using the Angular CLI.