### PR TITLE
docs: correct Signals documentation

### DIFF
--- a/aio/content/guide/signals.md
+++ b/aio/content/guide/signals.md
@@ -223,7 +223,7 @@ effect(() => {
 });
 ```
 
-This example logs a message when _either_ `currentUser` or `counter` changes. However, if the effect should only run only when `currentUser` changes, then the read of `counter` is only incidental and changes to `counter` shouldn't log a new message.
+This example logs a message when _either_ `currentUser` or `counter` changes. However, if the effect should only run when `currentUser` changes, then the read of `counter` is only incidental and changes to `counter` shouldn't log a new message.
 
 You can prevent a signal read from being tracked by calling its getter with `untracked`:
 


### PR DESCRIPTION
Remove "only" word from "Reading without tracking dependencies" effect explanation

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
 "However, if the effect should **only** run **only** when currentUser changes"

Issue Number: N/A


## What is the new behavior?
 "However, if the effect should **only** run when currentUser changes"

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

