### PR TITLE
test(compiler): Prevent back-sliding on already passing template pipeline tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "ng-dev": "ts-node --esm --project .ng-dev/tsconfig.json --transpile-only node_modules/@angular/ng-dev/bundles/cli.mjs",
     "build": "ts-node --esm --project scripts/tsconfig.json scripts/build/build-packages-dist.mts",
     "test": "bazelisk test",
-    "test:ci": "bazelisk test -- //... -//devtools/... -//aio/...",
+    "test:ci": "bazelisk test -- //... -//devtools/... -//aio/... && bazelisk test --//packages/compiler:use_template_pipeline //packages/compiler-cli/test/compliance/full",
     "test-tsec": "bazelisk test //... --build_tag_filters=tsec --test_tag_filters=tsec",
     "lint": "yarn -s tslint && yarn -s ng-dev format changed --check",
     "tslint": "tslint -c tslint.json --project tsconfig-tslint.json",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
@@ -69,7 +69,8 @@
             "constant_object_literals.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate a pure function for constant array literals",
@@ -83,7 +84,8 @@
             "constant_array_literals.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not share pure functions between null and object literals",
@@ -97,7 +99,8 @@
             "object_literals_null_vs_empty.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not share pure functions between null and array literals",
@@ -111,7 +114,8 @@
             "array_literals_null_vs_empty.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not share pure functions between null and function calls",
@@ -125,7 +129,8 @@
             "object_literals_null_vs_function.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should emit a valid setClassMetadata call in ES5 if a class with a custom decorator is referencing itself inside its own metadata",
@@ -159,7 +164,8 @@
             "ng_template_empty_binding.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support inline non-literal templates",
@@ -196,7 +202,9 @@
       "compilerOptions": {
         "baseUrl": ".",
         "paths": {
-          "external_library": ["./external_library"]
+          "external_library": [
+            "./external_library"
+          ]
         }
       }
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/content_projection/TEST_CASES.json
@@ -25,7 +25,8 @@
             }
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support multi-slot content projection with multiple wildcard slots",
@@ -39,7 +40,8 @@
             "multiple_wildcards.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support content projection in nested templates",
@@ -53,7 +55,8 @@
             "nested_template.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support content projection in both the root and nested templates",
@@ -67,7 +70,8 @@
             "root_and_nested.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should parse the selector that is passed into ngProjectAs",
@@ -81,7 +85,8 @@
             "ng_project_as_selector.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should take the first selector if multiple values are passed into ngProjectAs",
@@ -95,7 +100,8 @@
             "ng_project_as_compound_selector.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should include parsed ngProjectAs selectors into template attrs",
@@ -109,7 +115,8 @@
             "ng_project_as_attribute.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should capture the node name of ng-content with a structural directive",
@@ -123,7 +130,8 @@
             "ng_content_with_structural_dir.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/lifecycle_hooks/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/lifecycle_hooks/TEST_CASES.json
@@ -27,7 +27,8 @@
             "local_reference_nested.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support local refs mixed with context assignments",
@@ -41,7 +42,8 @@
             "local_reference_and_context_variables.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should gen hooks with a few simple components",
@@ -67,7 +69,8 @@
             }
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/pipes/TEST_CASES.json
@@ -52,7 +52,8 @@
             }
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should use appropriate function for a given no of pipe arguments",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/queries/TEST_CASES.json
@@ -87,7 +87,8 @@
             "content_query_for_directive.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support content queries with forwardRefs",
@@ -101,7 +102,8 @@
             "content_query_forward_ref.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support content queries with local refs",
@@ -130,7 +132,8 @@
             "static_content_query.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support content queries with read tokens specified",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/template_variables/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/template_variables/TEST_CASES.json
@@ -14,7 +14,8 @@
             "svg_embedded_view.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support a let variable and reference",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/value_composition/TEST_CASES.json
@@ -229,7 +229,8 @@
             "array_literals.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support 9+ bindings in array literals",
@@ -243,7 +244,8 @@
             "array_literals_many.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support object literals",
@@ -257,7 +259,8 @@
             "object_literals.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support expressions nested deeply in object/array literals",
@@ -271,7 +274,8 @@
             "literal_nested_expression.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support number literals with separators",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/TEST_CASES.json
