### PR TITLE
docs: fix obs variable name to obs$

### DIFF
--- a/aio/content/guide/rxjs-interop.md
+++ b/aio/content/guide/rxjs-interop.md
@@ -92,7 +92,7 @@ As the `query` signal changes, the `query$` Observable emits the latest query an
 Unlike Observables, signals never provide a synchronous notification of changes. Even if your code updates a signal's value multiple times, effects which depend on its value run only after the signal has "settled".
 
 ```ts
-const obs = toObservable(mySignal);
+const obs$ = toObservable(mySignal);
 obs$.subscribe(value => console.log(value));
 
 mySignal.set(1);


### PR DESCRIPTION
In the Timing of `toObservable` example, the `obs` observable not end by `$`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
