### PR TITLE
refactor(common): export `IMAGE_CONFIG`.

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -259,6 +259,9 @@ export class I18nSelectPipe implements PipeTransform {
 }
 
 // @public
+export const IMAGE_CONFIG: InjectionToken<ImageConfig>;
+
+// @public
 export const IMAGE_LOADER: InjectionToken<ImageLoader>;
 
 // @public

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -27,4 +27,4 @@ export {PLATFORM_BROWSER_ID as ɵPLATFORM_BROWSER_ID, PLATFORM_SERVER_ID as ɵPL
 export {VERSION} from './version';
 export {ViewportScroller, NullViewportScroller as ɵNullViewportScroller} from './viewport_scroller';
 export {XhrFactory} from './xhr';
-export {IMAGE_LOADER, ImageLoader, ImageLoaderConfig, NgOptimizedImage, PRECONNECT_CHECK_BLOCKLIST, provideCloudflareLoader, provideCloudinaryLoader, provideImageKitLoader, provideImgixLoader} from './directives/ng_optimized_image';
+export {IMAGE_CONFIG, IMAGE_LOADER, ImageLoader, ImageLoaderConfig, NgOptimizedImage, PRECONNECT_CHECK_BLOCKLIST, provideCloudflareLoader, provideCloudinaryLoader, provideImageKitLoader, provideImgixLoader} from './directives/ng_optimized_image';


### PR DESCRIPTION
`IMAGE_CONFIG` was missing from the exports in `14.3.0`

fixes #50455

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No