### PR TITLE
refactor(compiler): Generate `attribute` and `attributeInterpolate` instructions in template pipeline

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/attribute_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/attribute_bindings/TEST_CASES.json
@@ -13,8 +13,7 @@
             "chain_multiple_bindings.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should chain multiple single-interpolation attribute bindings into one instruction",
@@ -28,8 +27,7 @@
             "chain_multiple_single_interpolation.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should chain attribute bindings in the presence of other bindings",
@@ -118,8 +116,7 @@
             "interpolated_attributes.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     }
   ]
 }

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -122,6 +122,11 @@ export enum OpKind {
    * An operation to associate an attribute with an element.
    */
   Attribute,
+
+  /**
+   * An operation to interpolate text into an attribute binding.
+   */
+  InterpolateAttribute,
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -752,7 +752,12 @@ export function transformExpressionsInOp(
       break;
     case OpKind.Attribute:
       if (op.value) {
-        transformExpressionsInExpression(op.value, transform, flags);
+        op.value = transformExpressionsInExpression(op.value, transform, flags);
+      }
+      break;
+    case OpKind.InterpolateAttribute:
+      for (let i = 0; i < op.expressions.length; i++) {
+        op.expressions[i] = transformExpressionsInExpression(op.expressions[i], transform, flags);
       }
       break;
     case OpKind.Variable:

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -17,9 +17,9 @@ import {ListEndOp, NEW_OP, StatementOp, VariableOp} from './shared';
 /**
  * An operation usable on the update side of the IR.
  */
-export type UpdateOp = ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|StylePropOp|StyleMapOp|
-    InterpolatePropertyOp|InterpolateStylePropOp|InterpolateStyleMapOp|AttributeOp|
-    InterpolateTextOp|AdvanceOp|VariableOp<UpdateOp>;
+export type UpdateOp = ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|AttributeOp|StylePropOp|
+    StyleMapOp|InterpolatePropertyOp|InterpolateAttributeOp|InterpolateStylePropOp|
+    InterpolateStyleMapOp|AttributeOp|InterpolateTextOp|AdvanceOp|VariableOp<UpdateOp>;
 
 /**
  * A logical operation to perform string interpolation on a text node.
@@ -190,7 +190,7 @@ export interface AttributeOp extends Op<UpdateOp> {
   kind: OpKind.Attribute;
 
   /**
-   * The `XrefId` of the template-like element the attribte will belong to.
+   * The `XrefId` of the template-like element the attribute will belong to.
    */
   target: XrefId;
 
@@ -222,6 +222,8 @@ export function createAttributeOp(
     attributeKind,
     name,
     value,
+    ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
+    ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
   };
 }
@@ -273,6 +275,55 @@ export function createInterpolatePropertyOp(
     kind: OpKind.InterpolateProperty,
     target: xref,
     bindingKind,
+    name,
+    strings,
+    expressions,
+    ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
+    ...TRAIT_CONSUMES_VARS,
+    ...NEW_OP,
+  };
+}
+export interface InterpolateAttributeOp extends Op<UpdateOp>, ConsumesVarsTrait,
+                                                DependsOnSlotContextOpTrait {
+  kind: OpKind.InterpolateAttribute;
+
+  /**
+   * The `XrefId` of the template-like element the attribute will belong to.
+   */
+  target: XrefId;
+
+  /**
+   * The kind of attribute.
+   */
+  attributeKind: ElementAttributeKind;
+
+  /**
+   * The name of the attribute.
+   */
+  name: string;
+
+  /**
+   * All of the literal strings in the attribute interpolation, in order.
+   *
+   * Conceptually interwoven around the `expressions`.
+   */
+  strings: string[];
+
+  /**
+   * All of the dynamic expressions in the attribute interpolation, in order.
+   *
+   * Conceptually interwoven in between the `strings`.
+   */
+  expressions: o.Expression[];
+}
+
+export function createInterpolateAttributeOp(
+    target: XrefId, attributeKind: ElementAttributeKind, name: string, strings: string[],
+    expressions: o.Expression[]): InterpolateAttributeOp {
+  return {
+    kind: OpKind.InterpolateAttribute,
+    target: target,
+    attributeKind,
     name,
     strings,
     expressions,

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -140,6 +140,10 @@ export function property(name: string, expression: o.Expression): ir.UpdateOp {
   ]);
 }
 
