### PR TITLE
docs-infra: hide `Debugging the error` section.

### DIFF
--- a/aio/tools/transforms/templates/error/error.template.html
+++ b/aio/tools/transforms/templates/error/error.template.html
@@ -24,11 +24,13 @@
     {$ doc.description | marked $}
   </div>
 
+
+  {% if doc.debugging %}
   <br>
 
   <div class="debugging">
     <h2>Debugging the error</h2>
     {$ doc.debugging | marked $}
   </div>
-
+  {% endif%}
 </div>


### PR DESCRIPTION
On the error template, hide `Debugging the error` when there is none provided in the markdown file.

For example : https://next.angular.io/errors/NG5000

## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes