### PR TITLE
feat(devtools): added instances count and total time in bar chart

### DIFF
--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/bar-chart.component.html
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/bar-chart.component.html
@@ -5,9 +5,8 @@
     (click)="barClick.emit(originalData[i])"
     class="bar"
     [style.backgroundColor]="color"
-    [style.width.%]="bar.value"
-    [matTooltip]="bar.label"
-  >
-    <span>{{ bar.label }}</span>
+    [style.width.%]="bar.width"
+    [matTooltip]="bar.text">
+    <span>{{ bar.text }}</span>
   </div>
 </div>

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/bar-chart.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/bar-chart.component.ts
@@ -6,12 +6,18 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {animate, animateChild, query, stagger, style, transition, trigger} from '@angular/animations';
+import {animate, animateChild, query, stagger, style, transition, trigger,} from '@angular/animations';
 import {Component, EventEmitter, Input, Output} from '@angular/core';
 
-interface Data {
+import {BargraphNode} from '../record-formatter/bargraph-formatter/bargraph-formatter';
+
+interface BarData {
   label: string;
-  value: number;
+  count: number;
+  width: number;
+  time: number;
+
+  text: string;
 }
 
 @Component({
@@ -21,26 +27,36 @@ interface Data {
   animations: [
     trigger(
         'appear',
-        [transition(':enter', [style({width: 0}), animate('.3s ease', style({width: '*'}))])]),
+        [
+          transition(':enter', [style({width: 0}), animate('.3s ease', style({width: '*'}))]),
+        ]),
     trigger('stagger', [transition(':enter', [query(':enter', stagger('.1s', [animateChild()]))])]),
   ],
 })
 export class BarChartComponent {
   @Input()
-  set data(nodes: Data[]) {
+  set data(nodes: BargraphNode[]) {
     this.originalData = nodes;
     this.internalData = [];
     const max = nodes.reduce((a: number, c) => Math.max(a, c.value), -Infinity);
     for (const node of nodes) {
       this.internalData.push({
         label: node.label,
-        value: (node.value / max) * 100,
+        count: node.count ?? 1,
+        width: (node.value / max) * 100,
+        time: node.value,
+        text: createBarText(node),
       });
     }
   }
   @Input() color: string;
-  @Output() barClick = new EventEmitter<Data>();
+  @Output() barClick = new EventEmitter<BargraphNode>();
 
-  originalData: Data[];
-  internalData: Data[] = [];
+  originalData: BargraphNode[];
+  internalData: BarData[] = [];
+}
+
+export function createBarText(bar: BargraphNode) {
+  return `${bar.label} | ${bar.value.toFixed(1)} ms | ${bar.count} ${
+      bar.count === 1 ? 'instance' : 'instances'}`;
 }

--- a/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/bargraph-visualizer.component.ts
+++ b/devtools/projects/ng-devtools/src/lib/devtools-tabs/profiler/timeline/recording-visualizer/bargraph-visualizer.component.ts
@@ -50,7 +50,7 @@ export class BargraphVisualizerComponent implements OnInit, OnDestroy {
   }
 
   formatEntryData(bargraphNode: BargraphNode): SelectedDirective[] {
-    return formatDirectiveProfile(bargraphNode.original.directives);
+    return formatDirectiveProfile(bargraphNode.directives ?? []);
   }
 
   selectNode(node: BargraphNode): void {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

In the bar chart in the devtools now we can see the total time of all the component instances in one change detection run, and all the directive instances count.

<!-- Please check the one that applies to this PR using "x". -->

- [x] Feature


## What is the current behavior?
Currently, the time for single component/directive instances is shown. Because we can have the same with flamegraph, converting the bar chart to show this new feature was thought as the way to go (as we don't need the same stat twice). 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #50555


## What is the new behavior?
<img width="1512" alt="CleanShot 2023-06-27 at 21 07 20@2x" src="https://github.com/angular/angular/assets/25394362/f0e06500-9717-4947-b07f-cd253a605fb2">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
