### PR TITLE
Template Pipeline: Null-Safety

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/GOLDEN_PARTIAL.js
@@ -64,6 +64,59 @@ export declare class MyModule {
 }
 
 /****************************************************************************************************
+ * PARTIAL FILE: safe_access_deep.js
+ ****************************************************************************************************/
+import { Component, NgModule } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.p = null;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+  <span>Safe Property: {{ p?.a?.b?.c?.d }}</span>
+  <span>Safe Keyed: {{ p?.['a']?.['b']?.['c']?.['d'] }}</span>
+  <span>Mixed Property: {{ p?.a?.b.c.d?.e?.f?.g.h }}</span>
+  <span>Mixed Property and Keyed: {{ p.a['b'].c.d?.['e']?.['f']?.g['h']['i']?.j.k }}</span>
+`, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+  <span>Safe Property: {{ p?.a?.b?.c?.d }}</span>
+  <span>Safe Keyed: {{ p?.['a']?.['b']?.['c']?.['d'] }}</span>
+  <span>Mixed Property: {{ p?.a?.b.c.d?.e?.f?.g.h }}</span>
+  <span>Mixed Property and Keyed: {{ p.a['b'].c.d?.['e']?.['f']?.g['h']['i']?.j.k }}</span>
+`
+                }]
+        }] });
+export class MyModule {
+}
+MyModule.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, deps: [], target: i0.ɵɵFactoryTarget.NgModule });
+MyModule.ɵmod = i0.ɵɵngDeclareNgModule({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, declarations: [MyApp] });
+MyModule.ɵinj = i0.ɵɵngDeclareInjector({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyModule, decorators: [{
+            type: NgModule,
+            args: [{ declarations: [MyApp] }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: safe_access_deep.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    p: any;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never, false>;
+}
+export declare class MyModule {
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyModule, never>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<MyModule, [typeof MyApp], never, never>;
+    static ɵinj: i0.ɵɵInjectorDeclaration<MyModule>;
+}
+
+/****************************************************************************************************
  * PARTIAL FILE: safe_method_call.js
  ****************************************************************************************************/
 import { Component } from '@angular/core';

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
@@ -20,6 +20,23 @@
       "skipForTemplatePipeline": true
     },
     {
+      "description": "should handle deep safe property reads inside templates",
+      "inputFiles": [
+        "safe_access_deep.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "safe_access_deep_template.js",
+              "generated": "safe_access_deep.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ]
+    },
+    {
       "description": "should handle safe method calls inside templates",
       "inputFiles": [
         "safe_method_call.ts"

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_deep.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_deep.ts
@@ -1,0 +1,17 @@
+import {Component, NgModule} from '@angular/core';
+
+@Component({
+  template: `
+  <span>Safe Property: {{ p?.a?.b?.c?.d }}</span>
+  <span>Safe Keyed: {{ p?.['a']?.['b']?.['c']?.['d'] }}</span>
+  <span>Mixed Property: {{ p?.a?.b.c.d?.e?.f?.g.h }}</span>
+  <span>Mixed Property and Keyed: {{ p.a['b'].c.d?.['e']?.['f']?.g['h']['i']?.j.k }}</span>
+`
+})
+export class MyApp {
+  p: any = null;
+}
+
+@NgModule({declarations: [MyApp]})
+export class MyModule {
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_deep_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/safe_access_deep_template.js
@@ -1,0 +1,10 @@
+} if (rf & 2) {
+  i0.ɵɵadvance(1);
+  i0.ɵɵtextInterpolate1("Safe Property: ", ctx.p == null ? null : ctx.p.a == null ? null : ctx.p.a.b == null ? null : ctx.p.a.b.c == null ? null : ctx.p.a.b.c.d, "");
+  i0.ɵɵadvance(2);
+  i0.ɵɵtextInterpolate1("Safe Keyed: ", ctx.p == null ? null : ctx.p["a"] == null ? null : ctx.p["a"]["b"] == null ? null : ctx.p["a"]["b"]["c"] == null ? null : ctx.p["a"]["b"]["c"]["d"], "");
+  i0.ɵɵadvance(2);
+  i0.ɵɵtextInterpolate1("Mixed Property: ", ctx.p == null ? null : ctx.p.a == null ? null : ctx.p.a.b.c.d == null ? null : ctx.p.a.b.c.d.e == null ? null : ctx.p.a.b.c.d.e.f == null ? null : ctx.p.a.b.c.d.e.f.g.h, "");
+  i0.ɵɵadvance(2);
+  i0.ɵɵtextInterpolate1("Mixed Property and Keyed: ", ctx.p.a["b"].c.d == null ? null : ctx.p.a["b"].c.d["e"] == null ? null : ctx.p.a["b"].c.d["e"]["f"] == null ? null : ctx.p.a["b"].c.d["e"]["f"].g["h"]["i"] == null ? null : ctx.p.a["b"].c.d["e"]["f"].g["h"]["i"].j.k, "");
+}

--- a/packages/compiler/src/compiler_util/expression_converter.ts
+++ b/packages/compiler/src/compiler_util/expression_converter.ts
@@ -874,6 +874,7 @@ class InterpolationExpression extends o.Expression {
   override isConstant = unsupported;
   override isEquivalent = unsupported;
   override visitExpression = unsupported;
+  override clone = unsupported;
 }
 
 class DefaultLocalResolver implements LocalResolver {

--- a/packages/compiler/src/constant_pool.ts
+++ b/packages/compiler/src/constant_pool.ts
@@ -71,6 +71,10 @@ class FixupExpression extends o.Expression {
     return true;
   }
 
+  override clone(): FixupExpression {
+    throw new Error(`Not supported.`);
+  }
+
   fixup(expression: o.Expression) {
     this.resolved = expression;
     this.shared = true;

--- a/packages/compiler/src/output/output_ast.ts
+++ b/packages/compiler/src/output/output_ast.ts
@@ -183,6 +183,8 @@ export abstract class Expression {
    */
   abstract isConstant(): boolean;
 
+  abstract clone(): Expression;
+
   prop(name: string, sourceSpan?: ParseSourceSpan|null): ReadPropExpr {
     return new ReadPropExpr(this, name, null, sourceSpan);
   }
@@ -287,6 +289,10 @@ export class ReadVarExpr extends Expression {
     return visitor.visitReadVarExpr(this, context);
   }
 
+  override clone(): ReadVarExpr {
+    return new ReadVarExpr(this.name, this.type, this.sourceSpan);
+  }
+
   set(value: Expression): WriteVarExpr {
     return new WriteVarExpr(this.name, value, null, this.sourceSpan);
   }
@@ -308,6 +314,10 @@ export class TypeofExpr extends Expression {
   override isConstant(): boolean {
     return this.expr.isConstant();
   }
+
+  override clone(): TypeofExpr {
+    return new TypeofExpr(this.expr.clone());
+  }
 }
 
 export class WrappedNodeExpr<T> extends Expression {
@@ -325,6 +335,10 @@ export class WrappedNodeExpr<T> extends Expression {
 
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitWrappedNodeExpr(this, context);
+  }
+
+  override clone(): WrappedNodeExpr<T> {
+    return new WrappedNodeExpr(this.node, this.type, this.sourceSpan);
   }
 }
 
@@ -346,6 +360,10 @@ export class WriteVarExpr extends Expression {
 
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitWriteVarExpr(this, context);
+  }
+
+  override clone(): WriteVarExpr {
+    return new WriteVarExpr(this.name, this.value.clone(), this.type, this.sourceSpan);
   }
 
   toDeclStmt(type?: Type|null, modifiers?: StmtModifier): DeclareVarStmt {
@@ -379,6 +397,11 @@ export class WriteKeyExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitWriteKeyExpr(this, context);
   }
+
+  override clone(): WriteKeyExpr {
+    return new WriteKeyExpr(
+        this.receiver.clone(), this.index.clone(), this.value.clone(), this.type, this.sourceSpan);
+  }
 }
 
 
@@ -403,6 +426,11 @@ export class WritePropExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitWritePropExpr(this, context);
   }
+
+  override clone(): WritePropExpr {
+    return new WritePropExpr(
+        this.receiver.clone(), this.name, this.value.clone(), this.type, this.sourceSpan);
+  }
 }
 
 export class InvokeFunctionExpr extends Expression {
@@ -423,6 +451,11 @@ export class InvokeFunctionExpr extends Expression {
 
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitInvokeFunctionExpr(this, context);
+  }
+
+  override clone(): InvokeFunctionExpr {
+    return new InvokeFunctionExpr(
+        this.fn.clone(), this.args.map(arg => arg.clone()), this.type, this.sourceSpan, this.pure);
   }
 }
 
@@ -448,6 +481,11 @@ export class TaggedTemplateExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitTaggedTemplateExpr(this, context);
   }
+
+  override clone(): TaggedTemplateExpr {
+    return new TaggedTemplateExpr(
+        this.tag.clone(), this.template.clone(), this.type, this.sourceSpan);
+  }
 }
 
 
@@ -470,6 +508,11 @@ export class InstantiateExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitInstantiateExpr(this, context);
   }
+
+  override clone(): InstantiateExpr {
+    return new InstantiateExpr(
+        this.classExpr.clone(), this.args.map(arg => arg.clone()), this.type, this.sourceSpan);
+  }
 }
 
 
@@ -491,10 +534,19 @@ export class LiteralExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitLiteralExpr(this, context);
   }
+
+  override clone(): LiteralExpr {
+    return new LiteralExpr(this.value, this.type, this.sourceSpan);
+  }
 }
 
 export class TemplateLiteral {
   constructor(public elements: TemplateLiteralElement[], public expressions: Expression[]) {}
+
+  clone(): TemplateLiteral {
+    return new TemplateLiteral(
+        this.elements.map(el => el.clone()), this.expressions.map(expr => expr.clone()));
+  }
 }
 export class TemplateLiteralElement {
   rawText: string;
@@ -507,6 +559,10 @@ export class TemplateLiteralElement {
     // indicate the end of the template literal element.
     this.rawText =
         rawText ?? sourceSpan?.toString() ?? escapeForTemplateLiteral(escapeSlashes(text));
+  }
+
+  clone(): TemplateLiteralElement {
+    return new TemplateLiteralElement(this.text, this.sourceSpan, this.rawText);
   }
 }
 
