### PR TITLE
build: avoid shallow fetch for benchmark comparison

### DIFF
--- a/scripts/benchmarks/index.mts
+++ b/scripts/benchmarks/index.mts
@@ -164,7 +164,9 @@ async function runCompare(bazelTargetRaw: string | undefined, compareRef: string
 
   try {
     Log.log(green('Fetching comparison revision.'));
-    git.run(['fetch', '--depth=1', git.getRepoGitUrl(), compareRef]);
+    // Note: Not using a shallow fetch here as that would convert the local
+    // user repository into an incomplete repository.
+    git.run(['fetch', git.getRepoGitUrl(), compareRef]);
     Log.log(green('Checking out comparison revision.'));
     git.run(['checkout', 'FETCH_HEAD']);
 


### PR DESCRIPTION
Currently when `yarn benchmarks run-compare` is used, the local repository could be converted to
a shallow clone. This is not a problem but might result in confusion. We avoid this by not performing
a shallow fetch when a comparison is initiated.

The performance gains seem negligible.