### PR TITLE
perf(service-worker): fetch assets in parallel

### DIFF
--- a/packages/service-worker/worker/src/app-version.ts
+++ b/packages/service-worker/worker/src/app-version.ts
@@ -113,23 +113,15 @@ export class AppVersion implements UpdateSource {
 
   /**
    * Fully initialize this version of the application. If this Promise resolves successfully, all
-   * required
-   * data has been safely downloaded.
+   * required data has been safely downloaded.
    */
   async initializeFully(updateFrom?: UpdateSource): Promise<void> {
     try {
-      // Fully initialize each asset group, in series. Starts with an empty Promise,
-      // and waits for the previous groups to have been initialized before initializing
-      // the next one in turn.
-      await this.assetGroups.reduce<Promise<void>>(async (previous, group) => {
-        // Wait for the previous groups to complete initialization. If there is a
-        // failure, this will throw, and each subsequent group will throw, until the
-        // whole sequence fails.
-        await previous;
-
+      // Fully initialize each asset group, in parallel.
+      await Promise.all(this.assetGroups.map((group) => {
         // Initialize this group.
         return group.initializeFully(updateFrom);
-      }, Promise.resolve());
+      }));
     } catch (err) {
       this._okay = false;
       throw err;


### PR DESCRIPTION
Resources defined in assets groups are fetched in parallel to improve performance

Fixes #39491

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [x] Other: performance improvement


## What is the current behavior?
Currently, the service worker prefetches assets sequentially which can take several minutes for some medium/large apps.

Issue Number: #39491


## What is the new behavior?
Service worker prefetches assets in parallel which will improve download duration.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No



## Other information
I've used this new service worker implementation in a small application and was able to update to a new version successfully.