### PR TITLE
docs(forms): warn the user about getting old values and show how to a…

### DIFF
--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -585,10 +585,12 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   /**
    * A multicasting observable that emits an event every time the value of the control changes, in
    * the UI or programmatically. It also emits an event each time you call enable() or disable()
-   * without passing along {emitEvent: false} as a function argument. When accessing a value, 
-   * the emit happens when a value of a given control changes. Parent controls are updated after
-   * that, so if you try to access parent control value from the valueChanges or stateChanges 
-   * callback you may recieve an old value..
+   * without passing along {emitEvent: false} as a function argument.
+   * 
+   * **Note**: the emit happens right after a value of this control is updated. The value of a parent control
+   * (for example if this FormControl is a part of a FormGroup) is updated after that, so accessing a value of
+   * a parent control (using the `value` property) from the callback of this event might result in getting a
+   * value that has not been updated yet. Subscribe to the `valueChanges` event of the parent control instead.
    */
   public readonly valueChanges!: Observable<TValue>;
 

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -586,11 +586,12 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * A multicasting observable that emits an event every time the value of the control changes, in
    * the UI or programmatically. It also emits an event each time you call enable() or disable()
    * without passing along {emitEvent: false} as a function argument.
-   * 
-   * **Note**: the emit happens right after a value of this control is updated. The value of a parent control
-   * (for example if this FormControl is a part of a FormGroup) is updated after that, so accessing a value of
-   * a parent control (using the `value` property) from the callback of this event might result in getting a
-   * value that has not been updated yet. Subscribe to the `valueChanges` event of the parent control instead.
+   *
+   * **Note**: the emit happens right after a value of this control is updated. The value of a
+   * parent control (for example if this FormControl is a part of a FormGroup) is updated later, so
+   * accessing a value of a parent control (using the `value` property) from the callback of this
+   * event might result in getting a value that has not been updated yet. Subscribe to the
+   * `valueChanges` event of the parent control instead.
    */
   public readonly valueChanges!: Observable<TValue>;
 

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -585,7 +585,10 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
   /**
    * A multicasting observable that emits an event every time the value of the control changes, in
    * the UI or programmatically. It also emits an event each time you call enable() or disable()
-   * without passing along {emitEvent: false} as a function argument.
+   * without passing along {emitEvent: false} as a function argument. When accessing a value, 
+   * the emit happens when a value of a given control changes. Parent controls are updated after
+   * that, so if you try to access parent control value from the valueChanges or stateChanges 
+   * callback you may recieve an old value..
    */
   public readonly valueChanges!: Observable<TValue>;
 


### PR DESCRIPTION
I had to reopen #50065 because of a branch issue. The issue text is below:

This edit addresses issue #49898

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is no warning about trying to access the value of a form control using FormGroup.FormControl.value. Doing this can result in getting old values.
Issue Number: #49898


## What is the new behavior?
Advises the user to use FormGroup.controls.FormControl.value.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No