### PR TITLE
refactor(core): simplify state transfer escaping

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -30,7 +30,6 @@ export {_sanitizeHtml as ɵ_sanitizeHtml} from './sanitization/html_sanitizer';
 export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';
 export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from './signals';
 export {TESTABILITY as ɵTESTABILITY, TESTABILITY_GETTER as ɵTESTABILITY_GETTER} from './testability/testability';
-export {escapeTransferStateContent as ɵescapeTransferStateContent, unescapeTransferStateContent as ɵunescapeTransferStateContent} from './transfer_state';
 export {coerceToBoolean as ɵcoerceToBoolean} from './util/coercion';
 export {devModeEqual as ɵdevModeEqual} from './util/comparison';
 export {global as ɵglobal} from './util/global';

--- a/packages/core/src/transfer_state.ts
+++ b/packages/core/src/transfer_state.ts
@@ -144,8 +144,7 @@ export class TransferState {
     }
 
     // Escape script tag to avoid break out of <script> tag in serialized output.
-    // This is the same as
-    // http://google3/third_party/javascript/safevalues/builders/script_builders.ts?rcl=527450674&l=43
+    // Encoding of `<` is the same behaviour as G3 script_builders.
     return JSON.stringify(this.store).replace(/</g, '\\u003C');
   }
 }

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -141,9 +141,6 @@
     "name": "ERROR_ORIGINAL_ERROR"
   },
   {
-    "name": "ESCAPED_SCRIPT_TAG_REGEXP"
-  },
-  {
     "name": "EVENT_MANAGER_PLUGINS"
   },
   {
@@ -516,9 +513,6 @@
     "name": "TransferState"
   },
   {
-    "name": "UNESCAPED_SCRIPT_TAG_REGEXP"
-  },
-  {
     "name": "USE_VALUE"
   },
   {
@@ -757,9 +751,6 @@
   },
   {
     "name": "enterView"
-  },
-  {
-    "name": "escapeTransferStateContent"
   },
   {
     "name": "executeCheckHooks"
@@ -1050,9 +1041,6 @@
     "name": "isStableFactory"
   },
   {
-    "name": "isString"
-  },
-  {
     "name": "isTemplateNode"
   },
   {
@@ -1288,9 +1276,6 @@
   },
   {
     "name": "transferCacheInterceptorFn"
-  },
-  {
-    "name": "unescapeTransferStateContent"
   },
   {
     "name": "uniqueIdCounter"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -141,6 +141,9 @@
     "name": "ERROR_ORIGINAL_ERROR"
   },
   {
+    "name": "ESCAPED_SCRIPT_TAG_REGEXP"
+  },
+  {
     "name": "EVENT_MANAGER_PLUGINS"
   },
   {
@@ -513,6 +516,9 @@
     "name": "TransferState"
   },
   {
+    "name": "UNESCAPED_SCRIPT_TAG_REGEXP"
+  },
+  {
     "name": "USE_VALUE"
   },
   {
@@ -751,6 +757,9 @@
   },
   {
     "name": "enterView"
+  },
+  {
+    "name": "escapeTransferStateContent"
   },
   {
     "name": "executeCheckHooks"
@@ -1041,6 +1050,9 @@
     "name": "isStableFactory"
   },
   {
+    "name": "isString"
+  },
+  {
     "name": "isTemplateNode"
   },
   {
@@ -1276,6 +1288,9 @@
   },
   {
     "name": "transferCacheInterceptorFn"
+  },
+  {
+    "name": "unescapeTransferStateContent"
   },
   {
     "name": "uniqueIdCounter"

--- a/packages/platform-server/src/transfer_state.ts
+++ b/packages/platform-server/src/transfer_state.ts
@@ -7,7 +7,7 @@
  */
 
 import {DOCUMENT} from '@angular/common';
-import {APP_ID, NgModule, Provider, TransferState, ɵescapeTransferStateContent as escapeTransferStateContent} from '@angular/core';
+import {APP_ID, NgModule, Provider, TransferState} from '@angular/core';
 
 import {BEFORE_APP_SERIALIZED} from './tokens';
 
@@ -33,7 +33,7 @@ function serializeTransferStateFactory(doc: Document, appId: string, transferSto
     const script = doc.createElement('script');
     script.id = appId + '-state';
     script.setAttribute('type', 'application/json');
-    script.textContent = escapeTransferStateContent(content);
+    script.textContent = content;
 
     // It is intentional that we add the script at the very bottom. Angular CLI script tags for
     // bundles are always `type="module"`. These are deferred by default and cause the transfer

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -14,7 +14,6 @@ import {ApplicationRef, Component, ComponentRef, createComponent, destroyPlatfor
 import {Console} from '@angular/core/src/console';
 import {InitialRenderPendingTasks} from '@angular/core/src/initial_render_pending_tasks';
 import {getComponentDef} from '@angular/core/src/render3/definition';
-import {unescapeTransferStateContent} from '@angular/core/src/transfer_state';
 import {NoopNgZone} from '@angular/core/src/zone/ng_zone';
 import {TestBed} from '@angular/core/testing';
 import {bootstrapApplication, HydrationFeature, HydrationFeatureKind, provideClientHydration, withNoDomReuse} from '@angular/platform-browser';
@@ -185,9 +184,8 @@ function resetTViewsFor(...types: Type<unknown>[]) {
   }
 }
 
-function getHydrationInfoFromTransferState(input: string): string|null {
-  const rawContents = input.match(/<script[^>]+>(.*?)<\/script>/)?.[1];
-  return rawContents ? unescapeTransferStateContent(rawContents) : null;
+function getHydrationInfoFromTransferState(input: string): string|undefined {
+  return input.match(/<script[^>]+>(.*?)<\/script>/)?.[1];
 }
 
 function withNoopErrorHandler() {

--- a/packages/platform-server/test/integration_spec.ts
+++ b/packages/platform-server/test/integration_spec.ts
@@ -842,7 +842,7 @@ describe('platform-server integration', () => {
                renderModule(MyTransferStateModule, options);
            const expectedOutput =
                '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other"><div>Works!</div></app>' +
-               '<script id="ng-state" type="application/json">{&q;some-key&q;:&q;some-value&q;}</script></body></html>';
+               '<script id="ng-state" type="application/json">{"some-key":"some-value"}</script></body></html>';
            const output = await bootstrap;
            expect(output).toEqual(expectedOutput);
          });

--- a/packages/platform-server/test/transfer_state_spec.ts
+++ b/packages/platform-server/test/transfer_state_spec.ts
@@ -12,7 +12,7 @@ import {renderModule, ServerModule} from '@angular/platform-server';
 
 describe('transfer_state', () => {
   const defaultExpectedOutput =
-      '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other">Works!</app><script id="ng-state" type="application/json">{&q;test&q;:10}</script></body></html>';
+      '<html><head></head><body><app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other">Works!</app><script id="ng-state" type="application/json">{"test":10}</script></body></html>';
 
   it('adds transfer script tag when using renderModule', async () => {
     const STATE_KEY = makeStateKey<number>('test');
@@ -58,8 +58,8 @@ describe('transfer_state', () => {
     expect(output).toBe(
         '<html><head></head><body><esc-app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other">Works!</esc-app>' +
         '<script id="ng-state" type="application/json">' +
-        '{&q;testString&q;:&q;&l;/script&g;&l;script&g;' +
-        'alert(&s;Hello&a;&s; + \\&q;World\\&q;);&q;}</script></body></html>');
+        `{"testString":"&lt;/script>&lt;script>alert('Hello&' + \\"World\\");"}` +
+        '</script></body></html>');
   });
 
   it('adds transfer script tag when setting state during onSerialize', async () => {

--- a/packages/platform-server/test/transfer_state_spec.ts
+++ b/packages/platform-server/test/transfer_state_spec.ts
@@ -58,7 +58,7 @@ describe('transfer_state', () => {
     expect(output).toBe(
         '<html><head></head><body><esc-app ng-version="0.0.0-PLACEHOLDER" ng-server-context="other">Works!</esc-app>' +
         '<script id="ng-state" type="application/json">' +
-        `{"testString":"&lt;/script>&lt;script>alert('Hello&' + \\"World\\");"}` +
+        `{"testString":"\\u003C/script>\\u003Cscript>alert('Hello&' + \\"World\\");"}` +
         '</script></body></html>');
   });
 


### PR DESCRIPTION
This commit removes unnecessary transfer state escaping and updates this process to be done by the means of a `replacer` and `reviver` method as this removes the need to export the escaping and unescaping methods.

The only thing that we need to escape is `<script` and `</script` which are done by the browsers, but not Node.js.