### PR TITLE
fix(router): correct the return value type of `Router.navigateByUrl` …

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -720,8 +720,8 @@ export class Router {
     isActive(url: string | UrlTree, exact: boolean): boolean;
     isActive(url: string | UrlTree, matchOptions: IsActiveMatchOptions): boolean;
     get lastSuccessfulNavigation(): Navigation | null;
-    navigate(commands: any[], extras?: NavigationExtras): Promise<boolean>;
-    navigateByUrl(url: string | UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean>;
+    navigate(commands: any[], extras?: NavigationExtras): Promise<boolean | null>;
+    navigateByUrl(url: string | UrlTree, extras?: NavigationBehaviorOptions): Promise<boolean | null>;
     navigated: boolean;
     // (undocumented)
     ngOnDestroy(): void;

--- a/packages/core/schematics/BUILD.bazel
+++ b/packages/core/schematics/BUILD.bazel
@@ -22,6 +22,7 @@ pkg_npm(
         "//packages/core/schematics/migrations/compiler-options:bundle",
         "//packages/core/schematics/migrations/invalid-two-way-bindings:bundle",
         "//packages/core/schematics/migrations/transfer-state:bundle",
+        "//packages/core/schematics/migrations/router-navigate-null:bundle",
         "//packages/core/schematics/ng-generate/control-flow-migration:bundle",
         "//packages/core/schematics/ng-generate/standalone-migration:bundle",
     ],

--- a/packages/core/schematics/migrations.json
+++ b/packages/core/schematics/migrations.json
@@ -19,6 +19,11 @@
       "version": "17.3.0",
       "description": "Updates two-way bindings that have an invalid expression to use the longform expression instead.",
       "factory": "./migrations/invalid-two-way-bindings/bundle"
+    },
+    "migration-router-navigate-null": {
+      "version": "18.0.0",
+      "description": "As of Angular v18, the `Router.navigate` and `Router.navigateByUrl` functions may return `null` when navigation is skipped. This migration automatically identifies previous usages and adds a type cast from `Promise<boolean|null>` to `Promise<boolean>` in places where type error would occur in Angular v18.",
+      "factory": "./migrations/router-navigate-null/bundle"
     }
   }
 }

