### PR TITLE
refactor(forms): Log a warning when `FormGroup` keys include a dot.

### DIFF
--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -177,6 +177,7 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
       controls: TControl, validatorOrOpts?: ValidatorFn|ValidatorFn[]|AbstractControlOptions|null,
       asyncValidator?: AsyncValidatorFn|AsyncValidatorFn[]|null) {
     super(pickValidators(validatorOrOpts), pickAsyncValidators(asyncValidator, validatorOrOpts));
+    (typeof ngDevMode === 'undefined' || ngDevMode) && validateFormGroupControls(controls);
     this.controls = controls;
     this._initObservables();
     this._setUpdateStrategy(validatorOrOpts);
@@ -586,6 +587,21 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
         null;
   }
 }
+
+/**
+ * Will validate that none of the controls has a key with a dot
+ * Throws other wise
+ */
+function validateFormGroupControls<TControl>(
+    controls: {[K in keyof TControl]: AbstractControl<any, any>;}) {
+  const invalidKeys = Object.keys(controls).filter(key => key.includes('.'));
+  if (invalidKeys.length > 0) {
+    // TODO: make this an error once there are no more uses in G3
+    console.warn(`FormGroup keys cannot include \`.\`, please replace the keys for: ${
+        invalidKeys.join(',')}.`);
+  }
+}
+
 
 interface UntypedFormGroupCtor {
   new(controls: {[key: string]: AbstractControl},

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -223,7 +223,6 @@ describe('FormGroup', () => {
     });
   });
 
-
   describe('touched', () => {
     let c: FormControl, g: FormGroup;
 
@@ -2397,6 +2396,16 @@ describe('FormGroup', () => {
         }
       }
     });
+  });
+
+  it('should throw with invalid keys', () => {
+    const consoleWarnSpy = spyOn(console, 'warn');
+    new FormGroup({
+      foo: new FormControl('foo'),
+      bar: new FormControl('foo', [Validators.required]),
+      'baz.not.ok': new FormControl('baz')
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
   });
 });
 })();


### PR DESCRIPTION
Due to the dotted synthax to resolve controls, keys in FormGroups cannot include dots.

fixes #50608


## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [x] No