### PR TITLE
fix(core): update `ApplicationRef.isStable` to account for rendering pending tasks

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -52,7 +52,7 @@
   "standalone-bootstrap": {
     "uncompressed": {
       "runtime": 918,
-      "main": 87081,
+      "main": 91485,
       "polyfills": 33802
     }
   }

--- a/packages/common/http/src/transfer_cache.ts
+++ b/packages/common/http/src/transfer_cache.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {APP_BOOTSTRAP_LISTENER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES, ɵInitialRenderPendingTasks as InitialRenderPendingTasks} from '@angular/core';
+import {APP_BOOTSTRAP_LISTENER, ApplicationRef, inject, InjectionToken, makeStateKey, Provider, StateKey, TransferState, ɵENABLED_SSR_FEATURES as ENABLED_SSR_FEATURES} from '@angular/core';
 import {Observable, of} from 'rxjs';
 import {first, tap} from 'rxjs/operators';
 
@@ -165,16 +165,13 @@ export function withHttpTransferCache(): Provider[] {
       useFactory: () => {
         const appRef = inject(ApplicationRef);
         const cacheState = inject(CACHE_STATE);
-        const pendingTasks = inject(InitialRenderPendingTasks);
 
         return () => {
-          const isStablePromise = appRef.isStable.pipe(first((isStable) => isStable)).toPromise();
-          isStablePromise.then(() => pendingTasks.whenAllTasksComplete).then(() => {
+          appRef.isStable.pipe(first((isStable) => isStable)).toPromise().then(() => {
             cacheState.isCacheActive = false;
           });
         };
-      },
-      deps: [ApplicationRef, CACHE_STATE, InitialRenderPendingTasks]
+      }
     }
   ];
 }

--- a/packages/common/http/src/xhr.ts
+++ b/packages/common/http/src/xhr.ts
@@ -309,19 +309,6 @@ export class HttpXhrBackend implements HttpBackend {
               }
             }
 
-            let macroTaskCanceller: VoidFunction|undefined;
-
-            /** Tear down logic to cancel the backround macrotask. */
-            const onLoadStart = () => {
-              macroTaskCanceller ??= createBackgroundMacroTask();
-            };
-            const onLoadEnd = () => {
-              macroTaskCanceller?.();
-            };
-
-            xhr.addEventListener('loadstart', onLoadStart);
-            xhr.addEventListener('loadend', onLoadEnd);
-
             // Fire the request, and notify the event stream that it was fired.
             xhr.send(reqBody!);
             observer.next({type: HttpEventType.Sent});
@@ -329,15 +316,10 @@ export class HttpXhrBackend implements HttpBackend {
             // request cancellation handler.
             return () => {
               // On a cancellation, remove all registered event listeners.
-              xhr.removeEventListener('loadstart', onLoadStart);
-              xhr.removeEventListener('loadend', onLoadEnd);
               xhr.removeEventListener('error', onError);
               xhr.removeEventListener('abort', onError);
               xhr.removeEventListener('load', onLoad);
               xhr.removeEventListener('timeout', onError);
-
-              //  Cancel the background macrotask.
-              macroTaskCanceller?.();
 
               if (req.reportProgress) {
                 xhr.removeEventListener('progress', onDownProgress);
@@ -355,22 +337,4 @@ export class HttpXhrBackend implements HttpBackend {
         }),
     );
   }
-}
-
-// Cannot use `Number.MAX_VALUE` as it does not fit into a 32-bit signed integer.
-const MAX_INT = 2147483647;
-
-/**
- * A method that creates a background macrotask of up to Number.MAX_VALUE.
- *
- * This is so that Zone.js can intercept HTTP calls, this is important for server rendering,
- * as the application is only rendered once the application is stabilized, meaning there are pending
- * macro and micro tasks.
- *
- * @returns a callback method to cancel the macrotask.
- */
-function createBackgroundMacroTask(): VoidFunction {
-  const timeout = setTimeout(() => void 0, MAX_INT);
-
-  return () => clearTimeout(timeout);
 }

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -8,7 +8,8 @@
 
 import './util/ng_jit_mode';
 
-import {Subscription} from 'rxjs';
+import {Observable, of, Subscription} from 'rxjs';
+import {share, switchMap} from 'rxjs/operators';
 
 import {ApplicationInitStatus} from './application_init';
 import {PLATFORM_INITIALIZER} from './application_tokens';