--- a/packages/core/schematics/migrations/google3/BUILD.bazel
+++ b/packages/core/schematics/migrations/google3/BUILD.bazel
@@ -6,11 +6,21 @@ ts_library(
     tsconfig = "//packages/core/schematics:tsconfig.json",
     deps = [
         "//packages/core/schematics/migrations/compiler-options",
+        "//packages/core/schematics/migrations/router-navigate-null",
         "//packages/core/schematics/utils",
         "//packages/core/schematics/utils/tslint",
         "@npm//tslint",
         "@npm//typescript",
     ],
+)
+
+esbuild(
+    name = "router_navigate_null_cjs",
+    entry_point = ":routerNavigateNullRule.ts",
+    format = "cjs",
+    output = "routerNavigateNullCjsRule.js",
+    platform = "node",
+    deps = [":google3"],
 )
 
 esbuild(
@@ -25,6 +35,7 @@ esbuild(
 filegroup(
     name = "google3_cjs",
     srcs = [
+        ":router_navigate_null_cjs",
         ":wait_for_async_rule_cjs",
     ],
     visibility = ["//packages/core/schematics/test/google3:__pkg__"],

--- a/packages/core/schematics/migrations/google3/routerNavigateNullRule.ts
+++ b/packages/core/schematics/migrations/google3/routerNavigateNullRule.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Replacement, RuleFailure, Rules} from 'tslint';
+import ts from 'typescript';
+
+import {migrateFile} from '../router-navigate-null/util';
+
+/** TSLint rule for `Router.navigate` and `Router.navigateByUrl` migration. */
+export class Rule extends Rules.TypedRule {
+  override applyWithProgram(sourceFile: ts.SourceFile, program: ts.Program): RuleFailure[] {
+    const failures: RuleFailure[] = [];
+
+    const updater = (sourceFile: ts.SourceFile, node: ts.Node, content: string) => {
+      const start = node.getStart();
+      const end = node.getEnd();
+      const failure = new RuleFailure(
+          sourceFile, start, end,
+          `Router.navigate and Router.navigateByUrl functions may return null when navigation is skipped.`,
+          this.ruleName,
+          // "replace" by adding text right of the function call
+          Replacement.appendText(end, content));
+      failures.push(failure);
+    };
+
+    migrateFile(sourceFile, program.getTypeChecker(), updater);
+
+    return failures;
+  }
+}

--- a/packages/core/schematics/migrations/router-navigate-null/BUILD.bazel
+++ b/packages/core/schematics/migrations/router-navigate-null/BUILD.bazel
@@ -1,0 +1,33 @@
+load("//tools:defaults.bzl", "esbuild", "ts_library")
+
+package(
+    default_visibility = [
+        "//packages/core/schematics:__pkg__",
+        "//packages/core/schematics/migrations/google3:__pkg__",
+        "//packages/core/schematics/test:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "router-navigate-null",
+    srcs = glob(["**/*.ts"]),
+    tsconfig = "//packages/core/schematics:tsconfig.json",
+    deps = [
+        "//packages/core/schematics/utils",
+        "@npm//@angular-devkit/schematics",
+        "@npm//@types/node",
+        "@npm//typescript",
+    ],
+)
+
+esbuild(
+    name = "bundle",
+    entry_point = ":index.ts",
+    external = [
+        "@angular-devkit/*",
+        "typescript",
+    ],
+    format = "cjs",
+    platform = "node",
+    deps = [":router-navigate-null"],
+)

--- a/packages/core/schematics/migrations/router-navigate-null/README.md
+++ b/packages/core/schematics/migrations/router-navigate-null/README.md
@@ -1,0 +1,40 @@
+## Router `navigate` and `navigateByUrl` null type migration
+
+As of Angular v18, the `Router.navigate` and `Router.navigateByUrl` functions may return `null`
+when navigation is skipped. This migration automatically identifies previous usages and adds
+a type cast from `Promise<boolean|null>` to `Promise<boolean>` in places where type error would
+occur in Angular v18.
+
+#### Before
+
+```ts
+import {Component, inject} from '@angular/core';
+import {Router} from '@angular/router';
+@Component()
+export class MyComponent {
+  private _router = inject(Router);
+  navigateToHome(): Promise<boolean> {
+    return this._router.navigateByUrl('/home'); // <- Compilation error in v18.
+  }
+  navigateToAboutUs(): Promise<boolean> {
+    return this._router.navigate(['/about-us']); // <- Compilation error in v18.
+  }
+}
+```
+
+#### After
+
+```ts
+import {Component, inject} from '@angular/core';
+import {Router} from '@angular/router';
+@Component()
+export class MyComponent {
+  private _router = inject(Router);
+  navigateToHome(): Promise<boolean> {
+    return this._router.navigateByUrl('/home').then((result) => result!); // <- type cast added during the migration.
+  }
+  navigateToAboutUs(): Promise<boolean> {
+    return this._router.navigate(['/about-us']).then((result) => result!); // <- type cast added during the migration.
+  }
+}
+```

--- a/packages/core/schematics/migrations/router-navigate-null/index.ts
+++ b/packages/core/schematics/migrations/router-navigate-null/index.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Rule, SchematicsException, Tree} from '@angular-devkit/schematics';
+import {relative} from 'path';
+import ts from 'typescript';
+
+import {getProjectTsConfigPaths} from '../../utils/project_tsconfig_paths';
+import {createMigrationProgram} from '../../utils/typescript/compiler_host';
+
+import {migrateFile} from './util';
+
+/** Migration that casts `Router.navigate` and `Router.navigateByUrl` as `Promise<boolean>`s. */
+export default function(): Rule {
+  return async (tree: Tree) => {
+    const {buildPaths, testPaths} = await getProjectTsConfigPaths(tree);
+    const basePath = process.cwd();
+    const allPaths = [...buildPaths, ...testPaths];
+
+    if (!allPaths.length) {
+      throw new SchematicsException(
+          'Could not find any tsconfig file. Cannot migrate typing of Router.navigate nor Router.navigateByUrl.');
+    }
+
+    for (const tsconfigPath of allPaths) {
+      runNativeRouterNavigateMigration(tree, tsconfigPath, basePath);
+    }
+  };
+}
+
+function runNativeRouterNavigateMigration(tree: Tree, tsconfigPath: string, basePath: string) {
+  const program = createMigrationProgram(tree, tsconfigPath, basePath);
+  const typeChecker = program.getTypeChecker();
+  const sourceFiles = program.getSourceFiles().filter(
+      (f) => !f.isDeclarationFile && !program.isSourceFileFromExternalLibrary(f));
+
+  const updateFn = (sourceFile: ts.SourceFile, node: ts.Node, content: string) => {
+    const update = tree.beginUpdate(relative(basePath, sourceFile.fileName));
+    update.insertRight(node.getStart() + node.getWidth(), content);
+    tree.commitUpdate(update);
+  };
+
+  sourceFiles.forEach((sourceFile) => migrateFile(sourceFile, typeChecker, updateFn));
+}

--- a/packages/core/schematics/migrations/router-navigate-null/util.ts
+++ b/packages/core/schematics/migrations/router-navigate-null/util.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {getImportOfIdentifier} from '../../utils/typescript/imports';
+
+const routerFunctions = new Set(['navigate', 'navigateByUrl']);
+const routerModule = '@angular/router';
+
+type UpdateFn = (sourceFile: ts.SourceFile, node: ts.Node, content: string) => void;
+
+export function migrateFile(
+    sourceFile: ts.SourceFile, typeChecker: ts.TypeChecker, updateFn: UpdateFn) {
+  findRouterNavigateCalls(typeChecker, sourceFile)
+      .forEach((node) => updateFn(sourceFile, node, '.then((result) => result!)'));
+}
+
+/**
+ * Finds the `Node`s that are `Router.navigate` or `Router.navigateByUrl` function call expressions.
+ * Call expressions which values are not used are ignored.
+ */
+export function findRouterNavigateCalls(
+    typeChecker: ts.TypeChecker, sourceFile: ts.SourceFile): ts.Node[] {
+  const results: ts.Node[] = [];
+
+  sourceFile.forEachChild(function walk(node: ts.Node) {
+    if (ts.isPropertyAccessExpression(node) && !results.includes(node) &&
+        isRouterReference(typeChecker, node) && isRouterCallExpression(node.parent) &&
+        isCallExpressionUsed(typeChecker, node.parent)) {
+      results.unshift(node.parent);
+    }
+    node.forEachChild(walk);
+  });
+
+  return results;
+}
+
+function isRouterCallExpression(node: ts.Node): node is ts.CallExpression {
+  if (ts.isCallExpression(node)) {
+    // Walk through each children in this call expression and try to find call to any router
+    // function we are interested. This check is necessary to catch cases where the function is
+    // passed to another function and not called.
+    return (node.expression.forEachChild((child) => {
+      return ts.isIdentifier(child) && routerFunctions.has(child.getText());
+    }) ?? false);
+  }
+
+  return false;
+}
+
+/**
+ * Checks whether the given call expression node's return value is used.
+ * Return values of `fn()` and `await fn()` are not used, while `return fn()`,
+ * `const r = await fn()` and `fn().then()` are.
+ */
+function isCallExpressionUsed(typeChecker: ts.TypeChecker, node: ts.CallExpression) {
+  // In case the call expression is awaited, we are interested about the grandparent node
+  const resultNode = ts.isAwaitExpression(node.parent) ? node.parent.parent : node.parent;
+
+  if (ts.isPropertyAccessExpression(resultNode)) {
+    const hasThenIdentifier = resultNode.forEachChild((child) => {
+      return ts.isIdentifier(child) && child.getText() === 'then';
+    });
+
+    if (hasThenIdentifier) {
+      // Represents "navigateByUrl().then(...)" part
+      const parentCallExpr = resultNode.parent as ts.CallExpression;
+
+      // Represents whatever is inside the "then(...)" call
+      const thenExpr = parentCallExpr.arguments.at(0);
+
+      // If there are at least one parameter used by the function inside then() call,
+      // we can assume that the function is using navigation result.
+      return thenExpr && getFunctionParameterCount(typeChecker, thenExpr) > 0;
+    }
+  }
+
+  return !ts.isExpressionStatement(resultNode);
+}
+
+/** Returns count of parameters the given node accepts. */
+function getFunctionParameterCount(typeChecker: ts.TypeChecker, node: ts.Expression): number {
+  // Matches arrow functions "() => {}" and functions "function () {}"
+  if (ts.isFunctionLike(node)) {
+    // If the function has at least one parameter, it has a good change of using the
+    // navigation result
+    return node.parameters.length;
+  } else if (ts.isPropertyAccessExpression(node)) {
+    const symbol = typeChecker.getSymbolAtLocation(node);
+    const declaration = symbol?.declarations?.[0];
+
+    if (declaration) {
+      // Declaration might be an arrow function. Return count of parameters in property initializer
+      if (ts.isPropertyDeclaration(declaration) && declaration.initializer &&
+          ts.isArrowFunction(declaration.initializer)) {
+        return declaration.initializer.parameters.length;
+      }
+
+      // Declaration is a method
+      if (ts.isMethodDeclaration(declaration)) {
+        const signature = typeChecker.getSignatureFromDeclaration(declaration);
+        if (signature) {
+          return signature.getParameters().length;
+        }
+      }
+    }
+  }
+
+  return 0;
+}
+
+/** Checks whether a property access is coming from module `@angular/router`. */
+function isRouterReference(
+    typeChecker: ts.TypeChecker, node: ts.PropertyAccessExpression): boolean {
+  // Walks recursively down the node tree and tries to find either identifier or call expression
+  // that is coming from `@angular/router` module.
+  const visitChildren = (child: ts.Node): boolean => {
+    if (ts.isIdentifier(child) || ts.isCallExpression(child)) {
+      const type = getInjectedTypeIdentifier(typeChecker, child);
+      const importIdentifier = type && getImportOfIdentifier(typeChecker, type);
+      return importIdentifier?.importModule === routerModule;
+    }
+    return ts.forEachChild(child, visitChildren) ?? false;
+  };
+  return ts.forEachChild(node, visitChildren) ?? false;
+}
+
+/**
+ * Returns type identifier node that was used when initializing the variable or property via
+ * constructor injection or via `inject` function.
+ */
+function getInjectedTypeIdentifier(typeChecker: ts.TypeChecker, node: ts.Node) {
+  // Special handling for cases when return value of `inject` function is used right away
+  // e.g. `inject(Router).navigate(...)`
+  if (ts.isCallExpression(node)) {
+    return getInjectReturnType(node);
+  }
+
+  const symbol = typeChecker.getSymbolAtLocation(node);
+  const valueDecl = symbol?.valueDeclaration;
+
+  if (!symbol || !valueDecl) {
+    return null;
+  }
+
+  if (ts.isParameter(valueDecl) || ts.isPropertyDeclaration(valueDecl) ||
+      ts.isVariableDeclaration(valueDecl)) {
+    if (valueDecl.type && ts.isTypeReferenceNode(valueDecl.type) &&
+        ts.isIdentifier(valueDecl.type.typeName)) {
+      // Identifier has been declared via constructor or as a class property and has a type
+      // reference with type identifier that we can use
+      return valueDecl.type.typeName;
+    } else if (valueDecl.initializer && ts.isCallExpression(valueDecl.initializer)) {
+      // Identifier's type is inferred from initializer function `inject`
+      return getInjectReturnType(valueDecl.initializer);
+    }
+  }
+
+  return null;
+}
+
+/** Returns the first argument given to the `inject` function, if it's an identifier */
+function getInjectReturnType(node: ts.CallExpression) {
+  const {arguments: args, expression} = node;
+  const firstArgument = args.at(0);
+
+  // Return first argument of `inject` function
+  if (expression.getText() == 'inject' && firstArgument && ts.isIdentifier(firstArgument)) {
+    return firstArgument;
+  }
+
+  return null;
+}

--- a/packages/core/schematics/test/BUILD.bazel
+++ b/packages/core/schematics/test/BUILD.bazel
@@ -27,6 +27,8 @@ jasmine_node_test(
         "//packages/core/schematics/migrations/invalid-two-way-bindings:bundle",
         "//packages/core/schematics/migrations/transfer-state",
         "//packages/core/schematics/migrations/transfer-state:bundle",
+        "//packages/core/schematics/migrations/router-navigate-null",
+        "//packages/core/schematics/migrations/router-navigate-null:bundle",
         "//packages/core/schematics/ng-generate/control-flow-migration",
         "//packages/core/schematics/ng-generate/control-flow-migration:bundle",
         "//packages/core/schematics/ng-generate/control-flow-migration:static_files",

--- a/packages/core/schematics/test/google3/router_navigate_null_spec.ts
+++ b/packages/core/schematics/test/google3/router_navigate_null_spec.ts
@@ -1,0 +1,391 @@
+
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {runfiles} from '@bazel/runfiles';
+import {readFileSync, writeFileSync} from 'fs';
+import {dirname, join} from 'path';
+import shx from 'shelljs';
+import {Configuration, Linter} from 'tslint';
+
+describe('Google3 Router.navigate/navigateByUrl TSLint rule', () => {
+  const rulesDirectory = dirname(
+      runfiles.resolvePackageRelative('../../migrations/google3/routerNavigateNullCjsRule.js'));
+
+  let tmpDir: string;
+  let previousWorkingDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(process.env['TEST_TMPDIR']!, 'google3-test');
+    shx.mkdir('-p', tmpDir);
+    shx.cd(tmpDir);
+
+    writeFile('tsconfig.json', JSON.stringify({
+      compilerOptions: {
+        lib: ['es2015'],
+        strictNullChecks: true,
+      },
+    }));
+
+    shx.mkdir('-p', 'node_modules/@angular/router');
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('node_modules/@angular/router/index.d.ts', `
+       export declare class Router {
+         navigate(commands: any[], extras?: any): Promise<boolean | null>;
+         navigateByUrl(url: string, extras?: any): Promise<boolean | null>;
+       }
+     `);
+
+    shx.mkdir('-p', 'node_modules/@angular/core');
+    writeFile('/node_modules/@angular/core/index.d.ts', `
+       export interface Type<T> extends Function {
+        new(...args: any[]): T;
+       }
+       export declare function inject<T>(token: Type<T>): T;
+     `);
+
+    previousWorkingDir = shx.pwd();
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDir);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDir);
+  });
+
+  function runTSLint(fix: boolean) {
+    const program = Linter.createProgram(join(tmpDir, 'tsconfig.json'));
+    const linter = new Linter({fix, rulesDirectory: [rulesDirectory]}, program);
+    const config = Configuration.parseConfigFile({rules: {'router-navigate-null-cjs': true}});
+
+    program.getRootFileNames().forEach(fileName => {
+      linter.lint(fileName, program.getSourceFile(fileName)!.getFullText(), config);
+    });
+
+    return linter;
+  }
+
+  function writeFile(fileName: string, content: string) {
+    writeFileSync(join(tmpDir, fileName), content);
+  }
+
+  function getFile(fileName: string) {
+    return readFileSync(join(tmpDir, fileName), 'utf8');
+  }
+
+  it('should flag navigate and navigateByUrl usages', () => {
+    writeFile('/index.ts', `
+      import { Router } from '@angular/router';
+      class Component {
+        constructor(private _router: Router) {}
+        async navigate() {
+          const r1 = await this._router.navigate(['/']);
+          const r2 = await this._router.navigateByUrl('/');
+        }
+      }
+    `);
+
+    const linter = runTSLint(false);
+    const failures = linter.getResult().failures.map(failure => failure.getFailure());
+    expect(failures.length).toBe(2);
+    expect(failures[0])
+        .toMatch(
+            /Router\.navigate and Router\.navigateByUrl functions may return null when navigation is skipped/);
+    expect(failures[1])
+        .toMatch(
+            /Router\.navigate and Router\.navigateByUrl functions may return null when navigation is skipped/);
+  });
+
+  it('should add type cast to Router.navigate', () => {
+    writeFile('/index.ts', `
+      import { Router } from '@angular/router';
+      class Component {
+        constructor(private _router: Router) {}
+        async navigate() {
+          const result = await this._router.navigate(['/']);
+        }
+      }
+    `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts'))
+        .toContain(`const result = await this._router.navigate(['/']).then((result) => result!);`);
+  });
+
+  it('should add type cast to Router.navigateByUrl', () => {
+    writeFile('/index.ts', `
+      import { Router } from '@angular/router';
+      class Component {
+        constructor(private _router: Router) {}
+        async navigate() {
+          const result = await this._router.navigateByUrl('/home');
+        }
+      }
+    `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts'))
+        .toContain(
+            `const result = await this._router.navigateByUrl('/home').then((result) => result!)`);
+  });
+
+  it('should add type cast when router is injected via inject function', () => {
+    writeFile('/index.ts', `
+       import {inject} from '@angular/core';
+       import {Router} from '@angular/router';
+       class Component {
+         private _router = inject(Router);
+         navigate(): Promise<boolean> {
+           return this._router.navigateByUrl('/');
+         }
+       }
+     `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts'))
+        .toContain(`return this._router.navigateByUrl('/').then((result) => result!);`);
+  });
+
+  it('should add type cast when router is injected via inject function in local scope', () => {
+    writeFile('/index.ts', `
+       import {inject} from '@angular/core';
+       import {Router} from '@angular/router';
+       async function activateGuard(): Promise<boolean> {
+          const router = inject(Router);
+          return router.navigateByUrl('/');
+       }
+       async function loadGuard(): Promise<boolean> {
+        return inject(Router).navigate(['/']);
+       }
+     `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts'))
+        .toContain(`return router.navigateByUrl('/').then((result) => result!);`);
+    expect(getFile('/index.ts'))
+        .toContain(`return inject(Router).navigate(['/']).then((result) => result!);`);
+  });
+
+  it('should add type cast when the return value is stored into variable', () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         async navigate(): Promise<void> {
+           const promise = this._router.navigateByUrl('/');
+           const result = await this._router.navigateByUrl('/');
+         }
+       }
+     `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts'))
+        .toContain(`const promise = this._router.navigateByUrl('/').then((result) => result!);`);
+    expect(getFile('/index.ts'))
+        .toContain(
+            `const result = await this._router.navigateByUrl('/').then((result) => result!);`);
+  });
+
+  it('should add type cast when the return value is stored into a object', () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): void {
+           const obj = {prop: this._router.navigateByUrl('/')};
+         }
+       }
+     `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts'))
+        .toContain(
+            `const obj = {prop: this._router.navigateByUrl('/').then((result) => result!)};`);
+  });
+
+  it('should add type cast when the navigation result is returned', () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): Promise<boolean> {
+           return this._router.navigateByUrl('/');
+         }
+       }
+     `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts'))
+        .toContain(`return this._router.navigateByUrl('/').then((result) => result!);`);
+  });
+
+  it('should add type cast before .then() call when navigation result is used', () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): void {
+          // Return value is passed to function
+          this._router.navigateByUrl('/').then(this.next);
+          this._router.navigateByUrl('/').then(this.nextArrow);
+          this._router.navigateByUrl('/').then((v) => this.next(v));
+          this._router.navigateByUrl('/').then(function(v) { this.next(v) });
+         }
+         next(result: boolean) {}
+         nextArrow = (result: boolean) => {}
+       }
+     `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts'))
+        .toContain(`this._router.navigateByUrl('/').then((result) => result!).then(this.next);`);
+    expect(getFile('/index.ts'))
+        .toContain(
+            `this._router.navigateByUrl('/').then((result) => result!).then(this.nextArrow);`);
+    expect(getFile('/index.ts'))
+        .toContain(
+            `this._router.navigateByUrl('/').then((result) => result!).then((v) => this.next(v));`);
+    expect(getFile('/index.ts'))
+        .toContain(
+            `this._router.navigateByUrl('/').then((result) => result!).then(function(v) { this.next(v) });`);
+  });
+
+  it('should add type cast when return promise value is used as function parameter', () => {
+    writeFile('/index.ts', `
+      import { Router } from '@angular/router';
+      class Component {
+        constructor(private _router: Router) {}
+        navigate() {
+          this.wrapperFn(this._router.navigateByUrl('/'));
+        }
+        wrapperFn(result: Promise<boolean>) {}
+      }
+    `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts'))
+        .toContain(`this.wrapperFn(this._router.navigateByUrl('/').then((result) => result!));`);
+  });
+
+  it('should add type cast when return value is used as function parameter', () => {
+    writeFile('/index.ts', `
+      import { Router } from '@angular/router';
+      class Component {
+        constructor(private _router: Router) {}
+        navigate() {
+          this.wrapperFn(await this._router.navigateByUrl('/'));
+        }
+        wrapperFn(result: boolean) {}
+      }
+    `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts'))
+        .toContain(
+            `this.wrapperFn(await this._router.navigateByUrl('/').then((result) => result!));`);
+  });
+
+  it('should not add type cast if result of the navigation is not used', () => {
+    writeFile('/index.ts', `
+      import { Router } from '@angular/router';
+      class Component {
+        constructor(private _router: Router) {}
+        navigate() {
+          this._router.navigate(['/']);
+          this._router.navigateByUrl('/');
+        }
+      }
+    `);
+
+    runTSLint(true);
+    // No one is interested of the navigation result, no need to migrate
+    expect(getFile('/index.ts')).toContain(`this._router.navigate(['/']);`);
+    expect(getFile('/index.ts')).toContain(`this._router.navigateByUrl('/');`);
+  });
+
+  it('should not add type cast if the promise value is used', () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): void {
+           // Return value is not used in then expression
+           this._router.navigateByUrl('/').then();
+           this._router.navigateByUrl('/').then(this.ignored);
+           this._router.navigateByUrl('/').then(this.ignoredArrow);
+           this._router.navigateByUrl('/').then(() => this.ignored());
+           this._router.navigateByUrl('/').then(function() { this.ignored() });
+         }
+         ignored() {}
+         ignoredArrow = () => {}
+       }
+     `);
+
+    runTSLint(true);
+    // No one is interested of the navigation result, no need to migrate
+    expect(getFile('/index.ts')).toContain(`this._router.navigateByUrl('/').then();`);
+    expect(getFile('/index.ts')).toContain(`this._router.navigateByUrl('/').then(this.ignored);`);
+    expect(getFile('/index.ts'))
+        .toContain(`this._router.navigateByUrl('/').then(this.ignoredArrow);`);
+    expect(getFile('/index.ts'))
+        .toContain(`this._router.navigateByUrl('/').then(() => this.ignored());`);
+    expect(getFile('/index.ts'))
+        .toContain(`this._router.navigateByUrl('/').then(function() { this.ignored() });`);
+  });
+
+  it('should not add type cast if the function is not called', () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): void {
+           // Saved to variable
+           const fn = this._router.navigate;
+
+           // Real world use case could be: expect(router.navigate).toHaveBeenCalled...
+           this.wrapperFn(this._router.navigate).response;
+
+           this.promiseWrapperFn(this._router.navigate).then((v) => console.log(v));
+         }
+         wrapperFn(fn: any): any {
+           return { response: 1 };
+         }
+         promiseWrapperFn(): Promise<any[]> {
+           return Promise.resolve([]);
+         }
+       }
+     `);
+
+    runTSLint(true);
+    expect(getFile('/index.ts')).toContain(`const fn = this._router.navigate;`);
+    expect(getFile('/index.ts')).toContain(`this.wrapperFn(this._router.navigate).response;`);
+    expect(getFile('/index.ts'))
+        .toContain(`this.promiseWrapperFn(this._router.navigate).then((v) => console.log(v));`);
+  });
+
+  it('should not add type cast if awaited result of the navigation is not used', () => {
+    writeFile('/index.ts', `
+      import { Router } from '@angular/router';
+      class Component {
+        constructor(private _router: Router) {}
+        navigate() {
+          await this._router.navigate(['/']);
+          await this._router.navigateByUrl('/');
+        }
+      }
+    `);
+
+    runTSLint(true);
+    // No one is interested of the navigation result, no need to migrate
+    expect(getFile('/index.ts')).toContain(`await this._router.navigate(['/']);`);
+    expect(getFile('/index.ts')).toContain(`await this._router.navigateByUrl('/');`);
+  });
+});

