### PR TITLE
refactor(router): use transform to coerce input values

### DIFF
--- a/goldens/public-api/router/index.md
+++ b/goldens/public-api/router/index.md
@@ -793,24 +793,24 @@ class RouterLink implements OnChanges, OnDestroy {
     fragment?: string;
     href: string | null;
     // (undocumented)
+    static ngAcceptInputType_preserveFragment: unknown;
+    // (undocumented)
+    static ngAcceptInputType_replaceUrl: unknown;
+    // (undocumented)
+    static ngAcceptInputType_skipLocationChange: unknown;
+    // (undocumented)
     ngOnChanges(changes: SimpleChanges): void;
     // (undocumented)
     ngOnDestroy(): any;
     // (undocumented)
     onClick(button: number, ctrlKey: boolean, shiftKey: boolean, altKey: boolean, metaKey: boolean): boolean;
-    set preserveFragment(preserveFragment: boolean | string | null | undefined);
-    // (undocumented)
-    get preserveFragment(): boolean;
+    preserveFragment: boolean;
     queryParams?: Params | null;
     queryParamsHandling?: QueryParamsHandling | null;
     relativeTo?: ActivatedRoute | null;
-    set replaceUrl(replaceUrl: boolean | string | null | undefined);
-    // (undocumented)
-    get replaceUrl(): boolean;
+    replaceUrl: boolean;
     set routerLink(commands: any[] | string | null | undefined);
-    set skipLocationChange(skipLocationChange: boolean | string | null | undefined);
-    // (undocumented)
-    get skipLocationChange(): boolean;
+    skipLocationChange: boolean;
     state?: {
         [k: string]: any;
     };

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -2031,6 +2031,9 @@
     "name": "ɵEmptyOutletComponent"
   },
   {
+    "name": "ɵɵInputTransformsFeature"
+  },
+  {
     "name": "ɵɵNgOnChangesFeature"
   },
   {

--- a/packages/router/src/directives/router_link.ts
+++ b/packages/router/src/directives/router_link.ts
@@ -120,10 +120,6 @@ import {UrlTree} from '../url_tree';
   standalone: true,
 })
 export class RouterLink implements OnChanges, OnDestroy {
-  private _preserveFragment = false;
-  private _skipLocationChange = false;
-  private _replaceUrl = false;
-
   /**
    * Represents an `href` attribute value applied to a host element,
    * when a host element is `<a>`. For other tags, the value is `null`.
@@ -210,14 +206,7 @@ export class RouterLink implements OnChanges, OnDestroy {
    * @see {@link UrlCreationOptions#preserveFragment UrlCreationOptions#preserveFragment}
    * @see {@link Router#createUrlTree Router#createUrlTree}
    */
-  @Input()
-  set preserveFragment(preserveFragment: boolean|string|null|undefined) {
-    this._preserveFragment = booleanAttribute(preserveFragment);
-  }
-
-  get preserveFragment(): boolean {
-    return this._preserveFragment;
-  }
+  @Input({transform: booleanAttribute}) preserveFragment: boolean = false;
 
   /**
    * Passed to {@link Router#navigateByUrl Router#navigateByUrl} as part of the
@@ -225,14 +214,7 @@ export class RouterLink implements OnChanges, OnDestroy {
    * @see {@link NavigationBehaviorOptions#skipLocationChange NavigationBehaviorOptions#skipLocationChange}
    * @see {@link Router#navigateByUrl Router#navigateByUrl}
    */
-  @Input()
-  set skipLocationChange(skipLocationChange: boolean|string|null|undefined) {
-    this._skipLocationChange = booleanAttribute(skipLocationChange);
-  }
-
-  get skipLocationChange(): boolean {
-    return this._skipLocationChange;
-  }
+  @Input({transform: booleanAttribute}) skipLocationChange: boolean = false;
 
   /**
    * Passed to {@link Router#navigateByUrl Router#navigateByUrl} as part of the
@@ -240,14 +222,7 @@ export class RouterLink implements OnChanges, OnDestroy {
    * @see {@link NavigationBehaviorOptions#replaceUrl NavigationBehaviorOptions#replaceUrl}
    * @see {@link Router#navigateByUrl Router#navigateByUrl}
    */
-  @Input()
-  set replaceUrl(replaceUrl: boolean|string|null|undefined) {
-    this._replaceUrl = booleanAttribute(replaceUrl);
-  }
-
-  get replaceUrl(): boolean {
-    return this._replaceUrl;
-  }
+  @Input({transform: booleanAttribute}) replaceUrl: boolean = false;
 
   /**
    * Modifies the tab index if there was not a tabindex attribute on the element during

--- a/packages/router/test/router_link_spec.ts
+++ b/packages/router/test/router_link_spec.ts
@@ -30,9 +30,20 @@ describe('RouterLink', () => {
   });
 
   describe('on a non-anchor', () => {
-    @Component({template: `<div [routerLink]="link"></div>`})
+    @Component({
+      template: `
+        <div
+          [routerLink]="link"
+          [preserveFragment]="preserveFragment"
+          [skipLocationChange]="skipLocationChange"
+          [replaceUrl]="replaceUrl"></div>
+      `
+    })
     class LinkComponent {
       link: string|null|undefined = '/';
+      preserveFragment: unknown;
+      skipLocationChange: unknown;
+      replaceUrl: unknown;
     }
     let fixture: ComponentFixture<LinkComponent>;
     let link: HTMLDivElement;
@@ -76,18 +87,20 @@ describe('RouterLink', () => {
       const dir = fixture.debugElement.query(By.directive(RouterLink)).injector.get(RouterLink);
 
       for (const truthy of [true, '', 'true', 'anything']) {
-        dir.preserveFragment = truthy;
-        dir.skipLocationChange = truthy;
-        dir.replaceUrl = truthy;
+        fixture.componentInstance.preserveFragment = truthy;
+        fixture.componentInstance.skipLocationChange = truthy;
+        fixture.componentInstance.replaceUrl = truthy;
+        fixture.detectChanges();
         expect(dir.preserveFragment).toBeTrue();
         expect(dir.skipLocationChange).toBeTrue();
         expect(dir.replaceUrl).toBeTrue();
       }
 
       for (const falsy of [false, null, undefined, 'false']) {
-        dir.preserveFragment = falsy;
-        dir.skipLocationChange = falsy;
-        dir.replaceUrl = falsy;
+        fixture.componentInstance.preserveFragment = falsy;
+        fixture.componentInstance.skipLocationChange = falsy;
+        fixture.componentInstance.replaceUrl = falsy;
+        fixture.detectChanges();
         expect(dir.preserveFragment).toBeFalse();
         expect(dir.skipLocationChange).toBeFalse();
         expect(dir.replaceUrl).toBeFalse();
@@ -97,9 +110,20 @@ describe('RouterLink', () => {
 
   describe('on an anchor', () => {
     describe('RouterLink for elements with `href` attributes', () => {
-      @Component({template: `<a [routerLink]="link"></a>`})
+      @Component({
+        template: `
+          <a
+            [routerLink]="link"
+            [preserveFragment]="preserveFragment"
+            [skipLocationChange]="skipLocationChange"
+            [replaceUrl]="replaceUrl"></a>
+        `
+      })
       class LinkComponent {
         link: string|null|undefined = '/';
+        preserveFragment: unknown;
+        skipLocationChange: unknown;
+        replaceUrl: unknown;
       }
       let fixture: ComponentFixture<LinkComponent>;
       let link: HTMLAnchorElement;
@@ -132,18 +156,20 @@ describe('RouterLink', () => {
         const dir = fixture.debugElement.query(By.directive(RouterLink)).injector.get(RouterLink);
 
         for (const truthy of [true, '', 'true', 'anything']) {
-          dir.preserveFragment = truthy;
-          dir.skipLocationChange = truthy;
-          dir.replaceUrl = truthy;
+          fixture.componentInstance.preserveFragment = truthy;
+          fixture.componentInstance.skipLocationChange = truthy;
+          fixture.componentInstance.replaceUrl = truthy;
+          fixture.detectChanges();
           expect(dir.preserveFragment).toBeTrue();
           expect(dir.skipLocationChange).toBeTrue();
           expect(dir.replaceUrl).toBeTrue();
         }
 
         for (const falsy of [false, null, undefined, 'false']) {
-          dir.preserveFragment = falsy;
-          dir.skipLocationChange = falsy;
-          dir.replaceUrl = falsy;
+          fixture.componentInstance.preserveFragment = falsy;
+          fixture.componentInstance.skipLocationChange = falsy;
+          fixture.componentInstance.replaceUrl = falsy;
+          fixture.detectChanges();
           expect(dir.preserveFragment).toBeFalse();
           expect(dir.skipLocationChange).toBeFalse();
           expect(dir.replaceUrl).toBeFalse();


### PR DESCRIPTION
Uses the new `transform` option for inputs instead of getters and setters to coerce the incoming values.