### PR TITLE
fix(core): adds missing symbols for animation standalone bundling test to patch branch

### DIFF
--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -780,18 +780,6 @@
     "name": "detachMovedView"
   },
   {
-    "name": "detectChangesInChildComponents"
-  },
-  {
-    "name": "detectChangesInComponent"
-  },
-  {
-    "name": "detectChangesInEmbeddedViews"
-  },
-  {
-    "name": "detectChangesInView"
-  },
-  {
     "name": "detectChangesInternal"
   },
   {
@@ -1266,6 +1254,12 @@
     "name": "refCount"
   },
   {
+    "name": "refreshComponent"
+  },
+  {
+    "name": "refreshContainsDirtyView"
+  },
+  {
     "name": "refreshContentQueries"
   },
   {
@@ -1426,6 +1420,9 @@
   },
   {
     "name": "urlParsingNode"
+  },
+  {
+    "name": "viewAttachedToChangeDetector"
   },
   {
     "name": "visitDslNode"


### PR DESCRIPTION
This adds a few missing symbols into the goldens list that were causing CI to fail

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Other... Please describe:
testing changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