@@ -25,6 +26,7 @@ import {ErrorHandler} from './error_handler';
 import {formatRuntimeError, RuntimeError, RuntimeErrorCode} from './errors';
 import {DEFAULT_LOCALE_ID} from './i18n/localization';
 import {LOCALE_ID} from './i18n/tokens';
+import {InitialRenderPendingTasks} from './initial_render_pending_tasks';
 import {Type} from './interface/type';
 import {COMPILER_OPTIONS, CompilerOptions} from './linker/compiler';
 import {ComponentFactory, ComponentRef} from './linker/component_factory';
@@ -38,7 +40,7 @@ import {isStandalone} from './render3/definition';
 import {assertStandaloneComponentType} from './render3/errors';
 import {setLocaleId} from './render3/i18n/i18n_locale_id';
 import {setJitOptions} from './render3/jit/jit_options';
-import {createEnvironmentInjector, createNgModuleRefWithProviders, EnvironmentNgModuleRefAdapter, NgModuleFactory as R3NgModuleFactory} from './render3/ng_module_ref';
+import {createNgModuleRefWithProviders, EnvironmentNgModuleRefAdapter, NgModuleFactory as R3NgModuleFactory} from './render3/ng_module_ref';
 import {publishDefaultGlobalUtils as _publishDefaultGlobalUtils} from './render3/util/global_utils';
 import {setThrowInvalidWriteToSignalError} from './signals';
 import {TESTABILITY} from './testability/testability';
