### PR TITLE
build: allow for compliance specs only using template pipeline

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/test_case_schema.json
+++ b/packages/compiler-cli/test/compliance/test_cases/test_case_schema.json
@@ -134,7 +134,11 @@
             "type": "object"
           },
           "skipForTemplatePipeline": {
-            "tite": "Set to true to skip this test when running with use_template_pipeline",
+            "title": "Set to true to skip this test when running with use_template_pipeline",
+            "type": "boolean"
+          },
+          "onlyForTemplatePipeline": {
+            "title": "If set to `true`, this test will only execute when the template pipeline is used",
             "type": "boolean"
           },
           "focusTest": {

--- a/packages/compiler-cli/test/compliance/test_helpers/get_compliance_tests.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/get_compliance_tests.ts
@@ -52,6 +52,7 @@ export function* getComplianceTests(absTestConfigPath: AbsoluteFsPath): Generato
       expectations: parseExpectations(test.expectations, realTestPath, inputFiles),
       compilerOptions: getConfigOptions(test, 'compilerOptions', realTestPath),
       angularCompilerOptions: getConfigOptions(test, 'angularCompilerOptions', realTestPath),
+      onlyForTemplatePipeline: test.onlyForTemplatePipeline,
       skipForTemplatePipeline: test.skipForTemplatePipeline,
       focusTest: test.focusTest,
       excludeTest: test.excludeTest,
@@ -246,6 +247,8 @@ export interface ComplianceTest {
   expectations: Expectation[];
   /** If set to `true` this test is skipped when testing with use_template_pipeline */
   skipForTemplatePipeline?: boolean;
+  /** If set to `true`, this test will only execute when the template pipeline is used. */
+  onlyForTemplatePipeline?: boolean;
   /** If set to `true`, then focus on this test (equivalent to jasmine's 'fit()`). */
   focusTest?: boolean;
   /** If set to `true`, then exclude this test (equivalent to jasmine's 'xit()`). */
@@ -309,6 +312,7 @@ export interface TestCaseJson {
   };
   compilerOptions?: ConfigOptions;
   angularCompilerOptions?: ConfigOptions;
+  onlyForTemplatePipeline?: boolean;
   skipForTemplatePipeline?: boolean;
   focusTest?: boolean;
   excludeTest?: boolean;

--- a/packages/compiler-cli/test/compliance/test_helpers/test_runner.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/test_runner.ts
@@ -29,6 +29,9 @@ export function runTests(
       if (USE_TEMPLATE_PIPELINE && test.skipForTemplatePipeline) {
         continue;
       }
+      if (!USE_TEMPLATE_PIPELINE && test.onlyForTemplatePipeline) {
+        continue;
+      }
 
       describe(`[${test.relativePath}]`, () => {
         const itFn = test.focusTest ? fit : test.excludeTest ? xit : it;


### PR DESCRIPTION
When writing signal compliance tests, we need to limit these to only the template pipeline.