### PR TITLE
fix(docs-infra): replace use of turbo on StackBlitz with npm

### DIFF
--- a/aio/tools/stackblitz-builder/builder.mjs
+++ b/aio/tools/stackblitz-builder/builder.mjs
@@ -139,11 +139,8 @@ export class StackblitzBuilder {
 
   _addStackblitzrc(postData) {
     postData['project[files][.stackblitzrc]'] = JSON.stringify({
-      installDependencies: true,
-      startCommand: 'turbo start',
-      env: {
-        ENABLE_CJS_IMPORTS: true
-      }
+      installDependencies: false,
+      startCommand: 'npm install --legacy-peer-deps && npm start'
     });
   }
 


### PR DESCRIPTION
`turbo` is being deprecated (EOL planned for Q1 2024) and can be replaced by `npm` with some tweaks. In particular, the installation step needs `--legacy-peer-deps` to mimic `turbo`'s behaviour.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Explicit use of `turbo` on stackblitz.


## What is the new behavior?

Use `npm` in place of `turbo` on StackBlitz.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

In the coming weeks using `npm` on StackBlitz will actually use the real `npm` instead of a shim on top of `turbo`. :tada: 