### PR TITLE
refactor(compiler): add support for animation properties and listeners

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_animations/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_animations/TEST_CASES.json
@@ -39,8 +39,7 @@
           "failureMessage": "Incorrect template",
           "files": ["animation_listeners.js"]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ] 
     },
     {
       "description": "should generate animation host binding and listener code for directives",

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_animations/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_styling/component_animations/TEST_CASES.json
@@ -3,73 +3,52 @@
   "cases": [
     {
       "description": "should pass in the component metadata animations into the component definition",
-      "inputFiles": [
-        "metadata.ts"
-      ],
+      "inputFiles": ["metadata.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "metadata.js"
-          ]
+          "files": ["metadata.js"]
         }
       ]
     },
     {
       "description": "should include animations even if the provided array is empty",
-      "inputFiles": [
-        "metadata_empty.ts"
-      ],
+      "inputFiles": ["metadata_empty.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "metadata_empty.js"
-          ]
+          "files": ["metadata_empty.js"]
         }
       ]
     },
     {
       "description": "should generate any animation triggers into the component template",
-      "inputFiles": [
-        "animation_property_bindings.ts"
-      ],
+      "inputFiles": ["animation_property_bindings.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "animation_property_bindings.js"
-          ]
+          "files": ["animation_property_bindings.js"]
         }
