### PR TITLE
build: print benchmark results at the end of yarn benchmarks run invocation

### DIFF
--- a/scripts/benchmarks/index.mts
+++ b/scripts/benchmarks/index.mts
@@ -112,7 +112,16 @@ async function runBenchmarkCmd(bazelTargetRaw: string | undefined): Promise<void
   if (bazelTargetRaw === undefined) {
     bazelTargetRaw = await promptForBenchmarkTarget();
   }
-  await runBenchmarkTarget(await resolveTarget(bazelTargetRaw));
+  const bazelTarget = await resolveTarget(bazelTargetRaw);
+  const testlogPath = await getTestlogPath(bazelTarget);
+
+  await runBenchmarkTarget(bazelTarget);
+
+  const workingDirResults = await collectBenchmarkResults(testlogPath);
+
+  Log.info('\n\n\n');
+  Log.info(bold(green('Results!')));
+  Log.info(workingDirResults.summaryConsoleText);
 }
 
 /** Runs a benchmark Bazel target. */


### PR DESCRIPTION
We already collect and report benchmark results for comparison runs, but for normal benchmark runs we should do the same to make the results more discoverable (and not in the middle of Bazel output).