### PR TITLE
docs: add missing navigation item

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -1058,6 +1058,11 @@
                   "tooltip": "About Components, Templates, and Views."
                 },
                 {
+                  "url": "guide/architecture-services",
+                  "title": "Intro to services and DI",
+                  "tooltip": "About services and dependency injection."
+                },
+                {
                   "url": "guide/architecture-next-steps",
                   "title": "Next steps",
                   "tooltip": "Beyond the basics."


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## What is the current behavior?

The docs show no navigation sidebar when you open https://angular.io/guide/architecture-services.
This is because there is no navigation item to show the page in the navigation.

## What is the new behavior?

There is a new navigation item "Intro to services and DI". Now all children of "Angular concepts" are shown in the navigation.

![image](https://user-images.githubusercontent.com/2143782/235851303-a3f3aa6f-30d9-4be0-a84a-141244cb1ce0.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

