### PR TITLE
fix(benchpress): correctly report memory usage numbers

### DIFF
--- a/packages/benchpress/src/metric/perflog_metric.ts
+++ b/packages/benchpress/src/metric/perflog_metric.ts
@@ -344,9 +344,12 @@ export class PerflogMetric extends Metric {
           intervalStarts[name] = null!;
           if (name === 'gc') {
             result['gcTime'] += duration;
-            const amount =
-                (startEvent['args']!['usedHeapSize']! - event['args']!['usedHeapSize']!) / 1000;
-            result['gcAmount'] += amount;
+            const gcAmount = event['args']?.['gcAmount'] ?? 0;
+            const amount = gcAmount > 0 ?
+                gcAmount :
+                (startEvent['args']!['usedHeapSize']! - event['args']!['usedHeapSize']!);
+
+            result['gcAmount'] += amount / 1000;
             const majorGc = event['args']!['majorGc'];
             if (majorGc && majorGc) {
               result['majorGcTime'] += duration;

--- a/packages/benchpress/src/web_driver_extension.ts
+++ b/packages/benchpress/src/web_driver_extension.ts
@@ -21,6 +21,7 @@ export type PerfLogEvent = {
   args?: {
     encodedDataLength?: number,
     usedHeapSize?: number,
+    gcAmount?: number,
     majorGc?: boolean,
     url?: string,
     method?: string

--- a/packages/benchpress/src/webdriver/chrome_driver_extension.ts
+++ b/packages/benchpress/src/webdriver/chrome_driver_extension.ts
@@ -147,19 +147,9 @@ export class ChromeDriverExtension extends WebDriverExtension {
             categories, name, ['disabled-by-default-devtools.timeline'], 'CompositeLayers')) {
       return normalizeEvent(event, {'name': 'render'});
     } else if (this._isEvent(categories, name, ['devtools.timeline', 'v8'], 'MajorGC')) {
-      const normArgs = {
-        'majorGc': true,
-        'usedHeapSize': args['usedHeapSizeAfter'] !== undefined ? args['usedHeapSizeAfter'] :
-                                                                  args['usedHeapSizeBefore']
-      };
-      return normalizeEvent(event, {'name': 'gc', 'args': normArgs});
+      return normalizeGCEvent(event, true);
     } else if (this._isEvent(categories, name, ['devtools.timeline', 'v8'], 'MinorGC')) {
-      const normArgs = {
-        'majorGc': false,
-        'usedHeapSize': args['usedHeapSizeAfter'] !== undefined ? args['usedHeapSizeAfter'] :
-                                                                  args['usedHeapSizeBefore']
-      };
-      return normalizeEvent(event, {'name': 'gc', 'args': normArgs});
+      return normalizeGCEvent(event, false);
     } else if (
         this._isEvent(categories, name, ['devtools.timeline'], 'FunctionCall') &&
         (!args || !args['data'] ||
@@ -241,4 +231,19 @@ function normalizeEvent(chromeEvent: {[key: string]: any}, data: PerfLogEvent): 
     result[prop] = data[prop];
   }
   return result;
+}
+
+function normalizeGCEvent(chromeEvent: {[key: string]: any}, majorGc: boolean) {
+  const args = chromeEvent['args'];
+  const heapSizeBefore = args['usedHeapSizeBefore'];
+  const heapSizeAfter = args['usedHeapSizeAfter'];
+  const normalizedArgs = {
+    'majorGc': majorGc,
+    'usedHeapSize': heapSizeAfter !== undefined ? heapSizeAfter : heapSizeBefore,
+    'gcAmount': heapSizeBefore !== undefined && heapSizeAfter !== undefined ?
+        heapSizeBefore - heapSizeAfter :
+        0,
+  };
+
+  return normalizeEvent(chromeEvent, {'name': 'gc', 'args': normalizedArgs});
 }

--- a/packages/benchpress/src/webdriver/chrome_driver_extension.ts
+++ b/packages/benchpress/src/webdriver/chrome_driver_extension.ts
@@ -237,6 +237,13 @@ function normalizeGCEvent(chromeEvent: {[key: string]: any}, majorGc: boolean) {
   const args = chromeEvent['args'];
   const heapSizeBefore = args['usedHeapSizeBefore'];
   const heapSizeAfter = args['usedHeapSizeAfter'];
+
+  if (heapSizeBefore === undefined && heapSizeAfter === undefined) {
+    throw new Error(
+        `GC event didn't specify heap size to calculate amount of collected memory. Expected one of usedHeapSizeBefore / usedHeapSizeAfter arguments but got ${
+            JSON.stringify(args)}`);
+  }
+
   const normalizedArgs = {
     'majorGc': majorGc,
     'usedHeapSize': heapSizeAfter !== undefined ? heapSizeAfter : heapSizeBefore,

--- a/packages/benchpress/test/webdriver/chrome_driver_extension_spec.ts
+++ b/packages/benchpress/test/webdriver/chrome_driver_extension_spec.ts
@@ -153,9 +153,26 @@ import {TraceEventFactory} from '../trace_event_factory';
           .then((events) => {
             expect(events.length).toEqual(2);
             expect(events[0]).toEqual(
-                normEvents.start('gc', 1.0, {'usedHeapSize': 1000, 'majorGc': false}));
+                normEvents.start('gc', 1.0, {'usedHeapSize': 1000, 'majorGc': false, gcAmount: 0}));
             expect(events[1]).toEqual(
-                normEvents.end('gc', 2.0, {'usedHeapSize': 0, 'majorGc': false}));
+                normEvents.end('gc', 2.0, {'usedHeapSize': 0, 'majorGc': false, gcAmount: 0}));
+            done();
+          });
+    });
+
+    it('should report minor gc with GC amount', done => {
+      createExtension([
+        chromeTimelineV8Events.create(
+            'X', 'MinorGC', 1000, {'usedHeapSizeBefore': 5000, 'usedHeapSizeAfter': 2000}),
+      ])
+          .readPerfLog()
+          .then((events) => {
+            expect(events.length).toEqual(1);
+            expect(events[0]).toEqual({
+              ...normEvents.create(
+                  'X', 'gc', 1.0, {'usedHeapSize': 2000, 'majorGc': false, gcAmount: 3000}),
+              dur: 0
+            });
             done();
           });
     });
@@ -171,9 +188,26 @@ import {TraceEventFactory} from '../trace_event_factory';
           .then((events) => {
             expect(events.length).toEqual(2);
             expect(events[0]).toEqual(
-                normEvents.start('gc', 1.0, {'usedHeapSize': 1000, 'majorGc': true}));
+                normEvents.start('gc', 1.0, {'usedHeapSize': 1000, 'majorGc': true, gcAmount: 0}));
             expect(events[1]).toEqual(
-                normEvents.end('gc', 2.0, {'usedHeapSize': 0, 'majorGc': true}));
+                normEvents.end('gc', 2.0, {'usedHeapSize': 0, 'majorGc': true, gcAmount: 0}));
+            done();
+          });
+    });
+
+    it('should report major gc with GC amount', done => {
+      createExtension([
+        chromeTimelineV8Events.create(
+            'X', 'MajorGC', 1000, {'usedHeapSizeBefore': 5000, 'usedHeapSizeAfter': 2000}),
+      ])
+          .readPerfLog()
+          .then((events) => {
+            expect(events.length).toEqual(1);
+            expect(events[0]).toEqual({
+              ...normEvents.create(
+                  'X', 'gc', 1.0, {'usedHeapSize': 2000, 'majorGc': true, gcAmount: 3000}),
+              dur: 0
+            });
             done();
           });
     });


