### PR TITLE
docs: clarify imports in getting started tutorial

### DIFF
--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -219,7 +219,7 @@ This section walks you through creating a child component, `ProductAlertsCompone
     *   The template and style filenames reference the component's HTML and CSS
     *   The `@Component()` definition also exports the class, `ProductAlertsComponent`, which handles functionality for the component
 
-1.  To set up `ProductAlertsComponent` to receive product data, first import `Input` from `@angular/core`.
+1.  To set up `ProductAlertsComponent` to receive product data, first import `Input` from `@angular/core` and `Products` from `../products`.
 
     <code-example header="src/app/product-alerts/product-alerts.component.ts" path="getting-started/src/app/product-alerts/product-alerts.component.1.ts" region="imports"></code-example>
 


### PR DESCRIPTION
I added an instruction to import the Product interface as well, since it isn't present in the pre-defined project. But it's needed to complete the task.
And it's actually used in the code - just not mentioned in the text before (while the import of `Input` is described).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
- incomplete description of tutorial step


## What is the new behavior?
- complete description of step


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
