### PR TITLE
docs(docs-infra): fix the search-results label color on the dark theme.

### DIFF
--- a/aio/src/styles/2-modules/search-results/_search-results-theme.scss
+++ b/aio/src/styles/2-modules/search-results/_search-results-theme.scss
@@ -12,7 +12,7 @@
       background-color: constants.$darkgray;
       box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.3);
 
-      $item-color: if($is-dark-theme, constants.$offwhite, constants.$lightgray);
+      $item-color: if($is-dark-theme, constants.$lightgray, constants.$offwhite);
 
       .search-area {
         .search-section-header {
@@ -47,7 +47,7 @@
       .search-results {
         .search-area {
           .search-section-header {
-            color: constants.$darkgray;
+            color: if($is-dark-theme, constants.$offwhite, constants.$darkgray);
           }
 
           .search-result-item {


### PR DESCRIPTION
Theme color switching wasn't handled.

Before : 
![Screenshot 2023-04-30 at 00 21 55](https://user-images.githubusercontent.com/1300985/235326555-45e718e1-9d50-4170-9ad4-de53f373dbf2.png)

After:
![Screenshot 2023-04-30 at 00 21 39](https://user-images.githubusercontent.com/1300985/235326560-05a12c92-2473-4765-a768-ab04e904d437.png)