### PR TITLE
refactor(core): finalize rxjs-interop options & docs

### DIFF
--- a/goldens/public-api/core/rxjs-interop/index.md
+++ b/goldens/public-api/core/rxjs-interop/index.md
@@ -25,15 +25,28 @@ export interface ToObservableOptions {
 export function toSignal<T>(source: Observable<T>): Signal<T | undefined>;
 
 // @public
-export function toSignal<T, U extends T | null | undefined>(source: Observable<T>, options: {
+export function toSignal<T>(source: Observable<T>, options?: ToSignalOptions<undefined> & {
+    requireSync?: false;
+}): Signal<T | undefined>;
+
+// @public
+export function toSignal<T, U extends T | null | undefined>(source: Observable<T>, options: ToSignalOptions<U> & {
     initialValue: U;
     requireSync?: false;
 }): Signal<T | U>;
 
-// @public (undocumented)
-export function toSignal<T>(source: Observable<T>, options: {
+// @public
+export function toSignal<T>(source: Observable<T>, options: ToSignalOptions<undefined> & {
     requireSync: true;
 }): Signal<T>;
+
+// @public
+export interface ToSignalOptions<T> {
+    initialValue?: T;
+    injector?: Injector;
+    manualCleanup?: boolean;
+    requireSync?: boolean;
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/core/rxjs-interop/src/index.ts
+++ b/packages/core/rxjs-interop/src/index.ts
@@ -8,4 +8,4 @@
 
 export {takeUntilDestroyed} from './take_until_destroyed';
 export {toObservable, ToObservableOptions} from './to_observable';
-export {toSignal} from './to_signal';
+export {toSignal, ToSignalOptions} from './to_signal';

--- a/packages/core/rxjs-interop/src/to_observable.ts
+++ b/packages/core/rxjs-interop/src/to_observable.ts
@@ -16,7 +16,7 @@ import {Observable, ReplaySubject} from 'rxjs';
  */
 export interface ToObservableOptions {
   /**
-   * The `Injector` to use when creating the effect.
+   * The `Injector` to use when creating the underlying `effect` which watches the signal.
    *
    * If this isn't specified, the current injection context will be used.
    */
@@ -28,7 +28,7 @@ export interface ToObservableOptions {
  *
  * The signal's value will be propagated into the `Observable`'s subscribers using an `effect`.
  *
- * `toObservable` must be called in an injection context.
+ * `toObservable` must be called in an injection context unless an injector is provided via options.
  *
  * @developerPreview
  */


### PR DESCRIPTION
This commit introduces an interface for `toSignal` options to mirror that of `toObservable`, and adjusts docs for both symbols. It also adds the ability for `toSignal` to manually specify `DestroyRef` (similarly to `toObservable` accepting an injector) or for `toSignal` automatic cleanup to be disabled (in which case the subscription persists until the Observable completes). Either option allows `toSignal` to be used outside of a DI context, like `toObservable`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
