### PR TITLE
test: mark ngtsc test target as flaky

### DIFF
--- a/packages/compiler-cli/test/ngtsc/BUILD.bazel
+++ b/packages/compiler-cli/test/ngtsc/BUILD.bazel
@@ -32,6 +32,9 @@ jasmine_node_test(
         "//packages/compiler-cli/src/ngtsc/testing/fake_common:npm_package",
         "//packages/compiler-cli/src/ngtsc/testing/fake_core:npm_package",
     ],
+    # TODO: This target is flaky on Windows due to the global FS sometimes not being set/reset.
+    # See: https://app.circleci.com/pipelines/github/angular/angular/62261/workflows/6a4e952c-3d0b-44ab-b3db-c0a639af6bdc/jobs/1348755.
+    flaky = True,
     shard_count = 4,
     deps = [
         ":ngtsc_lib",


### PR DESCRIPTION
A larger investigation on why this is flaky is needed. Currently the test is flaky with around 77% success rate and negatively impacts team productivity. Subjectively, as reported by team members this it's much more flaky than a success rate of 77%.
