### PR TITLE
Template Pipeline: `$any`, `$event`, host binding functions, source maps, compat mode, in-phase binding specialization, and more

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/components_and_directives/TEST_CASES.json
@@ -3,150 +3,207 @@
   "cases": [
     {
       "description": "should instantiate directives in a closure when they are forward referenced",
-      "inputFiles": ["forward_referenced_directive.ts"],
+      "inputFiles": [
+        "forward_referenced_directive.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": ["forward_referenced_directive.js"]
+          "files": [
+            "forward_referenced_directive.js"
+          ]
         }
       ]
     },
     {
       "description": "should instantiate pipes in a closure when they are forward referenced",
-      "inputFiles": ["forward_referenced_pipe.ts"],
+      "inputFiles": [
+        "forward_referenced_pipe.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": ["forward_referenced_pipe.js"]
+          "files": [
+            "forward_referenced_pipe.js"
+          ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should split multiple `exportAs` values into an array",
-      "inputFiles": ["export_as.ts"],
+      "inputFiles": [
+        "export_as.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect SomeDirective.ɵdir",
-          "files": ["export_as.js"]
+          "files": [
+            "export_as.js"
+          ]
         }
       ]
     },
     {
       "description": "should not generate a selectors array if the directive does not have a selector",
-      "inputFiles": ["no_selector.ts"],
+      "inputFiles": [
+        "no_selector.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Invalid directive definition",
-          "files": ["no_selector.js"]
+          "files": [
+            "no_selector.js"
+          ]
         }
       ]
     },
     {
       "description": "should generate a pure function for constant object literals",
-      "inputFiles": ["constant_object_literals.ts"],
+      "inputFiles": [
+        "constant_object_literals.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": ["constant_object_literals.js"]
+          "files": [
+            "constant_object_literals.js"
+          ]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should generate a pure function for constant array literals",
-      "inputFiles": ["constant_array_literals.ts"],
+      "inputFiles": [
+        "constant_array_literals.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": ["constant_array_literals.js"]
+          "files": [
+            "constant_array_literals.js"
+          ]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should not share pure functions between null and object literals",
-      "inputFiles": ["object_literals_null_vs_empty.ts"],
+      "inputFiles": [
+        "object_literals_null_vs_empty.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": ["object_literals_null_vs_empty.js"]
+          "files": [
+            "object_literals_null_vs_empty.js"
+          ]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should not share pure functions between null and array literals",
-      "inputFiles": ["array_literals_null_vs_empty.ts"],
+      "inputFiles": [
+        "array_literals_null_vs_empty.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": ["array_literals_null_vs_empty.js"]
+          "files": [
+            "array_literals_null_vs_empty.js"
+          ]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should not share pure functions between null and function calls",
-      "inputFiles": ["object_literals_null_vs_function.ts"],
+      "inputFiles": [
+        "object_literals_null_vs_function.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Invalid component definition",
-          "files": ["object_literals_null_vs_function.js"]
+          "files": [
+            "object_literals_null_vs_function.js"
+          ]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should emit a valid setClassMetadata call in ES5 if a class with a custom decorator is referencing itself inside its own metadata",
-      "inputFiles": ["custom_decorator_es5.ts"],
+      "inputFiles": [
+        "custom_decorator_es5.ts"
+      ],
       "compilerOptions": {
         "target": "ES5"
       },
-      "compilationModeFilter": ["full compile"],
+      "compilationModeFilter": [
+        "full compile"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect setClassMetadata call",
-          "files": ["custom_decorator_es5.js"]
+          "files": [
+            "custom_decorator_es5.js"
+          ]
         }
       ]
     },
     {
       "description": "should support empty property bindings on ng-template",
-      "inputFiles": ["ng_template_empty_binding.ts"],
+      "inputFiles": [
+        "ng_template_empty_binding.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["ng_template_empty_binding.js"]
+          "files": [
+            "ng_template_empty_binding.js"
+          ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support inline non-literal templates",
-      "inputFiles": ["non_literal_template.ts"]
+      "inputFiles": [
+        "non_literal_template.ts"
+      ]
     },
     {
       "description": "should support inline non-literal templates using substitution",
-      "inputFiles": ["non_literal_template_with_substitution.ts"]
+      "inputFiles": [
+        "non_literal_template_with_substitution.ts"
+      ]
     },
     {
       "description": "should support inline non-literal templates using string concatenation",
-      "inputFiles": ["non_literal_template_with_concatenation.ts"]
+      "inputFiles": [
+        "non_literal_template_with_concatenation.ts"
+      ]
     },
     {
       "description": "should not use reexport names inside declarations when a direct export is available",
-      "inputFiles": ["external_library.d.ts", "library_exports.ts"],
+      "inputFiles": [
+        "external_library.d.ts",
+        "library_exports.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Invalid list of directives",
-          "files": ["library_exports.js"]
+          "files": [
+            "library_exports.js"
+          ]
         }
       ],
       "compilerOptions": {
         "baseUrl": ".",
         "paths": {
-          "external_library": ["./external_library"]
+          "external_library": [
+            "./external_library"
+          ]
         }
       }
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/TEST_CASES.json
@@ -211,7 +211,8 @@
         {
           "failureMessage": "Incorrect `hostBindings` function."
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should bind to class and style names",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/TEST_CASES.json
@@ -238,8 +238,7 @@
           ],
           "failureMessage": "Incorrect generated template."
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should de-duplicate attribute arrays",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/any/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/any/TEST_CASES.json
@@ -16,8 +16,7 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should preserve $any if it is accessed through `this`",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/nullish_coalescing/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/nullish_coalescing/TEST_CASES.json
@@ -52,7 +52,8 @@
           ],
           "failureMessage": "Incorrect host bindings"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler/safe_access/TEST_CASES.json
@@ -16,8 +16,7 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should handle deep safe property reads inside templates",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/host_bindings/TEST_CASES.json
@@ -27,7 +27,8 @@
             "host_bindings_with_temporaries.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support host bindings with pure functions",
@@ -41,7 +42,8 @@
             "host_bindings_with_pure_functions.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support host attribute bindings",
@@ -55,7 +57,8 @@
             "host_attribute_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support host attributes",
@@ -69,7 +72,8 @@
             "host_attributes.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should support host attributes together with host classes and styles",
@@ -83,7 +87,8 @@
             "host_attributes_with_classes_and_styles.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple host property bindings into a single instruction",
@@ -125,7 +130,8 @@
             "chain_property_bindings_mixed.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple synthetic properties into a single instruction call",
@@ -139,7 +145,8 @@
             "chain_synthetic_properties.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple host attribute bindings into a single instruction",
@@ -153,7 +160,8 @@
             "chain_multiple_attribute_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain both host attributes in the decorator and on the class",
@@ -167,7 +175,8 @@
             "chain_attribute_bindings_all.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple host attribute bindings in the presence of other bindings",
@@ -181,7 +190,8 @@
             "chain_attribute_bindings_mixed.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple host listeners into a single instruction",
@@ -195,7 +205,8 @@
             "chain_multiple_listeners.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple synthetic host listeners into a single instruction",
@@ -209,7 +220,8 @@
             "chain_synthetic_listeners.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should chain multiple regular and synthetic host listeners into two instructions",
@@ -223,7 +235,8 @@
             "chain_synthetic_listeners_mixed.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should handle host bindings with the same name as a primitive value",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_bindings/property_bindings/TEST_CASES.json
@@ -98,8 +98,7 @@
             "chain_multiple_bindings_mixed.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should not add interpolated properties to the property instruction chain",
@@ -113,8 +112,7 @@
             "chain_bindings_with_interpolations.js"
           ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should chain synthetic property bindings together with regular property bindings",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
@@ -16,8 +16,7 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should create listener instruction on other components",
@@ -34,8 +33,7 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should create multiple listener instructions that share a view snapshot",
@@ -201,8 +199,7 @@
           ],
           "failureMessage": "Incorrect event listener"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should preserve accesses to $event if it is done through `this` in a listener",
@@ -216,8 +213,7 @@
               "expected": "event_explicit_access_template.js",
               "generated": "event_explicit_access.js"
             }
-          ],
-          "failureMessage": "Incorrect event listener"
+          ]
         }
       ]
     },

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_listener/TEST_CASES.json
@@ -165,7 +165,8 @@
           ],
           "failureMessage": "Incorrect event listener"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate the $event argument if it is being used in a host listener",
@@ -182,7 +183,8 @@
           ],
           "failureMessage": "Incorrect event listener"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should assume $event is referring to the event variable in a listener by default",
@@ -249,7 +251,8 @@
           ],
           "failureMessage": "Incorrect event listener"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should preserve accesses to $event if it is done through `this` in a listener inside a host binding",
@@ -266,7 +269,8 @@
           ],
           "failureMessage": "Incorrect event listener"
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate the view restoration statements if a keyed write is used in an event listener from within an ng-template",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/binding_slots/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/binding_slots/TEST_CASES.json
@@ -13,7 +13,8 @@
             "component_host_binding_slots.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should count only non-style and non-class host bindings on Directives",
@@ -27,7 +28,8 @@
             "directive_host_binding_slots.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate the correct amount of host bindings when styling is present",
@@ -41,7 +43,8 @@
             "host_binding_slots.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_animations/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_animations/TEST_CASES.json
@@ -71,7 +71,8 @@
             "animation_host_bindings.js"
           ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/host_bindings/TEST_CASES.json
@@ -3,27 +3,39 @@
   "cases": [
     {
       "description": "should generate style/class instructions for a host component creation definition",
-      "inputFiles": ["static_and_dynamic.ts"],
+      "inputFiles": [
+        "static_and_dynamic.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["static_and_dynamic.js"]
+          "files": [
+            "static_and_dynamic.js"
+          ]
         }
-      ]
+      ],
+      "skipForTemplatePipeline": true
     },
     {
       "description": "should generate style/class instructions for multiple host binding definitions",
-      "inputFiles": ["multiple_dynamic.ts"],
+      "inputFiles": [
+        "multiple_dynamic.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["multiple_dynamic.js"]
+          "files": [
+            "multiple_dynamic.js"
+          ]
         }
       ]
     },
     {
       "description": "should generate override instructions for only single-level styling bindings when !important is present",
-      "inputFiles": ["important.ts"],
+      "inputFiles": [
+        "important.ts"
+      ],
+      "skipForTemplatePipeline": true,
       "expectations": [
         {
           "failureMessage": "Incorrect template",
@@ -47,31 +59,43 @@
     },
     {
       "description": "should support class interpolation",
-      "inputFiles": ["class_interpolation.ts"],
+      "inputFiles": [
+        "class_interpolation.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["class_interpolation.js"]
+          "files": [
+            "class_interpolation.js"
+          ]
         }
       ]
     },
     {
       "description": "should support style interpolation",
-      "inputFiles": ["style_interpolation.ts"],
+      "inputFiles": [
+        "style_interpolation.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["style_interpolation.js"]
+          "files": [
+            "style_interpolation.js"
+          ]
         }
       ]
     },
     {
       "description": "should generate styling instructions for multiple directives that contain host binding definitions",
-      "inputFiles": ["multiple_directives.ts"],
+      "inputFiles": [
+        "multiple_directives.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["multiple_directives.js"]
+          "files": [
+            "multiple_directives.js"
+          ]
         }
       ]
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/interpolations/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/interpolations/TEST_CASES.json
@@ -3,52 +3,71 @@
   "cases": [
     {
       "description": "should generate the proper update instructions for interpolated classes",
-      "inputFiles": ["class_interpolations.ts"],
+      "inputFiles": [
+        "class_interpolations.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect handling of interpolated classes",
-          "files": ["class_interpolations.js"]
+          "files": [
+            "class_interpolations.js"
+          ]
         }
       ]
     },
     {
       "description": "should generate the proper update instructions for interpolated style properties",
-      "inputFiles": ["style_properties.ts"],
+      "inputFiles": [
+        "style_properties.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect handling of interpolated style properties",
-          "files": ["style_properties.js"]
+          "files": [
+            "style_properties.js"
+          ]
         }
       ]
     },
     {
       "description": "should generate update instructions for interpolated style properties with a suffix",
-      "inputFiles": ["style_binding_suffixed.ts"],
+      "inputFiles": [
+        "style_binding_suffixed.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect handling of interpolated style properties",
-          "files": ["style_binding_suffixed.js"]
+          "files": [
+            "style_binding_suffixed.js"
+          ]
         }
       ]
     },
     {
       "description": "should generate update instructions for interpolated style properties with a sanitizer",
-      "inputFiles": ["style_binding_sanitizer.ts"],
+      "inputFiles": [
+        "style_binding_sanitizer.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect handling of interpolated style properties",
-          "files": ["style_binding_sanitizer.js"]
+          "files": [
+            "style_binding_sanitizer.js"
+          ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should generate update instructions for interpolated style properties with !important",
-      "inputFiles": ["style_binding_important.ts"],
+      "inputFiles": [
+        "style_binding_important.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect handling of interpolated style properties",
-          "files": ["style_binding_important.js"]
+          "files": [
+            "style_binding_important.js"
+          ]
         }
       ]
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/style_bindings/TEST_CASES.json
@@ -3,63 +3,86 @@
   "cases": [
     {
       "description": "should create style instructions on the element",
-      "inputFiles": ["style_binding.ts"],
+      "inputFiles": [
+        "style_binding.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["style_binding.js"]
+          "files": [
+            "style_binding.js"
+          ]
         }
       ]
     },
     {
       "description": "should correctly count the total slots required when style/class bindings include interpolation",
-      "inputFiles": ["binding_slots.ts"],
+      "inputFiles": [
+        "binding_slots.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["binding_slots.js"]
+          "files": [
+            "binding_slots.js"
+          ]
         }
       ]
     },
     {
       "description": "should place initial, multi, singular and application followed by attribute style instructions in the template code in that order",
-      "inputFiles": ["binding_slots_interpolations.ts"],
+      "inputFiles": [
+        "binding_slots_interpolations.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["binding_slots_interpolations.js"]
+          "files": [
+            "binding_slots_interpolations.js"
+          ]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should assign a sanitizer instance to the element style allocation instruction if any url-based properties are detected",
-      "inputFiles": ["style_ordering.ts"],
+      "inputFiles": [
+        "style_ordering.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["style_ordering.js"]
+          "files": [
+            "style_ordering.js"
+          ]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should support [style.foo.suffix] style bindings with a suffix",
-      "inputFiles": ["style_binding_suffixed.ts"],
+      "inputFiles": [
+        "style_binding_suffixed.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["style_binding_suffixed.js"]
+          "files": [
+            "style_binding_suffixed.js"
+          ]
         }
       ]
     },
     {
       "description": "should not create instructions for empty style bindings",
-      "inputFiles": ["empty_style_bindings.ts"],
+      "inputFiles": [
+        "empty_style_bindings.ts"
+      ],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": ["empty_style_bindings.js"]
+          "files": [
+            "empty_style_bindings.js"
+          ]
         }
       ]
     }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_template/TEST_CASES.json
@@ -286,8 +286,7 @@
           ],
           "failureMessage": "Incorrect template"
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should handle shorthand property declarations in templates",