@@ -819,6 +821,7 @@ export class ApplicationRef {
   /** @internal */
   _views: InternalViewRef[] = [];
   private readonly internalErrorHandler = inject(INTERNAL_APPLICATION_ERROR_HANDLER);
+  private readonly pendingTasks = inject(InitialRenderPendingTasks);
 
   /**
    * Indicates whether this instance was destroyed.
@@ -838,10 +841,16 @@ export class ApplicationRef {
    */
   public readonly components: ComponentRef<any>[] = [];
 
+  private readonly ngZoneStable = inject(ZONE_IS_STABLE_OBSERVABLE);
+
   /**
    * Returns an Observable that indicates when the application is stable or unstable.
    */
-  public readonly isStable = inject(ZONE_IS_STABLE_OBSERVABLE);
+  public readonly isStable: Observable<boolean> = this.pendingTasks.hasPendingTasks.pipe(
+      switchMap((hasPendingTasks) => {
+        return hasPendingTasks ? of(false) : this.ngZoneStable;
+      }),
+      share());
 
   private readonly _injector = inject(EnvironmentInjector);
   /**

--- a/packages/core/test/acceptance/initial_render_pending_tasks_spec.ts
+++ b/packages/core/test/acceptance/initial_render_pending_tasks_spec.ts
@@ -7,58 +7,55 @@
  */
 
 import {TestBed} from '@angular/core/testing';
+import {EMPTY, of} from 'rxjs';
+import {map, withLatestFrom} from 'rxjs/operators';
 
 import {InitialRenderPendingTasks} from '../../src/initial_render_pending_tasks';
 
 describe('InitialRenderPendingTasks', () => {
-  it('should resolve a promise even if there are no tasks', async () => {
-    const pendingTasks = TestBed.inject(InitialRenderPendingTasks);
-    expect(pendingTasks.completed).toBe(false);
-    await pendingTasks.whenAllTasksComplete;
-    expect(pendingTasks.completed).toBe(true);
-  });
-
   it('should wait until all tasks are completed', async () => {
     const pendingTasks = TestBed.inject(InitialRenderPendingTasks);
-    expect(pendingTasks.completed).toBe(false);
-
     const taskA = pendingTasks.add();
     const taskB = pendingTasks.add();
     const taskC = pendingTasks.add();
-    expect(pendingTasks.completed).toBe(false);
 
     pendingTasks.remove(taskA);
     pendingTasks.remove(taskB);
     pendingTasks.remove(taskC);
-    await pendingTasks.whenAllTasksComplete;
-    expect(pendingTasks.completed).toBe(true);
+    expect(await hasPendingTasks(pendingTasks)).toBeFalse();
   });
 
   it('should allow calls to remove the same task multiple times', async () => {
     const pendingTasks = TestBed.inject(InitialRenderPendingTasks);
-    expect(pendingTasks.completed).toBe(false);
+    expect(await hasPendingTasks(pendingTasks)).toBeFalse();
 
     const taskA = pendingTasks.add();
-
-    expect(pendingTasks.completed).toBe(false);
+    expect(await hasPendingTasks(pendingTasks)).toBeTrue();
 
     pendingTasks.remove(taskA);
     pendingTasks.remove(taskA);
     pendingTasks.remove(taskA);
 
-    await pendingTasks.whenAllTasksComplete;
-    expect(pendingTasks.completed).toBe(true);
+    expect(await hasPendingTasks(pendingTasks)).toBeFalse();
   });
 
   it('should be tolerant to removal of non-existent ids', async () => {
     const pendingTasks = TestBed.inject(InitialRenderPendingTasks);
-    expect(pendingTasks.completed).toBe(false);
+    expect(await hasPendingTasks(pendingTasks)).toBeFalse();
 
     pendingTasks.remove(Math.random());
     pendingTasks.remove(Math.random());
     pendingTasks.remove(Math.random());
 
-    await pendingTasks.whenAllTasksComplete;
-    expect(pendingTasks.completed).toBe(true);
+    expect(await hasPendingTasks(pendingTasks)).toBeFalse();
   });
 });
+
+function hasPendingTasks(pendingTasks: InitialRenderPendingTasks): Promise<boolean> {
+  return of(EMPTY)
+      .pipe(
+          withLatestFrom(pendingTasks.hasPendingTasks),
+          map(([_, hasPendingTasks]) => hasPendingTasks),
+          )
+      .toPromise();
+}

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -81,6 +81,9 @@
     "name": "BaseAnimationRenderer"
   },
   {
+    "name": "BehaviorSubject"
+  },
+  {
     "name": "BrowserAnimationBuilder"
   },
   {
@@ -154,6 +157,9 @@
   },
   {
     "name": "DefaultDomRenderer2"
+  },
+  {
+    "name": "DistinctUntilChangedSubscriber"
   },
   {
     "name": "DomAdapter"
@@ -858,6 +864,9 @@
     "name": "forwardRef"
   },
   {
+    "name": "fromArray"
+  },
+  {
     "name": "generateInitialInputs"
   },
   {
@@ -1125,6 +1134,9 @@
     "name": "isPromise2"
   },
   {
+    "name": "isScheduler"
+  },
+  {
     "name": "isStableFactory"
   },
   {
@@ -1174,9 +1186,6 @@
   },
   {
     "name": "makeTimingAst"
-  },
-  {
-    "name": "map"
   },
   {
     "name": "markAsComponentHost"
@@ -1384,6 +1393,9 @@
   },
   {
     "name": "setupStaticAttributes"
+  },
+  {
+    "name": "share"
   },
   {
     "name": "shareSubjectFactory"

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -243,6 +243,9 @@
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
   },
   {
+    "name": "InitialRenderPendingTasks"
+  },
+  {
     "name": "InjectFlags"
   },
   {
@@ -1171,6 +1174,9 @@
   },
   {
     "name": "makeTimingAst"
+  },
+  {
+    "name": "map"
   },
   {
     "name": "markAsComponentHost"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -183,6 +183,9 @@
     "name": "DefaultDomRenderer2"
   },
   {
+    "name": "DistinctUntilChangedSubscriber"
+  },
+  {
     "name": "DomAdapter"
   },
   {
@@ -538,12 +541,6 @@
   },
   {
     "name": "Subscription"
-  },
-  {
-    "name": "SwitchMapOperator"
-  },
-  {
-    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -930,9 +927,6 @@
     "name": "forwardRef"
   },
   {
-    "name": "from"
-  },
-  {
     "name": "fromArray"
   },
   {
@@ -1119,9 +1113,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerSubscribe"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1263,9 +1254,6 @@
     "name": "makeTimingAst"
   },
   {
-    "name": "map"
-  },
-  {
     "name": "markAsComponentHost"
   },
   {
@@ -1276,9 +1264,6 @@
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1510,9 +1495,6 @@
   },
   {
     "name": "subscribeToArray"
-  },
-  {
-    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -96,6 +96,9 @@
     "name": "BaseAnimationRenderer"
   },
   {
+    "name": "BehaviorSubject"
+  },
+  {
     "name": "BrowserAnimationBuilder"
   },
   {
@@ -262,6 +265,9 @@
   },
   {
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
+  },
+  {
+    "name": "InitialRenderPendingTasks"
   },
   {
     "name": "InjectFlags"
@@ -532,6 +538,12 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -918,6 +930,12 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
+    "name": "fromArray"
+  },
+  {
     "name": "generateInitialInputs"
   },
   {
@@ -1101,6 +1119,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1188,6 +1209,9 @@
     "name": "isPromise2"
   },
   {
+    "name": "isScheduler"
+  },
+  {
     "name": "isStableFactory"
   },
   {
@@ -1239,6 +1263,9 @@
     "name": "makeTimingAst"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAsComponentHost"
   },
   {
@@ -1249,6 +1276,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1455,6 +1485,9 @@
     "name": "setupStaticAttributes"
   },
   {
+    "name": "share"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1477,6 +1510,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -105,6 +105,9 @@
     "name": "DepComponent"
   },
   {
+    "name": "DistinctUntilChangedSubscriber"
+  },
+  {
     "name": "DomAdapter"
   },
   {
@@ -405,12 +408,6 @@
     "name": "Subscription"
   },
   {
-    "name": "SwitchMapOperator"
-  },
-  {
-    "name": "SwitchMapSubscriber"
-  },
-  {
     "name": "TESTABILITY"
   },
   {
@@ -705,9 +702,6 @@
     "name": "forwardRef"
   },
   {
-    "name": "from"
-  },
-  {
     "name": "fromArray"
   },
   {
@@ -885,9 +879,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerSubscribe"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1002,9 +993,6 @@
     "name": "makeRecord"
   },
   {
-    "name": "map"
-  },
-  {
     "name": "markAsComponentHost"
   },
   {
@@ -1015,9 +1003,6 @@
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1201,9 +1186,6 @@
   },
   {
     "name": "subscribeToArray"
-  },
-  {
-    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -36,6 +36,9 @@
     "name": "BROWSER_MODULE_PROVIDERS_MARKER"
   },
   {
+    "name": "BehaviorSubject"
+  },
+  {
     "name": "BrowserDomAdapter"
   },
   {
@@ -166,6 +169,9 @@
   },
   {
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
+  },
+  {
+    "name": "InitialRenderPendingTasks"
   },
   {
     "name": "InjectFlags"
@@ -397,6 +403,12 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -693,6 +705,12 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
+    "name": "fromArray"
+  },
+  {
     "name": "generateInitialInputs"
   },
   {
@@ -867,6 +885,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -942,6 +963,9 @@
     "name": "isPromise2"
   },
   {
+    "name": "isScheduler"
+  },
+  {
     "name": "isStableFactory"
   },
   {
@@ -978,6 +1002,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAsComponentHost"
   },
   {
@@ -988,6 +1015,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1149,6 +1179,9 @@
     "name": "setupStaticAttributes"
   },
   {
+    "name": "share"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1168,6 +1201,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -150,6 +150,9 @@
     "name": "DefaultValueAccessor"
   },
   {
+    "name": "DistinctUntilChangedSubscriber"
+  },
+  {
     "name": "DomAdapter"
   },
   {
@@ -544,12 +547,6 @@
   },
   {
     "name": "Subscription"
-  },
-  {
-    "name": "SwitchMapOperator"
-  },
-  {
-    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -1215,9 +1212,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerSubscribe"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1396,9 +1390,6 @@
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeAll"
   },
   {
     "name": "mergeErrors"
@@ -1660,9 +1651,6 @@
   },
   {
     "name": "subscribeToArray"
-  },
-  {
-    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -51,6 +51,9 @@
     "name": "BaseControlValueAccessor"
   },
   {
+    "name": "BehaviorSubject"
+  },
+  {
     "name": "BrowserDomAdapter"
   },
   {
@@ -244,6 +247,9 @@
   },
   {
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
+  },
+  {
+    "name": "InitialRenderPendingTasks"
   },
   {
     "name": "InjectFlags"
@@ -538,6 +544,12 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -954,6 +966,9 @@
     "name": "from"
   },
   {
+    "name": "fromArray"
+  },
+  {
     "name": "generateInitialInputs"
   },
   {
@@ -1200,6 +1215,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1297,6 +1315,9 @@
   },
   {
     "name": "isPromise2"
+  },
+  {
+    "name": "isScheduler"
   },
   {
     "name": "isStableFactory"
@@ -1617,6 +1638,9 @@
     "name": "setupStaticAttributes"
   },
   {
+    "name": "share"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1636,6 +1660,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -54,6 +54,9 @@
     "name": "BaseControlValueAccessor"
   },
   {
+    "name": "BehaviorSubject"
+  },
+  {
     "name": "BrowserDomAdapter"
   },
   {
@@ -229,6 +232,9 @@
   },
   {
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
+  },
+  {
+    "name": "InitialRenderPendingTasks"
   },
   {
     "name": "InjectFlags"
@@ -526,6 +532,12 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -921,6 +933,9 @@
     "name": "from"
   },
   {
+    "name": "fromArray"
+  },
+  {
     "name": "generateInitialInputs"
   },
   {
@@ -1164,6 +1179,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1255,6 +1273,9 @@
   },
   {
     "name": "isPromise2"
+  },
+  {
+    "name": "isScheduler"
   },
   {
     "name": "isStableFactory"
@@ -1593,6 +1614,9 @@
     "name": "setupStaticAttributes"
   },
   {
+    "name": "share"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1612,6 +1636,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -156,6 +156,9 @@
     "name": "DefaultValueAccessor"
   },
   {
+    "name": "DistinctUntilChangedSubscriber"
+  },
+  {
     "name": "DomAdapter"
   },
   {
@@ -532,12 +535,6 @@
   },
   {
     "name": "Subscription"
-  },
-  {
-    "name": "SwitchMapOperator"
-  },
-  {
-    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -1179,9 +1176,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerSubscribe"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1354,9 +1348,6 @@
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeAll"
   },
   {
     "name": "mergeErrors"
@@ -1636,9 +1627,6 @@
   },
   {
     "name": "subscribeToArray"
-  },
-  {
-    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -63,6 +63,9 @@
     "name": "DOCUMENT2"
   },
   {
+    "name": "DistinctUntilChangedSubscriber"
+  },
+  {
     "name": "DomAdapter"
   },
   {
@@ -312,12 +315,6 @@
     "name": "Subscription"
   },
   {
-    "name": "SwitchMapOperator"
-  },
-  {
-    "name": "SwitchMapSubscriber"
-  },
-  {
     "name": "TESTABILITY"
   },
   {
@@ -552,9 +549,6 @@
     "name": "forwardRef"
   },
   {
-    "name": "from"
-  },
-  {
     "name": "fromArray"
   },
   {
@@ -705,9 +699,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerSubscribe"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -789,9 +780,6 @@
     "name": "makeRecord"
   },
   {
-    "name": "map"
-  },
-  {
     "name": "markViewDirty"
   },
   {
@@ -799,9 +787,6 @@
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -949,9 +934,6 @@
   },
   {
     "name": "subscribeToArray"
-  },
-  {
-    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -24,6 +24,9 @@
     "name": "BLOOM_MASK"
   },
   {
+    "name": "BehaviorSubject"
+  },
+  {
     "name": "BrowserDomAdapter"
   },
   {
@@ -109,6 +112,9 @@
   },
   {
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
+  },
+  {
+    "name": "InitialRenderPendingTasks"
   },
   {
     "name": "InjectFlags"
@@ -304,6 +310,12 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -540,6 +552,12 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
+    "name": "fromArray"
+  },
+  {
     "name": "generateInitialInputs"
   },
   {
@@ -687,6 +705,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -735,6 +756,9 @@
     "name": "isPromise2"
   },
   {
+    "name": "isScheduler"
+  },
+  {
     "name": "isStableFactory"
   },
   {
@@ -765,6 +789,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markViewDirty"
   },
   {
@@ -772,6 +799,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -900,6 +930,9 @@
     "name": "setUpAttributes"
   },
   {
+    "name": "share"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -916,6 +949,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -33,6 +33,9 @@
     "name": "BROWSER_MODULE_PROVIDERS"
   },
   {
+    "name": "BehaviorSubject"
+  },
+  {
     "name": "BrowserDomAdapter"
   },
   {
@@ -453,6 +456,12 @@
     "name": "Subscription"
   },
   {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -753,6 +762,9 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
     "name": "fromArray"
   },
   {
@@ -933,6 +945,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1053,6 +1068,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markViewDirty"
   },
   {
@@ -1060,6 +1078,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1108,6 +1129,9 @@
   },
   {
     "name": "observable"
+  },
+  {
+    "name": "of"
   },
   {
     "name": "onEnter"
@@ -1212,6 +1236,9 @@
     "name": "setUpAttributes"
   },
   {
+    "name": "share"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1234,6 +1261,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwIfEmpty"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -111,6 +111,9 @@
     "name": "DefaultIfEmptySubscriber"
   },
   {
+    "name": "DistinctUntilChangedSubscriber"
+  },
+  {
     "name": "DomAdapter"
   },
   {
@@ -456,12 +459,6 @@
     "name": "Subscription"
   },
   {
-    "name": "SwitchMapOperator"
-  },
-  {
-    "name": "SwitchMapSubscriber"
-  },
-  {
     "name": "TESTABILITY"
   },
   {
@@ -762,9 +759,6 @@
     "name": "forwardRef"
   },
   {
-    "name": "from"
-  },
-  {
     "name": "fromArray"
   },
   {
@@ -945,9 +939,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerSubscribe"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1068,9 +1059,6 @@
     "name": "makeRecord"
   },
   {
-    "name": "map"
-  },
-  {
     "name": "markViewDirty"
   },
   {
@@ -1078,9 +1066,6 @@
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1261,9 +1246,6 @@
   },
   {
     "name": "subscribeToArray"
-  },
-  {
-    "name": "switchMap"
   },
   {
     "name": "throwIfEmpty"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -162,6 +162,9 @@
     "name": "DefaultUrlSerializer"
   },
   {
+    "name": "DistinctUntilChangedSubscriber"
+  },
+  {
     "name": "DoOperator"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1899,6 +1899,9 @@
     "name": "shallowEqual"
   },
   {
+    "name": "share"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -27,6 +27,9 @@
     "name": "BROWSER_MODULE_PROVIDERS"
   },
   {
+    "name": "BehaviorSubject"
+  },
+  {
     "name": "BrowserDomAdapter"
   },
   {
@@ -151,6 +154,9 @@
   },
   {
     "name": "INTERNAL_BROWSER_PLATFORM_PROVIDERS"
+  },
+  {
+    "name": "InitialRenderPendingTasks"
   },
   {
     "name": "InjectFlags"
@@ -364,6 +370,12 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -618,6 +630,12 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
+    "name": "fromArray"
+  },
+  {
     "name": "generateInitialInputs"
   },
   {
@@ -771,6 +789,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -825,6 +846,9 @@
     "name": "isPromise2"
   },
   {
+    "name": "isScheduler"
+  },
+  {
     "name": "isStableFactory"
   },
   {
@@ -858,6 +882,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markViewDirty"
   },
   {
@@ -865,6 +892,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -999,6 +1029,9 @@
     "name": "setUpAttributes"
   },
   {
+    "name": "share"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1018,6 +1051,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -87,6 +87,9 @@
     "name": "DefaultDomRenderer2"
   },
   {
+    "name": "DistinctUntilChangedSubscriber"
+  },
+  {
     "name": "DomAdapter"
   },
   {
@@ -372,12 +375,6 @@
     "name": "Subscription"
   },
   {
-    "name": "SwitchMapOperator"
-  },
-  {
-    "name": "SwitchMapSubscriber"
-  },
-  {
     "name": "TESTABILITY"
   },
   {
@@ -630,9 +627,6 @@
     "name": "forwardRef"
   },
   {
-    "name": "from"
-  },
-  {
     "name": "fromArray"
   },
   {
@@ -789,9 +783,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerSubscribe"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -882,9 +873,6 @@
     "name": "makeRecord"
   },
   {
-    "name": "map"
-  },
-  {
     "name": "markViewDirty"
   },
   {
@@ -892,9 +880,6 @@
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1051,9 +1036,6 @@
   },
   {
     "name": "subscribeToArray"
-  },
-  {
-    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -108,6 +108,9 @@
     "name": "DefaultIterableDifferFactory"
   },
   {
+    "name": "DistinctUntilChangedSubscriber"
+  },
+  {
     "name": "DomAdapter"
   },
   {
@@ -433,12 +436,6 @@
   },
   {
     "name": "Subscription"
-  },
-  {
-    "name": "SwitchMapOperator"
-  },
-  {
-    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -828,9 +825,6 @@
     "name": "forwardRef"
   },
   {
-    "name": "from"
-  },
-  {
     "name": "fromArray"
   },
   {
@@ -1056,9 +1050,6 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
-    "name": "innerSubscribe"
-  },
-  {
     "name": "insertBloom"
   },
   {
@@ -1197,9 +1188,6 @@
     "name": "makeRecord"
   },
   {
-    "name": "map"
-  },
-  {
     "name": "markAsComponentHost"
   },
   {
@@ -1213,9 +1201,6 @@
   },
   {
     "name": "maybeWrapInNotSelector"
-  },
-  {
-    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1426,9 +1411,6 @@
   },
   {
     "name": "subscribeToArray"
-  },
-  {
-    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -36,6 +36,9 @@
     "name": "BROWSER_MODULE_PROVIDERS_MARKER"
   },
   {
+    "name": "BehaviorSubject"
+  },
+  {
     "name": "BrowserDomAdapter"
   },
   {
@@ -169,6 +172,9 @@
   },
   {
     "name": "INTERNAL_APPLICATION_ERROR_HANDLER"
+  },
+  {
+    "name": "InitialRenderPendingTasks"
   },
   {
     "name": "InjectFlags"
@@ -427,6 +433,12 @@
   },
   {
     "name": "Subscription"
+  },
+  {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
   },
   {
     "name": "TESTABILITY"
@@ -816,6 +828,12 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
+    "name": "fromArray"
+  },
+  {
     "name": "generateInitialInputs"
   },
   {
@@ -1038,6 +1056,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1119,6 +1140,9 @@
     "name": "isPromise2"
   },
   {
+    "name": "isScheduler"
+  },
+  {
     "name": "isStableFactory"
   },
   {
@@ -1173,6 +1197,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAsComponentHost"
   },
   {
@@ -1186,6 +1213,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1374,6 +1404,9 @@
     "name": "setupStaticAttributes"
   },
   {
+    "name": "share"
+  },
+  {
     "name": "shareSubjectFactory"
   },
   {
@@ -1393,6 +1426,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/platform-server/src/utils.ts
+++ b/packages/platform-server/src/utils.ts
@@ -54,13 +54,9 @@ function appendServerContextInfo(applicationRef: ApplicationRef) {
 
 async function _render(platformRef: PlatformRef, applicationRef: ApplicationRef): Promise<string> {
   const environmentInjector = applicationRef.injector;
-  const isStablePromise =
-      applicationRef.isStable.pipe((first((isStable: boolean) => isStable))).toPromise();
-  const pendingTasks = environmentInjector.get(InitialRenderPendingTasks);
-  const pendingTasksPromise = pendingTasks.whenAllTasksComplete;
 
   // Block until application is stable.
-  await Promise.allSettled([isStablePromise, pendingTasksPromise]);
+  await applicationRef.isStable.pipe((first((isStable: boolean) => isStable))).toPromise();
 
   const platformState = platformRef.injector.get(PlatformState);
   if (applicationRef.injector.get(IS_HYDRATION_DOM_REUSE_ENABLED, false)) {

--- a/packages/platform-server/test/hydration_spec.ts
+++ b/packages/platform-server/test/hydration_spec.ts
@@ -99,10 +99,8 @@ function stripExcessiveSpaces(html: string): string {
 }
 
 /** Returns a Promise that resolves when the ApplicationRef becomes stable. */
-function whenStable(appRef: ApplicationRef): Promise<unknown> {
-  const isStablePromise = appRef.isStable.pipe(first((isStable: boolean) => isStable)).toPromise();
-  const pendingTasksPromise = appRef.injector.get(InitialRenderPendingTasks).whenAllTasksComplete;
-  return Promise.allSettled([isStablePromise, pendingTasksPromise]);
+function whenStable(appRef: ApplicationRef): Promise<void> {
+  return appRef.isStable.pipe(first((isStable: boolean) => isStable)).toPromise().then(() => {});
 }
 
 function verifyClientAndSSRContentsMatch(ssrContents: string, clientAppRootElement: HTMLElement) {


### PR DESCRIPTION
**fix(core): update `ApplicationRef.isStable` to account for rendering pending tasks**
    
This commit updates the `ApplicationRef.isStable` API to account for pending rendering task. This is needed as once a pending rendering task is done, new macrotask and microtask could be created which previously caused these not to be intercepted and thus ignored when doing SSR.


**refactor(http): replace zone.js macrotask creation with `InitialRenderPendingTasks`**

This commits refactors the HTTP client to use `InitialRenderPendingTasks` instead of Zone.js macrotask. This is another approach to https://github.com/angular/angular/pull/50406 which was revert due to a failure in G3.