### PR TITLE
build: resolve benchmark compare SHA from PR branch or upstream remote

### DIFF
--- a/.github/workflows/benchmark-compare.yml
+++ b/.github/workflows/benchmark-compare.yml
@@ -44,17 +44,11 @@ jobs:
         with:
           bazelrc: ./.bazelrc.user
 
-      - name: Extracting comment information
+      - name: Preparing benchmark for GitHub action
         id: info
-        run: yarn benchmarks extract-compare-comment "${{github.event.comment.body}}"
+        run: yarn benchmarks prepare-for-github-action "${{github.event.comment.body}}"
 
-      - name: Resolving current PR SHA
-        id: refs
-        run: |
-          echo "prSha=$(git rev-parse ${{steps.comment-branch.outputs.head_ref}})" >> "$GITHUB_OUTPUT"
-          echo "compareSha=$(git rev-parse ${{steps.info.outputs.compareRef}})" >> "$GITHUB_OUTPUT"
-
-      - run: yarn benchmarks run-compare ${{steps.refs.outputs.compareSha}} ${{steps.info.outputs.benchmarkTarget}}
+      - run: yarn benchmarks run-compare ${{steps.info.outputs.compareSha}} ${{steps.info.outputs.benchmarkTarget}}
         id: benchmark
         name: Running benchmark
 
@@ -66,8 +60,8 @@ jobs:
             ## Benchmark Test Results
             **Test**: `${{steps.info.outputs.benchmarkTarget}}`
 
-            ### PR (${{steps.refs.outputs.prSha}})
+            ### PR (${{steps.info.outputs.prHeadSha}})
             ${{steps.benchmark.outputs.workingStageResultsText}}
 
-            ### Compare Ref (${{steps.refs.outputs.compareSha}})
+            ### Compare Ref (${{steps.info.outputs.compareSha}})
             ${{steps.benchmark.outputs.comparisonResultsText}}

--- a/scripts/benchmarks/index.mts
+++ b/scripts/benchmarks/index.mts
@@ -86,8 +86,7 @@ async function prepareForGitHubAction(commentBody: string): Promise<void> {
   }
 
   const git = await GitClient.get();
-  const compareRefRaw = matches[1];
-  const benchmarkTarget = matches[2];
+  const [_, compareRefRaw, benchmarkTarget] = matches;
 
   // We assume the PR is checked out and therefore `HEAD` is the PR head SHA.
   const prHeadSha = git.run(['rev-parse', 'HEAD']).stdout.trim();

--- a/scripts/benchmarks/index.mts
+++ b/scripts/benchmarks/index.mts
@@ -45,10 +45,10 @@ await yargs(process.argv.slice(2))
     (args) => runBenchmarkCmd(args.bazelTarget)
   )
   .command(
-    'extract-compare-comment <comment-body>',
+    'prepare-for-github-action <comment-body>',
     false, // Do not show in help.
     (argv) => argv.positional('comment-body', {demandOption: true, type: 'string'}),
-    (args) => extractCompareComment(args.commentBody)
+    (args) => prepareForGitHubAction(args.commentBody)
   )
   .demandCommand()
   .scriptName('$0')
@@ -71,20 +71,42 @@ async function promptForBenchmarkTarget(): Promise<string> {
 }
 
 /**
- * Extracts arguments from a benchmark compare comment.
+ * Prepares a benchmark comparison running via GitHub action. This command is
+ * used by the GitHub action YML workflow and is responsible for extracting
+ * e.g. command information or fetching/resolving Git refs of the comparison range.
  *
  * This is a helper used by the GitHub action to perform benchmark
  * comparisons. Commands follow the format of: `/benchmark-compare <sha> <target>`.
  */
-async function extractCompareComment(commentBody: string): Promise<void> {
+async function prepareForGitHubAction(commentBody: string): Promise<void> {
   const matches = /\/[^ ]+ ([^ ]+) ([^ ]+)/.exec(commentBody);
   if (matches === null) {
     Log.error('Could not extract information from comment', commentBody);
     process.exit(1);
   }
 
-  setOutput('compareRef', matches[1]);
-  setOutput('benchmarkTarget', matches[2]);
+  const git = await GitClient.get();
+  const compareRefRaw = matches[1];
+  const benchmarkTarget = matches[2];
+
+  // We assume the PR is checked out and therefore `HEAD` is the PR head SHA.
+  const prHeadSha = git.run(['rev-parse', 'HEAD']).stdout.trim();
+
+  setOutput('benchmarkTarget', benchmarkTarget);
+  setOutput('prHeadSha', prHeadSha);
+
+  // Attempt to find the compare SHA. The commit may be either part of the
+  // pull request, or might be a commit unrelated to the PR- but part of the
+  // upstream repository. We attempt to fetch/resolve the SHA in both remotes.
+  let compareRefSha: string|null = null;
+  try {
+    compareRefSha = git.run(['rev-parse', compareRefRaw]).stdout.trim();
+  } catch {
+    git.run(['fetch', '--depth=1', git.getRepoGitUrl(), compareRefRaw]);
+    compareRefSha = git.run(['rev-parse', compareRefRaw]).stdout.trim();
+  }
+
+  setOutput('compareSha', compareRefSha);
 }
 
 /** Runs a specified benchmark, or a benchmark selected via prompt. */


### PR DESCRIPTION
If we try to resolve the benchmark compare ref (which may be just `main`), we are just looking inside the PR branch- but that may not include the `main` SHA. i.e. it's possible to run a comparison where the PR is slightly behind of the `main` branch, or a comparison commit from a different branch is used.

We fix this/ and simplify the logic by resolving the SHAs directly in the TypeScript code, instead of relying on the rather brittle Bash.

Note that current solution still works, but we sometimes may not be able to resolve to an actual SHA- causing issues as in 864bd72cb22bb87f83284959297ab3734230fa91