### PR TITLE
ci: enable colors for bazel in CircleCI

### DIFF
--- a/.circleci/bazel.common.rc
+++ b/.circleci/bazel.common.rc
@@ -10,3 +10,6 @@ test --flaky_test_attempts=2
 
 # More details on failures
 build --verbose_failures=true
+
+# CI supports colors but Bazel does not detect it.
+common --color=yes


### PR DESCRIPTION
Enables colors for Bazel in CircleCI. Bazel does not seem to detect color support
properly, but CircleCI does support such.

Colors make debugging a little easier with larger Bazel logs.