### PR TITLE
fix(docs-infra): remove extra slash from JSON-LD data

### DIFF
--- a/aio/tools/transforms/templates/api/base.template.html
+++ b/aio/tools/transforms/templates/api/base.template.html
@@ -10,7 +10,7 @@
           "@type": "BreadcrumbList",
           "itemListElement": [
             {%- for crumb in doc.breadCrumbs %}{$ comma() $}
-            { "@type": "ListItem", "position": {$ loop.index $}, "item": { "@id": "https://angular.io/{$ crumb.path $}", "name": "{$ crumb.text $}" } }{% endfor %}
+            { "@type": "ListItem", "position": {$ loop.index $}, "item": { "@id": "https://angular.io{% if crumb.path.startsWith('/') %}{$ crumb.path $}{% else %}{$ '/' + crumb.path $}{% endif %}", "name": "{$ crumb.text $}" } }{% endfor %}
           ]
         }
       </script>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

This is what is currently written to the `<script type="application/ld+json">` node in any docs page ([for example](https://angular.io/api/animations/animate)):
![image](https://user-images.githubusercontent.com/28087049/236152629-5a21a73f-c9d4-4c98-a663-9722fd2dd624.png)

Value of the `"@id"` field appears to have double slash: `"@id": "https://angular.io//api"`.

Issue Number: N/A


## What is the new behavior?
Value of the `"@id"` field does not have double slash anymore: `"@id": "https://angular.io/api"`.

![image](https://user-images.githubusercontent.com/28087049/236154854-2cf7211a-8552-4052-a45b-888b69fc33a1.png)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

I'm not experienced with the templating library used here, therefore I'm not sure if there's better way to achieve this. E.g. I tried replacing leading `/` using `replace`:

`"https://angular.io/{$ crumb.path.replace(/^[/]/, '') $}"`
`"https://angular.io/{$ crumb.path.replace(/^//, '') $}"`
`"https://angular.io/{$ crumb.path.replace('^/', '') $}"`

but they all seem to be having their own issues. If there's a better solution for this problem (instead of using `if`/`else` pattern), I'd gladly fix it.