### PR TITLE
build: fix benchmark sha resolution breaking when compare ref is abbreviated

### DIFF
--- a/scripts/benchmarks/index.mts
+++ b/scripts/benchmarks/index.mts
@@ -97,8 +97,8 @@ async function prepareForGitHubAction(commentBody: string): Promise<void> {
   // Attempt to find the compare SHA. The commit may be either part of the
   // pull request, or might be a commit unrelated to the PR- but part of the
   // upstream repository. We attempt to fetch/resolve the SHA in both remotes.
-  let compareRefSha: string | null = git.runGraceful(['rev-parse', compareRefRaw]).stdout.trim();
-  if (compareRefSha == null) {
+  let compareRefSha: string = git.runGraceful(['rev-parse', compareRefRaw]).stdout.trim();
+  if (compareRefSha === '') {
     git.run(['fetch', '--depth=1', git.getRepoGitUrl(), compareRefRaw]);
     compareRefSha = git.run(['rev-parse', 'FETCH_HEAD']).stdout.trim();
   }

--- a/scripts/benchmarks/index.mts
+++ b/scripts/benchmarks/index.mts
@@ -97,7 +97,7 @@ async function prepareForGitHubAction(commentBody: string): Promise<void> {
   // Attempt to find the compare SHA. The commit may be either part of the
   // pull request, or might be a commit unrelated to the PR- but part of the
   // upstream repository. We attempt to fetch/resolve the SHA in both remotes.
-  let compareRefSha: string = git.runGraceful(['rev-parse', compareRefRaw]).stdout.trim();
+  let compareRefSha = git.runGraceful(['rev-parse', compareRefRaw]).stdout.trim();
   if (compareRefSha === '') {
     git.run(['fetch', '--depth=1', git.getRepoGitUrl(), compareRefRaw]);
     compareRefSha = git.run(['rev-parse', 'FETCH_HEAD']).stdout.trim();

--- a/scripts/benchmarks/index.mts
+++ b/scripts/benchmarks/index.mts
@@ -97,12 +97,10 @@ async function prepareForGitHubAction(commentBody: string): Promise<void> {
   // Attempt to find the compare SHA. The commit may be either part of the
   // pull request, or might be a commit unrelated to the PR- but part of the
   // upstream repository. We attempt to fetch/resolve the SHA in both remotes.
-  let compareRefSha: string|null = null;
-  try {
-    compareRefSha = git.run(['rev-parse', compareRefRaw]).stdout.trim();
-  } catch {
+  let compareRefSha: string | null = git.runGraceful(['rev-parse', compareRefRaw]).stdout.trim();
+  if (compareRefSha == null) {
     git.run(['fetch', '--depth=1', git.getRepoGitUrl(), compareRefRaw]);
-    compareRefSha = git.run(['rev-parse', compareRefRaw]).stdout.trim();
+    compareRefSha = git.run(['rev-parse', 'FETCH_HEAD']).stdout.trim();
   }
 
   setOutput('compareSha', compareRefSha);


### PR DESCRIPTION
When we fetch e.g. `main`, the branch name will not be available locally, and `rev-parse`
will fail later. We can make the logic more safe by just using `FETCH_HEAD` then.