### PR DESCRIPTION
This PR fixes GC memory numbers reported by benchpress, where previously reported amount was always 0.

## The problem

To understand the fix we need to look into all the layers of the benchpress data processing from numbers reported by a browser, all the way up to the UI. Generally speaking there are 3 "interesting" layers involved:
* a browser
* a webdriver extension
* perflog metrics processing inside benchpress

Let's look at the GC memory numbers and data structures at each layer.

Firstly, the browser is going to report an event similar to:

```json
{
    "args": {
      "type": "finalize incremental marking via stack guard",
      "usedHeapSizeAfter": 19686548,
      "usedHeapSizeBefore": 23869760
    },
    "cat": "devtools.timeline,v8",
    "dur": 2250,
    "name": "MajorGC",
    "ph": "X",
    "pid": 89342,
    "tdur": 2090,
    "tid": 259,
    "ts": 367056011625,
    "tts": 239430
  },
```

Without going into the details, we can see that a GC event reports duration and before / after heap sizes (`usedHeapSizeBefore`, `usedHeapSizeAfter`). It seems like at this point we've got all the necessary information to report in the UI.

The data reported by the browser are then [normalized](https://github.com/angular/angular/blob/ac13b650743f4b8e5a4199eebf001f77d33ca401/packages/benchpress/src/webdriver/chrome_driver_extension.ts#L149-L162) to the `PerfLogEvent` data structure and the normalization process would produce:

```javascript
 {
    pid: 89342,
    ph: 'X',
    cat: 'timeline',
    ts: 367056011.625,
    dur: 2.25,
    name: 'gc',
    args: { majorGc: true, usedHeapSize: 19686548 }
  },
```

[This is the source of the bug](https://github.com/angular/angular/blob/ac13b650743f4b8e5a4199eebf001f77d33ca401/packages/benchpress/src/webdriver/chrome_driver_extension.ts#L149-L162) as we are **loosing information** (notice that we only capture `usedHeapSizeAfter` !).

The final transformation step [takes place in the metrics processing](https://github.com/angular/angular/blob/ac13b650743f4b8e5a4199eebf001f77d33ca401/packages/benchpress/src/metric/perflog_metric.ts#L186-L196) where the `X` event is split into a pair of begin / end events with the timestamp of the end event update to account for the duration:

```javascript
{
    pid: 89342,
    ph: 'B',
    cat: 'timeline',
    ts: 367056011.625,
    dur: 2.25,
    name: 'gc',
    args: { majorGc: true, usedHeapSize: 19686548 }
  },
{
    pid: 89342,
    ph: 'E',
    cat: 'timeline',
    ts: 367056013.875,
    dur: 2.25,
    name: 'gc',
    args: { majorGc: true, usedHeapSize: 19686548 }
  },
```

Notice that we are still loosing information here - one events was just split into a pair of events but each item in this pair only contains `usedHeapSize`.

Given this data the GC reporting logic can only calculate 0 as [the logic](https://github.com/angular/angular/blob/ac13b650743f4b8e5a4199eebf001f77d33ca401/packages/benchpress/src/metric/perflog_metric.ts#L347-L348) looks like follows:

```typescript
const amount =
                (startEvent['args']!['usedHeapSize']! - event['args']!['usedHeapSize']!) / 1000;
```

## The fix

The fix sketched in this PR adds a new `gcAmount` filed to the `PerfLogEvent` data structure and populates this data structure in the `ChromeDriverExtension`. 

This approach works only for Chrome, obviously. Open questions:
* what about other browsers?
* what about the Chrome version update - is the latest version of Chrome producing the same events?