### PR TITLE
docs: invert logic for disabled in getting started docs

### DIFF
--- a/aio/content/examples/what-is-angular/src/app/hello-world-bindings/hello-world-bindings.component.html
+++ b/aio/content/examples/what-is-angular/src/app/hello-world-bindings/hello-world-bindings.component.html
@@ -1,7 +1,7 @@
 <!-- #docregion event-binding -->
 <button
   type="button"
-  [disabled]="canClick"
+  [disabled]="!canClick"
   (click)="sayMessage()">
   Trigger alert message
 </button>

--- a/aio/content/examples/what-is-angular/src/app/hello-world-bindings/hello-world-bindings.component.ts
+++ b/aio/content/examples/what-is-angular/src/app/hello-world-bindings/hello-world-bindings.component.ts
@@ -7,7 +7,7 @@ import { Component } from '@angular/core';
 export class HelloWorldBindingsComponent {
   fontColor = 'blue';
   sayHelloId = 1;
-  canClick = false;
+  canClick = true;
   message = 'Hello, World';
 
 // #docregion method


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In the Getting Started docs in the template section, the button's disabled attribute is bind to `canClick` property. 

Issue Number: #50811 

## What is the new behavior?
Inverted the logic so the disabled attribute is assigned to `!canClick` value, making it more clear how it works:
- if canClick is true - the button is not disabled
- if canClick is false - the button is disabled

By default, the button is not disabled - as per e2e specs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