@@ -553,6 +609,12 @@ export class LocalizedString extends Expression {
 
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitLocalizedString(this, context);
+  }
+
+  override clone(): LocalizedString {
+    return new LocalizedString(
+        this.metaBlock, this.messageParts, this.placeHolderNames,
+        this.expressions.map(expr => expr.clone()), this.sourceSpan);
   }
 
   /**
@@ -681,6 +743,10 @@ export class ExternalExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitExternalExpr(this, context);
   }
+
+  override clone(): ExternalExpr {
+    return new ExternalExpr(this.value, this.type, this.typeParams, this.sourceSpan);
+  }
 }
 
 export class ExternalReference {
@@ -711,6 +777,12 @@ export class ConditionalExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitConditionalExpr(this, context);
   }
+
+  override clone(): ConditionalExpr {
+    return new ConditionalExpr(
+        this.condition.clone(), this.trueCase.clone(), this.falseCase?.clone(), this.type,
+        this.sourceSpan);
+  }
 }
 
 
@@ -730,6 +802,10 @@ export class NotExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitNotExpr(this, context);
   }
+
+  override clone(): NotExpr {
+    return new NotExpr(this.condition.clone(), this.sourceSpan);
+  }
 }
 
 export class FnParam {
@@ -737,6 +813,10 @@ export class FnParam {
 
   isEquivalent(param: FnParam): boolean {
     return this.name === param.name;
+  }
+
+  clone(): FnParam {
+    return new FnParam(this.name, this.type);
   }
 }
 
@@ -765,6 +845,12 @@ export class FunctionExpr extends Expression {
     return new DeclareFunctionStmt(
         name, this.params, this.statements, this.type, modifiers, this.sourceSpan);
   }
+
+  override clone(): FunctionExpr {
+    // TODO: Should we deep clone statements?
+    return new FunctionExpr(
+        this.params.map(p => p.clone()), this.statements, this.type, this.sourceSpan, this.name);
+  }
 }
 
 
@@ -786,6 +872,11 @@ export class UnaryOperatorExpr extends Expression {
 
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitUnaryOperatorExpr(this, context);
+  }
+
+  override clone(): UnaryOperatorExpr {
+    return new UnaryOperatorExpr(
+        this.operator, this.expr.clone(), this.type, this.sourceSpan, this.parens);
   }
 }
 
@@ -810,6 +901,11 @@ export class BinaryOperatorExpr extends Expression {
 
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitBinaryOperatorExpr(this, context);
+  }
+
+  override clone(): BinaryOperatorExpr {
+    return new BinaryOperatorExpr(
+        this.operator, this.lhs.clone(), this.rhs.clone(), this.type, this.sourceSpan, this.parens);
   }
 }
 
@@ -837,6 +933,10 @@ export class ReadPropExpr extends Expression {
   set(value: Expression): WritePropExpr {
     return new WritePropExpr(this.receiver, this.name, value, null, this.sourceSpan);
   }
+
+  override clone(): ReadPropExpr {
+    return new ReadPropExpr(this.receiver.clone(), this.name, this.type, this.sourceSpan);
+  }
 }
 
 
@@ -863,6 +963,10 @@ export class ReadKeyExpr extends Expression {
   set(value: Expression): WriteKeyExpr {
     return new WriteKeyExpr(this.receiver, this.index, value, null, this.sourceSpan);
   }
+
+  override clone(): ReadKeyExpr {
+    return new ReadKeyExpr(this.receiver, this.index.clone(), this.type, this.sourceSpan);
+  }
 }
 
 
@@ -883,12 +987,20 @@ export class LiteralArrayExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitLiteralArrayExpr(this, context);
   }
+
+  clone(): LiteralArrayExpr {
+    return new LiteralArrayExpr(this.entries.map(e => e.clone()), this.type, this.sourceSpan);
+  }
 }
 
 export class LiteralMapEntry {
   constructor(public key: string, public value: Expression, public quoted: boolean) {}
   isEquivalent(e: LiteralMapEntry): boolean {
     return this.key === e.key && this.value.isEquivalent(e.value);
+  }
+
+  clone(): LiteralMapEntry {
+    return new LiteralMapEntry(this.key, this.value.clone(), this.quoted);
   }
 }
 
@@ -913,6 +1025,11 @@ export class LiteralMapExpr extends Expression {
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitLiteralMapExpr(this, context);
   }
+
+  override clone(): LiteralMapExpr {
+    const entriesClone = this.entries.map(entry => entry.clone());
+    return new LiteralMapExpr(entriesClone, this.type as MapType | null, this.sourceSpan);
+  }
 }
 
 export class CommaExpr extends Expression {
@@ -930,6 +1047,10 @@ export class CommaExpr extends Expression {
 
   override visitExpression(visitor: ExpressionVisitor, context: any): any {
     return visitor.visitCommaExpr(this, context);
+  }
+
+  override clone(): CommaExpr {
+    return new CommaExpr(this.parts.map(p => p.clone()));
   }
 }
 

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -167,6 +167,26 @@ export enum ExpressionKind {
    * Binding to a pipe transformation with a variable number of arguments.
    */
   PipeBindingVariadic,
