### PR TITLE
fix(core): toSignal accepts Subscribable (in addition to Observable)

### DIFF
--- a/goldens/public-api/core/rxjs-interop/index.md
+++ b/goldens/public-api/core/rxjs-interop/index.md
@@ -9,6 +9,7 @@ import { Injector } from '@angular/core';
 import { MonoTypeOperatorFunction } from 'rxjs';
 import { Observable } from 'rxjs';
 import { Signal } from '@angular/core';
+import { Subscribable } from 'rxjs';
 
 // @public
 export function takeUntilDestroyed<T>(destroyRef?: DestroyRef): MonoTypeOperatorFunction<T>;
@@ -22,21 +23,21 @@ export interface ToObservableOptions {
 }
 
 // @public
-export function toSignal<T>(source: Observable<T>): Signal<T | undefined>;
+export function toSignal<T>(source: Observable<T> | Subscribable<T>): Signal<T | undefined>;
 
 // @public
-export function toSignal<T>(source: Observable<T>, options?: ToSignalOptions<undefined> & {
+export function toSignal<T>(source: Observable<T> | Subscribable<T>, options?: ToSignalOptions<undefined> & {
     requireSync?: false;
 }): Signal<T | undefined>;
 
 // @public
-export function toSignal<T, U extends T | null | undefined>(source: Observable<T>, options: ToSignalOptions<U> & {
+export function toSignal<T, U extends T | null | undefined>(source: Observable<T> | Subscribable<T>, options: ToSignalOptions<U> & {
     initialValue: U;
     requireSync?: false;
 }): Signal<T | U>;
 
 // @public
-export function toSignal<T>(source: Observable<T>, options: ToSignalOptions<undefined> & {
+export function toSignal<T>(source: Observable<T> | Subscribable<T>, options: ToSignalOptions<undefined> & {
     requireSync: true;
 }): Signal<T>;
 

--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -7,7 +7,7 @@
  */
 
 import {assertInInjectionContext, computed, DestroyRef, inject, Injector, signal, Signal, WritableSignal} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, Subscribable} from 'rxjs';
 
 import {RuntimeError, RuntimeErrorCode} from '../../src/errors';
 import {untracked} from '../../src/signals';
@@ -73,7 +73,7 @@ export interface ToSignalOptions<T> {
  * option can be specified instead, which disables the automatic subscription teardown. No injection
  * context is needed in this configuration as well.
  */
-export function toSignal<T>(source: Observable<T>): Signal<T|undefined>;
+export function toSignal<T>(source: Observable<T>|Subscribable<T>): Signal<T|undefined>;
 
 /**
  * Get the current value of an `Observable` as a reactive `Signal`.
@@ -99,7 +99,7 @@ export function toSignal<T>(source: Observable<T>): Signal<T|undefined>;
  * @developerPreview
  */
 export function toSignal<T>(
-    source: Observable<T>,
+    source: Observable<T>|Subscribable<T>,
     options?: ToSignalOptions<undefined>&{requireSync?: false}): Signal<T|undefined>;
 
 
@@ -127,7 +127,7 @@ export function toSignal<T>(
  * @developerPreview
  */
 export function toSignal<T, U extends T|null|undefined>(
-    source: Observable<T>,
+    source: Observable<T>|Subscribable<T>,
     options: ToSignalOptions<U>&{initialValue: U, requireSync?: false}): Signal<T|U>;
 
 /**
@@ -154,9 +154,10 @@ export function toSignal<T, U extends T|null|undefined>(
  * @developerPreview
  */
 export function toSignal<T>(
-    source: Observable<T>, options: ToSignalOptions<undefined>&{requireSync: true}): Signal<T>;
+    source: Observable<T>|Subscribable<T>,
+    options: ToSignalOptions<undefined>&{requireSync: true}): Signal<T>;
 export function toSignal<T, U = undefined>(
-    source: Observable<T>, options?: ToSignalOptions<U>): Signal<T|U> {
+    source: Observable<T>|Subscribable<T>, options?: ToSignalOptions<U>): Signal<T|U> {
   const requiresCleanup = !options?.manualCleanup;
   requiresCleanup && !options?.injector && assertInInjectionContext(toSignal);
   const cleanupRef =


### PR DESCRIPTION
This PR extends [`toSignal`](https://angular.io/api/core/rxjs-interop/toSignal) to accept any [`Subscribable`](https://rxjs.dev/api/index/interface/Subscribable) (instead of only [`Observable`](https://rxjs.dev/api/index/class/Observable)) for consistency with [`AsyncPipe`](https://angular.io/api/common/AsyncPipe#input-value) and for broader compatibility with any observable library (that is compatible with the `Subscribable` interface).

This is only a type change as the implementation does not use anything else than the `Subscribable` interface anyway.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`toSignal` only accepts `Observable`.

## What is the new behavior?

`toSignal` accepts any `Subscribable`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

This PR is similar to [PR 39627](https://github.com/angular/angular/pull/39627) that I had opened for `AsyncPipe`.