### PR TITLE
docs: fix missing word in first-app-lesson-02

### DIFF
--- a/aio/content/tutorial/first-app/first-app-lesson-02.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-02.md
@@ -25,7 +25,7 @@ If you have any trouble during this lesson, you can review the completed code fo
 
 Angular apps are built around components, which are Angular's building blocks.
 Components contain the code, HTML layout, and CSS style information that provide the function and appearance of an element in the app.
-In Angular, components can contain other components. An app's functions and appearance can divided and partitioned into components.
+In Angular, components can contain other components. An app's functions and appearance can be divided and partitioned into components.
 
 In [Lesson 1](tutorial/first-app/first-app-lesson-01), you updated the `AppComponent`, whose function is to contain all the other components.
 In this lesson, you create a `HomeComponent` to display the home page of the app.


### PR DESCRIPTION
I fixed paragraph `Conceptual preview of Angular components`, I believe the sentence: 

> An app's functions and appearance can divided and partitioned into components.

should contain a word "be":

> An app's functions and appearance can **be** divided and partitioned into components.



## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
