### PR TITLE
fix(core): Discard self-imports on standalone components.

### DIFF
--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -242,9 +242,10 @@ function getStandaloneDefFunctions(type: Type<any>, imports: Type<any>[]): {
   let cachedPipeDefs: PipeDefList|null = null;
   const directiveDefs = () => {
     if (cachedDirectiveDefs === null) {
+      const selfDefinition = getComponentDef(type)!;
       // Standalone components are always able to self-reference, so include the component's own
       // definition in its `directiveDefs`.
-      cachedDirectiveDefs = [getComponentDef(type)!];
+      cachedDirectiveDefs = [selfDefinition];
       const seen = new Set<Type<unknown>>();
 
       for (const rawDep of imports) {
@@ -267,7 +268,7 @@ function getStandaloneDefFunctions(type: Type<any>, imports: Type<any>[]): {
           }
         } else {
           const def = getComponentDef(dep) || getDirectiveDef(dep);
-          if (def) {
+          if (def && def !== selfDefinition) {
             cachedDirectiveDefs.push(def);
           }
         }

--- a/packages/core/test/acceptance/standalone_spec.ts
+++ b/packages/core/test/acceptance/standalone_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {CommonModule} from '@angular/common';
+import {CommonModule, NgIf} from '@angular/common';
 import {Component, createEnvironmentInjector, Directive, EnvironmentInjector, forwardRef, Injector, Input, isStandalone, NgModule, NO_ERRORS_SCHEMA, OnInit, Pipe, PipeTransform, ViewChild, ViewContainerRef} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
@@ -943,6 +943,27 @@ describe('standalone components, directives, and pipes', () => {
       const fixture = TestBed.createComponent(StandaloneCmpC);
       fixture.detectChanges();
       expect(fixture.nativeElement.textContent).toBe('((A)B)C');
+    });
+
+    it('should not throw if a standalone component imports itself', () => {
+      @Component({
+        selector: 'comp',
+        template: '<comp *ngIf="recurse"/>',
+        standalone: true,
+        imports: [Comp, NgIf]
+      })
+      class Comp {
+        @Input() recurse = false;
+      }
+
+      @Component({template: '<comp [recurse]="true"/>', standalone: true, imports: [Comp]})
+      class App {
+      }
+
+      expect(() => {
+        const fixture = TestBed.createComponent(App);
+        fixture.detectChanges();
+      }).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
Before this fix, a self import would define the component twice in the `directiveRegistry` which would then fire a `NG0300` when compiled with the JIT.

fixes #50525
Note: #50554 also fixes #50525, there were two issues in one. 

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] No