### PR TITLE
docs: release notes for the v16.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="16.1.2"></a>
+# 16.1.2 (2023-06-21)
+### http
+| Commit | Type | Description |
+| -- | -- | -- |
+| [9488a3fd46](https://github.com/angular/angular/commit/9488a3fd4640b902243f441cf54776160da1a0fe) | fix | Send query params on fetch request ([#50740](https://github.com/angular/angular/pull/50740)) |
+| [5ae001829c](https://github.com/angular/angular/commit/5ae001829c3f3594e3c10f30e0b89ea1eb2b84fb) | fix | use serializeBody to support JSON payload in FetchBackend ([#50776](https://github.com/angular/angular/pull/50776)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.1.1"></a>
 # 16.1.1 (2023-06-14)
 ### compiler-cli


### PR DESCRIPTION
Cherry-picks the changelog from the "16.1.x" branch to the next branch (main).