### PR TITLE
fix(compiler): resolve deprecation warning with TypeScript 5.1

### DIFF
--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -216,7 +216,7 @@ export class StaticInterpreter {
   private visitIdentifier(node: ts.Identifier, context: Context): ResolvedValue {
     const decl = this.host.getDeclarationOfIdentifier(node);
     if (decl === null) {
-      if (node.originalKeywordKind === ts.SyntaxKind.UndefinedKeyword) {
+      if (getOriginalKeywordKind(node) === ts.SyntaxKind.UndefinedKeyword) {
         return undefined;
       } else {
         // Check if the symbol here is imported.
@@ -762,4 +762,15 @@ function owningModule(context: Context, override: OwningModule|null = null): Own
   } else {
     return null;
   }
+}
+
+/**
+ * Gets the original keyword kind of an identifier. This is a compatibility
+ * layer while we need to support TypeScript versions less than 5.1
+ * TODO(crisbeto): remove this function once support for TS 4.9 is removed.
+ */
+function getOriginalKeywordKind(identifier: ts.Identifier): ts.SyntaxKind|undefined {
+  return typeof (ts as any).identifierToKeywordKind === 'function' ?
+      (ts as any).identifierToKeywordKind(identifier) :
+      identifier.originalKeywordKind;
 }


### PR DESCRIPTION
We have a code path that accesses the `originalKeywordKind` property which logs a deprecation warning in version 5.1, but isn't available in some of the earlier versions that we support. These changes add a compatibility layer that goes through the non-deprecated function, if it exists.