### PR TITLE
feat(http): Introduction of the `fetch` Backend for the `HttpClient`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,6 +67,11 @@ nodejs_register_toolchains(
     node_version = "16.14.0",
 )
 
+nodejs_register_toolchains(
+    name = "node18",
+    node_version = "18.10.0",
+)
+
 # Download npm dependencies.
 load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 load("//integration:npm_package_archives.bzl", "npm_package_archives")

--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -16,7 +16,7 @@ import { XhrFactory } from '@angular/common';
 // @public
 export class FetchBackend implements HttpBackend {
     // (undocumented)
-    handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
+    handle(request: HttpRequest<any>): Observable<HttpEvent<any>>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<FetchBackend, never>;
     // (undocumented)

--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -14,6 +14,16 @@ import { Provider } from '@angular/core';
 import { XhrFactory } from '@angular/common';
 
 // @public
+export class FetchBackend implements HttpBackend {
+    // (undocumented)
+    handle(req: HttpRequest<any>): Observable<HttpEvent<any>>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<FetchBackend, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<FetchBackend>;
+}
+
+// @public
 export const HTTP_INTERCEPTORS: InjectionToken<HttpInterceptor[]>;
 
 // @public
@@ -1741,6 +1751,8 @@ export enum HttpFeatureKind {
     // (undocumented)
     CustomXsrfConfiguration = 2,
     // (undocumented)
+    Fetch = 6,
+    // (undocumented)
     Interceptors = 0,
     // (undocumented)
     JsonpSupport = 4,
@@ -1783,7 +1795,7 @@ export class HttpHeaderResponse extends HttpResponseBase {
 export class HttpHeaders {
     constructor(headers?: string | {
         [name: string]: string | number | (string | number)[];
-    });
+    } | Headers);
     append(name: string, value: string | string[]): HttpHeaders;
     delete(name: string, value?: string | string[]): HttpHeaders;
     get(name: string): string | null;
@@ -2164,6 +2176,9 @@ export class JsonpInterceptor {
 
 // @public
 export function provideHttpClient(...features: HttpFeature<HttpFeatureKind>[]): EnvironmentProviders;
+
+// @public
+export function withFetch(): HttpFeature<HttpFeatureKind.Fetch>;
 
 // @public
 export function withInterceptors(interceptorFns: HttpInterceptorFn[]): HttpFeature<HttpFeatureKind.Interceptors>;

--- a/packages/common/http/public_api.ts
+++ b/packages/common/http/public_api.ts
@@ -9,12 +9,13 @@
 export {HttpBackend, HttpHandler} from './src/backend';
 export {HttpClient} from './src/client';
 export {HttpContext, HttpContextToken} from './src/context';
+export {FetchBackend} from './src/fetch';
 export {HttpHeaders} from './src/headers';
 export {HTTP_INTERCEPTORS, HttpHandlerFn, HttpInterceptor, HttpInterceptorFn, HttpInterceptorHandler as ɵHttpInterceptorHandler, HttpInterceptorHandler as ɵHttpInterceptingHandler} from './src/interceptor';
 export {JsonpClientBackend, JsonpInterceptor} from './src/jsonp';
 export {HttpClientJsonpModule, HttpClientModule, HttpClientXsrfModule} from './src/module';
 export {HttpParameterCodec, HttpParams, HttpParamsOptions, HttpUrlEncodingCodec} from './src/params';
-export {HttpFeature, HttpFeatureKind, provideHttpClient, withInterceptors, withInterceptorsFromDi, withJsonpSupport, withNoXsrfProtection, withRequestsMadeViaParent, withXsrfConfiguration} from './src/provider';
+export {HttpFeature, HttpFeatureKind, provideHttpClient, withFetch, withInterceptors, withInterceptorsFromDi, withJsonpSupport, withNoXsrfProtection, withRequestsMadeViaParent, withXsrfConfiguration} from './src/provider';
 export {HttpRequest} from './src/request';
 export {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpProgressEvent, HttpResponse, HttpResponseBase, HttpSentEvent, HttpStatusCode, HttpUploadProgressEvent, HttpUserEvent} from './src/response';
 export {withHttpTransferCache as ɵwithHttpTransferCache} from './src/transfer_cache';

--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -1,0 +1,251 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {inject, Injectable} from '@angular/core';
+import {BehaviorSubject, defer, merge, Observable} from 'rxjs';
+import {finalize} from 'rxjs/operators';
+
+import {HttpBackend} from './backend';
+import {HttpHeaders} from './headers';
+import {HttpRequest} from './request';
+import {HttpDownloadProgressEvent, HttpErrorResponse, HttpEvent, HttpEventType, HttpHeaderResponse, HttpResponse, HttpStatusCode} from './response';
+
+const XSSI_PREFIX = /^\)\]\}',?\n/;
+
+const REQUEST_URL_HEADER = `X-Request-URL`;
+
+/**
+ * Determine an appropriate URL for the response, by checking either
+ * response url or the X-Request-URL header.
+ */
+function getResponseUrl(response: Response): string|null {
+  if (response.url) {
+    return response.url;
+  }
+  // stored as lowercase in the map
+  const xRequestUrl = REQUEST_URL_HEADER.toLocaleLowerCase();
+  return response.headers.get(xRequestUrl);
+}
+
+/**
+ * Uses `fetch` to send requests to a backend server.
+ *
+ * This `FetchBackend` requires the support of the
+ * [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) which is available on all
+ * supported browsers and on Node.js v18 or later.
+ *
+ * @see {@link HttpHandler}
+ *
+ * @publicApi
+ * @developerPreview
+ */
+@Injectable()
+export class FetchBackend implements HttpBackend {
+  // We need to bind the native fetch to its context or it will throw an "illegal invocation"
+  private readonly fetchImpl =
+      inject(FetchFactory, {optional: true})?.fetch ?? fetch.bind(globalThis);
+
+  handle(req: HttpRequest<any>): Observable<HttpEvent<any>> {
+    // Deferring to allow creating a new AbortController on retry()
+    return defer(() => {
+      const abortController = new AbortController();
+
+      // TODO: use `AsyncGenerators` instead of `BehaviorSubject` when we no longer support RXJS 6.x
+      // We can't use it now because from() doesn't accept generators on RxJS 6.
+      // Just replace `reportEvent` calls with `yield`.
+      const eventStream = new BehaviorSubject<HttpEvent<any>>({type: HttpEventType.Sent});
+
+      // Everything happens on Observable subscription.
+      return merge(
+                 defer(() => {
+                   return this
+                       .doRequest(req, abortController.signal, (event) => eventStream.next(event))
+                       .finally(() => eventStream.complete());
+                 }),
+                 eventStream,
+                 )
+          .pipe(finalize(() => {
+            // Aborting the fetch call when the observable is unsubscribed
+            abortController.abort();
+          }));
+    });
+  }
+
+  private async doRequest(
+      request: HttpRequest<any>, signal: AbortSignal,
+      reportEvent: (event: HttpEvent<any>) => void): Promise<HttpResponse<any>> {
+    const init = this.createRequestInit(request);
+    let response;
+
+    try {
+      response = await this.fetchImpl(request.url, {signal, ...init});
+    } catch (error: any) {
+      throw new HttpErrorResponse({
+        error,
+        status: error.status ?? 0,
+        statusText: error.statusText,
+        url: request.url,
+        headers: error.headers,
+      });
+    }
+
+    const headers = new HttpHeaders(response.headers);
+    const statusText = response.statusText;
+    const url = getResponseUrl(response) ?? request.url;
+
+    let status = response.status;
+    let body: string|ArrayBuffer|Blob|object|null = null;
+
+    if (request.reportProgress) {
+      reportEvent(new HttpHeaderResponse({headers, status, statusText, url}));
+    }
+
+    if (response.body) {
+      // Read Progess
+      const contentLength = response.headers.get('content-length');
+      const chunks: Uint8Array[] = [];
+      const reader = response.body.getReader();
+      let receivedLength = 0;
+
+      let decoder: TextDecoder;
+      let partialText: string|undefined;
+
+      while (true) {
+        const {done, value} = await reader.read();
+
+        if (done) {
+          break;
+        }
+
+        chunks.push(value);
+        receivedLength += value.length;
+
+        if (request.reportProgress) {
+          partialText = request.responseType === 'text' ?
+              (partialText ?? '') + (decoder ??= new TextDecoder).decode(value, {stream: true}) :
+              undefined;
+
+          reportEvent({
+            type: HttpEventType.DownloadProgress,
+            total: contentLength ? +contentLength : undefined,
+            loaded: receivedLength,
+            partialText,
+          } as HttpDownloadProgressEvent);
+        }
+      }
+
+      // Combine all chunks.
+      const chunksAll = this.concatChunks(chunks, receivedLength);
+
+      body = this.parseBody(request, response, chunksAll);
+    }
+
+    // Same behavior as the XhrBackend
+    if (status === 0) {
+      status = body ? HttpStatusCode.Ok : 0;
+    }
+
+    // ok determines whether the response will be transmitted on the event or
+    // error channel. Unsuccessful status codes (not 2xx) will always be errors,
+    // but a successful status code can still result in an error if the user
+    // asked for JSON data and the body cannot be parsed as such.
+    const ok = status >= 200 && status < 300;
+
+    if (ok) {
+      return new HttpResponse({
+        body,
+        headers,
+        status,
+        statusText,
+        url,
+      });
+    }
+
+    throw new HttpErrorResponse({
+      error: body,
+      headers,
+      status,
+      statusText,
+      url,
+    });
+  }
+
+  private parseBody(request: HttpRequest<any>, response: Response, binContent: Uint8Array): string
+      |ArrayBuffer|Blob|object|null {
+    try {
+      switch (request.responseType) {
+        case 'json':
+          // stripping the XSSI when present
+          const text = new TextDecoder().decode(binContent).replace(XSSI_PREFIX, '');
+          return text === '' ? null : JSON.parse(text) as object;
+        case 'text':
+          return new TextDecoder().decode(binContent);
+        case 'blob':
+          return new Blob([binContent]);
+        case 'arraybuffer':
+          return binContent.buffer;
+      }
+    } catch (error) {
+      // body loading or parsing failed
+      throw new HttpErrorResponse({
+        error,
+        headers: new HttpHeaders(response.headers),
+        status: response.status,
+        statusText: response.statusText,
+        url: getResponseUrl(response) ?? request.url,
+      });
+    }
+  }
+
+  private createRequestInit(req: HttpRequest<any>): RequestInit {
+    // We could share some of this logic with the XhrBackend
+
+    const headers: Record<string, string> = {};
+    const credentials: RequestCredentials|undefined = req.withCredentials ? 'include' : undefined;
+
+    // Setting all the requested headers.
+    req.headers.forEach((name, values) => (headers[name] = values.join(',')));
+
+    // Add an Accept header if one isn't present already.
+    headers['Accept'] ??= 'application/json, text/plain, */*';
+
+    // Auto-detect the Content-Type header if one isn't present already.
+    if (!headers['Content-Type']) {
+      const detectedType = req.detectContentTypeHeader();
+      // Sometimes Content-Type detection fails.
+      if (detectedType !== null) {
+        headers['Content-Type'] = detectedType;
+      }
+    }
+
+    return {
+      body: req.body,
+      method: req.method,
+      headers,
+      credentials,
+    };
+  }
+
+  private concatChunks(chunks: Uint8Array[], totalLength: number): Uint8Array {
+    const chunksAll = new Uint8Array(totalLength);
+    let position = 0;
+    for (const chunk of chunks) {
+      chunksAll.set(chunk, position);
+      position += chunk.length;
+    }
+
+    return chunksAll;
+  }
+}
+
+/**
+ * Abstract class to provide a mocked implementation of `fetch()`
+ */
+export abstract class FetchFactory {
+  abstract fetch: typeof fetch;
+}