@@ -25,7 +25,8 @@
           ],
           "failureMessage": "Incorrect generated template."
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle SVG with an embedded ng-template",
@@ -42,7 +43,8 @@
           ],
           "failureMessage": "Incorrect template."
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle MathML",
@@ -68,7 +70,8 @@
           ],
           "failureMessage": "Incorrect generated template."
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should translate DOM structure",
@@ -94,7 +97,8 @@
           ],
           "failureMessage": "Incorrect generated template."
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support namespaced attributes",
@@ -120,7 +124,8 @@
           ],
           "failureMessage": "Incorrect generated template."
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support <ng-container>",
@@ -194,7 +199,8 @@
           ],
           "failureMessage": "Incorrect generated template."
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should reserve slots for pure functions in host binding function",
@@ -231,7 +237,8 @@
           ],
           "failureMessage": "Incorrect generated template."
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should de-duplicate attribute arrays",
@@ -242,7 +249,8 @@
         {
           "failureMessage": "Incorrect generated template."
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should specify security-sensitive constant attributes as template literals",
@@ -253,7 +261,8 @@
         {
           "failureMessage": "Incorrect generated template."
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/animations/TEST_CASES.json
@@ -16,7 +16,8 @@
           ],
           "failureMessage": "Incorrect initialization attributes"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should dedup multiple [@event] listeners",
@@ -33,7 +34,8 @@
           ],
           "failureMessage": "Incorrect initialization attributes"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/any/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/any/TEST_CASES.json
@@ -16,7 +16,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should preserve $any if it is accessed through `this`",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/nullish_coalescing/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/nullish_coalescing/TEST_CASES.json
@@ -16,7 +16,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle nullish coalescing inside property bindings",
@@ -33,7 +34,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle nullish coalescing inside host bindings",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
@@ -16,7 +16,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle safe method calls inside templates",
@@ -33,7 +34,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle safe calls inside templates",
@@ -50,7 +52,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle non-null assertions after a safe access",
@@ -67,7 +70,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/attribute_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/attribute_bindings/TEST_CASES.json
@@ -13,7 +13,8 @@
             "chain_multiple_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple single-interpolation attribute bindings into one instruction",
@@ -27,7 +28,8 @@
             "chain_multiple_single_interpolation.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain attribute bindings in the presence of other bindings",
@@ -41,7 +43,8 @@
             "chain_multiple_bindings_mixed.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not add interpolated attributes to the attribute instruction chain",
@@ -55,7 +58,8 @@
             "chain_bindings_with_interpolations.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple attribute bindings when there are multiple elements",
@@ -69,7 +73,8 @@
             "chain_multiple_bindings_for_multiple_elements.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple attribute bindings when there are child elements",
@@ -83,7 +88,8 @@
             "chain_multiple_bindings_with_child_elements.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should exclude attribute bindings from the attributes array",
@@ -97,7 +103,8 @@
             "exclude_bindings_from_consts.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate the proper update instructions for interpolated attributes",
@@ -111,7 +118,8 @@
             "interpolated_attributes.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/non_bindable_behavior/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/non_bindable_behavior/TEST_CASES.json
@@ -13,7 +13,8 @@
             "local_ref_on_host.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not have local refs for nested elements",
@@ -27,7 +28,8 @@
             "local_ref_on_nested.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not process property bindings and listeners",
@@ -41,7 +43,8 @@
             "property_bindings_and_listeners.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not generate extra instructions for elements with no children",
@@ -55,7 +58,8 @@
             "no_child_elements.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
@@ -69,7 +69,8 @@
             "temporary_variables.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple property bindings into a single instruction",
@@ -97,7 +98,8 @@
             "chain_multiple_bindings_mixed.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not add interpolated properties to the property instruction chain",
@@ -111,7 +113,8 @@
             "chain_bindings_with_interpolations.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain synthetic property bindings together with regular property bindings",
@@ -125,7 +128,8 @@
             "chain_synthetic_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple property bindings on an ng-template",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/TEST_CASES.json