+
+  /*
+   * A safe property read requiring expansion into a null check.
+   */
+  SafePropertyRead,
+
+  /**
+   * A safe keyed read requiring expansion into a null check.
+   */
+  SafeKeyedRead,
+
+  /**
+   * A safe function call requiring expansion into a null check.
+   */
+  SafeInvokeFunction,
+
+  /**
+   * An intermediate expression that will be expanded from a safe read into an explicit ternary.
+   */
+  SafeTernaryExpr,
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -75,6 +75,10 @@ export class LexicalReadExpr extends ExpressionBase {
   }
 
   override transformInternalExpressions(): void {}
+
+  override clone(): LexicalReadExpr {
+    return new LexicalReadExpr(this.name);
+  }
 }
 
 /**
@@ -102,6 +106,12 @@ export class ReferenceExpr extends ExpressionBase implements UsesSlotIndexTrait 
   }
 
   override transformInternalExpressions(): void {}
+
+  override clone(): ReferenceExpr {
+    const expr = new ReferenceExpr(this.target, this.offset);
+    expr.slot = this.slot;
+    return expr;
+  }
 }
 
 /**
@@ -125,6 +135,10 @@ export class ContextExpr extends ExpressionBase {
   }
 
   override transformInternalExpressions(): void {}
+
+  override clone(): ContextExpr {
+    return new ContextExpr(this.view);
+  }
 }
 
 /**
@@ -150,6 +164,12 @@ export class NextContextExpr extends ExpressionBase {
   }
 
   override transformInternalExpressions(): void {}
+
+  override clone(): NextContextExpr {
+    const expr = new NextContextExpr();
+    expr.steps = this.steps;
+    return expr;
+  }
 }
 
 /**
@@ -176,6 +196,10 @@ export class GetCurrentViewExpr extends ExpressionBase {
   }
 
   override transformInternalExpressions(): void {}
+
+  override clone(): GetCurrentViewExpr {
+    return new GetCurrentViewExpr();
+  }
 }
 
 /**
@@ -216,6 +240,10 @@ export class RestoreViewExpr extends ExpressionBase {
       this.view = transformExpressionsInExpression(this.view, transform, flags);
     }
   }
+
+  override clone(): RestoreViewExpr {
+    return new RestoreViewExpr(this.view instanceof o.Expression ? this.view.clone() : this.view);
+  }
 }
 
 /**
@@ -244,6 +272,10 @@ export class ResetViewExpr extends ExpressionBase {
       void {
     this.expr = transformExpressionsInExpression(this.expr, transform, flags);
   }
+
+  override clone(): ResetViewExpr {
+    return new ResetViewExpr(this.expr.clone());
+  }
 }
 
 /**
@@ -267,6 +299,12 @@ export class ReadVariableExpr extends ExpressionBase {
   }
 
   override transformInternalExpressions(): void {}
+
+  override clone(): ReadVariableExpr {
+    const expr = new ReadVariableExpr(this.xref);
+    expr.name = this.name;
+    return expr;
+  }
 }
 
 export class PureFunctionExpr extends ExpressionBase implements ConsumesVarsTrait,
@@ -297,7 +335,7 @@ export class PureFunctionExpr extends ExpressionBase implements ConsumesVarsTrai
    */
   fn: o.Expression|null = null;
 
