### PR TITLE
fix(platform-browser): `DomEventsPlugin` should always be the last plugin to be called for `supports()`.

### DIFF
--- a/packages/platform-browser/src/dom/events/dom_events.ts
+++ b/packages/platform-browser/src/dom/events/dom_events.ts
@@ -8,8 +8,7 @@
 
 import {DOCUMENT} from '@angular/common';
 import {Inject, Injectable, type ListenerOptions} from '@angular/core';
-
-import {EventManagerPlugin} from './event_manager';
+import {EventManagerPlugin} from './event_manager_plugin';
 
 @Injectable()
 export class DomEventsPlugin extends EventManagerPlugin {

--- a/packages/platform-browser/src/dom/events/event_manager_plugin.ts
+++ b/packages/platform-browser/src/dom/events/event_manager_plugin.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type {ListenerOptions} from '@angular/core';
+import type {EventManager} from './event_manager';
+
+/**
+ * The plugin definition for the `EventManager` class
+ *
+ * It can be used as a base class to create custom manager plugins, i.e. you can create your own
+ * class that extends the `EventManagerPlugin` one.
+ *
+ * @publicApi
+ */
+export abstract class EventManagerPlugin {
+  // TODO: remove (has some usage in G3)
+  constructor(private _doc: any) {}
+
+  // Using non-null assertion because it's set by EventManager's constructor
+  manager!: EventManager;
+
+  /**
+   * Should return `true` for every event name that should be supported by this plugin
+   */
+  abstract supports(eventName: string): boolean;
+
+  /**
+   * Implement the behaviour for the supported events
+   */
+  abstract addEventListener(
+    element: HTMLElement,
+    eventName: string,
+    handler: Function,
+    options?: ListenerOptions,
+  ): Function;
+}

--- a/packages/platform-browser/src/dom/events/hammer_gestures.ts
+++ b/packages/platform-browser/src/dom/events/hammer_gestures.ts
@@ -19,7 +19,8 @@ import {
   ɵConsole as Console,
 } from '@angular/core';
 
-import {EVENT_MANAGER_PLUGINS, EventManagerPlugin} from './event_manager';
+import {EVENT_MANAGER_PLUGINS} from './event_manager';
+import {EventManagerPlugin} from './event_manager_plugin';
 
 /**
  * Supported HammerJS recognizer event names.

--- a/packages/platform-browser/src/dom/events/key_events.ts
+++ b/packages/platform-browser/src/dom/events/key_events.ts
@@ -9,7 +9,7 @@
 import {DOCUMENT, ɵgetDOM as getDOM} from '@angular/common';
 import {Inject, Injectable, type ListenerOptions, NgZone} from '@angular/core';
 
-import {EventManagerPlugin} from './event_manager';
+import {EventManagerPlugin} from './event_manager_plugin';
 
 /**
  * Defines supported modifiers for key events.

--- a/packages/platform-browser/src/platform-browser.ts
+++ b/packages/platform-browser/src/platform-browser.ts
@@ -19,7 +19,8 @@ export {Title} from './browser/title';
 export {disableDebugTools, enableDebugTools} from './browser/tools/tools';
 export {By} from './dom/debug/by';
 export {REMOVE_STYLES_ON_COMPONENT_DESTROY} from './dom/dom_renderer';
-export {EVENT_MANAGER_PLUGINS, EventManager, EventManagerPlugin} from './dom/events/event_manager';
+export {EVENT_MANAGER_PLUGINS, EventManager} from './dom/events/event_manager';
+export {EventManagerPlugin} from './dom/events/event_manager_plugin';
 export {
   HAMMER_GESTURE_CONFIG,
   HAMMER_LOADER,

--- a/packages/platform-browser/test/dom/events/event_manager_spec.ts
+++ b/packages/platform-browser/test/dom/events/event_manager_spec.ts
@@ -9,7 +9,8 @@
 import {ɵgetDOM as getDOM} from '@angular/common';
 import {NgZone} from '@angular/core';
 import {DomEventsPlugin} from '../../../src/dom/events/dom_events';
-import {EventManager, EventManagerPlugin} from '../../../src/dom/events/event_manager';
+import {EventManager} from '../../../src/dom/events/event_manager';
+import {EventManagerPlugin} from '../../../src/dom/events/event_manager_plugin';
 
 import {TestBed} from '@angular/core/testing';
 import {isNode, createMouseEvent, el} from '@angular/private/testing';


### PR DESCRIPTION
This fixes the issues when `BrowserModule` is not the first module imported.

I choose not to introduce a specific token for the `DomEventsPlugin` as this would likely be breaking. 

Fixes #37149 #37850

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] No