### PR TITLE
refactor(core): drop `next` prefix from hydration guide link

### DIFF
--- a/packages/core/src/hydration/api.ts
+++ b/packages/core/src/hydration/api.ts
@@ -78,7 +78,7 @@ function printHydrationStats(injector: Injector) {
       `and ${ngDevMode!.hydratedNodes} node(s), ` +
       `${ngDevMode!.componentsSkippedHydration} component(s) were skipped. ` +
       `Note: this feature is in Developer Preview mode. ` +
-      `Learn more at https://next.angular.io/guide/hydration.`;
+      `Learn more at https://angular.io/guide/hydration.`;
   // tslint:disable-next-line:no-console
   console.log(message);
 }


### PR DESCRIPTION
This commit updates the content of the console log to drop the `next.` prefix from hydration guide link.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No