-  constructor(expression: o.Expression, args: o.Expression[]) {
+  constructor(expression: o.Expression|null, args: o.Expression[]) {
     super();
     this.body = expression;
     this.args = args;
@@ -337,6 +375,14 @@ export class PureFunctionExpr extends ExpressionBase implements ConsumesVarsTrai
       this.args[i] = transformExpressionsInExpression(this.args[i], transform, flags);
     }
   }
+
+  override clone(): PureFunctionExpr {
+    const expr =
+        new PureFunctionExpr(this.body?.clone() ?? null, this.args.map(arg => arg.clone()));
+    expr.fn = this.fn?.clone() ?? null;
+    expr.varOffset = this.varOffset;
+    return expr;
+  }
 }
 
 export class PureFunctionParameterExpr extends ExpressionBase {
@@ -357,6 +403,10 @@ export class PureFunctionParameterExpr extends ExpressionBase {
   }
 
   override transformInternalExpressions(): void {}
+
+  override clone(): PureFunctionParameterExpr {
+    return new PureFunctionParameterExpr(this.index);
+  }
 }
 
 export class PipeBindingExpr extends ExpressionBase implements UsesSlotIndexTrait,
@@ -394,6 +444,13 @@ export class PipeBindingExpr extends ExpressionBase implements UsesSlotIndexTrai
       this.args[idx] = transformExpressionsInExpression(this.args[idx], transform, flags);
     }
   }
