### PR TITLE
Template Pipeline: Refactor `expression.ts` and support null-safe reads

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
@@ -6,6 +6,7 @@
       "inputFiles": [
         "safe_keyed_read.ts"
       ],
+      "focusTest": true,
       "expectations": [
         {
           "files": [

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_keyed_read.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_keyed_read.ts
@@ -2,20 +2,13 @@ import {Component, NgModule} from '@angular/core';
 
 @Component({
   template: `
-    <span [title]="'Your last name is ' + (unknownNames?.[0] || 'unknown')">
-      Hello, {{ knownNames?.[0]?.[1] }}!
+    <span>
       You are a Balrog: {{ species?.[0]?.[1]?.[2]?.[3]?.[4]?.[5] || 'unknown' }}
-      You are an Elf: {{ speciesMap?.[keys?.[0] ?? 'key'] }}
-      You are an Orc: {{ speciesMap?.['key'] }}
     </span>
 `
 })
 export class MyApp {
-  unknownNames: string[]|null = null;
-  knownNames: string[][] = [['Frodo', 'Bilbo']];
   species = null;
-  keys = null;
-  speciesMap: Record<string, string> = {key: 'unknown'};
 }
 
 @NgModule({declarations: [MyApp]})

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -424,6 +424,10 @@ export class InvokeFunctionExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitInvokeFunctionExpr(this, context);
   }
+
+  get receiver(): Expression {
+    return this.fn;
+  }
 }
 
 

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -109,6 +109,21 @@ export enum ExpressionKind {
   LexicalRead,
 
   /**
+   * A safe read of a property, which needs to be expanded into a null check.
+   */
+  SafePropertyRead,
+
+  /**
+   * A safe keyed read, which needs to be expanded into a null check.
+   */
+  SafeKeyedRead,
+
+  /**
+   * A safe keyed function call, which needs to be expanded into a null check.
+   */
+  SafeInvokeFunctionExpr,
+
+  /**
    * A reference to the current view context.
    */
   Context,

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -17,14 +17,159 @@ import type {CreateOp} from './ops/create';
 import type {UpdateOp} from './ops/update';
 
 /**
- * An `o.Expression` subtype representing a logical expression in the intermediate representation.
+ * Expressions defined by the intermediate representation, as opposed to an `o.Expression`.
  */
 export type Expression = LexicalReadExpr|ReferenceExpr|ContextExpr|NextContextExpr|
     GetCurrentViewExpr|RestoreViewExpr|ResetViewExpr|ReadVariableExpr|PureFunctionExpr|
     PureFunctionParameterExpr|PipeBindingExpr|PipeBindingVariadicExpr;
 
 /**
- * Transformer type which converts expressions into general `o.Expression`s (which may be an
+ * A supplemented version of the output expression visitor, which also allows us to visit IR
+ * expressions.
+ */
+export interface ExpressionVisitor extends o.ExpressionVisitor {
+  visitLexicalReadExpr(ast: LexicalReadExpr, context: any): any;
+  visitReferenceExpr(ast: ReferenceExpr, context: any): any;
+  visitContextExpr(ast: ContextExpr, context: any): any;
+  visitNextContextExpr(ast: NextContextExpr, context: any): any;
+  visitGetCurrentViewExpr(ast: GetCurrentViewExpr, context: any): any;
+  visitRestoreViewExpr(ast: RestoreViewExpr, context: any): any;
+  visitResetViewExpr(ast: ResetViewExpr, context: any): any;
+  visitReadVariableExpr(ast: ReadVariableExpr, context: any): any;
+  visitPureFunctionExpr(ast: PureFunctionExpr, context: any): any;
+  visitPureFunctionParameterExpr(ast: PureFunctionParameterExpr, context: any): any;
+  visitPipeBindingExpr(ast: PipeBindingExpr, context: any): any;
+  visitPipeBindingVariadicExpr(ast: PipeBindingVariadicExpr, context: any): any;
+}
+
+/**
+ * The following type assertion statically ensures that the `ExpressionVisitor` supports all of the
+ * expressions described by the `Expression` type.
+ */
+type AllVisitableTypes = {
+  [method in keyof ExpressionVisitor]: Parameters<ExpressionVisitor[method]>[0]
+}[keyof ExpressionVisitor];
+type VisitorComplete = Expression extends AllVisitableTypes ? true : false;
+const visitorSupportsAllTypes = true satisfies VisitorComplete;
+
+/**
+ * An IR expression visitor where the result of visiting any AST node is null.
+ */
+export abstract class NullExpressionVisitor implements ExpressionVisitor {
+  visitReadVarExpr = (ast: o.ReadVarExpr, context: any) => null;
+  visitWriteVarExpr = (ast: o.WriteVarExpr, context: any) => null;
+  visitWriteKeyExpr = (ast: o.WriteKeyExpr, context: any) => null;
+  visitWritePropExpr = (ast: o.WritePropExpr, context: any) => null;
+  visitInvokeFunctionExpr = (ast: o.InvokeFunctionExpr, context: any) => null;
+  visitTaggedTemplateExpr = (ast: o.TaggedTemplateExpr, context: any) => null;
+  visitInstantiateExpr = (ast: o.InstantiateExpr, context: any) => null;
+  visitLiteralExpr = (ast: o.LiteralExpr, context: any) => null;
+  visitLocalizedString = (ast: o.LocalizedString, context: any) => null;
+  visitExternalExpr = (ast: o.ExternalExpr, context: any) => null;
+  visitConditionalExpr = (ast: o.ConditionalExpr, context: any) => null;
+  visitNotExpr = (ast: o.NotExpr, context: any) => null;
+  visitFunctionExpr = (ast: o.FunctionExpr, context: any) => null;
+  visitUnaryOperatorExpr = (ast: o.UnaryOperatorExpr, context: any) => null;
+  visitBinaryOperatorExpr = (ast: o.BinaryOperatorExpr, context: any) => null;
+  visitReadPropExpr = (ast: o.ReadPropExpr, context: any) => null;
+  visitReadKeyExpr = (ast: o.ReadKeyExpr, context: any) => null;
+  visitLiteralArrayExpr = (ast: o.LiteralArrayExpr, context: any) => null;
+  visitLiteralMapExpr = (ast: o.LiteralMapExpr, context: any) => null;
+  visitCommaExpr = (ast: o.CommaExpr, context: any) => null;
+  visitWrappedNodeExpr = (ast: o.WrappedNodeExpr<any>, context: any) => null;
+  visitTypeofExpr = (ast: o.TypeofExpr, context: any) => null;
+  visitLexicalReadExpr = (ast: LexicalReadExpr, context: any) => null;
+  visitReferenceExpr = (ast: ReferenceExpr, context: any) => null;
+  visitContextExpr = (ast: ContextExpr, context: any) => null;
+  visitNextContextExpr = (ast: NextContextExpr, context: any) => null;
+  visitGetCurrentViewExpr = (ast: GetCurrentViewExpr, context: any) => null;
+  visitRestoreViewExpr = (ast: RestoreViewExpr, context: any) => null;
+  visitResetViewExpr = (ast: ResetViewExpr, context: any) => null;
+  visitReadVariableExpr = (ast: ReadVariableExpr, context: any) => null;
+  visitPureFunctionExpr = (ast: PureFunctionExpr, context: any) => null;
+  visitPureFunctionParameterExpr = (ast: PureFunctionParameterExpr, context: any) => null;
+  visitPipeBindingExpr = (ast: PipeBindingExpr, context: any) => null;
+  visitPipeBindingVariadicExpr = (ast: PipeBindingVariadicExpr, context: any) => null;
+}
+
+/**
+ * An IR expression visitor which recursively visits the entire tree. By default, returns the
+ * identity expression. Accepts an optional argument, which causes each expression to be transformed
+ * before it is returned.
+ */
+export class EverythingVisitor implements ExpressionVisitor {
+  constructor(
+      private transform: (e: o.Expression|Expression, ctx: any) => (o.Expression | Expression) =
+          (e, context) => e) {}
+
+  private visitAll(
+      ast: Expression|o.Expression, context: any,
+      ...subexpressions: Array<Expression|o.Expression|null>): Expression|o.Expression {
+    for (const sub of subexpressions) {
+      if (sub != null) {
+        sub.visitExpression(this, context);
+      }
+    }
+    return this.transform(ast, context);
+  }
+  // Output expression types.
+  visitReadVarExpr = (ast: o.ReadVarExpr, context: any) => this.visitAll(ast, context);
+  visitWriteVarExpr = (ast: o.WriteVarExpr, context: any) => this.visitAll(ast, context, ast.value);
+  visitWriteKeyExpr = (ast: o.WriteKeyExpr, context: any) =>
+      this.visitAll(ast, context, ast.receiver, ast.index, ast.value);
+  visitWritePropExpr = (ast: o.WritePropExpr, context: any) =>
+      this.visitAll(ast, context, ast.receiver, ast.value);
+  visitInvokeFunctionExpr = (ast: o.InvokeFunctionExpr, context: any) =>
+      this.visitAll(ast, context, ast.fn, ...ast.args);
+  visitTaggedTemplateExpr = (ast: o.TaggedTemplateExpr, context: any) =>
+      this.visitAll(ast, context, ast.tag, ...ast.template.expressions);  // TODO: this is correct?
+  visitInstantiateExpr = (ast: o.InstantiateExpr, context: any) =>
+      this.visitAll(ast, context, ast.classExpr, ...ast.args);
+  visitLiteralExpr = (ast: o.LiteralExpr, context: any) => this.visitAll(ast, context);
+  visitLocalizedString = (ast: o.LocalizedString, context: any) =>
+      this.visitAll(ast, context, ...ast.expressions);
+  visitExternalExpr = (ast: o.ExternalExpr, context: any) => this.visitAll(ast, context);
+  visitConditionalExpr = (ast: o.ConditionalExpr, context: any) =>
+      this.visitAll(ast, context, ast.condition, ast.trueCase, ast.falseCase);
+  visitNotExpr = (ast: o.NotExpr, context: any) => this.visitAll(ast, context, ast.condition);
+  visitFunctionExpr = (ast: o.FunctionExpr, context: any) => this.visitAll(ast, context);
+  visitUnaryOperatorExpr = (ast: o.UnaryOperatorExpr, context: any) =>
+      this.visitAll(ast, context, ast.expr);
+  visitBinaryOperatorExpr = (ast: o.BinaryOperatorExpr, context: any) =>
+      this.visitAll(ast, context, ast.lhs, ast.rhs);
+  visitReadPropExpr = (ast: o.ReadPropExpr, context: any) =>
+      this.visitAll(ast, context, ast.receiver);
+  visitReadKeyExpr = (ast: o.ReadKeyExpr, context: any) =>
+      this.visitAll(ast, context, ast.receiver, ast.index);
+  visitLiteralArrayExpr = (ast: o.LiteralArrayExpr, context: any) =>
+      this.visitAll(ast, context, ...ast.entries);
+  visitLiteralMapExpr = (ast: o.LiteralMapExpr, context: any) =>
+      this.visitAll(ast, context, ...ast.entries.map(e => e.value));
+  visitCommaExpr = (ast: o.CommaExpr, context: any) => this.visitAll(ast, context, ...ast.parts);
+  visitWrappedNodeExpr = (ast: o.WrappedNodeExpr<any>, context: any) => this.visitAll(ast, context);
+  visitTypeofExpr = (ast: o.TypeofExpr, context: any) => this.visitAll(ast, context, ast.expr);
+  // IR expression types.
+  visitLexicalReadExpr = (ast: LexicalReadExpr, context: any) => this.visitAll(ast, context);
+  visitReferenceExpr = (ast: ReferenceExpr, context: any) => this.visitAll(ast, context);
+  visitContextExpr = (ast: ContextExpr, context: any) => this.visitAll(ast, context);
+  visitNextContextExpr = (ast: NextContextExpr, context: any) => this.visitAll(ast, context);
+  visitGetCurrentViewExpr = (ast: GetCurrentViewExpr, context: any) => this.visitAll(ast, context);
+  visitRestoreViewExpr = (ast: RestoreViewExpr, context: any) =>
+      typeof ast.view === 'number' ? ast : this.visitAll(ast, context, ast.view);
+  visitResetViewExpr = (ast: ResetViewExpr, context: any) => this.visitAll(ast, context, ast.expr);
+  visitReadVariableExpr = (ast: ReadVariableExpr, context: any) => this.visitAll(ast, context);
+  visitPureFunctionExpr = (ast: PureFunctionExpr, context: any) =>
+      this.visitAll(ast, context, ast.body, ...ast.args);
+  visitPureFunctionParameterExpr = (ast: PureFunctionParameterExpr, context: any) =>
+      this.visitAll(ast, context);
+  visitPipeBindingExpr = (ast: PipeBindingExpr, context: any) =>
+      this.visitAll(ast, context, ...ast.args);
+  visitPipeBindingVariadicExpr = (ast: PipeBindingVariadicExpr, context: any) =>
+      this.visitAll(ast, context, ast.args);
+}
+
+/**
+ * Transformer type which converts `o.Expression`s into other `o.Expression`s (which may be an
  * identity transformation).
  */
 export type ExpressionTransform = (expr: o.Expression, flags: VisitorContextFlag) => o.Expression;
@@ -52,6 +197,8 @@ export abstract class ExpressionBase extends o.Expression {
    */
   abstract transformInternalExpressions(transform: ExpressionTransform, flags: VisitorContextFlag):
       void;
+
+  abstract override visitExpression(visitor: ExpressionVisitor, context: any): any;
 }
 
 /**
@@ -64,7 +211,9 @@ export class LexicalReadExpr extends ExpressionBase {
     super();
   }
 
-  override visitExpression(visitor: o.ExpressionVisitor, context: any): void {}
+  override visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitLexicalReadExpr(this, context);
+  }
 
   override isEquivalent(): boolean {
     return false;
@@ -91,7 +240,9 @@ export class ReferenceExpr extends ExpressionBase implements UsesSlotIndexTrait 
     super();
   }
 
-  override visitExpression(): void {}
+  override visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitReferenceExpr(this, context);
+  }
 
   override isEquivalent(e: o.Expression): boolean {
     return e instanceof ReferenceExpr && e.target === this.target;
@@ -114,7 +265,9 @@ export class ContextExpr extends ExpressionBase {
     super();
   }
 
-  override visitExpression(): void {}
+  override visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitContextExpr(this, context);
+  }
 
   override isEquivalent(e: o.Expression): boolean {
     return e instanceof ContextExpr && e.view === this.view;
@@ -139,7 +292,9 @@ export class NextContextExpr extends ExpressionBase {
     super();
   }
 
-  override visitExpression(): void {}
+  override visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitNextContextExpr(this, context);
+  }
 
   override isEquivalent(e: o.Expression): boolean {
     return e instanceof NextContextExpr && e.steps === this.steps;
@@ -165,7 +320,9 @@ export class GetCurrentViewExpr extends ExpressionBase {
     super();
   }
 
-  override visitExpression(): void {}
+  override visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitGetCurrentViewExpr(this, context);
+  }
 
   override isEquivalent(e: o.Expression): boolean {
     return e instanceof GetCurrentViewExpr;
@@ -188,10 +345,8 @@ export class RestoreViewExpr extends ExpressionBase {
     super();
   }
 
-  override visitExpression(visitor: o.ExpressionVisitor, context: any): void {
-    if (typeof this.view !== 'number') {
-      this.view.visitExpression(visitor, context);
-    }
+  override visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitRestoreViewExpr(this, context);
   }
 
   override isEquivalent(e: o.Expression): boolean {
@@ -228,8 +383,8 @@ export class ResetViewExpr extends ExpressionBase {
     super();
   }
 
-  override visitExpression(visitor: o.ExpressionVisitor, context: any): any {
-    this.expr.visitExpression(visitor, context);
+  override visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitResetViewExpr(this, context);
   }
 
   override isEquivalent(e: o.Expression): boolean {
@@ -256,7 +411,9 @@ export class ReadVariableExpr extends ExpressionBase {
     super();
   }
 
-  override visitExpression(): void {}
+  override visitExpression(visitor: ExpressionVisitor, context: any): any {
+    return visitor.visitReadVariableExpr(this, context);
+  }
 
   override isEquivalent(other: o.Expression): boolean {
     return other instanceof ReadVariableExpr && other.xref === this.xref;
@@ -303,11 +460,8 @@ export class PureFunctionExpr extends ExpressionBase implements ConsumesVarsTrai
     this.args = args;
   }
 
-  override visitExpression(visitor: o.ExpressionVisitor, context: any) {
-    this.body?.visitExpression(visitor, context);
-    for (const arg of this.args) {
-      arg.visitExpression(visitor, context);
-    }
+  override visitExpression(visitor: ExpressionVisitor, context: any) {
+    visitor.visitPureFunctionExpr(this, context);
   }
 
   override isEquivalent(other: o.Expression): boolean {
@@ -346,7 +500,9 @@ export class PureFunctionParameterExpr extends ExpressionBase {
     super();
   }
 
-  override visitExpression(): void {}
+  override visitExpression(visitor: ExpressionVisitor, context: any) {
+    visitor.visitPureFunctionParameterExpr(this, context);
+  }
 
   override isEquivalent(other: o.Expression): boolean {
     return other instanceof PureFunctionParameterExpr && other.index === this.index;
@@ -374,10 +530,8 @@ export class PipeBindingExpr extends ExpressionBase implements UsesSlotIndexTrai
     super();
   }
 
-  override visitExpression(visitor: o.ExpressionVisitor, context: any): void {
-    for (const arg of this.args) {
-      arg.visitExpression(visitor, context);
-    }
+  override visitExpression(visitor: ExpressionVisitor, context: any) {
+    visitor.visitPipeBindingExpr(this, context);
   }
 
   override isEquivalent(): boolean {
@@ -413,8 +567,8 @@ export class PipeBindingVariadicExpr extends ExpressionBase implements UsesSlotI
     super();
   }
 
-  override visitExpression(visitor: o.ExpressionVisitor, context: any): void {
-    this.args.visitExpression(visitor, context);
+  override visitExpression(visitor: ExpressionVisitor, context: any) {
+    visitor.visitPipeBindingVariadicExpr(this, context);
   }
 
   override isEquivalent(): boolean {
@@ -431,8 +585,67 @@ export class PipeBindingVariadicExpr extends ExpressionBase implements UsesSlotI
   }
 }
 
+export enum VisitorContextFlag {
+  None = 0b0000,
+  InChildOperation = 0b0001,
+}
+
 /**
- * Visits all `Expression`s in the AST of `op` with the `visitor` function.
+ * Using a full-blown `Visitor` class, visit only the top-level expressions of this op.
+ * Note that unlike the other functions exported from this file, this function accepts a Visitor
+ * *class*, not a visitor *function*. This provides more customizable behavior than a plain
+ * `ExpressionTransform`, but unlike the other exported functions, you are responsible for
+ * recursively exploring the tree of expressions yourself.
+ */
+export function visitTopLevelExpressionsInOp(
+    op: CreateOp|UpdateOp, visitor: ExpressionVisitor, ctx: any) {
+  switch (op.kind) {
+    case OpKind.Property:
+      op.expression = op.expression.visitExpression(visitor, ctx);
+      break;
+    case OpKind.Statement:
+      if (op instanceof o.ExpressionStatement) {
+        op.expr = op.expr.visitExpression(visitor, ctx);
+      } else if (op instanceof o.ReturnStatement) {
+        op.value = op.value.visitExpression(visitor, ctx);
+      } else {
+        throw new Error(`Unhandled statement kind: ${op.constructor.name}`);
+      }
+      break;
+    case OpKind.Variable:
+      op.initializer = op.initializer.visitExpression(visitor, ctx);
+      break;
+    case OpKind.InterpolateText:
+      for (let i = 0; i < op.expressions.length; i++) {
+        op.expressions[i] = op.expressions[i].visitExpression(visitor, ctx);
+      }
+      break;
+    case OpKind.Listener:
+      let currFlags: VisitorContextFlag = ctx.flags ?
+          ctx.flags | VisitorContextFlag.InChildOperation :
+          VisitorContextFlag.InChildOperation;
+      for (const innerOp of op.handlerOps) {
+        visitTopLevelExpressionsInOp(innerOp, visitor, {flags: currFlags});
+      }
+      break;
+    case OpKind.Element:
+    case OpKind.ElementStart:
+    case OpKind.ElementEnd:
+    case OpKind.Container:
+    case OpKind.ContainerStart:
+    case OpKind.ContainerEnd:
+    case OpKind.Template:
+    case OpKind.Text:
+    case OpKind.Advance:
+      // These operations contain no expressions.
+      break;
+    default:
+      throw new Error(`AssertionError: expressionsInOp doesn't handle ${OpKind[op.kind]}`);
+  }
+}
+
+/**
+ * Applies a `visitor` function to all `Expression`s in the AST.
  */
 export function visitExpressionsInOp(
     op: CreateOp|UpdateOp, visitor: (expr: o.Expression, flags: VisitorContextFlag) => void): void {
@@ -440,11 +653,6 @@ export function visitExpressionsInOp(
     visitor(expr, flags);
     return expr;
   }, VisitorContextFlag.None);
-}
-
-export enum VisitorContextFlag {
-  None = 0b0000,
-  InChildOperation = 0b0001,
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -33,6 +33,7 @@ import {phasePipeCreation} from './phases/pipe_creation';
 import {phasePipeVariadic} from './phases/pipe_variadic';
 import {phasePureLiteralStructures} from './phases/pure_literal_structures';
 import {phaseAlignPipeVariadicVarOffset} from './phases/align_pipe_variadic_var_offset';
+import {phaseExpandSafeReads} from './phases/expand_safe_reads';
 
 /**
  * Run all transformation phases in the correct order against a `ComponentCompilation`. After this
@@ -43,6 +44,7 @@ export function transformTemplate(cpl: ComponentCompilation): void {
   phasePipeVariadic(cpl);
   phasePureLiteralStructures(cpl);
   phaseGenerateVariables(cpl);
+  phaseExpandSafeReads(cpl);
   phaseSaveRestoreView(cpl);
   phaseResolveNames(cpl);
   phaseResolveContexts(cpl);

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -151,6 +151,9 @@ function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
         operator, convertAst(ast.left, cpl), convertAst(ast.right, cpl));
   } else if (ast instanceof e.ThisReceiver) {
     return new ir.ContextExpr(cpl.root.xref);
+  } else if (ast instanceof e.NonNullAssert) {
+    // A non-null assertion shouldn't impact generated instructions, so we can just drop it.
+    return convertAst(ast.expression, cpl);
   } else if (ast instanceof e.KeyedRead) {
     return new o.ReadKeyExpr(convertAst(ast.receiver, cpl), convertAst(ast.key, cpl));
   } else if (ast instanceof e.Chain) {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -119,6 +119,8 @@ function ingestBoundText(view: ViewCompilation, text: t.BoundText): void {
 function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
   if (ast instanceof e.ASTWithSource) {
     return convertAst(ast.ast, cpl);
+  } else if (ast instanceof e.SafePropertyRead) {
+    return new ir.SafePropertyReadExpr(convertAst(ast.receiver, cpl), ast.name);
   } else if (ast instanceof e.PropertyRead) {
     if (ast.receiver instanceof e.ImplicitReceiver) {
       return new ir.LexicalReadExpr(ast.name);
@@ -133,6 +135,9 @@ function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
         convertAst(ast.key, cpl),
         convertAst(ast.value, cpl),
     );
+  } else if (ast instanceof e.SafeCall) {
+    return new ir.SafeInvokeFunctionExpr(
+        convertAst(ast.receiver, cpl), ast.args.map(a => convertAst(a, cpl)));
   } else if (ast instanceof e.Call) {
     if (ast.receiver instanceof e.ImplicitReceiver) {
       throw new Error(`Unexpected ImplicitReceiver`);
@@ -154,6 +159,8 @@ function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
   } else if (ast instanceof e.NonNullAssert) {
     // A non-null assertion shouldn't impact generated instructions, so we can just drop it.
     return convertAst(ast.expression, cpl);
+  } else if (ast instanceof e.SafeKeyedRead) {
+    return new ir.SafeKeyedReadExpr(convertAst(ast.receiver, cpl), convertAst(ast.key, cpl));
   } else if (ast instanceof e.KeyedRead) {
     return new o.ReadKeyExpr(convertAst(ast.receiver, cpl), convertAst(ast.key, cpl));
   } else if (ast instanceof e.Chain) {

--- a/packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as core from '../../../../core';
+import * as cdAst from '../../../../expression_parser/ast';
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import {ElementAttributes} from '../../ir/src/element';
+import {ComponentCompilation} from '../compilation';
+
+/**
+ * Finds all unresolved safe read expressions, and converts them into the appropriate output AST
+ * reads, guarded by null checks.
+ */
+export function phaseExpandSafeReads(cpl: ComponentCompilation): void {
+  for (const [_, view] of cpl.views) {
+    for (const op of view.ops()) {
+      ir.visitTopLevelExpressionsInOp(op, new ConvertSafeAccessVisitor(), {});
+    }
+  }
+}
+
+class LeftMostVisitor extends ir.NullExpressionVisitor {
+  constructor(private convertExpressionMap:
+                  Map<o.Expression|ir.Expression, o.Expression|ir.Expression>) {
+    super();
+  }
+
+  private visitAndReplace(ast: o.Expression|ir.Expression, ctx: any): any {
+    return (this.convertExpressionMap.get(ast) || ast).visitExpression(this, ctx);
+  }
+
+  override visitReadPropExpr = (ast: o.ReadPropExpr, ctx: any) =>
+      this.visitAndReplace(ast.receiver, ctx);
+  override visitReadKeyExpr = (ast: o.ReadKeyExpr, ctx: any) =>
+      this.visitAndReplace(ast.receiver, ctx);
+  override visitInvokeFunctionExpr = (ast: o.InvokeFunctionExpr, ctx: any) =>
+      this.visitAndReplace(ast.receiver, ctx);
+  override visitSafePropertyReadExpr = (ast: ir.SafePropertyReadExpr, ctx: any) =>
+      this.visitAndReplace(ast.receiver, ctx) || ast;
+  override visitSafeKeyedReadExpr = (ast: ir.SafeKeyedReadExpr, ctx: any) =>
+      this.visitAndReplace(ast.receiver, ctx) || ast;
+  override visitSafeInvokeFunctionExpr = (ast: ir.SafeInvokeFunctionExpr, ctx: any) =>
+      this.visitAndReplace(ast.receiver, ctx) || ast;
+}
+
+type UnsafeRead = o.ReadPropExpr|o.ReadKeyExpr|o.InvokeFunctionExpr;
+type SafeRead = ir.SafePropertyReadExpr|ir.SafeKeyedReadExpr|ir.SafeInvokeFunctionExpr;
+
+class ConvertSafeAccessVisitor extends ir.EverythingVisitor {
+  convertExpressionMap = new Map<o.Expression|ir.Expression, o.Expression|ir.Expression>();
+
+  private visitWithReplacement(ast: o.Expression|ir.Expression, ctx: any): any {
+    return (this.convertExpressionMap.get(ast) || ast).visitExpression(this, ctx);
+  }
+
+  private convertSafeAccess(ast: UnsafeRead|SafeRead, leftMostSafe: SafeRead, ctx: any): any {
+    const guardedExpression = this.visitWithReplacement(leftMostSafe.receiver, ctx);
+    const condition = guardedExpression.isBlank();
+    if (leftMostSafe instanceof ir.SafePropertyReadExpr) {
+      this.convertExpressionMap.set(
+          leftMostSafe,
+          new o.ReadPropExpr(
+              leftMostSafe.receiver, leftMostSafe.name, leftMostSafe.type,
+              leftMostSafe.sourceSpan));
+    } else if (leftMostSafe instanceof ir.SafeKeyedReadExpr) {
+      this.convertExpressionMap.set(
+          leftMostSafe,
+          new o.ReadKeyExpr(
+              leftMostSafe.receiver, leftMostSafe.index, leftMostSafe.type,
+              leftMostSafe.sourceSpan));
+    } else if (leftMostSafe instanceof ir.SafeInvokeFunctionExpr) {
+      this.convertExpressionMap.set(
+          leftMostSafe,
+          new o.InvokeFunctionExpr(
+              leftMostSafe.receiver, leftMostSafe.args, leftMostSafe.type, leftMostSafe.sourceSpan,
+              leftMostSafe.pure));
+    } else {
+      throw new Error('Cannot convert safe access of unsafe read');
+    }
+    const access = this.visitWithReplacement(ast, ctx);
+    this.convertExpressionMap.delete(leftMostSafe);
+    return condition.conditional(o.NULL_EXPR, access);
+  }
+
+  private leftMostSafeNode(ast: UnsafeRead|SafeRead, ctx: any): SafeRead|null {
+    return ast.visitExpression(new LeftMostVisitor(this.convertExpressionMap), ctx);
+  }
+
+  override visitReadPropExpr = (ast: o.ReadPropExpr, ctx: any) => {
+    const leftMostSafe = this.leftMostSafeNode(ast, ctx);
+    if (leftMostSafe) {
+      return this.convertSafeAccess(ast, leftMostSafe, ctx);
+    }
+    return this.visitWithReplacement(ast.receiver, ctx).prop(ast.name);
+  };
+
+  override visitReadKeyExpr = (ast: o.ReadKeyExpr, ctx: any) => {
+    const leftMostSafe = this.leftMostSafeNode(ast, ctx);
+    if (leftMostSafe) {
+      return this.convertSafeAccess(ast, leftMostSafe, ctx);
+    }
+    return this.visitWithReplacement(ast.receiver, ctx)
+        .key(this.visitWithReplacement(ast.index, ctx));
+  };
+
+  override visitInvokeFunctionExpr = (ast: o.InvokeFunctionExpr, ctx: any) => {
+    const leftMostSafe = this.leftMostSafeNode(ast, ctx);
+    if (leftMostSafe) {
+      return this.convertSafeAccess(ast, leftMostSafe, ctx);
+    }
+    const convertedArgs = ast.args.map(arg => this.visitWithReplacement(arg, ctx));
+    return this.visitWithReplacement(ast.receiver, ctx).callFn(convertedArgs);
+  };
+
+  override visitSafePropertyReadExpr = (ast: ir.SafePropertyReadExpr, ctx: any) =>
+      this.convertSafeAccess(ast, this.leftMostSafeNode(ast, ctx)!, ctx);
+
+  override visitSafeKeyedReadExpr =
+      (ast: ir.SafeKeyedReadExpr, ctx: any) => {
+        debugger;
+        const leftMost = this.leftMostSafeNode(ast, ctx)!;
+        return this.convertSafeAccess(ast, leftMost, ctx);
+      }
+
+  override visitSafeInvokeFunctionExpr = (ast: ir.SafeInvokeFunctionExpr, ctx: any) =>
+      this.convertSafeAccess(ast, this.leftMostSafeNode(ast, ctx)!, ctx);
+}

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -183,6 +183,9 @@ function reifyIrExpression(expr: o.Expression): o.Expression {
       return ng.pipeBind(expr.slot!, expr.varOffset!, expr.args);
     case ir.ExpressionKind.PipeBindingVariadic:
       return ng.pipeBindV(expr.slot!, expr.varOffset!, expr.args);
+    // case ir.ExpressionKind.SafeKeyedRead:
+    //   // TODO -- remove, for debugging only
+    //   return new o.ReadKeyExpr(expr.receiver, expr.index);
     default:
       throw new Error(`AssertionError: Unsupported reification of ir.Expression kind: ${
           ir.ExpressionKind[(expr as ir.Expression).kind]}`);


### PR DESCRIPTION
Refactor `expression.ts` in order to introduce initial support for safe property reads and safe keyed reads.

This needs to be reviewed especially for the refactor of expression handling.