### PR TITLE
refactor: improve type safety of interpolation AST

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/expression.ts
@@ -143,7 +143,7 @@ class AstTranslator implements AstVisitor {
     // interpolation's expressions. The chain is started using an actual string literal to ensure
     // the type is inferred as 'string'.
     return ast.expressions.reduce(
-        (lhs, ast) => ts.factory.createBinaryExpression(
+        (lhs: ts.Expression, ast: AST) => ts.factory.createBinaryExpression(
             lhs, ts.SyntaxKind.PlusToken, wrapForTypeChecker(this.translate(ast))),
         ts.factory.createStringLiteral(''));
   }

--- a/packages/compiler/src/expression_parser/ast.ts
+++ b/packages/compiler/src/expression_parser/ast.ts
@@ -205,8 +205,8 @@ export class LiteralMap extends AST {
 
 export class Interpolation extends AST {
   constructor(
-      span: ParseSpan, sourceSpan: AbsoluteSourceSpan, public strings: any[],
-      public expressions: any[]) {
+      span: ParseSpan, sourceSpan: AbsoluteSourceSpan, public strings: string[],
+      public expressions: AST[]) {
     super(span, sourceSpan);
   }
   override visit(visitor: AstVisitor, context: any = null): any {

--- a/packages/compiler/test/expression_parser/parser_spec.ts
+++ b/packages/compiler/test/expression_parser/parser_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {AbsoluteSourceSpan, ASTWithSource, BindingPipe, Call, EmptyExpr, Interpolation, ParserError, TemplateBinding, VariableBinding} from '@angular/compiler/src/expression_parser/ast';
+import {AbsoluteSourceSpan, ASTWithSource, BindingPipe, Call, EmptyExpr, Interpolation, ParserError, PropertyRead, TemplateBinding, VariableBinding} from '@angular/compiler/src/expression_parser/ast';
 import {Lexer} from '@angular/compiler/src/expression_parser/lexer';
 import {Parser, SplitInterpolation} from '@angular/compiler/src/expression_parser/parser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -932,21 +932,21 @@ describe('parser', () => {
       const ast = parseInterpolation('{{a}} {{example}<!--->}')!.ast as Interpolation;
       expect(ast.strings).toEqual(['', ' {{example}<!--->}']);
       expect(ast.expressions.length).toEqual(1);
-      expect(ast.expressions[0].name).toEqual('a');
+      expect((ast.expressions[0] as PropertyRead).name).toEqual('a');
     });
 
     it('should parse no prefix/suffix interpolation', () => {
       const ast = parseInterpolation('{{a}}')!.ast as Interpolation;
       expect(ast.strings).toEqual(['', '']);
       expect(ast.expressions.length).toEqual(1);
-      expect(ast.expressions[0].name).toEqual('a');
+      expect((ast.expressions[0] as PropertyRead).name).toEqual('a');
     });
 
     it('should parse interpolation inside quotes', () => {
       const ast = parseInterpolation('"{{a}}"')!.ast as Interpolation;
       expect(ast.strings).toEqual(['"', '"']);
       expect(ast.expressions.length).toEqual(1);
-      expect(ast.expressions[0].name).toEqual('a');
+      expect((ast.expressions[0] as PropertyRead).name).toEqual('a');
     });
 
     it('should parse interpolation with interpolation characters inside quotes', () => {


### PR DESCRIPTION
Instead of using `any`, we should use the actual types that are available from the parser.