### PR TITLE
docs: fix `takeUntilDestroyed` description's typo

### DIFF
--- a/aio/content/guide/lifecycle-hooks.md
+++ b/aio/content/guide/lifecycle-hooks.md
@@ -130,7 +130,7 @@ Like `ngOnDestroy`, `DestroyRef` works in any Angular service, directive, compon
 
 </div>
 
-When using RxJS Observables in components or directives, you may want to complete any observables when the component or directive is destroyed. Angular's `@angular/core/rxjs-interop` package provides an operator, `takeUntilDestroyed`, to simply this common task:
+When using RxJS Observables in components or directives, you may want to complete any observables when the component or directive is destroyed. Angular's `@angular/core/rxjs-interop` package provides an operator, `takeUntilDestroyed`, to simplify this common task:
 
 ```ts
 data$ = http.get('...').pipe(takeUntilDestroyed());


### PR DESCRIPTION
A tiny typo fix for the recently merged https://github.com/angular/angular/pull/50042  

-I think the intention is for the verb not the adverb-

- [x] Docs have been updated 


