### PR TITLE
build: speed up locale file generation to improve DX

### DIFF
--- a/packages/common/locales/generate-locales-tool/bin/write-locale-files-to-dist.ts
+++ b/packages/common/locales/generate-locales-tool/bin/write-locale-files-to-dist.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {writeFileSync} from 'fs';
+import fs from 'fs';
 import {join} from 'path';
 
 import {CldrData} from '../cldr-data';
@@ -21,7 +21,7 @@ import {BASE_LOCALE} from './base-locale';
  * Generates locale files for each available CLDR locale and writes it to the
  * specified directory.
  */
-function main(outputDir: string|undefined) {
+async function main(outputDir: string|undefined) {
   if (outputDir === undefined) {
     throw Error('No output directory specified.');
   }
@@ -35,16 +35,21 @@ function main(outputDir: string|undefined) {
   console.info(`Writing locales to: ${outputDir}`);
 
   // Generate locale files for all locales we have data for.
-  cldrData.availableLocales.forEach((localeData) => {
+  await Promise.all(cldrData.availableLocales.map(async (localeData) => {
     const locale = localeData.locale;
     const localeFile = generateLocale(locale, localeData, baseCurrencies);
     const localeExtraFile = generateLocaleExtra(locale, localeData);
     const localeGlobalFile = generateLocaleGlobalFile(locale, localeData, baseCurrencies);
 
-    writeFileSync(join(outputDir, `${locale}.ts`), localeFile);
-    writeFileSync(join(extraLocaleDir, `${locale}.ts`), localeExtraFile);
-    writeFileSync(join(globalLocaleDir, `${locale}.js`), localeGlobalFile);
-  });
+    await Promise.all([
+      fs.promises.writeFile(join(outputDir, `${locale}.ts`), localeFile),
+      fs.promises.writeFile(join(extraLocaleDir, `${locale}.ts`), localeExtraFile),
+      fs.promises.writeFile(join(globalLocaleDir, `${locale}.js`), localeGlobalFile),
+    ]);
+  }));
 }
 
-main(process.argv[2]);
+main(process.argv[2]).catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+})

--- a/packages/common/locales/generate-locales-tool/bin/write-locale-files-to-dist.ts
+++ b/packages/common/locales/generate-locales-tool/bin/write-locale-files-to-dist.ts
@@ -33,17 +33,17 @@ async function main(outputDir: string|undefined) {
   const globalLocaleDir = join(outputDir, 'global');
 
   // Generate locale files for all locales we have data for.
-  await Promise.all(cldrData.availableLocales.map(async (localeData) => {
+  await Promise.all(cldrData.availableLocales.flatMap(async (localeData) => {
     const locale = localeData.locale;
     const localeFile = generateLocale(locale, localeData, baseCurrencies);
     const localeExtraFile = generateLocaleExtra(locale, localeData);
     const localeGlobalFile = generateLocaleGlobalFile(locale, localeData, baseCurrencies);
 
-    await Promise.all([
+    return [
       fs.promises.writeFile(join(outputDir, `${locale}.ts`), localeFile),
       fs.promises.writeFile(join(extraLocaleDir, `${locale}.ts`), localeExtraFile),
       fs.promises.writeFile(join(globalLocaleDir, `${locale}.js`), localeGlobalFile),
-    ]);
+    ];
   }));
 }
 

--- a/packages/common/locales/generate-locales-tool/bin/write-locale-files-to-dist.ts
+++ b/packages/common/locales/generate-locales-tool/bin/write-locale-files-to-dist.ts
@@ -32,8 +32,6 @@ async function main(outputDir: string|undefined) {
   const extraLocaleDir = join(outputDir, 'extra');
   const globalLocaleDir = join(outputDir, 'global');
 
-  console.info(`Writing locales to: ${outputDir}`);
-
   // Generate locale files for all locales we have data for.
   await Promise.all(cldrData.availableLocales.map(async (localeData) => {
     const locale = localeData.locale;
@@ -52,4 +50,4 @@ async function main(outputDir: string|undefined) {
 main(process.argv[2]).catch(err => {
   console.error(err);
   process.exitCode = 1;
-})
+});

--- a/packages/common/locales/generate-locales-tool/plural-function.ts
+++ b/packages/common/locales/generate-locales-tool/plural-function.ts
@@ -12,6 +12,9 @@ import {CldrLocaleData} from './cldr-data';
 // There are no types available for `cldr`.
 const {load: createCldr} = await import('cldr' as any);
 
+// Load once to avoid re-parsing CLDR XML data on every invocation.
+const cldr = createCldr(runfiles.resolve('cldr_xml_data'));
+
 /**
  * Returns the plural function for a locale.
  */
@@ -21,7 +24,6 @@ export function getPluralFunction(localeData: CldrLocaleData, withTypes = true) 
   // we follow the CLDR-specified bundle lookup algorithm. A language does not necessarily
   // resolve directly to a bundle CLDR provides data for.
   const bundleName = localeData.attributes.bundle;
-  const cldr = createCldr(runfiles.resolve('cldr_xml_data'));
   let fn = cldr.extractPluralRuleFunction(bundleName).toString();
 
   const numberType = withTypes ? ': number' : '';


### PR DESCRIPTION
Fixes the bottleneck of locale generation impacting DX negatively, after auditing the common workflows

Before this commit, building everything to run `@angular/core` tests (`bazel clean` first) took:

```
INFO: Elapsed time: 76.496s, Critical Path: 72.92s
INFO: 225 processes: 125 internal, 5 linux-sandbox, 2 local, 93 worker.
INFO: Build completed successfully, 225 total actions
```

After:
```
INFO: Elapsed time: 41.756s, Critical Path: 38.18s
INFO: 225 processes: 125 internal, 5 linux-sandbox, 2 local, 93 worker.
INFO: Build completed successfully, 225 total actions
```

**76.5s to 41s. Clean Bazel build. 46.4% time reduction!**

Locale generation itself reduction: 69 -> 17s: 75.3% reduction

This being on a specialist Cloudtop.