### PR TITLE
refactor(compiler-cli): deprecate `allowEmptyCodegenFiles`

### DIFF
--- a/aio/content/guide/angular-compiler-options.md
+++ b/aio/content/guide/angular-compiler-options.md
@@ -26,13 +26,6 @@ For more information, see the [TypeScript Handbook](https://www.typescriptlang.o
 
 The following options are available for configuring the AOT template compiler.
 
-### `allowEmptyCodegenFiles`
-
-When `true`, create all possible files even if they are empty.
-Default is `false`.
-Used by the Bazel build rules to simplify how Bazel rules track file dependencies.
-Do not use this option outside of the Bazel rules.
-
 ### `annotationsAs`
 
 Modifies how Angular-specific annotations are emitted to improve tree-shaking.

--- a/goldens/public-api/compiler-cli/compiler_options.md
+++ b/goldens/public-api/compiler-cli/compiler_options.md
@@ -41,6 +41,7 @@ export interface I18nOptions {
 
 // @public
 export interface LegacyNgcOptions {
+    // @deprecated
     allowEmptyCodegenFiles?: boolean;
     flatModuleId?: string;
     flatModuleOutFile?: string;

--- a/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/public_options.ts
@@ -17,7 +17,10 @@ import {ExtendedTemplateDiagnosticName} from '../../../../ngtsc/diagnostics';
  * @publicApi
  */
 export interface LegacyNgcOptions {
-  /** generate all possible generated files  */
+  /**
+   * generate all possible generated files
+   *  @deprecated This option is not used anymore.
+   */
   allowEmptyCodegenFiles?: boolean;
 
   /**


### PR DESCRIPTION
The `allowEmptyCodegenFiles` option is not used anymore.

Usage was removed in #48268 

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)