### PR TITLE
refactor(localize): deprecate `@angular/localize/init`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -26,10 +26,6 @@ Each item is linked to the section later in this guide that describes the deprec
 
 <!--
 deprecation -> removal cheat sheet
-v4 - v7
-v5 - v8
-v6 - v9
-v7 - v10
 v8 - v11
 v9 - v12
 v10 - v13
@@ -123,6 +119,7 @@ v16 - v19
 | `@angular/platform-server`          | [`platformDynamicServer`](api/platform-server/platformDynamicServer) | v16           | v18               |
 | `@angular/platform-browser`         | [`BrowserModule.withServerTransition`](api/platform-browser/BrowserModule#withservertransition)            | v16           | v18         |
 | `@angular/platform-browser`         | [`makeStateKey`, `StateKey` and `TransferState`](#platform-browser), symbols were moved to `@angular/core`                                        | v16           | v18         |
+| `@angular/localize/init`         | use `@angular/localize` directly to expose `$localize` globally   | v16           | v18         |
 
 ### Deprecated features with no planned removal version
 

--- a/packages/localize/init/PACKAGE.md
+++ b/packages/localize/init/PACKAGE.md
@@ -1,2 +1,4 @@
+/!\ This package is deprecated. Use `@angular/localize` directly instead.
+
 The `@angular/localize` package exposes the `$localize` function in the global namespace, which can
 be used to tag i18n messages in your code that needs to be translated.

--- a/packages/localize/init/index.ts
+++ b/packages/localize/init/index.ts
@@ -5,9 +5,9 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {ɵ$localize as $localize, ɵ_global as _global, ɵLocalizeFn as LocalizeFn, ɵTranslateFn as TranslateFn} from '@angular/localize';
+import {ɵ$localize as $localize, ɵLocalizeFn as LocalizeFn, ɵTranslateFn as TranslateFn} from '@angular/localize';
 
+/**
+ * @deprecated Import `@angular/localize` instead of `@angular/localize/init`
+ */
 export {$localize, LocalizeFn, TranslateFn};
-
-// Attach $localize to the global context, as a side-effect of this module.
-_global.$localize = $localize;

--- a/packages/localize/localize.ts
+++ b/packages/localize/localize.ts
@@ -13,3 +13,8 @@ export {MessageId, TargetMessage} from './src/utils';
 
 // Exports that are not part of the public API
 export * from './private';
+
+import {_global, $localize} from './src/localize';
+
+// Attach $localize to the global context, as a side-effect of this module.
+_global.$localize = $localize;

--- a/packages/localize/private.ts
+++ b/packages/localize/private.ts
@@ -8,5 +8,5 @@
 
 // This file exports all the `utils` as private exports so that other parts of `@angular/localize`
 // can make use of them.
-export {$localize as ɵ$localize, _global as ɵ_global, LocalizeFn as ɵLocalizeFn, TranslateFn as ɵTranslateFn} from './src/localize';
+export {$localize as ɵ$localize, LocalizeFn as ɵLocalizeFn, TranslateFn as ɵTranslateFn} from './src/localize';
 export {computeMsgId as ɵcomputeMsgId, findEndOfBlock as ɵfindEndOfBlock, isMissingTranslationError as ɵisMissingTranslationError, makeParsedTranslation as ɵmakeParsedTranslation, makeTemplateObject as ɵmakeTemplateObject, MissingTranslationError as ɵMissingTranslationError, ParsedMessage as ɵParsedMessage, ParsedTranslation as ɵParsedTranslation, ParsedTranslations as ɵParsedTranslations, parseMessage as ɵparseMessage, parseMetadata as ɵparseMetadata, parseTranslation as ɵparseTranslation, SourceLocation as ɵSourceLocation, SourceMessage as ɵSourceMessage, splitBlock as ɵsplitBlock, translate as ɵtranslate} from './src/utils';


### PR DESCRIPTION
The angular compiler uses the global $localize there is no need to export it. Also as `@angular/localize/init` is only a re-export, it can be deprecated to simplify the usage.

You can import `@angular/localize` directly now to expose `localize$` globally.

Fixed #48545

## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)


## Does this PR introduce a breaking change?


- [x] No