### PR TITLE
fix(core): add extra component metadata to component ID generation

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -696,6 +696,10 @@ function getComponentId(componentDef: ComponentDef<unknown>): string {
     componentDef.decls,
     componentDef.encapsulation,
     componentDef.standalone,
+    componentDef.signals,
+    componentDef.exportAs,
+    JSON.stringify(componentDef.inputs),
+    JSON.stringify(componentDef.outputs),
     // We cannot use 'componentDef.type.name' as the name of the symbol will change and will not
     // match in the server and browser bundles.
     Object.getOwnPropertyNames(componentDef.type.prototype),


### PR DESCRIPTION
This commit add `exportAs`, `signals`, `inputs` and `outputs` into account when generating a component ID.

FYI, this PR re-introduces the mentioned fields without changing the `Array.join('|')` -> `JSON.stringify` (since that caused some breakages before due to the way `JSON.stringify` deals with functions).

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No