### PR TITLE
docs(docs-infra): Add a deprecated label

### DIFF
--- a/aio/src/styles/2-modules/label/_label.scss
+++ b/aio/src/styles/2-modules/label/_label.scss
@@ -9,6 +9,7 @@ label.api-status-label {
   margin-right: 8px;
   font-weight: 500;
   text-transform: uppercase;
+  line-height: initial;
 
   @media screen and (max-width: 600px) {
     display: block;

--- a/aio/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/aio/tools/transforms/templates/api/lib/memberHelpers.html
@@ -83,7 +83,7 @@
   {%- if method.name !== 'constructor' %}
   <thead><tr><th>
     <div class="with-github-links">
-      <h3>
+      <h3 {% if method.deprecated %} class="deprecated-api-item"{% endif %}>
         {%- if method.isCallMember %}<i>call signature</i>
         {%- elseif method.isNewMember %}<i>construct signature</i>
         {%- else %}{$ method.name $}()
@@ -93,6 +93,9 @@
       <label class="api-status-label dev-preview" title="This API is in Developer Preview">
         <a href="guide/releases#developer-preview">developer preview</a>
       </label>
+      {% endif %}
+      {%- if method.deprecated %}
+      <label class="api-status-label deprecated" title="This API is deprecated">Deprecated</label>
       {% endif %}
       {$ github.githubLinks(method, versionInfo) $}
     </div>
@@ -230,6 +233,9 @@
           <label class="api-status-label dev-preview" title="This API is in Developer Preview">
             <a href="guide/releases#developer-preview">developer preview</a>
           </label>
+          {% endif %}
+          {%- if property.deprecated %}
+          <label class="api-status-label deprecated" title="This API is deprecated">Deprecated</label>
           {% endif %}
 
           {%- if (property.isGetAccessor or property.isReadonly) and not property.isSetAccessor %}


### PR DESCRIPTION
This adds a deprecated label next to the other labels on the API pages for methods & properties.

Examples : 

* https://angular.io/api/router/Router#urlHandlingStrategy
* https://angular.io/api/core/EnvironmentInjector

![Screenshot 2023-05-14 at 11 17 54](https://github.com/angular/angular/assets/1300985/c6b95c5d-8f15-44b9-ade5-be686e6f7a6e)

![Screenshot 2023-05-14 at 11 18 06](https://github.com/angular/angular/assets/1300985/d9dc1db2-c9dc-46ee-b547-daef903043a0)


Fixes #44265