### PR TITLE
feat(docs-infra): add option to filter docs with developer preview status

### DIFF
--- a/aio/src/app/custom-elements/api/api-list.component.spec.ts
+++ b/aio/src/app/custom-elements/api/api-list.component.spec.ts
@@ -90,6 +90,11 @@ describe('ApiListComponent', () => {
         expectFilteredResult('status: security-risk', item => item.securityRisk);
       });
 
+      it('should be visible if they have the selected developer preview status', () => {
+        component.setStatus({value: 'developer-preview', title: 'Developer Preview'});
+        expectFilteredResult('status: developer-preview', item => item.developerPreview);
+      });
+
       it('should be visible if they match the selected API type', () => {
         component.setType({value: 'class', title: 'Class'});
         expectFilteredResult('type: class', item => item.docType === 'class');
@@ -144,6 +149,12 @@ describe('ApiListComponent', () => {
       locationService.query = {status: 'security-risk'};
       fixture.detectChanges();
       expectFilteredResult('security-risk', item => item.securityRisk);
+    });
+
+    it('should filter as expected when status is developer-preview', () => {
+      locationService.query = {status: 'developer-preview'};
+      fixture.detectChanges();
+      expectFilteredResult('developer-preview', item => item.developerPreview);
     });
 
     it('should filter as expected for ?type', () => {
@@ -235,6 +246,7 @@ const apiSections: ApiSection[] = [
         docType: 'class',
         stability: 'experimental',
         securityRisk: false,
+        developerPreview: false
       },
       {
         name: 'class_2',
@@ -243,6 +255,7 @@ const apiSections: ApiSection[] = [
         docType: 'class',
         stability: 'stable',
         securityRisk: false,
+        developerPreview: false
       },
       {
         name: 'directive_1',
@@ -251,6 +264,7 @@ const apiSections: ApiSection[] = [
         docType: 'directive',
         stability: 'stable',
         securityRisk: true,
+        developerPreview: false
       },
       {
         name: 'pipe_1',
@@ -259,6 +273,7 @@ const apiSections: ApiSection[] = [
         docType: 'pipe',
         stability: 'stable',
         securityRisk: true,
+        developerPreview: false
       },
     ],
   },
@@ -275,6 +290,7 @@ const apiSections: ApiSection[] = [
         docType: 'class',
         stability: 'experimental',
         securityRisk: false,
+        developerPreview: false
       },
       {
         name: 'function_1',
@@ -283,6 +299,7 @@ const apiSections: ApiSection[] = [
         docType: 'function',
         stability: 'deprecated',
         securityRisk: true,
+        developerPreview: false
       },
       {
         name: 'const_1',
@@ -291,6 +308,7 @@ const apiSections: ApiSection[] = [
         docType: 'const',
         stability: 'stable',
         securityRisk: false,
+        developerPreview: true
       },
     ],
   },

--- a/aio/src/app/custom-elements/api/api-list.component.ts
+++ b/aio/src/app/custom-elements/api/api-list.component.ts
@@ -59,6 +59,7 @@ export class ApiListComponent implements OnInit {
   statuses: Option[] = [
     { value: 'all', title: 'All' },
     { value: 'stable', title: 'Stable'},
+    { value: 'developer-preview', title: 'Developer Preview'},
     { value: 'deprecated', title: 'Deprecated' },
     { value: 'security-risk', title: 'Security Risk' }
   ];
@@ -119,7 +120,10 @@ export class ApiListComponent implements OnInit {
     const matchesQuery = (item: ApiItem) =>
       sectionNameMatches || item.name.indexOf(query) !== -1;
     const matchesStatus = (item: ApiItem) =>
-      status === 'all' || status === item.stability || (status === 'security-risk' && item.securityRisk);
+      status === 'all' ||
+      status === item.stability ||
+      (status === 'security-risk' && item.securityRisk) ||
+      (status === 'developer-preview' && item.developerPreview);
     const matchesType = (item: ApiItem) =>
       type === 'all' || type === item.docType;
 

--- a/aio/src/app/custom-elements/api/api.service.ts
+++ b/aio/src/app/custom-elements/api/api.service.ts
@@ -14,6 +14,7 @@ export interface ApiItem {
   docType: string;
   stability: string;
   securityRisk: boolean;
+  developerPreview: boolean;
 }
 
 export interface ApiSection {

--- a/aio/src/styles/2-modules/api-list/_api-list.scss
+++ b/aio/src/styles/2-modules/api-list/_api-list.scss
@@ -15,7 +15,7 @@ aio-api-list {
 
     /* API FILTER MENU */
     aio-select {
-      width: 200px;
+      width: 220px;
 
       @media screen and (max-width: 600px) {
         width: 100%;

--- a/aio/tools/transforms/angular-api-package/processors/generateApiListDoc.js
+++ b/aio/tools/transforms/angular-api-package/processors/generateApiListDoc.js
@@ -40,7 +40,8 @@ function getExportInfo(exportDoc) {
     path: exportDoc.path,
     docType: getDocType(exportDoc),
     stability: getStability(exportDoc),
-    securityRisk: !!exportDoc.security
+    securityRisk: !!exportDoc.security,
+    developerPreview: !!exportDoc.developerPreview
   };
 }
 

--- a/aio/tools/transforms/angular-api-package/processors/generateApiListDoc.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/generateApiListDoc.spec.js
@@ -67,17 +67,17 @@ describe('generateApiListDoc processor', () => {
     ];
     processor.$process(docs);
     expect(docs[2].data[0].items).toEqual([
-      { docType: 'directive', title: 'AaaAaa', name: 'aaaaaa', path: 'aaa', stability: '', securityRisk: false },
-      { docType: 'pipe', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: '', securityRisk: false },
-      { docType: 'decorator', title: 'CccCcc', name: 'cccccc', path: 'ccc', stability: '', securityRisk: false },
-      { docType: 'class', title: 'DddDdd', name: 'dddddd', path: 'ddd', stability: '', securityRisk: false }
+      { docType: 'directive', title: 'AaaAaa', name: 'aaaaaa', path: 'aaa', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'pipe', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'decorator', title: 'CccCcc', name: 'cccccc', path: 'ccc', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'class', title: 'DddDdd', name: 'dddddd', path: 'ddd', stability: '', securityRisk: false, developerPreview: false }
     ]);
     expect(docs[2].data[1].items).toEqual([
-      { docType: 'interface', title: 'EeeEee', name: 'eeeeee', path: 'eee', stability: '', securityRisk: false },
-      { docType: 'function', title: 'FffFff', name: 'ffffff', path: 'fff', stability: '', securityRisk: false },
-      { docType: 'enum', title: 'GggGgg', name: 'gggggg', path: 'ggg', stability: '', securityRisk: false },
-      { docType: 'type-alias', title: 'HhhHhh', name: 'hhhhhh', path: 'hhh', stability: '', securityRisk: false },
-      { docType: 'const', title: 'IiiIii', name: 'iiiiii', path: 'iii', stability: '', securityRisk: false },
+      { docType: 'interface', title: 'EeeEee', name: 'eeeeee', path: 'eee', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'function', title: 'FffFff', name: 'ffffff', path: 'fff', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'enum', title: 'GggGgg', name: 'gggggg', path: 'ggg', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'type-alias', title: 'HhhHhh', name: 'hhhhhh', path: 'hhh', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'const', title: 'IiiIii', name: 'iiiiii', path: 'iii', stability: '', securityRisk: false, developerPreview: false },
     ]);
   });
 
@@ -92,7 +92,7 @@ describe('generateApiListDoc processor', () => {
     ];
     processor.$process(docs);
     expect(docs[1].data[0].items).toEqual([
-      { docType: 'pipe', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: '', securityRisk: false },
+      { docType: 'pipe', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: '', securityRisk: false, developerPreview: false },
     ]);
   });
 
@@ -106,8 +106,8 @@ describe('generateApiListDoc processor', () => {
     ];
     processor.$process(docs);
     expect(docs[1].data[0].items).toEqual([
-      { docType: 'const', title: 'AaaAaa', name: 'aaaaaa', path: 'aaa', stability: '', securityRisk: false },
-      { docType: 'const', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: '', securityRisk: false },
+      { docType: 'const', title: 'AaaAaa', name: 'aaaaaa', path: 'aaa', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'const', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: '', securityRisk: false, developerPreview: false },
     ]);
   });
 
@@ -121,8 +121,23 @@ describe('generateApiListDoc processor', () => {
     ];
     processor.$process(docs);
     expect(docs[1].data[0].items).toEqual([
-      { docType: 'class', title: 'AaaAaa', name: 'aaaaaa', path: 'aaa', stability: '', securityRisk: true },
-      { docType: 'class', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: '', securityRisk: false },
+      { docType: 'class', title: 'AaaAaa', name: 'aaaaaa', path: 'aaa', stability: '', securityRisk: true, developerPreview: false },
+      { docType: 'class', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: '', securityRisk: false, developerPreview: false },
+    ]);
+  });
+
+  it('should convert developerPreview to a boolean developerPreview', () => {
+    const processor = processorFactory();
+    const docs = [
+      { docType: 'package', id: '@angular/common/index', exports: [
+        { docType: 'class', name: 'AaaAaa', path: 'aaa', developerPreview: true },
+        { docType: 'class', name: 'BbbBbb', path: 'bbb' },
+      ]}
+    ];
+    processor.$process(docs);
+    expect(docs[1].data[0].items).toEqual([
+      { docType: 'class', title: 'AaaAaa', name: 'aaaaaa', path: 'aaa', stability: '', securityRisk: false, developerPreview: true },
+      { docType: 'class', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: '', securityRisk: false, developerPreview: false },
     ]);
   });
 
@@ -138,10 +153,10 @@ describe('generateApiListDoc processor', () => {
     ];
     processor.$process(docs);
     expect(docs[1].data[0].items).toEqual([
-      { docType: 'class', title: 'AaaAaa', name: 'aaaaaa', path: 'aaa', stability: 'stable', securityRisk: false },
-      { docType: 'class', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: 'experimental', securityRisk: false },
-      { docType: 'class', title: 'CccCcc', name: 'cccccc', path: 'ccc', stability: 'deprecated', securityRisk: false },
-      { docType: 'class', title: 'DddDdd', name: 'dddddd', path: 'ddd', stability: '', securityRisk: false },
+      { docType: 'class', title: 'AaaAaa', name: 'aaaaaa', path: 'aaa', stability: 'stable', securityRisk: false, developerPreview: false },
+      { docType: 'class', title: 'BbbBbb', name: 'bbbbbb', path: 'bbb', stability: 'experimental', securityRisk: false, developerPreview: false },
+      { docType: 'class', title: 'CccCcc', name: 'cccccc', path: 'ccc', stability: 'deprecated', securityRisk: false, developerPreview: false },
+      { docType: 'class', title: 'DddDdd', name: 'dddddd', path: 'ddd', stability: '', securityRisk: false, developerPreview: false },
     ]);
   });
 
@@ -157,10 +172,10 @@ describe('generateApiListDoc processor', () => {
     ];
     processor.$process(docs);
     expect(docs[1].data[0].items).toEqual([
-      { docType: 'class', title: 'AaaAaa', name: 'aaaaaa', path: 'xxx', stability: '', securityRisk: false },
-      { docType: 'class', title: 'BbbBbb', name: 'bbbbbb', path: 'vvv', stability: '', securityRisk: false },
-      { docType: 'class', title: 'CccCcc', name: 'cccccc', path: 'yyy', stability: '', securityRisk: false },
-      { docType: 'class', title: 'DddDdd', name: 'dddddd', path: 'uuu', stability: '', securityRisk: false },
+      { docType: 'class', title: 'AaaAaa', name: 'aaaaaa', path: 'xxx', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'class', title: 'BbbBbb', name: 'bbbbbb', path: 'vvv', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'class', title: 'CccCcc', name: 'cccccc', path: 'yyy', stability: '', securityRisk: false, developerPreview: false },
+      { docType: 'class', title: 'DddDdd', name: 'dddddd', path: 'uuu', stability: '', securityRisk: false, developerPreview: false },
     ]);
   });
 });


### PR DESCRIPTION
Add a feature to the ApiListComponent with which users can filter documents based on the "developer preview" status.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
None.

## What is the new behavior?
This PR adds a new status dropdown option to the [API Reference](https://angular.io/api) page. The new option is "Developer Preview":

![image](https://user-images.githubusercontent.com/28087049/236218068-a98adad4-c928-4f6f-9f39-305f0b0ffdd4.png)

With this option, users can check which APIs have the "Developer Preview" badge:

![image](https://user-images.githubusercontent.com/28087049/236218830-d5063414-605a-459a-bd97-5c5a4f135d51.png)

This is a snapshot of the list of documents that have "Developer Preview" badge:

![image](https://user-images.githubusercontent.com/28087049/236218696-54d5886d-f8ef-435d-bf72-c92ec33f9cb7.png)



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
