### PR TITLE
refactor(compiler): Support `$any` in template pipeline

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/any/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/any/TEST_CASES.json
@@ -16,8 +16,7 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should preserve $any if it is accessed through `this`",

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -37,6 +37,7 @@ import {phaseVarCounting} from './phases/var_counting';
 import {phaseVariableOptimization} from './phases/variable_optimization';
 import {phaseExpandSafeReads} from './phases/expand_safe_reads';
 import {phaseTemporaryVariables} from './phases/temporary_variables';
+import {phaseFindAnyCasts} from './phases/any_cast';
 
 /**
  * Run all transformation phases in the correct order against a `ComponentCompilation`. After this
@@ -49,6 +50,7 @@ export function transformTemplate(cpl: ComponentCompilation): void {
   phasePureLiteralStructures(cpl);
   phaseGenerateVariables(cpl);
   phaseSaveRestoreView(cpl);
+  phaseFindAnyCasts(cpl);
   phaseResolveNames(cpl);
   phaseResolveContexts(cpl);
   phaseLocalRefs(cpl);

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -118,7 +118,7 @@ function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
   if (ast instanceof e.ASTWithSource) {
     return convertAst(ast.ast, cpl);
   } else if (ast instanceof e.PropertyRead) {
-    if (ast.receiver instanceof e.ImplicitReceiver) {
+    if (ast.receiver instanceof e.ImplicitReceiver && !(ast.receiver instanceof e.ThisReceiver)) {
       return new ir.LexicalReadExpr(ast.name);
     } else {
       return new o.ReadPropExpr(convertAst(ast.receiver, cpl), ast.name);

--- a/packages/compiler/src/template/pipeline/src/phases/any_cast.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/any_cast.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import {ComponentCompilation} from '../compilation';
+
+/**
+ * Finds all unresolved safe read expressions, and converts them into the appropriate output AST
+ * reads, guarded by null checks.
+ */
+export function phaseFindAnyCasts(cpl: ComponentCompilation): void {
+  for (const [_, view] of cpl.views) {
+    for (const op of view.ops()) {
+      ir.transformExpressionsInOp(op, removeAnys, ir.VisitorContextFlag.None);
+    }
+  }
+}
+
+function removeAnys(e: o.Expression): o.Expression {
+  if (e instanceof o.InvokeFunctionExpr && e.fn instanceof ir.LexicalReadExpr &&
+      e.fn.name === '$any') {
+    if (e.args.length !== 1) {
+      throw new Error('The $any builtin function expects exactly one argument.');
+    }
+    return e.args[0];
+  }
+  return e;
+}


### PR DESCRIPTION
`$any(...)` casts should be dropped, except when they are an explicit call on `this.$any(...)`. Fix a bug in which we were transforming `ThisReceiver` into an implicit receiver.
