### PR TITLE
fix(migrations): Prevent a component from importing itself.

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -719,7 +719,7 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     }
     const emitted = emittedRef.expression;
     if (emitted instanceof WrappedNodeExpr) {
-      if (emitted.node === inContext.name) {
+      if (refTo.node === inContext) {
         // Suppress self-imports since components do not have to import themselves.
         return null;
       }

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/checker.ts
@@ -719,6 +719,11 @@ export class TemplateTypeCheckerImpl implements TemplateTypeChecker {
     }
     const emitted = emittedRef.expression;
     if (emitted instanceof WrappedNodeExpr) {
+      if (emitted.node === inContext.name) {
+        // Suppress self-imports since components do not have to import themselves.
+        return null;
+      }
+
       let isForwardReference = false;
       if (emitted.node.getStart() > inContext.getStart()) {
         const declaration = this.programDriver.getProgram()

--- a/packages/core/schematics/test/standalone_migration_spec.ts
+++ b/packages/core/schematics/test/standalone_migration_spec.ts
@@ -1550,6 +1550,39 @@ describe('standalone migration', () => {
     `));
   });
 
+  it('should not generate a forwardRef for a self import', async () => {
+    writeFile('decls.ts', `
+      import {Component} from '@angular/core';
+
+      @Component({
+        selector: 'comp',
+        template: '<comp/>'
+      })
+      export class MyComp {}
+    `);
+
+    writeFile('module.ts', `
+      import {NgModule} from '@angular/core';
+      import {MyComp} from './decls';
+
+      @NgModule({declarations: [MyComp]})
+      export class Mod {}
+    `);
+
+    await runMigration('convert-to-standalone');
+
+    expect(stripWhitespace(tree.readContent('decls.ts'))).toEqual(stripWhitespace(`
+      import {Component} from '@angular/core';
+
+      @Component({
+        selector: 'comp',
+        template: '<comp/>',
+        standalone: true
+      })
+      export class MyComp {}
+    `));
+  });
+
   it('should not generate a forwardRef when adding an imported module dependency', async () => {
     writeFile('./comp.ts', `
       import {Component, NgModule} from '@angular/core';


### PR DESCRIPTION
This commit fixes the migrations for recursive components.

Before this fix, the migration was creating a forwardRef to the Component itself. 

fixes #50525

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] No