### PR TITLE
docs(docs-infra): Drop `ngcli-compat`

### DIFF
--- a/aio/.eslintrc.json
+++ b/aio/.eslintrc.json
@@ -13,59 +13,214 @@
         "createDefaultProgram": true
       },
       "extends": [
-        "plugin:@angular-eslint/ng-cli-compat",
-        "plugin:@angular-eslint/ng-cli-compat--formatting-add-on",
         "plugin:@angular-eslint/template/process-inline-templates"
       ],
+      "plugins": [
+        "@typescript-eslint",
+        "@angular-eslint",
+        "eslint-plugin-jsdoc",
+        "eslint-plugin-import",
+        "eslint-plugin-jsdoc",
+        "eslint-plugin-prefer-arrow"
+      ],
       "rules": {
-        "@typescript-eslint/ban-types": "error",
+        "@angular-eslint/component-class-suffix": "error",
         "@angular-eslint/component-selector": [
           "error",
           {
-            "type": "element",
             "prefix": "aio",
-            "style": "kebab-case"
+            "style": "kebab-case",
+            "type": "element"
           }
         ],
+        "@angular-eslint/contextual-lifecycle": "error",
+        "@angular-eslint/directive-class-suffix": "error",
         "@angular-eslint/directive-selector": [
           "error",
           {
-            "type": "attribute",
             "prefix": "aio",
-            "style": "camelCase"
+            "style": "camelCase",
+            "type": "attribute"
           }
         ],
-        "dot-notation": "error",
-        "indent": "off",
-        "max-len": ["error", 120],
-        "@typescript-eslint/member-delimiter-style": ["error", {
-          "singleline": {
-            "delimiter": "comma",
-            "requireLast": false
+        "@angular-eslint/no-conflicting-lifecycle": "error",
+        "@angular-eslint/no-host-metadata-property": "off",
+        "@angular-eslint/no-input-rename": "error",
+        "@angular-eslint/no-inputs-metadata-property": "error",
+        "@angular-eslint/no-output-native": "error",
+        "@angular-eslint/no-output-on-prefix": "error",
+        "@angular-eslint/no-output-rename": "error",
+        "@angular-eslint/no-outputs-metadata-property": "error",
+        "@angular-eslint/use-lifecycle-interface": "error",
+        "@angular-eslint/use-pipe-transform-interface": "error",
+        "@typescript-eslint/adjacent-overload-signatures": "error",
+        "@typescript-eslint/array-type": "off",
+        "@typescript-eslint/ban-types": "error",
+        "@typescript-eslint/consistent-type-assertions": "error",
+        "@typescript-eslint/dot-notation": "error",
+        "@typescript-eslint/explicit-member-accessibility": "off",
+        "@typescript-eslint/interface-name-prefix": "off",
+        "@typescript-eslint/member-delimiter-style": [
+          "error",
+          {
+            "singleline": {
+              "delimiter": "comma",
+              "requireLast": false
+            }
           }
-        }],
+        ],
         "@typescript-eslint/member-ordering": "off",
         "@typescript-eslint/naming-convention": "off",
-        "no-console": ["error", {"allow": ["log", "warn", "error"]}],
+        "@typescript-eslint/no-empty-function": "off",
+        "@typescript-eslint/no-empty-interface": "error",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/no-inferrable-types": [
+          "error",
+          {
+            "ignoreParameters": true
+          }
+        ],
+        "@typescript-eslint/no-misused-new": "error",
+        "@typescript-eslint/no-namespace": "error",
+        "@typescript-eslint/no-non-null-assertion": "error",
+        "@typescript-eslint/no-parameter-properties": "off",
+        "@typescript-eslint/no-shadow": [
+          "error"
+        ],
+        "@typescript-eslint/no-unused-expressions": "error",
+        "@typescript-eslint/no-use-before-define": "off",
+        "@typescript-eslint/no-var-requires": "off",
+        "@typescript-eslint/prefer-for-of": "error",
+        "@typescript-eslint/prefer-function-type": "error",
+        "@typescript-eslint/prefer-namespace-keyword": "error",
+        "@typescript-eslint/quotes": [
+          "error",
+          "single",
+          {
+            "avoidEscape": true
+          }
+        ],
+        "@typescript-eslint/semi": [
+          "error",
+          "always"
+        ],
+        "@typescript-eslint/triple-slash-reference": [
+          "error",
+          {
+            "lib": "always",
+            "path": "always",
+            "types": "prefer-import"
+          }
+        ],
+        "@typescript-eslint/type-annotation-spacing": "error",
+        "@typescript-eslint/unified-signatures": "error",
+        "arrow-body-style": "error",
+        "arrow-parens": "off",
+        "comma-dangle": "off",
+        "complexity": "off",
+        "constructor-super": "error",
+        "curly": "error",
+        "dot-notation": "error",
+        "eol-last": "error",
+        "eqeqeq": [
+          "error",
+          "smart"
+        ],
+        "guard-for-in": "error",
+        "id-denylist": [
+          "error",
+          "any",
+          "Number",
+          "number",
+          "String",
+          "string",
+          "Boolean",
+          "boolean",
+          "Undefined",
+          "undefined"
+        ],
+        "id-match": "error",
+        "import/no-deprecated": "warn",
+        "indent": "off",
+        "jsdoc/check-alignment": "error",
+        "jsdoc/newline-after-description": "error",
+        "jsdoc/no-types": "error",
+        "max-classes-per-file": "off",
+        "max-len": [
+          "error",
+          120
+        ],
+        "new-parens": "error",
+        "no-bitwise": "error",
+        "no-caller": "error",
+        "no-cond-assign": "error",
+        "no-console": [
+          "error",
+          {
+            "allow": [
+              "log",
+              "warn",
+              "error"
+            ]
+          }
+        ],
+        "no-debugger": "error",
+        "no-empty": "off",
         "no-empty-function": "off",
-        "@angular-eslint/no-host-metadata-property": "off",
+        "no-eval": "error",
+        "no-fallthrough": "error",
+        "no-invalid-this": "off",
+        "no-multiple-empty-lines": "off",
+        "no-new-wrappers": "error",
+        "no-restricted-imports": [
+          "error",
+          {
+            "message": "Please import directly from 'rxjs' instead",
+            "name": "rxjs/Rx"
+          }
+        ],
         "no-restricted-syntax": [
           "error",
           {
-            "selector": "CallExpression[callee.name=/^(fdescribe|fit)$/]",
-            "message": "Don't keep jasmine focus methods."
+            "message": "Don't keep jasmine focus methods.",
+            "selector": "CallExpression[callee.name=/^(fdescribe|fit)$/]"
           }
         ],
         "no-shadow": "off",
-        "@typescript-eslint/no-shadow": ["error"],
         "no-tabs": "error",
+        "no-throw-literal": "error",
+        "no-trailing-spaces": "error",
+        "no-undef-init": "error",
         "no-underscore-dangle": "off",
+        "no-unsafe-finally": "error",
         "no-unused-expressions": "off",
-        "@typescript-eslint/no-unused-expressions": ["error"],
+        "no-unused-labels": "error",
         "no-use-before-define": "off",
+        "no-var": "error",
+        "object-shorthand": "error",
+        "one-var": [
+          "error",
+          "never"
+        ],
         "prefer-arrow/prefer-arrow-functions": "off",
+        "prefer-const": "error",
+        "quote-props": [
+          "error",
+          "as-needed"
+        ],
         "quotes": "off",
-        "@typescript-eslint/quotes": ["error", "single", {"avoidEscape": true}]
+        "radix": "error",
+        "sort-keys": "off",
+        "space-before-function-paren": [
+          "error",
+          {
+            "anonymous": "never",
+            "asyncArrow": "always",
+            "named": "never"
+          }
+        ],
+        "use-isnan": "error",
+        "valid-typeof": "off"
       }
     },
     {


### PR DESCRIPTION
The `ng-cli-compat` rules have been removed from `angular-eslint` v16. This commit will allow to merge #50139.

See: https://github.com/angular-eslint/angular-eslint/blob/245317c7bd83a94000e704060186098cadcf0195/docs/MIGRATING_FROM_TSLINT.md#legacy-premade-eslint-configs 

I've also sorted the rules alphabetically. 

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] angular.io application / infrastructure changes


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No