### PR TITLE
Support for input transforms in @angular/elements

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -225,6 +225,7 @@ export abstract class ComponentFactory<C> {
     abstract get inputs(): {
         propName: string;
         templateName: string;
+        transform?: (value: any) => any;
     }[];
     abstract get ngContentSelectors(): string[];
     abstract get outputs(): {
@@ -246,6 +247,7 @@ export interface ComponentMirror<C> {
     get inputs(): ReadonlyArray<{
         readonly propName: string;
         readonly templateName: string;
+        readonly transform?: (value: any) => any;
     }>;
     get isStandalone(): boolean;
     get ngContentSelectors(): ReadonlyArray<string>;

--- a/goldens/public-api/elements/index.md
+++ b/goldens/public-api/elements/index.md
@@ -45,7 +45,7 @@ export interface NgElementStrategy {
     // (undocumented)
     getInputValue(propName: string): any;
     // (undocumented)
-    setInputValue(propName: string, value: string): void;
+    setInputValue(propName: string, value: string, transform?: (value: any) => any): void;
 }
 
 // @public

--- a/packages/core/src/linker/component_factory.ts
+++ b/packages/core/src/linker/component_factory.ts
@@ -106,7 +106,11 @@ export abstract class ComponentFactory<C> {
   /**
    * The inputs of the component.
    */
-  abstract get inputs(): {propName: string, templateName: string}[];
+  abstract get inputs(): {
+    propName: string,
+    templateName: string,
+    transform?: (value: any) => any,
+  }[];
   /**
    * The outputs of the component.
    */

--- a/packages/core/src/render3/component.ts
+++ b/packages/core/src/render3/component.ts
@@ -106,7 +106,11 @@ export interface ComponentMirror<C> {
   /**
    * The inputs of the component.
    */
-  get inputs(): ReadonlyArray<{readonly propName: string, readonly templateName: string}>;
+  get inputs(): ReadonlyArray<{
+    readonly propName: string,
+    readonly templateName: string,
+    readonly transform?: (value: any) => any,
+  }>;
   /**
    * The outputs of the component.
    */
@@ -178,7 +182,11 @@ export function reflectComponentType<C>(component: Type<C>): ComponentMirror<C>|
     get type(): Type<C> {
       return factory.componentType;
     },
-    get inputs(): ReadonlyArray<{propName: string, templateName: string}> {
+    get inputs(): ReadonlyArray<{
+      propName: string,
+      templateName: string,
+      transform?: (value: any) => any,
+    }> {
       return factory.inputs;
     },
     get outputs(): ReadonlyArray<{propName: string, templateName: string}> {

--- a/packages/core/src/render3/component_ref.ts
+++ b/packages/core/src/render3/component_ref.ts
@@ -118,8 +118,28 @@ export class ComponentFactory<T> extends AbstractComponentFactory<T> {
   override ngContentSelectors: string[];
   isBoundToModule: boolean;
 
-  override get inputs(): {propName: string; templateName: string;}[] {
-    return toRefArray(this.componentDef.inputs);
+  override get inputs(): {
+    propName: string,
+    templateName: string,
+    transform?: (value: any) => any,
+  }[] {
+    const componentDef = this.componentDef;
+    const inputTransforms = componentDef.inputTransforms;
+    const refArray = toRefArray(componentDef.inputs) as {
+      propName: string,
+      templateName: string,
+      transform?: (value: any) => any,
+    }[];
+
+    if (inputTransforms !== null) {
+      for (const input of refArray) {
+        if (inputTransforms.hasOwnProperty(input.propName)) {
+          input.transform = inputTransforms[input.propName];
+        }
+      }
+    }
+
+    return refArray;
   }
 
   override get outputs(): {propName: string; templateName: string;}[] {

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -924,6 +924,8 @@ describe('component', () => {
 
   describe('reflectComponentType', () => {
     it('should create an ComponentMirror for a standalone component', () => {
+      function transformFn() {}
+
       @Component({
         selector: 'standalone-component',
         standalone: true,
@@ -937,6 +939,7 @@ describe('component', () => {
         outputs: ['output-a', 'output-b:output-alias-b'],
       })
       class StandaloneComponent {
+        @Input({alias: 'input-alias-c', transform: transformFn}) inputC: unknown;
       }
 
       const mirror = reflectComponentType(StandaloneComponent)!;
@@ -946,7 +949,8 @@ describe('component', () => {
       expect(mirror.isStandalone).toEqual(true);
       expect(mirror.inputs).toEqual([
         {propName: 'input-a', templateName: 'input-a'},
-        {propName: 'input-b', templateName: 'input-alias-b'}
+        {propName: 'input-b', templateName: 'input-alias-b'},
+        {propName: 'inputC', templateName: 'input-alias-c', transform: transformFn},
       ]);
       expect(mirror.outputs).toEqual([
         {propName: 'output-a', templateName: 'output-a'},
@@ -958,6 +962,8 @@ describe('component', () => {
     });
 
     it('should create an ComponentMirror for a non-standalone component', () => {
+      function transformFn() {}
+
       @Component({
         selector: 'non-standalone-component',
         template: `
@@ -970,6 +976,7 @@ describe('component', () => {
         outputs: ['output-a', 'output-b:output-alias-b'],
       })
       class NonStandaloneComponent {
+        @Input({alias: 'input-alias-c', transform: transformFn}) inputC: unknown;
       }
 
       const mirror = reflectComponentType(NonStandaloneComponent)!;
@@ -979,7 +986,8 @@ describe('component', () => {
       expect(mirror.isStandalone).toEqual(false);
       expect(mirror.inputs).toEqual([
         {propName: 'input-a', templateName: 'input-a'},
-        {propName: 'input-b', templateName: 'input-alias-b'}
+        {propName: 'input-b', templateName: 'input-alias-b'},
+        {propName: 'inputC', templateName: 'input-alias-c', transform: transformFn},
       ]);
       expect(mirror.outputs).toEqual([
         {propName: 'output-a', templateName: 'output-a'},

--- a/packages/core/test/render3/component_ref_spec.ts
+++ b/packages/core/test/render3/component_ref_spec.ts
@@ -51,6 +51,8 @@ describe('ComponentFactory', () => {
     });
 
     it('should correctly populate defined properties', () => {
+      function transformFn() {}
+
       @Component({
         selector: 'test[foo], bar',
         standalone: true,
@@ -64,6 +66,8 @@ describe('ComponentFactory', () => {
         @Input() in1: unknown;
 
         @Input('input-attr-2') in2: unknown;
+
+        @Input({alias: 'input-attr-3', transform: transformFn}) in3: unknown;
 
         @Output() out1: unknown;
 
@@ -79,6 +83,7 @@ describe('ComponentFactory', () => {
       expect(cf.inputs).toEqual([
         {propName: 'in1', templateName: 'in1'},
         {propName: 'in2', templateName: 'input-attr-2'},
+        {propName: 'in3', templateName: 'input-attr-3', transform: transformFn},
       ]);
       expect(cf.outputs).toEqual([
         {propName: 'out1', templateName: 'out1'},

--- a/packages/elements/src/component-factory-strategy.ts
+++ b/packages/elements/src/component-factory-strategy.ts
@@ -154,8 +154,12 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
    * Sets the input value for the property. If the component has not yet been created, the value is
    * cached and set when the component is created.
    */
-  setInputValue(property: string, value: any): void {
+  setInputValue(property: string, value: any, transform?: (value: any) => any): void {
     this.runInZone(() => {
+      if (transform) {
+        value = transform.call(this.componentRef?.instance, value);
+      }
+
       if (this.componentRef === null) {
         this.initialInputValues.set(property, value);
         return;
@@ -205,11 +209,11 @@ export class ComponentNgElementStrategy implements NgElementStrategy {
 
   /** Set any stored initial inputs on the component's properties. */
   protected initializeInputs(): void {
-    this.componentFactory.inputs.forEach(({propName}) => {
+    this.componentFactory.inputs.forEach(({propName, transform}) => {
       if (this.initialInputValues.has(propName)) {
         // Call `setInputValue()` now that the component has been instantiated to update its
         // properties and fire `ngOnChanges()`.
-        this.setInputValue(propName, this.initialInputValues.get(propName));
+        this.setInputValue(propName, this.initialInputValues.get(propName), transform);
       }
     });
 

--- a/packages/elements/src/create-custom-element.ts
+++ b/packages/elements/src/create-custom-element.ts
@@ -148,7 +148,7 @@ export function createCustomElement<P>(
 
         // Re-apply pre-existing input values (set as properties on the element) through the
         // strategy.
-        inputs.forEach(({propName}) => {
+        inputs.forEach(({propName, transform}) => {
           if (!this.hasOwnProperty(propName)) {
             // No pre-existing value for `propName`.
             return;
@@ -157,7 +157,7 @@ export function createCustomElement<P>(
           // Delete the property from the instance and re-apply it through the strategy.
           const value = (this as any)[propName];
           delete (this as any)[propName];
-          strategy.setInputValue(propName, value);
+          strategy.setInputValue(propName, value, transform);
         });
       }
 
@@ -172,8 +172,8 @@ export function createCustomElement<P>(
 
     override attributeChangedCallback(
         attrName: string, oldValue: string|null, newValue: string, namespace?: string): void {
-      const propName = attributeToPropertyInputs[attrName]!;
-      this.ngElementStrategy.setInputValue(propName, newValue);
+      const [propName, transform] = attributeToPropertyInputs[attrName]!;
+      this.ngElementStrategy.setInputValue(propName, newValue, transform);
     }
 
     override connectedCallback(): void {
@@ -225,13 +225,13 @@ export function createCustomElement<P>(
   }
 
   // Add getters and setters to the prototype for each property input.
-  inputs.forEach(({propName}) => {
+  inputs.forEach(({propName, transform}) => {
     Object.defineProperty(NgElementImpl.prototype, propName, {
       get(): any {
         return this.ngElementStrategy.getInputValue(propName);
       },
       set(newValue: any): void {
-        this.ngElementStrategy.setInputValue(propName, newValue);
+        this.ngElementStrategy.setInputValue(propName, newValue, transform);
       },
       configurable: true,
       enumerable: true,

--- a/packages/elements/src/element-strategy.ts
+++ b/packages/elements/src/element-strategy.ts
@@ -30,7 +30,7 @@ export interface NgElementStrategy {
   connect(element: HTMLElement): void;
   disconnect(): void;
   getInputValue(propName: string): any;
-  setInputValue(propName: string, value: string): void;
+  setInputValue(propName: string, value: string, transform?: (value: any) => any): void;
 }
 
 /**

--- a/packages/elements/src/utils.ts
+++ b/packages/elements/src/utils.ts
@@ -98,10 +98,11 @@ export function strictEquals(value1: any, value2: any): boolean {
 
 /** Gets a map of default set of attributes to observe and the properties they affect. */
 export function getDefaultAttributeToPropertyInputs(
-    inputs: {propName: string, templateName: string}[]) {
-  const attributeToPropertyInputs: {[key: string]: string} = {};
-  inputs.forEach(({propName, templateName}) => {
-    attributeToPropertyInputs[camelToDashCase(templateName)] = propName;
+    inputs: {propName: string, templateName: string, transform?: (value: any) => any}[]) {
+  const attributeToPropertyInputs:
+      {[key: string]: [propName: string, transform: ((value: any) => any)|undefined]} = {};
+  inputs.forEach(({propName, templateName, transform}) => {
+    attributeToPropertyInputs[camelToDashCase(templateName)] = [propName, transform];
   });
 
   return attributeToPropertyInputs;
@@ -111,9 +112,12 @@ export function getDefaultAttributeToPropertyInputs(
  * Gets a component's set of inputs. Uses the injector to get the component factory where the inputs
  * are defined.
  */
-export function getComponentInputs(
-    component: Type<any>, injector: Injector): {propName: string, templateName: string}[] {
-  const componentFactoryResolver: ComponentFactoryResolver = injector.get(ComponentFactoryResolver);
+export function getComponentInputs(component: Type<any>, injector: Injector): {
+  propName: string,
+  templateName: string,
+  transform?: (value: any) => any,
+}[] {
+  const componentFactoryResolver = injector.get(ComponentFactoryResolver);
   const componentFactory = componentFactoryResolver.resolveComponentFactory(component);
   return componentFactory.inputs;
 }

--- a/packages/elements/test/create-custom-element_spec.ts
+++ b/packages/elements/test/create-custom-element_spec.ts
@@ -14,10 +14,11 @@ import {Subject} from 'rxjs';
 import {createCustomElement, NgElementConstructor} from '../src/create-custom-element';
 import {NgElementStrategy, NgElementStrategyEvent, NgElementStrategyFactory} from '../src/element-strategy';
 
-type WithFooBar = {
-  fooFoo: string,
-  barBar: string
-};
+interface WithFooBar {
+  fooFoo: string;
+  barBar: string;
+  fooTransformed: unknown;
+}
 
 describe('createCustomElement', () => {
   let selectorUid = 0;
@@ -52,18 +53,20 @@ describe('createCustomElement', () => {
   });
 
   it('should use a default strategy for converting component inputs', () => {
-    expect(NgElementCtor.observedAttributes).toEqual(['foo-foo', 'barbar']);
+    expect(NgElementCtor.observedAttributes).toEqual(['foo-foo', 'barbar', 'foo-transformed']);
   });
 
   it('should send input values from attributes when connected', () => {
     const element = new NgElementCtor(injector);
     element.setAttribute('foo-foo', 'value-foo-foo');
     element.setAttribute('barbar', 'value-barbar');
+    element.setAttribute('foo-transformed', 'truthy');
     element.connectedCallback();
     expect(strategy.connectedElement).toBe(element);
 
     expect(strategy.getInputValue('fooFoo')).toBe('value-foo-foo');
     expect(strategy.getInputValue('barBar')).toBe('value-barbar');
+    expect(strategy.getInputValue('fooTransformed')).toBe(true);
   });
 
   it('should work even if the constructor is not called (due to polyfill)', () => {
@@ -78,11 +81,13 @@ describe('createCustomElement', () => {
 
     element.setAttribute('foo-foo', 'value-foo-foo');
     element.setAttribute('barbar', 'value-barbar');
+    element.setAttribute('foo-transformed', 'truthy');
     element.connectedCallback();
 
     expect(strategy.connectedElement).toBe(element);
     expect(strategy.getInputValue('fooFoo')).toBe('value-foo-foo');
     expect(strategy.getInputValue('barBar')).toBe('value-barbar');
+    expect(strategy.getInputValue('fooTransformed')).toBe(true);
   });
 
   it('should listen to output events after connected', () => {
@@ -154,9 +159,11 @@ describe('createCustomElement', () => {
     const element = new NgElementCtor(injector);
     element.fooFoo = 'foo-foo-value';
     element.barBar = 'barBar-value';
+    element.fooTransformed = 'truthy';
 
     expect(strategy.inputs.get('fooFoo')).toBe('foo-foo-value');
     expect(strategy.inputs.get('barBar')).toBe('barBar-value');
+    expect(strategy.inputs.get('fooTransformed')).toBe(true);
   });
 
   it('should properly handle getting/setting properties on the element even if the constructor is not called',
@@ -170,9 +177,11 @@ describe('createCustomElement', () => {
 
        element.fooFoo = 'foo-foo-value';
        element.barBar = 'barBar-value';
+       element.fooTransformed = 'truthy';
 
        expect(strategy.inputs.get('fooFoo')).toBe('foo-foo-value');
        expect(strategy.inputs.get('barBar')).toBe('barBar-value');
+       expect(strategy.inputs.get('fooTransformed')).toBe(true);
      });
 
   it('should capture properties set before upgrading the element', () => {
@@ -181,18 +190,22 @@ describe('createCustomElement', () => {
     const element = Object.assign(document.createElement(selector), {
       fooFoo: 'foo-prop-value',
       barBar: 'bar-prop-value',
+      fooTransformed: 'truthy' as unknown,
     });
     expect(element.fooFoo).toBe('foo-prop-value');
     expect(element.barBar).toBe('bar-prop-value');
+    expect(element.fooTransformed).toBe('truthy');
 
     // Upgrade the element to a Custom Element and insert it into the DOM.
     customElements.define(selector, ElementCtor);
     testContainer.appendChild(element);
     expect(element.fooFoo).toBe('foo-prop-value');
     expect(element.barBar).toBe('bar-prop-value');
+    expect(element.fooTransformed).toBe(true);
 
     expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
     expect(strategy.inputs.get('barBar')).toBe('bar-prop-value');
+    expect(strategy.inputs.get('fooTransformed')).toBe(true);
   });
 
   it('should capture properties set after upgrading the element but before inserting it into the DOM',
@@ -202,25 +215,31 @@ describe('createCustomElement', () => {
        const element = Object.assign(document.createElement(selector), {
          fooFoo: 'foo-prop-value',
          barBar: 'bar-prop-value',
+         fooTransformed: 'truthy' as unknown,
        });
        expect(element.fooFoo).toBe('foo-prop-value');
        expect(element.barBar).toBe('bar-prop-value');
+       expect(element.fooTransformed).toBe('truthy');
 
        // Upgrade the element to a Custom Element (without inserting it into the DOM) and update a
        // property.
        customElements.define(selector, ElementCtor);
        customElements.upgrade(element);
        element.barBar = 'bar-prop-value-2';
+       element.fooTransformed = '';
        expect(element.fooFoo).toBe('foo-prop-value');
        expect(element.barBar).toBe('bar-prop-value-2');
+       expect(element.fooTransformed).toBe('');
 
        // Insert the element into the DOM.
        testContainer.appendChild(element);
        expect(element.fooFoo).toBe('foo-prop-value');
        expect(element.barBar).toBe('bar-prop-value-2');
+       expect(element.fooTransformed).toBe(false);
 
        expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
        expect(strategy.inputs.get('barBar')).toBe('bar-prop-value-2');
+       expect(strategy.inputs.get('fooTransformed')).toBe(false);
      });
 
   it('should allow overwriting properties with attributes after upgrading the element but before inserting it into the DOM',
@@ -230,25 +249,31 @@ describe('createCustomElement', () => {
        const element = Object.assign(document.createElement(selector), {
          fooFoo: 'foo-prop-value',
          barBar: 'bar-prop-value',
+         fooTransformed: 'truthy' as unknown,
        });
        expect(element.fooFoo).toBe('foo-prop-value');
        expect(element.barBar).toBe('bar-prop-value');
+       expect(element.fooTransformed).toBe('truthy');
 
        // Upgrade the element to a Custom Element (without inserting it into the DOM) and set an
        // attribute.
        customElements.define(selector, ElementCtor);
        customElements.upgrade(element);
        element.setAttribute('barbar', 'bar-attr-value');
+       element.setAttribute('foo-transformed', '');
        expect(element.fooFoo).toBe('foo-prop-value');
        expect(element.barBar).toBe('bar-attr-value');
+       expect(element.fooTransformed).toBe(false);
 
        // Insert the element into the DOM.
        testContainer.appendChild(element);
        expect(element.fooFoo).toBe('foo-prop-value');
        expect(element.barBar).toBe('bar-attr-value');
+       expect(element.fooTransformed).toBe(false);
 
        expect(strategy.inputs.get('fooFoo')).toBe('foo-prop-value');
        expect(strategy.inputs.get('barBar')).toBe('bar-attr-value');
+       expect(strategy.inputs.get('fooTransformed')).toBe(false);
      });
 
   // Helpers
@@ -274,6 +299,7 @@ describe('createCustomElement', () => {
   class TestComponent {
     @Input() fooFoo: string = 'foo';
     @Input('barbar') barBar!: string;
+    @Input({transform: (value: unknown) => !!value}) fooTransformed!: boolean;
 
     @Output() bazBaz = new EventEmitter<boolean>();
     @Output('quxqux') quxQux = new EventEmitter<Object>();
@@ -306,8 +332,8 @@ describe('createCustomElement', () => {
       return this.inputs.get(propName);
     }
 
-    setInputValue(propName: string, value: string): void {
-      this.inputs.set(propName, value);
+    setInputValue(propName: string, value: string, transform?: (value: any) => any): void {
+      this.inputs.set(propName, transform ? transform(value) : value);
     }
 
     reset(): void {


### PR DESCRIPTION
Split up across a couple of commits that aim to fix that input transforms weren't being used in `@angular/elements`. Includes:

1. Exposing the input transform function in `ComponentFactory.inputs` and `ComponentMirror.inputs`.
2. Updating `elements` to account for the transform function.

Fixes #50708.