### PR TITLE
refactor: fix input signal not allowing new values

### DIFF
--- a/packages/core/src/render3/instructions/property_create.ts
+++ b/packages/core/src/render3/instructions/property_create.ts
@@ -55,9 +55,16 @@ export function ɵɵpropertyCreate<T>(
       }
     } else {
       ngDevMode && assertIndexInRange(lView, directiveIndex);
-      // TODO(pk): make sure that we are creating one computed for all the inputs
+
       // PERF: megamorphic read on [privateName] access
-      (lView[directiveIndex][privateName][SIGNAL] as InternalInputSignal).bindToComputation(expr);
+      const inputSignal = (lView[directiveIndex][privateName][SIGNAL] as InternalInputSignal)
+
+      // TODO(pk): make sure that we are creating one computed for all the inputs
+      inputSignal.bindToComputation(expr);
+
+      // TODO: We want to set this after ALL inputs are set I think. This right now
+      // is just a trick because we did not fully implement the semantics around this.
+      inputSignal.initialized();
     }
   }
 

--- a/packages/core/test/render3/reactivity/input_signal_spec.ts
+++ b/packages/core/test/render3/reactivity/input_signal_spec.ts
@@ -6,13 +6,10 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AfterViewInit, Component, ContentChildren, createComponent, destroyPlatform, effect, EnvironmentInjector, inject, Injector, Input, NgZone, OnChanges, QueryList, signal, SimpleChanges, ViewChild} from '@angular/core';
+import {signal} from '@angular/core';
 import {input} from '@angular/core/src/render3/reactivity/input';
 import {InputSignal, InputSignalImpl} from '@angular/core/src/render3/reactivity/input_signal';
 import {SIGNAL} from '@angular/core/src/signals';
-import {TestBed} from '@angular/core/testing';
-import {bootstrapApplication} from '@angular/platform-browser';
-import {withBody} from '@angular/private/testing';
 
 describe('input signals', () => {
   it('should throw before initialization', () => {


### PR DESCRIPTION
If `InputSignal` is computed once, it will never re-compute unless the actual user-bound
computation changes. This may not be the case when:

- the input signal is only ever changing using `bindToValue`. e.g. when Zone components bind to the signal input.

- the input signal is initialized with an initial value, and read before the computation is set. This should never happen in practice because we are guarding by `initialized()` but it highlights the issue that `switchedComputation` needs a way to be notified of change.

Even if we set `stale=true`, it doesn't guarantee that `switchedComputation` is re-evaluated because
the reactive graph will actually poll all consumed producers and realize that nothing changes because
e.g. we always deal with static values.

We fix this for now (needs more optimization/performance insights) by adding an producer that we can
use to notify the computation.