### PR TITLE
docs: fix mistake in tutorial

### DIFF
--- a/aio/content/tutorial/first-app/first-app-lesson-14.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-14.md
@@ -160,7 +160,7 @@ The data source has been configured, the next step is to update your web app to 
 
 1.  In `src/app/housing.service.ts`, make the following changes:
 
-    1.  Update the code to remove `housingLocations` property and the array containing the data.
+    1.  Update the code to remove `housingLocationList` property and the array containing the data.
 
     1.  Add a string property called and set the value to `'http://localhost:3000/locations'`
         


### PR DESCRIPTION
I fixed `housingLocations` to `housingLocationList`.

When I tried to performed [step 2 in lesson 14](https://angular.io/tutorial/first-app/first-app-lesson-14#step-2---update-service-to-use-web-server-instead-of-local-array), the property `housingLocations` was not present in the actual code. I believe the correct name is housingLocationList.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
