### PR TITLE
refactor(core): remove legacy way of preventing default actions

### DIFF
--- a/packages/core/src/render3/instructions/listener.ts
+++ b/packages/core/src/render3/instructions/listener.ts
@@ -271,8 +271,6 @@ function wrapListener(
 
     if (wrapWithPreventDefault && result === false) {
       e.preventDefault();
-      // Necessary for legacy browsers that don't support preventDefault (e.g. IE)
-      e.returnValue = false;
     }
 
     return result;

--- a/packages/platform-browser/src/dom/dom_renderer.ts
+++ b/packages/platform-browser/src/dom/dom_renderer.ts
@@ -318,7 +318,6 @@ class DefaultDomRenderer2 implements Renderer2 {
           eventHandler(event);
       if (allowDefaultBehavior === false) {
         event.preventDefault();
-        event.returnValue = false;
       }
 
       return undefined;


### PR DESCRIPTION
Setting `returnValue = false` to prevent the default action of events hasn't been necessary since IE9.