@@ -13,7 +13,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/element_attributes/TEST_CASES.json
@@ -13,7 +13,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support i18n attributes on explicit <ng-template> elements",
@@ -27,7 +28,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support i18n attributes on explicit <ng-template> with structural directives",
@@ -41,7 +43,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support i18n attributes with interpolations on explicit <ng-template> elements",
@@ -55,7 +58,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support i18n attributes with interpolations on explicit <ng-template> elements with structural directives",
@@ -69,7 +73,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not create translations for empty attributes",
@@ -97,7 +102,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should translate static attributes",
@@ -111,7 +117,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should translate static attributes when used on an element with structural directive",
@@ -125,7 +132,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support interpolation",
@@ -139,7 +147,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support interpolation with custom interpolation config",
@@ -153,7 +162,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should correctly bind to context in nested template",
@@ -167,7 +177,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support complex expressions in interpolation",
@@ -181,7 +192,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support complex expressions in interpolation",
@@ -195,7 +207,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should work correctly when placed on i18n root node",
@@ -209,7 +222,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should sanitize ids and generate proper variable names",
@@ -226,7 +240,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/es5_support/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/es5_support/TEST_CASES.json
@@ -16,7 +16,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/icu_logic/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/icu_logic/TEST_CASES.json
@@ -13,7 +13,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should properly escape quotes in content",
@@ -27,7 +28,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support ICU-only templates",
@@ -41,7 +43,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate i18n instructions for icus generated outside of i18n blocks",
@@ -55,7 +58,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support interpolation with custom interpolation config",
@@ -69,7 +73,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle icus with html",
@@ -83,7 +88,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle icus with expressions",
@@ -97,7 +103,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle multiple icus in one block",
@@ -111,7 +118,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle multiple icus that share same placeholder",
@@ -125,7 +133,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle nested icus",
@@ -139,7 +148,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "nested with interpolations in \"other\" blocks",
@@ -153,7 +163,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle icus in different contexts",
@@ -167,7 +178,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle icus with interpolations",
@@ -181,7 +193,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle icus with named interpolations",
@@ -195,7 +208,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should attach metadata in case an ICU represents the whole message",
@@ -209,7 +223,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should produce proper messages when `select` or `plural` keywords have spaces after them",
@@ -223,7 +238,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/line_ending_normalization/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/line_ending_normalization/TEST_CASES.json
@@ -23,7 +23,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should normalize line breaks for non-legacy messages in 'inline templates' where i18nNormalizeLineEndingsInICUs is false",
@@ -47,7 +48,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should normalize line breaks for non-legacy messages in 'external templates' where i18nNormalizeLineEndingsInICUs is true",
@@ -71,7 +73,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should normalize line breaks for non-legacy messages in 'external templates' where i18nNormalizeLineEndingsInICUs is false",
@@ -95,7 +98,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should compute normalized legacy ids for messages in inline templates where i18nNormalizeLineEndingsInICUs is true",
@@ -122,7 +126,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should compute normalized legacy ids for messages in inline templates where i18nNormalizeLineEndingsInICUs is false",
@@ -149,7 +154,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should compute normalized legacy ids for messages in external templates where i18nNormalizeLineEndingsInICUs is true",
@@ -170,7 +176,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should compute non-normalized legacy ids for messages in external templates where i18nNormalizeLineEndingsInICUs is false",
@@ -191,7 +198,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/localize_legacy_message_ids/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/localize_legacy_message_ids/TEST_CASES.json
@@ -19,7 +19,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not add legacy message ids if `enableI18nLegacyMessageIdFormat` is false",
@@ -36,7 +37,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/namespaces/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/namespaces/TEST_CASES.json
@@ -13,7 +13,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle namespaces on i18n block containers",
@@ -27,7 +28,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/TEST_CASES.json
@@ -13,7 +13,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should ignore HTML comments within translated text",
@@ -27,7 +28,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should properly escape quotes in content",
@@ -41,7 +43,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle interpolations wrapped in backticks",
@@ -55,7 +58,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle i18n attributes with plain-text content",
@@ -69,7 +73,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support named interpolations",
@@ -83,7 +88,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support interpolation with custom interpolation config",
@@ -97,7 +103,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support interpolations with complex expressions",
@@ -111,7 +118,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle i18n attributes with bindings in content",
@@ -125,7 +133,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle i18n attributes with bindings and nested elements in content",
@@ -139,7 +148,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle i18n attributes with bindings in content and element attributes",
@@ -153,7 +163,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle i18n attributes in nested templates",
@@ -167,7 +178,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should ignore i18n attributes on self-closing tags",
@@ -181,7 +193,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle i18n context in nested templates",
@@ -195,7 +208,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle i18n attribute with directives",
@@ -209,7 +223,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate event listeners instructions before i18n ones",
@@ -223,7 +238,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/ng-container_ng-template/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/ng-container_ng-template/TEST_CASES.json
@@ -13,7 +13,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle single translation message using <ng-template>",
@@ -27,7 +28,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should be able to act as child elements inside i18n block",
@@ -41,7 +43,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle ICUs outside of translatable sections",
@@ -55,7 +58,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should correctly propagate i18n context through nested templates",
@@ -69,7 +73,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should work with ICUs",
@@ -83,7 +88,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle self-closing tags as content",
@@ -97,7 +103,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not emit duplicate i18n consts for nested <ng-container>s",
@@ -123,7 +130,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate a self-closing container instruction for ng-container inside i18n",
@@ -137,7 +145,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not generate a self-closing container instruction for ng-container with non-text ",
@@ -151,7 +160,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle structural directives",
@@ -165,7 +175,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/self-closing_i18n_instructions/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/self-closing_i18n_instructions/TEST_CASES.json
@@ -13,7 +13,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should be generated for ICU-only i18n blocks",
@@ -27,7 +28,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should be generated within <ng-container> and <ng-template> blocks",
@@ -41,7 +43,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not be generated in case we have styling instructions",
@@ -55,7 +58,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/whitespace_preserving_mode/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/whitespace_preserving_mode/TEST_CASES.json
@@ -13,7 +13,8 @@
             "verifyUniqueConsts"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