--- a/packages/core/schematics/test/router_navigate_null_spec.ts
+++ b/packages/core/schematics/test/router_navigate_null_spec.ts
@@ -1,0 +1,352 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {getSystemPath, normalize, virtualFs} from '@angular-devkit/core';
+import {TempScopedNodeJsSyncHost} from '@angular-devkit/core/node/testing';
+import {HostTree} from '@angular-devkit/schematics';
+import {SchematicTestRunner, UnitTestTree} from '@angular-devkit/schematics/testing';
+import {runfiles} from '@bazel/runfiles';
+import shx from 'shelljs';
+
+describe('Router.navigate/navigateByUrl migration', () => {
+  let runner: SchematicTestRunner;
+  let host: TempScopedNodeJsSyncHost;
+  let tree: UnitTestTree;
+  let tmpDirPath: string;
+  let previousWorkingDir: string;
+
+  beforeEach(() => {
+    runner = new SchematicTestRunner('test', runfiles.resolvePackageRelative('../migrations.json'));
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+
+    writeFile('/tsconfig.json', JSON.stringify({
+      compilerOptions: {lib: ['es2015'], strictNullChecks: true},
+    }));
+    writeFile('/angular.json', JSON.stringify({
+      version: 1,
+      projects: {t: {root: '', architect: {build: {options: {tsConfig: './tsconfig.json'}}}}}
+    }));
+
+    // We need to declare the Angular symbols we're testing for, otherwise type checking won't work.
+    writeFile('/node_modules/@angular/router/index.d.ts', `
+       export declare class Router {
+         navigate(commands: any[], extras?: any): Promise<boolean | null>;
+         navigateByUrl(url: string, extras?: any): Promise<boolean | null>;
+       }
+     `);
+
+    writeFile('/node_modules/@angular/core/index.d.ts', `
+        export interface Type<T> extends Function {
+          new(...args: any[]): T;
+        }
+        export declare function inject<T>(token: Type<T>): T;
+     `);
+
+    // Fake non-Angular package to make sure that we don't migrate packages we don't own.
+    writeFile('/node_modules/@not-angular/router/index.d.ts', `
+        export declare class Router {
+          navigate(commands: any[], extras?: any): Promise<boolean | null>;
+          navigateByUrl(url: string, extras?: any): Promise<boolean | null>;
+        }
+     `);
+
+    previousWorkingDir = shx.pwd();
+    tmpDirPath = getSystemPath(host.root);
+
+    // Switch into the temporary directory path. This allows us to run
+    // the schematic against our custom unit test tree.
+    shx.cd(tmpDirPath);
+  });
+
+  afterEach(() => {
+    shx.cd(previousWorkingDir);
+    shx.rm('-r', tmpDirPath);
+  });
+
+  it('should add type cast when router is injected via inject function', async () => {
+    writeFile('/index.ts', `
+       import {inject} from '@angular/core';
+       import {Router} from '@angular/router';
+       class Component {
+         private _router = inject(Router);
+         navigate(): Promise<boolean> {
+           return this._router.navigateByUrl('/');
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`return this._router.navigateByUrl('/').then((result) => result!);`);
+  });
+
+  it('should add type cast when router is injected via inject function in local scope',
+     async () => {
+       writeFile('/index.ts', `
+       import {inject} from '@angular/core';
+       import {Router} from '@angular/router';
+       async function activateGuard(): Promise<boolean> {
+        const router = inject(Router);
+        return router.navigateByUrl('/');
+       }
+       async function loadGuard(): Promise<boolean> {
+        return inject(Router).navigate(['/']);
+       }
+     `);
+
+       await runMigration();
+       expect(tree.readContent('/index.ts'))
+           .toContain(`return router.navigateByUrl('/').then((result) => result!);`);
+       expect(tree.readContent('/index.ts'))
+           .toContain(`return inject(Router).navigate(['/']).then((result) => result!);`);
+     });
+
+  it('should add type cast when router is injected via constructor', async () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): Promise<boolean> {
+           return this._router.navigate(['/']);
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`return this._router.navigate(['/']).then((result) => result!);`);
+  });
+
+  it('should add type cast when the return value is stored into variable', async () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         async navigate(): Promise<void> {
+           const promise = this._router.navigateByUrl('/');
+           const result = await this._router.navigateByUrl('/');
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`const promise = this._router.navigateByUrl('/').then((result) => result!);`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(
+            `const result = await this._router.navigateByUrl('/').then((result) => result!);`);
+  });
+
+  it('should add type cast when the return value is stored into a object', async () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): void {
+           const obj = {prop: this._router.navigateByUrl('/')};
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(
+            `const obj = {prop: this._router.navigateByUrl('/').then((result) => result!)};`);
+  });
+
+  it('should add type cast before .then() call when navigation result is used', async () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): void {
+          // Return value is passed to function
+          this._router.navigateByUrl('/').then(this.next);
+          this._router.navigateByUrl('/').then(this.nextArrow);
+          this._router.navigateByUrl('/').then((v) => this.next(v));
+          this._router.navigateByUrl('/').then(function(v) { this.next(v) });
+         }
+         next(result: boolean) {}
+         nextArrow = (result: boolean) => {}
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`this._router.navigateByUrl('/').then((result) => result!).then(this.next);`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(
+            `this._router.navigateByUrl('/').then((result) => result!).then(this.nextArrow);`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(
+            `this._router.navigateByUrl('/').then((result) => result!).then((v) => this.next(v));`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(
+            `this._router.navigateByUrl('/').then((result) => result!).then(function(v) { this.next(v) });`);
+  });
+
+  it('should add type cast when the return promise value is used as function parameter',
+     async () => {
+       writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): void {
+           this.wrapperFn(this._router.navigateByUrl('/'));
+         }
+         wrapperFn(result: Promise<boolean>) {}
+       }
+     `);
+
+       await runMigration();
+       expect(tree.readContent('/index.ts'))
+           .toContain(`this.wrapperFn(this._router.navigateByUrl('/').then((result) => result!));`);
+     });
+
+  it('should add type cast when the return value is used as function parameter', async () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         async navigate(): void {
+           this.wrapperFn(await this._router.navigateByUrl('/'));
+         }
+         wrapperFn(result: boolean) {}
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(
+            `this.wrapperFn(await this._router.navigateByUrl('/').then((result) => result!));`);
+  });
+
+  it('should not add type cast if the result of the navigation is not used', async () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): void {
+           this._router.navigate(['/']);
+           this._router.navigateByUrl('/');
+         }
+       }
+     `);
+
+    await runMigration();
+    // No one is interested of the navigation result, no need to migrate
+    expect(tree.readContent('/index.ts')).toContain(`this._router.navigate(['/']);`);
+    expect(tree.readContent('/index.ts')).toContain(`this._router.navigateByUrl('/');`);
+  });
+
+  it('should not add type cast if the awaited result of the navigation is not used', async () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         async navigate(): Promise<void> {
+           await this._router.navigate(['/']);
+           await this._router.navigateByUrl('/');
+         }
+       }
+     `);
+
+    await runMigration();
+    // No one is interested of the navigation result, no need to migrate
+    expect(tree.readContent('/index.ts')).toContain(`await this._router.navigate(['/']);`);
+    expect(tree.readContent('/index.ts')).toContain(`await this._router.navigateByUrl('/');`);
+  });
+
+  it('should not add type cast if the promise value is used', async () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): void {
+           // Return value is not used in then expression
+           this._router.navigateByUrl('/').then();
+           this._router.navigateByUrl('/').then(this.ignored);
+           this._router.navigateByUrl('/').then(this.ignoredArrow);
+           this._router.navigateByUrl('/').then(() => this.ignored());
+           this._router.navigateByUrl('/').then(function() { this.ignored() });
+         }
+         ignored() {}
+         ignoredArrow = () => {}
+       }
+     `);
+
+    await runMigration();
+    // No one is interested of the navigation result, no need to migrate
+    expect(tree.readContent('/index.ts')).toContain(`this._router.navigateByUrl('/').then();`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(`this._router.navigateByUrl('/').then(this.ignored);`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(`this._router.navigateByUrl('/').then(this.ignoredArrow);`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(`this._router.navigateByUrl('/').then(() => this.ignored());`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(`this._router.navigateByUrl('/').then(function() { this.ignored() });`);
+  });
+
+  it('should not add type cast if the function is not called', async () => {
+    writeFile('/index.ts', `
+       import {Router} from '@angular/router';
+       class Component {
+         constructor(private _router: Router) {}
+         navigate(): void {
+           // Saved to variable
+           const fn = this._router.navigate;
+
+           // Real world use case would be: expect(router.navigate).toHaveBeenCalled...
+           this.wrapperFn(this._router.navigate).response;
+
+           this.promiseWrapperFn(this._router.navigate).then((v) => console.log(v));
+         }
+         wrapperFn(fn: any): any {
+           return { response: 1 };
+         }
+         promiseWrapperFn(): Promise<any[]> {
+           return Promise.resolve([]);
+         }
+       }
+     `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts')).toContain(`const fn = this._router.navigate;`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(`this.wrapperFn(this._router.navigate).response;`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(`this.promiseWrapperFn(this._router.navigate).then((v) => console.log(v));`);
+  });
+
+  it('should not add type cast if the symbol does not come from @angular/router', async () => {
+    writeFile('/index.ts', `
+     import {Router} from '@not-angular/router';
+     async function notNavigate() {
+       const _router = new Router();
+       const r1 = await this._router.navigate(['/']);
+       const r2 = await this._router.navigateByUrl('/');
+     }
+   `);
+
+    await runMigration();
+    expect(tree.readContent('/index.ts'))
+        .toContain(`const r1 = await this._router.navigate(['/']);`);
+    expect(tree.readContent('/index.ts'))
+        .toContain(`const r2 = await this._router.navigateByUrl('/');`);
+  });
+
+  function writeFile(filePath: string, contents: string) {
+    host.sync.write(normalize(filePath), virtualFs.stringToFileBuffer(contents));
+  }
+
+  function runMigration() {
+    return runner.runSchematic('migration-router-navigate-null', {}, tree);
+  }
+});

--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -287,9 +287,9 @@ export interface NavigationTransition {
   urlAfterRedirects?: UrlTree;
   rawUrl: UrlTree;
   extras: NavigationExtras;
-  resolve: any;
-  reject: any;
-  promise: Promise<boolean>;
+  resolve: (value: boolean|null) => void;
+  reject: (reason?: any) => void;
+  promise: Promise<boolean|null>;
   source: NavigationTrigger;
   restoredState: RestoredState | null;
   currentSnapshot: RouterStateSnapshot;
@@ -404,8 +404,8 @@ export class NavigationTransitions {
       urlAfterRedirects: this.urlHandlingStrategy.extract(initialUrlTree),
       rawUrl: initialUrlTree,
       extras: {},
-      resolve: null,
-      reject: null,
+      resolve: () => {},
+      reject: () => {},
       promise: Promise.resolve(true),
       source: IMPERATIVE_NAVIGATION,
       restoredState: null,

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -498,8 +498,15 @@ export class Router {
    *     current URL.
    * @param extras An object containing properties that modify the navigation strategy.
    *
-   * @returns A Promise that resolves to 'true' when navigation succeeds,
-   * to 'false' when navigation fails, or is rejected on error.
+   * @returns A Promise that resolves to:
+   *
+   * * `true` - when navigation succeeds.
+   * * `false` - when navigation fails or is rejected on error.
+   * * `null` - when navigation was skipped because requested URL is same as the current one or the
+   * navigation was ignored by `UrlHandlingStrategy`.
+   *
+   * The Promise is rejected when an error occurs if `resolveNavigationPromiseOnError` is not
+   * `true`.
    *
    * @usageNotes
    *
@@ -520,7 +527,7 @@ export class Router {
     extras: NavigationBehaviorOptions = {
       skipLocationChange: false,
     },
-  ): Promise<boolean> {
+  ): Promise<boolean | null> {
     if (typeof ngDevMode === 'undefined' || ngDevMode) {
       if (this.isNgZoneEnabled && !NgZone.isInAngularZone()) {
         this.console.warn(
@@ -547,9 +554,15 @@ export class Router {
    * @param extras An options object that determines how the URL should be constructed or
    *     interpreted.
    *
-   * @returns A Promise that resolves to `true` when navigation succeeds, or `false` when navigation
-   *     fails. The Promise is rejected when an error occurs if `resolveNavigationPromiseOnError` is
-   * not `true`.
+   * @returns A Promise that resolves to:
+   *
+   * * `true` - when navigation succeeds.
+   * * `false` - when navigation fails or is rejected on error.
+   * * `null` - when navigation was skipped because requested URL is same as the current one or the
+   * navigation was ignored by `UrlHandlingStrategy`.
+   *
+   * The Promise is rejected when an error occurs if `resolveNavigationPromiseOnError` is not
+   * `true`.
    *
    * @usageNotes
    *
@@ -568,7 +581,7 @@ export class Router {
   navigate(
     commands: any[],
     extras: NavigationExtras = {skipLocationChange: false},
-  ): Promise<boolean> {
+  ): Promise<boolean | null> {
     validateCommands(commands);
     return this.navigateByUrl(this.createUrlTree(commands, extras), extras);
   }
@@ -636,21 +649,21 @@ export class Router {
     source: NavigationTrigger,
     restoredState: RestoredState | null,
     extras: NavigationExtras,
-    priorPromise?: {resolve: any; reject: any; promise: Promise<boolean>},
-  ): Promise<boolean> {
+    priorPromise?: {resolve: any; reject: any; promise: Promise<boolean | null>},
+  ): Promise<boolean | null> {
     if (this.disposed) {
       return Promise.resolve(false);
     }
 
     let resolve: any;
     let reject: any;
-    let promise: Promise<boolean>;
+    let promise: Promise<boolean | null>;
     if (priorPromise) {
       resolve = priorPromise.resolve;
       reject = priorPromise.reject;
       promise = priorPromise.promise;
     } else {
-      promise = new Promise<boolean>((res, rej) => {
+      promise = new Promise<boolean | null>((res, rej) => {
         resolve = res;
         reject = rej;
       });

--- a/packages/router/test/integration.spec.ts
+++ b/packages/router/test/integration.spec.ts
@@ -173,14 +173,14 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         const events: (NavigationStart | NavigationEnd)[] = [];
         router.events.subscribe((e) => onlyNavigationStartAndEnd(e) && events.push(e));
 
-        await router.navigateByUrl('/simple');
-        await router.navigateByUrl('/simple');
+        const firstNav = await router.navigateByUrl('/simple');
+        const secondNav = await router.navigateByUrl('/simple');
         // By default, the second navigation is ignored
         expectEvents(events, [
           [NavigationStart, '/simple'],
           [NavigationEnd, '/simple'],
         ]);
-        await router.navigateByUrl('/simple', {onSameUrlNavigation: 'reload'});
+        const thirdNav = await router.navigateByUrl('/simple', {onSameUrlNavigation: 'reload'});
         // We overrode the `onSameUrlNavigation` value. This navigation should be processed.
         expectEvents(events, [
           [NavigationStart, '/simple'],
@@ -188,6 +188,11 @@ for (const browserAPI of ['navigation', 'history'] as const) {
           [NavigationStart, '/simple'],
           [NavigationEnd, '/simple'],
         ]);
+
+        expect(firstNav).toBe(true);
+        // The second navigation was skipped, returning null
+        expect(secondNav).toBeNull();
+        expect(thirdNav).toBe(true);
       });
 
       it('should override default onSameUrlNavigation with extras', async () => {
@@ -203,8 +208,8 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         const events: (NavigationStart | NavigationEnd)[] = [];
         router.events.subscribe((e) => onlyNavigationStartAndEnd(e) && events.push(e));
 
-        await router.navigateByUrl('/simple');
-        await router.navigateByUrl('/simple');
+        const firstNav = await router.navigateByUrl('/simple');
+        const secondNav = await router.navigateByUrl('/simple');
         expectEvents(events, [
           [NavigationStart, '/simple'],
           [NavigationEnd, '/simple'],
@@ -213,8 +218,13 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         ]);
 
         events.length = 0;
-        await router.navigateByUrl('/simple', {onSameUrlNavigation: 'ignore'});
+        const thirdNav = await router.navigateByUrl('/simple', {onSameUrlNavigation: 'ignore'});
         expectEvents(events, []);
+
+        expect(firstNav).toBe(true);
+        expect(secondNav).toBe(true);
+        // The third navigation was skipped, returning null
+        expect(thirdNav).toBeNull();
       });
 
       it('should set transient navigation info', async () => {
@@ -4485,13 +4495,13 @@ for (const browserAPI of ['navigation', 'history'] as const) {
               advance(fixture);
               expect(location.path()).toEqual('/team/22');
 
-              let successStatus: boolean = false;
+              let successStatus: boolean | null = false;
               router.navigateByUrl('/team/33')!.then((res) => (successStatus = res));
               advance(fixture);
               expect(location.path()).toEqual('/team/33');
               expect(successStatus).toEqual(true);
 
-              let canceledStatus: boolean = false;
+              let canceledStatus: boolean | null = false;
               router.navigateByUrl('/team/44')!.then((res) => (canceledStatus = res));
               advance(fixture);
               expect(location.path()).toEqual('/team/33');
@@ -5196,8 +5206,8 @@ for (const browserAPI of ['navigation', 'history'] as const) {
               {path: 'lazy-true', canLoad: ['alwaysTrue'], loadChildren: () => LazyLoadedModule},
             ]);
 
-            let navFalseResult = true;
-            let navTrueResult = false;
+            let navFalseResult = true as boolean | null;
+            let navTrueResult = false as boolean | null;
             router.navigateByUrl('/lazy-false').then((v) => {
               navFalseResult = v;
             });
@@ -5989,7 +5999,7 @@ for (const browserAPI of ['navigation', 'history'] as const) {
         inject([Router], (router: Router) => {
           const fixture = createRoot(router, RootCmp);
           let result = null as boolean | null;
-          const callback = (r: boolean) => (result = r);
+          const callback = (r: boolean | null) => (result = r);
           router.resetConfig([{path: 'user/:name', component: UserCmp}]);
 
           router.navigateByUrl('/user/frodo').then(callback);


### PR DESCRIPTION
…and `Router.navigate`

The `navigateByUrl` and `navigate` functions of the Router may return Promise with either a `boolean` value when navigation succeeds or fails or a `null` when the navigation was skipped. Previously return type and documentation of these functions indicated that only `boolean` value could be returned.

BREAKING CHANGE: Possible return value of `Router.navigateByUrl` and `Router.navigate` functions now include `null`. Usage of these function may now require stricter typing.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

This is technically a breaking change, even though the router navigation logic haven't changed.


## Other information
