### PR TITLE
fix(docs-infra): labels with links should have the same font weight

### DIFF
--- a/aio/src/styles/2-modules/label/_label-theme.scss
+++ b/aio/src/styles/2-modules/label/_label-theme.scss
@@ -22,6 +22,7 @@
         color: inherit;
         line-height: inherit;
         font-size: inherit;
+        font-weight: inherit;
       }
     }
 


### PR DESCRIPTION
Fix anchor tag styling inside `label.api-status-label` to match font weight of label styling that does not have anchor tag.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, `label.api-status-label a` font weight styling does not match `label.api-status-label` font weight styling:

![image](https://github.com/angular/angular/assets/28087049/bbf1dd35-aca8-4435-afb4-e18381843c48)

Issue Number: N/A


## What is the new behavior?
Font weights are now matched, they look equal (and nicer IMHO). Here's a GIF that shows the difference in font-weight values before and after this CSS property being applied:

![Fix font weight](https://github.com/angular/angular/assets/28087049/0fd7b9bc-5956-4572-846b-a97f5d118446)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
None.