### PR TITLE
feat(benchpress): report gc and render time spent in script

### DIFF
--- a/packages/benchpress/src/metric/perflog_metric.ts
+++ b/packages/benchpress/src/metric/perflog_metric.ts
@@ -72,13 +72,15 @@ export class PerflogMetric extends Metric {
   override describe(): {[key: string]: string} {
     const res: {[key: string]: any} = {
       'scriptTime': 'script execution time in ms, including gc and render',
-      'pureScriptTime': 'script execution time in ms, without gc nor render'
+      'pureScriptTime': 'script execution time in ms, without gc nor render',
     };
     if (this._perfLogFeatures.render) {
       res['renderTime'] = 'render time in ms';
+      res['renderTimeInScript'] = 'render time in ms while executing script (usually means reflow)';
     }
     if (this._perfLogFeatures.gc) {
       res['gcTime'] = 'gc time in ms';
+      res['gcTimeInScript'] = 'gc time in ms while executing scripts';
       res['gcAmount'] = 'gc amount in kbytes';
       res['majorGcTime'] = 'time of major gcs in ms';
       if (this._forceGc) {
@@ -377,7 +379,11 @@ export class PerflogMetric extends Metric {
     if (frameTimes.length > 0) {
       this._addFrameMetrics(result, frameTimes);
     }
+
+    result['renderTimeInScript'] = renderTimeInScript;
+    result['gcTimeInScript'] = gcTimeInScript;
     result['pureScriptTime'] = result['scriptTime'] - gcTimeInScript - renderTimeInScript;
+
     return result;
   }
 


### PR DESCRIPTION
GC and render events can happen _while_ running scripts as well as outside of the script blocks. The new metric entries capture both the gc and render time happening in the scrip blocks.
