### PR TITLE
refactor(platform-server): exclude `provideHttpClient()` call from `provideServerRendering()`

### DIFF
--- a/packages/platform-server/src/provide_server.ts
+++ b/packages/platform-server/src/provide_server.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {provideHttpClient, withInterceptorsFromDi} from '@angular/common/http';
 import {EnvironmentProviders, makeEnvironmentProviders} from '@angular/core';
 import {provideNoopAnimations} from '@angular/platform-browser/animations';
 
@@ -29,7 +28,6 @@ import {PLATFORM_SERVER_PROVIDERS} from './server';
  */
 export function provideServerRendering(): EnvironmentProviders {
   return makeEnvironmentProviders([
-    provideHttpClient(withInterceptorsFromDi()),
     provideNoopAnimations(),
     ...PLATFORM_SERVER_PROVIDERS,
   ]);


### PR DESCRIPTION
Previously, we've used to have server-specific logic for HttpClient, so there was a need to re-provide it with the right config. Since v16, that logic was refactored and there is no need to re-provide HttpClient anymore. The code in the `provideServerRendering()` was retained for historical reasons and it makes application configuration more difficult, because it forces developers to copy HttpClient config into server config as well (otherwise it would not be take into account).

This commit removes the `provideHttpClient()` call from the `provideServerRendering()` function. This is **not** a breaking change, since we've also merge browser application config in the `app.config.server.ts`, so if an application is configured to use HttpClient, it will continue to work on both client and server sides.

Resolves #50454.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No