### PR TITLE
ci: re-enable RBE for http tests

### DIFF
--- a/packages/common/http/test/BUILD.bazel
+++ b/packages/common/http/test/BUILD.bazel
@@ -29,11 +29,6 @@ ts_library(
 jasmine_node_test(
     name = "test",
     bootstrap = ["//tools/testing:node"],
-    tags = [
-        # Remote execution doesn't work with Node.js 18 right now.
-        # See https://github.com/angular/dev-infra/issues/1017
-        "no-remote-exec",
-    ],
     # TODO remove once the Node 18 is the default toolchain.
     toolchain = select({
         "@bazel_tools//src/conditions:linux_x86_64": "@node18_linux_amd64//:node_toolchain",


### PR DESCRIPTION

This commit enables RBE for common http tests which is now possible as the latest version of build-tooling supports Node.js 18.