### PR TITLE
docs: fix non-relative links.

### DIFF
--- a/aio/content/guide/angular-package-format.md
+++ b/aio/content/guide/angular-package-format.md
@@ -324,7 +324,7 @@ If those symbols are not imported and used, it's often desirable to remove them 
 Build tools such as Webpack support a flag which allows packages to declare that they do not depend on side-effectful code at the top level of their modules, giving the tools more freedom to tree-shake code from the package.
 The end result of these optimizations should be smaller bundle size and better code distribution in bundle chunks after code-splitting.
 This optimization can break your code if it contains non-local side-effects - this is however not common in Angular applications and it's usually a sign of bad design.
-The recommendation is for all packages to claim the side-effect free status by setting the `sideEffects` property to `false`, and that developers follow the [Angular Style Guide](https://angular.io/guide/styleguide) which naturally results in code without non-local side-effects.
+The recommendation is for all packages to claim the side-effect free status by setting the `sideEffects` property to `false`, and that developers follow the [Angular Style Guide](/guide/styleguide) which naturally results in code without non-local side-effects.
 
 More info: [webpack docs on side effects](https://github.com/webpack/webpack/tree/master/examples/side-effects)
 

--- a/aio/content/guide/change-detection-skipping-subtrees.md
+++ b/aio/content/guide/change-detection-skipping-subtrees.md
@@ -4,7 +4,7 @@ JavaScript, by default, uses mutable data structures that you can reference from
 
 Change detection is sufficiently fast for most applications. However, when an application has an especially large component tree, running change detection across the whole application can cause performance issues. You can address this by configuring change detection to only run on a subset of the component tree.
 
-If you are confident that a part of the application is not affected by a state change, you can use [OnPush](https://angular.io/api/core/ChangeDetectionStrategy) to skip change detection in an entire component subtree.
+If you are confident that a part of the application is not affected by a state change, you can use [OnPush](/api/core/ChangeDetectionStrategy) to skip change detection in an entire component subtree.
 
 
 ## Using `OnPush`

--- a/aio/content/guide/change-detection-slow-computations.md
+++ b/aio/content/guide/change-detection-slow-computations.md
@@ -22,7 +22,7 @@ For example, in the preceding screenshot, the second recorded change detection c
 Here are several techniques to remove slow computations:
 
 * **Optimizing the underlying algorithm**. This is the recommended approach. If you can speed up the algorithm that is causing the problem, you can speed up the entire change detection mechanism.
-* **Caching using pure pipes**. You can move the heavy computation to a pure [pipe](https://angular.io/guide/pipes). Angular reevaluates a pure pipe only if it detects that its inputs have changed, compared to the previous time Angular called it.
+* **Caching using pure pipes**. You can move the heavy computation to a pure [pipe](/guide/pipes). Angular reevaluates a pure pipe only if it detects that its inputs have changed, compared to the previous time Angular called it.
 * **Using memoization**. [Memoization](https://en.wikipedia.org/wiki/Memoization) is a similar technique to pure pipes, with the difference that pure pipes preserve only the last result from the computation where memoization could store multiple results.
 * **Avoid repaints/reflows in lifecycle hooks**. Certain [operations](https://web.dev/avoid-large-complex-layouts-and-layout-thrashing/) cause the browser to either synchronously recalculate the layout of the page or re-render it. Since reflows and repaints are generally slow, you want to avoid performing them in every change detection cycle.
 

--- a/aio/content/guide/change-detection-zone-pollution.md
+++ b/aio/content/guide/change-detection-zone-pollution.md
@@ -21,7 +21,7 @@ In the image above, there is a series of change detection calls triggered by eve
 
 ## Run tasks outside `NgZone`
 
-In such cases, you can instruct Angular to avoid calling change detection for tasks scheduled by a given piece of code using [NgZone](https://angular.io/guide/zone).
+In such cases, you can instruct Angular to avoid calling change detection for tasks scheduled by a given piece of code using [NgZone](/guide/zone).
 
 ```ts
 import { Component, NgZone, OnInit } from '@angular/core';

--- a/aio/content/guide/class-binding.md
+++ b/aio/content/guide/class-binding.md
@@ -100,7 +100,7 @@ A single HTML element can have its CSS class list and style values bound to mult
 
 ## What’s next
 
-* [Component styles](https://angular.io/guide/component-styles)
-* [Introduction to Angular animations](https://angular.io/guide/animations)
+* [Component styles](/guide/component-styles)
+* [Introduction to Angular animations](/guide/animations)
 
 @reviewed 2022-05-09

--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -645,8 +645,8 @@ Projects that currently have `fullTemplateTypeCheck: true` configured can migrat
 
 ## JIT API changes due to ViewEngine deprecation
 
-In ViewEngine, [JIT compilation](https://angular.io/guide/glossary#jit) required special providers \(such as `Compiler` or `CompilerFactory`\) to be injected in the app and corresponding methods to be invoked.
-With Ivy, JIT compilation takes place implicitly if the Component, NgModule, etc. have not already been [AOT compiled](https://angular.io/guide/glossary#aot).
+In ViewEngine, [JIT compilation](/guide/glossary#jit) required special providers \(such as `Compiler` or `CompilerFactory`\) to be injected in the app and corresponding methods to be invoked.
+With Ivy, JIT compilation takes place implicitly if the Component, NgModule, etc. have not already been [AOT compiled](/guide/glossary#aot).
 Those special providers were made available in Ivy for backwards-compatibility with ViewEngine to make the transition to Ivy smoother.
 Since ViewEngine is deprecated and will soon be removed, those symbols are now deprecated as well.
 

--- a/aio/content/guide/docs-lint-errors.md
+++ b/aio/content/guide/docs-lint-errors.md
@@ -316,7 +316,7 @@ When necessary, you can apply these exceptions to your content.
 
 <!-- links -->
 
-[AioGuideDocsStyleGuide]: https://angular.io/guide/docs-style-guide "Angular documentation style guide | Angular"
+[AioGuideDocsStyleGuide]: /guide/docs-style-guide "Angular documentation style guide | Angular"
 
 <!-- external links -->
 

--- a/aio/content/guide/hydration.md
+++ b/aio/content/guide/hydration.md
@@ -2,7 +2,7 @@
 
 <div class="alert is-important">
 
-The hydration feature is available for [developer preview](https://angular.io/guide/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
+The hydration feature is available for [developer preview](/guide/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
 
 </div>
 
@@ -20,7 +20,7 @@ Without hydration enabled, server side rendered Angular applications will destro
 
 ## How do you enable hydration in Angular
 
-Before you can get started with hydration, you must have a server side rendered (SSR) application. Follow the [Angular Universal Guide](https://angular.io/guide/universal) to enable server side rendering first. Once you have SSR working with your application, you can enable hydration by visiting your main app component or module and importing `provideClientHydration` from `@angular/platform-browser`. You'll then add that provider to your app's bootstrapping providers list.
+Before you can get started with hydration, you must have a server side rendered (SSR) application. Follow the [Angular Universal Guide](/guide/universal) to enable server side rendering first. Once you have SSR working with your application, you can enable hydration by visiting your main app component or module and importing `provideClientHydration` from `@angular/platform-browser`. You'll then add that provider to your app's bootstrapping providers list.
 
 ```typescript
 import {

--- a/aio/content/guide/roadmap.md
+++ b/aio/content/guide/roadmap.md
@@ -61,7 +61,7 @@ We're working on updating the Angular getting started experience with standalone
 
 ### Improvements in the image directive
 
-We released the Angular [image directive](https://developer.chrome.com/blog/angular-image-directive/) as stable in v15. We introduced a new fill mode feature that enables images to fit within their parent container rather than having explicit dimensions. Currently, this feature is in [developer preview](https://angular.io/guide/releases#developer-preview). Next we'll be working on collecting feedback from developers before we promote fill mode as stable.
+We released the Angular [image directive](https://developer.chrome.com/blog/angular-image-directive/) as stable in v15. We introduced a new fill mode feature that enables images to fit within their parent container rather than having explicit dimensions. Currently, this feature is in [developer preview](/guide/releases#developer-preview). Next we'll be working on collecting feedback from developers before we promote fill mode as stable.
 
 ## Future
 
@@ -144,7 +144,7 @@ Using MDC Web aligns Angular Material more closely with the Material Design spec
 
 *Completed Q4 2022*
 
-In the process of making Angular simpler, we are working on [introducing APIs](https://angular.io/guide/standalone-components) that allow developers to initialize applications, instantiate components, and use the router without NgModules. Angular v14 introduces developer preview of the APIs for standalone components, directives, and pipes. In the next few quarters we'll collect feedback from developers and finalize the project making the APIs stable. As the next step we will work on improving use cases such as `TestBed`, Angular elements, etc.
+In the process of making Angular simpler, we are working on [introducing APIs](/guide/standalone-components) that allow developers to initialize applications, instantiate components, and use the router without NgModules. Angular v14 introduces developer preview of the APIs for standalone components, directives, and pipes. In the next few quarters we'll collect feedback from developers and finalize the project making the APIs stable. As the next step we will work on improving use cases such as `TestBed`, Angular elements, etc.
 
 ### Allow binding to protected fields in templates
 

--- a/aio/content/guide/standalone-components.md
+++ b/aio/content/guide/standalone-components.md
@@ -261,7 +261,7 @@ Angular applications can configure dependency injection by specifying a set of a
 
 #### Environment injectors
 
-Making `NgModule`s optional will require new ways of configuring "module" injectors with application-wide providers (for example, [HttpClient](https://angular.io/api/common/http/HttpClient)). In the standalone application (one created with `bootstrapApplication`), “module” providers can be configured during the bootstrap process, in the `providers` option: 
+Making `NgModule`s optional will require new ways of configuring "module" injectors with application-wide providers (for example, [HttpClient](/api/common/http/HttpClient)). In the standalone application (one created with `bootstrapApplication`), “module” providers can be configured during the bootstrap process, in the `providers` option: 
 
 ```ts
 bootstrapApplication(PhotoAppComponent, {

--- a/aio/content/guide/template-reference-variables.md
+++ b/aio/content/guide/template-reference-variables.md
@@ -97,7 +97,7 @@ Here, `ref2` is declared in the child scope created by `*ngIf`, and is not acces
 {@a template-input-variables}
 ## Template input variable
 
-A _template input variable_ is a variable with a value that is set when an instance of that template is created. See: [Writing structural directives](https://angular.io/guide/structural-directives)
+A _template input variable_ is a variable with a value that is set when an instance of that template is created. See: [Writing structural directives](/guide/structural-directives)
 
 Template input variables can be seen in action in the long-form usage of `NgFor`:
 
@@ -125,6 +125,6 @@ When an `<ng-template>` is instantiated, multiple named values can be passed whi
 
 ## What’s next
 
-[Writing structural directives](https://angular.io/guide/structural-directives)
+[Writing structural directives](/guide/structural-directives)
 
 @reviewed 2022-05-12

--- a/aio/content/guide/universal.md
+++ b/aio/content/guide/universal.md
@@ -102,7 +102,7 @@ The command updates the application code to enable SSR and adds extra files to t
 
 <div class="alert is-important">
 
-The hydration feature is available for [developer preview](https://angular.io/guide/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
+The hydration feature is available for [developer preview](/guide/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
 
 </div>
 


### PR DESCRIPTION
Relative links have 2 advantages :
* They're not marked as external links
* When on a specific doc version, the link point to the same version.



## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes