### PR TITLE
refactor(core): avoid using `def.signal` during component id computation

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -689,7 +689,6 @@ function getComponentId(componentDef: ComponentDef<unknown>): string {
     componentDef.decls,
     componentDef.encapsulation,
     componentDef.standalone,
-    componentDef.signals,
     componentDef.exportAs,
     componentDef.inputs,
     componentDef.outputs,


### PR DESCRIPTION
This commit updates the code in 16.0.x branch to avoid using the `def.signals` field on a component, while calculating component id. The `signal` field was introduced later and will be available in 16.1.0.


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No