### PR TITLE
build: resolve benchmark compare ref from upstream if rev-parse fails

### DIFF
--- a/scripts/benchmarks/index.mts
+++ b/scripts/benchmarks/index.mts
@@ -97,8 +97,9 @@ async function prepareForGitHubAction(commentBody: string): Promise<void> {
   // Attempt to find the compare SHA. The commit may be either part of the
   // pull request, or might be a commit unrelated to the PR- but part of the
   // upstream repository. We attempt to fetch/resolve the SHA in both remotes.
-  let compareRefSha = git.runGraceful(['rev-parse', compareRefRaw]).stdout.trim();
-  if (compareRefSha === '') {
+  const compareRefResolve = git.runGraceful(['rev-parse', compareRefRaw]);
+  let compareRefSha = compareRefResolve.stdout.trim();
+  if (compareRefSha === '' || compareRefResolve.status !== 0) {
     git.run(['fetch', '--depth=1', git.getRepoGitUrl(), compareRefRaw]);
     compareRefSha = git.run(['rev-parse', 'FETCH_HEAD']).stdout.trim();
   }


### PR DESCRIPTION
`rev-parse` returns the original ref name in stdout, even if it wasn't able to resolve the reference. This was preventing the upstream resolution from never happening- causing `main` to be never resolved to the actual SHA.