### PR TITLE
docs(forms): FormBuilder is not associated with ReactiveFormsModule

### DIFF
--- a/packages/forms/src/form_providers.ts
+++ b/packages/forms/src/form_providers.ts
@@ -54,7 +54,6 @@ export class FormsModule {
  * making them available for import by NgModules that import this module.
  *
  * Providers associated with this module:
- * * `FormBuilder`
  * * `RadioControlRegistry`
  *
  * @see [Forms Overview](guide/forms-overview)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/angular/angular/issues/48237

In the https://angular.io/api/forms/ReactiveFormsModule
![image](https://github.com/angular/angular/assets/8519685/ac501fee-9e41-4d69-9dc0-8e7155172e83)


## What is the new behavior?
In the above description section, `FormBuilder` will be removed.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
