### PR TITLE
refactor(compiler-cli): fix incremental compilation breaking when running compiler through closure

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -85,7 +85,7 @@ export class ComponentDecoratorHandler implements
   };
 
   readonly precedence = HandlerPrecedence.PRIMARY;
-  readonly name = ComponentDecoratorHandler.name;
+  readonly name = 'ComponentDecoratorHandler';
 
 
   detect(node: ClassDeclaration, decorators: Decorator[]|null): DetectResult<Decorator>|undefined {

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -58,7 +58,7 @@ export class DirectiveDecoratorHandler implements
       private annotateForClosureCompiler: boolean, private perf: PerfRecorder) {}
 
   readonly precedence = HandlerPrecedence.PRIMARY;
-  readonly name = DirectiveDecoratorHandler.name;
+  readonly name = 'DirectiveDecoratorHandler';
 
   detect(node: ClassDeclaration, decorators: Decorator[]|null):
       DetectResult<Decorator|null>|undefined {

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -180,7 +180,7 @@ export class NgModuleDecoratorHandler implements
       private injectableRegistry: InjectableClassRegistry, private perf: PerfRecorder) {}
 
   readonly precedence = HandlerPrecedence.PRIMARY;
-  readonly name = NgModuleDecoratorHandler.name;
+  readonly name = 'NgModuleDecoratorHandler';
 
   detect(node: ClassDeclaration, decorators: Decorator[]|null): DetectResult<Decorator>|undefined {
     if (!decorators) {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -42,7 +42,7 @@ export class InjectableDecoratorHandler implements
       private errorOnDuplicateProv = true) {}
 
   readonly precedence = HandlerPrecedence.SHARED;
-  readonly name = InjectableDecoratorHandler.name;
+  readonly name = 'InjectableDecoratorHandler';
 
   detect(node: ClassDeclaration, decorators: Decorator[]|null): DetectResult<Decorator>|undefined {
     if (!decorators) {

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -57,7 +57,7 @@ export class PipeDecoratorHandler implements
       private perf: PerfRecorder) {}
 
   readonly precedence = HandlerPrecedence.PRIMARY;
-  readonly name = PipeDecoratorHandler.name;
+  readonly name = 'PipeDecoratorHandler';
 
   detect(node: ClassDeclaration, decorators: Decorator[]|null): DetectResult<Decorator>|undefined {
     if (!decorators) {

--- a/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/compilation.ts
@@ -425,7 +425,7 @@ export class TraitCompiler implements ProgramTypeCheckAdapter {
             continue;
           case TraitState.Pending:
             throw new Error(`Resolving a trait that hasn't been analyzed: ${clazz.name.text} / ${
-                Object.getPrototypeOf(trait.handler).constructor.name}`);
+                trait.handler.name}`);
           case TraitState.Resolved:
             throw new Error(`Resolving an already resolved trait`);
         }


### PR DESCRIPTION
If the compiler CLI is running through closure compiler, the trait decorator handlers are converted
from classes to functions as ES5 is picked as default output target for the bundled version.

The problem is that currently all trait handlers end up having the same `name`. i.e. an empty string,
and therefore adopting previous traits from a previous build iteration result in the incorrect handler
being used for e.g. registrering, compiling etc- causing ambiguous/confusing errors down the line in other parts.

We can look into changing the output target in the future, but even then we are safer using an
actual literal due to property renaming.

```js
const $$closure$$NgModuleDecoratorHandler = function() {}
```

It is is questionable if we should just simply NOT run the compiler
through JSCompiler.