### PR TITLE
docs: fix npm link library command

### DIFF
--- a/aio/content/guide/schematics-for-libraries.md
+++ b/aio/content/guide/schematics-for-libraries.md
@@ -294,7 +294,7 @@ From the root of your workspace, run the `npm link` command with the path to you
 
 <code-example format="shell" language="shell">
 
-npm link dist/my-lib
+npm link dist/my-lib/
 
 </code-example>
 


### PR DESCRIPTION
Fixed the npm command as describe in descussion.

Fixes #50572

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
npm link dist/my-lib command not linking the library to local npm.

Issue Number: #50572 


## What is the new behavior?
npm link dist/my-lib/ command works properly.


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
