### PR TITLE
docs(docs-infra): Remove internal constructors from the doc.

### DIFF
--- a/aio/tools/transforms/angular-api-package/index.js
+++ b/aio/tools/transforms/angular-api-package/index.js
@@ -37,7 +37,7 @@ module.exports =
         .processor(require('./processors/computeSearchTitle'))
         .processor(require('./processors/simplifyMemberAnchors'))
         .processor(require('./processors/computeStability'))
-        .processor(require('./processors/removeInjectableConstructors'))
+        .processor(require('./processors/removeInjectableAndInternalConstructors'))
         .processor(require('./processors/processSpecialElements'))
         .processor(require('./processors/collectPackageContentDocs'))
         .processor(require('./processors/processPackages'))

--- a/aio/tools/transforms/angular-api-package/processors/removeInjectableAndInternalConstructors.js
+++ b/aio/tools/transforms/angular-api-package/processors/removeInjectableAndInternalConstructors.js
@@ -1,4 +1,4 @@
-module.exports = function removeInjectableConstructors() {
+module.exports = function removeInjectableAndInternalConstructors() {
   return {
     $runAfter: ['processing-docs', 'splitDescription'],
     $runBefore: ['docs-processed'],
@@ -10,6 +10,9 @@ module.exports = function removeInjectableConstructors() {
           !doc.constructorDoc.shortDescription &&
           doc.decorators &&
           doc.decorators.some(decorator => this.injectableDecorators.indexOf(decorator.name) !== -1)) {
+          delete doc.constructorDoc;
+        }
+        if(doc.constructorDoc && doc.constructorDoc.internal) {
           delete doc.constructorDoc;
         }
       });

--- a/aio/tools/transforms/angular-api-package/processors/removeInjectableAndInternalConstructors.spec.js
+++ b/aio/tools/transforms/angular-api-package/processors/removeInjectableAndInternalConstructors.spec.js
@@ -1,4 +1,4 @@
-const processorFactory = require('./removeInjectableConstructors');
+const processorFactory = require('./removeInjectableAndInternalConstructors');
 const testPackage = require('../../helpers/test-package');
 const Dgeni = require('dgeni');
 
@@ -7,7 +7,7 @@ describe('removeInjectableConstructors processor', () => {
   it('should be available on the injector', () => {
     const dgeni = new Dgeni([testPackage('angular-api-package')]);
     const injector = dgeni.configureInjector();
-    const processor = injector.get('removeInjectableConstructors');
+    const processor = injector.get('removeInjectableAndInternalConstructors');
     expect(processor.$process).toBeDefined();
     expect(processor.$runAfter).toEqual(['processing-docs', 'splitDescription']);
     expect(processor.$runBefore).toEqual(['docs-processed']);
@@ -23,6 +23,7 @@ describe('removeInjectableConstructors processor', () => {
       { constructorDoc: {}, decorators: [{ name: 'Directive' }] },
       { constructorDoc: {}, decorators: [{ name: 'Pipe' }] },
       { constructorDoc: {}, decorators: [{ name: 'Other' }, { name: 'Injectable' }] },
+
       { constructorDoc: {}, decorators: [{ name: 'Other' }] },
 
       { constructorDoc: { shortDescription: 'Blah' } },
@@ -33,6 +34,8 @@ describe('removeInjectableConstructors processor', () => {
       { constructorDoc: { shortDescription: 'Blah' }, decorators: [{ name: 'Pipe' }] },
       { constructorDoc: { shortDescription: 'Blah' }, decorators: [{ name: 'Other' }, { name: 'Injectable' }] },
       { constructorDoc: { shortDescription: 'Blah' }, decorators: [{ name: 'Other' }] },
+
+      { constructorDoc: { internal: true } },
     ];
 
     processor.$process(docs);
@@ -54,5 +57,7 @@ describe('removeInjectableConstructors processor', () => {
     expect(docs[13].constructorDoc).toBeDefined();
     expect(docs[14].constructorDoc).toBeDefined();
     expect(docs[15].constructorDoc).toBeDefined();
+
+    expect(docs[16].constructorDoc).toBeUndefined();
   });
 });


### PR DESCRIPTION
Internal constructors should not be exposed in the doc. This removes them.

Related to #50281

If you want to test it, check for example [RouterState](https://angular.io/api/router/RouterState#constructor). 

## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes