### PR TITLE
docs: updating the method to display first four items from dashboard …

### DIFF
--- a/aio/content/examples/toh-pt5/src/app/dashboard/dashboard.component.ts
+++ b/aio/content/examples/toh-pt5/src/app/dashboard/dashboard.component.ts
@@ -20,7 +20,7 @@ export class DashboardComponent implements OnInit {
   // #docregion getHeroes
   getHeroes(): void {
     this.heroService.getHeroes()
-      .subscribe(heroes => this.heroes = heroes.slice(1, 5));
+      .subscribe(heroes => this.heroes = heroes.slice(0, 4));
   }
   // #enddocregion getHeroes
 }

--- a/aio/content/examples/toh-pt6/src/app/dashboard/dashboard.component.ts
+++ b/aio/content/examples/toh-pt6/src/app/dashboard/dashboard.component.ts
@@ -19,6 +19,6 @@ export class DashboardComponent implements OnInit {
 
   getHeroes(): void {
     this.heroService.getHeroes()
-      .subscribe(heroes => this.heroes = heroes.slice(1, 5));
+      .subscribe(heroes => this.heroes = heroes.slice(0, 4));
   }
 }


### PR DESCRIPTION
Docs: updating the Hero Example to fix the below issue


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
https://github.com/angular/angular/issues/50821


Issue Number: https://github.com/angular/angular/issues/50821


## What is the new behavior?
In the Dashboard component, in the getHeroes method, there is a problem. The method should display the first four elements of the heroes array, but when using the slice method, it is written as (1, 5) instead of (0, 4)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