@@ -16,7 +16,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create listener instruction on other components",
@@ -33,7 +34,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create multiple listener instructions that share a view snapshot",
@@ -76,7 +78,8 @@
           ],
           "failureMessage": "Incorrect factory"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple listeners on the same element",
@@ -93,7 +96,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple listeners across elements",
@@ -110,7 +114,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple listeners on the same template",
@@ -127,7 +132,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not generate the $event argument if it is not being used in a template",
@@ -195,7 +201,8 @@
           ],
           "failureMessage": "Incorrect event listener"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should preserve accesses to $event if it is done through `this` in a listener",
@@ -280,7 +287,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should reference correct context in listener inside embedded view",
@@ -297,7 +305,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/chaining/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/chaining/TEST_CASES.json
@@ -13,7 +13,8 @@
             "class_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain styleProp instruction calls",
@@ -27,7 +28,8 @@
             "style_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain mixed styleProp and classProp calls",
@@ -41,7 +43,8 @@
             "mixed_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain style interpolations of the same kind",
@@ -55,7 +58,8 @@
             "interpolations_equal_arity.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain style interpolations of multiple kinds",
@@ -69,7 +73,8 @@
             "interpolations_different_arity.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should break into multiple chains if there are other styling instructions in between",
@@ -83,7 +88,8 @@
             "break_different_instructions.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should break into multiple chains if there are other styling interpolation instructions in between",
@@ -97,7 +103,8 @@
             "break_different_interpolation_instructions.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain styling instructions inside host bindings",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/class_bindings/TEST_CASES.json
@@ -13,7 +13,8 @@
             "class_binding.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should place initial, multi, singular and application followed by attribute class instructions in the template code in that order",
@@ -27,7 +28,8 @@
             "class_ordering.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not generate the styling apply instruction if there are only static style/class attributes",
@@ -41,7 +43,8 @@
             "static_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not create instructions for empty class bindings",
@@ -55,7 +58,8 @@
             "empty_class_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_animations/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_animations/TEST_CASES.json
@@ -41,7 +41,8 @@
             "animation_property_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate animation listeners",
@@ -55,7 +56,8 @@
             "animation_listeners.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate animation host binding and listener code for directives",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/TEST_CASES.json
@@ -53,7 +53,8 @@
             }
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support class interpolation",
@@ -67,7 +68,8 @@
             "class_interpolation.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support style interpolation",
@@ -81,7 +83,8 @@
             "style_interpolation.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate styling instructions for multiple directives that contain host binding definitions",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/interpolations/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/interpolations/TEST_CASES.json
@@ -13,7 +13,8 @@
             "class_interpolations.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate the proper update instructions for interpolated style properties",
@@ -27,7 +28,8 @@
             "style_properties.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate update instructions for interpolated style properties with a suffix",
@@ -41,7 +43,8 @@
             "style_binding_suffixed.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate update instructions for interpolated style properties with a sanitizer",
@@ -55,7 +58,8 @@
             "style_binding_sanitizer.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate update instructions for interpolated style properties with !important",
@@ -69,7 +73,8 @@
             "style_binding_important.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/invalid/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/invalid/TEST_CASES.json
