### PR TITLE
feat(core): add identification to signals (#50437)

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -361,6 +361,7 @@ export function createPlatformFactory(parentPlatformFactory: ((extraProviders?: 
 // @public
 export interface CreateSignalOptions<T> {
     equal?: ValueEqualityFn<T>;
+    id?: string;
 }
 
 // @public
@@ -1593,6 +1594,7 @@ export abstract class ViewRef extends ChangeDetectorRef {
 // @public
 export interface WritableSignal<T> extends Signal<T> {
     asReadonly(): Signal<T>;
+    id?: string;
     mutate(mutatorFn: (value: T) => void): void;
     set(value: T): void;
     update(updateFn: (value: T) => T): void;

--- a/packages/core/src/signals/README.md
+++ b/packages/core/src/signals/README.md
@@ -39,6 +39,20 @@ If the equality function determines that 2 values are equal it will:
 * block update of signal’s value;
 * skip change propagation.
 
+#### Identification
+
+One can specify an string identification (`id`) in the creation of the signal. This will provide better logging and debugging for the developer. Simply define its id in the `CreateSignalOptions` configuration:
+
+```typescript
+const counter = signal(0, { id: 'my-counter' });
+```
+
+The id can be read after by calling the attribute of the signal prototype:
+
+```typescript
+console.log(counter.id); // => my-counter
+```
+
 ### Declarative derived values: `computed()`
 
 `computed()` creates a memoizing signal, which calculates its value from the values of some number of input signals.

--- a/packages/core/src/signals/src/signal.ts
+++ b/packages/core/src/signals/src/signal.ts
@@ -25,6 +25,11 @@ let postSignalSetFn: (() => void)|null = null;
  */
 export interface WritableSignal<T> extends Signal<T> {
   /**
+   * String identifier of the given signal.
+   */
+  id?: string;
+
+  /**
    * Directly set the signal to a new value, and notify any dependents.
    */
   set(value: T): void;
@@ -134,6 +139,11 @@ class WritableSignalImpl<T> extends ReactiveNode {
  */
 export interface CreateSignalOptions<T> {
   /**
+   * Identifier of the signal.
+   */
+  id?: string;
+
+  /**
    * A comparison function which defines equality for signal values.
    */
   equal?: ValueEqualityFn<T>;
@@ -150,6 +160,7 @@ export function signal<T>(initialValue: T, options?: CreateSignalOptions<T>): Wr
   // Casting here is required for g3, as TS inference behavior is slightly different between our
   // version/options and g3's.
   const signalFn = createSignalFromFunction(signalNode, signalNode.signal.bind(signalNode), {
+                     id: options?.id,
                      set: signalNode.set.bind(signalNode),
                      update: signalNode.update.bind(signalNode),
                      mutate: signalNode.mutate.bind(signalNode),

--- a/packages/core/test/signals/signal_spec.ts
+++ b/packages/core/test/signals/signal_spec.ts
@@ -116,6 +116,14 @@ describe('signals', () => {
     expect(double()).toBe(4);
   });
 
+  it('should define signal names in its prototype', () => {
+    const s1 = signal(1);
+    const s2 = signal(2, {id: 'second signal'});
+
+    expect(s1.id).toBeUndefined();
+    expect(s2.id).toBe('second signal');
+  });
+
   describe('post-signal-set functions', () => {
     let prevPostSignalSetFn: (() => void)|null = null;
     let log: number;


### PR DESCRIPTION
This commit adds an identification attribute to WritableSignals interface. This make it easier to log and debug, providing better development experience.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #50437 


## What is the new behavior?

```typescript
const counter = signal(0, { id: 'my-counter' });

console.log(counter.id); // => my-counter
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The original idea was to use an attribute called `name` rather than `id`, but `name` was not working so well as TypeScript function already has this property. In order to keep things simple, I used `id` instead.