### PR TITLE
docs(docs-infra): Remove warning for `@Annotation`.

### DIFF
--- a/aio/tools/transforms/angular-api-package/tag-defs/annotation.js
+++ b/aio/tools/transforms/angular-api-package/tag-defs/annotation.js
@@ -1,0 +1,5 @@
+// @Annotation is load-bearing for tsickle's decorator downleveling transformation
+// We must provide a tag-def for it or the doc-gen will produce a warning.
+module.exports = function() {
+  return {name: 'Annotation'};
+};


### PR DESCRIPTION
Per #50206, `@Annotation` is needed for tsickle. This commit removes the warning `Invalid tags found` produced by dgeni for the annotation decorator.

And my apologies for the commit that was removing `@annotation` in the code base, I was lacking insight on it ! 