### PR TITLE
docs: Fix punctuation for better consistency

### DIFF
--- a/aio/content/tutorial/tour-of-heroes/index.md
+++ b/aio/content/tutorial/tour-of-heroes/index.md
@@ -18,7 +18,7 @@ You can edit the application in StackBlitz and see the results in real time.
 This *Tour of Heroes* tutorial provides an introduction to the fundamentals of Angular and shows you how to:
 
 * Set up your local Angular development environment.
-* Use the [Angular CLI](cli "CLI command reference") to develop an application
+* Use the [Angular CLI](cli "CLI command reference") to develop an application.
 
 The *Tour of Heroes* application that you build helps a staffing agency manage its stable of heroes.
 The application has many of the features that you'd expect to find in any data-driven application.


### PR DESCRIPTION
This is to fix a punctuation issue on the "Tour of Heroes - Introduction" page for better consistency.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The bullet list under the `This Tour of Heroes tutorial provides an introduction to the fundamentals of Angular and shows you how to:` section has an inconsistency in punctuation.

Page to be modified: https://angular.io/tutorial/tour-of-heroes


## What is the new behavior?
The punctuation inconsistency issue in the bullet list under the line `This Tour of Heroes tutorial provides an introduction to the fundamentals of Angular and shows you how to:` has been fixed.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
