### PR TITLE
refactor(core): Deprecate core/testing's `inject()`.

### DIFF
--- a/goldens/public-api/core/testing/index.md
+++ b/goldens/public-api/core/testing/index.md
@@ -69,7 +69,7 @@ export function flushMicrotasks(): void;
 // @public
 export function getTestBed(): TestBed;
 
-// @public
+// @public @deprecated
 export function inject(tokens: any[], fn: Function): () => any;
 
 // @public (undocumented)

--- a/packages/common/test/i18n/localization_spec.ts
+++ b/packages/common/test/i18n/localization_spec.ts
@@ -12,7 +12,7 @@ import localeSr from '@angular/common/locales/sr';
 import localeZgh from '@angular/common/locales/zgh';
 import {getPluralCategory, NgLocaleLocalization, NgLocalization} from '@angular/common/src/i18n/localization';
 import {LOCALE_ID, ɵregisterLocaleData, ɵunregisterLocaleData} from '@angular/core';
-import {inject, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 
 {
   describe('l10n', () => {
@@ -27,13 +27,13 @@ import {inject, TestBed} from '@angular/core/testing';
 
     describe('NgLocalization', () => {
       function roTests() {
-        it('should return plural cases for the provided locale',
-           inject([NgLocalization], (l10n: NgLocalization) => {
-             expect(l10n.getPluralCategory(0)).toEqual('few');
-             expect(l10n.getPluralCategory(1)).toEqual('one');
-             expect(l10n.getPluralCategory(1212)).toEqual('few');
-             expect(l10n.getPluralCategory(1223)).toEqual('other');
-           }));
+        it('should return plural cases for the provided locale', () => {
+          const l10n = TestBed.inject(NgLocalization);
+          expect(l10n.getPluralCategory(0)).toEqual('few');
+          expect(l10n.getPluralCategory(1)).toEqual('one');
+          expect(l10n.getPluralCategory(1212)).toEqual('few');
+          expect(l10n.getPluralCategory(1223)).toEqual('other');
+        });
       }
 
       describe('ro', () => {
@@ -47,17 +47,18 @@ import {inject, TestBed} from '@angular/core/testing';
       });
 
       function srTests() {
-        it('should return plural cases for the provided locale',
-           inject([NgLocalization], (l10n: NgLocalization) => {
-             expect(l10n.getPluralCategory(1)).toEqual('one');
-             expect(l10n.getPluralCategory(2.1)).toEqual('one');
+        it('should return plural cases for the provided locale', () => {
+          const l10n = TestBed.inject(NgLocalization);
 
-             expect(l10n.getPluralCategory(3)).toEqual('few');
-             expect(l10n.getPluralCategory(0.2)).toEqual('few');
+          expect(l10n.getPluralCategory(1)).toEqual('one');
+          expect(l10n.getPluralCategory(2.1)).toEqual('one');
 
-             expect(l10n.getPluralCategory(2.11)).toEqual('other');
-             expect(l10n.getPluralCategory(2.12)).toEqual('other');
-           }));
+          expect(l10n.getPluralCategory(3)).toEqual('few');
+          expect(l10n.getPluralCategory(0.2)).toEqual('few');
+
+          expect(l10n.getPluralCategory(2.11)).toEqual('other');
+          expect(l10n.getPluralCategory(2.12)).toEqual('other');
+        });
       }
 
       describe('sr', () => {

--- a/packages/common/upgrade/test/upgrade.spec.ts
+++ b/packages/common/upgrade/test/upgrade.spec.ts
@@ -6,8 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule, PathLocationStrategy} from '@angular/common';
-import {inject, TestBed} from '@angular/core/testing';
+import {CommonModule} from '@angular/common';
+import {TestBed} from '@angular/core/testing';
 import {UpgradeModule} from '@angular/upgrade/static';
 
 import {$locationShim} from '../src/location_shim';
@@ -92,10 +92,11 @@ describe('LocationProvider', () => {
     upgradeModule.$injector = {get: injectorFactory()};
   });
 
-  it('should instantiate LocationProvider', inject([$locationShim], ($location: $locationShim) => {
-       expect($location).toBeDefined();
-       expect($location instanceof $locationShim).toBe(true);
-     }));
+  it('should instantiate LocationProvider', () => {
+    const $location = TestBed.inject($locationShim);
+    expect($location).toBeDefined();
+    expect($location instanceof $locationShim).toBe(true);
+  });
 });
 
 
@@ -117,9 +118,9 @@ describe('LocationHtml5Url', function() {
     upgradeModule.$injector = {get: injectorFactory()};
   });
 
-  beforeEach(inject([$locationShim], (loc: $locationShim) => {
-    $location = loc;
-  }));
+  beforeEach(() => {
+    $location = TestBed.inject($locationShim);
+  });
 
 
   it('should set the URL', () => {
@@ -195,9 +196,9 @@ describe('NewUrl', function() {
     upgradeModule.$injector = {get: injectorFactory()};
   });
 
-  beforeEach(inject([$locationShim], (loc: $locationShim) => {
-    $location = loc;
-  }));
+  beforeEach(() => {
+    $location = TestBed.inject($locationShim);
+  });
 
   // Sets the default most of these tests rely on
   function setupUrl(url = '/path/b?search=a&b=c&d#hash') {
@@ -503,9 +504,9 @@ describe('New URL Parsing', () => {
     upgradeModule.$injector = {get: injectorFactory()};
   });
 
-  beforeEach(inject([$locationShim], (loc: $locationShim) => {
-    $location = loc;
-  }));
+  beforeEach(() => {
+    $location = TestBed.inject($locationShim);
+  });
 
   it('should prepend path with basePath', function() {
     $location.$$parse('http://server/base/abc?a');
@@ -534,9 +535,9 @@ describe('New URL Parsing', () => {
     upgradeModule.$injector = {get: injectorFactory()};
   });
 
-  beforeEach(inject([$locationShim], (loc: $locationShim) => {
-    $location = loc;
-  }));
+  beforeEach(() => {
+    $location = TestBed.inject($locationShim);
+  });
 
   it('should parse new url', function() {
     $location.$$parse('http://host.com/base');
@@ -580,9 +581,10 @@ describe('New URL Parsing', () => {
   describe('state', function() {
     let mock$rootScope: $rootScopeMock;
 
-    beforeEach(inject([UpgradeModule], (ngUpgrade: UpgradeModule) => {
+    beforeEach(() => {
+      const ngUpgrade = TestBed.inject(UpgradeModule);
       mock$rootScope = ngUpgrade.$injector.get('$rootScope');
-    }));
+    });
 
     it('should set $$state and return itself', function() {
       expect(($location as any).$$state).toEqual(null);
@@ -663,9 +665,9 @@ describe('$location.onChange()', () => {
     mock$rootScope = upgradeModule.$injector.get('$rootScope');
   });
 
-  beforeEach(inject([$locationShim], (loc: $locationShim) => {
-    $location = loc;
-  }));
+  beforeEach(() => {
+    $location = TestBed.inject($locationShim);
+  });
 
   it('should have onChange method', () => {
     expect(typeof $location.onChange).toBe('function');

--- a/packages/core/test/acceptance/providers_spec.ts
+++ b/packages/core/test/acceptance/providers_spec.ts
@@ -9,7 +9,7 @@
 import {CommonModule} from '@angular/common';
 import {Component, Directive, forwardRef, Inject, Injectable, InjectionToken, Injector, NgModule, Optional} from '@angular/core';
 import {leaveView, specOnlyIsInstructionStateEmpty} from '@angular/core/src/render3/state';
-import {inject, TestBed, waitForAsync} from '@angular/core/testing';
+import {TestBed, waitForAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
@@ -567,10 +567,10 @@ describe('providers', () => {
         TestBed.configureTestingModule({declarations: [MyComp], providers: [MyComp, MyService]});
       });
 
-      it('should support injecting without bootstrapping',
-         waitForAsync(inject([MyComp, MyService], (comp: MyComp, service: MyService) => {
+      it('should support injecting without bootstrapping', waitForAsync(() => {
+           const comp = TestBed.inject(MyComp);
            expect(comp.svc.value).toEqual('some value');
-         })));
+         }));
     });
   });
 

--- a/packages/core/test/application_module_spec.ts
+++ b/packages/core/test/application_module_spec.ts
@@ -7,7 +7,6 @@
  */
 
 import {DEFAULT_CURRENCY_CODE, LOCALE_ID} from '@angular/core';
-import {inject} from '@angular/core/testing';
 
 import {DEFAULT_LOCALE_ID} from '../src/i18n/localization';
 import {getLocaleId, setLocaleId} from '../src/render3';
@@ -20,14 +19,15 @@ import {TestBed} from '../testing';
       setLocaleId(DEFAULT_LOCALE_ID);
     });
 
-    it('should set the default locale to "en-US"', inject([LOCALE_ID], (defaultLocale: string) => {
-         expect(defaultLocale).toEqual('en-US');
-       }));
+    it('should set the default locale to "en-US"', () => {
+      const defaultLocale = TestBed.inject(LOCALE_ID);
+      expect(defaultLocale).toEqual('en-US');
+    });
 
-    it('should set the default currency code to "USD"',
-       inject([DEFAULT_CURRENCY_CODE], (defaultCurrencyCode: string) => {
-         expect(defaultCurrencyCode).toEqual('USD');
-       }));
+    it('should set the default currency code to "USD"', () => {
+      const defaultCurrencyCode = TestBed.inject(DEFAULT_CURRENCY_CODE);
+      expect(defaultCurrencyCode).toEqual('USD');
+    });
 
     it('should set the ivy locale with the configured LOCALE_ID', () => {
       TestBed.configureTestingModule({providers: [{provide: LOCALE_ID, useValue: 'fr'}]});

--- a/packages/core/test/directive_lifecycle_integration_spec.ts
+++ b/packages/core/test/directive_lifecycle_integration_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {AfterContentChecked, AfterContentInit, AfterViewChecked, AfterViewInit, Component, Directive, DoCheck, OnChanges, OnInit} from '@angular/core';
-import {inject, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 
 describe('directive lifecycle integration spec', () => {
@@ -24,11 +24,8 @@ describe('directive lifecycle integration spec', () => {
           providers: [Log]
         })
         .overrideComponent(MyComp5, {set: {template: '<div [field]="123" lifecycle></div>'}});
+    log = TestBed.inject(Log);
   });
-
-  beforeEach(inject([Log], (_log: any) => {
-    log = _log;
-  }));
 
   it('should invoke lifecycle methods ngOnChanges > ngOnInit > ngDoCheck > ngAfterContentChecked',
      () => {

--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, inject, tick} from '@angular/core/testing';
+import {discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, TestBed, tick} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 import {EventManager} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -32,10 +32,14 @@ const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'
       })('foo', 'bar');
     });
 
-    it('should work with inject()',
-       fakeAsync(inject([EventManager], (eventManager: EventManager) => {
+    it('should work with inject()', fakeAsync(() => {
+         const eventManager = TestBed.inject(EventManager);
          expect(eventManager).toBeAnInstanceOf(EventManager);
-       })));
+       }));
+
+    it('should work with inject()', fakeAsync(() => {
+         expect(TestBed.inject(EventManager)).toBeAnInstanceOf(EventManager);
+       }));
 
     it('should throw on nested calls', () => {
       expect(() => {

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -10,7 +10,7 @@ import {Compiler, Component, CUSTOM_ELEMENTS_SCHEMA, Directive, forwardRef, getM
 import {ɵɵdefineInjectable} from '@angular/core/src/di/interface/defs';
 import {NgModuleType} from '@angular/core/src/render3';
 import {getNgModuleDef} from '@angular/core/src/render3/definition';
-import {ComponentFixture, inject} from '@angular/core/testing';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {InternalNgModuleRef, NgModuleFactory} from '../../src/linker/ng_module_factory';
@@ -78,10 +78,10 @@ describe('NgModule', () => {
   let compiler: Compiler;
   let injector: Injector;
 
-  beforeEach(inject([Compiler, Injector], (_compiler: Compiler, _injector: Injector) => {
-    compiler = _compiler;
-    injector = _injector;
-  }));
+  beforeEach(() => {
+    compiler = TestBed.inject(Compiler);
+    injector = TestBed.inject(Injector);
+  });
 
   function createModuleFactory<T>(moduleType: Type<T>): NgModuleFactory<T> {
     return compiler.compileModuleSync(moduleType);

--- a/packages/core/test/linker/regression_integration_spec.ts
+++ b/packages/core/test/linker/regression_integration_spec.ts
@@ -8,7 +8,7 @@
 
 import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
 import {ApplicationRef, Component, ComponentRef, ContentChild, createComponent, destroyPlatform, Directive, EnvironmentInjector, ErrorHandler, EventEmitter, HostListener, InjectionToken, Injector, Input, NgModule, NgZone, Output, Pipe, PipeTransform, Provider, QueryList, Renderer2, SimpleChanges, TemplateRef, ViewChildren, ViewContainerRef} from '@angular/core';
-import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {BrowserModule, By} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -354,15 +354,16 @@ describe('regressions using bootstrap', () => {
   let logger: MockConsole;
   let errorHandler: ErrorHandler;
 
-  beforeEach(inject([DOCUMENT], (doc: any) => {
+  beforeEach(() => {
     destroyPlatform();
+    const doc = TestBed.inject(DOCUMENT);
     const el = getDOM().createElement(COMP_SELECTOR, doc);
     doc.body.appendChild(el);
 
     logger = new MockConsole();
     errorHandler = new ErrorHandler();
     (errorHandler as any)._console = logger as any;
-  }));
+  });
 
   afterEach(() => {
     destroyPlatform();

--- a/packages/core/test/zone/ng_zone_spec.ts
+++ b/packages/core/test/zone/ng_zone_spec.ts
@@ -7,7 +7,7 @@
  */
 
 import {EventEmitter, NgZone} from '@angular/core';
-import {fakeAsync, flushMicrotasks, inject, waitForAsync} from '@angular/core/testing';
+import {fakeAsync, flushMicrotasks, TestBed, waitForAsync} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 import {browserDetection} from '@angular/platform-browser/testing/src/browser_util';
 
@@ -873,10 +873,10 @@ function commonTests() {
     describe('#10503', () => {
       let ngZone: NgZone;
 
-      beforeEach(inject([NgZone], (_ngZone: NgZone) => {
+      beforeEach(() => {
         // Create a zone outside the fakeAsync.
-        ngZone = _ngZone;
-      }));
+        ngZone = TestBed.inject(NgZone);
+      });
 
       it('should fakeAsync even if the NgZone was created outside.', fakeAsync(() => {
            let result: string = null!;

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -774,6 +774,7 @@ export const TestBed: TestBedStatic = TestBedImpl;
  * })
  * ```
  *
+ * @deprecated use `TestBed.inject` instead
  * @publicApi
  */
 export function inject(tokens: any[], fn: Function): () => any {

--- a/packages/core/testing/src/testing_internal.ts
+++ b/packages/core/testing/src/testing_internal.ts
@@ -6,6 +6,4 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {inject} from './test_bed';
-
 export * from './logger';

--- a/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
+++ b/packages/platform-browser-dynamic/test/testing_public_browser_spec.ts
@@ -8,7 +8,7 @@
 
 import {ResourceLoader} from '@angular/compiler';
 import {Compiler, Component, NgModule} from '@angular/core';
-import {fakeAsync, inject, TestBed, tick, waitForAsync} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick, waitForAsync} from '@angular/core/testing';
 import {ResourceLoaderImpl} from '@angular/platform-browser-dynamic/src/resource_loader/resource_loader_impl';
 
 // Components for the tests.
@@ -59,20 +59,20 @@ if (isBrowser) {
               {providers: [{provide: FancyService, useValue: new FancyService()}]});
         });
 
-        it('provides a real ResourceLoader instance',
-           inject([ResourceLoader], (resourceLoader: ResourceLoader) => {
-             expect(resourceLoader instanceof ResourceLoaderImpl).toBeTruthy();
-           }));
+        it('provides a real ResourceLoader instance', () => {
+          const resourceLoader = TestBed.inject(ResourceLoader);
+          expect(resourceLoader instanceof ResourceLoaderImpl).toBeTruthy();
+        });
 
-        it('should allow the use of fakeAsync',
-           fakeAsync(inject([FancyService], (service: any /** TODO #9100 */) => {
+        it('should allow the use of fakeAsync', fakeAsync(() => {
+             const service = TestBed.inject(FancyService);
              let value: any /** TODO #9100 */;
              service.getAsyncValue().then(function(val: any /** TODO #9100 */) {
                value = val;
              });
              tick();
              expect(value).toEqual('async value');
-           })));
+           }));
       });
     });
 

--- a/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
+++ b/packages/platform-browser/test/dom/events/hammer_gestures_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {ApplicationRef, NgZone} from '@angular/core';
-import {fakeAsync, inject, TestBed, tick} from '@angular/core/testing';
+import {fakeAsync, TestBed, tick} from '@angular/core/testing';
 import {EventManager} from '@angular/platform-browser';
 import {HammerGestureConfig, HammerGesturesPlugin,} from '@angular/platform-browser/src/dom/events/hammer_gestures';
 
@@ -59,9 +59,9 @@ import {HammerGestureConfig, HammerGesturesPlugin,} from '@angular/platform-brow
       // Inject the NgZone so that we can make it available to the plugin through a fake
       // EventManager.
       let ngZone: NgZone;
-      beforeEach(inject([NgZone], (z: NgZone) => {
-        ngZone = z;
-      }));
+      beforeEach(() => {
+        ngZone = TestBed.inject(NgZone);
+      });
 
       let loaderCalled = 0;
       let loaderIsCalledInAngularZone: boolean|null = null;

--- a/packages/router/test/router.spec.ts
+++ b/packages/router/test/router.spec.ts
@@ -8,7 +8,7 @@
 
 import {Location} from '@angular/common';
 import {EnvironmentInjector} from '@angular/core';
-import {inject, TestBed} from '@angular/core/testing';
+import {TestBed} from '@angular/core/testing';
 import {RouterModule} from '@angular/router';
 import {of} from 'rxjs';
 
@@ -85,20 +85,22 @@ describe('Router', () => {
       TestBed.configureTestingModule({imports: [RouterModule.forRoot([])]});
     });
 
-    it('should be idempotent', inject([Router, Location], (r: Router, location: Location) => {
-         r.setUpLocationChangeListener();
-         const a = (<any>r).locationSubscription;
-         r.setUpLocationChangeListener();
-         const b = (<any>r).locationSubscription;
+    it('should be idempotent', () => {
+      const r = TestBed.inject(Router);
+      const location = TestBed.inject(Location);
+      r.setUpLocationChangeListener();
+      const a = (<any>r).locationSubscription;
+      r.setUpLocationChangeListener();
+      const b = (<any>r).locationSubscription;
 
-         expect(a).toBe(b);
+      expect(a).toBe(b);
 
-         r.dispose();
-         r.setUpLocationChangeListener();
-         const c = (<any>r).locationSubscription;
+      r.dispose();
+      r.setUpLocationChangeListener();
+      const c = (<any>r).locationSubscription;
 
-         expect(c).not.toBe(b);
-       }));
+      expect(c).not.toBe(b);
+    });
   });
 
   describe('PreActivation', () => {
@@ -144,11 +146,12 @@ describe('Router', () => {
       });
     });
 
-    beforeEach(inject([Logger], (_logger: Logger) => {
+    beforeEach(() => {
+      const _logger = TestBed.inject(Logger);
       empty = createEmptyStateSnapshot(serializer.parse('/'), null!);
       logger = _logger;
       events = [];
-    }));
+    });
 
     describe('ChildActivation', () => {
       it('should run', () => {


### PR DESCRIPTION
In order to improve DX (poke the more famous `inject()`), let's deprecate the other one which can be replaced by `TestBed.inject()`

Fixes #46085

## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)

- [ ] Yes
- [x] No
