### PR TITLE
[16.0.x] fix(core): add additional component metadata to component ID generation

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -689,6 +689,9 @@ function getComponentId(componentDef: ComponentDef<unknown>): string {
     componentDef.decls,
     componentDef.encapsulation,
     componentDef.standalone,
+    componentDef.exportAs,
+    JSON.stringify(componentDef.inputs),
+    JSON.stringify(componentDef.outputs),
     // We cannot use 'componentDef.type.name' as the name of the symbol will change and will not
     // match in the server and browser bundles.
     Object.getOwnPropertyNames(componentDef.type.prototype),


### PR DESCRIPTION
This commit add `exportAs`, `inputs` and `outputs` into account when generating a component ID.

This PR is effectively a copy of https://github.com/angular/angular/pull/50336, but without `signals` field, which became available in main (would be a part of 16.1.0), but not in a patch branch.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No