--- a/packages/compiler-cli/test/compliance/test_cases/source_mapping/external_templates/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/source_mapping/external_templates/TEST_CASES.json
@@ -12,8 +12,7 @@
       "compilerOptions": {
         "sourceMap": true,
         "inlineSources": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should create external template source-mapping (linked compile)",
@@ -53,8 +52,7 @@
           ".",
           "extraRootDir"
         ]
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should create correct mappings when templateUrl is in a different rootDir (linked compile)",
@@ -94,8 +92,7 @@
       "compilerOptions": {
         "sourceMap": true,
         "inlineSources": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should handle unusual escaped chars when source-mapping (linked compile)",

--- a/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/TEST_CASES.json
@@ -910,8 +910,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should create (simple string) inline template source-mapping (partial compile)",

--- a/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/source_mapping/inline_templates/TEST_CASES.json
@@ -11,8 +11,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map simple element with content (partial compile)",
@@ -46,8 +45,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map void element (partial compile)",
@@ -81,8 +79,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map a mix of interpolated and static content (partial compile)",
@@ -116,8 +113,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map a complex interpolated expression (partial compile)",
@@ -151,8 +147,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map interpolated properties (partial compile)",
@@ -186,8 +181,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map interpolation with pipe (partial compile)",
@@ -221,8 +215,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map a simple input binding expression (partial compile)",
@@ -256,8 +249,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map a complex input binding expression (partial compile)",
@@ -291,8 +283,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map a longhand input binding expression (partial compile)",
@@ -536,8 +527,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map *ngIf scenario (partial compile)",
@@ -571,8 +561,7 @@
       ],
       "compilerOptions": {
         "sourceMap": true
-      },
-      "skipForTemplatePipeline": true
+      }
     },
     {
       "description": "should map ng-template [ngIf] scenario (partial compile)",

--- a/packages/compiler-cli/test/compliance/test_helpers/sourcemap_helpers.ts
+++ b/packages/compiler-cli/test/compliance/test_helpers/sourcemap_helpers.ts
@@ -35,6 +35,7 @@ import {SourceFileLoader} from '../../../src/ngtsc/sourcemaps';
 export function checkMappings(
     fs: ReadonlyFileSystem, generated: string, generatedPath: AbsoluteFsPath,
     expectedSource: string, expectedPath: AbsoluteFsPath): string {
+  // Generate the candidate source maps.
   const actualMappings = getMappedSegments(fs, generatedPath, generated);
 
   const {expected, mappings} = extractMappings(fs, expectedSource);

--- a/packages/compiler/src/expression_parser/parser.ts
+++ b/packages/compiler/src/expression_parser/parser.ts
@@ -81,6 +81,7 @@ export class Parser {
     return checker.errors;
   }
 
+  // Host bindings parsed here
   parseSimpleBinding(
       input: string, location: string, absoluteOffset: number,
       interpolationConfig: InterpolationConfig = DEFAULT_INTERPOLATION_CONFIG): ASTWithSource {

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -554,7 +554,7 @@ function createHostBindingsFunction(
   const eventBindings =
       bindingParser.createDirectiveHostEventAsts(hostBindingsMetadata.listeners, typeSourceSpan);
 
-  if (/* TODO: temporarily switched off */ false && USE_TEMPLATE_PIPELINE) {
+  if (USE_TEMPLATE_PIPELINE) {
     // TODO: host binding metadata is not yet parsed in the template pipeline, so we need to extract
     // that code from below. Then, we will ingest a `HostBindingJob`, and run the template pipeline
     // phases.
@@ -568,13 +568,11 @@ function createHostBindingsFunction(
     transformHostBinding(hostJob);
 
     const varCount = hostJob.root.vars;
-    if (varCount !== null && varCount! > 0) {
+    if (varCount !== null && varCount > 0) {
       definitionMap.set('hostVars', o.literal(varCount));
     }
 
-    const fn = emitHostBindingFunction(hostJob);
-    // TODO: what if there's no create/update ops?
-    return fn;
+    return emitHostBindingFunction(hostJob);
   }
   const bindingContext = o.variable(CONTEXT_NAME);
   const styleBuilder = new StylingBuilder(bindingContext);

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -546,6 +546,11 @@ function createHostBindingsFunction(
     hostBindingsMetadata: R3HostMetadata, typeSourceSpan: ParseSourceSpan,
     bindingParser: BindingParser, constantPool: ConstantPool, selector: string, name: string,
     definitionMap: DefinitionMap): o.Expression|null {
+  if (USE_TEMPLATE_PIPELINE) {
+    // TODO: host binding metadata is not yet parsed in the template pipeline, so we need to extract
+    // that code from below. Then, we will ingest a `HostBindingJob`, and run the template pipeline
+    // phases.
+  }
   const bindingContext = o.variable(CONTEXT_NAME);
   const styleBuilder = new StylingBuilder(bindingContext);
 

--- a/packages/compiler/src/template/pipeline/ir/index.ts
+++ b/packages/compiler/src/template/pipeline/ir/index.ts
@@ -11,6 +11,7 @@ export * from './src/expression';
 export * from './src/enums';
 export * from './src/operations';
 export * from './src/ops/create';
+export * from './src/ops/host';
 export * from './src/ops/shared';
 export * from './src/ops/update';
 export * from './src/traits';

--- a/packages/compiler/src/template/pipeline/ir/src/element.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/element.ts
@@ -13,7 +13,7 @@ import * as o from '../../../../output/output_ast';
 /**
  * Enumeration of the types of attributes which can be applied to an element.
  */
-export enum ElementAttributeKind {
+export enum BindingKind {
   /**
    * Static attributes.
    */
@@ -22,20 +22,20 @@ export enum ElementAttributeKind {
   /**
    * Class bindings.
    */
-  Class,
+  ClassName,
 
   /**
    * Style bindings.
    */
-  Style,
+  StyleProperty,
 
   /**
-   * Dynamic property or attribute bindings.
+   * Dynamic property bindings.
    */
-  Binding,
+  Property,
 
   /**
-   * Attributes on a template node.
+   * Property or attribute bindings on a template.
    */
   Template,
 
@@ -43,6 +43,11 @@ export enum ElementAttributeKind {
    * Internationalized attributes.
    */
   I18n,
+
+  /**
+   * TODO: Consider how Animations are handled, and if they should be a distinct BindingKind.
+   */
+  Animation,
 }
 
 const FLYWEIGHT_ARRAY: ReadonlyArray<o.Expression> = Object.freeze<o.Expression[]>([]);
@@ -52,42 +57,42 @@ const FLYWEIGHT_ARRAY: ReadonlyArray<o.Expression> = Object.freeze<o.Expression[
  */
 export class ElementAttributes {
   private known = new Set<string>();
-  private byKind = new Map<ElementAttributeKind, o.Expression[]>;
+  private byKind = new Map<BindingKind, o.Expression[]>;
 
   projectAs: string|null = null;
 
   get attributes(): ReadonlyArray<o.Expression> {
-    return this.byKind.get(ElementAttributeKind.Attribute) ?? FLYWEIGHT_ARRAY;
+    return this.byKind.get(BindingKind.Attribute) ?? FLYWEIGHT_ARRAY;
   }
 
   get classes(): ReadonlyArray<o.Expression> {
-    return this.byKind.get(ElementAttributeKind.Class) ?? FLYWEIGHT_ARRAY;
+    return this.byKind.get(BindingKind.ClassName) ?? FLYWEIGHT_ARRAY;
   }
 
   get styles(): ReadonlyArray<o.Expression> {
-    return this.byKind.get(ElementAttributeKind.Style) ?? FLYWEIGHT_ARRAY;
+    return this.byKind.get(BindingKind.StyleProperty) ?? FLYWEIGHT_ARRAY;
   }
 
   get bindings(): ReadonlyArray<o.Expression> {
-    return this.byKind.get(ElementAttributeKind.Binding) ?? FLYWEIGHT_ARRAY;
+    return this.byKind.get(BindingKind.Property) ?? FLYWEIGHT_ARRAY;
   }
 
   get template(): ReadonlyArray<o.Expression> {
-    return this.byKind.get(ElementAttributeKind.Template) ?? FLYWEIGHT_ARRAY;
+    return this.byKind.get(BindingKind.Template) ?? FLYWEIGHT_ARRAY;
   }
 
   get i18n(): ReadonlyArray<o.Expression> {
-    return this.byKind.get(ElementAttributeKind.I18n) ?? FLYWEIGHT_ARRAY;
+    return this.byKind.get(BindingKind.I18n) ?? FLYWEIGHT_ARRAY;
   }
 
-  add(kind: ElementAttributeKind, name: string, value: o.Expression|null): void {
+  add(kind: BindingKind, name: string, value: o.Expression|null): void {
     if (this.known.has(name)) {
       return;
     }
     this.known.add(name);
     const array = this.arrayFor(kind);
     array.push(...getAttributeNameLiterals(name));
-    if (kind === ElementAttributeKind.Attribute || kind === ElementAttributeKind.Style) {
+    if (kind === BindingKind.Attribute || kind === BindingKind.StyleProperty) {
       if (value === null) {
         throw Error('Attribute & style element attributes must have a value');
       }
@@ -95,7 +100,7 @@ export class ElementAttributes {
     }
   }
 
-  private arrayFor(kind: ElementAttributeKind): o.Expression[] {
+  private arrayFor(kind: BindingKind): o.Expression[] {
     if (!this.byKind.has(kind)) {
       this.byKind.set(kind, []);
     }

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -79,6 +79,12 @@ export enum OpKind {
   InterpolateText,
 
   /**
+   * An intermediate binding op, that has not yet been processed into an individual property,
+   * attribute, style, etc.
+   */
+  Binding,
+
+  /**
    * An operation to bind an expression to a property of an element.
    */
   Property,
@@ -104,26 +110,6 @@ export enum OpKind {
   ClassMap,
 
   /**
-   * An operation to interpolate text into a property binding.
-   */
-  InterpolateProperty,
-
-  /**
-   * An operation to interpolate text into a style property binding.
-   */
-  InterpolateStyleProp,
-
-  /**
-   * An operation to interpolate text into a style mapping.
-   */
-  InterpolateStyleMap,
-
-  /**
-   * An operation to interpolate text into a class mapping.
-   */
-  InterpolateClassMap,
-
-  /**
    * An operation to advance the runtime's implicit slot context during the update phase of a view.
    */
   Advance,
@@ -137,11 +123,6 @@ export enum OpKind {
    * An operation to associate an attribute with an element.
    */
   Attribute,
-
-  /**
-   * An operation to interpolate text into an attribute binding.
-   */
-  InterpolateAttribute,
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -263,3 +263,13 @@ export enum SemanticVariableKind {
    */
   SavedView,
 }
+
+/**
+ * Whether to compile in compatibilty mode. In compatibility mode, the template pipeline will
+ * attempt to match the output of `TemplateDefinitionBuilder` as exactly as possible, at the cost of
+ * producing quirky or larger code in some cases.
+ */
+export enum CompatibilityMode {
+  Normal,
+  TemplateDefinitionBuilder,
+}

--- a/packages/compiler/src/template/pipeline/ir/src/enums.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/enums.ts
@@ -123,6 +123,13 @@ export enum OpKind {
    * An operation to associate an attribute with an element.
    */
   Attribute,
+
+  /**
+   * A host binding property.
+   */
+  HostProperty,
+
+  // TODO: Add Host Listeners, and possibly other host ops also.
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/ir/src/expression.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/expression.ts
@@ -749,6 +749,7 @@ export function transformExpressionsInOp(
     case OpKind.ClassMap:
     case OpKind.Attribute:
     case OpKind.Binding:
+    case OpKind.HostProperty:
       if (op.expression instanceof Interpolation) {
         transformExpressionsInInterpolation(op.expression, transform, flags);
       } else {

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -275,6 +275,11 @@ export interface ListenerOp extends Op<CreateOp>, UsesSlotIndexTrait {
    * Name of the function
    */
   handlerFnName: string|null;
+
+  /**
+   * Whether this listener is known to consume `$event` in its body.
+   */
+  consumesDollarEvent: boolean;
 }
 
 /**
@@ -288,6 +293,7 @@ export function createListenerOp(target: XrefId, name: string, tag: string): Lis
     name,
     handlerOps: new OpList(),
     handlerFnName: null,
+    consumesDollarEvent: false,
     ...NEW_OP,
     ...TRAIT_USES_SLOT_INDEX,
   };

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {ParseSourceSpan} from '../../../../../parse_util';
 import {ElementAttributes} from '../element';
 import {OpKind} from '../enums';
 import {Op, OpList, XrefId} from '../operations';
@@ -91,6 +92,8 @@ export interface ElementOrContainerOpBase extends Op<CreateOp>, ConsumesSlotOpTr
    * compilation.
    */
   localRefs: LocalRef[]|ConstIndex|null;
+
+  sourceSpan: ParseSourceSpan;
 }
 
 export interface ElementOpBase extends ElementOrContainerOpBase {
@@ -112,13 +115,15 @@ export interface ElementStartOp extends ElementOpBase {
 /**
  * Create an `ElementStartOp`.
  */
-export function createElementStartOp(tag: string, xref: XrefId): ElementStartOp {
+export function createElementStartOp(
+    tag: string, xref: XrefId, sourceSpan: ParseSourceSpan): ElementStartOp {
   return {
     kind: OpKind.ElementStart,
     xref,
     tag,
     attributes: new ElementAttributes(),
     localRefs: [],
+    sourceSpan,
     ...TRAIT_CONSUMES_SLOT,
     ...NEW_OP,
   };
@@ -153,7 +158,8 @@ export interface TemplateOp extends ElementOpBase {
 /**
  * Create a `TemplateOp`.
  */
-export function createTemplateOp(xref: XrefId, tag: string): TemplateOp {
+export function createTemplateOp(
+    xref: XrefId, tag: string, sourceSpan: ParseSourceSpan): TemplateOp {
   return {
     kind: OpKind.Template,
     xref,
@@ -162,6 +168,7 @@ export function createTemplateOp(xref: XrefId, tag: string): TemplateOp {
     decls: null,
     vars: null,
     localRefs: [],
+    sourceSpan,
     ...TRAIT_CONSUMES_SLOT,
     ...NEW_OP,
   };
@@ -179,15 +186,18 @@ export interface ElementEndOp extends Op<CreateOp> {
    * The `XrefId` of the element declared via `ElementStart`.
    */
   xref: XrefId;
+
+  sourceSpan: ParseSourceSpan|null;
 }
 
 /**
  * Create an `ElementEndOp`.
  */
-export function createElementEndOp(xref: XrefId): ElementEndOp {
+export function createElementEndOp(xref: XrefId, sourceSpan: ParseSourceSpan|null): ElementEndOp {
   return {
     kind: OpKind.ElementEnd,
     xref,
+    sourceSpan,
     ...NEW_OP,
   };
 }
@@ -218,6 +228,8 @@ export interface ContainerEndOp extends Op<CreateOp> {
    * The `XrefId` of the element declared via `ContainerStart`.
    */
   xref: XrefId;
+
+  sourceSpan: ParseSourceSpan;
 }
 
 /**
@@ -235,16 +247,20 @@ export interface TextOp extends Op<CreateOp>, ConsumesSlotOpTrait {
    * The static initial value of the text node.
    */
   initialValue: string;
+
+  sourceSpan: ParseSourceSpan|null;
 }
 
 /**
  * Create a `TextOp`.
  */
-export function createTextOp(xref: XrefId, initialValue: string): TextOp {
+export function createTextOp(
+    xref: XrefId, initialValue: string, sourceSpan: ParseSourceSpan|null): TextOp {
   return {
     kind: OpKind.Text,
     xref,
     initialValue,
+    sourceSpan,
     ...TRAIT_CONSUMES_SLOT,
     ...NEW_OP,
   };

--- a/packages/compiler/src/template/pipeline/ir/src/ops/host.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/host.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../../../src/output/output_ast';
+import {ParseSourceSpan} from '../../../../../../src/parse_util';
+import {OpKind} from '../enums';
+import {Op} from '../operations';
+import {ConsumesVarsTrait, TRAIT_CONSUMES_VARS} from '../traits';
+
+import {NEW_OP} from './shared';
+
+import type {Interpolation, UpdateOp} from './update';
+
+
+/**
+ * Logical operation representing a host binding to a property.
+ */
+export interface HostPropertyOp extends Op<UpdateOp>, ConsumesVarsTrait {
+  kind: OpKind.HostProperty;
+  name: string;
+  expression: o.Expression|Interpolation;
+
+  sourceSpan: ParseSourceSpan|null;
+}
+
+export function createHostPropertyOp(
+    name: string, expression: o.Expression|Interpolation,
+    sourceSpan: ParseSourceSpan|null): HostPropertyOp {
+  return {
+    kind: OpKind.HostProperty,
+    name,
+    expression,
+    sourceSpan,
+    ...TRAIT_CONSUMES_VARS,
+    ...NEW_OP,
+  };
+}

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -14,13 +14,15 @@ import {Op, XrefId} from '../operations';
 import {ConsumesVarsTrait, DependsOnSlotContextOpTrait, TRAIT_CONSUMES_VARS, TRAIT_DEPENDS_ON_SLOT_CONTEXT} from '../traits';
 
 import {ListEndOp, NEW_OP, StatementOp, VariableOp} from './shared';
+import type {HostPropertyOp} from './host';
 
 
 /**
  * An operation usable on the update side of the IR.
  */
-export type UpdateOp = ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|AttributeOp|StylePropOp|
-    ClassPropOp|StyleMapOp|ClassMapOp|InterpolateTextOp|AdvanceOp|VariableOp<UpdateOp>|BindingOp;
+export type UpdateOp =
+    ListEndOp<UpdateOp>|StatementOp<UpdateOp>|PropertyOp|AttributeOp|StylePropOp|ClassPropOp|
+    StyleMapOp|ClassMapOp|InterpolateTextOp|AdvanceOp|VariableOp<UpdateOp>|BindingOp|HostPropertyOp;
 
 /**
  * A logical operation to perform string interpolation on a text node.

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -7,6 +7,7 @@
  */
 
 import * as o from '../../../../../output/output_ast';
+import {ParseSourceSpan} from '../../../../../parse_util';
 import {ElementAttributeKind} from '../element';
 import {OpKind} from '../enums';
 import {Op, XrefId} from '../operations';
@@ -50,18 +51,22 @@ export interface InterpolateTextOp extends Op<UpdateOp>, ConsumesVarsTrait {
    * Conceptually interwoven in between the `strings`.
    */
   expressions: o.Expression[];
+
+  sourceSpan: ParseSourceSpan;
 }
 
 /**
  * Create an `InterpolationTextOp`.
  */
 export function createInterpolateTextOp(
-    xref: XrefId, strings: string[], expressions: o.Expression[]): InterpolateTextOp {
+    xref: XrefId, strings: string[], expressions: o.Expression[],
+    sourceSpan: ParseSourceSpan): InterpolateTextOp {
   return {
     kind: OpKind.InterpolateText,
     target: xref,
     strings,
     expressions,
+    sourceSpan,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -93,6 +98,8 @@ export interface PropertyOp extends Op<UpdateOp>, ConsumesVarsTrait, DependsOnSl
    * The kind of binding represented by this op, either a template binding or a normal binding.
    */
   bindingKind: ElementAttributeKind.Template|ElementAttributeKind.Binding;
+
+  sourceSpan: ParseSourceSpan;
 }
 
 /**
@@ -100,13 +107,14 @@ export interface PropertyOp extends Op<UpdateOp>, ConsumesVarsTrait, DependsOnSl
  */
 export function createPropertyOp(
     xref: XrefId, bindingKind: ElementAttributeKind.Template|ElementAttributeKind.Binding,
-    name: string, expression: o.Expression): PropertyOp {
+    name: string, expression: o.Expression, sourceSpan: ParseSourceSpan): PropertyOp {
   return {
     kind: OpKind.Property,
     target: xref,
     bindingKind,
     name,
     expression,
+    sourceSpan,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -149,6 +157,7 @@ export function createStylePropOp(
     name,
     expression,
     unit,
+    sourceSpan: null!,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -187,6 +196,7 @@ export function createClassPropOp(
     target: xref,
     name,
     expression,
+    sourceSpan: null!,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -216,6 +226,7 @@ export function createStyleMapOp(xref: XrefId, expression: o.Expression): StyleM
     kind: OpKind.StyleMap,
     target: xref,
     expression,
+    sourceSpan: null!,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -247,6 +258,7 @@ export function createClassMapOp(xref: XrefId, expression: o.Expression): ClassM
     kind: OpKind.ClassMap,
     target: xref,
     expression,
+    sourceSpan: null!,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -333,6 +345,8 @@ export interface InterpolatePropertyOp extends Op<UpdateOp>, ConsumesVarsTrait,
    * The kind of binding represented by this op, either a template binding or a normal binding.
    */
   bindingKind: ElementAttributeKind.Template|ElementAttributeKind.Binding;
+
+  sourceSpan: ParseSourceSpan;
 }
 
 /**
@@ -340,7 +354,8 @@ export interface InterpolatePropertyOp extends Op<UpdateOp>, ConsumesVarsTrait,
  */
 export function createInterpolatePropertyOp(
     xref: XrefId, bindingKind: ElementAttributeKind.Template|ElementAttributeKind.Binding,
-    name: string, strings: string[], expressions: o.Expression[]): InterpolatePropertyOp {
+    name: string, strings: string[], expressions: o.Expression[],
+    sourceSpan: ParseSourceSpan): InterpolatePropertyOp {
   return {
     kind: OpKind.InterpolateProperty,
     target: xref,
@@ -348,6 +363,7 @@ export function createInterpolatePropertyOp(
     name,
     strings,
     expressions,
+    sourceSpan,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -389,7 +405,7 @@ export interface InterpolateAttributeOp extends Op<UpdateOp>, ConsumesVarsTrait,
 
 export function createInterpolateAttributeOp(
     target: XrefId, attributeKind: ElementAttributeKind, name: string, strings: string[],
-    expressions: o.Expression[]): InterpolateAttributeOp {
+    expressions: o.Expression[], sourceSpan: ParseSourceSpan): InterpolateAttributeOp {
   return {
     kind: OpKind.InterpolateAttribute,
     target: target,
@@ -397,6 +413,7 @@ export function createInterpolateAttributeOp(
     name,
     strings,
     expressions,
+    sourceSpan,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -453,6 +470,7 @@ export function createInterpolateStylePropOp(
     strings,
     expressions,
     unit,
+    sourceSpan: null!,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -496,6 +514,7 @@ export function createInterpolateStyleMapOp(
     target: xref,
     strings,
     expressions,
+    sourceSpan: null!,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -539,6 +558,7 @@ export function createInterpolateClassMapOp(
     target: xref,
     strings,
     expressions,
+    sourceSpan: null!,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,
     ...TRAIT_CONSUMES_VARS,
     ...NEW_OP,
@@ -555,15 +575,19 @@ export interface AdvanceOp extends Op<UpdateOp> {
    * Delta by which to advance the pointer.
    */
   delta: number;
+
+  // Source span of the binding that caused the advance
+  sourceSpan: ParseSourceSpan;
 }
 
 /**
  * Create an `AdvanceOp`.
  */
-export function createAdvanceOp(delta: number): AdvanceOp {
+export function createAdvanceOp(delta: number, sourceSpan: ParseSourceSpan): AdvanceOp {
   return {
     kind: OpKind.Advance,
     delta,
+    sourceSpan,
     ...NEW_OP,
   };
 }

--- a/packages/compiler/src/template/pipeline/ir/src/traits.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/traits.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import type {ParseSourceSpan} from '../../../../parse_util';
 import type {Op, XrefId} from './operations';
 import type {Expression} from './expression';
 
@@ -78,6 +79,8 @@ export interface DependsOnSlotContextOpTrait {
    * this operation can be executed.
    */
   target: XrefId;
+
+  sourceSpan: ParseSourceSpan;
 }
 
 
@@ -142,9 +145,10 @@ export const TRAIT_USES_SLOT_INDEX: Omit<UsesSlotIndexTrait, 'target'> = {
  * Default values for most `DependsOnSlotContextOpTrait` fields (used with the spread operator to
  * initialize implementors of the trait).
  */
-export const TRAIT_DEPENDS_ON_SLOT_CONTEXT: Omit<DependsOnSlotContextOpTrait, 'target'> = {
-  [DependsOnSlotContext]: true,
-} as const;
+export const TRAIT_DEPENDS_ON_SLOT_CONTEXT:
+    Omit<DependsOnSlotContextOpTrait, 'target'|'sourceSpan'> = {
+      [DependsOnSlotContext]: true,
+    } as const;
 
 /**
  * Default values for `UsesVars` fields (used with the spread operator to initialize

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -125,9 +125,6 @@ export class HostBindingCompilationJob extends CompilationUnit implements Compil
   }
 }
 
-// TODO: delete this type export and bulk-rename in all the phases.
-export type ComponentCompilation = ComponentCompilationJob;
-
 /**
  * Compilation-in-progress of a whole component's template, including the main template and any
  * embedded views or host bindings.
@@ -143,9 +140,9 @@ export class ComponentCompilationJob implements CompilationJob {
   /**
    * Map of view IDs to `ViewCompilation`s.
    */
-  readonly views = new Map<ir.XrefId, ViewCompilation>();
+  readonly views = new Map<ir.XrefId, ViewCompilationUnit>();
 
-  get units(): Iterable<ViewCompilation> {
+  get units(): Iterable<ViewCompilationUnit> {
     return this.views.values();
   }
 
@@ -159,7 +156,7 @@ export class ComponentCompilationJob implements CompilationJob {
   /**
    * The root view, representing the component's template.
    */
-  readonly root: ViewCompilation;
+  readonly root: ViewCompilationUnit;
 
   constructor(
       readonly componentName: string, readonly pool: ConstantPool,
@@ -173,7 +170,7 @@ export class ComponentCompilationJob implements CompilationJob {
   /**
    * Add a `ViewCompilation` for a new embedded view to this compilation.
    */
-  allocateView(parent: ir.XrefId): ViewCompilation {
+  allocateView(parent: ir.XrefId): ViewCompilationUnit {
     const view = new ViewCompilationUnit(this, this.allocateXrefId(), parent);
     this.views.set(view.xref, view);
     return view;
@@ -200,9 +197,6 @@ export class ComponentCompilationJob implements CompilationJob {
     return idx as ir.ConstIndex;
   }
 }
-
-// TODO: delete this type export and bulk-rename in all the phases.
-export type ViewCompilation = ViewCompilationUnit;
 
 /**
  * Compilation-in-progress of an individual view within a template.

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -26,6 +26,7 @@ export abstract class CompilationUnit {
    * List of update operations for this view.
    */
   readonly update = new ir.OpList<ir.UpdateOp>();
+  abstract readonly job: CompilationJob;
 
   constructor(readonly xref: ir.XrefId) {}
 
@@ -93,22 +94,27 @@ export interface CompilationJob {
 export class HostBindingCompilationJob extends CompilationUnit implements CompilationJob {
   readonly units = [this];
 
+  /**
+   * Tracks the next `ir.XrefId` which can be assigned as template structures are ingested.
+   */
+  private nextXrefId: ir.XrefId;
+
   // TODO: Perhaps we should accept a reference to the enclosing component, and get the name from
   // there?
   constructor(
-      readonly componentName: string, readonly pool: ConstantPool, xref: ir.XrefId,
+      readonly componentName: string, readonly pool: ConstantPool,
       readonly compatibility: ir.CompatibilityMode) {
-    super(xref);
+    super(0 as ir.XrefId);
+    this.nextXrefId = 1 as ir.XrefId;
+  }
+
+  override get job() {
+    return this;
   }
 
   get root() {
     return this;
   }
-
-  /**
-   * Tracks the next `ir.XrefId` which can be assigned as template structures are ingested.
-   */
-  private nextXrefId: ir.XrefId = 0 as ir.XrefId;
 
   allocateXrefId(): ir.XrefId {
     return this.nextXrefId++ as ir.XrefId;

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -66,6 +66,8 @@ export abstract class CompilationUnit {
 export interface CompilationJob {
   get units(): Iterable<CompilationUnit>;
 
+  get fnSuffix(): string;
+
   /**
    * Whether to compile in compatibility mode, to imitate the output of `TemplateDefinitionBuilder`.
    */
@@ -92,6 +94,8 @@ export interface CompilationJob {
 }
 
 export class HostBindingCompilationJob extends CompilationUnit implements CompilationJob {
+  readonly fnSuffix = 'HostBindings';
+
   readonly units = [this];
 
   /**
@@ -129,6 +133,8 @@ export type ComponentCompilation = ComponentCompilationJob;
  * embedded views or host bindings.
  */
 export class ComponentCompilationJob implements CompilationJob {
+  readonly fnSuffix = 'Template';
+
   /**
    * Tracks the next `ir.XrefId` which can be assigned as template structures are ingested.
    */

--- a/packages/compiler/src/template/pipeline/src/compilation.ts
+++ b/packages/compiler/src/template/pipeline/src/compilation.ts
@@ -10,6 +10,8 @@ import {ConstantPool} from '../../../constant_pool';
 import * as o from '../../../output/output_ast';
 import * as ir from '../ir';
 
+
+
 /**
  * Compilation-in-progress of a whole component's template, including the main template and any
  * embedded views or host bindings.
@@ -37,7 +39,9 @@ export class ComponentCompilation {
    */
   readonly root: ViewCompilation;
 
-  constructor(readonly componentName: string, readonly pool: ConstantPool) {
+  constructor(
+      readonly componentName: string, readonly pool: ConstantPool,
+      readonly compatibility: ir.CompatibilityMode) {
     // Allocate the root view.
     const root = new ViewCompilation(this, this.allocateXrefId(), null);
     this.views.set(root.xref, root);
@@ -137,5 +141,9 @@ export class ViewCompilation {
     for (const op of this.update) {
       yield op;
     }
+  }
+
+  get compatibility(): ir.CompatibilityMode {
+    return this.tpl.compatibility;
   }
 }

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -10,7 +10,7 @@ import * as o from '../../../../src/output/output_ast';
 import {ConstantPool} from '../../../constant_pool';
 import * as ir from '../ir';
 
-import type {ComponentCompilation, ViewCompilation, HostBindingCompilationJob, ComponentCompilationJob} from './compilation';
+import type {ComponentCompilationJob, ViewCompilationUnit, HostBindingCompilationJob} from './compilation';
 
 import {phaseAlignPipeVariadicVarOffset} from './phases/align_pipe_variadic_var_offset';
 import {phaseAttributeExtraction} from './phases/attribute_extraction';
@@ -111,13 +111,13 @@ export function transformHostBinding(job: HostBindingCompilationJob): void {
  * Compile all views in the given `ComponentCompilation` into the final template function, which may
  * reference constants defined in a `ConstantPool`.
  */
-export function emitTemplateFn(tpl: ComponentCompilation, pool: ConstantPool): o.FunctionExpr {
+export function emitTemplateFn(tpl: ComponentCompilationJob, pool: ConstantPool): o.FunctionExpr {
   const rootFn = emitView(tpl.root);
   emitChildViews(tpl.root, pool);
   return rootFn;
 }
 
-function emitChildViews(parent: ViewCompilation, pool: ConstantPool): void {
+function emitChildViews(parent: ViewCompilationUnit, pool: ConstantPool): void {
   for (const view of parent.job.views.values()) {
     if (view.parent !== parent.xref) {
       continue;
@@ -135,7 +135,7 @@ function emitChildViews(parent: ViewCompilation, pool: ConstantPool): void {
  * Emit a template function for an individual `ViewCompilation` (which may be either the root view
  * or an embedded view).
  */
-function emitView(view: ViewCompilation): o.FunctionExpr {
+function emitView(view: ViewCompilationUnit): o.FunctionExpr {
   if (view.fnName === null) {
     throw new Error(`AssertionError: view ${view.xref} is unnamed`);
   }

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -46,7 +46,7 @@ import {phaseResolveDollarEvent} from './phases/resolve_dollar_event';
  * processing, the compilation should be in a state where it can be emitted via `emitTemplateFn`.s
  */
 export function transformTemplate(cpl: ComponentCompilation): void {
-  phaseAttributeExtraction(cpl, /* compatibility */ true);
+  phaseAttributeExtraction(cpl);
   phasePipeCreation(cpl);
   phasePipeVariadic(cpl);
   phasePureLiteralStructures(cpl);
@@ -59,13 +59,13 @@ export function transformTemplate(cpl: ComponentCompilation): void {
   phaseLocalRefs(cpl);
   phaseConstCollection(cpl);
   phaseNullishCoalescing(cpl);
-  phaseExpandSafeReads(cpl, true);
+  phaseExpandSafeReads(cpl);
   phaseTemporaryVariables(cpl);
   phaseSlotAllocation(cpl);
   phaseVarCounting(cpl);
   phaseGenerateAdvance(cpl);
-  phaseVariableOptimization(cpl, {conservative: true});
-  phaseNaming(cpl, true);
+  phaseVariableOptimization(cpl);
+  phaseNaming(cpl);
   phaseMergeNextContext(cpl);
   phaseNgContainer(cpl);
   phaseEmptyElements(cpl);

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -82,14 +82,14 @@ export function transformTemplate(job: ComponentCompilationJob): void {
  */
 export function transformHostBindingFunction(job: HostBindingCompilationJob): void {
   // TODO: Finish updating these phases to support host bindings.
-  // phasePureLiteralStructures(job);
+  phasePureLiteralStructures(job);
   // phaseGenerateVariables(job);
   // phaseSaveRestoreView(job); // TODO: Is this needed?
-  // phaseNullishCoalescing(job);
-  // phaseExpandSafeReads(job);
-  // phaseVariableOptimization(job);
-  // phaseNaming(job);
-  // phasePureFunctionExtraction(job);
+  phaseNullishCoalescing(job);
+  phaseExpandSafeReads(job);
+  phaseVariableOptimization(job);
+  phaseNaming(job);
+  phasePureFunctionExtraction(job);
   phaseReify(job);
   phaseChaining(job);
 }
@@ -105,7 +105,7 @@ export function emitTemplateFn(tpl: ComponentCompilation, pool: ConstantPool): o
 }
 
 function emitChildViews(parent: ViewCompilation, pool: ConstantPool): void {
-  for (const view of parent.tpl.views.values()) {
+  for (const view of parent.job.views.values()) {
     if (view.parent !== parent.xref) {
       continue;
     }

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -39,6 +39,7 @@ import {phaseTemporaryVariables} from './phases/temporary_variables';
 import {phaseVarCounting} from './phases/var_counting';
 import {phaseVariableOptimization} from './phases/variable_optimization';
 import {phaseFindAnyCasts} from './phases/any_cast';
+import {phaseResolveDollarEvent} from './phases/resolve_dollar_event';
 
 /**
  * Run all transformation phases in the correct order against a `ComponentCompilation`. After this
@@ -52,6 +53,7 @@ export function transformTemplate(cpl: ComponentCompilation): void {
   phaseGenerateVariables(cpl);
   phaseSaveRestoreView(cpl);
   phaseFindAnyCasts(cpl);
+  phaseResolveDollarEvent(cpl);
   phaseResolveNames(cpl);
   phaseResolveContexts(cpl);
   phaseLocalRefs(cpl);

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -10,7 +10,7 @@ import * as o from '../../../../src/output/output_ast';
 import {ConstantPool} from '../../../constant_pool';
 import * as ir from '../ir';
 
-import type {ComponentCompilation, ViewCompilation} from './compilation';
+import type {ComponentCompilation, ViewCompilation, HostBindingCompilationJob, ComponentCompilationJob} from './compilation';
 
 import {phaseAlignPipeVariadicVarOffset} from './phases/align_pipe_variadic_var_offset';
 import {phaseAttributeExtraction} from './phases/attribute_extraction';
@@ -43,37 +43,55 @@ import {phaseResolveDollarEvent} from './phases/resolve_dollar_event';
 
 /**
  * Run all transformation phases in the correct order against a `ComponentCompilation`. After this
- * processing, the compilation should be in a state where it can be emitted via `emitTemplateFn`.s
+ * processing, the compilation should be in a state where it can be emitted.
  */
-export function transformTemplate(cpl: ComponentCompilation): void {
-  phaseAttributeExtraction(cpl);
-  phasePipeCreation(cpl);
-  phasePipeVariadic(cpl);
-  phasePureLiteralStructures(cpl);
-  phaseGenerateVariables(cpl);
-  phaseSaveRestoreView(cpl);
-  phaseFindAnyCasts(cpl);
-  phaseResolveDollarEvent(cpl);
-  phaseResolveNames(cpl);
-  phaseResolveContexts(cpl);
-  phaseLocalRefs(cpl);
-  phaseConstCollection(cpl);
-  phaseNullishCoalescing(cpl);
-  phaseExpandSafeReads(cpl);
-  phaseTemporaryVariables(cpl);
-  phaseSlotAllocation(cpl);
-  phaseVarCounting(cpl);
-  phaseGenerateAdvance(cpl);
-  phaseVariableOptimization(cpl);
-  phaseNaming(cpl);
-  phaseMergeNextContext(cpl);
-  phaseNgContainer(cpl);
-  phaseEmptyElements(cpl);
-  phasePureFunctionExtraction(cpl);
-  phaseAlignPipeVariadicVarOffset(cpl);
-  phasePropertyOrdering(cpl);
-  phaseReify(cpl);
-  phaseChaining(cpl);
+export function transformTemplate(job: ComponentCompilationJob): void {
+  phaseAttributeExtraction(job);
+  phasePipeCreation(job);
+  phasePipeVariadic(job);
+  phasePureLiteralStructures(job);
+  phaseGenerateVariables(job);
+  phaseSaveRestoreView(job);
+  phaseFindAnyCasts(job);
+  phaseResolveDollarEvent(job);
+  phaseResolveNames(job);
+  phaseResolveContexts(job);
+  phaseLocalRefs(job);
+  phaseConstCollection(job);
+  phaseNullishCoalescing(job);
+  phaseExpandSafeReads(job);
+  phaseTemporaryVariables(job);
+  phaseSlotAllocation(job);
+  phaseVarCounting(job);
+  phaseGenerateAdvance(job);
+  phaseVariableOptimization(job);
+  phaseNaming(job);
+  phaseMergeNextContext(job);
+  phaseNgContainer(job);
+  phaseEmptyElements(job);
+  phasePureFunctionExtraction(job);
+  phaseAlignPipeVariadicVarOffset(job);
+  phasePropertyOrdering(job);
+  phaseReify(job);
+  phaseChaining(job);
+}
+
+/**
+ * Run all transformation phases in the correct order against a `HostBindingCompilationJob`. After
+ * this processing, the compilation should be in a state where it can be emitted.
+ */
+export function transformHostBindingFunction(job: HostBindingCompilationJob): void {
+  // TODO: Finish updating these phases to support host bindings.
+  // phasePureLiteralStructures(job);
+  // phaseGenerateVariables(job);
+  // phaseSaveRestoreView(job); // TODO: Is this needed?
+  // phaseNullishCoalescing(job);
+  // phaseExpandSafeReads(job);
+  // phaseVariableOptimization(job);
+  // phaseNaming(job);
+  // phasePureFunctionExtraction(job);
+  phaseReify(job);
+  phaseChaining(job);
 }
 
 /**

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -38,6 +38,7 @@ import {phaseSlotAllocation} from './phases/slot_allocation';
 import {phaseTemporaryVariables} from './phases/temporary_variables';
 import {phaseVarCounting} from './phases/var_counting';
 import {phaseVariableOptimization} from './phases/variable_optimization';
+import {phaseFindAnyCasts} from './phases/any_cast';
 
 /**
  * Run all transformation phases in the correct order against a `ComponentCompilation`. After this
@@ -50,6 +51,7 @@ export function transformTemplate(cpl: ComponentCompilation): void {
   phasePureLiteralStructures(cpl);
   phaseGenerateVariables(cpl);
   phaseSaveRestoreView(cpl);
+  phaseFindAnyCasts(cpl);
   phaseResolveNames(cpl);
   phaseResolveContexts(cpl);
   phaseLocalRefs(cpl);

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -64,8 +64,8 @@ export function transformTemplate(cpl: ComponentCompilation): void {
   phaseSlotAllocation(cpl);
   phaseVarCounting(cpl);
   phaseGenerateAdvance(cpl);
-  phaseNaming(cpl, /* compatibility */ true);
   phaseVariableOptimization(cpl, {conservative: true});
+  phaseNaming(cpl, true);
   phaseMergeNextContext(cpl);
   phaseNgContainer(cpl);
   phaseEmptyElements(cpl);

--- a/packages/compiler/src/template/pipeline/src/emit.ts
+++ b/packages/compiler/src/template/pipeline/src/emit.ts
@@ -40,13 +40,21 @@ import {phaseVarCounting} from './phases/var_counting';
 import {phaseVariableOptimization} from './phases/variable_optimization';
 import {phaseFindAnyCasts} from './phases/any_cast';
 import {phaseResolveDollarEvent} from './phases/resolve_dollar_event';
+import {phaseBindingSpecialization} from './phases/binding_specialization';
+import {phaseStyleBindingSpecialization} from './phases/style_binding_specialization';
+import {phaseRemoveEmptyBindings} from './phases/remove_empty_bindings';
+import {phaseNoListenersOnTemplates} from './phases/no_listeners_on_templates';
 
 /**
  * Run all transformation phases in the correct order against a `ComponentCompilation`. After this
  * processing, the compilation should be in a state where it can be emitted.
  */
 export function transformTemplate(job: ComponentCompilationJob): void {
+  phaseStyleBindingSpecialization(job);
+  phaseBindingSpecialization(job);
   phaseAttributeExtraction(job);
+  phaseRemoveEmptyBindings(job);
+  phaseNoListenersOnTemplates(job);
   phasePipeCreation(job);
   phasePipeVariadic(job);
   phasePureLiteralStructures(job);

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -12,8 +12,10 @@ import * as o from '../../../output/output_ast';
 import * as t from '../../../render3/r3_ast';
 import * as ir from '../ir';
 
-import {ComponentCompilation, ViewCompilation} from './compilation';
+import {ComponentCompilation, ComponentCompilationJob, ViewCompilation} from './compilation';
 import {BINARY_OPERATORS} from './conversion';
+
+const compatibilityMode = ir.CompatibilityMode.TemplateDefinitionBuilder;
 
 /**
  * Process a template AST and convert it into a `ComponentCompilation` in the intermediate
@@ -21,8 +23,7 @@ import {BINARY_OPERATORS} from './conversion';
  */
 export function ingest(
     componentName: string, template: t.Node[], constantPool: ConstantPool): ComponentCompilation {
-  const cpl = new ComponentCompilation(
-      componentName, constantPool, ir.CompatibilityMode.TemplateDefinitionBuilder);
+  const cpl = new ComponentCompilationJob(componentName, constantPool, compatibilityMode);
   ingestNodes(cpl.root, template);
   return cpl;
 }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -21,7 +21,8 @@ import {BINARY_OPERATORS} from './conversion';
  */
 export function ingest(
     componentName: string, template: t.Node[], constantPool: ConstantPool): ComponentCompilation {
-  const cpl = new ComponentCompilation(componentName, constantPool);
+  const cpl = new ComponentCompilation(
+      componentName, constantPool, ir.CompatibilityMode.TemplateDefinitionBuilder);
   ingestNodes(cpl.root, template);
   return cpl;
 }

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -55,8 +55,17 @@ export function ingestHostBinding(
 
 export function ingestHostProperty(
     job: HostBindingCompilationJob, property: e.ParsedProperty): void {
-  job.update.push(ir.createHostPropertyOp(
-      property.name, convertAst(property.expression, job), null /* TODO: source span */));
+  let expression: o.Expression|ir.Interpolation;
+  const ast = property.expression.ast;
+  if (ast instanceof e.Interpolation) {
+    expression =
+        new ir.Interpolation(ast.strings, ast.expressions.map(expr => convertAst(expr, job)));
+  } else {
+    expression = convertAst(ast, job);
+  }
+  job.update.push(ir.createBindingOp(
+      job.root.xref, ir.BindingKind.Property, property.name, expression, null, false,
+      property.sourceSpan));
 }
 
 export function ingestHostEvent(job: HostBindingCompilationJob, event: e.ParsedEvent) {}

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -118,7 +118,7 @@ function convertAst(ast: e.AST, cpl: ComponentCompilation): o.Expression {
   if (ast instanceof e.ASTWithSource) {
     return convertAst(ast.ast, cpl);
   } else if (ast instanceof e.PropertyRead) {
-    if (ast.receiver instanceof e.ImplicitReceiver) {
+    if (ast.receiver instanceof e.ImplicitReceiver && !(ast.receiver instanceof e.ThisReceiver)) {
       return new ir.LexicalReadExpr(ast.name);
     } else {
       return new o.ReadPropExpr(convertAst(ast.receiver, cpl), ast.name);

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -7,6 +7,7 @@
  */
 
 import * as o from '../../../output/output_ast';
+import {ParseSourceSpan} from '../../../parse_util';
 import {Identifiers} from '../../../render3/r3_identifiers';
 import * as ir from '../ir';
 
@@ -15,18 +16,22 @@ import * as ir from '../ir';
 // depending on the exact arguments.
 
 export function element(
-    slot: number, tag: string, constIndex: number|null, localRefIndex: number|null): ir.CreateOp {
-  return elementOrContainerBase(Identifiers.element, slot, tag, constIndex, localRefIndex);
+    slot: number, tag: string, constIndex: number|null, localRefIndex: number|null,
+    sourceSpan: ParseSourceSpan): ir.CreateOp {
+  return elementOrContainerBase(
+      Identifiers.element, slot, tag, constIndex, localRefIndex, sourceSpan);
 }
 
 export function elementStart(
-    slot: number, tag: string, constIndex: number|null, localRefIndex: number|null): ir.CreateOp {
-  return elementOrContainerBase(Identifiers.elementStart, slot, tag, constIndex, localRefIndex);
+    slot: number, tag: string, constIndex: number|null, localRefIndex: number|null,
+    sourceSpan: ParseSourceSpan): ir.CreateOp {
+  return elementOrContainerBase(
+      Identifiers.elementStart, slot, tag, constIndex, localRefIndex, sourceSpan);
 }
 
 function elementOrContainerBase(
     instruction: o.ExternalReference, slot: number, tag: string|null, constIndex: number|null,
-    localRefIndex: number|null): ir.CreateOp {
+    localRefIndex: number|null, sourceSpan: ParseSourceSpan): ir.CreateOp {
   const args: o.Expression[] = [o.literal(slot)];
   if (tag !== null) {
     args.push(o.literal(tag));
@@ -40,60 +45,75 @@ function elementOrContainerBase(
     args.push(o.literal(constIndex));
   }
 
-  return call(instruction, args);
+  return call(instruction, args, sourceSpan);
 }
 
-export function elementEnd(): ir.CreateOp {
-  return call(Identifiers.elementEnd, []);
+export function elementEnd(sourceSpan: ParseSourceSpan|null): ir.CreateOp {
+  return call(Identifiers.elementEnd, [], sourceSpan);
 }
 
 export function elementContainerStart(
-    slot: number, constIndex: number|null, localRefIndex: number|null): ir.CreateOp {
+    slot: number, constIndex: number|null, localRefIndex: number|null,
+    sourceSpan: ParseSourceSpan): ir.CreateOp {
   return elementOrContainerBase(
-      Identifiers.elementContainerStart, slot, /* tag */ null, constIndex, localRefIndex);
+      Identifiers.elementContainerStart, slot, /* tag */ null, constIndex, localRefIndex,
+      sourceSpan);
 }
 
 export function elementContainer(
-    slot: number, constIndex: number|null, localRefIndex: number|null): ir.CreateOp {
+    slot: number, constIndex: number|null, localRefIndex: number|null,
+    sourceSpan: ParseSourceSpan): ir.CreateOp {
   return elementOrContainerBase(
-      Identifiers.elementContainer, slot, /* tag */ null, constIndex, localRefIndex);
+      Identifiers.elementContainer, slot, /* tag */ null, constIndex, localRefIndex, sourceSpan);
 }
 
 export function elementContainerEnd(): ir.CreateOp {
-  return call(Identifiers.elementContainerEnd, []);
+  return call(Identifiers.elementContainerEnd, [], null);
 }
 
 export function template(
     slot: number, templateFnRef: o.Expression, decls: number, vars: number, tag: string,
-    constIndex: number): ir.CreateOp {
-  return call(Identifiers.templateCreate, [
-    o.literal(slot),
-    templateFnRef,
-    o.literal(decls),
-    o.literal(vars),
-    o.literal(tag),
-    o.literal(constIndex),
-  ]);
+    constIndex: number, sourceSpan: ParseSourceSpan): ir.CreateOp {
+  return call(
+      Identifiers.templateCreate,
+      [
+        o.literal(slot),
+        templateFnRef,
+        o.literal(decls),
+        o.literal(vars),
+        o.literal(tag),
+        o.literal(constIndex),
+      ],
+      sourceSpan);
 }
 
 export function listener(name: string, handlerFn: o.Expression): ir.CreateOp {
-  return call(Identifiers.listener, [
-    o.literal(name),
-    handlerFn,
-  ]);
+  return call(
+      Identifiers.listener,
+      [
+        o.literal(name),
+        handlerFn,
+      ],
+      null);
 }
 
 export function pipe(slot: number, name: string): ir.CreateOp {
-  return call(Identifiers.pipe, [
-    o.literal(slot),
-    o.literal(name),
-  ]);
+  return call(
+      Identifiers.pipe,
+      [
+        o.literal(slot),
+        o.literal(name),
+      ],
+      null);
 }
 
-export function advance(delta: number): ir.UpdateOp {
-  return call(Identifiers.advance, [
-    o.literal(delta),
-  ]);
+export function advance(delta: number, sourceSpan: ParseSourceSpan): ir.UpdateOp {
+  return call(
+      Identifiers.advance,
+      [
+        o.literal(delta),
+      ],
+      sourceSpan);
 }
 
 export function reference(slot: number): o.Expression {
@@ -125,23 +145,28 @@ export function resetView(returnValue: o.Expression): o.Expression {
   ]);
 }
 
-export function text(slot: number, initialValue: string): ir.CreateOp {
-  const args: o.Expression[] = [o.literal(slot)];
+export function text(
+    slot: number, initialValue: string, sourceSpan: ParseSourceSpan|null): ir.CreateOp {
+  const args: o.Expression[] = [o.literal(slot, null)];
   if (initialValue !== '') {
     args.push(o.literal(initialValue));
   }
-  return call(Identifiers.text, args);
+  return call(Identifiers.text, args, sourceSpan);
 }
 
-export function property(name: string, expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.property, [
-    o.literal(name),
-    expression,
-  ]);
+export function property(
+    name: string, expression: o.Expression, sourceSpan: ParseSourceSpan): ir.UpdateOp {
+  return call(
+      Identifiers.property,
+      [
+        o.literal(name),
+        expression,
+      ],
+      sourceSpan);
 }
 
 export function attribute(name: string, expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.attribute, [o.literal(name), expression]);
+  return call(Identifiers.attribute, [o.literal(name), expression], null);
 }
 
 export function styleProp(name: string, expression: o.Expression, unit: string|null): ir.UpdateOp {
@@ -149,19 +174,19 @@ export function styleProp(name: string, expression: o.Expression, unit: string|n
   if (unit !== null) {
     args.push(o.literal(unit));
   }
-  return call(Identifiers.styleProp, args);
+  return call(Identifiers.styleProp, args, null);
 }
 
 export function classProp(name: string, expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.classProp, [o.literal(name), expression]);
+  return call(Identifiers.classProp, [o.literal(name), expression], null);
 }
 
 export function styleMap(expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.styleMap, [expression]);
+  return call(Identifiers.styleMap, [expression], null);
 }
 
 export function classMap(expression: o.Expression): ir.UpdateOp {
-  return call(Identifiers.classMap, [expression]);
+  return call(Identifiers.classMap, [expression], null);
 }
 
 const PIPE_BINDINGS: o.ExternalReference[] = [
@@ -192,7 +217,8 @@ export function pipeBindV(slot: number, varOffset: number, args: o.Expression): 
   ]);
 }
 
-export function textInterpolate(strings: string[], expressions: o.Expression[]): ir.UpdateOp {
+export function textInterpolate(
+    strings: string[], expressions: o.Expression[], sourceSpan: ParseSourceSpan): ir.UpdateOp {
   if (strings.length < 1 || expressions.length !== strings.length - 1) {
     throw new Error(
         `AssertionError: expected specific shape of args for strings/expressions in interpolation`);
@@ -210,15 +236,17 @@ export function textInterpolate(strings: string[], expressions: o.Expression[]):
     interpolationArgs.push(o.literal(strings[idx]));
   }
 
-  return callVariadicInstruction(TEXT_INTERPOLATE_CONFIG, [], interpolationArgs);
+  return callVariadicInstruction(TEXT_INTERPOLATE_CONFIG, [], interpolationArgs, [], sourceSpan);
 }
 
 
 export function propertyInterpolate(
-    name: string, strings: string[], expressions: o.Expression[]): ir.UpdateOp {
+    name: string, strings: string[], expressions: o.Expression[],
+    sourceSpan: ParseSourceSpan): ir.UpdateOp {
   const interpolationArgs = collateInterpolationArgs(strings, expressions);
 
-  return callVariadicInstruction(PROPERTY_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs);
+  return callVariadicInstruction(
+      PROPERTY_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs, [], sourceSpan);
 }
 
 export function attributeInterpolate(
@@ -226,7 +254,7 @@ export function attributeInterpolate(
   const interpolationArgs = collateInterpolationArgs(strings, expressions);
 
   return callVariadicInstruction(
-      ATTRIBUTE_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs);
+      ATTRIBUTE_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs, [], null);
 }
 
 export function stylePropInterpolate(
@@ -238,19 +266,19 @@ export function stylePropInterpolate(
   }
 
   return callVariadicInstruction(
-      STYLE_PROP_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs, extraArgs);
+      STYLE_PROP_INTERPOLATE_CONFIG, [o.literal(name)], interpolationArgs, extraArgs, null);
 }
 
 export function styleMapInterpolate(strings: string[], expressions: o.Expression[]): ir.UpdateOp {
   const interpolationArgs = collateInterpolationArgs(strings, expressions);
 
-  return callVariadicInstruction(STYLE_MAP_INTERPOLATE_CONFIG, [], interpolationArgs);
+  return callVariadicInstruction(STYLE_MAP_INTERPOLATE_CONFIG, [], interpolationArgs, [], null);
 }
 
 export function classMapInterpolate(strings: string[], expressions: o.Expression[]): ir.UpdateOp {
   const interpolationArgs = collateInterpolationArgs(strings, expressions);
 
-  return callVariadicInstruction(CLASS_MAP_INTERPOLATE_CONFIG, [], interpolationArgs);
+  return callVariadicInstruction(CLASS_MAP_INTERPOLATE_CONFIG, [], interpolationArgs, [], null);
 }
 
 export function pureFunction(
@@ -262,6 +290,8 @@ export function pureFunction(
         fn,
       ],
       args,
+      [],
+      null,
   );
 }
 
@@ -290,8 +320,9 @@ function collateInterpolationArgs(strings: string[], expressions: o.Expression[]
 }
 
 function call<OpT extends ir.CreateOp|ir.UpdateOp>(
-    instruction: o.ExternalReference, args: o.Expression[]): OpT {
-  return ir.createStatementOp(o.importExpr(instruction).callFn(args).toStmt()) as OpT;
+    instruction: o.ExternalReference, args: o.Expression[], sourceSpan: ParseSourceSpan|null): OpT {
+  const expr = o.importExpr(instruction).callFn(args, sourceSpan);
+  return ir.createStatementOp(new o.ExpressionStatement(expr, sourceSpan)) as OpT;
 }
 
 /**
@@ -467,18 +498,16 @@ const PURE_FUNCTION_CONFIG: VariadicInstructionConfig = {
 
 function callVariadicInstructionExpr(
     config: VariadicInstructionConfig, baseArgs: o.Expression[], interpolationArgs: o.Expression[],
-    extraArgs: o.Expression[] = []): o.Expression {
+    extraArgs: o.Expression[], sourceSpan: ParseSourceSpan|null): o.Expression {
   const n = config.mapping(interpolationArgs.length);
   if (n < config.constant.length) {
     // Constant calling pattern.
-    return o.importExpr(config.constant[n]).callFn([
-      ...baseArgs, ...interpolationArgs, ...extraArgs
-    ]);
+    return o.importExpr(config.constant[n])
+        .callFn([...baseArgs, ...interpolationArgs, ...extraArgs], sourceSpan);
   } else if (config.variable !== null) {
     // Variable calling pattern.
-    return o.importExpr(config.variable).callFn([
-      ...baseArgs, o.literalArr(interpolationArgs), ...extraArgs
-    ]);
+    return o.importExpr(config.variable)
+        .callFn([...baseArgs, o.literalArr(interpolationArgs), ...extraArgs], sourceSpan);
   } else {
     throw new Error(`AssertionError: unable to call variadic function`);
   }
@@ -486,7 +515,8 @@ function callVariadicInstructionExpr(
 
 function callVariadicInstruction(
     config: VariadicInstructionConfig, baseArgs: o.Expression[], interpolationArgs: o.Expression[],
-    extraArgs: o.Expression[] = []): ir.UpdateOp {
+    extraArgs: o.Expression[], sourceSpan: ParseSourceSpan|null): ir.UpdateOp {
   return ir.createStatementOp(
-      callVariadicInstructionExpr(config, baseArgs, interpolationArgs, extraArgs).toStmt());
+      callVariadicInstructionExpr(config, baseArgs, interpolationArgs, extraArgs, sourceSpan)
+          .toStmt());
 }

--- a/packages/compiler/src/template/pipeline/src/instruction.ts
+++ b/packages/compiler/src/template/pipeline/src/instruction.ts
@@ -281,6 +281,10 @@ export function classMapInterpolate(strings: string[], expressions: o.Expression
   return callVariadicInstruction(CLASS_MAP_INTERPOLATE_CONFIG, [], interpolationArgs, [], null);
 }
 
+export function hostProperty(name: string, expression: o.Expression): ir.UpdateOp {
+  return call(Identifiers.hostProperty, [o.literal(name), expression], null);
+}
+
 export function pureFunction(
     varOffset: number, fn: o.Expression, args: o.Expression[]): o.Expression {
   return callVariadicInstructionExpr(

--- a/packages/compiler/src/template/pipeline/src/phases/align_pipe_variadic_var_offset.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/align_pipe_variadic_var_offset.ts
@@ -8,10 +8,10 @@
 
 import * as ir from '../../ir';
 
-import type {ComponentCompilation} from '../compilation';
+import type {ComponentCompilationJob} from '../compilation';
 import {varsUsedByIrExpression} from './var_counting';
 
-export function phaseAlignPipeVariadicVarOffset(cpl: ComponentCompilation): void {
+export function phaseAlignPipeVariadicVarOffset(cpl: ComponentCompilationJob): void {
   for (const view of cpl.views.values()) {
     for (const op of view.update) {
       ir.visitExpressionsInOp(op, expr => {

--- a/packages/compiler/src/template/pipeline/src/phases/any_cast.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/any_cast.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import {ComponentCompilation} from '../compilation';
+
+/**
+ * Find any function calls to `$any`, excluding `this.$any`, and delete them.
+ */
+export function phaseFindAnyCasts(cpl: ComponentCompilation): void {
+  for (const [_, view] of cpl.views) {
+    for (const op of view.ops()) {
+      ir.transformExpressionsInOp(op, removeAnys, ir.VisitorContextFlag.None);
+    }
+  }
+}
+
+function removeAnys(e: o.Expression): o.Expression {
+  if (e instanceof o.InvokeFunctionExpr && e.fn instanceof ir.LexicalReadExpr &&
+      e.fn.name === '$any') {
+    if (e.args.length !== 1) {
+      throw new Error('The $any builtin function expects exactly one argument.');
+    }
+    return e.args[0];
+  }
+  return e;
+}

--- a/packages/compiler/src/template/pipeline/src/phases/any_cast.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/any_cast.ts
@@ -8,12 +8,12 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import {ComponentCompilation} from '../compilation';
+import {ComponentCompilationJob} from '../compilation';
 
 /**
  * Find any function calls to `$any`, excluding `this.$any`, and delete them.
  */
-export function phaseFindAnyCasts(cpl: ComponentCompilation): void {
+export function phaseFindAnyCasts(cpl: ComponentCompilationJob): void {
   for (const [_, view] of cpl.views) {
     for (const op of view.ops()) {
       ir.transformExpressionsInOp(op, removeAnys, ir.VisitorContextFlag.None);

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -8,13 +8,13 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import {ComponentCompilation, ViewCompilation} from '../compilation';
+import {ComponentCompilationJob, ViewCompilationUnit} from '../compilation';
 
 /**
  * Find all attribute and binding ops, and collect them into the ElementAttribute structures.
  * In cases where no instruction needs to be generated for the attribute or binding, it is removed.
  */
-export function phaseAttributeExtraction(cpl: ComponentCompilation): void {
+export function phaseAttributeExtraction(cpl: ComponentCompilationJob): void {
   for (const [_, view] of cpl.views) {
     populateElementAttributes(view);
   }
@@ -36,7 +36,7 @@ function lookupElement(
  * Populates the ElementAttributes map for the given view, and removes ops for any bindings that do
  * not need further processing.
  */
-function populateElementAttributes(view: ViewCompilation) {
+function populateElementAttributes(view: ViewCompilationUnit) {
   const elements = new Map<ir.XrefId, ir.ElementOrContainerOps>();
   for (const op of view.create) {
     if (!ir.isElementOrContainerOp(op)) {

--- a/packages/compiler/src/template/pipeline/src/phases/binding_specialization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/binding_specialization.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {CompilationJob} from '../compilation';
+
+export function phaseBindingSpecialization(cpl: CompilationJob): void {
+  for (const unit of cpl.units) {
+    for (const op of unit.update) {
+      if (op.kind !== ir.OpKind.Binding) {
+        continue;
+      }
+
+      switch (op.bindingKind) {
+        case ir.BindingKind.Attribute:
+          ir.OpList.replace<ir.UpdateOp>(
+              op,
+              ir.createAttributeOp(
+                  op.target, op.name, op.expression, op.isTemplate, op.sourceSpan));
+          break;
+        case ir.BindingKind.Property:
+          // TODO: host bindings
+          ir.OpList.replace<ir.UpdateOp>(
+              op,
+              ir.createPropertyOp(op.target, op.name, op.expression, op.isTemplate, op.sourceSpan));
+          break;
+        case ir.BindingKind.I18n:
+        case ir.BindingKind.ClassName:
+        case ir.BindingKind.StyleProperty:
+          throw new Error(`Unhandled binding of kind ${ir.BindingKind[op.bindingKind]}`);
+      }
+    }
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/binding_specialization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/binding_specialization.ts
@@ -8,10 +8,10 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import type {CompilationJob} from '../compilation';
+import {CompilationJob, HostBindingCompilationJob} from '../compilation';
 
-export function phaseBindingSpecialization(cpl: CompilationJob): void {
-  for (const unit of cpl.units) {
+export function phaseBindingSpecialization(job: CompilationJob): void {
+  for (const unit of job.units) {
     for (const op of unit.update) {
       if (op.kind !== ir.OpKind.Binding) {
         continue;
@@ -25,10 +25,16 @@ export function phaseBindingSpecialization(cpl: CompilationJob): void {
                   op.target, op.name, op.expression, op.isTemplate, op.sourceSpan));
           break;
         case ir.BindingKind.Property:
-          // TODO: host bindings
-          ir.OpList.replace<ir.UpdateOp>(
-              op,
-              ir.createPropertyOp(op.target, op.name, op.expression, op.isTemplate, op.sourceSpan));
+          if (job instanceof HostBindingCompilationJob) {
+            ir.OpList.replace<ir.UpdateOp>(
+                op, ir.createHostPropertyOp(op.name, op.expression, op.sourceSpan));
+          } else {
+            ir.OpList.replace<ir.UpdateOp>(
+                op,
+                ir.createPropertyOp(
+                    op.target, op.name, op.expression, op.isTemplate, op.sourceSpan));
+          }
+
           break;
         case ir.BindingKind.I18n:
         case ir.BindingKind.ClassName:

--- a/packages/compiler/src/template/pipeline/src/phases/chaining.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/chaining.ts
@@ -9,7 +9,7 @@
 import * as o from '../../../../output/output_ast';
 import {Identifiers as R3} from '../../../../render3/r3_identifiers';
 import * as ir from '../../ir';
-import {ComponentCompilation} from '../compilation';
+import {CompilationJob} from '../compilation';
 
 const CHAINABLE = new Set([
   R3.elementStart,
@@ -49,10 +49,10 @@ const CHAINABLE = new Set([
  * elementStart(0, 'div')(1, 'span');
  * ```
  */
-export function phaseChaining(cpl: ComponentCompilation): void {
-  for (const [_, view] of cpl.views) {
-    chainOperationsInList(view.create);
-    chainOperationsInList(view.update);
+export function phaseChaining(job: CompilationJob): void {
+  for (const unit of job.units) {
+    chainOperationsInList(unit.create);
+    chainOperationsInList(unit.update);
   }
 }
 

--- a/packages/compiler/src/template/pipeline/src/phases/chaining.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/chaining.ts
@@ -15,6 +15,7 @@ const CHAINABLE = new Set([
   R3.elementStart,
   R3.elementEnd,
   R3.property,
+  R3.hostProperty,
   R3.styleProp,
   R3.attribute,
   R3.stylePropInterpolate1,

--- a/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/const_collection.ts
@@ -10,13 +10,13 @@ import * as core from '../../../../core';
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
 import {ElementAttributes} from '../../ir/src/element';
-import {ComponentCompilation} from '../compilation';
+import {ComponentCompilationJob} from '../compilation';
 
 /**
  * Converts the semantic attributes of element-like operations (elements, templates) into constant
  * array expressions, and lifts them into the overall component `consts`.
  */
-export function phaseConstCollection(cpl: ComponentCompilation): void {
+export function phaseConstCollection(cpl: ComponentCompilationJob): void {
   for (const [_, view] of cpl.views) {
     for (const op of view.create) {
       if (op.kind !== ir.OpKind.ElementStart && op.kind !== ir.OpKind.Element &&

--- a/packages/compiler/src/template/pipeline/src/phases/empty_elements.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/empty_elements.ts
@@ -7,7 +7,7 @@
  */
 
 import * as ir from '../../ir';
-import {ComponentCompilation} from '../compilation';
+import {ComponentCompilationJob} from '../compilation';
 
 const REPLACEMENTS = new Map<ir.OpKind, [ir.OpKind, ir.OpKind]>([
   [ir.OpKind.ElementEnd, [ir.OpKind.ElementStart, ir.OpKind.Element]],
@@ -18,7 +18,7 @@ const REPLACEMENTS = new Map<ir.OpKind, [ir.OpKind, ir.OpKind]>([
  * Replace sequences of mergable elements (e.g. `ElementStart` and `ElementEnd`) with a consolidated
  * element (e.g. `Element`).
  */
-export function phaseEmptyElements(cpl: ComponentCompilation): void {
+export function phaseEmptyElements(cpl: ComponentCompilationJob): void {
   for (const [_, view] of cpl.views) {
     for (const op of view.create) {
       const opReplacements = REPLACEMENTS.get(op.kind);

--- a/packages/compiler/src/template/pipeline/src/phases/generate_advance.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/generate_advance.ts
@@ -54,7 +54,8 @@ export function phaseGenerateAdvance(cpl: ComponentCompilation): void {
           throw new Error(`AssertionError: slot counter should never need to move backwards`);
         }
 
-        ir.OpList.insertBefore<ir.UpdateOp>(ir.createAdvanceOp(delta), op);
+        ir.OpList.insertBefore<ir.UpdateOp>(
+            ir.createAdvanceOp(delta, (op as ir.DependsOnSlotContextOpTrait).sourceSpan), op);
         slotContext = slot;
       }
     }

--- a/packages/compiler/src/template/pipeline/src/phases/generate_advance.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/generate_advance.ts
@@ -7,13 +7,13 @@
  */
 
 import * as ir from '../../ir';
-import {ComponentCompilation} from '../compilation';
+import {ComponentCompilationJob} from '../compilation';
 
 /**
  * Generate `ir.AdvanceOp`s in between `ir.UpdateOp`s that ensure the runtime's implicit slot
  * context will be advanced correctly.
  */
-export function phaseGenerateAdvance(cpl: ComponentCompilation): void {
+export function phaseGenerateAdvance(cpl: ComponentCompilationJob): void {
   for (const [_, view] of cpl.views) {
     // First build a map of all of the declarations in the view that have assigned slots.
     const slotMap = new Map<ir.XrefId, number>();

--- a/packages/compiler/src/template/pipeline/src/phases/generate_variables.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/generate_variables.ts
@@ -44,7 +44,7 @@ function recursivelyProcessView(view: ViewCompilation, parentScope: Scope|null):
     switch (op.kind) {
       case ir.OpKind.Template:
         // Descend into child embedded views.
-        recursivelyProcessView(view.tpl.views.get(op.xref)!, scope);
+        recursivelyProcessView(view.job.views.get(op.xref)!, scope);
         break;
       case ir.OpKind.Listener:
         // Prepend variables to listener handler functions.
@@ -178,20 +178,20 @@ function generateVariablesInScopeForView(
     // view with a `nextContext` expression. This context switching operation itself declares a
     // variable, because the context of the view may be referenced directly.
     newOps.push(ir.createVariableOp(
-        view.tpl.allocateXrefId(), scope.viewContextVariable, new ir.NextContextExpr()));
+        view.job.allocateXrefId(), scope.viewContextVariable, new ir.NextContextExpr()));
   }
 
   // Add variables for all context variables available in this scope's view.
-  for (const [name, value] of view.tpl.views.get(scope.view)!.contextVariables) {
+  for (const [name, value] of view.job.views.get(scope.view)!.contextVariables) {
     newOps.push(ir.createVariableOp(
-        view.tpl.allocateXrefId(), scope.contextVariables.get(name)!,
+        view.job.allocateXrefId(), scope.contextVariables.get(name)!,
         new o.ReadPropExpr(new ir.ContextExpr(scope.view), value)));
   }
 
   // Add variables for all local references declared for elements in this scope.
   for (const ref of scope.references) {
     newOps.push(ir.createVariableOp(
-        view.tpl.allocateXrefId(), ref.variable, new ir.ReferenceExpr(ref.targetId, ref.offset)));
+        view.job.allocateXrefId(), ref.variable, new ir.ReferenceExpr(ref.targetId, ref.offset)));
   }
 
   if (scope.parent !== null) {

--- a/packages/compiler/src/template/pipeline/src/phases/generate_variables.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/generate_variables.ts
@@ -9,7 +9,7 @@
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
 
-import type {ComponentCompilation, ViewCompilation} from '../compilation';
+import type {ComponentCompilationJob, ViewCompilationUnit} from '../compilation';
 
 /**
  * Generate a preamble sequence for each view creation block and listener function which declares
@@ -25,7 +25,7 @@ import type {ComponentCompilation, ViewCompilation} from '../compilation';
  * Variables are generated here unconditionally, and may optimized away in future operations if it
  * turns out their values (and any side effects) are unused.
  */
-export function phaseGenerateVariables(cpl: ComponentCompilation): void {
+export function phaseGenerateVariables(cpl: ComponentCompilationJob): void {
   recursivelyProcessView(cpl.root, /* there is no parent scope for the root view */ null);
 }
 
@@ -36,7 +36,7 @@ export function phaseGenerateVariables(cpl: ComponentCompilation): void {
  * @param `parentScope` a scope extracted from the parent view which captures any variables which
  *     should be inherited by this view. `null` if the current view is the root view.
  */
-function recursivelyProcessView(view: ViewCompilation, parentScope: Scope|null): void {
+function recursivelyProcessView(view: ViewCompilationUnit, parentScope: Scope|null): void {
   // Extract a `Scope` from this view.
   const scope = getScopeForView(view, parentScope);
 
@@ -113,7 +113,7 @@ interface Reference {
  * Process a view and generate a `Scope` representing the variables available for reference within
  * that view.
  */
-function getScopeForView(view: ViewCompilation, parent: Scope|null): Scope {
+function getScopeForView(view: ViewCompilationUnit, parent: Scope|null): Scope {
   const scope: Scope = {
     view: view.xref,
     viewContextVariable: {
@@ -170,7 +170,7 @@ function getScopeForView(view: ViewCompilation, parent: Scope|null): Scope {
  * itself may have inherited variables, etc.
  */
 function generateVariablesInScopeForView(
-    view: ViewCompilation, scope: Scope): ir.VariableOp<ir.UpdateOp>[] {
+    view: ViewCompilationUnit, scope: Scope): ir.VariableOp<ir.UpdateOp>[] {
   const newOps: ir.VariableOp<ir.UpdateOp>[] = [];
 
   if (scope.view !== view.xref) {

--- a/packages/compiler/src/template/pipeline/src/phases/host_style_property_parsing.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/host_style_property_parsing.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+
+import type {HostBindingCompilationJob} from '../compilation';
+
+const STYLE_DOT = 'style.';
+const CLASS_DOT = 'class.';
+
+export function phaseHostStylePropertyParsing(job: HostBindingCompilationJob): void {
+  for (const op of job.update) {
+    if (op.kind !== ir.OpKind.Binding) {
+      continue;
+    }
+
+    if (op.name.startsWith(STYLE_DOT)) {
+      op.bindingKind = ir.BindingKind.StyleProperty;
+      op.name = op.name.substring(STYLE_DOT.length);
+
+      if (isCssCustomProperty(op.name)) {
+        op.name = hyphenate(op.name);
+      }
+
+      const {property, suffix} = parseProperty(op.name);
+      op.name = property;
+      op.unit = suffix;
+    } else if (op.name.startsWith('style!')) {
+      // TODO: do we only transform !important?
+      op.name = 'style';
+    } else if (op.name.startsWith(CLASS_DOT)) {
+      op.bindingKind = ir.BindingKind.ClassName;
+      op.name = parseProperty(op.name.substring(CLASS_DOT.length)).property;
+    }
+  }
+}
+
+
+/**
+ * Checks whether property name is a custom CSS property.
+ * See: https://www.w3.org/TR/css-variables-1
+ */
+function isCssCustomProperty(name: string): boolean {
+  return name.startsWith('--');
+}
+
+function hyphenate(value: string): string {
+  return value
+      .replace(
+          /[a-z][A-Z]/g,
+          v => {
+            return v.charAt(0) + '-' + v.charAt(1);
+          })
+      .toLowerCase();
+}
+
+function parseProperty(name: string): {property: string, suffix: string|null} {
+  const overrideIndex = name.indexOf('!important');
+  if (overrideIndex !== -1) {
+    name = overrideIndex > 0 ? name.substring(0, overrideIndex) : '';
+  }
+
+  let suffix: string|null = null;
+  let property = name;
+  const unitIndex = name.lastIndexOf('.');
+  if (unitIndex > 0) {
+    suffix = name.slice(unitIndex + 1);
+    property = name.substring(0, unitIndex);
+  }
+
+  return {property, suffix};
+}

--- a/packages/compiler/src/template/pipeline/src/phases/local_refs.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/local_refs.ts
@@ -9,13 +9,13 @@
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
 
-import type {ComponentCompilation} from '../compilation';
+import type {ComponentCompilationJob} from '../compilation';
 
 /**
  * Lifts local reference declarations on element-like structures within each view into an entry in
  * the `consts` array for the whole component.
  */
-export function phaseLocalRefs(cpl: ComponentCompilation): void {
+export function phaseLocalRefs(cpl: ComponentCompilationJob): void {
   for (const view of cpl.views.values()) {
     for (const op of view.create) {
       switch (op.kind) {

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -40,8 +40,10 @@ function addNamesToView(
           if (op.slot === null) {
             throw new Error(`Expected a slot to be assigned`);
           }
+          const safeTagName = op.tag.replace('-', '_');
+
           op.handlerFnName =
-              sanitizeIdentifier(`${view.fnName}_${op.tag}_${op.name}_${op.slot}_listener`);
+              sanitizeIdentifier(`${view.fnName}_${safeTagName}_${op.name}_${op.slot}_listener`);
         }
         break;
       case ir.OpKind.Variable:

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -89,6 +89,9 @@ function addNamesToView(
 function getVariableName(variable: ir.SemanticVariable, state: {index: number}): string {
   if (variable.name === null) {
     switch (variable.kind) {
+      case ir.SemanticVariableKind.Context:
+        variable.name = `ctx_r${state.index++}`;
+        break;
       case ir.SemanticVariableKind.Identifier:
         variable.name = `${variable.identifier}_${state.index++}`;
         break;

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -26,7 +26,7 @@ export function phaseNaming(cpl: CompilationJob): void {
 function addNamesToView(
     unit: CompilationUnit, baseName: string, state: {index: number}, compatibility: boolean): void {
   if (unit.fnName === null) {
-    unit.fnName = sanitizeIdentifier(`${baseName}_Template`);
+    unit.fnName = sanitizeIdentifier(`${baseName}_${unit.job.fnSuffix}`);
   }
 
   // Keep track of the names we assign to variables in the view. We'll need to propagate these

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -9,7 +9,7 @@
 import {sanitizeIdentifier} from '../../../../parse_util';
 import {hyphenate} from '../../../../render3/view/style_parser';
 import * as ir from '../../ir';
-import type {ComponentCompilation, ViewCompilation} from '../compilation';
+import {type CompilationJob, type CompilationUnit, ViewCompilationUnit} from '../compilation';
 
 /**
  * Generate names for functions and variables across all views.
@@ -17,23 +17,23 @@ import type {ComponentCompilation, ViewCompilation} from '../compilation';
  * This includes propagating those names into any `ir.ReadVariableExpr`s of those variables, so that
  * the reads can be emitted correctly.
  */
-export function phaseNaming(cpl: ComponentCompilation): void {
+export function phaseNaming(cpl: CompilationJob): void {
   addNamesToView(
       cpl.root, cpl.componentName, {index: 0},
       cpl.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder);
 }
 
 function addNamesToView(
-    view: ViewCompilation, baseName: string, state: {index: number}, compatibility: boolean): void {
-  if (view.fnName === null) {
-    view.fnName = sanitizeIdentifier(`${baseName}_Template`);
+    unit: CompilationUnit, baseName: string, state: {index: number}, compatibility: boolean): void {
+  if (unit.fnName === null) {
+    unit.fnName = sanitizeIdentifier(`${baseName}_Template`);
   }
 
   // Keep track of the names we assign to variables in the view. We'll need to propagate these
   // into reads of those variables afterwards.
   const varNames = new Map<ir.XrefId, string>();
 
-  for (const op of view.ops()) {
+  for (const op of unit.ops()) {
     switch (op.kind) {
       case ir.OpKind.Listener:
         if (op.handlerFnName === null) {
@@ -45,14 +45,17 @@ function addNamesToView(
           const safeTagName = op.tag.replace('-', '_');
 
           op.handlerFnName =
-              sanitizeIdentifier(`${view.fnName}_${safeTagName}_${op.name}_${op.slot}_listener`);
+              sanitizeIdentifier(`${unit.fnName}_${safeTagName}_${op.name}_${op.slot}_listener`);
         }
         break;
       case ir.OpKind.Variable:
         varNames.set(op.xref, getVariableName(op.variable, state));
         break;
       case ir.OpKind.Template:
-        const childView = view.tpl.views.get(op.xref)!;
+        if (!(unit instanceof ViewCompilationUnit)) {
+          throw new Error(`AssertionError: must be compiling a component`);
+        }
+        const childView = unit.job.views.get(op.xref)!;
         if (op.slot === null) {
           throw new Error(`Expected slot to be assigned`);
         }
@@ -75,7 +78,7 @@ function addNamesToView(
 
   // Having named all variables declared in the view, now we can push those names into the
   // `ir.ReadVariableExpr` expressions which represent reads of those variables.
-  for (const op of view.ops()) {
+  for (const op of unit.ops()) {
     ir.visitExpressionsInOp(op, expr => {
       if (!(expr instanceof ir.ReadVariableExpr) || expr.name !== null) {
         return;

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -17,8 +17,10 @@ import type {ComponentCompilation, ViewCompilation} from '../compilation';
  * This includes propagating those names into any `ir.ReadVariableExpr`s of those variables, so that
  * the reads can be emitted correctly.
  */
-export function phaseNaming(cpl: ComponentCompilation, compatibility: boolean): void {
-  addNamesToView(cpl.root, cpl.componentName, {index: 0}, compatibility);
+export function phaseNaming(cpl: ComponentCompilation): void {
+  addNamesToView(
+      cpl.root, cpl.componentName, {index: 0},
+      cpl.compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder);
 }
 
 function addNamesToView(

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -62,7 +62,6 @@ function addNamesToView(
         addNamesToView(childView, `${baseName}_${op.tag}_${op.slot}`, state, compatibility);
         break;
       case ir.OpKind.StyleProp:
-      case ir.OpKind.InterpolateStyleProp:
         op.name = normalizeStylePropName(op.name);
         if (compatibility) {
           op.name = stripImportant(op.name);

--- a/packages/compiler/src/template/pipeline/src/phases/next_context_merging.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/next_context_merging.ts
@@ -9,7 +9,7 @@
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
 
-import type {ComponentCompilation} from '../compilation';
+import type {ComponentCompilationJob} from '../compilation';
 
 /**
  * Merges logically sequential `NextContextExpr` operations.
@@ -23,7 +23,7 @@ import type {ComponentCompilation} from '../compilation';
  *     is, the call is purely side-effectful).
  *   * No operations in between them uses the implicit context.
  */
-export function phaseMergeNextContext(cpl: ComponentCompilation): void {
+export function phaseMergeNextContext(cpl: ComponentCompilationJob): void {
   for (const view of cpl.views.values()) {
     for (const op of view.create) {
       if (op.kind === ir.OpKind.Listener) {

--- a/packages/compiler/src/template/pipeline/src/phases/ng_container.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/ng_container.ts
@@ -7,14 +7,14 @@
  */
 
 import * as ir from '../../ir';
-import {ComponentCompilation} from '../compilation';
+import {ComponentCompilationJob} from '../compilation';
 
 const CONTAINER_TAG = 'ng-container';
 
 /**
  * Replace an `Element` or `ElementStart` whose tag is `ng-container` with a specific op.
  */
-export function phaseNgContainer(cpl: ComponentCompilation): void {
+export function phaseNgContainer(cpl: ComponentCompilationJob): void {
   for (const [_, view] of cpl.views) {
     const updatedElementXrefs = new Set<ir.XrefId>();
     for (const op of view.create) {

--- a/packages/compiler/src/template/pipeline/src/phases/no_listeners_on_templates.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/no_listeners_on_templates.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {CompilationJob} from '../compilation';
+
+/**
+ * Transforms special-case bindings with 'style' or 'class' in their names. Must run before the
+ * main binding specialization pass.
+ */
+export function phaseNoListenersOnTemplates(job: CompilationJob): void {
+  for (const unit of job.units) {
+    let inTemplate = false;
+    for (const op of unit.create) {
+      switch (op.kind) {
+        case ir.OpKind.Template:
+          inTemplate = true;
+          break;
+        case ir.OpKind.ElementStart:
+        case ir.OpKind.Element:
+        case ir.OpKind.ContainerStart:
+        case ir.OpKind.Container:
+          inTemplate = false;
+          break;
+        case ir.OpKind.Listener:
+          if (inTemplate) {
+            ir.OpList.remove<ir.CreateOp>(op);
+          }
+          break;
+      }
+    }
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/nullish_coalescing.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/nullish_coalescing.ts
@@ -8,19 +8,19 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import type {ComponentCompilation} from '../compilation';
+import type {CompilationJob} from '../compilation';
 
 
-export function phaseNullishCoalescing(cpl: ComponentCompilation): void {
-  for (const view of cpl.views.values()) {
-    for (const op of view.ops()) {
+export function phaseNullishCoalescing(job: CompilationJob): void {
+  for (const unit of job.units) {
+    for (const op of unit.ops()) {
       ir.transformExpressionsInOp(op, expr => {
         if (!(expr instanceof o.BinaryOperatorExpr) ||
             expr.operator !== o.BinaryOperator.NullishCoalesce) {
           return expr;
         }
 
-        const assignment = new ir.AssignTemporaryExpr(expr.lhs.clone(), cpl.allocateXrefId());
+        const assignment = new ir.AssignTemporaryExpr(expr.lhs.clone(), job.allocateXrefId());
         const read = new ir.ReadTemporaryExpr(assignment.xref);
 
         // TODO: When not in compatibility mode for TemplateDefinitionBuilder, we can just emit

--- a/packages/compiler/src/template/pipeline/src/phases/pipe_creation.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/pipe_creation.ts
@@ -7,15 +7,15 @@
  */
 
 import * as ir from '../../ir';
-import type {ComponentCompilation, ViewCompilation} from '../compilation';
+import type {ComponentCompilationJob, ViewCompilationUnit} from '../compilation';
 
-export function phasePipeCreation(cpl: ComponentCompilation): void {
+export function phasePipeCreation(cpl: ComponentCompilationJob): void {
   for (const view of cpl.views.values()) {
     processPipeBindingsInView(view);
   }
 }
 
-function processPipeBindingsInView(view: ViewCompilation): void {
+function processPipeBindingsInView(view: ViewCompilationUnit): void {
   for (const updateOp of view.update) {
     ir.visitExpressionsInOp(updateOp, (expr, flags) => {
       if (!ir.isIrExpression(expr)) {
@@ -41,7 +41,7 @@ function processPipeBindingsInView(view: ViewCompilation): void {
 }
 
 function addPipeToCreationBlock(
-    view: ViewCompilation, afterTargetXref: ir.XrefId, binding: ir.PipeBindingExpr): void {
+    view: ViewCompilationUnit, afterTargetXref: ir.XrefId, binding: ir.PipeBindingExpr): void {
   // Find the appropriate point to insert the Pipe creation operation.
   // We're looking for `afterTargetXref` (and also want to insert after any other pipe operations
   // which might be beyond it).

--- a/packages/compiler/src/template/pipeline/src/phases/pipe_variadic.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/pipe_variadic.ts
@@ -9,9 +9,9 @@
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
 
-import type {ComponentCompilation} from '../compilation';
+import type {ComponentCompilationJob} from '../compilation';
 
-export function phasePipeVariadic(cpl: ComponentCompilation): void {
+export function phasePipeVariadic(cpl: ComponentCompilationJob): void {
   for (const view of cpl.views.values()) {
     for (const op of view.update) {
       ir.transformExpressionsInOp(op, expr => {

--- a/packages/compiler/src/template/pipeline/src/phases/property_ordering.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/property_ordering.ts
@@ -9,28 +9,45 @@
 import * as ir from '../../ir';
 import {ComponentCompilation} from '../compilation';
 
+function kindTest(kind: ir.OpKind): (op: ir.UpdateOp) => boolean {
+  return (op: ir.UpdateOp) => op.kind === kind;
+}
+
 /**
  * Defines the groups based on `OpKind` that ops will be divided into. Ops will be collected into
  * groups, then optionally transformed, before recombining the groups in the order defined here.
  */
 const ORDERING: {
-  kinds: Set<ir.OpKind>,
-  transform?: (ops: Array<ir.UpdateOp|ir.CreateOp>) => Array<ir.UpdateOp|ir.CreateOp>
+  test: (op: ir.UpdateOp) => boolean,
+  transform?: (ops: Array<ir.UpdateOp>) => Array<ir.UpdateOp>
 }[] =
     [
-      {kinds: new Set([ir.OpKind.StyleMap, ir.OpKind.InterpolateStyleMap]), transform: keepLast},
-      {kinds: new Set([ir.OpKind.ClassMap, ir.OpKind.InterpolateClassMap]), transform: keepLast},
-      {kinds: new Set([ir.OpKind.StyleProp, ir.OpKind.InterpolateStyleProp])},
-      {kinds: new Set([ir.OpKind.ClassProp])},
-      {kinds: new Set([ir.OpKind.InterpolateProperty])},
-      {kinds: new Set([ir.OpKind.Property])},
-      {kinds: new Set([ir.OpKind.Attribute, ir.OpKind.InterpolateAttribute])},
+      {test: kindTest(ir.OpKind.StyleMap), transform: keepLast},
+      {test: kindTest(ir.OpKind.ClassMap), transform: keepLast},
+      {test: kindTest(ir.OpKind.StyleProp)},
+      {test: kindTest(ir.OpKind.ClassProp)},
+      {
+        test: (op: ir.UpdateOp) =>
+            op.kind === ir.OpKind.Property && op.expression instanceof ir.Interpolation
+      },
+      {
+        test: (op: ir.UpdateOp) =>
+            op.kind === ir.OpKind.Property && !(op.expression instanceof ir.Interpolation)
+      },
+      {test: kindTest(ir.OpKind.Attribute)},
     ];
 
 /**
  * The set of all op kinds we handle in the reordering phase.
  */
-const handledOpKinds = new Set(ORDERING.flatMap(group => [...group.kinds]));
+const handledOpKinds = new Set([
+  ir.OpKind.StyleMap,
+  ir.OpKind.ClassMap,
+  ir.OpKind.StyleProp,
+  ir.OpKind.ClassProp,
+  ir.OpKind.Property,
+  ir.OpKind.Attribute,
+]);
 
 /**
  * Reorders property and attribute ops according to the following ordering:
@@ -61,7 +78,7 @@ export function phasePropertyOrdering(cpl: ComponentCompilation) {
     }
     // If we still have ops pulled at the end, put them back in the correct order.
     for (const orderedOp of reorder(opsToOrder)) {
-      view.update.push(orderedOp as ir.UpdateOp);
+      view.update.push(orderedOp);
     }
   }
 }
@@ -69,11 +86,11 @@ export function phasePropertyOrdering(cpl: ComponentCompilation) {
 /**
  * Reorders the given list of ops according to the ordering defined by `ORDERING`.
  */
-function reorder(ops: Array<ir.UpdateOp|ir.CreateOp>): Array<ir.UpdateOp|ir.CreateOp> {
+function reorder(ops: Array<ir.UpdateOp>): Array<ir.UpdateOp> {
   // Break the ops list into groups based on OpKind.
-  const groups = Array.from(ORDERING, () => new Array<ir.UpdateOp|ir.CreateOp>());
+  const groups = Array.from(ORDERING, () => new Array<ir.UpdateOp>());
   for (const op of ops) {
-    const groupIndex = ORDERING.findIndex(o => o.kinds.has(op.kind));
+    const groupIndex = ORDERING.findIndex(o => o.test(op));
     groups[groupIndex].push(op);
   }
   // Reassemble the groups into a single list, in the correct order.
@@ -86,6 +103,6 @@ function reorder(ops: Array<ir.UpdateOp|ir.CreateOp>): Array<ir.UpdateOp|ir.Crea
 /**
  * Keeps only the last op in a list of ops.
  */
-function keepLast(ops: Array<ir.UpdateOp|ir.CreateOp>) {
+function keepLast<T>(ops: Array<T>) {
   return ops.slice(ops.length - 1);
 }

--- a/packages/compiler/src/template/pipeline/src/phases/pure_function_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/pure_function_extraction.ts
@@ -10,10 +10,10 @@ import {GenericKeyFn, SharedConstantDefinition} from '../../../../constant_pool'
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
 
-import type {ComponentCompilation} from '../compilation';
+import type {CompilationJob} from '../compilation';
 
-export function phasePureFunctionExtraction(cpl: ComponentCompilation): void {
-  for (const view of cpl.views.values()) {
+export function phasePureFunctionExtraction(job: CompilationJob): void {
+  for (const view of job.units) {
     for (const op of view.ops()) {
       ir.visitExpressionsInOp(op, expr => {
         if (!(expr instanceof ir.PureFunctionExpr) || expr.body === null) {
@@ -21,7 +21,7 @@ export function phasePureFunctionExtraction(cpl: ComponentCompilation): void {
         }
 
         const constantDef = new PureFunctionConstant(expr.args.length);
-        expr.fn = cpl.pool.getSharedConstant(constantDef, expr.body);
+        expr.fn = job.pool.getSharedConstant(constantDef, expr.body);
         expr.body = null;
       });
     }

--- a/packages/compiler/src/template/pipeline/src/phases/pure_literal_structures.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/pure_literal_structures.ts
@@ -8,10 +8,10 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import type {ComponentCompilation} from '../compilation';
+import type {CompilationJob} from '../compilation';
 
-export function phasePureLiteralStructures(cpl: ComponentCompilation): void {
-  for (const view of cpl.views.values()) {
+export function phasePureLiteralStructures(job: CompilationJob): void {
+  for (const view of job.units) {
     for (const op of view.update) {
       ir.transformExpressionsInOp(op, (expr, flags) => {
         if (flags & ir.VisitorContextFlag.InChildOperation) {

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -180,6 +180,13 @@ function reifyUpdateOperations(_unit: CompilationUnit, ops: ir.OpList<ir.UpdateO
           ir.OpList.replace(op, ng.attribute(op.name, op.expression));
         }
         break;
+      case ir.OpKind.HostProperty:
+        if (op.expression instanceof ir.Interpolation) {
+          throw new Error('not yet handled');
+        } else {
+          ir.OpList.replace(op, ng.hostProperty(op.name, op.expression));
+        }
+        break;
       case ir.OpKind.Variable:
         if (op.variable.name === null) {
           throw new Error(`AssertionError: unnamed variable ${op.xref}`);

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -8,7 +8,7 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import {CompilationJob, CompilationUnit, ViewCompilation, ViewCompilationUnit} from '../compilation';
+import {type CompilationJob, type CompilationUnit, ViewCompilationUnit} from '../compilation';
 import * as ng from '../instruction';
 
 /**

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -72,7 +72,7 @@ function reifyCreateOperations(unit: CompilationUnit, ops: ir.OpList<ir.CreateOp
         if (!(unit instanceof ViewCompilationUnit)) {
           throw new Error(`AssertionError: must be compiling a component`);
         }
-        const childView = unit.tpl.views.get(op.xref)!;
+        const childView = unit.job.views.get(op.xref)!;
         ir.OpList.replace(
             op,
             ng.template(

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -33,34 +33,38 @@ function reifyCreateOperations(view: ViewCompilation, ops: ir.OpList<ir.CreateOp
 
     switch (op.kind) {
       case ir.OpKind.Text:
-        ir.OpList.replace(op, ng.text(op.slot!, op.initialValue));
+        ir.OpList.replace(op, ng.text(op.slot!, op.initialValue, op.sourceSpan));
         break;
       case ir.OpKind.ElementStart:
         ir.OpList.replace(
             op,
             ng.elementStart(
-                op.slot!, op.tag, op.attributes as number | null, op.localRefs as number | null));
+                op.slot!, op.tag, op.attributes as number | null, op.localRefs as number | null,
+                op.sourceSpan));
         break;
       case ir.OpKind.Element:
         ir.OpList.replace(
             op,
             ng.element(
-                op.slot!, op.tag, op.attributes as number | null, op.localRefs as number | null));
+                op.slot!, op.tag, op.attributes as number | null, op.localRefs as number | null,
+                op.sourceSpan));
         break;
       case ir.OpKind.ElementEnd:
-        ir.OpList.replace(op, ng.elementEnd());
+        ir.OpList.replace(op, ng.elementEnd(op.sourceSpan));
         break;
       case ir.OpKind.ContainerStart:
         ir.OpList.replace(
             op,
             ng.elementContainerStart(
-                op.slot!, op.attributes as number | null, op.localRefs as number | null));
+                op.slot!, op.attributes as number | null, op.localRefs as number | null,
+                op.sourceSpan));
         break;
       case ir.OpKind.Container:
         ir.OpList.replace(
             op,
             ng.elementContainer(
-                op.slot!, op.attributes as number | null, op.localRefs as number | null));
+                op.slot!, op.attributes as number | null, op.localRefs as number | null,
+                op.sourceSpan));
         break;
       case ir.OpKind.ContainerEnd:
         ir.OpList.replace(op, ng.elementContainerEnd());
@@ -76,6 +80,7 @@ function reifyCreateOperations(view: ViewCompilation, ops: ir.OpList<ir.CreateOp
                 childView.vars!,
                 op.tag,
                 op.attributes as number,
+                op.sourceSpan,
                 ),
         );
         break;
@@ -117,10 +122,10 @@ function reifyUpdateOperations(_view: ViewCompilation, ops: ir.OpList<ir.UpdateO
 
     switch (op.kind) {
       case ir.OpKind.Advance:
-        ir.OpList.replace(op, ng.advance(op.delta));
+        ir.OpList.replace(op, ng.advance(op.delta, op.sourceSpan));
         break;
       case ir.OpKind.Property:
-        ir.OpList.replace(op, ng.property(op.name, op.expression));
+        ir.OpList.replace(op, ng.property(op.name, op.expression, op.sourceSpan));
         break;
       case ir.OpKind.StyleProp:
         ir.OpList.replace(op, ng.styleProp(op.name, op.expression, op.unit));
@@ -135,7 +140,8 @@ function reifyUpdateOperations(_view: ViewCompilation, ops: ir.OpList<ir.UpdateO
         ir.OpList.replace(op, ng.classMap(op.expression));
         break;
       case ir.OpKind.InterpolateProperty:
-        ir.OpList.replace(op, ng.propertyInterpolate(op.name, op.strings, op.expressions));
+        ir.OpList.replace(
+            op, ng.propertyInterpolate(op.name, op.strings, op.expressions, op.sourceSpan));
         break;
       case ir.OpKind.InterpolateStyleProp:
         ir.OpList.replace(
@@ -148,7 +154,7 @@ function reifyUpdateOperations(_view: ViewCompilation, ops: ir.OpList<ir.UpdateO
         ir.OpList.replace(op, ng.classMapInterpolate(op.strings, op.expressions));
         break;
       case ir.OpKind.InterpolateText:
-        ir.OpList.replace(op, ng.textInterpolate(op.strings, op.expressions));
+        ir.OpList.replace(op, ng.textInterpolate(op.strings, op.expressions, op.sourceSpan));
         break;
       case ir.OpKind.Attribute:
         ir.OpList.replace(op, ng.attribute(op.name, op.value));

--- a/packages/compiler/src/template/pipeline/src/phases/reify.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/reify.ts
@@ -127,42 +127,58 @@ function reifyUpdateOperations(_unit: CompilationUnit, ops: ir.OpList<ir.UpdateO
         ir.OpList.replace(op, ng.advance(op.delta, op.sourceSpan));
         break;
       case ir.OpKind.Property:
-        ir.OpList.replace(op, ng.property(op.name, op.expression, op.sourceSpan));
+        if (op.expression instanceof ir.Interpolation) {
+          ir.OpList.replace(
+              op,
+              ng.propertyInterpolate(
+                  op.name, op.expression.strings, op.expression.expressions, op.sourceSpan));
+        } else {
+          ir.OpList.replace(op, ng.property(op.name, op.expression, op.sourceSpan));
+        }
         break;
       case ir.OpKind.StyleProp:
-        ir.OpList.replace(op, ng.styleProp(op.name, op.expression, op.unit));
+        if (op.expression instanceof ir.Interpolation) {
+          ir.OpList.replace(
+              op,
+              ng.stylePropInterpolate(
+                  op.name, op.expression.strings, op.expression.expressions, op.unit));
+        } else {
+          ir.OpList.replace(op, ng.styleProp(op.name, op.expression, op.unit));
+        }
         break;
       case ir.OpKind.ClassProp:
         ir.OpList.replace(op, ng.classProp(op.name, op.expression));
         break;
       case ir.OpKind.StyleMap:
-        ir.OpList.replace(op, ng.styleMap(op.expression));
+        if (op.expression instanceof ir.Interpolation) {
+          ir.OpList.replace(
+              op, ng.styleMapInterpolate(op.expression.strings, op.expression.expressions));
+        } else {
+          ir.OpList.replace(op, ng.styleMap(op.expression));
+        }
         break;
       case ir.OpKind.ClassMap:
-        ir.OpList.replace(op, ng.classMap(op.expression));
-        break;
-      case ir.OpKind.InterpolateProperty:
-        ir.OpList.replace(
-            op, ng.propertyInterpolate(op.name, op.strings, op.expressions, op.sourceSpan));
-        break;
-      case ir.OpKind.InterpolateStyleProp:
-        ir.OpList.replace(
-            op, ng.stylePropInterpolate(op.name, op.strings, op.expressions, op.unit));
-        break;
-      case ir.OpKind.InterpolateStyleMap:
-        ir.OpList.replace(op, ng.styleMapInterpolate(op.strings, op.expressions));
-        break;
-      case ir.OpKind.InterpolateClassMap:
-        ir.OpList.replace(op, ng.classMapInterpolate(op.strings, op.expressions));
+        if (op.expression instanceof ir.Interpolation) {
+          ir.OpList.replace(
+              op, ng.classMapInterpolate(op.expression.strings, op.expression.expressions));
+        } else {
+          ir.OpList.replace(op, ng.classMap(op.expression));
+        }
         break;
       case ir.OpKind.InterpolateText:
-        ir.OpList.replace(op, ng.textInterpolate(op.strings, op.expressions, op.sourceSpan));
+        ir.OpList.replace(
+            op,
+            ng.textInterpolate(
+                op.interpolation.strings, op.interpolation.expressions, op.sourceSpan));
         break;
       case ir.OpKind.Attribute:
-        ir.OpList.replace(op, ng.attribute(op.name, op.value));
-        break;
-      case ir.OpKind.InterpolateAttribute:
-        ir.OpList.replace(op, ng.attributeInterpolate(op.name, op.strings, op.expressions));
+        if (op.expression instanceof ir.Interpolation) {
+          ir.OpList.replace(
+              op,
+              ng.attributeInterpolate(op.name, op.expression.strings, op.expression.expressions));
+        } else {
+          ir.OpList.replace(op, ng.attribute(op.name, op.expression));
+        }
         break;
       case ir.OpKind.Variable:
         if (op.variable.name === null) {

--- a/packages/compiler/src/template/pipeline/src/phases/remove_empty_bindings.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/remove_empty_bindings.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {CompilationJob} from '../compilation';
+
+export function phaseRemoveEmptyBindings(job: CompilationJob): void {
+  for (const unit of job.units) {
+    for (const op of unit.update) {
+      switch (op.kind) {
+        case ir.OpKind.Attribute:
+        case ir.OpKind.Binding:
+        case ir.OpKind.ClassProp:
+        case ir.OpKind.ClassMap:
+        case ir.OpKind.Property:
+        case ir.OpKind.StyleProp:
+        case ir.OpKind.StyleMap:
+          if (op.expression instanceof ir.EmptyExpr) {
+            ir.OpList.remove<ir.UpdateOp>(op);
+          }
+          break;
+      }
+    }
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_contexts.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_contexts.ts
@@ -8,21 +8,21 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import {ComponentCompilation, ViewCompilation} from '../compilation';
+import {CompilationJob, CompilationUnit, ComponentCompilation, ViewCompilation} from '../compilation';
 
 /**
  * Resolves `ir.ContextExpr` expressions (which represent embedded view or component contexts) to
  * either the `ctx` parameter to component functions (for the current view context) or to variables
  * that store those contexts (for contexts accessed via the `nextContext()` instruction).
  */
-export function phaseResolveContexts(cpl: ComponentCompilation): void {
-  for (const view of cpl.views.values()) {
-    processLexicalScope(view, view.create);
-    processLexicalScope(view, view.update);
+export function phaseResolveContexts(cpl: CompilationJob): void {
+  for (const unit of cpl.units) {
+    processLexicalScope(unit, unit.create);
+    processLexicalScope(unit, unit.update);
   }
 }
 
-function processLexicalScope(view: ViewCompilation, ops: ir.OpList<ir.CreateOp|ir.UpdateOp>): void {
+function processLexicalScope(view: CompilationUnit, ops: ir.OpList<ir.CreateOp|ir.UpdateOp>): void {
   // Track the expressions used to access all available contexts within the current view, by the
   // view `ir.XrefId`.
   const scope = new Map<ir.XrefId, o.Expression>();

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_contexts.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_contexts.ts
@@ -8,7 +8,7 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import {CompilationJob, CompilationUnit, ComponentCompilation, ViewCompilation} from '../compilation';
+import {CompilationJob, CompilationUnit, ComponentCompilationJob, ViewCompilationUnit} from '../compilation';
 
 /**
  * Resolves `ir.ContextExpr` expressions (which represent embedded view or component contexts) to

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_dollar_event.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_dollar_event.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {ComponentCompilation, ViewCompilation} from '../compilation';
+
+/**
+ * Any variable inside a listener with the name `$event` will be transformed into a output lexical
+ * read immediately, and does not participate in any of the normal logic for handling variables.
+ */
+export function phaseResolveDollarEvent(cpl: ComponentCompilation): void {
+  for (const [_, view] of cpl.views) {
+    resolveDollarEvent(view, view.create);
+    resolveDollarEvent(view, view.update);
+  }
+}
+
+function resolveDollarEvent(
+    view: ViewCompilation, ops: ir.OpList<ir.CreateOp>|ir.OpList<ir.UpdateOp>): void {
+  for (const op of ops) {
+    if (op.kind === ir.OpKind.Listener) {
+      ir.transformExpressionsInOp(op, (expr) => {
+        if (expr instanceof ir.LexicalReadExpr && expr.name === '$event') {
+          op.consumesDollarEvent = true;
+          return new o.ReadVarExpr(expr.name);
+        }
+        return expr;
+      }, ir.VisitorContextFlag.InChildOperation);
+    }
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_dollar_event.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_dollar_event.ts
@@ -8,13 +8,13 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import type {ComponentCompilation, ViewCompilation} from '../compilation';
+import type {ComponentCompilationJob, ViewCompilationUnit} from '../compilation';
 
 /**
  * Any variable inside a listener with the name `$event` will be transformed into a output lexical
  * read immediately, and does not participate in any of the normal logic for handling variables.
  */
-export function phaseResolveDollarEvent(cpl: ComponentCompilation): void {
+export function phaseResolveDollarEvent(cpl: ComponentCompilationJob): void {
   for (const [_, view] of cpl.views) {
     resolveDollarEvent(view, view.create);
     resolveDollarEvent(view, view.update);
@@ -22,7 +22,7 @@ export function phaseResolveDollarEvent(cpl: ComponentCompilation): void {
 }
 
 function resolveDollarEvent(
-    view: ViewCompilation, ops: ir.OpList<ir.CreateOp>|ir.OpList<ir.UpdateOp>): void {
+    view: ViewCompilationUnit, ops: ir.OpList<ir.CreateOp>|ir.OpList<ir.UpdateOp>): void {
   for (const op of ops) {
     if (op.kind === ir.OpKind.Listener) {
       ir.transformExpressionsInOp(op, (expr) => {

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
@@ -70,7 +70,11 @@ function processLexicalScope(
   // scope. Also, look for `ir.RestoreViewExpr`s and match them with the snapshotted view context
   // variable.
   for (const op of ops) {
-    ir.transformExpressionsInOp(op, expr => {
+    if (op.kind == ir.OpKind.Listener) {
+      // Listeners were already processed above with their own scopes.
+      continue;
+    }
+    ir.transformExpressionsInOp(op, (expr, flags) => {
       if (expr instanceof ir.LexicalReadExpr) {
         // `expr` is a read of a name within the lexical scope of this view.
         // Either that name is defined within the current view, or it represents a property from the

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
@@ -8,7 +8,7 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import {CompilationJob, CompilationUnit, ViewCompilation} from '../compilation';
+import {CompilationJob, CompilationUnit, ViewCompilationUnit} from '../compilation';
 
 /**
  * Resolves lexical references in views (`ir.LexicalReadExpr`) to either a target variable or to

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
@@ -8,7 +8,7 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import {ComponentCompilation, ViewCompilation} from '../compilation';
+import {CompilationJob, CompilationUnit, ViewCompilation} from '../compilation';
 
 /**
  * Resolves lexical references in views (`ir.LexicalReadExpr`) to either a target variable or to
@@ -17,15 +17,15 @@ import {ComponentCompilation, ViewCompilation} from '../compilation';
  * Also matches `ir.RestoreViewExpr` expressions with the variables of their corresponding saved
  * views.
  */
-export function phaseResolveNames(cpl: ComponentCompilation): void {
-  for (const [_, view] of cpl.views) {
-    processLexicalScope(view, view.create, null);
-    processLexicalScope(view, view.update, null);
+export function phaseResolveNames(cpl: CompilationJob): void {
+  for (const unit of cpl.units) {
+    processLexicalScope(unit, unit.create, null);
+    processLexicalScope(unit, unit.update, null);
   }
 }
 
 function processLexicalScope(
-    view: ViewCompilation, ops: ir.OpList<ir.CreateOp>|ir.OpList<ir.UpdateOp>,
+    unit: CompilationUnit, ops: ir.OpList<ir.CreateOp>|ir.OpList<ir.UpdateOp>,
     savedView: SavedView|null): void {
   // Maps names defined in the lexical scope of this template to the `ir.XrefId`s of the variable
   // declarations which represent those values.
@@ -61,7 +61,7 @@ function processLexicalScope(
       case ir.OpKind.Listener:
         // Listener functions have separate variable declarations, so process them as a separate
         // lexical scope.
-        processLexicalScope(view, op.handlerOps, savedView);
+        processLexicalScope(unit, op.handlerOps, savedView);
         break;
     }
   }
@@ -84,14 +84,14 @@ function processLexicalScope(
           return new ir.ReadVariableExpr(scope.get(expr.name)!);
         } else {
           // Reading from the component context.
-          return new o.ReadPropExpr(new ir.ContextExpr(view.job.root.xref), expr.name);
+          return new o.ReadPropExpr(new ir.ContextExpr(unit.job.root.xref), expr.name);
         }
       } else if (expr instanceof ir.RestoreViewExpr && typeof expr.view === 'number') {
         // `ir.RestoreViewExpr` happens in listener functions and restores a saved view from the
         // parent creation list. We expect to find that we captured the `savedView` previously, and
         // that it matches the expected view to be restored.
         if (savedView === null || savedView.view !== expr.view) {
-          throw new Error(`AssertionError: no saved view ${expr.view} from view ${view.xref}`);
+          throw new Error(`AssertionError: no saved view ${expr.view} from view ${unit.xref}`);
         }
         expr.view = new ir.ReadVariableExpr(savedView.variable);
         return expr;

--- a/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/resolve_names.ts
@@ -84,7 +84,7 @@ function processLexicalScope(
           return new ir.ReadVariableExpr(scope.get(expr.name)!);
         } else {
           // Reading from the component context.
-          return new o.ReadPropExpr(new ir.ContextExpr(view.tpl.root.xref), expr.name);
+          return new o.ReadPropExpr(new ir.ContextExpr(view.job.root.xref), expr.name);
         }
       } else if (expr instanceof ir.RestoreViewExpr && typeof expr.view === 'number') {
         // `ir.RestoreViewExpr` happens in listener functions and restores a saved view from the

--- a/packages/compiler/src/template/pipeline/src/phases/save_restore_view.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/save_restore_view.ts
@@ -8,9 +8,9 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import type {ComponentCompilation, ViewCompilation} from '../compilation';
+import type {ComponentCompilationJob, ViewCompilationUnit} from '../compilation';
 
-export function phaseSaveRestoreView(cpl: ComponentCompilation): void {
+export function phaseSaveRestoreView(cpl: ComponentCompilationJob): void {
   for (const view of cpl.views.values()) {
     view.create.prepend([
       ir.createVariableOp<ir.CreateOp>(
@@ -48,7 +48,7 @@ export function phaseSaveRestoreView(cpl: ComponentCompilation): void {
   }
 }
 
-function addSaveRestoreViewOperationToListener(view: ViewCompilation, op: ir.ListenerOp) {
+function addSaveRestoreViewOperationToListener(view: ViewCompilationUnit, op: ir.ListenerOp) {
   op.handlerOps.prepend([
     ir.createVariableOp<ir.UpdateOp>(
         view.job.allocateXrefId(), {

--- a/packages/compiler/src/template/pipeline/src/phases/save_restore_view.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/save_restore_view.ts
@@ -14,7 +14,7 @@ export function phaseSaveRestoreView(cpl: ComponentCompilation): void {
   for (const view of cpl.views.values()) {
     view.create.prepend([
       ir.createVariableOp<ir.CreateOp>(
-          view.tpl.allocateXrefId(), {
+          view.job.allocateXrefId(), {
             kind: ir.SemanticVariableKind.SavedView,
             name: null,
             view: view.xref,
@@ -51,7 +51,7 @@ export function phaseSaveRestoreView(cpl: ComponentCompilation): void {
 function addSaveRestoreViewOperationToListener(view: ViewCompilation, op: ir.ListenerOp) {
   op.handlerOps.prepend([
     ir.createVariableOp<ir.UpdateOp>(
-        view.tpl.allocateXrefId(), {
+        view.job.allocateXrefId(), {
           kind: ir.SemanticVariableKind.Context,
           name: null,
           view: view.xref,

--- a/packages/compiler/src/template/pipeline/src/phases/slot_allocation.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/slot_allocation.ts
@@ -7,7 +7,7 @@
  */
 
 import * as ir from '../../ir';
-import type {ComponentCompilation} from '../compilation';
+import type {ComponentCompilationJob} from '../compilation';
 
 /**
  * Assign data slots for all operations which implement `ConsumesSlotOpTrait`, and propagate the
@@ -17,7 +17,7 @@ import type {ComponentCompilation} from '../compilation';
  * This phase is also responsible for counting the number of slots used for each view (its `decls`)
  * and propagating that number into the `Template` operations which declare embedded views.
  */
-export function phaseSlotAllocation(cpl: ComponentCompilation): void {
+export function phaseSlotAllocation(cpl: ComponentCompilationJob): void {
   // Map of all declarations in all views within the component which require an assigned slot index.
   // This map needs to be global (across all views within the component) since it's possible to
   // reference a slot from one view from an expression within another (e.g. local references work

--- a/packages/compiler/src/template/pipeline/src/phases/style_binding_specialization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/style_binding_specialization.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as o from '../../../../output/output_ast';
+import * as ir from '../../ir';
+import type {CompilationJob} from '../compilation';
+
+/**
+ * Transforms special-case bindings with 'style' or 'class' in their names. Must run before the
+ * main binding specialization pass.
+ */
+export function phaseStyleBindingSpecialization(cpl: CompilationJob): void {
+  for (const unit of cpl.units) {
+    for (const op of unit.update) {
+      if (op.kind !== ir.OpKind.Binding) {
+        continue;
+      }
+
+      switch (op.bindingKind) {
+        case ir.BindingKind.ClassName:
+          if (op.expression instanceof ir.Interpolation) {
+            throw new Error(`Unexpected interpolation in ClassName binding`);
+          }
+          ir.OpList.replace<ir.UpdateOp>(
+              op, ir.createClassPropOp(op.target, op.name, op.expression, op.sourceSpan));
+          break;
+        case ir.BindingKind.StyleProperty:
+          ir.OpList.replace<ir.UpdateOp>(
+              op, ir.createStylePropOp(op.target, op.name, op.expression, op.unit, op.sourceSpan));
+          break;
+        case ir.BindingKind.Property:
+        case ir.BindingKind.Template:
+          if (op.name === 'style') {
+            ir.OpList.replace<ir.UpdateOp>(
+                op, ir.createStyleMapOp(op.target, op.expression, op.sourceSpan));
+          } else if (op.name === 'class') {
+            ir.OpList.replace<ir.UpdateOp>(
+                op, ir.createClassMapOp(op.target, op.expression, op.sourceSpan));
+          }
+          break;
+      }
+    }
+  }
+}

--- a/packages/compiler/src/template/pipeline/src/phases/temporary_variables.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/temporary_variables.ts
@@ -8,7 +8,7 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import {ComponentCompilation} from '../compilation';
+import {ComponentCompilationJob} from '../compilation';
 
 /**
  * Find all assignments and usages of temporary variables, which are linked to each other with cross
@@ -19,7 +19,7 @@ import {ComponentCompilation} from '../compilation';
  * in the double keyed read `a?.[f()]?.[f()]`, the two function calls have non-overlapping scopes.
  * Implement an algorithm for reuse.
  */
-export function phaseTemporaryVariables(cpl: ComponentCompilation): void {
+export function phaseTemporaryVariables(cpl: ComponentCompilationJob): void {
   for (const view of cpl.views.values()) {
     let opCount = 0;
     let generatedStatements: Array<ir.StatementOp<ir.UpdateOp>> = [];

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -65,6 +65,7 @@ function varsUsedByOp(op: (ir.CreateOp|ir.UpdateOp)&ir.ConsumesVarsTrait): numbe
   let slots: number;
   switch (op.kind) {
     case ir.OpKind.Property:
+    case ir.OpKind.HostProperty:
     case ir.OpKind.Attribute:
       // All of these bindings use 1 variable slot, plus 1 slot for every interpolated expression,
       // if any.

--- a/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/var_counting.ts
@@ -7,17 +7,17 @@
  */
 
 import * as ir from '../../ir';
-import {ComponentCompilation} from '../compilation';
+import {CompilationJob, ComponentCompilationJob} from '../compilation';
 
 /**
  * Counts the number of variable slots used within each view, and stores that on the view itself, as
  * well as propagates it to the `ir.TemplateOp` for embedded views.
  */
-export function phaseVarCounting(cpl: ComponentCompilation): void {
+export function phaseVarCounting(job: CompilationJob): void {
   // First, count the vars used in each view, and update the view-level counter.
-  for (const [_, view] of cpl.views) {
+  for (const unit of job.units) {
     let varCount = 0;
-    for (const op of view.ops()) {
+    for (const op of unit.ops()) {
       if (ir.hasConsumesVarsTrait(op)) {
         varCount += varsUsedByOp(op);
       }
@@ -38,19 +38,21 @@ export function phaseVarCounting(cpl: ComponentCompilation): void {
       });
     }
 
-    view.vars = varCount;
+    unit.vars = varCount;
   }
 
-  // Add var counts for each view to the `ir.TemplateOp` which declares that view (if the view is an
-  // embedded view).
-  for (const [_, view] of cpl.views) {
-    for (const op of view.create) {
-      if (op.kind !== ir.OpKind.Template) {
-        continue;
-      }
+  if (job instanceof ComponentCompilationJob) {
+    // Add var counts for each view to the `ir.TemplateOp` which declares that view (if the view is
+    // an embedded view).
+    for (const view of job.views.values()) {
+      for (const op of view.create) {
+        if (op.kind !== ir.OpKind.Template) {
+          continue;
+        }
 
-      const childView = cpl.views.get(op.xref)!;
-      op.vars = childView.vars;
+        const childView = job.views.get(op.xref)!;
+        op.vars = childView.vars;
+      }
     }
   }
 }
@@ -60,32 +62,31 @@ export function phaseVarCounting(cpl: ComponentCompilation): void {
  * count the variables used by any particular `op`.
  */
 function varsUsedByOp(op: (ir.CreateOp|ir.UpdateOp)&ir.ConsumesVarsTrait): number {
+  let slots: number;
   switch (op.kind) {
     case ir.OpKind.Property:
     case ir.OpKind.Attribute:
-      // Property & attribute bindings use 1 variable slot.
-      return 1;
+      // All of these bindings use 1 variable slot, plus 1 slot for every interpolated expression,
+      // if any.
+      slots = 1;
+      if (op.expression instanceof ir.Interpolation) {
+        slots += op.expression.expressions.length;
+      }
+      return slots;
     case ir.OpKind.StyleProp:
     case ir.OpKind.ClassProp:
     case ir.OpKind.StyleMap:
     case ir.OpKind.ClassMap:
-      // Style & class bindings use 2 variable slots.
-      return 2;
+      // Style & class bindings use 2 variable slots, plus 1 slot for every interpolated expression,
+      // if any.
+      slots = 2;
+      if (op.expression instanceof ir.Interpolation) {
+        slots += op.expression.expressions.length;
+      }
+      return slots;
     case ir.OpKind.InterpolateText:
       // `ir.InterpolateTextOp`s use a variable slot for each dynamic expression.
-      return op.expressions.length;
-    case ir.OpKind.InterpolateProperty:
-      // `ir.InterpolatePropertyOp`s use a variable slot for each dynamic expression, plus one for
-      // the result.
-      return 1 + op.expressions.length;
-    case ir.OpKind.InterpolateAttribute:
-      // One variable slot for each dynamic expression, plus one for the result.
-      return 1 + op.expressions.length;
-    case ir.OpKind.InterpolateStyleProp:
-    case ir.OpKind.InterpolateStyleMap:
-    case ir.OpKind.InterpolateClassMap:
-      // One variable slot for each dynamic expression, plus two for binding the result.
-      return 2 + op.expressions.length;
+      return op.interpolation.expressions.length;
     default:
       throw new Error(`Unhandled op: ${ir.OpKind[op.kind]}`);
   }

--- a/packages/compiler/src/template/pipeline/src/phases/variable_optimization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/variable_optimization.ts
@@ -10,10 +10,6 @@ import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
 import {ComponentCompilation} from '../compilation';
 
-export interface VariableOptimizationOptions {
-  conservative: boolean;
-}
-
 /**
  * Optimize variables declared and used in the IR.
  *
@@ -32,15 +28,14 @@ export interface VariableOptimizationOptions {
  * To guarantee correctness, analysis of "fences" in the instruction lists is used to determine
  * which optimizations are safe to perform.
  */
-export function phaseVariableOptimization(
-    cpl: ComponentCompilation, options: VariableOptimizationOptions): void {
+export function phaseVariableOptimization(cpl: ComponentCompilation): void {
   for (const [_, view] of cpl.views) {
-    optimizeVariablesInOpList(view.create, options);
-    optimizeVariablesInOpList(view.update, options);
+    optimizeVariablesInOpList(view.create, cpl.compatibility);
+    optimizeVariablesInOpList(view.update, cpl.compatibility);
 
     for (const op of view.create) {
       if (op.kind === ir.OpKind.Listener) {
-        optimizeVariablesInOpList(op.handlerOps, options);
+        optimizeVariablesInOpList(op.handlerOps, cpl.compatibility);
       }
     }
   }
@@ -104,7 +99,7 @@ interface OpInfo {
  * Process a list of operations and optimize variables within that list.
  */
 function optimizeVariablesInOpList(
-    ops: ir.OpList<ir.CreateOp|ir.UpdateOp>, options: VariableOptimizationOptions): void {
+    ops: ir.OpList<ir.CreateOp|ir.UpdateOp>, compatibility: ir.CompatibilityMode): void {
   const varDecls = new Map<ir.XrefId, ir.VariableOp<ir.CreateOp|ir.UpdateOp>>();
   const varUsages = new Map<ir.XrefId, number>();
 
@@ -210,7 +205,8 @@ function optimizeVariablesInOpList(
 
       // Is the variable used in this operation?
       if (opInfo.variablesUsed.has(candidate)) {
-        if (options.conservative && !allowConservativeInlining(decl, targetOp)) {
+        if (compatibility === ir.CompatibilityMode.TemplateDefinitionBuilder &&
+            !allowConservativeInlining(decl, targetOp)) {
           // We're in conservative mode, and this variable is not eligible for inlining into the
           // target operation in this mode.
           break;

--- a/packages/compiler/src/template/pipeline/src/phases/variable_optimization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/variable_optimization.ts
@@ -8,7 +8,7 @@
 
 import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
-import {ComponentCompilation} from '../compilation';
+import {CompilationJob} from '../compilation';
 
 /**
  * Optimize variables declared and used in the IR.
@@ -28,14 +28,14 @@ import {ComponentCompilation} from '../compilation';
  * To guarantee correctness, analysis of "fences" in the instruction lists is used to determine
  * which optimizations are safe to perform.
  */
-export function phaseVariableOptimization(cpl: ComponentCompilation): void {
-  for (const [_, view] of cpl.views) {
-    optimizeVariablesInOpList(view.create, cpl.compatibility);
-    optimizeVariablesInOpList(view.update, cpl.compatibility);
+export function phaseVariableOptimization(job: CompilationJob): void {
+  for (const unit of job.units) {
+    optimizeVariablesInOpList(unit.create, job.compatibility);
+    optimizeVariablesInOpList(unit.update, job.compatibility);
 
-    for (const op of view.create) {
+    for (const op of unit.create) {
       if (op.kind === ir.OpKind.Listener) {
-        optimizeVariablesInOpList(op.handlerOps, cpl.compatibility);
+        optimizeVariablesInOpList(op.handlerOps, job.compatibility);
       }
     }
   }


### PR DESCRIPTION
Wide-ranging PR on the template pipeline. Particular highlights include:

- We can now compile a number of host binding functions (although not all)
- For some input AST, source maps are now preserved
- Special template features `$event` and `$any` are supported
- A unified compatibility mode concept
- Major refactors to simplify binding processing across the board
- Major refactors of the compilation unit abstractions

See individual commit messages for details.