### PR TITLE
refactor(core): fix Tnode/TView assertion.

### DIFF
--- a/packages/core/src/render3/assert.ts
+++ b/packages/core/src/render3/assert.ts
@@ -27,10 +27,13 @@ export function assertTNodeForLView(tNode: TNode, lView: LView) {
 
 export function assertTNodeForTView(tNode: TNode, tView: TView) {
   assertTNode(tNode);
-  tNode.hasOwnProperty('tView_') &&
-      assertEqual(
-          (tNode as any as {tView_: TView}).tView_, tView,
-          'This TNode does not belong to this TView.');
+  const tData = tView.data;
+  for (let i = HEADER_OFFSET; i < tData.length; i++) {
+    if (tData[i] === tNode) {
+      return;
+    }
+  }
+  throwError('This TNode does not belong to this TView.');
 }
 
 export function assertTNode(tNode: TNode) {

--- a/packages/core/test/render3/di_spec.ts
+++ b/packages/core/test/render3/di_spec.ts
@@ -13,7 +13,7 @@ import {TestBed} from '@angular/core/testing';
 
 import {bloomAdd, bloomHashBitOrFactory as bloomHash, bloomHasToken, getOrCreateNodeInjectorForNode} from '../../src/render3/di';
 import {TNodeType} from '../../src/render3/interfaces/node';
-import {LViewFlags, TVIEW, TViewType} from '../../src/render3/interfaces/view';
+import {HEADER_OFFSET, LViewFlags, TVIEW, TViewType} from '../../src/render3/interfaces/view';
 import {enterView, leaveView} from '../../src/render3/state';
 
 describe('di', () => {
@@ -147,7 +147,8 @@ describe('di', () => {
           null);
       enterView(contentView);
       try {
-        const parentTNode = getOrCreateTNode(contentView[TVIEW], 0, TNodeType.Element, null, null);
+        const parentTNode =
+            getOrCreateTNode(contentView[TVIEW], HEADER_OFFSET, TNodeType.Element, null, null);
         // Simulate the situation where the previous parent is not initialized.
         // This happens on first bootstrap because we don't init existing values
         // so that we have smaller HelloWorld.

--- a/packages/core/test/render3/view_fixture.ts
+++ b/packages/core/test/render3/view_fixture.ts
@@ -16,7 +16,7 @@ import {renderView} from '../../src/render3/instructions/render';
 import {createLView, createTNode, createTView} from '../../src/render3/instructions/shared';
 import {DirectiveDef, DirectiveDefList, DirectiveTypesOrFactory, PipeDef, PipeDefList, PipeTypesOrFactory, RenderFlags} from '../../src/render3/interfaces/definition';
 import {TConstants, TElementNode, TNodeType} from '../../src/render3/interfaces/node';
-import {LView, LViewFlags, TView, TViewType} from '../../src/render3/interfaces/view';
+import {HEADER_OFFSET, LView, LViewFlags, TView, TViewType} from '../../src/render3/interfaces/view';
 import {enterView, leaveView, specOnlyIsInstructionStateEmpty} from '../../src/render3/state';
 import {noop} from '../../src/util/noop';
 
@@ -98,6 +98,8 @@ export class ViewFixture {
         consts || null, null);
     const hostTNode =
         createTNode(hostTView, null, TNodeType.Element, 0, 'host-element', null) as TElementNode;
+    // Store TNode at the first slot right after the header part
+    hostTView.data[HEADER_OFFSET] = hostTNode;
     this.lView = createLView(
         hostLView, this.tView, context || {}, LViewFlags.CheckAlways, this.host, hostTNode, null,
         hostRenderer, null, null, null);


### PR DESCRIPTION
The debug data structure was removed in #48281. Before this fix the assertion relied on it.




## Does this PR introduce a breaking change?

- [x] No