### PR TITLE
fix(animations): Ensure elements are removed from the cache after leave animation.

### DIFF
--- a/packages/animations/browser/test/render/transition_animation_engine_spec.ts
+++ b/packages/animations/browser/test/render/transition_animation_engine_spec.ts
@@ -113,13 +113,20 @@ describe('TransitionAnimationEngine', () => {
       registerTrigger(element, engine, trig);
       setProperty(element, engine, 'myTrigger', 'value');
       engine.flush();
+      expect(engine.statesByElement.has(element))
+          .toBe(true, 'Expected element data to be defined.');
+      expect(engine.playersByElement.has(element))
+          .toBe(true, 'Expected element data to be defined.');
 
-      expect(engine.elementContainsData(DEFAULT_NAMESPACE_ID, element)).toBeTruthy();
-
+      engine.destroy(DEFAULT_NAMESPACE_ID, null);
       engine.removeNode(DEFAULT_NAMESPACE_ID, element, true);
       engine.flush();
+      engine.players[0].finish();
 
-      expect(engine.elementContainsData(DEFAULT_NAMESPACE_ID, element)).toBeTruthy();
+      expect(engine.statesByElement.has(element))
+          .toBe(false, 'Expected element data to be undefined.');
+      expect(engine.playersByElement.has(element))
+          .toBe(false, 'Expected element data to be undefined.');
     });
 
     it('should create and recreate a namespace for a host element with the same component source',


### PR DESCRIPTION
This commit fixes a memory leak where references were retained in multiple `Map` structures. 

`_namespaceLookup` was cleared before the call to `processLeaveNode()` which was using the lookup.
Without that lookup `clearElementCache()` wasn't called thus keeping a reference to the element.  

Fixes #24197 & #50533

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [x] No
