### PR TITLE
refactor(core): minor updates to TestBed error messages

### DIFF
--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -465,7 +465,7 @@ export class TestBedImpl implements TestBed {
 
   configureCompiler(config: {providers?: any[]; useJit?: boolean;}): this {
     if (config.useJit != null) {
-      throw new Error('the Render3 compiler JiT mode is not configurable !');
+      throw new Error('JIT compiler is not configurable via TestBed APIs.');
     }
 
     if (config.providers !== undefined) {
@@ -475,7 +475,7 @@ export class TestBedImpl implements TestBed {
   }
 
   configureTestingModule(moduleDef: TestModuleMetadata): this {
-    this.assertNotInstantiated('R3TestBed.configureTestingModule', 'configure the test module');
+    this.assertNotInstantiated('TestBed.configureTestingModule', 'configure the test module');
 
     // Trigger module scoping queue flush before executing other TestBed operations in a test.
     // This is needed for the first test invocation to ensure that globally declared modules have
@@ -555,7 +555,7 @@ export class TestBedImpl implements TestBed {
 
   overrideTemplateUsingTestingModule(component: Type<any>, template: string): this {
     this.assertNotInstantiated(
-        'R3TestBed.overrideTemplateUsingTestingModule',
+        'TestBed.overrideTemplateUsingTestingModule',
         'Cannot override template when the test module has already been instantiated');
     this.compiler.overrideTemplateUsingTestingModule(component, template);
     return this;


### PR DESCRIPTION
This commit updates TestBed error messages to avoid using `R3TestBed` reference and just use `TestBed` instead.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No