### PR TITLE
fix(upgrade): allow for downgraded components to work with component-router

### DIFF
--- a/packages/upgrade/src/common/src/downgrade_component.ts
+++ b/packages/upgrade/src/common/src/downgrade_component.ts
@@ -98,6 +98,11 @@ export function downgradeComponent(info: {
       restrict: 'E',
       terminal: true,
       require: [REQUIRE_INJECTOR, REQUIRE_NG_MODEL],
+      // Controller needs to be set so that `angular-component-router.js` (from beta Angular 2)
+      // configuration properties can be made available. See:
+      // See G3: javascript/angular2/angular1_router_lib.js
+      // https://github.com/angular/angular.js/blob/47bf11ee94664367a26ed8c91b9b586d3dd420f5/src/ng/compile.js#L1670-L1691.
+      controller: function() {},
       link: (scope: IScope, element: IAugmentedJQuery, attrs: IAttributes, required: any[]) => {
         // We might have to compile the contents asynchronously, because this might have been
         // triggered by `UpgradeNg1ComponentAdapterBuilder`, before the Angular templates have


### PR DESCRIPTION
In the past, we had an implementation of the "Angular 2" router that also worked with AngularJS. Published as `@angular/router`. We continued to expose that router implementation in G3 and some applications still use it. Now, when upgrading, they are seeing issues where the router throws because it cannot find a route config/ or `$canActivate` on the controller- simply because there is no `controller` function for downgraded components.

We can fix this and unblock the update by simply ensuring a controller function is defined.

Context: https://critique.corp.google.com/cl/539971007