### PR TITLE
Added instructions to include router-outlet in app.component.html

### DIFF
--- a/aio/content/start/start-routing.md
+++ b/aio/content/start/start-routing.md
@@ -29,7 +29,9 @@ This section shows you how to define a route to show individual product details.
 1.  In `app.module.ts`, add a route for product details, with a `path` of `products/:productId` and `ProductDetailsComponent` for the `component`.
 
     <code-example header="src/app/app.module.ts" path="getting-started/src/app/app.module.ts" region="product-details-route"></code-example>
-
+1. Add `router-outlet` to the `app.component.html`.
+    <code-example header="src/app/app.component.html" path="getting-started/src/app/app.component.html" region="product-details-route"></code-example>
+    
 1.  Open `product-list.component.html`.
 
 1.  Modify the product name anchor to include a `routerLink` with the `product.id` as a parameter.


### PR DESCRIPTION
The "start routing" readme didn't have the instructions to include `router-outlet` in the `app.component.html` file, and it leads to confusion as the routing did not work even after following the instructions because the `app.component.html` file was missing the `router-outlet`.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently when a user follows the instructions of `start-routing` readme file, the routing will not work even after following the instructions as the user did not added `router-outlet` to the `app.component.html` file, and the readme did not mention to add one.

Issue Number: N/A


## What is the new behavior?
Now the user will have one more step to follow in which he updates the `app.component.html` file with the required data to make the routing work.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
