### PR TITLE
Revert "docs(docs-infra): Remove unused annotation template (#50114)"

### DIFF
--- a/aio/tools/transforms/templates/api/includes/annotations.html
+++ b/aio/tools/transforms/templates/api/includes/annotations.html
@@ -1,0 +1,13 @@
+{%- if doc.decorators.length %}
+<section class="annotations">
+  <h2>Annotations</h2>
+
+  {%- for decorator in doc.decorators %}
+  <code-example language="ts" hideCopy="true" class="no-box api-heading{% if decorator.deprecated %} deprecated-api-item{% endif %}">@{$ decorator.name $}({$ decorator.arguments $})</code-example>
+
+  {%- if not decorator.notYetDocumented %}
+  {$ decorator.description | marked $}
+  {%- endif %}
+  {%- endfor %}
+</section>
+{%- endif -%}

--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -85,6 +85,7 @@ export interface Injectable {
 /**
  * Injectable decorator and metadata.
  *
+ * @Annotation
  * @publicApi
  */
 export const Injectable: InjectableDecorator = makeDecorator(

--- a/packages/core/src/di/metadata.ts
+++ b/packages/core/src/di/metadata.ts
@@ -54,6 +54,7 @@ export interface Inject {
 /**
  * Inject decorator and metadata.
  *
+ * @Annotation
  * @publicApi
  */
 export const Inject: InjectDecorator = attachInjectFlag(
@@ -98,7 +99,7 @@ export interface Optional {}
 /**
  * Optional decorator and metadata.
  *
-
+ * @Annotation
  * @publicApi
  */
 export const Optional: OptionalDecorator =
@@ -146,7 +147,7 @@ export interface Self {}
 /**
  * Self decorator and metadata.
  *
-
+ * @Annotation
  * @publicApi
  */
 export const Self: SelfDecorator =
@@ -194,7 +195,7 @@ export interface SkipSelf {}
 /**
  * `SkipSelf` decorator and metadata.
  *
-
+ * @Annotation
  * @publicApi
  */
 export const SkipSelf: SkipSelfDecorator =
@@ -237,7 +238,7 @@ export interface Host {}
 /**
  * Host decorator and metadata.
  *
-
+ * @Annotation
  * @publicApi
  */
 export const Host: HostDecorator =

--- a/packages/core/src/di/metadata_attr.ts
+++ b/packages/core/src/di/metadata_attr.ts
@@ -56,6 +56,7 @@ export interface Attribute {
 /**
  * Attribute decorator and metadata.
  *
+ * @Annotation
  * @publicApi
  */
 export const Attribute: AttributeDecorator = makeParamDecorator(

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -150,6 +150,7 @@ export interface ContentChildrenDecorator {
    *
    * {@example core/di/ts/contentChildren/content_children_example.ts region='Component'}
    *
+   * @Annotation
    */
   (selector: ProviderToken<unknown>|Function|string, opts?: {
     descendants?: boolean,
@@ -164,6 +165,7 @@ export interface ContentChildrenDecorator {
  * Type of the ContentChildren metadata.
  *
  *
+ * @Annotation
  * @publicApi
  */
 export type ContentChildren = Query;
@@ -172,6 +174,7 @@ export type ContentChildren = Query;
  * ContentChildren decorator and metadata.
  *
  *
+ * @Annotation
  * @publicApi
  */
 export const ContentChildren: ContentChildrenDecorator = makePropDecorator(
@@ -239,6 +242,7 @@ export interface ContentChildDecorator {
    *
    * {@example core/di/ts/contentChild/content_child_example.ts region='Component'}
    *
+   * @Annotation
    */
   (selector: ProviderToken<unknown>|Function|string,
    opts?: {descendants?: boolean, read?: any, static?: boolean}): any;
@@ -257,7 +261,7 @@ export type ContentChild = Query;
  * ContentChild decorator and metadata.
  *
  *
-
+ * @Annotation
  *
  * @publicApi
  */
@@ -324,6 +328,7 @@ export interface ViewChildrenDecorator {
    *
    * {@example core/di/ts/viewChildren/view_children_example.ts region='Component'}
    *
+   * @Annotation
    */
   (selector: ProviderToken<unknown>|Function|string,
    opts?: {read?: any, emitDistinctChangesOnly?: boolean}): any;
@@ -341,7 +346,7 @@ export type ViewChildren = Query;
 /**
  * ViewChildren decorator and metadata.
  *
-
+ * @Annotation
  * @publicApi
  */
 export const ViewChildren: ViewChildrenDecorator = makePropDecorator(
@@ -405,6 +410,7 @@ export interface ViewChildDecorator {
    *
    * {@example core/di/ts/viewChild/view_child_howto.ts region='HowTo'}
    *
+   * @Annotation
    */
   (selector: ProviderToken<unknown>|Function|string, opts?: {read?: any, static?: boolean}): any;
   new(selector: ProviderToken<unknown>|Function|string,
@@ -421,7 +427,7 @@ export type ViewChild = Query;
 /**
  * ViewChild decorator and metadata.
  *
-
+ * @Annotation
  * @publicApi
  */
 export const ViewChild: ViewChildDecorator = makePropDecorator(

--- a/packages/core/src/metadata/directives.ts
+++ b/packages/core/src/metadata/directives.ts
@@ -98,6 +98,7 @@ export interface DirectiveDecorator {
    *    accessible for components outside of the NgModule.
    *
    *
+   * @Annotation
    */
   (obj?: Directive): TypeDecorator;
 
@@ -110,6 +111,7 @@ export interface DirectiveDecorator {
 /**
  * Directive decorator and metadata.
  *
+ * @Annotation
  * @publicApi
  */
 export interface Directive {
@@ -289,6 +291,7 @@ export interface Directive {
    * }
    * ```
    *
+   * @Annotation
    */
   queries?: {[key: string]: any};
 
@@ -508,6 +511,7 @@ export interface ComponentDecorator {
    * To preserve sequences of whitespace characters, use the
    * `ngPreserveWhitespaces` attribute.
    *
+   * @Annotation
    */
   (obj: Component): TypeDecorator;
   /**
@@ -659,7 +663,7 @@ export interface Component extends Directive {
 /**
  * Component decorator and metadata.
  *
-
+ * @Annotation
  * @publicApi
  */
 export const Component: ComponentDecorator = makeDecorator(
@@ -737,7 +741,7 @@ export interface Pipe {
 }
 
 /**
-
+ * @Annotation
  * @publicApi
  */
 export const Pipe: PipeDecorator = makeDecorator(
@@ -816,7 +820,7 @@ export interface Input {
 }
 
 /**
-
+ * @Annotation
  * @publicApi
  */
 export const Input: InputDecorator =
@@ -866,7 +870,7 @@ export interface Output {
 }
 
 /**
-
+ * @Annotation
  * @publicApi
  */
 export const Output: OutputDecorator = makePropDecorator('Output', (alias?: string) => ({alias}));
@@ -925,7 +929,7 @@ export interface HostBinding {
 }
 
 /**
-
+ * @Annotation
  * @publicApi
  */
 export const HostBinding: HostBindingDecorator =
@@ -1029,7 +1033,7 @@ export interface HostListener {
  * The global target names that can be used to prefix an event name are
  * `document:`, `window:` and `body:`.
  *
-
+ * @Annotation
  * @publicApi
  */
 export const HostListener: HostListenerDecorator =

--- a/packages/core/src/metadata/ng_module.ts
+++ b/packages/core/src/metadata/ng_module.ts
@@ -203,6 +203,7 @@ export interface NgModule {
 }
 
 /**
+ * @Annotation
  */
 export const NgModule: NgModuleDecorator = makeDecorator(
     'NgModule', (ngModule: NgModule) => ngModule, undefined, undefined,


### PR DESCRIPTION
This reverts commit a1ca162fd6e8f6f5b1171e8d8f1c6b7b1973e353.

This commit causes failures in g3, because `@Annotation` is load-bearing for tsickle's decorator downleveling transformation.
