### PR TITLE
docs : Removing alert message which no longer applicable after Angular 15

### DIFF
--- a/aio/content/start/index.md
+++ b/aio/content/start/index.md
@@ -258,13 +258,6 @@ The Phone XL price is over &dollar;700, so the **Notify Me** button appears on t
 To make the **Notify Me** button work, the child component needs to notify and pass the data to the parent component.
 The `ProductAlertsComponent` needs to emit an event when the user clicks **Notify Me** and the `ProductListComponent` needs to respond to the event.
 
-<div class="alert is-helpful">
-
-In new components, the Angular Generator includes an empty `constructor()`, the `OnInit` interface, and the `ngOnInit()` method.
-Since these steps don't use them, the following code examples omit them for brevity.
-
-</div>
-
 1.  In `product-alerts.component.ts`, import `Output` and `EventEmitter` from `@angular/core`.
 
     <code-example header="src/app/product-alerts/product-alerts.component.ts" path="getting-started/src/app/product-alerts/product-alerts.component.ts" region="imports"></code-example>


### PR DESCRIPTION
Removing alert message which no longer applicable after Angular 15 under documents

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
component generation schematics wont create an empty constructor and ngOnInit from version 15 onwards the alert message from in the docs is a bit confusing. 
https://github.com/angular/angular/issues/50825

Issue Number: https://github.com/angular/angular/issues/50825


## What is the new behavior?
component generation schematics wont create an empty constructor and ngOnInit from version 15 onwards the alert message from in the docs is a bit confusing. So Removing the warning message from the docs. Warning message no longer available under docs

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
