### PR TITLE
refactor(compiler): add support for style properties to template pipeline

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/chaining/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/chaining/TEST_CASES.json
@@ -3,120 +3,87 @@
   "cases": [
     {
       "description": "should chain classProp instruction calls",
-      "inputFiles": [
-        "class_bindings.ts"
-      ],
+      "inputFiles": ["class_bindings.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "class_bindings.js"
-          ]
+          "files": ["class_bindings.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should chain styleProp instruction calls",
-      "inputFiles": [
-        "style_bindings.ts"
-      ],
+      "inputFiles": ["style_bindings.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "style_bindings.js"
-          ]
+          "files": ["style_bindings.js"]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should chain mixed styleProp and classProp calls",
-      "inputFiles": [
-        "mixed_bindings.ts"
-      ],
+      "inputFiles": ["mixed_bindings.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "mixed_bindings.js"
-          ]
+          "files": ["mixed_bindings.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should chain style interpolations of the same kind",
-      "inputFiles": [
-        "interpolations_equal_arity.ts"
-      ],
+      "inputFiles": ["interpolations_equal_arity.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "interpolations_equal_arity.js"
-          ]
+          "files": ["interpolations_equal_arity.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should chain style interpolations of multiple kinds",
-      "inputFiles": [
-        "interpolations_different_arity.ts"
-      ],
+      "inputFiles": ["interpolations_different_arity.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "interpolations_different_arity.js"
-          ]
+          "files": ["interpolations_different_arity.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should break into multiple chains if there are other styling instructions in between",
-      "inputFiles": [
-        "break_different_instructions.ts"
-      ],
+      "inputFiles": ["break_different_instructions.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "break_different_instructions.js"
-          ]
+          "files": ["break_different_instructions.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should break into multiple chains if there are other styling interpolation instructions in between",
-      "inputFiles": [
-        "break_different_interpolation_instructions.ts"
-      ],
+      "inputFiles": ["break_different_interpolation_instructions.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "break_different_interpolation_instructions.js"
-          ]
+          "files": ["break_different_interpolation_instructions.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should chain styling instructions inside host bindings",
-      "inputFiles": [
-        "host_bindings.ts"
-      ],
+      "inputFiles": ["host_bindings.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "host_bindings.js"
-          ]
+          "files": ["host_bindings.js"]
         }
       ]
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/TEST_CASES.json
@@ -3,37 +3,27 @@
   "cases": [
     {
       "description": "should generate style/class instructions for a host component creation definition",
-      "inputFiles": [
-        "static_and_dynamic.ts"
-      ],
+      "inputFiles": ["static_and_dynamic.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "static_and_dynamic.js"
-          ]
+          "files": ["static_and_dynamic.js"]
         }
       ]
     },
     {
       "description": "should generate style/class instructions for multiple host binding definitions",
-      "inputFiles": [
-        "multiple_dynamic.ts"
-      ],
+      "inputFiles": ["multiple_dynamic.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "multiple_dynamic.js"
-          ]
+          "files": ["multiple_dynamic.js"]
         }
       ]
     },
     {
       "description": "should generate override instructions for only single-level styling bindings when !important is present",
-      "inputFiles": [
-        "important.ts"
-      ],
+      "inputFiles": ["important.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
@@ -58,45 +48,32 @@
     },
     {
       "description": "should support class interpolation",
-      "inputFiles": [
-        "class_interpolation.ts"
-      ],
+      "inputFiles": ["class_interpolation.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "class_interpolation.js"
-          ]
+          "files": ["class_interpolation.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should support style interpolation",
-      "inputFiles": [
-        "style_interpolation.ts"
-      ],
+      "inputFiles": ["style_interpolation.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "style_interpolation.js"
-          ]
+          "files": ["style_interpolation.js"]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should generate styling instructions for multiple directives that contain host binding definitions",
-      "inputFiles": [
-        "multiple_directives.ts"
-      ],
+      "inputFiles": ["multiple_directives.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "multiple_directives.js"
-          ]
+          "files": ["multiple_directives.js"]
         }
       ]
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/interpolations/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/interpolations/TEST_CASES.json
@@ -3,75 +3,54 @@
   "cases": [
     {
       "description": "should generate the proper update instructions for interpolated classes",
-      "inputFiles": [
-        "class_interpolations.ts"
-      ],
+      "inputFiles": ["class_interpolations.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect handling of interpolated classes",
-          "files": [
-            "class_interpolations.js"
-          ]
+          "files": ["class_interpolations.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should generate the proper update instructions for interpolated style properties",
-      "inputFiles": [
-        "style_properties.ts"
-      ],
+      "inputFiles": ["style_properties.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect handling of interpolated style properties",
-          "files": [
-            "style_properties.js"
-          ]
+          "files": ["style_properties.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should generate update instructions for interpolated style properties with a suffix",
-      "inputFiles": [
-        "style_binding_suffixed.ts"
-      ],
+      "inputFiles": ["style_binding_suffixed.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect handling of interpolated style properties",
-          "files": [
-            "style_binding_suffixed.js"
-          ]
+          "files": ["style_binding_suffixed.js"]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should generate update instructions for interpolated style properties with a sanitizer",
-      "inputFiles": [
-        "style_binding_sanitizer.ts"
-      ],
+      "inputFiles": ["style_binding_sanitizer.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect handling of interpolated style properties",
-          "files": [
-            "style_binding_sanitizer.js"
-          ]
+          "files": ["style_binding_sanitizer.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should generate update instructions for interpolated style properties with !important",
-      "inputFiles": [
-        "style_binding_important.ts"
-      ],
+      "inputFiles": ["style_binding_important.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect handling of interpolated style properties",
-          "files": [
-            "style_binding_important.js"
-          ]
+          "files": ["style_binding_important.js"]
         }
       ],
       "skipForTemplatePipeline": true

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
@@ -52,8 +52,7 @@
           "failureMessage": "Incorrect template",
           "files": ["style_binding_suffixed.js"]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should not create instructions for empty style bindings",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
@@ -3,90 +3,65 @@
   "cases": [
     {
       "description": "should create style instructions on the element",
-      "inputFiles": [
-        "style_binding.ts"
-      ],
+      "inputFiles": ["style_binding.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "style_binding.js"
-          ]
+          "files": ["style_binding.js"]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should correctly count the total slots required when style/class bindings include interpolation",
-      "inputFiles": [
-        "binding_slots.ts"
-      ],
+      "inputFiles": ["binding_slots.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "binding_slots.js"
-          ]
+          "files": ["binding_slots.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should place initial, multi, singular and application followed by attribute style instructions in the template code in that order",
-      "inputFiles": [
-        "binding_slots_interpolations.ts"
-      ],
+      "inputFiles": ["binding_slots_interpolations.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "binding_slots_interpolations.js"
-          ]
+          "files": ["binding_slots_interpolations.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should assign a sanitizer instance to the element style allocation instruction if any url-based properties are detected",
-      "inputFiles": [
-        "style_ordering.ts"
-      ],
+      "inputFiles": ["style_ordering.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "style_ordering.js"
-          ]
+          "files": ["style_ordering.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should support [style.foo.suffix] style bindings with a suffix",
-      "inputFiles": [
-        "style_binding_suffixed.ts"
-      ],
+      "inputFiles": ["style_binding_suffixed.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "style_binding_suffixed.js"
-          ]
+          "files": ["style_binding_suffixed.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should not create instructions for empty style bindings",
-      "inputFiles": [
-        "empty_style_bindings.ts"
-      ],
+      "inputFiles": ["empty_style_bindings.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "empty_style_bindings.js"
-          ]
+          "files": ["empty_style_bindings.js"]
         }
       ],
       "skipForTemplatePipeline": true

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
@@ -62,8 +62,7 @@
           "failureMessage": "Incorrect template",
           "files": ["empty_style_bindings.js"]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     }
   ]
 }

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -1054,6 +1054,28 @@ export class CommaExpr extends Expression {
   }
 }
 
+export class EmptyExpr extends Expression {
+  constructor(sourceSpan?: ParseSourceSpan|null) {
+    super(null, sourceSpan);
+  }
+
+  override isEquivalent(e: Expression): boolean {
+    return e instanceof EmptyExpr;
+  }
+
+  override isConstant() {
+    return true;
+  }
+
+  override visitExpression(): any {
+    throw Error('Visiting EmptyExpr that should have been stripped');
+  }
+
+  override clone(): EmptyExpr {
+    return new EmptyExpr();
+  }
+}
+
 export interface ExpressionVisitor {
   visitReadVarExpr(ast: ReadVarExpr, context: any): any;
   visitWriteVarExpr(expr: WriteVarExpr, context: any): any;

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -1054,28 +1054,6 @@ export class CommaExpr extends Expression {
   }
 }
 
-export class EmptyExpr extends Expression {
-  constructor(sourceSpan?: ParseSourceSpan|null) {
-    super(null, sourceSpan);
-  }
-
-  override isEquivalent(e: Expression): boolean {
-    return e instanceof EmptyExpr;
-  }
-
-  override isConstant() {
-    return true;
-  }
-
-  override visitExpression(): any {
-    throw Error('Visiting EmptyExpr that should have been stripped');
-  }
-
-  override clone(): EmptyExpr {
-    return new EmptyExpr();
-  }
-}
-
 export interface ExpressionVisitor {
   visitReadVarExpr(ast: ReadVarExpr, context: any): any;
   visitWriteVarExpr(expr: WriteVarExpr, context: any): any;

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -104,6 +104,11 @@ export enum OpKind {
   InterpolateStyleProp,
 
   /**
+   * An operation to interpolate text into a style mapping.
+   */
+  InterpolateStyleMap,
+
+  /**
    * An operation to advance the runtime's implicit slot context during the update phase of a view.
    */
   Advance,

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -84,6 +84,11 @@ export enum OpKind {
   Property,
 
   /**
+   * An operation to bind an expression to a style property of an element.
+   */
+  StyleProp,
+
+  /**
    * An operation to interpolate text into a property binding.
    */
   InterpolateProperty,

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -89,6 +89,11 @@ export enum OpKind {
   StyleProp,
 
   /**
+   * An operation to bind an expression to the styles of an element.
+   */
+  StyleMap,
+
+  /**
    * An operation to interpolate text into a property binding.
    */
   InterpolateProperty,

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -99,6 +99,11 @@ export enum OpKind {
   InterpolateProperty,
 
   /**
+   * An operation to interpolate text into a style property binding.
+   */
+  InterpolateStyleProp,
+
+  /**
    * An operation to advance the runtime's implicit slot context during the update phase of a view.
    */
   Advance,

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -207,6 +207,11 @@ export enum ExpressionKind {
    * An intermediate expression that will be expanded from a safe read into an explicit ternary.
    */
   SafeTernaryExpr,
+
+  /**
+   * An empty expression that will be stipped before generating the final output.
+   */
+  EmptyExpr,
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -636,6 +636,7 @@ export function transformExpressionsInOp(
   switch (op.kind) {
     case OpKind.Property:
     case OpKind.StyleProp:
+    case OpKind.StyleMap:
       op.expression = transformExpressionsInExpression(op.expression, transform, flags);
       break;
     case OpKind.InterpolateProperty:

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -635,6 +635,7 @@ export function transformExpressionsInOp(
     op: CreateOp|UpdateOp, transform: ExpressionTransform, flags: VisitorContextFlag): void {
   switch (op.kind) {
     case OpKind.Property:
+    case OpKind.StyleProp:
       op.expression = transformExpressionsInExpression(op.expression, transform, flags);
       break;
     case OpKind.InterpolateProperty:

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -640,6 +640,8 @@ export function transformExpressionsInOp(
       op.expression = transformExpressionsInExpression(op.expression, transform, flags);
       break;
     case OpKind.InterpolateProperty:
+    case OpKind.InterpolateStyleProp:
+    case OpKind.InterpolateText:
       for (let i = 0; i < op.expressions.length; i++) {
         op.expressions[i] = transformExpressionsInExpression(op.expressions[i], transform, flags);
       }
@@ -654,11 +656,6 @@ export function transformExpressionsInOp(
       break;
     case OpKind.Variable:
       op.initializer = transformExpressionsInExpression(op.initializer, transform, flags);
-      break;
-    case OpKind.InterpolateText:
-      for (let i = 0; i < op.expressions.length; i++) {
-        op.expressions[i] = transformExpressionsInExpression(op.expressions[i], transform, flags);
-      }
       break;
     case OpKind.Listener:
       for (const innerOp of op.handlerOps) {

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -641,6 +641,7 @@ export function transformExpressionsInOp(
       break;
     case OpKind.InterpolateProperty:
     case OpKind.InterpolateStyleProp:
+    case OpKind.InterpolateStyleMap:
     case OpKind.InterpolateText:
       for (let i = 0; i < op.expressions.length; i++) {
         op.expressions[i] = transformExpressionsInExpression(op.expressions[i], transform, flags);

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -22,7 +22,7 @@ import type {UpdateOp} from './ops/update';
 export type Expression =
     LexicalReadExpr|ReferenceExpr|ContextExpr|NextContextExpr|GetCurrentViewExpr|RestoreViewExpr|
     ResetViewExpr|ReadVariableExpr|PureFunctionExpr|PureFunctionParameterExpr|PipeBindingExpr|
-    PipeBindingVariadicExpr|SafePropertyReadExpr|SafeKeyedReadExpr|SafeInvokeFunctionExpr;
+    PipeBindingVariadicExpr|SafePropertyReadExpr|SafeKeyedReadExpr|SafeInvokeFunctionExpr|EmptyExpr;
 
 /**
  * Transformer type which converts expressions into general `o.Expression`s (which may be an
@@ -609,6 +609,26 @@ export class SafeTernaryExpr extends ExpressionBase {
   }
 }
 
+export class EmptyExpr extends ExpressionBase {
+  override readonly kind = ExpressionKind.EmptyExpr;
+
+  override visitExpression(visitor: o.ExpressionVisitor, context: any): any {}
+
+  override isEquivalent(e: Expression): boolean {
+    return e instanceof EmptyExpr;
+  }
+
+  override isConstant() {
+    return true;
+  }
+
+  override clone(): EmptyExpr {
+    return new EmptyExpr();
+  }
+
+  override transformInternalExpressions(): void {}
+}
+
 /**
  * Visits all `Expression`s in the AST of `op` with the `visitor` function.
  */
@@ -727,7 +747,7 @@ export function transformExpressionsInExpression(
     }
   } else if (
       expr instanceof o.ReadVarExpr || expr instanceof o.ExternalExpr ||
-      expr instanceof o.LiteralExpr || expr instanceof o.EmptyExpr) {
+      expr instanceof o.LiteralExpr) {
     // No action for these types.
   } else {
     throw new Error(`Unhandled expression kind: ${expr.constructor.name}`);

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -729,7 +729,7 @@ export function transformExpressionsInExpression(
     }
   } else if (
       expr instanceof o.ReadVarExpr || expr instanceof o.ExternalExpr ||
-      expr instanceof o.LiteralExpr) {
+      expr instanceof o.LiteralExpr || expr instanceof o.EmptyExpr) {
     // No action for these types.
   } else {
     throw new Error(`Unhandled expression kind: ${expr.constructor.name}`);

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -17,8 +17,8 @@ import {ListEndOp, NEW_OP, StatementOp, VariableOp} from './shared';
 /**
  * An operation usable on the update side of the IR.
  */
-export type UpdateOp = ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|InterpolatePropertyOp|
-    AttributeOp|InterpolateTextOp|AdvanceOp|VariableOp<UpdateOp>;
+export type UpdateOp = ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|StylePropOp|
+    InterpolatePropertyOp|AttributeOp|InterpolateTextOp|AdvanceOp|VariableOp<UpdateOp>;
 
 /**
  * A logical operation to perform string interpolation on a text node.
@@ -103,6 +103,42 @@ export function createPropertyOp(
     kind: OpKind.Property,
     target: xref,
     bindingKind,
+    name,
+    expression,
+    ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
+    ...TRAIT_CONSUMES_VARS,
+    ...NEW_OP,
+  };
+}
+
+/**
+ * A logical operation representing binding to a style property in the update IR.
+ */
+export interface StylePropOp extends Op<UpdateOp>, ConsumesVarsTrait, DependsOnSlotContextOpTrait {
+  kind: OpKind.StyleProp;
+
+  /**
+   * Reference to the element on which the property is bound.
+   */
+  target: XrefId;
+
+  /**
+   * Name of the bound property.
+   */
+  name: string;
+
+  /**
+   * Expression which is bound to the property.
+   */
+  expression: o.Expression;
+}
+
+/** Create a `StylePropOp`. */
+export function createStylePropOp(
+    xref: XrefId, name: string, expression: o.Expression): StylePropOp {
+  return {
+    kind: OpKind.StyleProp,
+    target: xref,
     name,
     expression,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -131,16 +131,22 @@ export interface StylePropOp extends Op<UpdateOp>, ConsumesVarsTrait, DependsOnS
    * Expression which is bound to the property.
    */
   expression: o.Expression;
+
+  /**
+   * The unit of the expression value.
+   */
+  unit: string|null;
 }
 
 /** Create a `StylePropOp`. */
 export function createStylePropOp(
-    xref: XrefId, name: string, expression: o.Expression): StylePropOp {
+    xref: XrefId, name: string, expression: o.Expression, unit: string|null): StylePropOp {
   return {
     kind: OpKind.StyleProp,
     target: xref,
     name,
     expression,
+    unit,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -17,7 +17,7 @@ import {ListEndOp, NEW_OP, StatementOp, VariableOp} from './shared';
 /**
  * An operation usable on the update side of the IR.
  */
-export type UpdateOp = ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|StylePropOp|
+export type UpdateOp = ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|StylePropOp|StyleMapOp|
     InterpolatePropertyOp|AttributeOp|InterpolateTextOp|AdvanceOp|VariableOp<UpdateOp>;
 
 /**
@@ -140,6 +140,35 @@ export function createStylePropOp(
     kind: OpKind.StyleProp,
     target: xref,
     name,
+    expression,
+    ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
+    ...TRAIT_CONSUMES_VARS,
+    ...NEW_OP,
+  };
+}
+
+/**
+ * A logical operation representing binding to a style map in the update IR.
+ */
+export interface StyleMapOp extends Op<UpdateOp>, ConsumesVarsTrait, DependsOnSlotContextOpTrait {
+  kind: OpKind.StyleMap;
+
+  /**
+   * Reference to the element on which the property is bound.
+   */
+  target: XrefId;
+
+  /**
+   * Expression which is bound to the property.
+   */
+  expression: o.Expression;
+}
+
+/** Create a `StyleMapOp`. */
+export function createStyleMapOp(xref: XrefId, expression: o.Expression): StyleMapOp {
+  return {
+    kind: OpKind.StyleMap,
+    target: xref,
     expression,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -18,7 +18,8 @@ import {ListEndOp, NEW_OP, StatementOp, VariableOp} from './shared';
  * An operation usable on the update side of the IR.
  */
 export type UpdateOp = ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|StylePropOp|StyleMapOp|
-    InterpolatePropertyOp|AttributeOp|InterpolateTextOp|AdvanceOp|VariableOp<UpdateOp>;
+    InterpolatePropertyOp|InterpolateStylePropOp|AttributeOp|InterpolateTextOp|AdvanceOp|
+    VariableOp<UpdateOp>;
 
 /**
  * A logical operation to perform string interpolation on a text node.
@@ -133,7 +134,7 @@ export interface StylePropOp extends Op<UpdateOp>, ConsumesVarsTrait, DependsOnS
   expression: o.Expression;
 
   /**
-   * The unit of the expression value.
+   * The unit of the bound value.
    */
   unit: string|null;
 }
@@ -281,7 +282,61 @@ export function createInterpolatePropertyOp(
   };
 }
 
+/**
+ * A logical operation representing binding an interpolation to a style property in the update IR.
+ */
+export interface InterpolateStylePropOp extends Op<UpdateOp>, ConsumesVarsTrait,
+                                                DependsOnSlotContextOpTrait {
+  kind: OpKind.InterpolateStyleProp;
 
+  /**
+   * Reference to the element on which the property is bound.
+   */
+  target: XrefId;
+
+  /**
+   * Name of the bound property.
+   */
+  name: string;
+
+  /**
+   * All of the literal strings in the property interpolation, in order.
+   *
+   * Conceptually interwoven around the `expressions`.
+   */
+  strings: string[];
+
+  /**
+   * All of the dynamic expressions in the property interpolation, in order.
+   *
+   * Conceptually interwoven in between the `strings`.
+   */
+  expressions: o.Expression[];
+
+  /**
+   * The unit of the bound value.
+   */
+  unit: string|null;
+}
+
+/**
+ * Create a `InterpolateStyleProp`.
+ */
+export function createInterpolateStylePropOp(
+    xref: XrefId, name: string, strings: string[], expressions: o.Expression[],
+    unit: string|null): InterpolateStylePropOp {
+  return {
+    kind: OpKind.InterpolateStyleProp,
+    target: xref,
+    name,
+    strings,
+    expressions,
+    unit,
+    ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
+    ...TRAIT_CONSUMES_VARS,
+    ...NEW_OP,
+  };
+}
 
 /**
  * Logical operation to advance the runtime's internal slot pointer in the update IR.

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -18,8 +18,8 @@ import {ListEndOp, NEW_OP, StatementOp, VariableOp} from './shared';
  * An operation usable on the update side of the IR.
  */
 export type UpdateOp = ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|StylePropOp|StyleMapOp|
-    InterpolatePropertyOp|InterpolateStylePropOp|AttributeOp|InterpolateTextOp|AdvanceOp|
-    VariableOp<UpdateOp>;
+    InterpolatePropertyOp|InterpolateStylePropOp|InterpolateStyleMapOp|AttributeOp|
+    InterpolateTextOp|AdvanceOp|VariableOp<UpdateOp>;
 
 /**
  * A logical operation to perform string interpolation on a text node.
@@ -337,6 +337,50 @@ export function createInterpolateStylePropOp(
     ...NEW_OP,
   };
 }
+
+/**
+ * A logical operation representing binding an interpolation to a style mapping in the update IR.
+ */
+export interface InterpolateStyleMapOp extends Op<UpdateOp>, ConsumesVarsTrait,
+                                               DependsOnSlotContextOpTrait {
+  kind: OpKind.InterpolateStyleMap;
+
+  /**
+   * Reference to the element on which the property is bound.
+   */
+  target: XrefId;
+
+  /**
+   * All of the literal strings in the property interpolation, in order.
+   *
+   * Conceptually interwoven around the `expressions`.
+   */
+  strings: string[];
+
+  /**
+   * All of the dynamic expressions in the property interpolation, in order.
+   *
+   * Conceptually interwoven in between the `strings`.
+   */
+  expressions: o.Expression[];
+}
+
+/**
+ * Create a `InterpolateStyleMap`.
+ */
+export function createInterpolateStyleMapOp(
+    xref: XrefId, strings: string[], expressions: o.Expression[]): InterpolateStyleMapOp {
+  return {
+    kind: OpKind.InterpolateStyleMap,
+    target: xref,
+    strings,
+    expressions,
+    ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
+    ...TRAIT_CONSUMES_VARS,
+    ...NEW_OP,
+  };
+}
+
 
 /**
  * Logical operation to advance the runtime's internal slot pointer in the update IR.

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -273,6 +273,12 @@ function ingestPropertyBinding(
       case e.BindingType.Property:
         view.update.push(ir.createPropertyOp(xref, bindingKind, name, convertAst(value, view.tpl)));
         break;
+      case e.BindingType.Style:
+        if (bindingKind !== ir.ElementAttributeKind.Binding) {
+          throw Error('Unexpected style binding on ng-template');
+        }
+        view.update.push(ir.createStylePropOp(xref, name, convertAst(value, view.tpl)));
+        break;
       default:
         // TODO: implement remaining binding types.
         throw Error(`Property binding type not handled: ${type}`);

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -266,6 +266,14 @@ function ingestPropertyBinding(
             xref, bindingKind, name, value.strings,
             value.expressions.map(expr => convertAst(expr, view.tpl))));
         break;
+      case e.BindingType.Style:
+        if (bindingKind !== ir.ElementAttributeKind.Binding) {
+          throw Error('Unexpected style binding on ng-template');
+        }
+        view.update.push(ir.createInterpolateStylePropOp(
+            xref, name, value.strings, value.expressions.map(expr => convertAst(expr, view.tpl)),
+            unit));
+        break;
       default:
         // TODO: implement remaining binding types.
         throw Error(`Interpolated property binding type not handled: ${type}`);

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -271,7 +271,16 @@ function ingestPropertyBinding(
   } else {
     switch (type) {
       case e.BindingType.Property:
-        view.update.push(ir.createPropertyOp(xref, bindingKind, name, convertAst(value, view.tpl)));
+        // Bindings to [style] are mapped to their own special instruction.
+        if (name === 'style') {
+          if (bindingKind !== ir.ElementAttributeKind.Binding) {
+            throw Error('Unexpected style binding on ng-template');
+          }
+          view.update.push(ir.createStyleMapOp(xref, convertAst(value, view.tpl)));
+        } else {
+          view.update.push(
+              ir.createPropertyOp(xref, bindingKind, name, convertAst(value, view.tpl)));
+        }
         break;
       case e.BindingType.Style:
         if (bindingKind !== ir.ElementAttributeKind.Binding) {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -252,7 +252,7 @@ function ingestBindings(
 function ingestPropertyBinding(
     view: ViewCompilation, xref: ir.XrefId,
     bindingKind: ir.ElementAttributeKind.Binding|ir.ElementAttributeKind.Template,
-    {name, value, type}: t.BoundAttribute): void {
+    {name, value, type, unit}: t.BoundAttribute): void {
   if (value instanceof e.ASTWithSource) {
     value = value.ast;
   }
@@ -286,7 +286,7 @@ function ingestPropertyBinding(
         if (bindingKind !== ir.ElementAttributeKind.Binding) {
           throw Error('Unexpected style binding on ng-template');
         }
-        view.update.push(ir.createStylePropOp(xref, name, convertAst(value, view.tpl)));
+        view.update.push(ir.createStylePropOp(xref, name, convertAst(value, view.tpl), unit));
         break;
       default:
         // TODO: implement remaining binding types.

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -262,9 +262,17 @@ function ingestPropertyBinding(
   if (value instanceof e.Interpolation) {
     switch (type) {
       case e.BindingType.Property:
-        view.update.push(ir.createInterpolatePropertyOp(
-            xref, bindingKind, name, value.strings,
-            value.expressions.map(expr => convertAst(expr, view.tpl))));
+        if (name === 'style') {
+          if (bindingKind !== ir.ElementAttributeKind.Binding) {
+            throw Error('Unexpected style binding on ng-template');
+          }
+          view.update.push(ir.createInterpolateStyleMapOp(
+              xref, value.strings, value.expressions.map(expr => convertAst(expr, view.tpl))));
+        } else {
+          view.update.push(ir.createInterpolatePropertyOp(
+              xref, bindingKind, name, value.strings,
+              value.expressions.map(expr => convertAst(expr, view.tpl))));
+        }
         break;
       case e.BindingType.Style:
         if (bindingKind !== ir.ElementAttributeKind.Binding) {

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -186,6 +186,8 @@ function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
   } else if (ast instanceof e.SafeCall) {
     return new ir.SafeInvokeFunctionExpr(
         convertAst(ast.receiver, cpl), ast.args.map(a => convertAst(a, cpl)));
+  } else if (ast instanceof e.EmptyExpr) {
+    return new o.EmptyExpr();
   } else {
     throw new Error(`Unhandled expression type: ${ast.constructor.name}`);
   }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -187,7 +187,7 @@ function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
     return new ir.SafeInvokeFunctionExpr(
         convertAst(ast.receiver, cpl), ast.args.map(a => convertAst(a, cpl)));
   } else if (ast instanceof e.EmptyExpr) {
-    return new o.EmptyExpr();
+    return new ir.EmptyExpr();
   } else {
     throw new Error(`Unhandled expression type: ${ast.constructor.name}`);
   }

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -140,6 +140,13 @@ export function property(name: string, expression: o.Expression): ir.UpdateOp {
   ]);
 }
 
+export function styleProp(name: string, expression: o.Expression): ir.UpdateOp {
+  return call(Identifiers.styleProp, [
+    o.literal(name),
+    expression,
+  ]);
+}
+
 const PIPE_BINDINGS: o.ExternalReference[] = [
   Identifiers.pipeBind1,
   Identifiers.pipeBind2,

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -140,11 +140,12 @@ export function property(name: string, expression: o.Expression): ir.UpdateOp {
   ]);
 }
 
-export function styleProp(name: string, expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.styleProp, [
-    o.literal(name),
-    expression,
-  ]);
+export function styleProp(name: string, expression: o.Expression, unit: string|null): ir.UpdateOp {
+  const args = [o.literal(name), expression];
+  if (unit !== null) {
+    args.push(o.literal(unit));
+  }
+  return call(Identifiers.styleProp, args);
 }
 
 export function styleMap(expression: o.Expression): ir.UpdateOp {

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -221,6 +221,12 @@ export function stylePropInterpolate(
       STYLE_PROP_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs, extraArgs);
 }
 
+export function styleMapInterpolate(strings: string[], expressions: o.Expression[]): ir.UpdateOp {
+  const interpolationArgs = collateInterpolationArgs(strings, expressions);
+
+  return callVariadicInstruction(STYLE_MAP_INTERPOLATE_CONFIG, [], interpolationArgs);
+}
+
 export function pureFunction(
     varOffset: number, fn: o.Expression, args: o.Expression[]): o.Expression {
   return callVariadicInstructionExpr(
@@ -326,7 +332,7 @@ const PROPERTY_INTERPOLATE_CONFIG: VariadicInstructionConfig = {
  */
 const STYLE_PROP_INTERPOLATE_CONFIG: VariadicInstructionConfig = {
   constant: [
-    null!,  // Interpolation with 0 variables is not supported.
+    null!,  // Single argument stylePropInterpolate is converted to styleProp instruction.
     Identifiers.stylePropInterpolate1,
     Identifiers.stylePropInterpolate2,
     Identifiers.stylePropInterpolate3,
@@ -337,6 +343,33 @@ const STYLE_PROP_INTERPOLATE_CONFIG: VariadicInstructionConfig = {
     Identifiers.stylePropInterpolate8,
   ],
   variable: Identifiers.stylePropInterpolateV,
+  mapping: n => {
+    if (n % 2 === 0) {
+      throw new Error(`Expected odd number of arguments`);
+    }
+    if (n < 3) {
+      throw new Error(`Expected at least 3 arguments`);
+    }
+    return (n - 1) / 2;
+  },
+};
+
+/**
+ * `InterpolationConfig` for the `styleMapInterpolate` instruction.
+ */
+const STYLE_MAP_INTERPOLATE_CONFIG: VariadicInstructionConfig = {
+  constant: [
+    null!,  // Single argument styleMapInterpolate is converted to styleMap instruction.
+    Identifiers.styleMapInterpolate1,
+    Identifiers.styleMapInterpolate2,
+    Identifiers.styleMapInterpolate3,
+    Identifiers.styleMapInterpolate4,
+    Identifiers.styleMapInterpolate5,
+    Identifiers.styleMapInterpolate6,
+    Identifiers.styleMapInterpolate7,
+    Identifiers.styleMapInterpolate8,
+  ],
+  variable: Identifiers.styleMapInterpolateV,
   mapping: n => {
     if (n % 2 === 0) {
       throw new Error(`Expected odd number of arguments`);

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -147,6 +147,10 @@ export function styleProp(name: string, expression: o.Expression): ir.UpdateOp {
   ]);
 }
 
+export function styleMap(expression: o.Expression): ir.UpdateOp {
+  return call(Identifiers.styleMap, [expression]);
+}
+
 const PIPE_BINDINGS: o.ExternalReference[] = [
   Identifiers.pipeBind1,
   Identifiers.pipeBind2,

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -11,6 +11,16 @@ import * as ir from '../../ir';
 import {ComponentCompilation, ViewCompilation} from '../compilation';
 
 /**
+ * Find all attribute and binding ops, and collect them into the ElementAttribute structures.
+ * In cases where no instruction needs to be generated for the attribute or binding, it is removed.
+ */
+export function phaseAttributeExtraction(cpl: ComponentCompilation, compatibility: boolean): void {
+  for (const [_, view] of cpl.views) {
+    populateElementAttributes(view, compatibility);
+  }
+}
+
+/**
  * Looks up an element in the given map by xref ID.
  */
 function lookupElement(
@@ -23,13 +33,14 @@ function lookupElement(
 }
 
 /**
- * Find all attribute and binding ops, and collect them into the ElementAttribute structures.
- * In cases where no instruction needs to be generated for the attribute or binding, it is removed.
+ * Removes the op if its expression is empty.
  */
-export function phaseAttributeExtraction(cpl: ComponentCompilation, compatibility: boolean): void {
-  for (const [_, view] of cpl.views) {
-    populateElementAttributes(view, compatibility);
+function removeIfExpressionIsEmpty(op: ir.UpdateOp|ir.CreateOp, expression: o.Expression) {
+  if (expression instanceof o.EmptyExpr) {
+    ir.OpList.remove(op as ir.UpdateOp);
+    return true;
   }
+  return false;
 }
 
 /**
@@ -52,6 +63,8 @@ function populateElementAttributes(view: ViewCompilation, compatibility: boolean
         ownerOp = lookupElement(elements, op.target);
         ir.assertIsElementAttributes(ownerOp.attributes);
 
+        // The old compiler only extracted string constants, so we emulate that behavior in
+        // compaitiblity mode, otherwise we optimize more aggressively.
         let extractable = compatibility ?
             (op.value instanceof o.LiteralExpr && typeof op.value.value === 'string') :
             (op.value.isConstant());
@@ -64,11 +77,27 @@ function populateElementAttributes(view: ViewCompilation, compatibility: boolean
         break;
 
       case ir.OpKind.Property:
+        ownerOp = lookupElement(elements, op.target);
+        ir.assertIsElementAttributes(ownerOp.attributes);
+        removeIfExpressionIsEmpty(op, op.expression);
+        ownerOp.attributes.add(op.bindingKind, op.name, null);
+        break;
+
       case ir.OpKind.InterpolateProperty:
         ownerOp = lookupElement(elements, op.target);
         ir.assertIsElementAttributes(ownerOp.attributes);
-
         ownerOp.attributes.add(op.bindingKind, op.name, null);
+        break;
+
+      case ir.OpKind.StyleProp:
+        ownerOp = lookupElement(elements, op.target);
+        ir.assertIsElementAttributes(ownerOp.attributes);
+
+        // The old compiler treated empty style bindings as regular bindings for the purpose of
+        // directive matching. That behavior is incorrect, but we emulate it in compatibility mode.
+        if (removeIfExpressionIsEmpty(op, op.expression) && compatibility) {
+          ownerOp.attributes.add(ir.ElementAttributeKind.Binding, op.name, null);
+        }
         break;
 
       case ir.OpKind.Listener:

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -36,7 +36,7 @@ function lookupElement(
  * Removes the op if its expression is empty.
  */
 function removeIfExpressionIsEmpty(op: ir.UpdateOp|ir.CreateOp, expression: o.Expression) {
-  if (expression instanceof o.EmptyExpr) {
+  if (expression instanceof ir.EmptyExpr) {
     ir.OpList.remove(op as ir.UpdateOp);
     return true;
   }

--- a/packages/compiler/src/template/pipeline/src/phases/chaining.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/chaining.ts
@@ -15,6 +15,7 @@ const CHAINABLE = new Set([
   R3.elementStart,
   R3.elementEnd,
   R3.property,
+  R3.styleProp,
   R3.elementContainerStart,
   R3.elementContainerEnd,
   R3.elementContainer,

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -134,6 +134,9 @@ function reifyUpdateOperations(_view: ViewCompilation, ops: ir.OpList<ir.UpdateO
         ir.OpList.replace(
             op, ng.stylePropInterpolate(op.name, op.strings, op.expressions, op.unit));
         break;
+      case ir.OpKind.InterpolateStyleMap:
+        ir.OpList.replace(op, ng.styleMapInterpolate(op.strings, op.expressions));
+        break;
       case ir.OpKind.InterpolateText:
         ir.OpList.replace(op, ng.textInterpolate(op.strings, op.expressions));
         break;

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -122,7 +122,7 @@ function reifyUpdateOperations(_view: ViewCompilation, ops: ir.OpList<ir.UpdateO
         ir.OpList.replace(op, ng.property(op.name, op.expression));
         break;
       case ir.OpKind.StyleProp:
-        ir.OpList.replace(op, ng.styleProp(op.name, op.expression));
+        ir.OpList.replace(op, ng.styleProp(op.name, op.expression, op.unit));
         break;
       case ir.OpKind.StyleMap:
         ir.OpList.replace(op, ng.styleMap(op.expression));

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -124,6 +124,9 @@ function reifyUpdateOperations(_view: ViewCompilation, ops: ir.OpList<ir.UpdateO
       case ir.OpKind.StyleProp:
         ir.OpList.replace(op, ng.styleProp(op.name, op.expression));
         break;
+      case ir.OpKind.StyleMap:
+        ir.OpList.replace(op, ng.styleMap(op.expression));
+        break;
       case ir.OpKind.InterpolateProperty:
         ir.OpList.replace(op, ng.propertyInterpolate(op.name, op.strings, op.expressions));
         break;

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -130,6 +130,10 @@ function reifyUpdateOperations(_view: ViewCompilation, ops: ir.OpList<ir.UpdateO
       case ir.OpKind.InterpolateProperty:
         ir.OpList.replace(op, ng.propertyInterpolate(op.name, op.strings, op.expressions));
         break;
+      case ir.OpKind.InterpolateStyleProp:
+        ir.OpList.replace(
+            op, ng.stylePropInterpolate(op.name, op.strings, op.expressions, op.unit));
+        break;
       case ir.OpKind.InterpolateText:
         ir.OpList.replace(op, ng.textInterpolate(op.strings, op.expressions));
         break;

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -121,6 +121,9 @@ function reifyUpdateOperations(_view: ViewCompilation, ops: ir.OpList<ir.UpdateO
       case ir.OpKind.Property:
         ir.OpList.replace(op, ng.property(op.name, op.expression));
         break;
+      case ir.OpKind.StyleProp:
+        ir.OpList.replace(op, ng.styleProp(op.name, op.expression));
+        break;
       case ir.OpKind.InterpolateProperty:
         ir.OpList.replace(op, ng.propertyInterpolate(op.name, op.strings, op.expressions));
         break;

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -70,6 +70,7 @@ function varsUsedByOp(op: (ir.CreateOp|ir.UpdateOp)&ir.ConsumesVarsTrait): numbe
       // `ir.InterpolateTextOp`s use a variable slot for each dynamic expression.
       return op.expressions.length;
     case ir.OpKind.InterpolateProperty:
+    case ir.OpKind.InterpolateStyleProp:
       // `ir.InterpolatePropertyOp`s use a variable slot for each dynamic expression, plus one for
       // the result.
       return 1 + op.expressions.length;

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -63,6 +63,7 @@ function varsUsedByOp(op: (ir.CreateOp|ir.UpdateOp)&ir.ConsumesVarsTrait): numbe
   switch (op.kind) {
     case ir.OpKind.Property:
     case ir.OpKind.StyleProp:
+    case ir.OpKind.StyleMap:
       // Property bindings use 1 variable slot.
       return 1;
     case ir.OpKind.InterpolateText:

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -71,6 +71,7 @@ function varsUsedByOp(op: (ir.CreateOp|ir.UpdateOp)&ir.ConsumesVarsTrait): numbe
       return op.expressions.length;
     case ir.OpKind.InterpolateProperty:
     case ir.OpKind.InterpolateStyleProp:
+    case ir.OpKind.InterpolateStyleMap:
       // `ir.InterpolatePropertyOp`s use a variable slot for each dynamic expression, plus one for
       // the result.
       return 1 + op.expressions.length;

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -62,6 +62,7 @@ export function phaseVarCounting(cpl: ComponentCompilation): void {
 function varsUsedByOp(op: (ir.CreateOp|ir.UpdateOp)&ir.ConsumesVarsTrait): number {
   switch (op.kind) {
     case ir.OpKind.Property:
+    case ir.OpKind.StyleProp:
       // Property bindings use 1 variable slot.
       return 1;
     case ir.OpKind.InterpolateText:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Template pipeline does not support style property or style map bindings.


## What is the new behavior?

Template pipeline supports style property and style map bindings.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
