### PR TITLE
docs(core): mark `toSignal` and `ToSignalOptions` as "Developer Preview" items in the docs

### DIFF
--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -16,6 +16,7 @@ import {untracked} from '../../src/signals';
  * Options for `toSignal`.
  *
  * @publicApi
+ * @developerPreview
  */
 export interface ToSignalOptions<T> {
   /**

--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -48,7 +48,7 @@ export interface ToSignalOptions<T> {
    * `toObservable`'s creation context is destroyed.
    *
    * If manual cleanup is enabled, then `DestroyRef` is not used, and the subscription will persist
-   * until the `Observable` itself completes.
+   * until the `Observable` itself completes or errors.
    */
   manualCleanup?: boolean;
 }
@@ -56,45 +56,26 @@ export interface ToSignalOptions<T> {
 /**
  * Get the current value of an `Observable` as a reactive `Signal`.
  *
- * `toSignal` returns a `Signal` which provides synchronous reactive access to values produced
- * by the given `Observable`, by subscribing to that `Observable`. The returned `Signal` will always
- * have the most recent value emitted by the subscription, and will throw an error if the
- * `Observable` errors.
- *
  * Before the `Observable` emits its first value, the `Signal` will return `undefined`. To avoid
  * this, either an `initialValue` can be passed or the `requireSync` option enabled.
  *
- * By default, the subscription will be automatically cleaned up when the current injection context
- * is destroyed. For example, when `toObservable` is called during the construction of a component,
- * the subscription will be cleaned up when the component is destroyed. If an injection context is
- * not available, an explicit `Injector` can be passed instead.
+ * @param source The `Observable` that will be converted to a `Signal`.
+ * @return A reactive `Signal` composed of the passed in `Observable`.
  *
- * If the subscription should persist until the `Observable` itself completes, the `manualCleanup`
- * option can be specified instead, which disables the automatic subscription teardown. No injection
- * context is needed in this configuration as well.
+ * @developerPreview
  */
 export function toSignal<T>(source: Observable<T>|Subscribable<T>): Signal<T|undefined>;
 
 /**
  * Get the current value of an `Observable` as a reactive `Signal`.
  *
- * `toSignal` returns a `Signal` which provides synchronous reactive access to values produced
- * by the given `Observable`, by subscribing to that `Observable`. The returned `Signal` will always
- * have the most recent value emitted by the subscription, and will throw an error if the
- * `Observable` errors.
- *
  * Before the `Observable` emits its first value, the `Signal` will return the configured
  * `initialValue`, or `undefined` if no `initialValue` is provided. If the `Observable` is
  * guaranteed to emit synchronously, then the `requireSync` option can be passed instead.
  *
- * By default, the subscription will be automatically cleaned up when the current injection context
- * is destroyed. For example, when `toObservable` is called during the construction of a component,
- * the subscription will be cleaned up when the component is destroyed. If an injection context is
- * not available, an explicit `Injector` can be passed instead.
- *
- * If the subscription should persist until the `Observable` itself completes, the `manualCleanup`
- * option can be specified instead, which disables the automatic subscription teardown. No injection
- * context is needed in this configuration as well.
+ * @param source The `Observable` that will be converted to a `Signal`.
+ * @param options The options object used to configure conversion behavior.
+ * @return A reactive `Signal` composed of the passed in `Observable`.
  *
  * @developerPreview
  */
@@ -106,23 +87,13 @@ export function toSignal<T>(
 /**
  * Get the current value of an `Observable` as a reactive `Signal`.
  *
- * `toSignal` returns a `Signal` which provides synchronous reactive access to values produced
- * by the given `Observable`, by subscribing to that `Observable`. The returned `Signal` will always
- * have the most recent value emitted by the subscription, and will throw an error if the
- * `Observable` errors.
- *
  * Before the `Observable` emits its first value, the `Signal` will return the configured
  * `initialValue`. If the `Observable` is guaranteed to emit synchronously, then the `requireSync`
  * option can be passed instead.
  *
- * By default, the subscription will be automatically cleaned up when the current injection context
- * is destroyed. For example, when `toObservable` is called during the construction of a component,
- * the subscription will be cleaned up when the component is destroyed. If an injection context is
- * not available, an explicit `Injector` can be passed instead.
- *
- * If the subscription should persist until the `Observable` itself completes, the `manualCleanup`
- * option can be specified instead, which disables the automatic subscription teardown. No injection
- * context is needed in this configuration as well.
+ * @param source The `Observable` that will be converted to a `Signal`.
+ * @param options The options object used to configure conversion behavior.
+ * @return A reactive `Signal` composed of the passed in `Observable`.
  *
  * @developerPreview
  */
@@ -133,14 +104,27 @@ export function toSignal<T, U extends T|null|undefined>(
 /**
  * Get the current value of an `Observable` as a reactive `Signal`.
  *
+ * With `requireSync` set to `true`, `toSignal` will assert that the `Observable` produces a value
+ * immediately upon subscription. No `initialValue` is needed in this case, and the returned signal
+ * does not include an `undefined` type.
+ *
+ * @param source The `Observable` that will be converted to a `Signal`.
+ * @param options The options object used to configure conversion behavior.
+ * @return A reactive `Signal` composed of the passed in `Observable`.
+ *
+ * @developerPreview
+ */
+export function toSignal<T>(
+    source: Observable<T>|Subscribable<T>,
+    options: ToSignalOptions<undefined>&{requireSync: true}): Signal<T>;
+
+/**
+ * Get the current value of an `Observable` as a reactive `Signal`.
+ *
  * `toSignal` returns a `Signal` which provides synchronous reactive access to values produced
  * by the given `Observable`, by subscribing to that `Observable`. The returned `Signal` will always
  * have the most recent value emitted by the subscription, and will throw an error if the
  * `Observable` errors.
- *
- * With `requireSync` set to `true`, `toSignal` will assert that the `Observable` produces a value
- * immediately upon subscription. No `initialValue` is needed in this case, and the returned signal
- * does not include an `undefined` type.
  *
  * By default, the subscription will be automatically cleaned up when the current injection context
  * is destroyed. For example, when `toObservable` is called during the construction of a component,
@@ -151,11 +135,12 @@ export function toSignal<T, U extends T|null|undefined>(
  * option can be specified instead, which disables the automatic subscription teardown. No injection
  * context is needed in this configuration as well.
  *
+ * @param source The `Observable` that will be converted to a `Signal`.
+ * @param options The options object used to configure conversion behavior.
+ * @return A reactive `Signal` composed of the passed in `Observable`.
+ *
  * @developerPreview
  */
-export function toSignal<T>(
-    source: Observable<T>|Subscribable<T>,
-    options: ToSignalOptions<undefined>&{requireSync: true}): Signal<T>;
 export function toSignal<T, U = undefined>(
     source: Observable<T>|Subscribable<T>, options?: ToSignalOptions<U>): Signal<T|U> {
   const requiresCleanup = !options?.manualCleanup;


### PR DESCRIPTION
The function implementation signature needs to have JSDocs comment so that docs generator could parse it and use the data from the comment to generate valid docs content.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
[`toSignal`](https://angular.io/api/core/rxjs-interop/toSignal) is not marked as a "Developer Preview" item.

Issue Number: N/A

## What is the new behavior?
This PR marks [`toSignal`](https://angular.io/api/core/rxjs-interop/toSignal) as a "Developer Preview" item:

![image](https://github.com/angular/angular/assets/28087049/265a79ae-88c9-44b6-906e-bb6e199fa57e)

~It also adds basic docs for the parameters and **Returns** docs:~

![image](https://github.com/angular/angular/assets/28087049/a5a1c3a4-2524-428d-8690-74da5e406b79)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

In my [other proposed PR](https://github.com/angular/angular/pull/50142) where users can filter items based on the "Developer Preview" status, `toSignal` could not be found, even though it was marked with `@developerPreview` tag def. It looks like the docs generator only takes data from JSDocs comments from the implementation of the function, therefore I added only basic docs above the code that implements `toSignal`.

~I was thinking about adding only this JSDocs comment:~

```ts
/**
 * @developerPreview
 */
export function toSignal<T, U = undefined>(source: Observable<T>, options?: ToSignalOptions<U>): Signal<T|U> {
  // impl...
}
```

~But then I saw that the docs seem a bit empty, so I added heading, `@params` and `@return` docs as well.~

EDIT:

These sentences from JSDoc comments:
 - -
   ```
   `toSignal` returns a `Signal` which provides synchronous reactive access to values produced
   by the given `Observable`, by subscribing to that `Observable`. The returned `Signal` will always
   have the most recent value emitted by the subscription, and will throw an error if the
   `Observable` errors.`
   ```
 - 
   ```
   By default, the subscription will be automatically cleaned up when the current injection context
   is destroyed. For example, when `toObservable` is called during the construction of a component,
   the subscription will be cleaned up when the component is destroyed. If an injection context is
   not available, an explicit `Injector` can be passed instead.
   ```
 - 
   ```
   If the subscription should persist until the `Observable` itself completes, the `manualCleanup`
   option can be specified instead, which disables the automatic subscription teardown. No injection
   context is needed in this configuration as well.
   ```

are moved to the function implementation signature. The reason is that all 4 overloads had the same sentence in every JSDoc comment, therefore editing one of them would require editing the same sentence in all 4 places. Now, it is only visible in one place. And, they are now part of the **Description** heading:

![image](https://github.com/angular/angular/assets/28087049/1fbe317a-b778-4365-a43b-5ee486c49b0b)

Overload signatures now have `@param` and `@return` docs + the [first overload](https://github.com/angular/angular/blob/cc286be7af31c7f999d6c469d3fd8f9becb28ce7/packages/core/rxjs-interop/src/to_signal.ts#L76) has `@developerPreview` tag.

![image](https://github.com/angular/angular/assets/28087049/ebe29788-545a-43d4-aa7d-035ec4672a76)


_Sidenote_: I updated `manualCleanup` docs where I stated that Observables can manually terminate themselves on errors as well.