### PR TITLE
fix(forms): `hasError` should not return `false` when the error is not `null`

### DIFF
--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -1261,7 +1261,7 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
    * If the control is not present, false is returned.
    */
   hasError(errorCode: string, path?: Array<string|number>|string): boolean {
-    return !!this.getError(errorCode, path);
+    return this.getError(errorCode, path) !== null;
   }
 
   /**

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -925,6 +925,11 @@ describe('FormGroup', () => {
       expect(c.getError('required')).toEqual(true);
       expect(g1.getError('required', ['one', 0, 'two'])).toEqual(true);
     });
+
+    it('should return true when the erorr is not null but falsy', () => {
+      const c = new FormControl('', () => ({'min': 0}));
+      expect(c.hasError('min')).toEqual(true);
+    });
   });
 
   describe('validator', () => {


### PR DESCRIPTION
fixes #45556

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix