### PR TITLE
refactor: removed the obsolete Tag and updated the files

### DIFF
--- a/aio/src/app/custom-elements/live-example/live-example.component.ts
+++ b/aio/src/app/custom-elements/live-example/live-example.component.ts
@@ -136,7 +136,7 @@ export class LiveExampleComponent implements AfterContentInit {
  */
 @Component({
   selector: 'aio-embedded-stackblitz',
-  template: '<iframe #iframe frameborder="0" width="100%" height="100%"></iframe>',
+  template: '<iframe #iframe style="border: 0" width="100%" height="100%"></iframe>',
   styles: [ 'iframe { min-height: 400px; }' ]
 })
 export class EmbeddedStackblitzComponent implements AfterViewInit {

--- a/aio/tools/transforms/templates/error/error.template.html
+++ b/aio/tools/transforms/templates/error/error.template.html
@@ -12,7 +12,7 @@
   <div class="video-container">
     <iframe
     src="{$ doc.videoUrl $}"
-    frameborder="0"
+    style="border: 0"
     allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
     allowfullscreen></iframe>
   </div>


### PR DESCRIPTION
frameborder tag of iframe is obsolete now and used css instead, you can refer here = https://developer.mozilla.org/en-US/docs/web/html/element/iframe#attr-frameborder

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
