### PR TITLE
fix(core): wait for HTTP in `ngOnInit` correctly before server render

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -2,7 +2,7 @@
   "cli-hello-world": {
     "uncompressed": {
       "runtime": 908,
-      "main": 129295,
+      "main": 134468,
       "polyfills": 33792
     }
   },
@@ -24,14 +24,14 @@
   "forms": {
     "uncompressed": {
       "runtime": 888,
-      "main": 160778,
+      "main": 166256,
       "polyfills": 33772
     }
   },
   "animations": {
     "uncompressed": {
       "runtime": 898,
-      "main": 159461,
+      "main": 164757,
       "polyfills": 33782
     }
   },

--- a/integration/platform-server/e2e/src/http-transferstate-lazy-on-init-spec.ts
+++ b/integration/platform-server/e2e/src/http-transferstate-lazy-on-init-spec.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {browser, by, element} from 'protractor';
+import {bootstrapClientApp, navigateTo, verifyNoBrowserErrors} from './util';
+
+describe('Http TransferState Lazy On Init', () => {
+  beforeEach(async () => {
+    // Don't wait for Angular since it is not bootstrapped automatically.
+    await browser.waitForAngularEnabled(false);
+
+    // Load the page without waiting for Angular since it is not bootstrapped automatically.
+    await navigateTo('http-transferstate-lazy-on-init');
+  });
+
+  afterEach(async () => {
+    // Make sure there were no client side errors.
+    await verifyNoBrowserErrors();
+  });
+
+  it('should transfer http state in lazy component', async () => {
+    // Test the contents from the server.
+    expect(await element(by.css('div.one')).getText()).toBe('API 1 response');
+
+    // Bootstrap the client side app and retest the contents
+    await bootstrapClientApp();
+    expect(await element(by.css('div.one')).getText()).toBe('API 1 response');
+
+    // Validate that there were no HTTP calls to '/api'.
+    const requests = await browser.executeScript(() => {
+      return performance.getEntriesByType('resource');
+    });
+    const apiRequests = (requests as {name: string}[])
+      .filter(({name}) => name.includes('/api'))
+      .map(({name}) => name);
+
+    expect(apiRequests).toEqual([]);
+  });
+});

--- a/integration/platform-server/projects/ngmodule/src/app/app-routing.module.ts
+++ b/integration/platform-server/projects/ngmodule/src/app/app-routing.module.ts
@@ -19,6 +19,13 @@ const routes: Routes = [
         (m) => m.HttpTransferStateModule
       ),
   },
+  {
+    path: 'http-transferstate-lazy-on-init',
+    loadChildren: () =>
+      import('./http-transferstate-lazy-on-init/http-transferstate-lazy-on-init.module').then(
+        (m) => m.HttpTransferStateOnInitModule
+      ),
+  },
 ];
 
 @NgModule({

--- a/integration/platform-server/projects/ngmodule/src/app/http-transferstate-lazy-on-init/http-transferstate-lazy-on-init.component.ts
+++ b/integration/platform-server/projects/ngmodule/src/app/http-transferstate-lazy-on-init/http-transferstate-lazy-on-init.component.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HttpClient} from '@angular/common/http';
+import {Component, OnInit} from '@angular/core';
+
+@Component({
+  selector: 'transfer-state-http-on-init',
+  template: ` <div class="one">{{ responseOne }}</div> `,
+})
+export class TransferStateComponentOnInit implements OnInit {
+  responseOne: string = '';
+
+  constructor(private readonly httpClient: HttpClient) {}
+
+  ngOnInit(): void {
+    // Test that HTTP cache works when HTTP call is made in a lifecycle hook.
+    this.httpClient.get<any>('http://localhost:4206/api').subscribe((response) => {
+      this.responseOne = response.data;
+    });
+  }
+}

--- a/integration/platform-server/projects/ngmodule/src/app/http-transferstate-lazy-on-init/http-transferstate-lazy-on-init.module.ts
+++ b/integration/platform-server/projects/ngmodule/src/app/http-transferstate-lazy-on-init/http-transferstate-lazy-on-init.module.ts
@@ -1,0 +1,18 @@
+import {CommonModule} from '@angular/common';
+import {HttpClientModule} from '@angular/common/http';
+import {NgModule} from '@angular/core';
+import {RouterModule, Routes} from '@angular/router';
+import {TransferStateComponentOnInit} from './http-transferstate-lazy-on-init.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: TransferStateComponentOnInit,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes), HttpClientModule, CommonModule],
+  declarations: [TransferStateComponentOnInit],
+})
+export class HttpTransferStateOnInitModule {}

--- a/integration/platform-server/projects/standalone/src/app/app.routes.ts
+++ b/integration/platform-server/projects/standalone/src/app/app.routes.ts
@@ -18,4 +18,11 @@ export const routes: Routes = [
         (c) => c.TransferStateComponent
       ),
   },
+  {
+    path: 'http-transferstate-lazy-on-init',
+    loadComponent: () =>
+      import('./http-transferstate-lazy-on-init/http-transfer-state-on-init.component').then(
+        (c) => c.TransferStateOnInitComponent
+      ),
+  },
 ];

