### PR TITLE
build: do not attempt deflaking locally

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,10 @@
 # Enable debugging tests with --config=debug
 test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
 
+# Do not attempt to de-flake locally.
+# On CI we might set this to `2` to run with deflaking.
+test --flaky_test_attempts=1
+
 ###############################
 # Filesystem interactions     #
 ###############################

--- a/.bazelrc
+++ b/.bazelrc
@@ -2,7 +2,7 @@
 test:debug --test_arg=--node_options=--inspect-brk --test_output=streamed --test_strategy=exclusive --test_timeout=9999 --nocache_test_results
 
 # Do not attempt to de-flake locally.
-# On CI we might set this to `2` to run with deflaking.
+# On CI we might set this to `3` to run with deflaking.
 test --flaky_test_attempts=1
 
 ###############################

--- a/.circleci/bazel.common.rc
+++ b/.circleci/bazel.common.rc
@@ -6,7 +6,8 @@
 build --announce_rc
 
 # Retry in the event of flakes, eg. https://circleci.com/gh/angular/angular/31309
-test --flaky_test_attempts=2
+# By default this is set in the project `.bazelrc` to `1`.
+test --flaky_test_attempts=3
 
 # More details on failures
 build --verbose_failures=true


### PR DESCRIPTION
We've recently marked the ngtsc test as flaky for the Windows job. We should not attempt
running tests 3 times locally. This negatively impacts the debugging/developer workflow.

Instead, flaky test attempts can still be made on CI. Using the default attempt count of 3.