### PR TITLE
Build: Update Glob to fast-glob memory leak fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "cldrjs": "0.5.5",
     "conventional-changelog": "^3.1.24",
     "firebase-tools": "^12.0.0",
+    "fast-glob": "3.2.12",
     "glob": "8.1.0",
     "gulp": "^4.0.2",
     "gulp-conventional-changelog": "^3.0.0",

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {
     "@babel/core": "7.21.8",
-    "glob": "8.1.0",
+    "fast-glob": "3.2.12",
     "yargs": "^17.2.1"
   },
   "peerDependencies": {

--- a/packages/localize/tools/BUILD.bazel
+++ b/packages/localize/tools/BUILD.bazel
@@ -16,10 +16,9 @@ ts_library(
         "@npm//@babel/core",
         "@npm//@types/babel__core",
         "@npm//@types/babel__traverse",
-        "@npm//@types/glob",
         "@npm//@types/node",
         "@npm//@types/yargs",
-        "@npm//glob",
+        "@npm//fast-glob",
     ],
 )
 
@@ -43,7 +42,7 @@ esbuild(
         "@angular/compiler-cli/private/localize",
         "@babel/core",
         "yargs",
-        "glob",
+        "fast-glob",
     ],
     format = "esm",
     platform = "node",

--- a/packages/localize/tools/src/extract/cli.ts
+++ b/packages/localize/tools/src/extract/cli.ts
@@ -8,7 +8,7 @@
  */
 
 import {ConsoleLogger, LogLevel, NodeJSFileSystem, setFileSystem} from '@angular/compiler-cli/private/localize';
-import glob from 'glob';
+import glob from 'fast-glob';
 import yargs from 'yargs';
 
 import {DiagnosticHandlingStrategy} from '../diagnostics';
@@ -94,7 +94,7 @@ const fileSystem = new NodeJSFileSystem();
 setFileSystem(fileSystem);
 
 const rootPath = options.r;
-const sourceFilePaths = glob.sync(options.s, {cwd: rootPath, nodir: true});
+const sourceFilePaths = glob.sync(options.s, {cwd: rootPath});
 const logLevel = options.loglevel as (keyof typeof LogLevel) | undefined;
 const logger = new ConsoleLogger(logLevel ? LogLevel[logLevel] : LogLevel.warn);
 const duplicateMessageHandling = options.d as DiagnosticHandlingStrategy;

--- a/packages/localize/tools/src/migrate/cli.ts
+++ b/packages/localize/tools/src/migrate/cli.ts
@@ -8,7 +8,7 @@
  */
 
 import {ConsoleLogger, LogLevel, NodeJSFileSystem, setFileSystem} from '@angular/compiler-cli/private/localize';
-import glob from 'glob';
+import glob from 'fast-glob';
 import yargs from 'yargs';
 import {migrateFiles} from './index';
 
@@ -44,7 +44,7 @@ const fs = new NodeJSFileSystem();
 setFileSystem(fs);
 
 const rootPath = options.r;
-const translationFilePaths = glob.sync(options.f, {cwd: rootPath, nodir: true});
+const translationFilePaths = glob.sync(options.f, {cwd: rootPath, onlyFiles: true});
 const logger = new ConsoleLogger(LogLevel.warn);
 
 migrateFiles({rootPath, translationFilePaths, mappingFilePath: options.m, logger});

--- a/packages/localize/tools/src/translate/cli.ts
+++ b/packages/localize/tools/src/translate/cli.ts
@@ -7,7 +7,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {NodeJSFileSystem, setFileSystem} from '@angular/compiler-cli/private/localize';
-import glob from 'glob';
+import glob from 'fast-glob';
 import yargs from 'yargs';
 
 import {DiagnosticHandlingStrategy, Diagnostics} from '../diagnostics';
@@ -94,7 +94,7 @@ const fs = new NodeJSFileSystem();
 setFileSystem(fs);
 
 const sourceRootPath = options.r;
-const sourceFilePaths = glob.sync(options.s, {cwd: sourceRootPath, nodir: true});
+const sourceFilePaths = glob.sync(options.s, {cwd: sourceRootPath, onlyFiles: true});
 const translationFilePaths: (string|string[])[] = convertArraysFromArgs(options.t);
 const outputPathFn = getOutputPathFn(fs, fs.resolve(options.o));
 const diagnostics = new Diagnostics();

--- a/packages/localize/tools/test/BUILD.bazel
+++ b/packages/localize/tools/test/BUILD.bazel
@@ -22,7 +22,7 @@ ts_library(
         "@npm//@babel/template",
         "@npm//@types/babel__generator",
         "@npm//@types/babel__template",
-        "@npm//@types/glob",
+        "@npm//fast-glob",
     ],
 )
 
@@ -31,6 +31,6 @@ jasmine_node_test(
     bootstrap = ["//tools/testing:node_no_angular"],
     deps = [
         ":test_lib",
-        "@npm//glob",
+        "@npm//fast-glob",
     ],
 )

--- a/packages/localize/tools/test/extract/integration/BUILD.bazel
+++ b/packages/localize/tools/test/extract/integration/BUILD.bazel
@@ -29,7 +29,7 @@ jasmine_node_test(
     ],
     deps = [
         ":test_lib",
-        "@npm//glob",
+        "@npm//fast-glob",
         "@npm//yargs",
     ],
 )

--- a/packages/localize/tools/test/migrate/integration/BUILD.bazel
+++ b/packages/localize/tools/test/migrate/integration/BUILD.bazel
@@ -34,7 +34,7 @@ jasmine_node_test(
     ],
     deps = [
         ":test_lib",
-        "@npm//glob",
+        "@npm//fast-glob",
         "@npm//yargs",
     ],
 )

--- a/packages/localize/tools/test/translate/integration/BUILD.bazel
+++ b/packages/localize/tools/test/translate/integration/BUILD.bazel
@@ -25,7 +25,7 @@ jasmine_node_test(
     ],
     deps = [
         ":test_lib",
-        "@npm//glob",
+        "@npm//fast-glob",
         "@npm//yargs",
     ],
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -8014,7 +8014,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.11, fast-glob@^3.2.9:
+fast-glob@3.2.12, fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
   integrity sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==


### PR DESCRIPTION
Updating Glob to fast-glob to remove the dependency on Inflight which contains a memory leak. 
Inflight has been removed from Glob since version 9.

https://github.com/isaacs/inflight/issues/5


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