+export function attribute(name: string, expression: o.Expression): ir.UpdateOp {
+  return call(Identifiers.attribute, [o.literal(name), expression]);
+}
+
 export function styleProp(name: string, expression: o.Expression, unit: string|null): ir.UpdateOp {
   const args = [o.literal(name), expression];
   if (unit !== null) {
@@ -207,6 +211,14 @@ export function propertyInterpolate(
   const interpolationArgs = collateInterpolationArgs(strings, expressions);
 
   return callVariadicInstruction(PROPERTY_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs);
+}
+
+export function attributeInterpolate(
+    name: string, strings: string[], expressions: o.Expression[]): ir.UpdateOp {
+  const interpolationArgs = collateInterpolationArgs(strings, expressions);
+
+  return callVariadicInstruction(
+      ATTRIBUTE_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs);
 }
 
 export function stylePropInterpolate(
@@ -349,6 +361,30 @@ const STYLE_PROP_INTERPOLATE_CONFIG: VariadicInstructionConfig = {
     }
     if (n < 3) {
       throw new Error(`Expected at least 3 arguments`);
+    }
+    return (n - 1) / 2;
+  },
+};
+
+/**
+ * `InterpolationConfig` for the `attributeInterpolate` instruction.
+ */
+const ATTRIBUTE_INTERPOLATE_CONFIG: VariadicInstructionConfig = {
+  constant: [
+    Identifiers.attribute,
+    Identifiers.attributeInterpolate1,
+    Identifiers.attributeInterpolate2,
+    Identifiers.attributeInterpolate3,
+    Identifiers.attributeInterpolate4,
+    Identifiers.attributeInterpolate5,
+    Identifiers.attributeInterpolate6,
+    Identifiers.attributeInterpolate7,
+    Identifiers.attributeInterpolate8,
+  ],
+  variable: Identifiers.attributeInterpolateV,
+  mapping: n => {
+    if (n % 2 === 0) {
+      throw new Error(`Expected odd number of arguments`);
     }
     return (n - 1) / 2;
   },

--- a/packages/compiler/src/template/pipeline/src/phases/chaining.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/chaining.ts
@@ -16,6 +16,7 @@ const CHAINABLE = new Set([
   R3.elementEnd,
   R3.property,
   R3.styleProp,
+  R3.attribute,
   R3.elementContainerStart,
   R3.elementContainerEnd,
   R3.elementContainer,

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -140,6 +140,12 @@ function reifyUpdateOperations(_view: ViewCompilation, ops: ir.OpList<ir.UpdateO
       case ir.OpKind.InterpolateText:
         ir.OpList.replace(op, ng.textInterpolate(op.strings, op.expressions));
         break;
+      case ir.OpKind.Attribute:
+        ir.OpList.replace(op, ng.attribute(op.name, op.value));
+        break;
+      case ir.OpKind.InterpolateAttribute:
+        ir.OpList.replace(op, ng.attributeInterpolate(op.name, op.strings, op.expressions));
+        break;
       case ir.OpKind.Variable:
         if (op.variable.name === null) {
           throw new Error(`AssertionError: unnamed variable ${op.xref}`);

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
@@ -96,6 +96,15 @@ function processLexicalScope(
       }
     }, ir.VisitorContextFlag.None);
   }
+
+  for (const op of ops) {
+    ir.visitExpressionsInOp(op, expr => {
+      if (expr instanceof ir.LexicalReadExpr) {
+        throw new Error(
+            `AssertionError: no lexical reads should remain, but found read of ${expr.name}`);
+      }
+    });
+  }
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -66,6 +66,9 @@ function varsUsedByOp(op: (ir.CreateOp|ir.UpdateOp)&ir.ConsumesVarsTrait): numbe
     case ir.OpKind.StyleMap:
       // Property bindings use 1 variable slot.
       return 1;
+    case ir.OpKind.Attribute:
+      // Attribute bindings use 1 variable slot.
+      return 1;
     case ir.OpKind.InterpolateText:
       // `ir.InterpolateTextOp`s use a variable slot for each dynamic expression.
       return op.expressions.length;
@@ -74,6 +77,9 @@ function varsUsedByOp(op: (ir.CreateOp|ir.UpdateOp)&ir.ConsumesVarsTrait): numbe
     case ir.OpKind.InterpolateStyleMap:
       // `ir.InterpolatePropertyOp`s use a variable slot for each dynamic expression, plus one for
       // the result.
+      return 1 + op.expressions.length;
+    case ir.OpKind.InterpolateAttribute:
+      // One variable slot for each dynamic expression, plus one for the result.
       return 1 + op.expressions.length;
     default:
       throw new Error(`Unhandled op: ${ir.OpKind[op.kind]}`);


### PR DESCRIPTION
This commit adds the ability to generate attribute instructions as a result of property bindings such as `[attr.foo]='bar'` or `attr.foo='{{bar}}'`. "Singleton" interpolations, such as the previous example, will also be transformed into a simple `attribute` instruction.

(This is based on a previous commit, in which @mmalerba and I recently refactored of the way property bindings are injested.)