@@ -17,7 +17,8 @@
       ],
       "compilationModeFilter": [
         "full compile"
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/mixed_style_and_class/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/mixed_style_and_class/TEST_CASES.json
@@ -13,7 +13,8 @@
             "mixed.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should stamp out pipe definitions in the creation block if used by styling bindings",
@@ -27,7 +28,8 @@
             "pipe_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should properly offset multiple style pipe references for styling bindings",
@@ -41,7 +43,8 @@
             "pipe_bindings_slots.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should always generate advance() statements before any styling instructions",
@@ -55,7 +58,8 @@
             "multiple_elements.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
@@ -13,7 +13,8 @@
             "style_binding.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should correctly count the total slots required when style/class bindings include interpolation",
@@ -27,7 +28,8 @@
             "binding_slots.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should place initial, multi, singular and application followed by attribute style instructions in the template code in that order",
@@ -41,7 +43,8 @@
             "binding_slots_interpolations.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should assign a sanitizer instance to the element style allocation instruction if any url-based properties are detected",
@@ -55,7 +58,8 @@
             "style_ordering.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support [style.foo.suffix] style bindings with a suffix",
@@ -69,7 +73,8 @@
             "style_binding_suffixed.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should not create instructions for empty style bindings",
@@ -83,7 +88,8 @@
             "empty_style_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/TEST_CASES.json
@@ -16,7 +16,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should correctly bind to context in nested template with many bindings",
@@ -84,7 +85,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should correctly skip contexts as needed",
@@ -135,7 +137,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support directive outputs on <ng-template>",
@@ -152,7 +155,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should allow directive inputs as an interpolated prop on <ng-template>",
@@ -195,7 +199,8 @@
           ],
           "failureMessage": "Incorrect outer template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create unique template function names even for similar nested template structures",
@@ -205,7 +210,11 @@
       "expectations": [
         {
           "extraChecks": [
-            ["verifyUniqueFunctions", "Template", 16]
+            [
+              "verifyUniqueFunctions",
+              "Template",
+              16
+            ]
           ]
         }
       ]
