### PR TITLE
docs(docs-infra): remove transitions on sidenav

### DIFF
--- a/aio/src/styles/1-layouts/sidenav/_sidenav.scss
+++ b/aio/src/styles/1-layouts/sidenav/_sidenav.scss
@@ -108,7 +108,6 @@ aio-nav-menu {
         visibility: visible;
         opacity: 1;
         padding-left: 0;
-        max-height: 4000px; // Arbitrary max-height. Can increase if needed. Must have measurement to transition height.
         transition: visibility 500ms, opacity 500ms, max-height 500ms;
         transition-timing-function: ease-in-out;
       }


### PR DESCRIPTION
The style of the sidenav can be breaking when height > 4000. Lets remove this transition to not depend on a max height.

fixes #50537

## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes


## Does this PR introduce a breaking change?

- [x] No
