### PR TITLE
feat(language-service): support to fix missing required inputs diagno…

### DIFF
--- a/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/api/checker.ts
@@ -140,6 +140,10 @@ export interface TemplateTypeChecker {
   getSymbolOfNode(node: TmplAstElement, component: ts.ClassDeclaration): ElementSymbol | null;
   getSymbolOfNode(node: TmplAstTemplate, component: ts.ClassDeclaration): TemplateSymbol | null;
   getSymbolOfNode(
+    node: TmplAstTemplate | TmplAstElement,
+    component: ts.ClassDeclaration,
+  ): TemplateSymbol | ElementSymbol | null;
+  getSymbolOfNode(
     node: TmplAstComponent,
     component: ts.ClassDeclaration,
   ): SelectorlessComponentSymbol | null;

--- a/packages/language-service/src/codefixes/all_codefixes_metas.ts
+++ b/packages/language-service/src/codefixes/all_codefixes_metas.ts
@@ -10,6 +10,7 @@ import {fixInvalidBananaInBoxMeta} from './fix_invalid_banana_in_box';
 import {missingImportMeta} from './fix_missing_import';
 import {missingMemberMeta} from './fix_missing_member';
 import {fixUnusedStandaloneImportsMeta} from './fix_unused_standalone_imports';
+import {fixMissingRequiredInput} from './fix_missing_required_inputs';
 import {CodeActionMeta} from './utils';
 
 export const ALL_CODE_FIXES_METAS: CodeActionMeta[] = [
@@ -17,4 +18,5 @@ export const ALL_CODE_FIXES_METAS: CodeActionMeta[] = [
   fixInvalidBananaInBoxMeta,
   missingImportMeta,
   fixUnusedStandaloneImportsMeta,
+  fixMissingRequiredInput,
 ];

--- a/packages/language-service/src/codefixes/fix_missing_required_inputs.ts
+++ b/packages/language-service/src/codefixes/fix_missing_required_inputs.ts
@@ -7,9 +7,7 @@
  */
 
 import {
-  AST,
   BindingType,
-  R3Identifiers,
   TmplAstBoundAttribute,
   TmplAstElement,
   TmplAstNode,
@@ -61,7 +59,7 @@ export const fixMissingRequiredInput: CodeActionMeta = {
     }
 
     let insertPosition = node.startSourceSpan.start.offset + tagName.length + 1;
-    const lastAttribute = findLastAttributeInTheElement(node, positionDetails.parent);
+    const lastAttribute = findLastAttributeInTheElement(node);
     if (lastAttribute !== null) {
       insertPosition = lastAttribute.sourceSpan.end.offset;
     }
@@ -98,91 +96,36 @@ export const fixMissingRequiredInput: CodeActionMeta = {
       }
 
       for (const input of meta.inputs) {
-        if (input.required && !seenRequiredInputs.has(input.classPropertyName)) {
-          const typeCheck = compiler.getCurrentProgram().getTypeChecker();
-          const memberSymbol = typeCheck.getPropertyOfType(
-            dirSymbol.tsType,
-            input.classPropertyName,
-          );
-          if (memberSymbol === undefined) {
-            continue;
-          }
-
-          const memberType = getInputType(
-            memberSymbol,
-            typeCheck,
-            input.isSignal,
-            input.transform?.type.node,
-          );
-          // For boolean inputs, suggest adding the attribute name directly (e.g., `attrName`).
-          // This is a common way to set boolean inputs to true.
-          if (memberType.flags & ts.TypeFlags.BooleanLike) {
-            const insertText = input.bindingPropertyName;
-            codeActions.push({
-              fixName: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
-              // fixId: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
-              // fixAllDescription: '',
-              description: `Create ${insertText} attribute for "${tagName}"`,
-              changes: [
-                {
-                  fileName,
-                  textChanges: [
-                    {
-                      span: ts.createTextSpan(insertPosition, 0),
-                      newText: ' ' + insertText,
-                    },
-                  ],
-                },
-              ],
-            });
-            // For string inputs, suggest adding an empty string binding (e.g., `attrName=""`).
-          } else if (memberType.flags & ts.TypeFlags.StringLike) {
-            const insertInterpolations = `${input.bindingPropertyName}=""`;
-            codeActions.push({
-              fixName: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
-              // fixId: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
-              // fixAllDescription: '',
-              description: `Create ${insertInterpolations} attribute for "${tagName}"`,
-              changes: [
-                {
-                  fileName,
-                  textChanges: [
-                    {
-                      span: ts.createTextSpan(insertPosition, 0),
-                      newText: ' ' + insertInterpolations,
-                    },
-                  ],
-                },
-              ],
-            });
-          } else {
-            // For other input types (numbers, objects, etc.), no type-specific shorthand
-            // attribute suggestion is generated here. The general property binding suggestion
-            // `[inputName]=""` (added below for all missing inputs) covers these cases.
-          }
-
-          // As a general solution, always offer a property binding suggestion (e.g., `[inputName]=""`).
-          // This is the most versatile way for users to satisfy a required input,
-          // allowing them to bind to component properties or provide initial literal values.
-          const insertBoundText = `[${input.bindingPropertyName}]=""`;
-          codeActions.push({
-            fixName: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
-            // fixId: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
-            // fixAllDescription: '',
-            description: `Create ${insertBoundText} attribute for "${tagName}"`,
-            changes: [
-              {
-                fileName,
-                textChanges: [
-                  {
-                    span: ts.createTextSpan(insertPosition, 0),
-                    newText: ' ' + insertBoundText,
-                  },
-                ],
-              },
-            ],
-          });
+        if (!input.required || seenRequiredInputs.has(input.classPropertyName)) {
+          continue;
         }
+        const typeCheck = compiler.getCurrentProgram().getTypeChecker();
+        const memberSymbol = typeCheck.getPropertyOfType(dirSymbol.tsType, input.classPropertyName);
+        if (memberSymbol === undefined) {
+          continue;
+        }
+
+        // As a general solution, always offer a property binding suggestion (e.g., `[inputName]=""`).
+        // This is the most versatile way for users to satisfy a required input,
+        // allowing them to bind to component properties or provide initial literal values.
+        const insertBoundText = `[${input.bindingPropertyName}]=""`;
+        codeActions.push({
+          fixName: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
+          // fixId: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
+          // fixAllDescription: '',
+          description: `Create ${insertBoundText} attribute for "${tagName}"`,
+          changes: [
+            {
+              fileName,
+              textChanges: [
+                {
+                  span: ts.createTextSpan(insertPosition, 0),
+                  newText: ' ' + insertBoundText,
+                },
+              ],
+            },
+          ],
+        });
       }
     }
 
@@ -245,7 +188,6 @@ function getBoundAttributes(
  */
 function findLastAttributeInTheElement(
   element: TmplAstElement | TmplAstTemplate,
-  parent: TmplAstNode | AST | null,
 ): TmplAstNode | null {
   let lastAttribute: TmplAstNode | null = null;
 
@@ -262,88 +204,9 @@ function findLastAttributeInTheElement(
 
   const attrNodes = [...element.attributes, ...element.inputs, ...element.outputs];
 
-  /**
-   * Skip the template attributes. For example, `<a *ngFor=""></a>`, its shorthand is `<ng-template
-   * ngFor>`, the `valueSpan` of `ngFor` is empty, the info of `=""` is lost, so it can't use to
-   * insert the missing attribute after it.
-   */
-  // if (element instanceof TmplAstElement && isStructuralDirectiveShorthand(parent, element)) {
-  //   attrNodes.push(...parent.templateAttrs);
-  // }
-
   for (const attr of attrNodes) {
     updateAttribute(attr);
   }
 
   return lastAttribute;
-}
-
-function isStructuralDirectiveShorthand(
-  parent: TmplAstNode | AST | null,
-  node: TmplAstNode,
-): parent is TmplAstTemplate {
-  if (parent instanceof TmplAstTemplate && node instanceof TmplAstElement) {
-    if (parent.sourceSpan.start.offset === node.sourceSpan.start.offset) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/**
- * If the input is a decorator, return the type of the symbol; if there is a
- * transform for the input, return the transform type.
- *
- * If the input is a signal, the real input type is wrapped by the signal type.
- */
-function getInputType(
-  symbol: ts.Symbol,
-  typeCheck: ts.TypeChecker,
-  isSignal: boolean,
-  transformTypeNode: ts.TypeNode | undefined,
-): ts.Type {
-  if (isSignal) {
-    return getSignalMemberTypeOfSymbol(symbol, typeCheck);
-  } else {
-    const transformType =
-      transformTypeNode !== undefined ? typeCheck.getTypeAtLocation(transformTypeNode) : undefined;
-    return transformType ?? typeCheck.getTypeOfSymbol(symbol);
-  }
-}
-
-/**
- * The return of `input.required` is extended from the `InputSignalWithTransform`,
- * return the type of `TransformT` for the signal input
- *
- * ```ts
- * export interface InputSignalWithTransform<T, TransformT> extends Signal<T> {
- *    [SIGNAL]: InputSignalNode<T, TransformT>;
- *    [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: T;
- *    [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: TransformT;
- * }
- * ```
- */
-function getSignalMemberTypeOfSymbol(symbol: ts.Symbol, typeCheck: ts.TypeChecker): ts.Type {
-  const memberType = typeCheck.getTypeOfSymbol(symbol);
-  const properties = typeCheck.getPropertiesOfType(memberType);
-  for (const property of properties) {
-    const propertyNode =
-      property.declarations !== undefined && property.declarations.length > 0
-        ? property.declarations[0]
-        : undefined;
-    if (propertyNode === undefined) {
-      continue;
-    }
-
-    if (ts.isPropertySignature(propertyNode)) {
-      if (ts.isComputedPropertyName(propertyNode.name)) {
-        if (
-          propertyNode.name.expression.getText() === R3Identifiers.InputSignalBrandWriteType.name
-        ) {
-          return typeCheck.getTypeOfSymbol(property);
-        }
-      }
-    }
-  }
-  return typeCheck.getUnknownType();
 }

--- a/packages/language-service/src/codefixes/fix_missing_required_inputs.ts
+++ b/packages/language-service/src/codefixes/fix_missing_required_inputs.ts
@@ -1,0 +1,349 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  AST,
+  BindingType,
+  R3Identifiers,
+  TmplAstBoundAttribute,
+  TmplAstElement,
+  TmplAstNode,
+  TmplAstTemplate,
+  TmplAstTextAttribute,
+} from '@angular/compiler';
+import {ErrorCode, ngErrorCode} from '@angular/compiler-cli/src/ngtsc/diagnostics';
+import {TypeCheckableDirectiveMeta} from '@angular/compiler-cli/src/ngtsc/typecheck/api';
+import ts from 'typescript';
+
+import {getTargetAtPosition, TargetNodeKind} from '../template_target';
+
+import {CodeActionContext, CodeActionMeta, FixIdForCodeFixesAll} from './utils';
+
+/**
+ * This code action will fix the missing required input of an element.
+ */
+export const fixMissingRequiredInput: CodeActionMeta = {
+  errorCodes: [ngErrorCode(ErrorCode.MISSING_REQUIRED_INPUTS)],
+  getCodeActions: function ({typeCheckInfo, start, compiler, fileName}: CodeActionContext) {
+    if (typeCheckInfo === null) {
+      return [];
+    }
+
+    const positionDetails = getTargetAtPosition(typeCheckInfo.nodes, start);
+    if (positionDetails === null) {
+      return [];
+    }
+
+    // For two-way bindings, we actually only need to be concerned with the bound attribute because
+    // the bindings in the template are written with the attribute name, not the event name.
+    const node =
+      positionDetails.context.kind === TargetNodeKind.TwoWayBindingContext
+        ? positionDetails.context.nodes[0]
+        : positionDetails.context.node;
+
+    if (!(node instanceof TmplAstElement || node instanceof TmplAstTemplate)) {
+      return [];
+    }
+
+    let tagName: string | null = null;
+    if (node instanceof TmplAstElement) {
+      tagName = node.name;
+    } else {
+      tagName = node.tagName;
+    }
+    if (tagName === null) {
+      return [];
+    }
+
+    let insertPosition = node.startSourceSpan.start.offset + tagName.length + 1;
+    const lastAttribute = findLastAttributeInTheElement(node, positionDetails.parent);
+    if (lastAttribute !== null) {
+      insertPosition = lastAttribute.sourceSpan.end.offset;
+    }
+
+    const ttc = compiler.getTemplateTypeChecker();
+
+    const symbol = ttc.getSymbolOfNode(node, typeCheckInfo.declaration);
+    if (symbol === null) {
+      return [];
+    }
+
+    const codeActions: ts.CodeFixAction[] = [];
+
+    for (const dirSymbol of symbol.directives) {
+      const directive = dirSymbol.tsSymbol.valueDeclaration;
+      if (!ts.isClassDeclaration(directive)) {
+        continue;
+      }
+
+      const meta = ttc.getDirectiveMetadata(directive);
+      if (meta === null) {
+        continue;
+      }
+
+      const seenRequiredInputs = new Set<string>();
+
+      const boundAttrs = getBoundAttributes(meta, node);
+      for (const attr of boundAttrs) {
+        for (const {fieldName, required} of attr.inputs) {
+          if (required) {
+            seenRequiredInputs.add(fieldName);
+          }
+        }
+      }
+
+      for (const input of meta.inputs) {
+        if (input.required && !seenRequiredInputs.has(input.classPropertyName)) {
+          const typeCheck = compiler.getCurrentProgram().getTypeChecker();
+          const memberSymbol = typeCheck.getPropertyOfType(
+            dirSymbol.tsType,
+            input.classPropertyName,
+          );
+          if (memberSymbol === undefined) {
+            continue;
+          }
+
+          const memberType = getInputType(
+            memberSymbol,
+            typeCheck,
+            input.isSignal,
+            input.transform?.type.node,
+          );
+          // For boolean inputs, suggest adding the attribute name directly (e.g., `attrName`).
+          // This is a common way to set boolean inputs to true.
+          if (memberType.flags & ts.TypeFlags.BooleanLike) {
+            const insertText = input.bindingPropertyName;
+            codeActions.push({
+              fixName: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
+              // fixId: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
+              // fixAllDescription: '',
+              description: `Create ${insertText} attribute for "${tagName}"`,
+              changes: [
+                {
+                  fileName,
+                  textChanges: [
+                    {
+                      span: ts.createTextSpan(insertPosition, 0),
+                      newText: ' ' + insertText,
+                    },
+                  ],
+                },
+              ],
+            });
+            // For string inputs, suggest adding an empty string binding (e.g., `attrName=""`).
+          } else if (memberType.flags & ts.TypeFlags.StringLike) {
+            const insertInterpolations = `${input.bindingPropertyName}=""`;
+            codeActions.push({
+              fixName: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
+              // fixId: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
+              // fixAllDescription: '',
+              description: `Create ${insertInterpolations} attribute for "${tagName}"`,
+              changes: [
+                {
+                  fileName,
+                  textChanges: [
+                    {
+                      span: ts.createTextSpan(insertPosition, 0),
+                      newText: ' ' + insertInterpolations,
+                    },
+                  ],
+                },
+              ],
+            });
+          } else {
+            // For other input types (numbers, objects, etc.), no type-specific shorthand
+            // attribute suggestion is generated here. The general property binding suggestion
+            // `[inputName]=""` (added below for all missing inputs) covers these cases.
+          }
+
+          // As a general solution, always offer a property binding suggestion (e.g., `[inputName]=""`).
+          // This is the most versatile way for users to satisfy a required input,
+          // allowing them to bind to component properties or provide initial literal values.
+          const insertBoundText = `[${input.bindingPropertyName}]=""`;
+          codeActions.push({
+            fixName: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
+            // fixId: FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS,
+            // fixAllDescription: '',
+            description: `Create ${insertBoundText} attribute for "${tagName}"`,
+            changes: [
+              {
+                fileName,
+                textChanges: [
+                  {
+                    span: ts.createTextSpan(insertPosition, 0),
+                    newText: ' ' + insertBoundText,
+                  },
+                ],
+              },
+            ],
+          });
+        }
+      }
+    }
+
+    return codeActions;
+  },
+  fixIds: [FixIdForCodeFixesAll.FIX_MISSING_REQUIRED_INPUTS],
+  getAllCodeActions: function () {
+    return {
+      changes: [],
+    };
+  },
+};
+
+interface TcbBoundAttribute {
+  attribute: TmplAstBoundAttribute | TmplAstTextAttribute;
+  inputs: {
+    fieldName: string;
+    required: boolean;
+  }[];
+}
+
+function getBoundAttributes(
+  directive: TypeCheckableDirectiveMeta,
+  node: TmplAstTemplate | TmplAstElement,
+): TcbBoundAttribute[] {
+  const boundInputs: TcbBoundAttribute[] = [];
+
+  const processAttribute = (attr: TmplAstBoundAttribute | TmplAstTextAttribute) => {
+    // Skip non-property bindings.
+    if (attr instanceof TmplAstBoundAttribute && attr.type !== BindingType.Property) {
+      return;
+    }
+
+    // Skip the attribute if the directive does not have an input for it.
+    const inputs = directive.inputs.getByBindingPropertyName(attr.name);
+
+    if (inputs !== null) {
+      boundInputs.push({
+        attribute: attr,
+        inputs: inputs.map((input) => ({
+          fieldName: input.classPropertyName,
+          required: input.required,
+        })),
+      });
+    }
+  };
+
+  node.inputs.forEach(processAttribute);
+  node.attributes.forEach(processAttribute);
+  if (node instanceof TmplAstTemplate) {
+    node.templateAttrs.forEach(processAttribute);
+  }
+
+  return boundInputs;
+}
+
+/**
+ * If the last attribute is from the structural directive, it is skipped and returns
+ * the previous attribute.
+ */
+function findLastAttributeInTheElement(
+  element: TmplAstElement | TmplAstTemplate,
+  parent: TmplAstNode | AST | null,
+): TmplAstNode | null {
+  let lastAttribute: TmplAstNode | null = null;
+
+  const updateAttribute = (attr: TmplAstNode) => {
+    if (lastAttribute === null) {
+      lastAttribute = attr;
+      return;
+    }
+    if (attr.sourceSpan.end.offset < lastAttribute.sourceSpan.end.offset) {
+      return;
+    }
+    lastAttribute = attr;
+  };
+
+  const attrNodes = [...element.attributes, ...element.inputs, ...element.outputs];
+
+  /**
+   * Skip the template attributes. For example, `<a *ngFor=""></a>`, its shorthand is `<ng-template
+   * ngFor>`, the `valueSpan` of `ngFor` is empty, the info of `=""` is lost, so it can't use to
+   * insert the missing attribute after it.
+   */
+  // if (element instanceof TmplAstElement && isStructuralDirectiveShorthand(parent, element)) {
+  //   attrNodes.push(...parent.templateAttrs);
+  // }
+
+  for (const attr of attrNodes) {
+    updateAttribute(attr);
+  }
+
+  return lastAttribute;
+}
+
+function isStructuralDirectiveShorthand(
+  parent: TmplAstNode | AST | null,
+  node: TmplAstNode,
+): parent is TmplAstTemplate {
+  if (parent instanceof TmplAstTemplate && node instanceof TmplAstElement) {
+    if (parent.sourceSpan.start.offset === node.sourceSpan.start.offset) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * If the input is a decorator, return the type of the symbol; if there is a
+ * transform for the input, return the transform type.
+ *
+ * If the input is a signal, the real input type is wrapped by the signal type.
+ */
+function getInputType(
+  symbol: ts.Symbol,
+  typeCheck: ts.TypeChecker,
+  isSignal: boolean,
+  transformTypeNode: ts.TypeNode | undefined,
+): ts.Type {
+  if (isSignal) {
+    return getSignalMemberTypeOfSymbol(symbol, typeCheck);
+  } else {
+    const transformType =
+      transformTypeNode !== undefined ? typeCheck.getTypeAtLocation(transformTypeNode) : undefined;
+    return transformType ?? typeCheck.getTypeOfSymbol(symbol);
+  }
+}
+
+/**
+ * The return of `input.required` is extended from the `InputSignalWithTransform`,
+ * return the type of `TransformT` for the signal input
+ *
+ * ```ts
+ * export interface InputSignalWithTransform<T, TransformT> extends Signal<T> {
+ *    [SIGNAL]: InputSignalNode<T, TransformT>;
+ *    [ɵINPUT_SIGNAL_BRAND_READ_TYPE]: T;
+ *    [ɵINPUT_SIGNAL_BRAND_WRITE_TYPE]: TransformT;
+ * }
+ * ```
+ */
+function getSignalMemberTypeOfSymbol(symbol: ts.Symbol, typeCheck: ts.TypeChecker): ts.Type {
+  const memberType = typeCheck.getTypeOfSymbol(symbol);
+  const properties = typeCheck.getPropertiesOfType(memberType);
+  for (const property of properties) {
+    const propertyNode =
+      property.declarations !== undefined && property.declarations.length > 0
+        ? property.declarations[0]
+        : undefined;
+    if (propertyNode === undefined) {
+      continue;
+    }
+
+    if (ts.isPropertySignature(propertyNode)) {
+      if (ts.isComputedPropertyName(propertyNode.name)) {
+        if (
+          propertyNode.name.expression.getText() === R3Identifiers.InputSignalBrandWriteType.name
+        ) {
+          return typeCheck.getTypeOfSymbol(property);
+        }
+      }
+    }
+  }
+  return typeCheck.getUnknownType();
+}

--- a/packages/language-service/src/codefixes/utils.ts
+++ b/packages/language-service/src/codefixes/utils.ts
@@ -138,4 +138,5 @@ export enum FixIdForCodeFixesAll {
   FIX_INVALID_BANANA_IN_BOX = 'fixInvalidBananaInBox',
   FIX_MISSING_IMPORT = 'fixMissingImport',
   FIX_UNUSED_STANDALONE_IMPORTS = 'fixUnusedStandaloneImports',
+  FIX_MISSING_REQUIRED_INPUTS = 'fixMissingRequiredInputs',
 }

--- a/packages/language-service/test/code_fixes_spec.ts
+++ b/packages/language-service/test/code_fixes_spec.ts
@@ -237,6 +237,456 @@ describe('code fixes', () => {
     });
   });
 
+  describe('should fix missing required input', () => {
+    it('for different type', () => {
+      const files = {
+        'app.ts': `
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: '<foo />',
+           standalone: false,
+         })
+         export class AppComponent {
+           title = '';
+           banner = '';
+         }
+       `,
+        'foo.ts': `
+        import {Component, Input} from '@angular/core';
+
+        @Component({
+          selector: 'foo',
+          template: '',
+          standalone: false,
+        })
+        export class Foo {
+          @Input({required: true}) name: string = "";
+          @Input({required: true}) isShow = false;
+          @Input({required: true}) product: {name?: string} = {};
+        }
+       `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      const diags = project.getDiagnosticsForFile('app.ts');
+      appFile.moveCursorToText('<foo¦');
+
+      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
+        diags[0].code,
+      ]);
+
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` [name]=""`,
+        fileName: 'app.ts',
+      });
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` name=""`,
+        fileName: 'app.ts',
+      });
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` [product]=""`,
+        fileName: 'app.ts',
+      });
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` isShow`,
+        fileName: 'app.ts',
+      });
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` [isShow]=""`,
+        fileName: 'app.ts',
+      });
+    });
+    it('for signal inputs', () => {
+      const files = {
+        'app.ts': `
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: '<foo />',
+           standalone: false,
+         })
+         export class AppComponent {
+           title = '';
+           banner = '';
+         }
+       `,
+        'foo.ts': `
+        import {Component, input} from '@angular/core';
+
+        @Component({
+          selector: 'foo',
+          template: '',
+          standalone: false,
+        })
+        export class Foo {
+          name = input.required<string>();
+        }
+       `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      const diags = project.getDiagnosticsForFile('app.ts');
+      appFile.moveCursorToText('<foo¦');
+
+      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
+        diags[0].code,
+      ]);
+
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` [name]=""`,
+        fileName: 'app.ts',
+      });
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` name=""`,
+        fileName: 'app.ts',
+      });
+    });
+    it('for the structural directives', () => {
+      const files = {
+        'app.ts': `
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: '<foo *ngFor="" />',
+           standalone: false,
+         })
+         export class AppComponent {
+           title = '';
+           banner = '';
+         }
+       `,
+        'foo.ts': `
+        import {Component, Input} from '@angular/core';
+
+        @Component({
+          selector: 'foo',
+          template: '',
+          standalone: false,
+        })
+        export class Foo {
+          @Input({required: true}) name: string = "";
+        }
+       `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      const diags = project.getDiagnosticsForFile('app.ts');
+      appFile.moveCursorToText('<foo¦');
+
+      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
+        diags[0].code,
+      ]);
+
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        /**
+         * <foo [name]="" *ngFor="" />
+         * TODO: This should be <foo *ngFor="" [name]="" />
+         */
+        text: ` [name]=""`,
+        fileName: 'app.ts',
+      });
+    });
+    it('for the alias input name', () => {
+      const files = {
+        'app.ts': `
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: '<foo />',
+           standalone: false,
+         })
+         export class AppComponent {
+           title = '';
+           banner = '';
+         }
+       `,
+        'foo.ts': `
+        import {Component, Input} from '@angular/core';
+
+        @Component({
+          selector: 'foo',
+          template: '',
+          standalone: false,
+        })
+        export class Foo {
+          @Input({required: true, alias: "name"}) _name: string = "";
+        }
+       `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      const diags = project.getDiagnosticsForFile('app.ts');
+      appFile.moveCursorToText('<foo¦');
+
+      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
+        diags[0].code,
+      ]);
+
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` [name]=""`,
+        fileName: 'app.ts',
+      });
+    });
+    it('and insert the attribute after the text interpolations', () => {
+      const files = {
+        'app.ts': `
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: '<foo class="selected" />',
+           standalone: false,
+         })
+         export class AppComponent {
+           title = '';
+           banner = '';
+         }
+       `,
+        'foo.ts': `
+        import {Component, Input} from '@angular/core';
+
+        @Component({
+          selector: 'foo',
+          template: '',
+          standalone: false,
+        })
+        export class Foo {
+          @Input({required: true}) name: string = "";
+        }
+       `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      const diags = project.getDiagnosticsForFile('app.ts');
+      appFile.moveCursorToText('¦<foo');
+
+      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
+        diags[0].code,
+      ]);
+
+      appFile.moveCursorToText('class="selected"¦');
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` [name]=""`,
+        fileName: 'app.ts',
+      });
+    });
+    it('and insert the attribute after the property binding', () => {
+      const files = {
+        'app.ts': `
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: '<foo [isShow]="show" />',
+           standalone: false,
+         })
+         export class AppComponent {
+           show = true;
+         }
+       `,
+        'foo.ts': `
+        import {Component, Input} from '@angular/core';
+
+        @Component({
+          selector: 'foo',
+          template: '',
+          standalone: false,
+        })
+        export class Foo {
+          @Input({required: true}) name: string = "";
+          @Input({required: true}) isShow = true;
+        }
+       `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      const diags = project.getDiagnosticsForFile('app.ts');
+      appFile.moveCursorToText('¦<foo');
+
+      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
+        diags[0].code,
+      ]);
+
+      appFile.moveCursorToText('[isShow]="show"¦');
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` [name]=""`,
+        fileName: 'app.ts',
+      });
+    });
+    it('and insert the attribute after the output', () => {
+      const files = {
+        'app.ts': `
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: '<foo (click)="" />',
+           standalone: false,
+         })
+         export class AppComponent {
+           title = '';
+           banner = '';
+         }
+       `,
+        'foo.ts': `
+        import {Component, Input} from '@angular/core';
+
+        @Component({
+          selector: 'foo',
+          template: '',
+          standalone: false,
+        })
+        export class Foo {
+          @Input({required: true}) name: string = "";
+        }
+       `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      const diags = project.getDiagnosticsForFile('app.ts');
+      appFile.moveCursorToText('¦<foo');
+
+      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
+        diags[0].code,
+      ]);
+
+      appFile.moveCursorToText('(click)=""¦');
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` [name]=""`,
+        fileName: 'app.ts',
+      });
+    });
+
+    it('for transform type for @input', () => {
+      const files = {
+        'app.ts': `
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: '<foo (click)="" />',
+           standalone: false,
+         })
+         export class AppComponent {
+           title = '';
+           banner = '';
+         }
+       `,
+        'foo.ts': `
+        import {Component, Input} from '@angular/core';
+
+        @Component({
+          selector: 'foo',
+          template: '',
+          standalone: false,
+        })
+        export class Foo {
+          @Input({required: true, transform: stringToNumber}) test = 0;
+        }
+        function stringToNumber(value: string): number {
+          return +value;
+        }
+       `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      const diags = project.getDiagnosticsForFile('app.ts');
+      appFile.moveCursorToText('¦<foo');
+
+      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
+        diags[0].code,
+      ]);
+
+      appFile.moveCursorToText('(click)=""¦');
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` test=""`,
+        fileName: 'app.ts',
+      });
+    });
+
+    it('for transform type for signal input', () => {
+      const files = {
+        'app.ts': `
+         import {Component} from '@angular/core';
+
+         @Component({
+           template: '<foo (click)="" />',
+           standalone: false,
+         })
+         export class AppComponent {
+           title = '';
+           banner = '';
+         }
+       `,
+        'foo.ts': `
+        import {Component, input} from '@angular/core';
+
+        @Component({
+          selector: 'foo',
+          template: '',
+          standalone: false,
+        })
+        export class Foo {
+          test = input.required({
+            transform: stringToNumber
+          });
+        }
+        function stringToNumber(value: string): number {
+          return +value;
+        }
+       `,
+      };
+
+      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
+      const appFile = project.openFile('app.ts');
+      const diags = project.getDiagnosticsForFile('app.ts');
+      appFile.moveCursorToText('¦<foo');
+
+      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
+        diags[0].code,
+      ]);
+
+      appFile.moveCursorToText('(click)=""¦');
+      expectIncludeAddText({
+        codeActions,
+        position: appFile.cursor,
+        text: ` test=""`,
+        fileName: 'app.ts',
+      });
+    });
+  });
+
   describe('should fix missing selector imports', () => {
     it('for a new standalone component import', () => {
       const standaloneFiles = {

--- a/packages/language-service/test/code_fixes_spec.ts
+++ b/packages/language-service/test/code_fixes_spec.ts
@@ -286,19 +286,7 @@ describe('code fixes', () => {
       expectIncludeAddText({
         codeActions,
         position: appFile.cursor,
-        text: ` name=""`,
-        fileName: 'app.ts',
-      });
-      expectIncludeAddText({
-        codeActions,
-        position: appFile.cursor,
         text: ` [product]=""`,
-        fileName: 'app.ts',
-      });
-      expectIncludeAddText({
-        codeActions,
-        position: appFile.cursor,
-        text: ` isShow`,
         fileName: 'app.ts',
       });
       expectIncludeAddText({
@@ -349,12 +337,6 @@ describe('code fixes', () => {
         codeActions,
         position: appFile.cursor,
         text: ` [name]=""`,
-        fileName: 'app.ts',
-      });
-      expectIncludeAddText({
-        codeActions,
-        position: appFile.cursor,
-        text: ` name=""`,
         fileName: 'app.ts',
       });
     });
@@ -582,106 +564,6 @@ describe('code fixes', () => {
         codeActions,
         position: appFile.cursor,
         text: ` [name]=""`,
-        fileName: 'app.ts',
-      });
-    });
-
-    it('for transform type for @input', () => {
-      const files = {
-        'app.ts': `
-         import {Component} from '@angular/core';
-
-         @Component({
-           template: '<foo (click)="" />',
-           standalone: false,
-         })
-         export class AppComponent {
-           title = '';
-           banner = '';
-         }
-       `,
-        'foo.ts': `
-        import {Component, Input} from '@angular/core';
-
-        @Component({
-          selector: 'foo',
-          template: '',
-          standalone: false,
-        })
-        export class Foo {
-          @Input({required: true, transform: stringToNumber}) test = 0;
-        }
-        function stringToNumber(value: string): number {
-          return +value;
-        }
-       `,
-      };
-
-      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
-      const appFile = project.openFile('app.ts');
-      const diags = project.getDiagnosticsForFile('app.ts');
-      appFile.moveCursorToText('¦<foo');
-
-      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
-        diags[0].code,
-      ]);
-
-      appFile.moveCursorToText('(click)=""¦');
-      expectIncludeAddText({
-        codeActions,
-        position: appFile.cursor,
-        text: ` test=""`,
-        fileName: 'app.ts',
-      });
-    });
-
-    it('for transform type for signal input', () => {
-      const files = {
-        'app.ts': `
-         import {Component} from '@angular/core';
-
-         @Component({
-           template: '<foo (click)="" />',
-           standalone: false,
-         })
-         export class AppComponent {
-           title = '';
-           banner = '';
-         }
-       `,
-        'foo.ts': `
-        import {Component, input} from '@angular/core';
-
-        @Component({
-          selector: 'foo',
-          template: '',
-          standalone: false,
-        })
-        export class Foo {
-          test = input.required({
-            transform: stringToNumber
-          });
-        }
-        function stringToNumber(value: string): number {
-          return +value;
-        }
-       `,
-      };
-
-      const project = createModuleAndProjectWithDeclarations(env, 'test', files);
-      const appFile = project.openFile('app.ts');
-      const diags = project.getDiagnosticsForFile('app.ts');
-      appFile.moveCursorToText('¦<foo');
-
-      const codeActions = project.getCodeFixesAtPosition('app.ts', appFile.cursor, appFile.cursor, [
-        diags[0].code,
-      ]);
-
-      appFile.moveCursorToText('(click)=""¦');
-      expectIncludeAddText({
-        codeActions,
-        position: appFile.cursor,
-        text: ` test=""`,
         fileName: 'app.ts',
       });
     });


### PR DESCRIPTION
…stic

Support to add the missing required inputs into the element and append after the last attribute of the element.

But it skips the structural directive shorthand attribute. For example, `<a *ngFor=""></a>`, its shorthand is `<ng-template ngFor>`, the `valueSpan` of the `ngFor` is empty, and the info is lost, so it can't use to insert the missing attribute after it.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
