### PR TITLE
docs: fix two grammatical/typographical errors present in first-app-lesson-06.md

### DIFF
--- a/aio/content/tutorial/first-app/first-app-lesson-06.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-06.md
@@ -1,4 +1,4 @@
-# Lesson 6 - Add a property binding to an component’s template
+# Lesson 6 - Add a property binding to a component’s template
 
 This tutorial lesson demonstrates how to add property binding to a template and use it to pass dynamic data to components.
 
@@ -51,7 +51,7 @@ In the code editor:
 
 ## Lesson review
 
-In this lesson, you added a new property binding and passed in a reference to a class property. Now, the `HousingLocationComponent` has access to data that it can use to customize the the component's display.
+In this lesson, you added a new property binding and passed in a reference to a class property. Now, the `HousingLocationComponent` has access to data that it can use to customize the component's display.
 
 If you are having any trouble with this lesson, you can review the completed code for it in the <live-example></live-example>.
 


### PR DESCRIPTION
fix two grammatical/typographical errors present in the document.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Lesson has typographical errors.
https://angular.io/tutorial/first-app/first-app-lesson-06

Issue Number: N/A


## What is the new behavior?
Lesson's grammar has been fixed and reviewed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
