### PR TITLE
docs: selector precisions

### DIFF
--- a/aio/content/special-elements/core/ng-content.md
+++ b/aio/content/special-elements/core/ng-content.md
@@ -1,5 +1,7 @@
 The `<ng-content>` element specifies where to project content inside a component template.
 
-&commat;elementAttribute select="selector"
+@elementAttribute select="selector"
 
 Only select elements from the projected content that match the given CSS `selector`.
+
+Angular supports [selectors](https://developer.mozilla.org/docs/Web/CSS/CSS_Selectors) for any combination of tag name, attribute, CSS class, and the `:not` pseudo-class.


### PR DESCRIPTION
This commit fixes the layout of the page and adds a precision on what selectors are supported by ng-content

See #50511