### PR TITLE
Revert: fix(platform-browser): wait until animation completion before destroying renderer

### DIFF
--- a/packages/animations/browser/src/render/animation_engine_next.ts
+++ b/packages/animations/browser/src/render/animation_engine_next.ts
@@ -113,8 +113,4 @@ export class AnimationEngine {
   whenRenderingDone(): Promise<any> {
     return this._transitionEngine.whenRenderingDone();
   }
-
-  afterFlushAnimationsDone(cb: VoidFunction): void {
-    this._transitionEngine.afterFlushAnimationsDone(cb);
-  }
 }

--- a/packages/animations/browser/src/render/animation_engine_next.ts
+++ b/packages/animations/browser/src/render/animation_engine_next.ts
@@ -106,10 +106,8 @@ export class AnimationEngine {
   }
 
   get players(): AnimationPlayer[] {
-    return [
-      ...this._transitionEngine.players,
-      ...this._timelineEngine.players,
-    ];
+    return (this._transitionEngine.players as AnimationPlayer[])
+        .concat(this._timelineEngine.players as AnimationPlayer[]);
   }
 
   whenRenderingDone(): Promise<any> {

--- a/packages/platform-browser/animations/src/animation_renderer.ts
+++ b/packages/platform-browser/animations/src/animation_renderer.ts
@@ -138,24 +138,19 @@ export class AnimationRendererFactory implements RendererFactory2 {
 export class BaseAnimationRenderer implements Renderer2 {
   constructor(
       protected namespaceId: string, public delegate: Renderer2, public engine: AnimationEngine,
-      private _onDestroy?: () => void) {}
+      private _onDestroy?: () => void) {
+    this.destroyNode = this.delegate.destroyNode ? (n) => delegate.destroyNode!(n) : null;
+  }
 
   get data() {
     return this.delegate.data;
   }
 
-  destroyNode(node: any): void {
-    this.delegate.destroyNode?.(node);
-  }
+  destroyNode: ((n: any) => void)|null;
 
   destroy(): void {
     this.engine.destroy(this.namespaceId, this.delegate);
-    this.engine.afterFlushAnimationsDone(() => {
-      // Call the renderer destroy method after the animations has finished as otherwise styles will
-      // be removed too early which will cause an unstyled animation.
-      this.delegate.destroy();
-    });
-
+    this.delegate.destroy();
     this._onDestroy?.();
   }
 


### PR DESCRIPTION
This PR reverts the changes from #50677, since there is some extra work that needs to happen in Google's codebase. We'll attempt to land it shortly (later this week).