### PR TITLE
refactor(compiler): remove convertIndexImportShorthand

### DIFF
--- a/packages/compiler-cli/src/main.ts
+++ b/packages/compiler-cli/src/main.ts
@@ -102,16 +102,14 @@ function createEmitCallback(options: api.CompilerOptions, tsickle?: TsickleModul
   const tsickleHost: Pick<
       TsickleHost,
       'shouldSkipTsickleProcessing'|'pathToModuleName'|'shouldIgnoreWarningsForPath'|
-      'fileNameToModuleId'|'googmodule'|'untyped'|'convertIndexImportShorthand'|
-      'transformDecorators'|'transformTypesToClosure'|'generateExtraSuppressions'|
-      'rootDirsRelative'> = {
+      'fileNameToModuleId'|'googmodule'|'untyped'|'transformDecorators'|'transformTypesToClosure'|
+      'generateExtraSuppressions'|'rootDirsRelative'> = {
     shouldSkipTsickleProcessing: (fileName) => fileName.endsWith('.d.ts'),
     pathToModuleName: (context, importPath) => '',
     shouldIgnoreWarningsForPath: (filePath) => false,
     fileNameToModuleId: (fileName) => fileName,
     googmodule: false,
     untyped: true,
-    convertIndexImportShorthand: false,
     // Decorators are transformed as part of the Angular compiler programs. To avoid
     // conflicts, we disable decorator transformations for tsickle.
     transformDecorators: false,


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Refactoring (no functional changes, no api changes)

## What is the change?

Remove convertIndexImportShorthand tsickle option. It's going to be removed from tsickle in https://github.com/angular/tsickle/pull/1442. `false` is the default value, so setting it here has no effect currently.

## Does this PR introduce a breaking change?

- [x] No