### PR TITLE
docs(common): remove `@developerPreview` from `NgOptimizedImage` related items

### DIFF
--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -94,7 +94,6 @@ export const BUILT_IN_LOADERS = [imgixLoaderInfo, imageKitLoaderInfo, cloudinary
  * Learn more about the responsive image configuration in [the NgOptimizedImage
  * guide](guide/image-directive).
  * @publicApi
- * @developerPreview
  */
 export type ImageConfig = {
   breakpoints?: number[]
@@ -109,7 +108,6 @@ const defaultConfig: ImageConfig = {
  *
  * @see {@link NgOptimizedImage}
  * @publicApi
- * @developerPreview
  */
 export const IMAGE_CONFIG = new InjectionToken<ImageConfig>(
     'ImageConfig', {providedIn: 'root', factory: () => defaultConfig});
@@ -307,8 +305,6 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
   /**
    * Sets the image to "fill mode", which eliminates the height/width requirement and adds
    * styles such that the image fills its containing element.
-   *
-   * @developerPreview
    */
   @Input({transform: booleanAttribute}) fill = false;
 


### PR DESCRIPTION
NgOptimizedImage API is now stable, therefore remove `@developerPreview` from:
- `ImageConfig`;
- `IMAGE_CONFIG`;
- `@Input() fill`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Documentation content changes


## What is the current behavior?
On to docs site, we can now filter [developer preview items](https://angular.io/api?status=developer-preview) and these two items pop-up:
![image](https://github.com/angular/angular/assets/28087049/bdbcacb6-69ef-4d02-a09a-5f9db04ce545)

However, they no longer have developer preview status.

Issue Number: N/A


## What is the new behavior?
Remove developer preview status of stable APIs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