--- a/integration/platform-server/projects/standalone/src/app/http-transferstate-lazy-on-init/http-transfer-state-on-init.component.ts
+++ b/integration/platform-server/projects/standalone/src/app/http-transferstate-lazy-on-init/http-transfer-state-on-init.component.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {HttpClient} from '@angular/common/http';
+import {Component, OnInit} from '@angular/core';
+
+@Component({
+  selector: 'transfer-state-http',
+  standalone: true,
+  template: ` <div class="one">{{ responseOne }}</div> `,
+  providers: [HttpClient],
+})
+export class TransferStateOnInitComponent implements OnInit {
+  responseOne: string = '';
+
+  constructor(private readonly httpClient: HttpClient) {}
+
+  ngOnInit(): void {
+    // Test that HTTP cache works when HTTP call is made in a lifecycle hook.
+    this.httpClient.get<any>('http://localhost:4206/api').subscribe((response) => {
+      this.responseOne = response.data;
+    });
+  }
+}

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -9,7 +9,7 @@
 import './util/ng_jit_mode';
 
 import {Observable, of, Subscription} from 'rxjs';
-import {distinctUntilChanged, mergeMap, share} from 'rxjs/operators';
+import {distinctUntilChanged, share, switchMap} from 'rxjs/operators';
 
 import {ApplicationInitStatus} from './application_init';
 import {PLATFORM_INITIALIZER} from './application_tokens';
@@ -847,7 +847,7 @@ export class ApplicationRef {
   public readonly isStable: Observable<boolean> =
       inject(InitialRenderPendingTasks)
           .hasPendingTasks.pipe(
-              mergeMap(hasPendingTasks => hasPendingTasks ? of(false) : this.zoneIsStable),
+              switchMap(hasPendingTasks => hasPendingTasks ? of(false) : this.zoneIsStable),
               distinctUntilChanged(),
               share(),
           );

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -501,6 +501,12 @@
     "name": "Subscription"
   },
   {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -864,6 +870,9 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
     "name": "fromArray"
   },
   {
@@ -1047,6 +1056,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1188,6 +1200,9 @@
     "name": "makeTimingAst"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAsComponentHost"
   },
   {
@@ -1198,6 +1213,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1420,6 +1438,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -543,6 +543,12 @@
     "name": "Subscription"
   },
   {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -927,6 +933,9 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
     "name": "fromArray"
   },
   {
@@ -1113,6 +1122,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1254,6 +1266,9 @@
     "name": "makeTimingAst"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAsComponentHost"
   },
   {
@@ -1264,6 +1279,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1495,6 +1513,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -408,6 +408,12 @@
     "name": "Subscription"
   },
   {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -702,6 +708,9 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
     "name": "fromArray"
   },
   {
@@ -879,6 +888,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -993,6 +1005,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAsComponentHost"
   },
   {
@@ -1003,6 +1018,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1186,6 +1204,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -549,6 +549,12 @@
     "name": "Subscription"
   },
   {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -1212,6 +1218,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1390,6 +1399,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeErrors"
@@ -1651,6 +1663,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -537,6 +537,12 @@
     "name": "Subscription"
   },
   {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -1176,6 +1182,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1348,6 +1357,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeErrors"
@@ -1627,6 +1639,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -315,6 +315,12 @@
     "name": "Subscription"
   },
   {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -549,6 +555,9 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
     "name": "fromArray"
   },
   {
@@ -699,6 +708,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -780,6 +792,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markViewDirty"
   },
   {
@@ -787,6 +802,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -934,6 +952,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -459,6 +459,12 @@
     "name": "Subscription"
   },
   {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -759,6 +765,9 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
     "name": "fromArray"
   },
   {
@@ -939,6 +948,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1059,6 +1071,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markViewDirty"
   },
   {
@@ -1066,6 +1081,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1246,6 +1264,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwIfEmpty"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -375,6 +375,12 @@
     "name": "Subscription"
   },
   {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -627,6 +633,9 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
     "name": "fromArray"
   },
   {
@@ -783,6 +792,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -873,6 +885,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markViewDirty"
   },
   {
@@ -880,6 +895,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1036,6 +1054,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -438,6 +438,12 @@
     "name": "Subscription"
   },
   {
+    "name": "SwitchMapOperator"
+  },
+  {
+    "name": "SwitchMapSubscriber"
+  },
+  {
     "name": "TESTABILITY"
   },
   {
@@ -825,6 +831,9 @@
     "name": "forwardRef"
   },
   {
+    "name": "from"
+  },
+  {
     "name": "fromArray"
   },
   {
@@ -1050,6 +1059,9 @@
     "name": "injectableDefOrInjectorDefFactory"
   },
   {
+    "name": "innerSubscribe"
+  },
+  {
     "name": "insertBloom"
   },
   {
@@ -1188,6 +1200,9 @@
     "name": "makeRecord"
   },
   {
+    "name": "map"
+  },
+  {
     "name": "markAsComponentHost"
   },
   {
@@ -1201,6 +1216,9 @@
   },
   {
     "name": "maybeWrapInNotSelector"
+  },
+  {
+    "name": "mergeAll"
   },
   {
     "name": "mergeHostAttribute"
@@ -1411,6 +1429,9 @@
   },
   {
     "name": "subscribeToArray"
+  },
+  {
+    "name": "switchMap"
   },
   {
     "name": "throwProviderNotFoundError"


### PR DESCRIPTION
Previously, with `mergeMap` we did not cancel previous subscriptions to zoneIsStable which caused the application to be stablized before hand.

Closes: #50562