+
+  override clone() {
+    const r = new PipeBindingExpr(this.target, this.name, this.args.map(a => a.clone()));
+    r.slot = this.slot;
+    r.varOffset = this.varOffset;
+    return r;
+  }
 }
 
 export class PipeBindingVariadicExpr extends ExpressionBase implements UsesSlotIndexTrait,
@@ -428,6 +485,13 @@ export class PipeBindingVariadicExpr extends ExpressionBase implements UsesSlotI
   override transformInternalExpressions(transform: ExpressionTransform, flags: VisitorContextFlag):
       void {
     this.args = transformExpressionsInExpression(this.args, transform, flags);
+  }
+
+  override clone(): PipeBindingVariadicExpr {
+    const r = new PipeBindingVariadicExpr(this.target, this.name, this.args.clone(), this.numArgs);
+    r.slot = this.slot;
+    r.varOffset = this.varOffset;
+    return r;
   }
 }
 

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -18,6 +18,7 @@ import {phaseChaining} from './phases/chaining';
 import {phaseConstCollection} from './phases/const_collection';
 import {phaseEmptyElements} from './phases/empty_elements';
 import {phaseGenerateAdvance} from './phases/generate_advance';
+import {phaseNullishCoalescing} from './phases/nullish_coalescing';
 import {phaseGenerateVariables} from './phases/generate_variables';
 import {phaseLocalRefs} from './phases/local_refs';
 import {phaseNaming} from './phases/naming';
