### PR TITLE
feat(core): rename `QueryList.get` to `QueryList.at`

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1194,6 +1194,7 @@ export class QueryList<T> implements Iterable<T> {
     // (undocumented)
     [Symbol.iterator]: () => Iterator<T>;
     constructor(_emitDistinctChangesOnly?: boolean);
+    at(index: number): T | undefined;
     get changes(): Observable<any>;
     destroy(): void;
     // (undocumented)
@@ -1205,6 +1206,7 @@ export class QueryList<T> implements Iterable<T> {
     // (undocumented)
     readonly first: T;
     forEach(fn: (item: T, index: number, array: T[]) => void): void;
+    // @deprecated
     get(index: number): T | undefined;
     // (undocumented)
     readonly last: T;

--- a/packages/core/src/linker/query_list.ts
+++ b/packages/core/src/linker/query_list.ts
@@ -75,8 +75,16 @@ export class QueryList<T> implements Iterable<T> {
 
   /**
    * Returns the QueryList entry at `index`.
+   * @deprecated Use at instead
    */
   get(index: number): T|undefined {
+    return this.at(index);
+  }
+
+  /**
+   * Returns the QueryList entry at `index`.
+   */
+  at(index: number): T|undefined {
     return this._results[index];
   }
 

--- a/packages/core/test/linker/query_list_spec.ts
+++ b/packages/core/test/linker/query_list_spec.ts
@@ -50,8 +50,9 @@ import {fakeAsync, tick} from '@angular/core/testing';
       expect(queryList.length).toEqual(2);
     });
 
-    it('should support get', () => {
+    it('should support at/get', () => {
       queryList.reset(['one', 'two']);
+      expect(queryList.at(1)).toEqual('two');
       expect(queryList.get(1)).toEqual('two');
     });
 


### PR DESCRIPTION
I propose this minor API change: 

`Array`, `FormArray` both use the `at` method to access an item, lets be consistent.

This commit deprecates `QueryList.get` in favor of `QueryList.at`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
