### PR TITLE
refactor(router): remove private export of `withPreloading`

### DIFF
--- a/packages/router/src/private_export.ts
+++ b/packages/router/src/private_export.ts
@@ -9,6 +9,5 @@
 
 export {ɵEmptyOutletComponent} from './components/empty_outlet';
 export {RestoredState as ɵRestoredState} from './navigation_transition';
-export {withPreloading as ɵwithPreloading} from './provide_router';
 export {ROUTER_PROVIDERS as ɵROUTER_PROVIDERS} from './router_module';
 export {afterNextNavigation as ɵafterNextNavigation} from './utils/navigations';

--- a/packages/router/testing/src/router_testing_module.ts
+++ b/packages/router/testing/src/router_testing_module.ts
@@ -9,7 +9,7 @@
 import {Location} from '@angular/common';
 import {provideLocationMocks} from '@angular/common/testing';
 import {Compiler, inject, Injector, ModuleWithProviders, NgModule} from '@angular/core';
-import {ChildrenOutletContexts, ExtraOptions, NoPreloading, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, TitleStrategy, UrlHandlingStrategy, UrlSerializer, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS, ɵwithPreloading as withPreloading} from '@angular/router';
+import {ChildrenOutletContexts, ExtraOptions, NoPreloading, Route, Router, ROUTER_CONFIGURATION, RouteReuseStrategy, RouterModule, ROUTES, Routes, TitleStrategy, UrlHandlingStrategy, UrlSerializer, withPreloading, ɵROUTER_PROVIDERS as ROUTER_PROVIDERS} from '@angular/router';
 
 function isUrlHandlingStrategy(opts: ExtraOptions|
                                UrlHandlingStrategy): opts is UrlHandlingStrategy {


### PR DESCRIPTION
`withPreloading` is part of the public API.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [x] No