### PR TITLE
fix(zone.js): patch form-associated custom element callbacks

### DIFF
--- a/packages/zone.js/lib/browser/custom-elements.ts
+++ b/packages/zone.js/lib/browser/custom-elements.ts
@@ -12,8 +12,12 @@ export function patchCustomElements(_global: any, api: _ZonePrivate) {
     return;
   }
 
-  const callbacks =
-      ['connectedCallback', 'disconnectedCallback', 'adoptedCallback', 'attributeChangedCallback'];
+  // https://html.spec.whatwg.org/multipage/custom-elements.html#concept-custom-element-definition-lifecycle-callbacks
+  const callbacks = [
+    'connectedCallback', 'disconnectedCallback', 'adoptedCallback', 'attributeChangedCallback',
+    'formAssociatedCallback', 'formDisabledCallback', 'formResetCallback',
+    'formStateRestoreCallback'
+  ];
 
   api.patchCallbacks(api, _global.customElements, 'customElements', 'define', callbacks);
 }

--- a/packages/zone.js/lib/zone.configurations.api.ts
+++ b/packages/zone.js/lib/zone.configurations.api.ts
@@ -414,6 +414,10 @@ declare global {
      *   disconnectedCallback() {}
      *   attributeChangedCallback(attrName, oldVal, newVal) {}
      *   adoptedCallback() {}
+     *   formAssociatedCallback(form) {}
+     *   formDisabledCallback(isDisabled) {}
+     *   formResetCallback() {}
+     *   formStateRestoreCallback(state, reason) {}
      * }
      *
      * const zone = Zone.fork({name: 'myZone'});


### PR DESCRIPTION
This commit updates the implementation of the `customElements` patch and also patches FACE callbacks (`formAssociatedCallback`, `formDisabledCallback`, `formResetCallback` and `formStateRestoreCallback`). This now allows invoking those callbacks in the same zone where the custom element has been defined.