### PR TITLE
build: start only the minimum number of Saucelabs browsers required

### DIFF
--- a/scripts/test/run-saucelabs-tests.sh
+++ b/scripts/test/run-saucelabs-tests.sh
@@ -6,6 +6,7 @@
 set -eu -o pipefail
 
 NUMBER_OF_PARALLEL_BROWSERS="${1:-2}"
+shift
 
 if [[ -z "${SAUCE_USERNAME:-}" ]]; then
   echo "ERROR: SAUCE_USERNAME environment variable must be set; see tools/saucelabs-daemon/README.md for more info."
@@ -50,6 +51,6 @@ trap kill_background_service INT TERM
 sleep 2
 
 # Run all of the saucelabs test targets
-yarn bazel test --config=saucelabs --jobs="$NUMBER_OF_PARALLEL_BROWSERS" ${TESTS}
+yarn bazel test --config=saucelabs --jobs="$NUMBER_OF_PARALLEL_BROWSERS" ${TESTS} "$@"
 
 kill_background_service

--- a/tools/saucelabs-daemon/background-service/cli.ts
+++ b/tools/saucelabs-daemon/background-service/cli.ts
@@ -48,7 +48,7 @@ const daemon = new SaucelabsDaemon(
     username,
     accessKey,
     process.env.CIRCLE_BUILD_NUM!,
-    customLaunchers,
+    Object.values(customLaunchers) as Browser[],
     parallelExecutions,
     sauceConnect,
     {tunnelIdentifier},

--- a/tools/saucelabs-daemon/background-service/cli.ts
+++ b/tools/saucelabs-daemon/background-service/cli.ts
@@ -43,17 +43,13 @@ if (!parallelExecutions) {
   throw Error(`Please specify a non-zero number of parallel browsers to start.`);
 }
 
-const browserInstances: Browser[] = [];
-for (let i = 0; i < parallelExecutions; i++) {
-  browserInstances.push(...Object.values(customLaunchers) as any);
-}
-
 // Start the daemon and launch the given browser
 const daemon = new SaucelabsDaemon(
     username,
     accessKey,
     process.env.CIRCLE_BUILD_NUM!,
-    browserInstances,
+    customLaunchers,
+    parallelExecutions,
     sauceConnect,
     {tunnelIdentifier},
 );


### PR DESCRIPTION
This should save on Saucelabs resources so that if only one saucelabs test is run then only one set of browsers will be started.

Tested locally that ,

- `./scripts/test/run-saucelabs-tests.sh 1 --nocache_test_results` starts just 1 browser
- `./scripts/test/run-saucelabs-tests.sh 8 --nocache_test_results` starts 8 browsers one at a time
- `./scripts/test/run-saucelabs-tests.sh 100 --nocache_test_results --jobs=4` starts just 4 browsers since that is the maximum # of parallel tests run

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