@@ -218,10 +227,15 @@
       "expectations": [
         {
           "extraChecks": [
-            ["verifyUniqueFunctions", "Template", 4]
+            [
+              "verifyUniqueFunctions",
+              "Template",
+              4
+            ]
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create unique listener function names even for similar nested template structures",
@@ -231,7 +245,11 @@
       "expectations": [
         {
           "extraChecks": [
-            ["verifyUniqueFunctions", "listener", 3]
+            [
+              "verifyUniqueFunctions",
+              "listener",
+              3
+            ]
           ]
         }
       ]
@@ -268,7 +286,8 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle shorthand property declarations in templates",

--- a/packages/compiler-cli/test/compliance/test_cases/source_mapping/external_templates/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/source_mapping/external_templates/TEST_CASES.json
@@ -12,7 +12,8 @@
       "compilerOptions": {
         "sourceMap": true,
         "inlineSources": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create external template source-mapping (linked compile)",
@@ -52,7 +53,8 @@
           ".",
           "extraRootDir"
         ]
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create correct mappings when templateUrl is in a different rootDir (linked compile)",
@@ -92,7 +94,8 @@
       "compilerOptions": {
         "sourceMap": true,
         "inlineSources": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle unusual escaped chars when source-mapping (linked compile)",

--- a/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/TEST_CASES.json
@@ -11,7 +11,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map simple element with content (partial compile)",
@@ -45,7 +46,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map void element (partial compile)",
@@ -79,7 +81,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a mix of interpolated and static content (partial compile)",
@@ -113,7 +116,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a complex interpolated expression (partial compile)",
@@ -147,7 +151,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map interpolated properties (partial compile)",
@@ -181,7 +186,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map interpolation with pipe (partial compile)",
@@ -215,7 +221,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a simple input binding expression (partial compile)",
@@ -249,7 +256,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a complex input binding expression (partial compile)",
@@ -283,7 +291,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a longhand input binding expression (partial compile)",
@@ -317,7 +326,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a simple output binding expression (partial compile)",
@@ -351,7 +361,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a complex output binding expression (partial compile)",
@@ -385,7 +396,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a longhand output binding expression (partial compile)",
@@ -419,7 +431,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a two-way binding expression (partial compile)",
@@ -453,7 +466,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a longhand two-way binding expression (partial compile)",
@@ -487,7 +501,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map a class input binding (partial compile)",
@@ -521,7 +536,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map *ngIf scenario (partial compile)",
@@ -555,7 +571,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map ng-template [ngIf] scenario (partial compile)",
@@ -589,7 +606,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map *ngFor scenario (partial compile)",
@@ -623,7 +641,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map ng-template [ngFor] scenario (partial compile)",
@@ -657,7 +676,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should map default and selected projection (partial compile)",
@@ -691,7 +711,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create simple i18n message source-mapping (partial compile)",
@@ -725,7 +746,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create placeholder i18n message source-mappings (partial compile)",
@@ -759,7 +781,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle encoded entities in i18n message source-mappings (partial compile)",
@@ -793,7 +816,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should correctly handle collapsed whitespace in interpolation placeholder i18n message source-mappings (partial compile)",
@@ -827,7 +851,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should correctly handle collapsed whitespace in element placeholder i18n message source-mappings (partial compile)",
@@ -861,7 +886,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create tag (container) placeholder i18n message source-mappings (partial compile)",
@@ -895,7 +921,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create (simple string) inline template source-mapping (partial compile)",
@@ -929,7 +956,8 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      }
+      },
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should create correct inline template source-mapping when the source contains escape sequences (partial compile)",

--- a/packages/compiler-cli/test/compliance/test_cases/test_case_schema.json
+++ b/packages/compiler-cli/test/compliance/test_cases/test_case_schema.json
@@ -133,6 +133,10 @@
             "title": "Additional options to pass to the Angular compiler",
             "type": "object"
           },
+          "skipForTemplatePipeline": {
+            "tite": "Set to true to skip this test when running with use_template_pipeline",
+            "type": "boolean"
+          },
           "focusTest": {
             "title": "Set to true to focus on this test - equivalent to jasmine's `fit()` function",
             "type": "boolean"

--- a/packages/compiler-cli/test/compliance/test_helpers/BUILD.bazel
+++ b/packages/compiler-cli/test/compliance/test_helpers/BUILD.bazel
@@ -18,6 +18,7 @@ ts_library(
         "//packages/compiler-cli/src/ngtsc/logging",
         "//packages/compiler-cli/src/ngtsc/sourcemaps",
         "//packages/compiler-cli/src/ngtsc/testing",
+        "//packages/compiler/src/template/pipeline/switch",
         "@npm//@bazel/runfiles",
         "@npm//typescript",
     ],

--- a/packages/compiler-cli/test/compliance/test_helpers/get_compliance_tests.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/get_compliance_tests.ts
@@ -52,6 +52,7 @@ export function* getComplianceTests(absTestConfigPath: AbsoluteFsPath): Generato
       expectations: parseExpectations(test.expectations, realTestPath, inputFiles),
       compilerOptions: getConfigOptions(test, 'compilerOptions', realTestPath),
       angularCompilerOptions: getConfigOptions(test, 'angularCompilerOptions', realTestPath),
+      skipForTemplatePipeline: test.skipForTemplatePipeline,
       focusTest: test.focusTest,
       excludeTest: test.excludeTest,
     };
@@ -243,6 +244,8 @@ export interface ComplianceTest {
   compilationModeFilter: CompilationMode[];
   /** A list of expectations to check for this test case. */
   expectations: Expectation[];
+  /** If set to `true` this test is skipped when testing with use_template_pipeline */
+  skipForTemplatePipeline?: boolean;
   /** If set to `true`, then focus on this test (equivalent to jasmine's 'fit()`). */
   focusTest?: boolean;
   /** If set to `true`, then exclude this test (equivalent to jasmine's 'xit()`). */
@@ -306,6 +309,7 @@ export interface TestCaseJson {
   };
   compilerOptions?: ConfigOptions;
   angularCompilerOptions?: ConfigOptions;
+  skipForTemplatePipeline?: boolean;
   focusTest?: boolean;
   excludeTest?: boolean;
 }

--- a/packages/compiler-cli/test/compliance/test_helpers/test_runner.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/test_runner.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {USE_TEMPLATE_PIPELINE} from '../../../../compiler/src/template/pipeline/switch';
 import {FileSystem} from '../../../src/ngtsc/file_system';
 
 import {checkErrors, checkNoUnexpectedErrors} from './check_errors';
@@ -23,6 +24,9 @@ export function runTests(
   describe(`compliance tests (${type})`, () => {
     for (const test of getAllComplianceTests()) {
       if (!test.compilationModeFilter.includes(type)) {
+        continue;
+      }
+      if (USE_TEMPLATE_PIPELINE && test.skipForTemplatePipeline) {
         continue;
       }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
All tests run, even ones for features not yet implemented in the template pipeline, this prevented the tests from running on CI, as the status would be red.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Adds support to testing infrastructure to skip specific tests when running with the new template pipeline. This allows the already passing tests to run on CI.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
