### PR TITLE
refactor(compiler): implement block syntax in html ast

### DIFF
--- a/packages/compiler/src/i18n/extractor_merger.ts
+++ b/packages/compiler/src/i18n/extractor_merger.ts
@@ -292,6 +292,16 @@ class _Visitor implements html.Visitor {
     throw new Error('unreachable code');
   }
 
+  visitBlockGroup(group: html.BlockGroup, context: any) {
+    html.visitAll(this, group.blocks, context);
+  }
+
+  visitBlock(block: html.Block, context: any) {
+    html.visitAll(this, block.children, context);
+  }
+
+  visitBlockParameter(parameter: html.BlockParameter, context: any) {}
+
   private _init(mode: _VisitorMode, interpolationConfig: InterpolationConfig): void {
     this._mode = mode;
     this._inI18nBlock = false;

--- a/packages/compiler/src/i18n/i18n_parser.ts
+++ b/packages/compiler/src/i18n/i18n_parser.ts
@@ -162,6 +162,20 @@ class _I18nVisitor implements html.Visitor {
     throw new Error('Unreachable code');
   }
 
+  visitBlockGroup(group: html.BlockGroup, context: I18nMessageVisitorContext) {
+    const children = html.visitAll(this, group.blocks, context);
+    const node = new i18n.Container(children, group.sourceSpan);
+    return context.visitNodeFn(group, node);
+  }
+
+  visitBlock(block: html.Block, context: I18nMessageVisitorContext) {
+    const children = html.visitAll(this, block.children, context);
+    const node = new i18n.Container(children, block.sourceSpan);
+    return context.visitNodeFn(block, node);
+  }
+
+  visitBlockParameter(_parameter: html.BlockParameter, _context: I18nMessageVisitorContext) {}
+
   /**
    * Convert, text and interpolated tokens up into text and placeholder pieces.
    *

--- a/packages/compiler/src/i18n/serializers/xliff.ts
+++ b/packages/compiler/src/i18n/serializers/xliff.ts
@@ -261,6 +261,12 @@ class XliffParser implements ml.Visitor {
 
   visitExpansionCase(expansionCase: ml.ExpansionCase, context: any): any {}
 
+  visitBlockGroup(group: ml.BlockGroup, context: any) {}
+
+  visitBlock(block: ml.Block, context: any) {}
+
+  visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
+
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));
   }
@@ -328,6 +334,12 @@ class XmlToI18n implements ml.Visitor {
   visitComment(comment: ml.Comment, context: any) {}
 
   visitAttribute(attribute: ml.Attribute, context: any) {}
+
+  visitBlockGroup(group: ml.BlockGroup, context: any) {}
+
+  visitBlock(block: ml.Block, context: any) {}
+
+  visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
 
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));

--- a/packages/compiler/src/i18n/serializers/xliff2.ts
+++ b/packages/compiler/src/i18n/serializers/xliff2.ts
@@ -283,6 +283,12 @@ class Xliff2Parser implements ml.Visitor {
 
   visitExpansionCase(expansionCase: ml.ExpansionCase, context: any): any {}
 
+  visitBlockGroup(group: ml.BlockGroup, context: any) {}
+
+  visitBlock(block: ml.Block, context: any) {}
+
+  visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
+
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));
   }
@@ -370,6 +376,12 @@ class XmlToI18n implements ml.Visitor {
   visitComment(comment: ml.Comment, context: any) {}
 
   visitAttribute(attribute: ml.Attribute, context: any) {}
+
+  visitBlockGroup(group: ml.BlockGroup, context: any) {}
+
+  visitBlock(block: ml.Block, context: any) {}
+
+  visitBlockParameter(parameter: ml.BlockParameter, context: any) {}
 
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));

--- a/packages/compiler/src/i18n/serializers/xtb.ts
+++ b/packages/compiler/src/i18n/serializers/xtb.ts
@@ -152,6 +152,12 @@ class XtbParser implements ml.Visitor {
 
   visitExpansionCase(expansionCase: ml.ExpansionCase, context: any): any {}
 
+  visitBlockGroup(group: ml.BlockGroup, context: any) {}
+
+  visitBlock(block: ml.Block, context: any) {}
+
+  visitBlockParameter(block: ml.BlockParameter, context: any) {}
+
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));
   }
@@ -214,6 +220,12 @@ class XmlToI18n implements ml.Visitor {
   visitComment(comment: ml.Comment, context: any) {}
 
   visitAttribute(attribute: ml.Attribute, context: any) {}
+
+  visitBlockGroup(group: ml.BlockGroup, context: any) {}
+
+  visitBlock(block: ml.Block, context: any) {}
+
+  visitBlockParameter(block: ml.BlockParameter, context: any) {}
 
   private _addError(node: ml.Node, message: string): void {
     this._errors.push(new I18nError(node.sourceSpan, message));

--- a/packages/compiler/src/ml_parser/html_whitespaces.ts
+++ b/packages/compiler/src/ml_parser/html_whitespaces.ts
@@ -97,6 +97,22 @@ export class WhitespaceVisitor implements html.Visitor {
   visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {
     return expansionCase;
   }
+
+  visitBlockGroup(group: html.BlockGroup, context: any): any {
+    return new html.BlockGroup(
+        visitAllWithSiblings(this, group.blocks), group.sourceSpan, group.startSourceSpan,
+        group.endSourceSpan);
+  }
+
+  visitBlock(block: html.Block, context: any): any {
+    return new html.Block(
+        block.name, block.parameters, visitAllWithSiblings(this, block.children), block.sourceSpan,
+        block.startSourceSpan);
+  }
+
+  visitBlockParameter(parameter: html.BlockParameter, context: any) {
+    return parameter;
+  }
 }
 
 function createWhitespaceProcessedTextToken({type, parts, sourceSpan}: TextToken): TextToken {

--- a/packages/compiler/src/ml_parser/icu_ast_expander.ts
+++ b/packages/compiler/src/ml_parser/icu_ast_expander.ts
@@ -87,6 +87,22 @@ class _Expander implements html.Visitor {
   visitExpansionCase(icuCase: html.ExpansionCase, context: any): any {
     throw new Error('Should not be reached');
   }
+
+  visitBlockGroup(group: html.BlockGroup, context: any) {
+    return new html.BlockGroup(
+        html.visitAll(this, group.blocks), group.sourceSpan, group.startSourceSpan,
+        group.endSourceSpan);
+  }
+
+  visitBlock(block: html.Block, context: any) {
+    return new html.Block(
+        block.name, block.parameters, html.visitAll(this, block.children), block.sourceSpan,
+        block.startSourceSpan);
+  }
+
+  visitBlockParameter(parameter: html.BlockParameter, context: any) {
+    return parameter;
+  }
 }
 
 // Plural forms are expanded to `NgPlural` and `NgPluralCase`s

--- a/packages/compiler/src/ml_parser/parser.ts
+++ b/packages/compiler/src/ml_parser/parser.ts
@@ -12,7 +12,15 @@ import * as html from './ast';
 import {NAMED_ENTITIES} from './entities';
 import {tokenize, TokenizeOptions} from './lexer';
 import {getNsPrefix, mergeNsAndName, splitNsName, TagDefinition} from './tags';
-import {AttributeNameToken, AttributeQuoteToken, CdataStartToken, CommentStartToken, ExpansionCaseExpressionEndToken, ExpansionCaseExpressionStartToken, ExpansionCaseValueToken, ExpansionFormStartToken, IncompleteTagOpenToken, InterpolatedAttributeToken, InterpolatedTextToken, TagCloseToken, TagOpenStartToken, TextToken, Token, TokenType} from './tokens';
+import {AttributeNameToken, AttributeQuoteToken, BlockGroupCloseToken, BlockGroupOpenStartToken, BlockOpenStartToken, BlockParameterToken, CdataStartToken, CommentStartToken, ExpansionCaseExpressionEndToken, ExpansionCaseExpressionStartToken, ExpansionCaseValueToken, ExpansionFormStartToken, IncompleteTagOpenToken, InterpolatedAttributeToken, InterpolatedTextToken, TagCloseToken, TagOpenStartToken, TextToken, Token, TokenType} from './tokens';
+
+/** Nodes that can contain other nodes. */
+type NodeContainer = html.Element|html.Block|html.BlockGroup;
+
+/** Class that can construct a `NodeContainer`. */
+interface NodeContainerConstructor extends Function {
+  new(...args: any[]): NodeContainer;
+}
 
 export class TreeError extends ParseError {
   static create(elementName: string|null, span: ParseSourceSpan, msg: string): TreeError {
@@ -46,7 +54,7 @@ class _TreeBuilder {
   private _index: number = -1;
   // `_peek` will be initialized by the call to `_advance()` in the constructor.
   private _peek!: Token;
-  private _elementStack: html.Element[] = [];
+  private _containerStack: NodeContainer[] = [];
 
   rootNodes: html.Node[] = [];
   errors: TreeError[] = [];
@@ -76,6 +84,15 @@ class _TreeBuilder {
         this._consumeText(this._advance<TextToken>());
       } else if (this._peek.type === TokenType.EXPANSION_FORM_START) {
         this._consumeExpansion(this._advance<ExpansionFormStartToken>());
+      } else if (this._peek.type === TokenType.BLOCK_GROUP_OPEN_START) {
+        this._closeVoidElement();
+        this._consumeBlockGroupOpen(this._advance<BlockGroupOpenStartToken>());
+      } else if (this._peek.type === TokenType.BLOCK_OPEN_START) {
+        this._closeVoidElement();
+        this._consumeBlock(this._advance<BlockOpenStartToken>(), TokenType.BLOCK_OPEN_END);
+      } else if (this._peek.type === TokenType.BLOCK_GROUP_CLOSE) {
+        this._closeVoidElement();
+        this._consumeBlockGroupClose(this._advance<BlockGroupCloseToken>());
       } else {
         // Skip all other tokens...
         this._advance();
@@ -221,7 +238,15 @@ class _TreeBuilder {
     const startSpan = token.sourceSpan;
     let text = token.parts[0];
     if (text.length > 0 && text[0] === '\n') {
-      const parent = this._getParentElement();
+      const parent = this._getContainer();
+
+      // This is unlikely to happen, but we have an assertion just in case.
+      if (parent instanceof html.BlockGroup) {
+        this.errors.push(TreeError.create(
+            null, startSpan, 'Text cannot be placed directly inside of a block group.'));
+        return null;
+      }
+
       if (parent != null && parent.children.length === 0 &&
           this.getTagDefinition(parent.name).ignoreFirstLf) {
         text = text.substring(1);
@@ -256,9 +281,9 @@ class _TreeBuilder {
   }
 
   private _closeVoidElement(): void {
-    const el = this._getParentElement();
-    if (el && this.getTagDefinition(el.name).isVoid) {
-      this._elementStack.pop();
+    const el = this._getContainer();
+    if (el instanceof html.Element && this.getTagDefinition(el.name).isVoid) {
+      this._containerStack.pop();
     }
   }
 
@@ -268,7 +293,7 @@ class _TreeBuilder {
     while (this._peek.type === TokenType.ATTR_NAME) {
       attrs.push(this._consumeAttr(this._advance<AttributeNameToken>()));
     }
-    const fullName = this._getElementFullName(prefix, name, this._getParentElement());
+    const fullName = this._getElementFullName(prefix, name, this._getClosestParentElement());
     let selfClosing = false;
     // Note: There could have been a tokenizer error
     // so that we don't get a token for the end tag...
@@ -293,40 +318,42 @@ class _TreeBuilder {
     const startSpan = new ParseSourceSpan(
         startTagToken.sourceSpan.start, end, startTagToken.sourceSpan.fullStart);
     const el = new html.Element(fullName, attrs, [], span, startSpan, undefined);
-    this._pushElement(el);
+    const parentEl = this._getContainer();
+    this._pushContainer(
+        el,
+        parentEl instanceof html.Element &&
+            this.getTagDefinition(parentEl.name).isClosedByChild(el.name));
     if (selfClosing) {
       // Elements that are self-closed have their `endSourceSpan` set to the full span, as the
       // element start tag also represents the end tag.
-      this._popElement(fullName, span);
+      this._popContainer(fullName, html.Element, span);
     } else if (startTagToken.type === TokenType.INCOMPLETE_TAG_OPEN) {
       // We already know the opening tag is not complete, so it is unlikely it has a corresponding
       // close tag. Let's optimistically parse it as a full element and emit an error.
-      this._popElement(fullName, null);
+      this._popContainer(fullName, html.Element, null);
       this.errors.push(
           TreeError.create(fullName, span, `Opening tag "${fullName}" not terminated.`));
     }
   }
 
-  private _pushElement(el: html.Element) {
-    const parentEl = this._getParentElement();
-
-    if (parentEl && this.getTagDefinition(parentEl.name).isClosedByChild(el.name)) {
-      this._elementStack.pop();
+  private _pushContainer(node: NodeContainer, isClosedByChild: boolean) {
+    if (isClosedByChild) {
+      this._containerStack.pop();
     }
 
-    this._addToParent(el);
-    this._elementStack.push(el);
+    this._addToParent(node);
+    this._containerStack.push(node);
   }
 
   private _consumeEndTag(endTagToken: TagCloseToken) {
     const fullName = this._getElementFullName(
-        endTagToken.parts[0], endTagToken.parts[1], this._getParentElement());
+        endTagToken.parts[0], endTagToken.parts[1], this._getClosestParentElement());
 
     if (this.getTagDefinition(fullName).isVoid) {
       this.errors.push(TreeError.create(
           fullName, endTagToken.sourceSpan,
           `Void elements do not have end tags "${endTagToken.parts[1]}"`));
-    } else if (!this._popElement(fullName, endTagToken.sourceSpan)) {
+    } else if (!this._popContainer(fullName, html.Element, endTagToken.sourceSpan)) {
       const errMsg = `Unexpected closing tag "${
           fullName}". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags`;
       this.errors.push(TreeError.create(fullName, endTagToken.sourceSpan, errMsg));
@@ -339,22 +366,27 @@ class _TreeBuilder {
    * not have a closing tag (for example, this happens when an incomplete
    * opening tag is recovered).
    */
-  private _popElement(fullName: string, endSourceSpan: ParseSourceSpan|null): boolean {
+  private _popContainer(
+      fullName: string, expectedType: NodeContainerConstructor,
+      endSourceSpan: ParseSourceSpan|null): boolean {
     let unexpectedCloseTagDetected = false;
-    for (let stackIndex = this._elementStack.length - 1; stackIndex >= 0; stackIndex--) {
-      const el = this._elementStack[stackIndex];
-      if (el.name === fullName) {
+    for (let stackIndex = this._containerStack.length - 1; stackIndex >= 0; stackIndex--) {
+      const node = this._containerStack[stackIndex];
+      const name = node instanceof html.BlockGroup ? node.blocks[0]?.name : node.name;
+
+      if (name === fullName && node instanceof expectedType) {
         // Record the parse span with the element that is being closed. Any elements that are
         // removed from the element stack at this point are closed implicitly, so they won't get
         // an end source span (as there is no explicit closing element).
-        el.endSourceSpan = endSourceSpan;
-        el.sourceSpan.end = endSourceSpan !== null ? endSourceSpan.end : el.sourceSpan.end;
-
-        this._elementStack.splice(stackIndex, this._elementStack.length - stackIndex);
+        node.endSourceSpan = endSourceSpan;
+        node.sourceSpan.end = endSourceSpan !== null ? endSourceSpan.end : node.sourceSpan.end;
+        this._containerStack.splice(stackIndex, this._containerStack.length - stackIndex);
         return !unexpectedCloseTagDetected;
       }
 
-      if (!this.getTagDefinition(el.name).closedByParent) {
+      // Blocks are self-closing while block groups and (most times) elements are not.
+      if (node instanceof html.BlockGroup ||
+          node instanceof html.Element && !this.getTagDefinition(node.name).closedByParent) {
         // Note that we encountered an unexpected close tag but continue processing the element
         // stack so we can assign an `endSourceSpan` if there is a corresponding start tag for this
         // end tag in the stack.
@@ -421,16 +453,115 @@ class _TreeBuilder {
         undefined);
   }
 
-  private _getParentElement(): html.Element|null {
-    return this._elementStack.length > 0 ? this._elementStack[this._elementStack.length - 1] : null;
+
+  private _consumeBlockGroupOpen(token: BlockGroupOpenStartToken) {
+    const end = this._peek.sourceSpan.fullStart;
+    const span = new ParseSourceSpan(token.sourceSpan.start, end, token.sourceSpan.fullStart);
+    // Create a separate `startSpan` because `span` will be modified when there is an `end` span.
+    const startSpan = new ParseSourceSpan(token.sourceSpan.start, end, token.sourceSpan.fullStart);
+    const blockGroup = new html.BlockGroup([], span, startSpan, null);
+    this._pushContainer(blockGroup, false);
+    const implicitBlock = this._consumeBlock(token, TokenType.BLOCK_GROUP_OPEN_END);
+
+    // Block parameters are consumed as a part of the implicit block so we need to expand the
+    // start source span once the block is parsed to include the full opening tag.
+    startSpan.end = implicitBlock.startSourceSpan.end;
+  }
+
+  private _consumeBlock(
+      token: BlockOpenStartToken|BlockGroupOpenStartToken, closeToken: TokenType) {
+    // The start of a block implicitly closes the previous block.
+    this._conditionallyClosePreviousBlock();
+
+    const parameters: html.BlockParameter[] = [];
+
+    while (this._peek.type === TokenType.BLOCK_PARAMETER) {
+      const paramToken = this._advance<BlockParameterToken>();
+      parameters.push(new html.BlockParameter(paramToken.parts[0], paramToken.sourceSpan));
+    }
+
+    if (this._peek.type === closeToken) {
+      this._advance();
+    }
+
+    const end = this._peek.sourceSpan.fullStart;
+    const span = new ParseSourceSpan(token.sourceSpan.start, end, token.sourceSpan.fullStart);
+    // Create a separate `startSpan` because `span` will be modified when there is an `end` span.
+    const startSpan = new ParseSourceSpan(token.sourceSpan.start, end, token.sourceSpan.fullStart);
+    const block = new html.Block(token.parts[0], parameters, [], span, startSpan);
+    const parent = this._getContainer();
+
+    if (!(parent instanceof html.BlockGroup)) {
+      this.errors.push(TreeError.create(
+          block.name, block.sourceSpan, 'Blocks can only be placed inside of block groups.'));
+    } else {
+      parent.blocks.push(block);
+      this._containerStack.push(block);
+    }
+
+    return block;
+  }
+
+  private _consumeBlockGroupClose(token: BlockGroupCloseToken) {
+    const name = token.parts[0];
+    const previousContainer = this._getContainer();
+
+    // Blocks are implcitly closed by the block group.
+    this._conditionallyClosePreviousBlock();
+
+    if (!this._popContainer(name, html.BlockGroup, token.sourceSpan)) {
+      const context = previousContainer instanceof html.Element ?
+          `There is an unclosed "${
+              previousContainer.name}" HTML tag named that may have to be closed first.` :
+          `The block may have been closed earlier.`;
+      this.errors.push(TreeError.create(
+          name, token.sourceSpan, `Unexpected closing block "${name}". ${context}`));
+    }
+  }
+
+  private _conditionallyClosePreviousBlock() {
+    const container = this._getContainer();
+
+    if (container instanceof html.Block) {
+      // Blocks don't have an explicit closing tag, they're closed either by the next block or
+      // the end of the block group. Infer the end span from the last child node.
+      const lastChild =
+          container.children.length ? container.children[container.children.length - 1] : null;
+      const endSpan = lastChild === null ?
+          null :
+          new ParseSourceSpan(lastChild.sourceSpan.end, lastChild.sourceSpan.end);
+
+      this._popContainer(container.name, html.Block, endSpan);
+    }
+  }
+
+  private _getContainer(): NodeContainer|null {
+    return this._containerStack.length > 0 ? this._containerStack[this._containerStack.length - 1] :
+                                             null;
+  }
+
+  private _getClosestParentElement(): html.Element|null {
+    for (let i = this._containerStack.length - 1; i > -1; i--) {
+      if (this._containerStack[i] instanceof html.Element) {
+        return this._containerStack[i] as html.Element;
+      }
+    }
+
+    return null;
   }
 
   private _addToParent(node: html.Node) {
-    const parent = this._getParentElement();
-    if (parent != null) {
-      parent.children.push(node);
-    } else {
+    const parent = this._getContainer();
+
+    if (parent === null) {
       this.rootNodes.push(node);
+    } else if (parent instanceof html.BlockGroup) {
+      // Due to how parsing is set up, we're unlikely to hit this code path, but we
+      // have the assertion here just in case and to satisfy the type checker.
+      this.errors.push(
+          TreeError.create(null, node.sourceSpan, 'Block groups can only contain blocks.'));
+    } else {
+      parent.children.push(node);
     }
   }
 

--- a/packages/compiler/src/ml_parser/xml_parser.ts
+++ b/packages/compiler/src/ml_parser/xml_parser.ts
@@ -15,7 +15,8 @@ export class XmlParser extends Parser {
     super(getXmlTagDefinition);
   }
 
-  override parse(source: string, url: string, options?: TokenizeOptions): ParseTreeResult {
-    return super.parse(source, url, options);
+  override parse(source: string, url: string, options: TokenizeOptions = {}): ParseTreeResult {
+    // Blocks aren't supported in an XML context.
+    return super.parse(source, url, {...options, tokenizeBlocks: false});
   }
 }

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -306,6 +306,18 @@ class HtmlAstToIvyAst implements html.Visitor {
     return null;
   }
 
+  visitBlockGroup(group: html.BlockGroup, context: any) {
+    throw new Error('TODO');
+  }
+
+  visitBlock(block: html.Block, context: any) {
+    throw new Error('TODO');
+  }
+
+  visitBlockParameter(parameter: html.BlockParameter, context: any) {
+    throw new Error('TODO');
+  }
+
   // convert view engine `ParsedProperty` to a format suitable for IVY
   private extractAttributes(
       elementName: string, properties: ParsedProperty[],
@@ -541,6 +553,18 @@ class NonBindableVisitor implements html.Visitor {
 
   visitExpansionCase(expansionCase: html.ExpansionCase): any {
     return null;
+  }
+
+  visitBlockGroup(group: html.BlockGroup, context: any) {
+    throw new Error('TODO');
+  }
+
+  visitBlock(block: html.Block, context: any) {
+    throw new Error('TODO');
+  }
+
+  visitBlockParameter(parameter: html.BlockParameter, context: any) {
+    throw new Error('TODO');
   }
 }
 

--- a/packages/compiler/src/render3/view/i18n/meta.ts
+++ b/packages/compiler/src/render3/view/i18n/meta.ts
@@ -165,6 +165,20 @@ export class I18nMetaVisitor implements html.Visitor {
     return expansionCase;
   }
 
+  visitBlockGroup(group: html.BlockGroup, context: any) {
+    html.visitAll(this, group.blocks, context);
+    return group;
+  }
+
+  visitBlock(block: html.Block, context: any) {
+    html.visitAll(this, block.children, context);
+    return block;
+  }
+
+  visitBlockParameter(parameter: html.BlockParameter, context: any) {
+    return parameter;
+  }
+
   /**
    * Parse the general form `meta` passed into extract the explicit metadata needed to create a
    * `Message`.

--- a/packages/compiler/test/i18n/extractor_merger_spec.ts
+++ b/packages/compiler/test/i18n/extractor_merger_spec.ts
@@ -106,6 +106,78 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
     });
 
     describe('blocks', () => {
+      it('should extract from elements inside block groups', () => {
+        expect(extract(
+                   '{#defer}<span i18n="a|b|c">main <span>nested</span></span>' +
+                   '{:loading}<div i18n="d|e|f">loading <span>nested</span></div>' +
+                   '{:placeholder}<strong i18n="g|h|i">placeholder <span>nested</span></strong>' +
+                   '{/defer}'))
+            .toEqual([
+              [
+                ['main ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'], 'a',
+                'b|c', ''
+              ],
+              [
+                ['loading ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'],
+                'd', 'e|f', ''
+              ],
+              [
+                ['placeholder ', '<ph tag name="START_TAG_SPAN">nested</ph name="CLOSE_TAG_SPAN">'],
+                'g', 'h|i', ''
+              ]
+            ]);
+      });
+
+      it('should extract from i18n comment blocks inside block groups', () => {
+        expect(
+            extract(
+                '{#defer}<!-- i18n: mainMeaning|mainDesc -->main message<!-- /i18n -->' +
+                '{:loading}<!-- i18n: loadingMeaning|loadingDesc -->loading message<!-- /i18n -->' +
+                '{:placeholder}<!-- i18n: placeholderMeaning|placeholderDesc -->placeholder message<!-- /i18n -->' +
+                '{/defer}'))
+            .toEqual([
+              [['main message'], 'mainMeaning', 'mainDesc', ''],
+              [['loading message'], 'loadingMeaning', 'loadingDesc', ''],
+              [['placeholder message'], 'placeholderMeaning', 'placeholderDesc', '']
+            ]);
+      });
+
+      it('should extract ICUs from elements inside block groups', () => {
+        expect(extract(
+                   '{#defer}<div i18n="a|b">{count, plural, =0 {mainText}}</div>' +
+                   '{:loading}<div i18n="c|d">{count, plural, =0 {loadingText}}</div>' +
+                   '{:placeholder}<div i18n="e|f">{count, plural, =0 {placeholderText}}</div>' +
+                   '{/defer}'))
+            .toEqual([
+              [['{count, plural, =0 {[mainText]}}'], 'a', 'b', ''],
+              [['{count, plural, =0 {[loadingText]}}'], 'c', 'd', ''],
+              [['{count, plural, =0 {[placeholderText]}}'], 'e', 'f', '']
+            ]);
+      });
+
+      it('should not extract messages from ICUs directly inside block groups', () => {
+        const expression = '{count, plural, =0 {text}}';
+
+        expect(extract(
+                   `{#defer}${expression}` +
+                   `{:loading}${expression}` +
+                   `{:placeholder}${expression}` +
+                   `{/defer}`))
+            .toEqual([]);
+      });
+
+      it('should handle blocks inside of translated elements', () => {
+        expect(extract('<span i18n="a|b|c">{#if cond}main content{:else}else content{/if}</span>'))
+            .toEqual([[['[[main content], [else content]]'], 'a', 'b|c', '']]);
+      });
+
+      it('should handle blocks inside of translated elements', () => {
+        expect(extract('<span i18n="a|b|c">{#if cond}main content{:else}else content{/if}</span>'))
+            .toEqual([[['[[main content], [else content]]'], 'a', 'b|c', '']]);
+      });
+    });
+
+    describe('i18n comment blocks', () => {
       it('should extract from blocks', () => {
         expect(extract(`<!-- i18n: meaning1|desc1 -->message1<!-- /i18n -->
          <!-- i18n: desc2 -->message2<!-- /i18n -->
@@ -422,7 +494,7 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
       });
     });
 
-    describe('blocks', () => {
+    describe('i18n comment blocks', () => {
       it('should console.warn if we use i18n comments', () => {
         // TODO(ocombe): expect a warning message when we have a proper log service
         extract('<!-- i18n --><p><b i18n-title="m|d" title="msg"></b></p><!-- /i18n -->');
@@ -519,7 +591,8 @@ import {serializeNodes as serializeHtmlNodes} from '../ml_parser/util/util';
 
 function parseHtml(html: string): html.Node[] {
   const htmlParser = new HtmlParser();
-  const parseResult = htmlParser.parse(html, 'extractor spec', {tokenizeExpansionForms: true});
+  const parseResult = htmlParser.parse(
+      html, 'extractor spec', {tokenizeExpansionForms: true, tokenizeBlocks: true});
   if (parseResult.errors.length > 1) {
     throw new Error(`unexpected parse errors: ${parseResult.errors.join('\n')}`);
   }

--- a/packages/compiler/test/ml_parser/ast_spec_utils.ts
+++ b/packages/compiler/test/ml_parser/ast_spec_utils.ts
@@ -84,6 +84,33 @@ class _Humanizer implements html.Visitor {
     this.result.push(res);
   }
 
+  visitBlockGroup(group: html.BlockGroup, context: any) {
+    const res = this._appendContext(group, [html.BlockGroup, this.elDepth++]);
+    if (this.includeSourceSpan) {
+      res.push(group.startSourceSpan.toString() ?? null);
+      res.push(group.endSourceSpan?.toString() ?? null);
+    }
+    this.result.push(res);
+    html.visitAll(this, group.blocks);
+    this.elDepth--;
+  }
+
+  visitBlock(block: html.Block, context: any) {
+    const res = this._appendContext(block, [html.Block, block.name, this.elDepth++]);
+    if (this.includeSourceSpan) {
+      res.push(block.startSourceSpan.toString() ?? null);
+      res.push(block.endSourceSpan?.toString() ?? null);
+    }
+    this.result.push(res);
+    html.visitAll(this, block.parameters);
+    html.visitAll(this, block.children);
+    this.elDepth--;
+  }
+
+  visitBlockParameter(parameter: html.BlockParameter, context: any) {
+    this.result.push(this._appendContext(parameter, [html.BlockParameter, parameter.expression]));
+  }
+
   private _appendContext(ast: html.Node, input: any[]): any[] {
     if (!this.includeSourceSpan) return input;
     input.push(ast.sourceSpan.toString());

--- a/packages/compiler/test/ml_parser/html_parser_spec.ts
+++ b/packages/compiler/test/ml_parser/html_parser_spec.ts
@@ -759,6 +759,281 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
         });
       });
 
+      describe('blocks', () => {
+        // TODO(crisbeto): temporary utility while blocks are disabled by default.
+        const options = {tokenizeBlocks: true};
+
+        function humanizeBlocks(input: string): any[] {
+          return humanizeDom(parser.parse(input, 'TestComp', options));
+        }
+
+        it('should parse a block group', () => {
+          expect(humanizeBlocks('{#foo a b; c d}hello{/foo}')).toEqual([
+            [html.BlockGroup, 0],
+            [html.Block, 'foo', 1],
+            [html.BlockParameter, 'a b'],
+            [html.BlockParameter, 'c d'],
+            [html.Text, 'hello', 2, ['hello']],
+          ]);
+        });
+
+        it('should parse a block group with an HTML element in the primary block', () => {
+          expect(humanizeBlocks('{#defer}<my-cmp/>{/defer}')).toEqual([
+            [html.BlockGroup, 0],
+            [html.Block, 'defer', 1],
+            [html.Element, 'my-cmp', 2],
+          ]);
+        });
+
+        it('should parse a block group with blocks', () => {
+          expect(humanizeBlocks(
+                     '{#defer when isVisible()}<my-cmp/>' +
+                     '{:loading after 100ms}Loading...' +
+                     '{:placeholder minimum 50ms}Placeholder' +
+                     '{/defer}'))
+              .toEqual([
+                [html.BlockGroup, 0],
+                [html.Block, 'defer', 1],
+                [html.BlockParameter, 'when isVisible()'],
+                [html.Element, 'my-cmp', 2],
+                [html.Block, 'loading', 1],
+                [html.BlockParameter, 'after 100ms'],
+                [html.Text, 'Loading...', 2, ['Loading...']],
+                [html.Block, 'placeholder', 1],
+                [html.BlockParameter, 'minimum 50ms'],
+                [html.Text, 'Placeholder', 2, ['Placeholder']],
+              ]);
+        });
+
+        it('should parse a block group with blocks containing mixed plain text and HTML', () => {
+          expect(humanizeBlocks(
+                     '{#defer when isVisible()}hello<my-cmp/>there' +
+                         '{:loading after 100ms}<p>Loading...</p>' +
+                         '{:placeholder minimum 50ms}P<strong>laceh<i>ol</i>de</strong>r' +
+                         '{/defer}',
+                     ))
+              .toEqual([
+                [html.BlockGroup, 0],
+                [html.Block, 'defer', 1],
+                [html.BlockParameter, 'when isVisible()'],
+                [html.Text, 'hello', 2, ['hello']],
+                [html.Element, 'my-cmp', 2],
+                [html.Text, 'there', 2, ['there']],
+                [html.Block, 'loading', 1],
+                [html.BlockParameter, 'after 100ms'],
+                [html.Element, 'p', 2],
+                [html.Text, 'Loading...', 3, ['Loading...']],
+                [html.Block, 'placeholder', 1],
+                [html.BlockParameter, 'minimum 50ms'],
+                [html.Text, 'P', 2, ['P']],
+                [html.Element, 'strong', 2],
+                [html.Text, 'laceh', 3, ['laceh']],
+                [html.Element, 'i', 3],
+                [html.Text, 'ol', 4, ['ol']],
+                [html.Text, 'de', 3, ['de']],
+                [html.Text, 'r', 2, ['r']],
+              ]);
+        });
+
+        it('should parse nested block groups', () => {
+          // clang-format off
+          const markup = `<root-sibling-one/>` +
+            `{#root}` +
+              `<outer-child-one/>` +
+              `<outer-child-two>` +
+                `{#child}` +
+                  `{:innerChild}` +
+                    `<inner-child-one/>` +
+                    `{#grandchild}` +
+                      `{:innerGrandChild}` +
+                        `<inner-grand-child-one/>` +
+                      `{:innerGrandChild}` +
+                        `<inner-grand-child-two/>` +
+                  `{/grandchild}` +
+                  `{:innerChild}` +
+                  `<inner-child-two/>` +
+                `{/child}` +
+              `</outer-child-two>` +
+              `{:outerChild}` +
+                `<outer-child-three/>` +
+            `{/root} <root-sibling-two/>`;
+          // clang-format on
+
+          expect(humanizeBlocks(markup)).toEqual([
+            [html.Element, 'root-sibling-one', 0],
+            [html.BlockGroup, 0],
+            [html.Block, 'root', 1],
+            [html.Element, 'outer-child-one', 2],
+            [html.Element, 'outer-child-two', 2],
+            [html.BlockGroup, 3],
+            [html.Block, 'child', 4],
+            [html.Block, 'innerChild', 4],
+            [html.Element, 'inner-child-one', 5],
+            [html.BlockGroup, 5],
+            [html.Block, 'grandchild', 6],
+            [html.Block, 'innerGrandChild', 6],
+            [html.Element, 'inner-grand-child-one', 7],
+            [html.Block, 'innerGrandChild', 6],
+            [html.Element, 'inner-grand-child-two', 7],
+            [html.Block, 'innerChild', 4],
+            [html.Element, 'inner-child-two', 5],
+            [html.Block, 'outerChild', 1],
+            [html.Element, 'outer-child-three', 2],
+            [html.Text, ' ', 0, [' ']],
+            [html.Element, 'root-sibling-two', 0],
+          ]);
+        });
+
+        it('should infer namespace through block group boundary', () => {
+          expect(humanizeBlocks('<svg>{#if cond}<circle/>{/if}</svg>')).toEqual([
+            [html.Element, ':svg:svg', 0],
+            [html.BlockGroup, 1],
+            [html.Block, 'if', 2],
+            [html.BlockParameter, 'cond'],
+            [html.Element, ':svg:circle', 3],
+          ]);
+        });
+
+        it('should create an implicit empty block if there is a block at the root', () => {
+          expect(humanizeBlocks(
+                     '{#switch cond}' +
+                     '{:case a}' +
+                     'a case' +
+                     '{:case b}' +
+                     'b case' +
+                     '{:default}' +
+                     'no case' +
+                     '{/switch}'))
+              .toEqual([
+                [html.BlockGroup, 0],
+                [html.Block, 'switch', 1],
+                [html.BlockParameter, 'cond'],
+                [html.Block, 'case', 1],
+                [html.BlockParameter, 'a'],
+                [html.Text, 'a case', 2, ['a case']],
+                [html.Block, 'case', 1],
+                [html.BlockParameter, 'b'],
+                [html.Text, 'b case', 2, ['b case']],
+                [html.Block, 'default', 1],
+                [html.Text, 'no case', 2, ['no case']],
+              ]);
+        });
+
+        it('should parse a block group with empty blocks', () => {
+          expect(humanizeBlocks('{#foo}{:a}{:b}{:c}{/foo}')).toEqual([
+            [html.BlockGroup, 0],
+            [html.Block, 'foo', 1],
+            [html.Block, 'a', 1],
+            [html.Block, 'b', 1],
+            [html.Block, 'c', 1],
+          ]);
+        });
+
+        it('should parse a block group with void elements', () => {
+          expect(humanizeBlocks('{#foo}<br>{:bar}<img>{/foo}')).toEqual([
+            [html.BlockGroup, 0],
+            [html.Block, 'foo', 1],
+            [html.Element, 'br', 2],
+            [html.Block, 'bar', 1],
+            [html.Element, 'img', 2],
+          ]);
+        });
+
+        it('should close void elements used right before a block group', () => {
+          expect(humanizeBlocks('<img>{#foo}hello{/foo}')).toEqual([
+            [html.Element, 'img', 0],
+            [html.BlockGroup, 0],
+            [html.Block, 'foo', 1],
+            [html.Text, 'hello', 2, ['hello']],
+          ]);
+        });
+
+        it('should report an unexpected block close', () => {
+          const errors = parser.parse('hello{/foo}', 'TestComp', options).errors;
+          expect(errors.length).toEqual(1);
+          expect(humanizeErrors(errors)).toEqual([[
+            'foo', 'Unexpected closing block "foo". The block may have been closed earlier.', '0:5'
+          ]]);
+        });
+
+        it('should report unclosed tags inside of a block group', () => {
+          const errors = parser.parse('{#foo}<strong>hello{/foo}', 'TestComp', options).errors;
+          expect(errors.length).toEqual(1);
+          expect(humanizeErrors(errors)).toEqual([[
+            'foo',
+            'Unexpected closing block "foo". There is an unclosed "strong" HTML tag named that may have to be closed first.',
+            '0:19'
+          ]]);
+        });
+
+        it('should report block used at the root', () => {
+          const errors = parser.parse('{:foo}hello', 'TestComp', options).errors;
+          expect(errors.length).toEqual(1);
+          expect(humanizeErrors(errors)).toEqual([
+            ['foo', 'Blocks can only be placed inside of block groups.', '0:0']
+          ]);
+        });
+
+        it('should report block used inside of an HTML element', () => {
+          const errors =
+              parser.parse('{#group}<div>{:foo}hello</div>{/group}', 'TestComp', options).errors;
+          expect(errors.length).toEqual(1);
+          expect(humanizeErrors(errors)).toEqual([
+            ['foo', 'Blocks can only be placed inside of block groups.', '0:13']
+          ]);
+        });
+
+        it('should report an unexpected closing tag inside a block', () => {
+          const errors =
+              parser.parse('<div>{#if cond}hello</div>{/if}', 'TestComp', options).errors;
+          expect(errors.length).toEqual(2);
+          expect(humanizeErrors(errors)).toEqual([
+            [
+              'div',
+              'Unexpected closing tag "div". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags',
+              '0:20'
+            ],
+            [
+              'if', 'Unexpected closing block "if". The block may have been closed earlier.', '0:26'
+            ],
+          ]);
+        });
+
+        it('should store the source locations of block groups and blocks', () => {
+          const markup = '{#defer when isVisible()}<div>hello</div>world' +
+              '{:loading after 100ms}Loading...' +
+              '{:placeholder minimum 50ms}Placeholde<strong>r</strong>' +
+              '{/defer}';
+
+          expect(humanizeDomSourceSpans(parser.parse(markup, 'TestComp', options))).toEqual([
+            [html.BlockGroup, 0, markup, '{#defer when isVisible()}', '{/defer}'],
+            [
+              html.Block, 'defer', 1, '{#defer when isVisible()}<div>hello</div>world',
+              '{#defer when isVisible()}', ''
+            ],
+            [html.BlockParameter, 'when isVisible()', 'when isVisible()'],
+            [html.Element, 'div', 2, '<div>hello</div>', '<div>', '</div>'],
+            [html.Text, 'hello', 3, ['hello'], 'hello'],
+            [html.Text, 'world', 2, ['world'], 'world'],
+            [
+              html.Block, 'loading', 1, '{:loading after 100ms}Loading...',
+              '{:loading after 100ms}', ''
+            ],
+            [html.BlockParameter, 'after 100ms', 'after 100ms'],
+            [html.Text, 'Loading...', 2, ['Loading...'], 'Loading...'],
+            [
+              html.Block, 'placeholder', 1,
+              '{:placeholder minimum 50ms}Placeholde<strong>r</strong>',
+              '{:placeholder minimum 50ms}', ''
+            ],
+            [html.BlockParameter, 'minimum 50ms', 'minimum 50ms'],
+            [html.Text, 'Placeholde', 2, ['Placeholde'], 'Placeholde'],
+            [html.Element, 'strong', 2, '<strong>r</strong>', '<strong>', '</strong>'],
+            [html.Text, 'r', 3, ['r'], 'r'],
+          ]);
+        });
+      });
+
       describe('source spans', () => {
         it('should store the location', () => {
           expect(humanizeDomSourceSpans(parser.parse(
@@ -964,7 +1239,7 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
           const result =
               parser.parse('<div id="foo"><span id="bar">a</span><span>b</span></div>', 'TestComp');
           const accumulator: html.Node[] = [];
-          const visitor = new class {
+          const visitor = new class implements html.Visitor {
             visit(node: html.Node, context: any) {
               accumulator.push(node);
             }
@@ -979,6 +1254,14 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
               html.visitAll(this, expansion.cases);
             }
             visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {}
+            visitBlockGroup(group: html.BlockGroup, context: any) {
+              html.visitAll(this, group.blocks);
+            }
+            visitBlock(block: html.Block, context: any) {
+              html.visitAll(this, block.parameters);
+              html.visitAll(this, block.children);
+            }
+            visitBlockParameter(parameter: html.BlockParameter, context: any) {}
           };
 
           html.visitAll(visitor, result.rootNodes);
@@ -989,7 +1272,7 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
         });
 
         it('should skip typed visit if visit() returns a truthy value', () => {
-          const visitor = new class {
+          const visitor = new class implements html.Visitor {
             visit(node: html.Node, context: any) {
               return true;
             }
@@ -1009,6 +1292,15 @@ import {humanizeDom, humanizeDomSourceSpans, humanizeLineColumn, humanizeNodes} 
               throw Error('Unexpected');
             }
             visitExpansionCase(expansionCase: html.ExpansionCase, context: any): any {
+              throw Error('Unexpected');
+            }
+            visitBlockGroup(group: html.BlockGroup, context: any) {
+              throw Error('Unexpected');
+            }
+            visitBlock(block: html.Block, context: any) {
+              throw Error('Unexpected');
+            }
+            visitBlockParameter(parameter: html.BlockParameter, context: any) {
               throw Error('Unexpected');
             }
           };

--- a/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
+++ b/packages/compiler/test/ml_parser/html_whitespaces_spec.ts
@@ -65,6 +65,25 @@ import {humanizeDom} from './ast_spec_utils';
       expect(parseAndRemoveWS('   \n foo  \t ')).toEqual([[html.Text, ' foo ', 0, [' foo ']]]);
     });
 
+    it('shuld remove whitespace inside of block groups', () => {
+      const markup = '{#if cond}<br>  <br>\t<br>\n<br>{:else}<br>  <br>\t<br>\n<br>{/if}';
+
+      expect(parseAndRemoveWS(markup, {tokenizeBlocks: true})).toEqual([
+        [html.BlockGroup, 0],
+        [html.Block, 'if', 1],
+        [html.BlockParameter, 'cond'],
+        [html.Element, 'br', 2],
+        [html.Element, 'br', 2],
+        [html.Element, 'br', 2],
+        [html.Element, 'br', 2],
+        [html.Block, 'else', 1],
+        [html.Element, 'br', 2],
+        [html.Element, 'br', 2],
+        [html.Element, 'br', 2],
+        [html.Element, 'br', 2],
+      ]);
+    });
+
     it('should not replace &nbsp;', () => {
       expect(parseAndRemoveWS('&nbsp;')).toEqual([
         [html.Text, '\u00a0', 0, [''], ['\u00a0', '&nbsp;'], ['']]

--- a/packages/compiler/test/ml_parser/icu_ast_expander_spec.ts
+++ b/packages/compiler/test/ml_parser/icu_ast_expander_spec.ts
@@ -9,15 +9,16 @@
 import * as html from '../../src/ml_parser/ast';
 import {HtmlParser} from '../../src/ml_parser/html_parser';
 import {expandNodes, ExpansionResult} from '../../src/ml_parser/icu_ast_expander';
+import {TokenizeOptions} from '../../src/ml_parser/lexer';
 import {ParseError} from '../../src/parse_util';
 
 import {humanizeNodes} from './ast_spec_utils';
 
 {
   describe('Expander', () => {
-    function expand(template: string): ExpansionResult {
+    function expand(template: string, options: TokenizeOptions = {}): ExpansionResult {
       const htmlParser = new HtmlParser();
-      const res = htmlParser.parse(template, 'url', {tokenizeExpansionForms: true});
+      const res = htmlParser.parse(template, 'url', {tokenizeExpansionForms: true, ...options});
       return expandNodes(res.rootNodes);
     }
 
@@ -106,6 +107,28 @@ import {humanizeNodes} from './ast_spec_utils';
         [html.Element, 'ng-template', 3],
         [html.Attribute, 'ngSwitchCase', '=4'],
         [html.Text, 'c', 4, ['c']],
+      ]);
+    });
+
+    it('should parse an expansion forms inside of blocks', () => {
+      const res =
+          expand('{#if cond}{a, b, =4 {c}}{:else}{d, e, =4 {f}}{/if}', {tokenizeBlocks: true});
+
+      expect(humanizeNodes(res.nodes)).toEqual([
+        [html.BlockGroup, 0],
+        [html.Block, 'if', 1],
+        [html.BlockParameter, 'cond'],
+        [html.Element, 'ng-container', 2],
+        [html.Attribute, '[ngSwitch]', 'a'],
+        [html.Element, 'ng-template', 3],
+        [html.Attribute, 'ngSwitchCase', '=4'],
+        [html.Text, 'c', 4, ['c']],
+        [html.Block, 'else', 1],
+        [html.Element, 'ng-container', 2],
+        [html.Attribute, '[ngSwitch]', 'd'],
+        [html.Element, 'ng-template', 3],
+        [html.Attribute, 'ngSwitchCase', '=4'],
+        [html.Text, 'f', 4, ['f']],
       ]);
     });
 

--- a/packages/localize/tools/src/translate/translation_files/base_visitor.ts
+++ b/packages/localize/tools/src/translate/translation_files/base_visitor.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {Attribute, Comment, Element, Expansion, ExpansionCase, Text, Visitor} from '@angular/compiler';
+import {Attribute, Block, BlockGroup, BlockParameter, Comment, Element, Expansion, ExpansionCase, Node, Text, Visitor} from '@angular/compiler';
 
 /**
  * A simple base class for the  `Visitor` interface, which is a noop for every method.
@@ -19,4 +19,7 @@ export class BaseVisitor implements Visitor {
   visitComment(_comment: Comment, _context: any): any {}
   visitExpansion(_expansion: Expansion, _context: any): any {}
   visitExpansionCase(_expansionCase: ExpansionCase, _context: any): any {}
+  visitBlockGroup(_group: BlockGroup, _context: any) {}
+  visitBlock(_block: Block, _context: any) {}
+  visitBlockParameter(_parameter: BlockParameter, _context: any) {}
 }


### PR DESCRIPTION
⚠️Disclaimer⚠️ this PR implements syntax that is still in an open RFC. It will be adjusted once the RFC is closed.

Built on top of https://github.com/angular/angular/pull/50895. All the new code is in the second commit.

These changes implement the `BlockGroup` and `Block` AST nodes that will then be used to generate instructions based on the new syntax. A `BlockGroup` is a container for `Block` instances. The first block of a block is always implicit and required while any subsequent blocks are optional.