### PR TITLE
fix(compiler): return full spans for Comment nodes

### DIFF
--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -124,9 +124,13 @@ class _TreeBuilder {
 
   private _consumeComment(token: CommentStartToken) {
     const text = this._advanceIf(TokenType.RAW_TEXT);
-    this._advanceIf(TokenType.COMMENT_END);
+    const endToken = this._advanceIf(TokenType.COMMENT_END);
     const value = text != null ? text.parts[0].trim() : null;
-    this._addToParent(new html.Comment(value, token.sourceSpan));
+    const sourceSpan = endToken == null ?
+        token.sourceSpan :
+        new ParseSourceSpan(
+            token.sourceSpan.start, endToken.sourceSpan.end, token.sourceSpan.fullStart);
+    this._addToParent(new html.Comment(value, sourceSpan));
   }
 
   private _consumeExpansion(token: ExpansionFormStartToken) {

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -423,40 +423,40 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
       describe('blocks', () => {
         it('should report nested blocks', () => {
           expect(extractErrors(`<!-- i18n --><!-- i18n --><!-- /i18n --><!-- /i18n -->`)).toEqual([
-            ['Could not start a block inside a translatable section', '<!--'],
-            ['Trying to close an unopened block', '<!--'],
+            ['Could not start a block inside a translatable section', '<!-- i18n -->'],
+            ['Trying to close an unopened block', '<!-- /i18n -->'],
           ]);
         });
 
         it('should report unclosed blocks', () => {
           expect(extractErrors(`<!-- i18n -->`)).toEqual([
-            ['Unclosed block', '<!--'],
+            ['Unclosed block', '<!-- i18n -->'],
           ]);
         });
 
         it('should report translatable blocks in translatable elements', () => {
           expect(extractErrors(`<p i18n><!-- i18n --><!-- /i18n --></p>`)).toEqual([
-            ['Could not start a block inside a translatable section', '<!--'],
-            ['Trying to close an unopened block', '<!--'],
+            ['Could not start a block inside a translatable section', '<!-- i18n -->'],
+            ['Trying to close an unopened block', '<!-- /i18n -->'],
           ]);
         });
 
         it('should report translatable blocks in implicit elements', () => {
           expect(extractErrors(`<p><!-- i18n --><!-- /i18n --></p>`, ['p'])).toEqual([
-            ['Could not start a block inside a translatable section', '<!--'],
-            ['Trying to close an unopened block', '<!--'],
+            ['Could not start a block inside a translatable section', '<!-- i18n -->'],
+            ['Trying to close an unopened block', '<!-- /i18n -->'],
           ]);
         });
 
         it('should report when start and end of a block are not at the same level', () => {
           expect(extractErrors(`<!-- i18n --><p><!-- /i18n --></p>`)).toEqual([
-            ['I18N blocks should not cross element boundaries', '<!--'],
+            ['I18N blocks should not cross element boundaries', '<!-- /i18n -->'],
             ['Unclosed block', '<p><!-- /i18n --></p>'],
           ]);
 
           expect(extractErrors(`<p><!-- i18n --></p><!-- /i18n -->`)).toEqual([
-            ['I18N blocks should not cross element boundaries', '<!--'],
-            ['Unclosed block', '<!--'],
+            ['I18N blocks should not cross element boundaries', '<!-- /i18n -->'],
+            ['Unclosed block', '<!-- /i18n -->'],
           ]);
         });
       });

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -251,7 +251,7 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
             ],
             [html.Element, 'span', 1, '<span>x {{ expr }<!---->} y</span>', '<span>', '</span>'],
             [html.Text, 'x {{ expr }', 2, ['x '], ['{{', ' expr }'], [''], 'x {{ expr }'],
-            [html.Comment, '', 2, '<!--'],
+            [html.Comment, '', 2, '<!---->'],
             [html.Text, '} y', 2, ['} y'], '} y'],
             [html.Element, 'div', 1, '<div></div>', '<div>', '</div>'],
           ]);

--- a/packages/compiler/test/render3/view/parse_template_options_spec.ts
+++ b/packages/compiler/test/render3/view/parse_template_options_spec.ts
@@ -39,9 +39,13 @@ describe('collectCommentNodes', () => {
         .toEqual('eslint-disable-next-line');
     expect(templateCommentsOptionEnabled.commentNodes![0].sourceSpan)
         .toBeInstanceOf(ParseSourceSpan);
+    expect(templateCommentsOptionEnabled.commentNodes![0].sourceSpan.toString())
+        .toEqual('<!-- eslint-disable-next-line -->');
     expect(templateCommentsOptionEnabled.commentNodes![1]).toBeInstanceOf(Comment);
     expect(templateCommentsOptionEnabled.commentNodes![1].value).toEqual('some nested comment');
     expect(templateCommentsOptionEnabled.commentNodes![1].sourceSpan)
         .toBeInstanceOf(ParseSourceSpan);
+    expect(templateCommentsOptionEnabled.commentNodes![1].sourceSpan.toString())
+        .toEqual('<!-- some nested comment -->');
   });
 });


### PR DESCRIPTION
Change sourceSpan for Comment nodes to cover the whole comment instead of just the opening token.

The primary motivation for this is the interaction between ESLint and `@angular-eslint`. ESLint can detect unused `eslint-disable` directives in comments and automatically remove them when running with `--fix`. 

This is based on ranges computed from AST spans, and as a result does not work inside Angular templates - right now all comments claim to be 4 characters long so only the opening `<!--` is removed.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
The HTML parser creates `Comment` nodes with `ParseSourceSpan` taken directly from the opening `COMMENT_START ` token, causing every comment to claim to be 4 characters long - `sourceSpan.toString()` always returns `<!--`.

## What is the new behavior?
The parser computes a new `ParseSourceSpan` from the start and end tokens, covering the full comment.
`sourceSpan.toString()` returns the whole comment starting with `<!--` and ending with `-->`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

Not sure honestly. Several tests for `@angular/compiler` had to be updated because they expected a stringified version of the AST node to be `<!--`, similar issues might occur in any third-party code that uses the AST directly.

## Other information
Example of what the `@angular-eslint` interaction mentioned above looks like:
```html
<!-- eslint-disable @angular-eslint/template/no-call-expression -->
<p>no lint errors in this file</p>
```
Since there are no call expressions, linting this file reports an unused directive:
```
src/app/app.component.html
  1:1  warning  Unused eslint-disable directive (no problems were reported from '@angular-eslint/template/no-call-expression')

✖ 1 problem (0 errors, 1 warning)
  0 errors and 1 warning potentially fixable with the `--fix` option.
```
Running  with `--fix` should remove the comment entirely, but instead produces the following change:
```diff
-<!-- eslint-disable @angular-eslint/template/no-call-expression -->
+  eslint-disable @angular-eslint/template/no-call-expression -->
<p>no lint errors in this file</p>
```
The eslint directive ends up as text inside the component, which is not ideal.