### PR TITLE
docs: Avoid absolute links to angular.io

### DIFF
--- a/aio/content/guide/esbuild.md
+++ b/aio/content/guide/esbuild.md
@@ -2,7 +2,7 @@
 
 <div class="alert is-important">
 
-The esbuild-based ECMAScript module (ESM) application build system feature is available for [developer preview](guide/releases#developer-preview).
+The esbuild-based ECMAScript module (ESM) application build system feature is available for [developer preview](/guide/releases#developer-preview).
 It's ready for you to try, but it might change before it is stable and is not yet recommended for production builds.
 
 </div>
@@ -64,7 +64,7 @@ ng serve
 
 </code-example>
 
-You can continue to use the [command line options](https://angular.io/cli/serve) you have used in the past with the development server.
+You can continue to use the [command line options](/cli/serve) you have used in the past with the development server.
 
 <div class="alert is-important">
 

--- a/aio/content/guide/rxjs-interop.md
+++ b/aio/content/guide/rxjs-interop.md
@@ -2,7 +2,7 @@
 
 <div class="alert is-important">
 
-The RxJS Interop package is available for [developer preview](https://angular.io/guide/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
+The RxJS Interop package is available for [developer preview](/guide/releases#developer-preview). It's ready for you to try, but it might change before it is stable.
 
 </div>
 

--- a/aio/content/guide/signals.md
+++ b/aio/content/guide/signals.md
@@ -5,7 +5,7 @@ rendering updates.
 
 <div class="alert is-important">
 
-Angular signals are available for [developer preview](https://angular.io/guide/releases#developer-preview). They're ready for you to try, but may change before they are stable.
+Angular signals are available for [developer preview](/guide/releases#developer-preview). They're ready for you to try, but may change before they are stable.
 
 </div>
 
@@ -107,7 +107,7 @@ Note that dependencies can be removed as well as added. If `showCount` is later 
 
 ## Reading signals in `OnPush` components
 
-When an `OnPush` component uses a signal's value in its template, Angular will track the signal as a dependency of that component. When that signal is updated, Angular automatically [marks](https://angular.io/api/core/ChangeDetectorRef#markforcheck) the component to ensure it gets updated the next time change detection runs. Refer to the [Skipping component subtrees](https://angular.io/guide/change-detection-skipping-subtrees) guide for more information about `OnPush` components.
+When an `OnPush` component uses a signal's value in its template, Angular will track the signal as a dependency of that component. When that signal is updated, Angular automatically [marks](/api/core/ChangeDetectorRef#markforcheck) the component to ensure it gets updated the next time change detection runs. Refer to the [Skipping component subtrees](/guide/change-detection-skipping-subtrees) guide for more information about `OnPush` components.
 
 ## Effects
 

--- a/aio/content/marketing/README.md
+++ b/aio/content/marketing/README.md
@@ -1,6 +1,6 @@
 # Contributors page
 
-We have an official accounting of who is on the Angular Team \(see https://angular.io/about?group=Angular\), who are "trusted collaborators" \(see https://angular.io/about?group=Collaborators\), and so on.
+We have an official accounting of who is on the Angular Team \(see [this link](/about?group=Angular)\), who are "trusted collaborators" \(see [this link](/about?group=Collaborators)\), and so on.
 
 The `contributors.json` should be maintained to keep our "org chart" in a single consistent place.
 
@@ -12,7 +12,7 @@ There are two pages:
 (Googlers: source at http://google3/googledata/devsite/content/en/experts/all/technology/angular.html) which is maintained by Dawid Ostrowski based on a spreadsheet https://docs.google.com/spreadsheets/d/1_Ls2Kle7NxPBIG8f3OEVZ4gJZ8OCTtBxGYwMPb1TUVE/edit#gid=0.
     <!-- gkalpak: That URL doesn't seem to work anymore. New URL: https://developers.google.com/programs/experts/directory/ (?) -->
 
-*   Ours: https://angular.io/about?group=GDE which is derived from `contributors.json`.
+*   [Ours](/about?group=GDE) which is derived from `contributors.json`.
 
 ## About the data
 

--- a/aio/content/tutorial/first-app/first-app-lesson-01.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-01.md
@@ -130,5 +130,5 @@ If have any trouble with this lesson, review the completed code for it in the <l
 
 For more information about the topics covered in this lesson, visit:
 
-* [Angular Components](https://angular.io/guide/component-overview)
-* [Creating applications with the Angular CLI](https://angular.io/cli)
+* [Angular Components](/guide/component-overview)
+* [Creating applications with the Angular CLI](/cli)

--- a/aio/content/tutorial/first-app/first-app-lesson-02.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-02.md
@@ -1,6 +1,6 @@
 # First Angular app lesson 2 - Create Home component
 
-This tutorial lesson demonstrates how to create a new [component](https://angular.io/guide/component-overview) for your Angular app.
+This tutorial lesson demonstrates how to create a new [component](/guide/component-overview) for your Angular app.
 
 **Time required:** expect to spend about 10 minutes to complete this lesson.
 
@@ -40,7 +40,7 @@ When you create your `HomeComponent`, you use these properties:
 *   `template`: to describe the component's HTML markup and layout.
 *   `styleUrls`: to list the URLs of the CSS files that the component users in an array.
 
-Components have other [properties](https://angular.io/api/core/Component), but these are the ones used by `HomeComponent`.
+Components have other [properties](/api/core/Component), but these are the ones used by `HomeComponent`.
 
 ## Lesson steps
 

--- a/aio/content/tutorial/first-app/first-app-lesson-13.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-13.md
@@ -50,7 +50,7 @@ The `HomeComponent` already contains an input field that you will use to capture
         &lt;input type="text" placeholder="Filter by city" #filter&gt;
     </code-example>
 
-    This example uses a [template variable](https://angular.io/guide/template-reference-variables) to get access to the input as its value.
+    This example uses a [template variable](/guide/template-reference-variables) to get access to the input as its value.
 
 1.  Next, update the component template to attach an event handler to the "search" button.
 

--- a/aio/content/tutorial/first-app/index.md
+++ b/aio/content/tutorial/first-app/index.md
@@ -77,7 +77,7 @@ If you do not have a version of `node.js` installed, please follow the [directio
 
 ### Step 3 - Install the latest version of Angular
 
-With `node.js` and `npm` installed, the next step is to install the [Angular CLI](https://angular.io/cli) which provides tooling for effective Angular development.
+With `node.js` and `npm` installed, the next step is to install the [Angular CLI](/cli) which provides tooling for effective Angular development.
 
 From a **Terminal** window:
 
@@ -103,5 +103,5 @@ In this lesson, you learned about the app that you build in this tutorial and pr
 
 For more information about the topics covered in this lesson, visit:
 
-* [What is Angular](https://angular.io/guide/what-is-angular)
-* [Angular CLI Reference](https://angular.io/cli)
+* [What is Angular](/guide/what-is-angular)
+* [Angular CLI Reference](/cli)

--- a/aio/tools/transforms/angular-base-package/index.js
+++ b/aio/tools/transforms/angular-base-package/index.js
@@ -38,6 +38,7 @@ module.exports = new Package('angular-base', [
   .processor(require('./processors/checkContentRules'))
   .processor(require('./processors/splitDescription'))
   .processor(require('./processors/disambiguateDocPaths'))
+  .processor(require('./processors/checkAbsoluteAioLinks'))
 
   // overrides base packageInfo and returns the one for the 'angular/angular' repo.
   .factory('packageInfo', function() { return require(path.resolve(PROJECT_ROOT, 'package.json')); })

--- a/aio/tools/transforms/angular-base-package/processors/checkAbsoluteAioLinks.js
+++ b/aio/tools/transforms/angular-base-package/processors/checkAbsoluteAioLinks.js
@@ -1,0 +1,26 @@
+/**
+ * @dgProcessor checkAioAbsoluteLinks
+ * @description
+ * Searches for absolute links to aio.
+ * Absolute links are to be avoided because they appear as external links and won't point to the
+ * currently visited version of the docs
+ */
+module.exports = function checkAioAbsoluteLinks(log, createDocMessage) {
+  return {
+    $runAfter: ['inlineTagProcessor'],
+    $runBefore: ['convertToJsonProcessor'],
+    $process: function (docs) {
+      docs
+        .filter((doc) => !doc.fileInfo?.relativePath?.endsWith('json'))
+        .forEach((doc) => {
+          const matches = [...doc.renderedContent.matchAll(/href="(https:\/\/angular.io\/.*?)"/g)];
+          if (matches.length > 0) {
+            log.warn(createDocMessage('AIO link', doc));
+            matches.forEach(([, group]) => {
+              log.warn(`• ${group}`);
+            });
+          }
+        });
+    },
+  };
+};

--- a/packages/common/src/i18n/format_date.ts
+++ b/packages/common/src/i18n/format_date.ts
@@ -57,7 +57,7 @@ enum TranslationType {
  * @returns The formatted date string.
  *
  * @see `DatePipe`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */

--- a/packages/common/src/i18n/format_number.ts
+++ b/packages/common/src/i18n/format_number.ts
@@ -143,7 +143,7 @@ function formatNumberToLocaleString(
  *
  * @see `formatNumber()`
  * @see `DecimalPipe`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -184,7 +184,7 @@ export function formatCurrency(
  *
  * @see `formatNumber()`
  * @see `DecimalPipe`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  * @publicApi
  *
  */
@@ -210,7 +210,7 @@ export function formatPercent(value: number, locale: string, digitsInfo?: string
  * `{minIntegerDigits}.{minFractionDigits}-{maxFractionDigits}`. See `DecimalPipe` for more details.
  *
  * @returns The formatted text string.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */

--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -14,7 +14,7 @@ import {CURRENCIES_EN, CurrenciesSymbols} from './currencies';
 /**
  * Format styles that can be used to represent numbers.
  * @see `getLocaleNumberFormat()`.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -30,7 +30,7 @@ export enum NumberFormatStyle {
  *
  * @see `NgPlural`
  * @see `NgPluralCase`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -48,7 +48,7 @@ export enum Plural {
  * Typically the standalone version is for the nominative form of the word,
  * and the format version is used for the genitive case.
  * @see [CLDR website](http://cldr.unicode.org/translation/date-time-1/date-time#TOC-Standalone-vs.-Format-Styles)
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -83,7 +83,7 @@ export enum TranslationWidth {
  * @see `getLocaleDateFormat()`
  * @see `getLocaleTimeFormat()`
  * @see `getLocaleDateTimeFormat()`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  * @publicApi
  */
 export enum FormatWidth {
@@ -114,7 +114,7 @@ export enum FormatWidth {
  * Examples are based on `en-US` values.
  *
  * @see `getLocaleNumberSymbol()`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -213,7 +213,7 @@ export enum WeekDay {
  * The loaded locale could be, for example, a global one rather than a regional one.
  * @param locale A locale code, such as `fr-FR`.
  * @returns The locale code. For example, `fr`.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -228,7 +228,7 @@ export function getLocaleId(locale: string): string {
  * @param formStyle The required grammatical form.
  * @param width The required character width.
  * @returns An array of localized period strings. For example, `[AM, PM]` for `en-US`.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -250,7 +250,7 @@ export function getLocaleDayPeriods(
  * @param width The required character width.
  * @returns An array of localized name strings.
  * For example,`[Sunday, Monday, ... Saturday]` for `en-US`.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -271,7 +271,7 @@ export function getLocaleDayNames(
  * @param width The required character width.
  * @returns An array of localized name strings.
  * For example,  `[January, February, ...]` for `en-US`.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -291,7 +291,7 @@ export function getLocaleMonthNames(
 
  * @returns An array of localized era strings.
  * For example, `[AD, BC]` for `en-US`.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -309,7 +309,7 @@ export function getLocaleEraNames(
  * @returns A day index number, using the 0-based week-day index for `en-US`
  * (Sunday = 0, Monday = 1, ...).
  * For example, for `fr-FR`, returns 1 to indicate that the first day is Monday.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -323,7 +323,7 @@ export function getLocaleFirstDayOfWeek(locale: string): WeekDay {
  *
  * @param locale A locale code for the locale format rules to use.
  * @returns The range of day values, `[startDay, endDay]`.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -339,7 +339,7 @@ export function getLocaleWeekEndRange(locale: string): [WeekDay, WeekDay] {
  * @param width The format type.
  * @returns The localized formatting string.
  * @see `FormatWidth`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -355,7 +355,7 @@ export function getLocaleDateFormat(locale: string, width: FormatWidth): string 
  * @param width The format type.
  * @returns The localized formatting string.
  * @see `FormatWidth`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
 
  * @publicApi
  */
@@ -371,7 +371,7 @@ export function getLocaleTimeFormat(locale: string, width: FormatWidth): string 
  * @param width The format type.
  * @returns The localized formatting string.
  * @see `FormatWidth`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -387,7 +387,7 @@ export function getLocaleDateTimeFormat(locale: string, width: FormatWidth): str
  * @param symbol The symbol to localize.
  * @returns The character for the localized symbol.
  * @see `NumberSymbol`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -435,7 +435,7 @@ export function getLocaleNumberSymbol(locale: string, symbol: NumberSymbol): str
  * @returns The localized format string.
  * @see `NumberFormatStyle`
  * @see [CLDR website](http://cldr.unicode.org/translation/number-patterns)
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -451,7 +451,7 @@ export function getLocaleNumberFormat(locale: string, type: NumberFormatStyle): 
  * @param locale A locale code for the locale format rules to use.
  * @returns The localized symbol character,
  * or `null` if the main country cannot be determined.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -466,7 +466,7 @@ export function getLocaleCurrencySymbol(locale: string): string|null {
  * @param locale A locale code for the locale format rules to use.
  * @returns The currency name,
  * or `null` if the main country cannot be determined.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -493,7 +493,7 @@ export function getLocaleCurrencyCode(locale: string): string|null {
  * Retrieves the currency values for a given locale.
  * @param locale A locale code for the locale format rules to use.
  * @returns The currency values.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  */
 function getLocaleCurrencies(locale: string): {[code: string]: CurrenciesSymbols} {
   const data = ɵfindLocaleData(locale);
@@ -533,7 +533,7 @@ function checkFullData(data: any) {
  * or null if no periods are available.
  *
  * @see `getLocaleExtraDayPeriods()`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -562,7 +562,7 @@ export function getLocaleExtraDayPeriodRules(locale: string): (Time|[Time, Time]
  * @param width The required character width.
  * @returns The translated day-period strings.
  * @see `getLocaleExtraDayPeriodRules()`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -583,7 +583,7 @@ export function getLocaleExtraDayPeriods(
  * @param locale A locale code for the locale format rules to use.
  * @publicApi
  * @returns 'rtl' or 'ltr'
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  */
 export function getLocaleDirection(locale: string): 'ltr'|'rtl' {
   const data = ɵfindLocaleData(locale);
@@ -599,7 +599,7 @@ export function getLocaleDirection(locale: string): 'ltr'|'rtl' {
  * @param data The data array to retrieve from.
  * @param index A 0-based index into the array to start from.
  * @returns The value immediately before the given index position.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -643,7 +643,7 @@ function extractTime(time: string): Time {
  * @param locale A locale code for the locale format rules to use.
  *
  * @returns The symbol, or the currency code if no symbol is available.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */
@@ -667,7 +667,7 @@ const DEFAULT_NB_OF_CURRENCY_DIGITS = 2;
  *
  * @param code The currency code.
  * @returns The number of decimal digits, typically 0 or 2.
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi
  */

--- a/packages/core/src/i18n/locale_data_api.ts
+++ b/packages/core/src/i18n/locale_data_api.ts
@@ -88,7 +88,7 @@ export function getLocaleCurrencyCode(locale: string): string|null {
  * @param locale A locale code for the locale format rules to use.
  * @returns The plural function for the locale.
  * @see `NgPlural`
- * @see [Internationalization (i18n) Guide](https://angular.io/guide/i18n-overview)
+ * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  */
 export function getLocalePluralCase(locale: string): (value: number) => number {
   const data = findLocaleData(locale);

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -62,12 +62,12 @@ import {assertComponentDef} from './errors';
  * @param component Component class reference.
  * @param options Set of options to use:
  *  * `environmentInjector`: An `EnvironmentInjector` instance to be used for the component, see
- * additional info about it at https://angular.io/guide/standalone-components#environment-injectors.
+ * additional info about it [here](/guide/standalone-components#environment-injectors).
  *  * `hostElement` (optional): A DOM node that should act as a host node for the component. If not
  * provided, Angular creates one based on the tag name used in the component selector (and falls
  * back to using `div` if selector doesn't have tag name info).
- *  * `elementInjector` (optional): An `ElementInjector` instance, see additional info about it at
- * https://angular.io/guide/hierarchical-dependency-injection#elementinjector.
+ *  * `elementInjector` (optional): An `ElementInjector` instance, see additional info about it
+ * [here](/guide/hierarchical-dependency-injection#elementinjector).
  *  * `projectableNodes` (optional): A list of DOM nodes that should be projected through
  *                      [`<ng-content>`](api/core/ng-content) of the new component instance.
  * @returns ComponentRef instance that represents a given Component.

--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -593,7 +593,7 @@ export function getPipeDef<T>(type: any): PipeDef<T>|null {
 /**
  * Checks whether a given Component, Directive or Pipe is marked as standalone.
  * This will return false if passed anything other than a Component, Directive, or Pipe class
- * See this guide for additional information: https://angular.io/guide/standalone-components
+ * See [this guide](/guide/standalone-components) for additional information:
  *
  * @param type A reference to a Component, Directive or Pipe.
  * @publicApi

--- a/packages/core/testing/src/test_bed_common.ts
+++ b/packages/core/testing/src/test_bed_common.ts
@@ -51,14 +51,14 @@ export interface TestModuleMetadata {
    * Whether NG0304 runtime errors should be thrown when unknown elements are present in component's
    * template. Defaults to `false`, where the error is simply logged. If set to `true`, the error is
    * thrown.
-   * @see https://angular.io/errors/NG8001 for the description of the problem and how to fix it
+   * @see [NG8001](/errors/NG8001) for the description of the problem and how to fix it
    */
   errorOnUnknownElements?: boolean;
   /**
    * Whether errors should be thrown when unknown properties are present in component's template.
    * Defaults to `false`, where the error is simply logged.
    * If set to `true`, the error is thrown.
-   * @see https://angular.io/errors/NG8002 for the description of the error and how to fix it
+   * @see [NG8002](/errors/NG8002) for the description of the error and how to fix it
    */
   errorOnUnknownProperties?: boolean;
 }
@@ -75,14 +75,14 @@ export interface TestEnvironmentOptions {
    * Whether errors should be thrown when unknown elements are present in component's template.
    * Defaults to `false`, where the error is simply logged.
    * If set to `true`, the error is thrown.
-   * @see https://angular.io/errors/NG8001 for the description of the error and how to fix it
+   * @see [NG8001](/errors/NG8001) for the description of the error and how to fix it
    */
   errorOnUnknownElements?: boolean;
   /**
    * Whether errors should be thrown when unknown properties are present in component's template.
    * Defaults to `false`, where the error is simply logged.
    * If set to `true`, the error is thrown.
-   * @see https://angular.io/errors/NG8002 for the description of the error and how to fix it
+   * @see [NG8002](/errors/NG8002) for the description of the error and how to fix it
    */
   errorOnUnknownProperties?: boolean;
 }


### PR DESCRIPTION
This PR introduces a new transform processor to warn about absolute links to angular.io. 

Absolute links to aio should be avoided as they will appear as external links in the doc and they break the navigation when on specific version of the documentation. 

This is a follow-up work of #50080 