### PR TITLE
refactor(common): use `transform` functions in NgOptimizedImage inputs

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -599,19 +599,23 @@ export abstract class NgLocalization {
 
 // @public
 export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
-    set disableOptimizedSrcset(value: string | boolean | undefined);
-    // (undocumented)
-    get disableOptimizedSrcset(): boolean;
-    set fill(value: string | boolean | undefined);
-    // (undocumented)
-    get fill(): boolean;
-    set height(value: string | number | undefined);
-    // (undocumented)
-    get height(): number | undefined;
+    disableOptimizedSrcset: boolean;
+    fill: boolean;
+    height: number | undefined;
     loaderParams?: {
         [key: string]: any;
     };
     loading?: 'lazy' | 'eager' | 'auto';
+    // (undocumented)
+    static ngAcceptInputType_disableOptimizedSrcset: unknown;
+    // (undocumented)
+    static ngAcceptInputType_fill: unknown;
+    // (undocumented)
+    static ngAcceptInputType_height: unknown;
+    // (undocumented)
+    static ngAcceptInputType_priority: unknown;
+    // (undocumented)
+    static ngAcceptInputType_width: unknown;
     // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
@@ -620,15 +624,11 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     ngOnInit(): void;
     ngSrc: string;
     ngSrcset: string;
-    set priority(value: string | boolean | undefined);
-    // (undocumented)
-    get priority(): boolean;
+    priority: boolean;
     sizes?: string;
-    set width(value: string | number | undefined);
+    width: number | undefined;
     // (undocumented)
-    get width(): number | undefined;
-    // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[ngSrc]", never, { "ngSrc": { "alias": "ngSrc"; "required": false; }; "ngSrcset": { "alias": "ngSrcset"; "required": false; }; "sizes": { "alias": "sizes"; "required": false; }; "width": { "alias": "width"; "required": false; }; "height": { "alias": "height"; "required": false; }; "loading": { "alias": "loading"; "required": false; }; "priority": { "alias": "priority"; "required": false; }; "loaderParams": { "alias": "loaderParams"; "required": false; }; "disableOptimizedSrcset": { "alias": "disableOptimizedSrcset"; "required": false; }; "fill": { "alias": "fill"; "required": false; }; "src": { "alias": "src"; "required": false; }; "srcset": { "alias": "srcset"; "required": false; }; }, {}, never, never, true, never, false>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<NgOptimizedImage, "img[ngSrc]", never, { "ngSrc": { "alias": "ngSrc"; "required": true; }; "ngSrcset": { "alias": "ngSrcset"; "required": false; }; "sizes": { "alias": "sizes"; "required": false; }; "width": { "alias": "width"; "required": false; }; "height": { "alias": "height"; "required": false; }; "loading": { "alias": "loading"; "required": false; }; "priority": { "alias": "priority"; "required": false; }; "loaderParams": { "alias": "loaderParams"; "required": false; }; "disableOptimizedSrcset": { "alias": "disableOptimizedSrcset"; "required": false; }; "fill": { "alias": "fill"; "required": false; }; "src": { "alias": "src"; "required": false; }; "srcset": { "alias": "srcset"; "required": false; }; }, {}, never, never, true, never, false>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<NgOptimizedImage, never>;
 }

--- a/packages/common/test/directives/ng_optimized_image_spec.ts
+++ b/packages/common/test/directives/ng_optimized_image_spec.ts
@@ -377,7 +377,7 @@ describe('Image directive', () => {
           .toThrowError(
               'NG02952: The NgOptimizedImage directive (activated on an <img> ' +
               'element with the `ngSrc="img.png"`) has detected that `width` ' +
-              'has an invalid value (`0`). To fix this, provide `width` as ' +
+              'has an invalid value. To fix this, provide `width` as ' +
               'a number greater than 0.');
     });
 
@@ -392,7 +392,7 @@ describe('Image directive', () => {
           .toThrowError(
               'NG02952: The NgOptimizedImage directive (activated on an <img> ' +
               'element with the `ngSrc="img.png"`) has detected that `width` ' +
-              'has an invalid value (`10px`). To fix this, provide `width` ' +
+              'has an invalid value. To fix this, provide `width` ' +
               'as a number greater than 0.');
     });
 
@@ -424,7 +424,7 @@ describe('Image directive', () => {
           .toThrowError(
               'NG02952: The NgOptimizedImage directive (activated on an <img> ' +
               'element with the `ngSrc="img.png"`) has detected that `height` ' +
-              'has an invalid value (`0`). To fix this, provide `height` as a number ' +
+              'has an invalid value. To fix this, provide `height` as a number ' +
               'greater than 0.');
     });
 
@@ -439,7 +439,7 @@ describe('Image directive', () => {
           .toThrowError(
               'NG02952: The NgOptimizedImage directive (activated on an <img> element ' +
               'with the `ngSrc="img.png"`) has detected that `height` has an invalid ' +
-              'value (`10%`). To fix this, provide `height` as a number greater than 0.');
+              'value. To fix this, provide `height` as a number greater than 0.');
     });
 
     it('should throw if `ngSrc` value is not provided', () => {


### PR DESCRIPTION
This commit refactors the code of NgOptimizedImage directive to switch from getter/setter approach to convert inputs to use the `transform` function instead.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No