### PR TITLE
docs(docs-infra): rimraf requires the glob flag.

### DIFF
--- a/aio/tools/transforms/angular.io-package/processors/cleanGeneratedFiles.js
+++ b/aio/tools/transforms/angular.io-package/processors/cleanGeneratedFiles.js
@@ -1,10 +1,10 @@
-const rimraf = require('rimraf');
+const {rimrafSync} = require('rimraf');
 module.exports = function cleanGeneratedFiles() {
   return {
     $runAfter: ['writing-files'],
     $runBefore: ['writeFilesProcessor'],
     $process: function() {
-      rimraf.sync('src/generated/{docs,*.json}');
+      rimrafSync('src/generated/{docs,*.json}', {glob: true});
     }
   };
 };


### PR DESCRIPTION
On windows rimraf requires since v4 the glob flag to support wildcards in path.

fixes #49806