### PR TITLE
feat(core): add `static` option for `ViewChildren`  decorators.

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1538,11 +1538,13 @@ export interface ViewChildrenDecorator {
     (selector: ProviderToken<unknown> | Function | string, opts?: {
         read?: any;
         emitDistinctChangesOnly?: boolean;
+        static?: boolean;
     }): any;
     // (undocumented)
     new (selector: ProviderToken<unknown> | Function | string, opts?: {
         read?: any;
         emitDistinctChangesOnly?: boolean;
+        static?: boolean;
     }): ViewChildren;
 }
 

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -293,6 +293,7 @@ export interface ViewChildrenDecorator {
    *
    * * **selector** - The directive type or the name used for querying.
    * * **read** - Used to read a different token from the queried elements.
+   * * **static** - True to resolve query results before change detection runs,
    * * **emitDistinctChangesOnly** - The ` QueryList#changes` observable will emit new values only
    *   if the QueryList result has changed. When `false` the `changes` observable might emit even
    *   if the QueryList has not changed.
@@ -331,9 +332,9 @@ export interface ViewChildrenDecorator {
    * @Annotation
    */
   (selector: ProviderToken<unknown>|Function|string,
-   opts?: {read?: any, emitDistinctChangesOnly?: boolean}): any;
+   opts?: {read?: any, emitDistinctChangesOnly?: boolean, static?: boolean}): any;
   new(selector: ProviderToken<unknown>|Function|string,
-      opts?: {read?: any, emitDistinctChangesOnly?: boolean}): ViewChildren;
+      opts?: {read?: any, emitDistinctChangesOnly?: boolean, static?: boolean}): ViewChildren;
 }
 
 /**

--- a/packages/core/test/acceptance/query_spec.ts
+++ b/packages/core/test/acceptance/query_spec.ts
@@ -121,6 +121,8 @@ describe('query logic', () => {
       // static ViewChild query should be set in creation mode, before CD runs
       expect(component.textDir).toBeAnInstanceOf(TextDirective);
       expect(component.textDir.text).toEqual('');
+      expect(component.textDirectives.length).toEqual(2);
+      expect(component.textDirectives.get(0)).toBeAnInstanceOf(TextDirective);
       expect(component.setEvents).toEqual(['textDir set']);
 
       // dynamic ViewChild query should not have been resolved yet
@@ -2710,6 +2712,7 @@ class TextDirective {
   selector: 'static-view-query-comp',
   template: `
     <div [text]="text"></div>
+    <div [text]="text"></div>
     <span #foo></span>
   `
 })
@@ -2717,6 +2720,8 @@ class StaticViewQueryComp {
   private _textDir!: TextDirective;
   private _foo!: ElementRef;
   setEvents: string[] = [];
+
+  @ViewChildren(TextDirective, {static: true}) textDirectives!: QueryList<TextDirective>;
 
   @ViewChild(TextDirective, {static: true})
   get textDir(): TextDirective {


### PR DESCRIPTION
No functionnal changes, it already worked before so lets reflect that on the API.

Fixes #36876

## PR Type
What kind of change does this PR introduce?

- [x] Feature

## Does this PR introduce a breaking change?

- [x] No