### PR TITLE
docs: remove remaining internal methods/constructors 

### DIFF
--- a/packages/animations/browser/testing/src/mock_animation_driver.ts
+++ b/packages/animations/browser/testing/src/mock_animation_driver.ts
@@ -84,12 +84,12 @@ export class MockAnimationPlayer extends NoopAnimationPlayer {
     }
   }
 
-  /* @internal */
+  /** @internal */
   onInit(fn: () => any) {
     this._onInitFns.push(fn);
   }
 
-  /* @internal */
+  /** @internal */
   override init() {
     super.init();
     this._onInitFns.forEach(fn => fn());
@@ -111,7 +111,7 @@ export class MockAnimationPlayer extends NoopAnimationPlayer {
     this.__finished = true;
   }
 
-  /* @internal */
+  /** @internal */
   triggerMicrotask() {}
 
   override play(): void {

--- a/packages/platform-browser-dynamic/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/src/compiler_factory.ts
@@ -32,7 +32,7 @@ export const COMPILER_PROVIDERS =
 export class JitCompilerFactory implements CompilerFactory {
   private _defaultOptions: CompilerOptions[];
 
-  /* @internal */
+  /** @internal */
   constructor(defaultOptions: CompilerOptions[]) {
     const compilerOptions: CompilerOptions = {
       useJit: true,
@@ -42,6 +42,7 @@ export class JitCompilerFactory implements CompilerFactory {
 
     this._defaultOptions = [compilerOptions, ...defaultOptions];
   }
+
   createCompiler(options: CompilerOptions[] = []): Compiler {
     const opts = _mergeOptions(this._defaultOptions.concat(options));
     const injector = Injector.create({


### PR DESCRIPTION
I found 2 pages in the doc where we had internal methods/constructors displayed : 

* https://angular.io/api/platform-browser-dynamic/JitCompilerFactory#constructor
* https://angular.io/api/animations/browser/testing/MockAnimationPlayer

There where due to a malformed JSDoc with a single leading `/*` instead of `/**`. 

There is 1 commit for each impacted package. 

---
The fixed pages : 
* https://ng-dev-previews-fw--pr-angular-angular-50893-tvrljh0x.web.app/api/platform-browser-dynamic/JitCompilerFactory#constructor
* https://ng-dev-previews-fw--pr-angular-angular-50893-tvrljh0x.web.app/api/animations/browser/testing/MockAnimationPlayer