### PR TITLE
feat(compiler): scope selectors in @scope queries

### DIFF
--- a/packages/compiler/src/shadow_css.ts
+++ b/packages/compiler/src/shadow_css.ts
@@ -560,7 +560,7 @@ export class ShadowCss {
       } else if (
           rule.selector.startsWith('@media') || rule.selector.startsWith('@supports') ||
           rule.selector.startsWith('@document') || rule.selector.startsWith('@layer') ||
-          rule.selector.startsWith('@container')) {
+          rule.selector.startsWith('@container') || rule.selector.startsWith('@scope')) {
         content = this._scopeSelectors(rule.content, scopeSelector, hostSelector);
       } else if (rule.selector.startsWith('@font-face') || rule.selector.startsWith('@page')) {
         content = this._stripScopingSelectors(rule.content);

--- a/packages/compiler/test/shadow_css/at_rules_spec.ts
+++ b/packages/compiler/test/shadow_css/at_rules_spec.ts
@@ -173,6 +173,34 @@ describe('ShadowCss, at-rules', () => {
     });
   });
 
+  describe('@scope', () => {
+    it('should scope normal selectors inside a scope rule with scoping limits', () => {
+      const css = `
+          @scope (.media-object) to (.content > *) {
+              img { border-radius: 50%; }
+              .content { padding: 1em; }
+          }`;
+      const result = shim(css, 'host-a');
+      expect(result).toEqualCss(`
+        @scope (.media-object) to (.content > *) {
+          img[host-a] { border-radius: 50%; }
+          .content[host-a] { padding: 1em; }
+        }`);
+    });
+
+    it('should scope normal selectors inside a scope rule', () => {
+      const css = `
+          @scope (.light-scheme) {
+              a { color: darkmagenta; }
+          }`;
+      const result = shim(css, 'host-a');
+      expect(result).toEqualCss(`
+        @scope (.light-scheme) {
+          a[host-a] { color: darkmagenta; }
+        }`);
+    });
+  });
+
   describe('@document', () => {
     it('should handle document rules', () => {
       const css = '@document url(http://www.w3.org/) {div {font-size:50px;}}';


### PR DESCRIPTION
This pull request makes sure selectors inside @scope queries are correctly scoped.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently there is no support in the Angular compiler for the scope at-rule [CSSWG](https://drafts.csswg.org/css-cascade-6/#scope-atrule) [1] which is targeted for support in Chrome 117 [Chrome Status](https://chromestatus.com/feature/5100672734199808) [2] which means usage of this feature results in CSS that is not correctly scoped.

## What is the new behavior?

Using the CSS scope at-rule results in properly scoped CSS.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Angular will be ready for the new browser features when they ship.