### PR TITLE
fix(core): fix `Self` flag inside embedded views with custom injectors

### DIFF
--- a/packages/core/src/render3/di.ts
+++ b/packages/core/src/render3/di.ts
@@ -399,7 +399,10 @@ export function getOrCreateInjectable<T>(
   if (tNode !== null) {
     // If the view or any of its ancestors have an embedded
     // view injector, we have to look it up there first.
-    if (lView[FLAGS] & LViewFlags.HasEmbeddedViewInjector) {
+    if (lView[FLAGS] & LViewFlags.HasEmbeddedViewInjector &&
+        // The token must be present on the current node injector when the `Self`
+        // flag is set, so the lookup on embedded view injector(s) can be skipped.
+        !(flags & InjectFlags.Self)) {
       const embeddedInjectorValue =
           lookupTokenUsingEmbeddedInjector(tNode, lView, token, flags, NOT_FOUND);
       if (embeddedInjectorValue !== NOT_FOUND) {

--- a/packages/core/test/acceptance/di_spec.ts
+++ b/packages/core/test/acceptance/di_spec.ts
@@ -4517,6 +4517,38 @@ describe('di', () => {
       expect(fixture.componentInstance.menu.tokenValue).toBe('hello');
     });
 
+    it('should check only the current node with @Self when providing an injection token through an embedded view injector',
+       () => {
+         @Directive({selector: 'menu'})
+         class Menu {
+           constructor(@Inject(token) @Self() @Optional() public tokenValue: string) {}
+         }
+
+         @Component({
+           template: `
+          <menu-trigger [triggerFor]="menuTemplate"></menu-trigger>
+          <ng-template #menuTemplate>
+            <menu></menu>
+          </ng-template>
+        `,
+           providers: [{provide: token, useValue: 'root'}]
+         })
+         class App {
+           @ViewChild(MenuTrigger) trigger!: MenuTrigger;
+           @ViewChild(Menu) menu!: Menu;
+         }
+
+         TestBed.configureTestingModule({declarations: [App, MenuTrigger, Menu]});
+         const injector = Injector.create({providers: [{provide: token, useValue: 'hello'}]});
+         const fixture = TestBed.createComponent(App);
+         fixture.detectChanges();
+
+         fixture.componentInstance.trigger.open(injector);
+         fixture.detectChanges();
+
+         expect(fixture.componentInstance.menu.tokenValue).toBeNull();
+       });
+
     it('should be able to provide an injection token to a nested template through a custom injector',
        () => {
          @Directive({selector: 'menu'})


### PR DESCRIPTION
When an embedded view injector is present anywhere above a node in the tree, the `Self` flag was effectively ignored. With this change, embedded view injectors are not checked at all when the `Self` flag is present, because resolution should stop at the current node before reaching any embedded view injector(s).

Fixes #49959

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`@Self` is ignored when using `createEmbeddedView` with a custom injector.

Issue Number: #49959


## What is the new behavior?
`@Self` is no longer ignored when using `createEmbeddedView` with a custom injector.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I initially made a change to `lookupTokenUsingEmbeddedInjector` so that it would bail out after checking the current node if the `Self` flag was set, but I think skipping the embedded view injector lookup entirely makes more sense, and it avoids a case where the current node injector would be checked twice when both the `Self` and `Optional` flags are set.

I called this a "fix", but I could see how someone could've become reliant on this behavior in the last year or so since this feature was released. Is that enough to call this a breaking change?

I'm not certain about this, but I think there might be a similar issue with the `Host` flag and embedded view injectors. I don't see any special handling of the `Host` flag in the `lookupTokenUsingEmbeddedInjector` function, so I assume that if you created a hierarchy like `hostNode -> embeddedView -> hostNode -> embeddedView -> node` and used `@Host` on that last node, it would reach all the way up to the top node (past its "host") to find the token it was looking for. I ran out of time to look into this today, but I can take a look next week.