### PR TITLE
fix(http): use `serializeBody` to support JSON payload in FetchBackend

### DIFF
--- a/packages/common/http/src/fetch.ts
+++ b/packages/common/http/src/fetch.ts
@@ -221,7 +221,7 @@ export class FetchBackend implements HttpBackend {
     }
 
     return {
-      body: req.body,
+      body: req.serializeBody(),
       method: req.method,
       headers,
       credentials,

--- a/packages/common/http/test/fetch_spec.ts
+++ b/packages/common/http/test/fetch_spec.ts
@@ -33,6 +33,10 @@ const TEST_POST = new HttpRequest('POST', '/test', 'some body', {
   responseType: 'text',
 });
 
+const TEST_POST_WITH_JSON_BODY = new HttpRequest('POST', '/test', {'some': 'body'}, {
+  responseType: 'text',
+});
+
 const XSSI_PREFIX = ')]}\'\n';
 
 describe('FetchBackend', async () => {
@@ -97,6 +101,11 @@ describe('FetchBackend', async () => {
   it('sets outgoing body correctly', () => {
     callFetchAndFlush(TEST_POST);
     expect(fetchMock.request.body).toBe('some body');
+  });
+
+  it('sets outgoing body correctly when request payload is json', () => {
+    callFetchAndFlush(TEST_POST_WITH_JSON_BODY);
+    expect(fetchMock.request.body).toBe('{"some":"body"}');
   });
 
   it('sets outgoing headers, including default headers', () => {

--- a/packages/common/http/test/xhr_spec.ts
+++ b/packages/common/http/test/xhr_spec.ts
@@ -24,6 +24,10 @@ const TEST_POST = new HttpRequest('POST', '/test', 'some body', {
   responseType: 'text',
 });
 
+const TEST_POST_WITH_JSON_BODY = new HttpRequest('POST', '/test', {'some': 'body'}, {
+  responseType: 'text',
+});
+
 const XSSI_PREFIX = ')]}\'\n';
 
 {
@@ -48,6 +52,10 @@ const XSSI_PREFIX = ')]}\'\n';
     it('sets outgoing body correctly', () => {
       backend.handle(TEST_POST).subscribe();
       expect(factory.mock.body).toBe('some body');
+    });
+    it('sets outgoing body correctly when request payload is json', () => {
+      backend.handle(TEST_POST_WITH_JSON_BODY).subscribe();
+      expect(factory.mock.body).toBe('{"some":"body"}');
     });
     it('sets outgoing headers, including default headers', () => {
       const post = TEST_POST.clone({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/50775 


## What is the new behavior?
it correctly serialize request body (same behavior with HttpXhrBackend)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