-      ],
-      "skipForTemplatePipeline": true
+      ]
     },
     {
       "description": "should generate animation listeners",
-      "inputFiles": [
-        "animation_listeners.ts"
-      ],
+      "inputFiles": ["animation_listeners.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "animation_listeners.js"
-          ]
+          "files": ["animation_listeners.js"]
         }
       ],
       "skipForTemplatePipeline": true
     },
     {
       "description": "should generate animation host binding and listener code for directives",
-      "inputFiles": [
-        "animation_host_bindings.ts"
-      ],
+      "inputFiles": ["animation_host_bindings.ts"],
       "expectations": [
         {
           "failureMessage": "Incorrect template",
-          "files": [
-            "animation_host_bindings.js"
-          ]
+          "files": ["animation_host_bindings.js"]
         }
       ],
       "skipForTemplatePipeline": true

--- a/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/create.ts
@@ -352,6 +352,16 @@ export interface ListenerOp extends Op<CreateOp>, UsesSlotIndexTrait {
    * Whether this listener is known to consume `$event` in its body.
    */
   consumesDollarEvent: boolean;
+
+  /**
+   * Whether the listener is listening for an animation event.
+   */
+  isAnimationListener: boolean;
+
+  /**
+   * The animation phase of the listener.
+   */
+  animationPhase: string|null;
 }
 
 /**
@@ -366,6 +376,28 @@ export function createListenerOp(target: XrefId, name: string, tag: string): Lis
     handlerOps: new OpList(),
     handlerFnName: null,
     consumesDollarEvent: false,
+    isAnimationListener: false,
+    animationPhase: null,
+    ...NEW_OP,
+    ...TRAIT_USES_SLOT_INDEX,
+  };
+}
+
+/**
+ * Create a `ListenerOp` for an animation.
+ */
+export function createListenerOpForAnimation(
+    target: XrefId, name: string, animationPhase: string, tag: string): ListenerOp {
+  return {
+    kind: OpKind.Listener,
+    target,
+    tag,
+    name,
+    handlerOps: new OpList(),
+    handlerFnName: null,
+    consumesDollarEvent: false,
+    isAnimationListener: true,
+    animationPhase,
     ...NEW_OP,
     ...TRAIT_USES_SLOT_INDEX,
   };

--- a/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
+++ b/packages/compiler/src/template/pipeline/ir/src/ops/update.ts
@@ -13,8 +13,8 @@ import {OpKind} from '../enums';
 import {Op, XrefId} from '../operations';
 import {ConsumesVarsTrait, DependsOnSlotContextOpTrait, TRAIT_CONSUMES_VARS, TRAIT_DEPENDS_ON_SLOT_CONTEXT} from '../traits';
 
-import {ListEndOp, NEW_OP, StatementOp, VariableOp} from './shared';
 import type {HostPropertyOp} from './host';
+import {ListEndOp, NEW_OP, StatementOp, VariableOp} from './shared';
 
 
 /**
@@ -124,6 +124,11 @@ export interface PropertyOp extends Op<UpdateOp>, ConsumesVarsTrait, DependsOnSl
    */
   expression: o.Expression|Interpolation;
 
+  /**
+   * Whether this property is an animation trigger.
+   */
+  isAnimationTrigger: boolean;
+
   isTemplate: boolean;
 
   sourceSpan: ParseSourceSpan;
@@ -133,13 +138,16 @@ export interface PropertyOp extends Op<UpdateOp>, ConsumesVarsTrait, DependsOnSl
  * Create a `PropertyOp`.
  */
 export function createPropertyOp(
-    target: XrefId, name: string, expression: o.Expression|Interpolation, isTemplate: boolean,
+    target: XrefId, name: string, expression: o.Expression|Interpolation,
+    isAnimationTrigger: boolean, isTemplate: boolean,
+
     sourceSpan: ParseSourceSpan): PropertyOp {
   return {
     kind: OpKind.Property,
     target,
     name,
     expression,
+    isAnimationTrigger,
     isTemplate,
     sourceSpan,
     ...TRAIT_DEPENDS_ON_SLOT_CONTEXT,

--- a/packages/compiler/src/template/pipeline/src/ingest.ts
+++ b/packages/compiler/src/template/pipeline/src/ingest.ts
@@ -15,7 +15,7 @@ import * as t from '../../../render3/r3_ast';
 import {BindingParser} from '../../../template_parser/binding_parser';
 import * as ir from '../ir';
 
-import {type CompilationJob, ComponentCompilationJob, HostBindingCompilationJob, type ViewCompilationUnit} from './compilation';
+import {ComponentCompilationJob, HostBindingCompilationJob, type CompilationJob, type ViewCompilationUnit} from './compilation';
 import {BINARY_OPERATORS, namespaceForKey} from './conversion';
 
 const compatibilityMode = ir.CompatibilityMode.TemplateDefinitionBuilder;
@@ -296,7 +296,15 @@ function ingestBindings(
   }
 
   for (const output of element.outputs) {
-    const listenerOp = ir.createListenerOp(op.xref, output.name, op.tag);
+    let listenerOp: ir.ListenerOp;
+    if (output.type === e.ParsedEventType.Animation) {
+      if (output.phase === null) {
+        throw Error('Animation listener should have a phase');
+      }
+      listenerOp = ir.createListenerOpForAnimation(op.xref, output.name, output.phase!, op.tag);
+    } else {
+      listenerOp = ir.createListenerOp(op.xref, output.name, op.tag);
+    }
     // if output.handler is a chain, then push each statement from the chain separately, and
     // return the last one?
     let inputExprs: e.AST[];

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -97,6 +97,9 @@ function populateElementAttributes(view: ViewCompilationUnit) {
         }
         break;
       case ir.OpKind.Listener:
+        if (op.isAnimationListener) {
+          continue;  // Don't extract animation listeners.
+        }
         ownerOp = lookupElement(elements, op.target);
         ir.assertIsElementAttributes(ownerOp.attributes);
 

--- a/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/attribute_extraction.ts
@@ -71,6 +71,10 @@ function populateElementAttributes(view: ViewCompilationUnit) {
         }
         break;
       case ir.OpKind.Property:
+        if (op.isAnimationTrigger) {
+          continue;  // Don't extract animation properties.
+        }
+
         ownerOp = lookupElement(elements, op.target);
         ir.assertIsElementAttributes(ownerOp.attributes);
 

--- a/packages/compiler/src/template/pipeline/src/phases/binding_specialization.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/binding_specialization.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import * as o from '../../../../output/output_ast';
 import * as ir from '../../ir';
 import {CompilationJob, HostBindingCompilationJob} from '../compilation';
 
@@ -53,14 +52,17 @@ export function phaseBindingSpecialization(job: CompilationJob): void {
           }
           break;
         case ir.BindingKind.Property:
+        case ir.BindingKind.Animation:
           if (job instanceof HostBindingCompilationJob) {
+            // TODO: host property animations
             ir.OpList.replace<ir.UpdateOp>(
                 op, ir.createHostPropertyOp(op.name, op.expression, op.sourceSpan));
           } else {
             ir.OpList.replace<ir.UpdateOp>(
                 op,
                 ir.createPropertyOp(
-                    op.target, op.name, op.expression, op.isTemplate, op.sourceSpan));
+                    op.target, op.name, op.expression, op.bindingKind === ir.BindingKind.Animation,
+                    op.isTemplate, op.sourceSpan));
           }
 
           break;

--- a/packages/compiler/src/template/pipeline/src/phases/chaining.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/chaining.ts
@@ -14,6 +14,7 @@ import {CompilationJob} from '../compilation';
 const CHAINABLE = new Set([
   R3.elementStart,
   R3.elementEnd,
+  R3.element,
   R3.property,
   R3.hostProperty,
   R3.styleProp,

--- a/packages/compiler/src/template/pipeline/src/phases/chaining.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/chaining.ts
@@ -29,6 +29,7 @@ const CHAINABLE = new Set([
   R3.stylePropInterpolate8,
   R3.stylePropInterpolateV,
   R3.classProp,
+  R3.listener,
   R3.elementContainerStart,
   R3.elementContainerEnd,
   R3.elementContainer,

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -43,15 +43,18 @@ function addNamesToView(
         break;
       case ir.OpKind.Listener:
         if (op.handlerFnName === null) {
-          // TODO(alxhub): convert this temporary name to match how the
-          // `TemplateDefinitionBuilder` names listener functions.
           if (op.slot === null) {
             throw new Error(`Expected a slot to be assigned`);
           }
           const safeTagName = op.tag.replace('-', '_');
-
-          op.handlerFnName =
-              sanitizeIdentifier(`${unit.fnName}_${safeTagName}_${op.name}_${op.slot}_listener`);
+          if (op.isAnimationListener) {
+            op.handlerFnName = sanitizeIdentifier(`${unit.fnName}_${safeTagName}_animation_${
+                op.name}_${op.animationPhase}_${op.slot}_listener`);
+            op.name = `@${op.name}.${op.animationPhase}`;
+          } else {
+            op.handlerFnName =
+                sanitizeIdentifier(`${unit.fnName}_${safeTagName}_${op.name}_${op.slot}_listener`);
+          }
         }
         break;
       case ir.OpKind.Variable:

--- a/packages/compiler/src/template/pipeline/src/phases/naming.ts
+++ b/packages/compiler/src/template/pipeline/src/phases/naming.ts
@@ -9,8 +9,8 @@
 import {sanitizeIdentifier} from '../../../../parse_util';
 import {hyphenate} from '../../../../render3/view/style_parser';
 import * as ir from '../../ir';
-import {type CompilationJob, type CompilationUnit, ViewCompilationUnit} from '../compilation';
-import {keyForNamespace, prefixWithNamespace} from '../conversion';
+import {ViewCompilationUnit, type CompilationJob, type CompilationUnit} from '../compilation';
+import {prefixWithNamespace} from '../conversion';
 
 /**
  * Generate names for functions and variables across all views.
@@ -36,6 +36,11 @@ function addNamesToView(
 
   for (const op of unit.ops()) {
     switch (op.kind) {
+      case ir.OpKind.Property:
+        if (op.isAnimationTrigger) {
+          op.name = '@' + op.name;
+        }
+        break;
       case ir.OpKind.Listener:
         if (op.handlerFnName === null) {
           // TODO(alxhub): convert this temporary name to match how the


### PR DESCRIPTION
Depends on #50818, #50805, #50899

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Template pipeline does not handle animation property or listener bindings correctly

## What is the new behavior?

Template pipeline handles animation property and listener bindings correctly

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
