### PR TITLE
feat(platform-browser): `EventManagerPlugin` to support passive event listeners

### DIFF
--- a/packages/platform-browser/src/dom/events/passive_events.ts
+++ b/packages/platform-browser/src/dom/events/passive_events.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {DOCUMENT} from '@angular/common';
+import {inject, Injectable} from '@angular/core';
+
+import {EventManagerPlugin} from './event_manager';
+
+/**
+ * @publicApi
+ * A browser plug-in that provides support for handling of passive event listeners in Angular.
+ */
+@Injectable()
+export class PassiveListenersPlugin extends EventManagerPlugin {
+  /**
+   * Initializes an instance of the browser plug-in.
+   * @param doc The document in which the events will be detected.
+   */
+  constructor() {
+    super(inject(DOCUMENT));
+  }
+
+  /**
+   * Reports whether a named event is supported.
+   * @param eventName The event name to query.
+   * @return True if the named event is supported.
+   */
+  override supports(eventName: string): boolean {
+    return eventName.endsWith('.passive');
+  }
+
+  override addEventListener(
+      element: HTMLElement, eventName: string, handler: (event: Event) => void): Function {
+    // striping the passive modifier from the event name;
+    const nonModifiedEventName = eventName.replace(/\.passive$/, '');
+
+    element.addEventListener(nonModifiedEventName, handler as EventListener, {passive: true});
+    return () => element.removeEventListener(eventName, handler as EventListener);
+  }
+}


### PR DESCRIPTION
I propose this `EventManagerPlugin` to support passive event listeners. 
Note: The solution [proposed here](https://angular.io/guide/event-binding#binding-to-passive-events) is global)

I choose to not enable it by default and propose that its activation is opt-in. So `BROWSER_MODULE_PROVIDERS` stays unchanged. 

If this PR moves forward, I'll provide the doc updates. 

Usage : use `(scroll.passive)` as event binding.

Fixes #8866

## PR Type
What kind of change does this PR introduce?


- [x] Feature

## Does this PR introduce a breaking change?

- [x] No