### PR TITLE
docs: replace blossom emoji with tulip

### DIFF
--- a/aio/content/examples/resolution-modifiers/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/resolution-modifiers/e2e/src/app.e2e-spec.ts
@@ -12,8 +12,8 @@ describe('Resolution-modifiers-example', () => {
     expect(await element.all(by.css('p')).get(1).getText()).toContain('🌿');
   });
 
-  it('shows yellow flower in host child', async () => {
-    expect(await element.all(by.css('p')).get(9).getText()).toContain('🌼');
+  it('shows tulip in host child', async () => {
+    expect(await element.all(by.css('p')).get(9).getText()).toContain('🌷');
   });
 
 });

--- a/aio/content/examples/resolution-modifiers/src/app/host/host.component.ts
+++ b/aio/content/examples/resolution-modifiers/src/app/host/host.component.ts
@@ -7,7 +7,7 @@ import { FlowerService } from '../flower.service';
   templateUrl: './host.component.html',
   styleUrls: ['./host.component.css'],
   //  provide the service
-  providers: [{ provide: FlowerService, useValue: { emoji: '🌼' } }]
+  providers: [{ provide: FlowerService, useValue: { emoji: '🌷' } }]
 })
 export class HostComponent {
   // use @Host() in the constructor when injecting the service

--- a/aio/content/examples/resolution-modifiers/src/app/self/self.component.ts
+++ b/aio/content/examples/resolution-modifiers/src/app/self/self.component.ts
@@ -6,7 +6,7 @@ import { FlowerService } from '../flower.service';
   selector: 'app-self',
   templateUrl: './self.component.html',
   styleUrls: ['./self.component.css'],
-  providers: [{ provide: FlowerService, useValue: { emoji: '🌼' } }]
+  providers: [{ provide: FlowerService, useValue: { emoji: '🌷' } }]
 
 })
 export class SelfComponent {

--- a/aio/content/guide/hierarchical-dependency-injection.md
+++ b/aio/content/guide/hierarchical-dependency-injection.md
@@ -12,7 +12,7 @@ This topic uses the following pictographs.
 |:---         |:--- |
 | <code>&#x1F33A;</code> | red hibiscus \(`🌺`\)  |
 | <code>&#x1F33B;</code> | sunflower \(`🌻`\)     |
-| <code>&#x1F33C;</code> | yellow flower \(`🌼`\) |
+| <code>&#x1F337;</code> | tulip \(`🌷`\)         |
 | <code>&#x1F33F;</code> | fern \(`🌿`\)          |
 | <code>&#x1F341;</code> | maple leaf \(`🍁`\)    |
 | <code>&#x1F433;</code> | whale \(`🐳`\)         |
@@ -235,7 +235,7 @@ For example, in the following `SelfComponent`, notice the injected `LeafService`
 In this example, there is a parent provider and injecting the service will return the value, however, injecting the service with `@Self()` and `@Optional()` will return `null` because `@Self()` tells the injector to stop searching in the current host element.
 
 Another example shows the component class with a provider for `FlowerService`.
-In this case, the injector looks no further than the current `ElementInjector` because it finds the `FlowerService` and returns the yellow flower <code>&#x1F33C;</code>.
+In this case, the injector looks no further than the current `ElementInjector` because it finds the `FlowerService` and returns the tulip <code>&#x1F337;</code>.
 
 <code-example header="resolution-modifiers/src/app/self/self.component.ts" path="resolution-modifiers/src/app/self/self.component.ts" region="self-component"></code-example>
 
@@ -278,7 +278,7 @@ Use `@Host()` as follows:
 
 <code-example header="resolution-modifiers/src/app/host/host.component.ts" path="resolution-modifiers/src/app/host/host.component.ts" region="host-component"></code-example>
 
-Since `HostComponent` has `@Host()` in its constructor, no matter what the parent of `HostComponent` might have as a `flower.emoji` value, the `HostComponent` will use yellow flower <code>&#x1F33C;</code>.
+Since `HostComponent` has `@Host()` in its constructor, no matter what the parent of `HostComponent` might have as a `flower.emoji` value, the `HostComponent` will use tulip <code>&#x1F337;</code>.
 
 ## Logical structure of the template
 


### PR DESCRIPTION
The blossom emoji is referred to as "yellow flower" in the docs, but it's not yellow on all platforms. Since "flower" or "blossom" is too generic, the "tulip" emoji is used instead.

Fixes #50347

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #50347


## What is the new behavior?
The tulip emoji is used instead of the blossom emoji.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I went with the tulip emoji (https://unicode.org/emoji/charts/full-emoji-list.html#1f337) because it's fairly consistent across platforms and is distinct from the other emojis used in this document.