@@ -50,6 +51,7 @@ export function transformTemplate(cpl: ComponentCompilation): void {
   phaseResolveContexts(cpl);
   phaseLocalRefs(cpl);
   phaseConstCollection(cpl);
+  phaseNullishCoalescing(cpl);
   phaseSlotAllocation(cpl);
   phaseVarCounting(cpl);
   phaseGenerateAdvance(cpl);

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -35,6 +35,7 @@ import {phaseSaveRestoreView} from './phases/save_restore_view';
 import {phaseSlotAllocation} from './phases/slot_allocation';
 import {phaseVarCounting} from './phases/var_counting';
 import {phaseVariableOptimization} from './phases/variable_optimization';
+import {phaseExpandSafeReads} from './phases/expand_safe_reads';
 
 /**
  * Run all transformation phases in the correct order against a `ComponentCompilation`. After this
@@ -52,6 +53,7 @@ export function transformTemplate(cpl: ComponentCompilation): void {
   phaseLocalRefs(cpl);
   phaseConstCollection(cpl);
   phaseNullishCoalescing(cpl);
+  phaseExpandSafeReads(cpl);
   phaseSlotAllocation(cpl);
   phaseVarCounting(cpl);
   phaseGenerateAdvance(cpl);

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -167,6 +167,9 @@ function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
         convertAst(ast.trueExp, cpl),
         convertAst(ast.falseExp, cpl),
     );
+  } else if (ast instanceof e.NonNullAssert) {
+    // A non-null assertion shouldn't impact generated instructions, so we can just drop it.
+    return convertAst(ast.expression, cpl);
   } else if (ast instanceof e.BindingPipe) {
     return new ir.PipeBindingExpr(
         cpl.allocateXrefId(),

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -179,6 +179,13 @@ function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
           ...ast.args.map(arg => convertAst(arg, cpl)),
         ],
     );
+  } else if (ast instanceof e.SafeKeyedRead) {
+    return new ir.SafeKeyedReadExpr(convertAst(ast.receiver, cpl), convertAst(ast.key, cpl));
+  } else if (ast instanceof e.SafePropertyRead) {
+    return new ir.SafePropertyReadExpr(convertAst(ast.receiver, cpl), ast.name);
+  } else if (ast instanceof e.SafeCall) {
+    return new ir.SafeInvokeFunctionExpr(
+        convertAst(ast.receiver, cpl), ast.args.map(a => convertAst(a, cpl)));
   } else {
     throw new Error(`Unhandled expression type: ${ast.constructor.name}`);
   }

--- a/packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/expand_safe_reads.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import {ComponentCompilation} from '../compilation';
+
+/**
+ * Finds all unresolved safe read expressions, and converts them into the appropriate output AST
+ * reads, guarded by null checks.
+ */
+export function phaseExpandSafeReads(cpl: ComponentCompilation): void {
+  for (const [_, view] of cpl.views) {
+    for (const op of view.ops()) {
+      ir.transformExpressionsInOp(op, safeTransform, ir.VisitorContextFlag.None);
+      ir.transformExpressionsInOp(op, ternaryTransform, ir.VisitorContextFlag.None);
+    }
+  }
+}
+
+function isSafeAccessExpression(e: o.Expression): e is ir.SafePropertyReadExpr|
+    ir.SafeKeyedReadExpr {
+  return e instanceof ir.SafePropertyReadExpr || e instanceof ir.SafeKeyedReadExpr;
+}
+
+function isUnsafeAccessExpression(e: o.Expression): e is o.ReadPropExpr|o.ReadKeyExpr {
+  return e instanceof o.ReadPropExpr || e instanceof o.ReadKeyExpr;
+}
+
+function isAccessExpression(e: o.Expression): e is o.ReadPropExpr|ir.SafePropertyReadExpr|
+    o.ReadKeyExpr|ir.SafeKeyedReadExpr {
+  return isSafeAccessExpression(e) || isUnsafeAccessExpression(e);
+}
+
+function deepestSafeTernary(e: o.Expression): ir.SafeTernaryExpr|null {
+  if (isAccessExpression(e) && e.receiver instanceof ir.SafeTernaryExpr) {
+    let st = e.receiver;
+    while (st.expr instanceof ir.SafeTernaryExpr) {
+      st = st.expr;
+    }
+    return st;
+  }
+  return null;
+}
+
+// TODO: When strict compatibility with TemplateDefinitionBuilder is not required, we can use `&&`
+// instead.
+function safeTransform(e: o.Expression): o.Expression {
+  if (e instanceof ir.SafeInvokeFunctionExpr) {
+    // TODO: Implement safe function calls in a subsequent commit.
+    return new o.InvokeFunctionExpr(e.receiver, e.args);
+  }
+
+  if (!isAccessExpression(e)) {
+    return e;
+  }
+
+  const dst = deepestSafeTernary(e);
+
+  if (dst) {
+    if (e instanceof o.ReadPropExpr) {
+      dst.expr = dst.expr.prop(e.name);
+      return e.receiver;
+    }
+    if (e instanceof o.ReadKeyExpr) {
+      dst.expr = dst.expr.key(e.index);
+      return e.receiver;
+    }
+    if (e instanceof ir.SafePropertyReadExpr) {
+      dst.expr = new ir.SafeTernaryExpr(dst.expr.clone(), dst.expr.prop(e.name));
+      return e.receiver;
+    }
+    if (e instanceof ir.SafeKeyedReadExpr) {
+      dst.expr = new ir.SafeTernaryExpr(dst.expr.clone(), dst.expr.key(e.index));
+      return e.receiver;
+    }
+  } else {
+    if (e instanceof ir.SafePropertyReadExpr) {
+      return new ir.SafeTernaryExpr(e.receiver.clone(), e.receiver.prop(e.name));
+    }
+    if (e instanceof ir.SafeKeyedReadExpr) {
+      return new ir.SafeTernaryExpr(e.receiver.clone(), e.receiver.key(e.index));
+    }
+  }
+
+  return e;
+}
+
+function ternaryTransform(e: o.Expression): o.Expression {
+  if (!(e instanceof ir.SafeTernaryExpr)) {
+    return e;
+  }
+  return new o.ConditionalExpr(
+      new o.BinaryOperatorExpr(o.BinaryOperator.Equals, e.guard, o.NULL_EXPR),
+      o.NULL_EXPR,
+      e.expr,
+  );
+}

--- a/packages/compiler/src/template/pipeline/src/phases/nullish_coalescing.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/nullish_coalescing.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {ComponentCompilation} from '../compilation';
+
+
+export function phaseNullishCoalescing(cpl: ComponentCompilation): void {
+  for (const view of cpl.views.values()) {
+    for (const op of view.ops()) {
+      ir.transformExpressionsInOp(op, expr => {
+        if (!(expr instanceof o.BinaryOperatorExpr) ||
+            expr.operator !== o.BinaryOperator.NullishCoalesce) {
+          return expr;
+        }
+
+        // TODO: We need to unconditionally emit a temporary variable to match
+        // TemplateDefinitionBuilder. (We could also emit one conditionally when not in
+        // compatibility mode.)
+        return new o.ConditionalExpr(
+            new o.BinaryOperatorExpr(
+                o.BinaryOperator.And,
+                new o.BinaryOperatorExpr(o.BinaryOperator.NotIdentical, expr.lhs, o.NULL_EXPR),
+                new o.BinaryOperatorExpr(
+                    o.BinaryOperator.NotIdentical, expr.lhs, new o.LiteralExpr(undefined))),
+            expr.lhs,
+            expr.rhs,
+        );
+      }, ir.VisitorContextFlag.None);
+    }
+  }
+}


### PR DESCRIPTION
Various improvements to the template pipeline, including

- null-safe navigation (both property and keyed reads)
- non-null assertions
- initial processing of nullish coalescing

Several features, such as reads of pipes or null-safe calls, will require generating temporary variables to be fully complete. This will be handled in a temporary variables pass, in a subsequent PR.

See individual commits for details.