### PR TITLE
docs: clarify usage of --help flag in CLI docs

### DIFF
--- a/aio/content/cli/index.md
+++ b/aio/content/cli/index.md
@@ -29,6 +29,14 @@ ng generate --help
 
 </code-example>
 
+<div class="alert is-helpful">
+
+**NOTE**: <br />
+The `--help` flag is only available when running the Angular CLI inside a [workspace](guide/setup-local).
+Using the `--help` flag outside a workspace (as described above) is expected to result in an error. 
+
+</div>
+
 To create, build, and serve a new, basic Angular project on a development server, go to the parent directory of your new workspace use the following commands:
 
 <code-example format="shell" language="shell">


### PR DESCRIPTION
This may prevent confusion once people try to run the `ng generate --help` command & get an error (as described [in this issue](https://github.com/angular/angular/issues/50078))

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [25107 in angular cli](https://github.com/angular/angular/issues/50078)


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
