### PR TITLE
refactor(compiler): reflect arrow function definition

### DIFF
--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -413,6 +413,11 @@ export interface FunctionDefinition {
    * Metadata regarding the function's parameters, including possible default value expressions.
    */
   parameters: Parameter[];
+
+  /**
+   * Generic type parameters of the function.
+   */
+  typeParameters: ts.TypeParameterDeclaration[]|null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -396,7 +396,8 @@ export interface FunctionDefinition {
   /**
    * A reference to the node which declares the function.
    */
-  node: ts.MethodDeclaration|ts.FunctionDeclaration|ts.FunctionExpression|ts.VariableDeclaration;
+  node: ts.MethodDeclaration|ts.FunctionDeclaration|ts.FunctionExpression|ts.VariableDeclaration|
+      ts.ArrowFunction;
 
   /**
    * Statements of the function body, if a body is present, or null if no body is present or the
@@ -432,6 +433,11 @@ export interface Parameter {
    * Expression which represents the default value of the parameter, if any.
    */
   initializer: ts.Expression|null;
+
+  /**
+   * Type of the parameter.
+   */
+  type: ts.TypeNode|null;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -164,16 +164,25 @@ export class TypeScriptReflectionHost implements ReflectionHost {
 
   getDefinitionOfFunction(node: ts.Node): FunctionDefinition|null {
     if (!ts.isFunctionDeclaration(node) && !ts.isMethodDeclaration(node) &&
-        !ts.isFunctionExpression(node)) {
+        !ts.isFunctionExpression(node) && !ts.isArrowFunction(node)) {
       return null;
     }
+
+    let body: ts.Statement[]|null = null;
+
+    if (node.body !== undefined) {
+      // The body might be an expression if the node is an arrow function.
+      body = ts.isBlock(node.body) ? Array.from(node.body.statements) :
+                                     [ts.factory.createReturnStatement(node.body)];
+    }
+
     return {
       node,
-      body: node.body !== undefined ? Array.from(node.body.statements) : null,
+      body,
       parameters: node.parameters.map(param => {
         const name = parameterName(param.name);
         const initializer = param.initializer || null;
-        return {name, node: param, initializer};
+        return {name, node: param, initializer, type: param.type || null};
       }),
     };
   }

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -179,6 +179,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return {
       node,
       body,
+      typeParameters: node.typeParameters === undefined ? null : Array.from(node.typeParameters),
       parameters: node.parameters.map(param => {
         const name = parameterName(param.name);
         const initializer = param.initializer || null;


### PR DESCRIPTION
Adds some logic to reflect an arrow function to `ReflectionHost.getDefinitionOfFunction`. This will be useful for some upcoming work.