### PR TITLE
docs: clarify Injectable decorator usage w/ inject

### DIFF
--- a/packages/core/src/di/injectable.ts
+++ b/packages/core/src/di/injectable.ts
@@ -46,6 +46,10 @@ export interface InjectableDecorator {
    *
    * <code-example path="core/di/ts/metadata_spec.ts" region="Injectable"></code-example>
    *
+   * Note: Using `@Injectable` is vital when dependencies are injected
+   * through a `constructor`, as demonstrated in the `NeedsService`
+   * example above. However, when dependencies are acquired using the
+   * `inject` function, this decorator is not required.
    */
   (): TypeDecorator;
   (options?: {providedIn: Type<any>|'root'|'platform'|'any'|null}&


### PR DESCRIPTION
In this commit, a note was added to the @Injectable documentation emphasizing its non-necessity for services using the `inject` function.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The documentation had room for additional clarification on the optional use of @Injectable when acquiring dependencies through the inject function.

Issue Number: N/A

## What is the new behavior?

The updated documentation includes a note that highlights the non-essential role of `@Injectable` for services using the `inject` function, providing clarity for developers on its usage.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