--- a/packages/common/http/src/request.ts
+++ b/packages/common/http/src/request.ts
@@ -113,6 +113,8 @@ export class HttpRequest<T> {
    *
    * Progress events are expensive (change detection runs on each event) and so
    * they should only be requested if the consumer intends to monitor them.
+   *
+   * Note: The `FetchBackend` doesn't support progress report on uploads.
    */
   readonly reportProgress: boolean = false;
 

--- a/packages/common/http/src/response.ts
+++ b/packages/common/http/src/response.ts
@@ -21,6 +21,8 @@ export enum HttpEventType {
 
   /**
    * An upload progress event was received.
+   *
+   * Note: The `FetchBackend` doesn't support progress report on uploads.
    */
   UploadProgress,
 
@@ -86,6 +88,8 @@ export interface HttpDownloadProgressEvent extends HttpProgressEvent {
 
 /**
  * An upload progress event.
+ *
+ * Note: The `FetchBackend` doesn't support progress report on uploads.
  *
  * @publicApi
  */

--- a/packages/common/http/test/BUILD.bazel
+++ b/packages/common/http/test/BUILD.bazel
@@ -29,6 +29,17 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node"],
+    tags = [
+        # Remote execution doesn't work with Node.js 18 right now.
+        # See https://github.com/angular/dev-infra/issues/1017
+        "no-remote-exec",
+    ],
+    # TODO remove once the Node 18 is the default toolchain.
+    toolchain = select({
+        "@bazel_tools//src/conditions:linux_x86_64": "@node18_linux_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:darwin": "@node18_darwin_amd64//:node_toolchain",
+        "@bazel_tools//src/conditions:windows": "@node18_windows_amd64//:node_toolchain",
+    }),
     deps = [
         ":test_lib",
     ],

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -1,0 +1,469 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HttpEvent, HttpEventType, HttpRequest, HttpResponse} from '@angular/common/http';
+import {TestBed} from '@angular/core/testing';
+import {Observable, of, Subject} from 'rxjs';
+import {catchError, retry, scan, skip, take, toArray} from 'rxjs/operators';
+
+import {HttpDownloadProgressEvent, HttpErrorResponse, HttpHeaderResponse, HttpStatusCode} from '../public_api';
+import {FetchBackend, FetchFactory} from '../src/fetch';
+
+function trackEvents(obs: Observable<any>): Promise<any[]> {
+  return obs
+      .pipe(
+          // We don't want the promise to fail on HttpErrorResponse
+          catchError((e) => of(e)),
+          scan(
+              (acc, event) => {
+                acc.push(event);
+                return acc;
+              },
+              [] as any[]),
+          )
+      .toPromise();
+}
+
+const TEST_POST = new HttpRequest('POST', '/test', 'some body', {
+  responseType: 'text',
+});
+
+const XSSI_PREFIX = ')]}\'\n';
+
+describe('FetchBackend', async () => {
+  let fetchMock: MockFetchFactory = null!;
+  let backend: FetchBackend = null!;
+  let fetchSpy: jasmine.Spy<typeof fetch>;
+
+  function callFetchAndFlush(req: HttpRequest<any>): void {
+    backend.handle(req).pipe(take(1)).subscribe();
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'some response');
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: FetchFactory, useClass: MockFetchFactory},
+        FetchBackend,
+      ]
+    });
+
+    fetchMock = TestBed.inject(FetchFactory) as MockFetchFactory;
+    fetchSpy = spyOn(fetchMock, 'fetch').and.callThrough();
+    backend = TestBed.inject(FetchBackend);
+  });
+
+  it('emits status immediately', () => {
+    let event!: HttpEvent<any>;
+    // subscribe is sync
+    backend.handle(TEST_POST).pipe(take(1)).subscribe((e) => event = e);
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'some response');
+    expect(event.type).toBe(HttpEventType.Sent);
+  });
+
+  it('should not call fetch without a subscribe', () => {
+    const handle = backend.handle(TEST_POST);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    handle.subscribe();
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'some response');
+    expect(fetchSpy).toHaveBeenCalled();
+  });
+
+  it('should be able to retry', ((done) => {
+       const handle = backend.handle(TEST_POST);
+       // Skippin both HttpSentEvent (from the 1st subscription + retry)
+       handle.pipe(retry(1), skip(2)).subscribe((response) => {
+         expect(response.type).toBe(HttpEventType.Response);
+         expect((response as HttpResponse<any>).body).toBe('some response');
+         done();
+       });
+       fetchMock.mockErrorEvent('Error 1');
+       fetchMock.resetFetchPromise();
+
+       fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'some response');
+     }));
+
+  it('sets method, url, and responseType correctly', () => {
+    callFetchAndFlush(TEST_POST);
+    expect(fetchMock.request.method).toBe('POST');
+    expect(fetchMock.request.url).toBe('/test');
+  });
+
+  it('sets outgoing body correctly', () => {
+    callFetchAndFlush(TEST_POST);
+    expect(fetchMock.request.body).toBe('some body');
+  });
+
+  it('sets outgoing headers, including default headers', () => {
+    const post = TEST_POST.clone({
+      setHeaders: {
+        'Test': 'Test header',
+      },
+    });
+    callFetchAndFlush(post);
+    expect(fetchMock.request.headers).toEqual({
+      'Test': 'Test header',
+      'Accept': 'application/json, text/plain, */*',
+      'Content-Type': 'text/plain',
+    });
+  });
+
+  it('sets outgoing headers, including overriding defaults', () => {
+    const setHeaders = {
+      'Test': 'Test header',
+      'Accept': 'text/html',
+      'Content-Type': 'text/css',
+    };
+    callFetchAndFlush(TEST_POST.clone({setHeaders}));
+    expect(fetchMock.request.headers).toEqual(setHeaders);
+  });
+
+  it('passes withCredentials through', () => {
+    callFetchAndFlush(TEST_POST.clone({withCredentials: true}));
+    expect(fetchMock.request.credentials).toBe('include');
+  });
+
+  it('handles a text response', (async () => {
+       const promise = trackEvents(backend.handle(TEST_POST));
+       fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'some response');
+       const events = await promise;
+       expect(events.length).toBe(2);
+       expect(events[1].type).toBe(HttpEventType.Response);
+       expect(events[1] instanceof HttpResponse).toBeTruthy();
+       const res = events[1] as HttpResponse<string>;
+       expect(res.body).toBe('some response');
+       expect(res.status).toBe(HttpStatusCode.Ok);
+       expect(res.statusText).toBe('OK');
+     }));
+
+  it('handles a json response', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', JSON.stringify({data: 'some data'}));
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<{data: string}>;
+    expect(res.body!.data).toBe('some data');
+  });
+
+  it('handles a blank json response', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', '');
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<{data: string}>;
+    expect(res.body).toBeNull();
+  });
+
+  it('handles a json error response', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    fetchMock.mockFlush(
+        HttpStatusCode.InternalServerError, 'Error', JSON.stringify({data: 'some data'}));
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as any as HttpErrorResponse;
+    expect(res.error.data).toBe('some data');
+  });
+
+  it('handles a json error response with XSSI prefix', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    fetchMock.mockFlush(
+        HttpStatusCode.InternalServerError, 'Error',
+        XSSI_PREFIX + JSON.stringify({data: 'some data'}));
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as any as HttpErrorResponse;
+    expect(res.error.data).toBe('some data');
+  });
+
+  it('handles a json string response', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', JSON.stringify('this is a string'));
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<string>;
+    expect(res.body).toEqual('this is a string');
+  });
+
+  it('handles a json response with an XSSI prefix', async () => {
+    const promise = trackEvents(backend.handle(TEST_POST.clone({responseType: 'json'})));
+    fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', XSSI_PREFIX + JSON.stringify({data: 'some data'}));
+    const events = await promise;
+    expect(events.length).toBe(2);
+    const res = events[1] as HttpResponse<{data: string}>;
+    expect(res.body!.data).toBe('some data');
+  });
+
+  it('emits unsuccessful responses via the error path', done => {
+    backend.handle(TEST_POST).subscribe({
+      error: (err: HttpErrorResponse) => {
+        expect(err instanceof HttpErrorResponse).toBe(true);
+        expect(err.error).toBe('this is the error');
+        done();
+      }
+    });
+    fetchMock.mockFlush(HttpStatusCode.BadRequest, 'Bad Request', 'this is the error');
+  });
+
+  it('emits real errors via the error path', done => {
+    // Skipping the HttpEventType.Sent that is sent first
+    backend.handle(TEST_POST).pipe(skip(1)).subscribe({
+      error: (err: HttpErrorResponse) => {
+        expect(err instanceof HttpErrorResponse).toBe(true);
+        expect(err.error instanceof Error).toBeTrue();
+        expect(err.url).toBe('/test');
+        done();
+      }
+    });
+    fetchMock.mockErrorEvent(new Error('blah'));
+  });
+
+  it('emits an error when browser cancels a request', done => {
+    backend.handle(TEST_POST).subscribe({
+      error: (err: HttpErrorResponse) => {
+        expect(err instanceof HttpErrorResponse).toBe(true);
+        expect(err.error instanceof DOMException).toBeTruthy();
+        done();
+      }
+    });
+    fetchMock.mockAbortEvent();
+  });
+
+  describe('progress events', () => {
+    it('are emitted for download progress', done => {
+      backend.handle(TEST_POST.clone({reportProgress: true})).pipe(toArray()).subscribe(events => {
+        expect(events.map(event => event.type)).toEqual([
+          HttpEventType.Sent,
+          HttpEventType.ResponseHeader,
+          HttpEventType.DownloadProgress,
+          HttpEventType.DownloadProgress,
+          HttpEventType.DownloadProgress,
+          HttpEventType.Response,
+        ]);
+        const [progress1, progress2, response] = [
+          events[2] as HttpDownloadProgressEvent, events[3] as HttpDownloadProgressEvent,
+          events[5] as HttpResponse<string>
+        ];
+        expect(progress1.partialText).toBe('down');
+        expect(progress1.loaded).toBe(4);
+        expect(progress1.total).toBe(10);
+        expect(progress2.partialText).toBe('download');
+        expect(progress2.loaded).toBe(8);
+        expect(progress2.total).toBe(10);
+        expect(response.body).toBe('downloaded');
+        done();
+      });
+      fetchMock.mockProgressEvent(4);
+      fetchMock.mockProgressEvent(8);
+      fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'downloaded');
+    });
+
+    it('include ResponseHeader with headers and status', done => {
+      backend.handle(TEST_POST.clone({reportProgress: true})).pipe(toArray()).subscribe(events => {
+        expect(events.map(event => event.type)).toEqual([
+          HttpEventType.Sent,
+          HttpEventType.ResponseHeader,
+          HttpEventType.DownloadProgress,
+          HttpEventType.DownloadProgress,
+          HttpEventType.Response,
+        ]);
+        const partial = events[1] as HttpHeaderResponse;
+        expect(partial.type).toEqual(HttpEventType.ResponseHeader);
+        expect(partial.headers.get('Content-Type')).toEqual('text/plain');
+        expect(partial.headers.get('Test')).toEqual('Test header');
+        done();
+      });
+      fetchMock.response.headers = {'Test': 'Test header', 'Content-Type': 'text/plain'};
+      fetchMock.mockProgressEvent(200);
+      fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'Done');
+    });
+  });
+  describe('gets response URL', async () => {
+    it('from the response URL', done => {
+      backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
+        expect(events.length).toBe(2);
+        expect(events[1].type).toBe(HttpEventType.Response);
+        const response = events[1] as HttpResponse<string>;
+        expect(response.url).toBe('/response/url');
+        done();
+      });
+      fetchMock.response.url = '/response/url';
+      fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
+    });
+
+    it('from X-Request-URL header if the response URL is not present', done => {
+      backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
+        expect(events.length).toBe(2);
+        expect(events[1].type).toBe(HttpEventType.Response);
+        const response = events[1] as HttpResponse<string>;
+        expect(response.url).toBe('/response/url');
+        done();
+      });
+      fetchMock.response.headers = {'X-Request-URL': '/response/url'};
+      fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
+    });
+
+    it('falls back on Request.url if neither are available', done => {
+      backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
+        expect(events.length).toBe(2);
+        expect(events[1].type).toBe(HttpEventType.Response);
+        const response = events[1] as HttpResponse<string>;
+        expect(response.url).toBe('/test');
+        done();
+      });
+      fetchMock.mockFlush(HttpStatusCode.Ok, 'OK', 'Test');
+    });
+  });
+  describe('corrects for quirks', async () => {
+    it('by normalizing 0 status to 200 if a body is present', done => {
+      backend.handle(TEST_POST).pipe(toArray()).subscribe(events => {
+        expect(events.length).toBe(2);
+        expect(events[1].type).toBe(HttpEventType.Response);
+        const response = events[1] as HttpResponse<string>;
+        expect(response.status).toBe(HttpStatusCode.Ok);
+        done();
+      });
+      fetchMock.mockFlush(0, 'CORS 0 status', 'Test');
+    });
+    it('by leaving 0 status as 0 if a body is not present', done => {
+      backend.handle(TEST_POST).pipe(toArray()).subscribe({
+        error: (error: HttpErrorResponse) => {
+          expect(error.status).toBe(0);
+          done();
+        }
+      });
+      fetchMock.mockFlush(0, 'CORS 0 status');
+    });
+  });
+});
+
+export class MockFetchFactory extends FetchFactory {
+  public readonly response = new MockFetchResponse();
+  public readonly request = new MockFetchRequest();
+  private resolve!: Function;
+  private reject!: Function;
+
+  private clearWarningTimeout?: VoidFunction;
+
+  private promise = new Promise<Response>((resolve, reject) => {
+    this.resolve = resolve;
+    this.reject = reject;
+  });
+
+  override fetch = (input: RequestInfo|URL, init?: RequestInit):
+      Promise<Response> => {
+        this.request.method = init?.method;
+        this.request.url = input;
+        this.request.body = init?.body;
+        this.request.headers = init?.headers;
+        this.request.credentials = init?.credentials;
+
+        if (init?.signal) {
+          init?.signal.addEventListener('abort', () => {
+            this.reject();
+            this.clearWarningTimeout?.();
+          });
+        }
+
+        // Fetch uses a Macrotask to keep the NgZone unstable during the fetch
+        // If the promise is not resolved/rejected the unit will succeed but the test suite will
+        // fail with a timeout
+        const timeoutId = setTimeout(() => {
+          console.error('*********  You forgot to resolve/reject the promise ********* ');
+          this.reject();
+        }, 5000);
+        this.clearWarningTimeout = () => clearTimeout(timeoutId);
+
+        return this.promise;
+      }
+
+  mockFlush(status: number, statusText: string, body?: string): void {
+    this.clearWarningTimeout?.();
+    this.response.setupBodyStream(body);
+
+    const response =
+        new Response(this.response.stream, {statusText, headers: this.response.headers});
+
+    // Have to be set outside the constructor because it might throw
+    // RangeError: init["status"] must be in the range of 200 to 599, inclusive
+    Object.defineProperty(response, 'status', {value: status});
+
+    if (this.response.url) {
+      // url is readonly
+      Object.defineProperty(response, 'url', {value: this.response.url});
+    }
+    this.resolve(response);
+  }
+
+  mockProgressEvent(loaded: number): void {
+    this.response.progress.push(loaded);
+  }
+
+  mockErrorEvent(error: any) {
+    this.reject(error);
+  }
+
+  mockAbortEvent() {
+    // When `abort()` is called, the fetch() promise rejects with an Error of type DOMException,
+    // with name AbortError. see
+    // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
+    this.reject(new DOMException('', 'AbortError'));
+  }
+
+  resetFetchPromise() {
+    this.promise = new Promise<Response>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+class MockFetchRequest {
+  public url!: RequestInfo|URL;
+  public method?: string;
+  public body: any;
+  public credentials?: RequestCredentials;
+  public headers?: HeadersInit;
+}
+
+class MockFetchResponse {
+  public url?: string;
+  public headers: Record<string, string> = {};
+
+  public progress: number[] = [];
+
+  private sub$ = new Subject<any>();
+  public stream = new ReadableStream({
+
+    start: (controler) => {
+      this.sub$.subscribe({
+        next: (val) => {
+          controler.enqueue(new TextEncoder().encode(val));
+        },
+        complete: () => {
+          controler.close();
+        }
+      });
+    },
+  });
+
+  public setupBodyStream(body?: string) {
+    if (body && this.progress.length) {
+      this.headers['content-length'] = `${body.length}`;
+      let shift = 0;
+      this.progress.forEach((loaded) => {
+        this.sub$.next(body.substring(shift, loaded));
+        shift = loaded;
+      });
+      this.sub$.next(body.substring(shift, body.length));
+    } else {
+      this.sub$.next(body);
+    }
+
+    this.sub$.complete();
+  }
+}


### PR DESCRIPTION
This commit introduces a new `HttpBackend` implentation which makes requests using the fetch API

This feature is a developer preview and is opt-in.
It is enabled by setting the providers with `provideHttpClient(withFetch())`.

Currently the report progress is not implemented and using `reportProgress: true` will throw an error.  

NB: The fetch API is experimental on Node but available without flags from Node 18 onwards.
NB2: The tests provided in the PR won't run, as `fetch` is not available on the node version provided by the bazel workspace (`16.14`)

---- 
Edit: pinning a answer I gave bellow on the purpose of this new backend: 

`Xhr` is not supported natively on NodeJS an requires a polyfill. Currently Angular uses [xhr2](https://www.npmjs.com/package/xhr2) for this. However, the polyfill is side-effectful and doesn't work in non-Node.js environments (such as Edge Workers). There are also others issues like https://github.com/angular/angular/issues/46930 (its doesn't support Gzip).


## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [x] No


Closes https://github.com/angular/angular/issues/27689