### PR TITLE
feat(core): add getCurrentInjector() to public API

### DIFF
--- a/packages/core/src/di/index.ts
+++ b/packages/core/src/di/index.ts
@@ -23,7 +23,7 @@ export {EnvironmentInjector} from './r3_injector';
 export {importProvidersFrom, ImportProvidersSource, makeEnvironmentProviders} from './provider_collection';
 export {ENVIRONMENT_INITIALIZER} from './initializer_token';
 export {ProviderToken} from './provider_token';
-export {ɵɵinject, inject, ɵɵinvalidFactoryDep} from './injector_compatibility';
+export {ɵɵinject, inject, ɵɵinvalidFactoryDep, getCurrentInjector} from './injector_compatibility';
 export {InjectOptions} from './interface/injector';
 export {INJECTOR} from './injector_token';
 export {ClassProvider, ModuleWithProviders, ClassSansProvider, ImportedNgModuleProviders, ConstructorProvider, EnvironmentProviders, ConstructorSansProvider, ExistingProvider, ExistingSansProvider, FactoryProvider, FactorySansProvider, Provider, StaticClassProvider, StaticClassSansProvider, StaticProvider, TypeProvider, ValueProvider, ValueSansProvider} from './interface/provider';

--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -43,6 +43,12 @@ export const SOURCE = '__source';
  */
 let _currentInjector: Injector|undefined|null = undefined;
 
+/**
+ * Get current injector value
+ *
+ * @see _currentInjector
+ * @publicApi
+ */
 export function getCurrentInjector(): Injector|undefined|null {
   return _currentInjector;
 }


### PR DESCRIPTION
Using `getCurrentInjector()`, developers could get an instance of the current injector in their functions for later usage. For example:
```ts
function effect(generator) {
  const injector = getCurrentInjector();
  const destroyRef = injector.get(DestroyRef);
  const origin$ = new Subject<ObservableType>();

  generator(origin$ as OriginType)
    .pipe(takeUntilDestroyed(destroyRef))
    .subscribe();

  return ((observableOrValue?) => {
    const observable$ = isObservable(observableOrValue)
      ? observableOrValue
      : of(observableOrValue);

    return observable$.pipe(takeUntilDestroyed(destroyRef)).subscribe((value) => {
      origin$.next(value);
    });
  });
}
```
Without `getCurrentInjector()` here we would need to change function's signature and ask for another argument: injector (because we need `destroyRef` in the second call of `takeUntilDestroyed()`).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information

I'm not sure if tests are required here, because it's an already existing function (containing a single, one-line return statement).