### PR TITLE
Implement runtime deps tracker

### DIFF
--- a/goldens/public-api/core/errors.md
+++ b/goldens/public-api/core/errors.md
@@ -111,6 +111,8 @@ export const enum RuntimeErrorCode {
     // (undocumented)
     REQUIRE_SYNC_WITHOUT_SYNC_EMIT = 601,
     // (undocumented)
+    RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 1000,
+    // (undocumented)
     SIGNAL_WRITE_FROM_ILLEGAL_CONTEXT = 600,
     // (undocumented)
     TEMPLATE_STRUCTURE_ERROR = 305,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -108,6 +108,9 @@ export const enum RuntimeErrorCode {
   UNSAFE_IFRAME_ATTRS = -910,
   VIEW_ALREADY_DESTROYED = 911,
   COMPONENT_ID_COLLISION = -912,
+
+  // Runtime dependency tracker errors
+  RUNTIME_DEPS_INVALID_IMPORTED_TYPE = 1000,
 }
 
 

--- a/packages/core/src/render3/deps_tracker/api.ts
+++ b/packages/core/src/render3/deps_tracker/api.ts
@@ -8,14 +8,14 @@
 
 import {Type} from '../../core';
 import {NgModuleType} from '../../metadata/ng_module_def';
-import {ComponentType, DependencyTypeList, DirectiveTypeList, NgModuleScopeInfoFromDecorator, PipeTypeList} from '../interfaces/definition';
+import {ComponentType, DependencyTypeList, DirectiveType, NgModuleScopeInfoFromDecorator, PipeType} from '../interfaces/definition';
 
 /**
  * Represents the set of dependencies of a type in a certain context.
  */
 interface ScopeData {
-  pipes: PipeTypeList;
-  directives: DirectiveTypeList;
+  pipes: Set<PipeType<any>>;
+  directives: Set<DirectiveType<any>|ComponentType<any>|Type<any>>;
 
   /**
    * If true it indicates that calculating this scope somehow was not successful. The consumers

--- a/packages/core/src/render3/deps_tracker/api.ts
+++ b/packages/core/src/render3/deps_tracker/api.ts
@@ -58,10 +58,15 @@ export interface DepsTrackerApi {
    * present in the component's template (This set might contain directives/components/pipes not
    * necessarily used in the component's template depending on the implementation).
    *
+   * Standalone components should specify `rawImports` as this information is not available from
+   * their type. The consumer (e.g., {@link getStandaloneDefFunctions}) is expected to pass this
+   * parameter.
+   *
    * The implementation is expected to use some caching mechanism in order to optimize the resources
    * needed to do this computation.
    */
-  getComponentDependencies(cmp: ComponentType<any>): ComponentDependencies;
+  getComponentDependencies(cmp: ComponentType<any>, rawImports?: (Type<any>|(() => Type<any>))[]):
+      ComponentDependencies;
 
   /**
    * Registers an NgModule into the tracker with the given scope info.

--- a/packages/core/src/render3/deps_tracker/api.ts
+++ b/packages/core/src/render3/deps_tracker/api.ts
@@ -90,11 +90,16 @@ export interface DepsTrackerApi {
   getNgModuleScope(type: NgModuleType<any>): NgModuleScope;
 
   /**
-   * Returns the scope of standalone component. Mainly to be used by JIT.
+   * Returns the scope of standalone component. Mainly to be used by JIT. This method should be
+   * called lazily after the initial parsing so that all the forward refs can be resolved.
+   *
+   * @param rawImports the imports statement as appears on the component decorate which consists of
+   *     Type as well as forward refs.
    *
    * The scope value here is memoized. To enforce a new calculation bust the cache by using
    * `clearScopeCacheFor` method.
    */
-  getStandaloneComponentScope(type: ComponentType<any>, imports: Type<any>[]):
-      StandaloneComponentScope;
+  getStandaloneComponentScope(
+      type: ComponentType<any>,
+      rawImports: (Type<any>|(() => Type<any>))[]): StandaloneComponentScope;
 }

--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -6,9 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {Type} from '../../interface/type';
 import {NgModuleType} from '../../metadata/ng_module_def';
+import {getNgModuleDef, isStandalone} from '../definition';
 import {ComponentType, NgModuleScopeInfoFromDecorator} from '../interfaces/definition';
+import {isComponent, isDirective, isModuleWithProviders, isNgModule, isPipe} from '../jit/util';
+import {maybeUnwrapFn} from '../util/misc_utils';
 
 import {ComponentDependencies, DepsTrackerApi, NgModuleScope, StandaloneComponentScope} from './api';
 
@@ -38,17 +42,108 @@ class DepsTracker implements DepsTrackerApi {
 
   /** @override */
   getNgModuleScope(type: NgModuleType<any>): NgModuleScope {
-    // TODO: implement this.
-    return {exported: {directives: [], pipes: []}, compilation: {directives: [], pipes: []}};
+    if (this.ngModulesScopeCache.has(type)) {
+      return this.ngModulesScopeCache.get(type)!;
+    }
+
+    const scope = this.computeNgModuleScope(type);
+    this.ngModulesScopeCache.set(type, scope);
+
+    return scope;
+  }
+
+  /** Compute NgModule scope afresh. */
+  private computeNgModuleScope(type: NgModuleType<any>): NgModuleScope {
+    const def = getNgModuleDef(type, true);
+    const scope: NgModuleScope = {
+      exported: {directives: new Set(), pipes: new Set()},
+      compilation: {directives: new Set(), pipes: new Set()},
+    };
+
+    // Analyzing imports
+    for (const imported of maybeUnwrapFn(def.imports)) {
+      if (isNgModule(imported)) {
+        const importedScope = this.getNgModuleScope(imported);
+
+        // When this module imports another, the imported module's exported directives and pipes
+        // are added to the compilation scope of this module.
+        addSet(importedScope.exported.directives, scope.compilation.directives);
+        addSet(importedScope.exported.pipes, scope.compilation.pipes);
+      } else if (isStandalone(imported)) {
+        if (isDirective(imported) || isComponent(imported)) {
+          scope.compilation.directives.add(imported);
+        } else if (isPipe(imported)) {
+          scope.compilation.pipes.add(imported);
+        } else {
+          // The standalone thing is neither a component nor a directive nor a pipe ... (what?)
+          throw new RuntimeError(
+              RuntimeErrorCode.RUNTIME_DEPS_INVALID_IMPORTED_TYPE,
+              'The standalone imported type is neither a component nor a directive nor a pipe');
+        }
+      } else {
+        // The import is neither a module nor a module-with-providers nor a standalone thing. This
+        // is going to be an error. So we short circuit.
+        scope.compilation.isPoisoned = true;
+        break;
+      }
+    }
+
+    // Analyzing declarations
+    if (!scope.compilation.isPoisoned) {
+      for (const decl of maybeUnwrapFn(def.declarations)) {
+        // Cannot declare another NgModule or a standalone thing
+        if (isNgModule(decl) || isStandalone(decl)) {
+          scope.compilation.isPoisoned = true;
+          break;
+        }
+
+        if (isPipe(decl)) {
+          scope.compilation.pipes.add(decl);
+        } else {
+          // decl is either a directive or a component. The component may not yet have the ɵcmp due
+          // to async compilation.
+          scope.compilation.directives.add(decl);
+        }
+      }
+    }
+
+    // Analyzing exports
+    for (const exported of maybeUnwrapFn(def.exports)) {
+      if (isNgModule(exported)) {
+        // When this module exports another, the exported module's exported directives and pipes
+        // are added to both the compilation and exported scopes of this module.
+        const exportedScope = this.getNgModuleScope(exported);
+
+        // Based on the current logic there is no way to have poisoned exported scope. So no need to
+        // check for it.
+        addSet(exportedScope.exported.directives, scope.exported.directives);
+        addSet(exportedScope.exported.pipes, scope.exported.pipes);
+
+      } else if (isPipe(exported)) {
+        scope.exported.pipes.add(exported);
+      } else {
+        scope.exported.directives.add(exported);
+      }
+    }
+
+    return scope;
   }
 
   /** @override */
   getStandaloneComponentScope(type: ComponentType<any>, imports: Type<any>[]):
       StandaloneComponentScope {
     // TODO: implement this.
-    return {compilation: {directives: [], pipes: []}};
+    return {compilation: {directives: new Set(), pipes: new Set()}};
+  }
+}
+
+function addSet<T>(sourceSet: Set<T>, targetSet: Set<T>): void {
+  for (const m of sourceSet) {
+    targetSet.add(m);
   }
 }
 
 /** The deps tracker to be used in the current Angular app in dev mode. */
 export const depsTracker = new DepsTracker();
+
+export const TEST_ONLY = {DepsTracker};

--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -39,7 +39,11 @@ class DepsTracker implements DepsTrackerApi {
 
   /** @override */
   clearScopeCacheFor(type: ComponentType<any>|NgModuleType): void {
-    // TODO: implement this.
+    if (isNgModule(type)) {
+      this.ngModulesScopeCache.delete(type);
+    } else if (isComponent(type)) {
+      this.standaloneComponentsScopeCache.delete(type);
+    }
   }
 
   /** @override */

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -193,7 +193,7 @@ function getDependencyTypeForError(type: Type<any>) {
   return 'type';
 }
 
-function verifyStandaloneImport(depType: Type<unknown>, importingType: Type<unknown>) {
+export function verifyStandaloneImport(depType: Type<unknown>, importingType: Type<unknown>) {
   if (isForwardRef(depType)) {
     depType = resolveForwardRef(depType);
     if (!depType) {

--- a/packages/core/src/render3/jit/util.ts
+++ b/packages/core/src/render3/jit/util.ts
@@ -9,7 +9,8 @@
 import {ModuleWithProviders} from '../../di/interface/provider';
 import {Type} from '../../interface/type';
 import {NgModuleDef} from '../../metadata/ng_module_def';
-import {getNgModuleDef} from '../definition';
+import {getComponentDef, getDirectiveDef, getNgModuleDef, getPipeDef} from '../definition';
+import {ComponentType, DirectiveType, PipeType} from '../interfaces/definition';
 
 export function isModuleWithProviders(value: any): value is ModuleWithProviders<{}> {
   return (value as {ngModule?: any}).ngModule !== undefined;
@@ -17,4 +18,16 @@ export function isModuleWithProviders(value: any): value is ModuleWithProviders<
 
 export function isNgModule<T>(value: Type<T>): value is Type<T>&{ɵmod: NgModuleDef<T>} {
   return !!getNgModuleDef(value);
+}
+
+export function isPipe<T>(value: Type<T>): value is PipeType<T> {
+  return !!getPipeDef(value);
+}
+
+export function isDirective<T>(value: Type<T>): value is DirectiveType<T> {
+  return !!getDirectiveDef(value);
+}
+
+export function isComponent<T>(value: Type<T>): value is ComponentType<T> {
+  return !!getComponentDef(value);
 }

--- a/packages/core/test/render3/deps_tracker_spec.ts
+++ b/packages/core/test/render3/deps_tracker_spec.ts
@@ -8,7 +8,7 @@
 
 import {Component, Directive, forwardRef, NgModule, Pipe, Type} from '@angular/core';
 import {NgModuleDef} from '@angular/core/src/r3_symbols';
-import {NgModuleType} from '@angular/core/src/render3';
+import {ComponentType, NgModuleType} from '@angular/core/src/render3';
 
 import {TEST_ONLY} from '../../src/render3/deps_tracker/deps_tracker';
 
@@ -656,6 +656,168 @@ describe('runtime dependency tracker', () => {
              directives: new Set([Component1, Directive1]),
            });
          });
+    });
+  });
+
+  describe('getStandaloneComponentScope method', () => {
+    it('should only include the component itself in the compilation scope when there is no imports',
+       () => {
+         class MainComponent {}
+
+         const ans =
+             depsTracker.getStandaloneComponentScope(MainComponent as ComponentType<any>, []);
+
+         expect(ans.compilation).toEqual({
+           pipes: new Set([]),
+           directives: new Set([MainComponent]),
+         });
+       });
+
+    it('should include the imported standalone component/directive/pipes in the compilation scope',
+       () => {
+         @Component({standalone: true})
+         class Component1 {
+         }
+
+         @Directive({standalone: true})
+         class Directive1 {
+         }
+
+         @Pipe({name: 'pipe1', standalone: true})
+         class Pipe1 {
+         }
+
+         class MainComponent {}
+
+         const ans = depsTracker.getStandaloneComponentScope(
+             MainComponent as ComponentType<any>, [Component1, Directive1, Pipe1]);
+
+         expect(ans.compilation).toEqual({
+           pipes: new Set([Pipe1]),
+           directives: new Set([MainComponent, Component1, Directive1]),
+         });
+       });
+
+    it('should poison the compilation scope if an import is not standalone', () => {
+      @Component({})
+      class Component1 {
+      }
+
+      class MainComponent {}
+
+      const ans = depsTracker.getStandaloneComponentScope(
+          MainComponent as ComponentType<any>, [Component1]);
+
+      expect(ans.compilation.isPoisoned).toBeTrue();
+    });
+
+    it('should include the exported scope of an imported module in the compilation scope', () => {
+      @Directive({})
+      class Directive1 {
+      }
+
+      @Pipe({name: 'pipe1'})
+      class Pipe1 {
+      }
+
+      @Component({})
+      class Component1 {
+      }
+
+      @Component({})
+      class PrivateComponent {
+      }
+
+      @NgModule({
+        exports: [Directive1, Component1, Pipe1],
+        declarations: [PrivateComponent],
+      })
+      class SubSubModule {
+      }
+
+      class MainComponent {}
+
+      const ans = depsTracker.getStandaloneComponentScope(
+          MainComponent as ComponentType<any>, [SubSubModule]);
+
+      expect(ans.compilation).toEqual({
+        pipes: new Set([Pipe1]),
+        directives: new Set([MainComponent, Component1, Directive1]),
+      });
+    });
+
+    it('should resolve the imported forward refs and include them in the compilation scope', () => {
+      @Component({standalone: true})
+      class Component1 {
+      }
+
+      @Directive({standalone: true})
+      class Directive1 {
+      }
+
+      @Pipe({name: 'pipe1', standalone: true})
+      class Pipe1 {
+      }
+
+      @Component({})
+      class SubModuleComponent {
+      }
+
+      @Directive({})
+      class SubModuleDirective {
+      }
+
+      @Pipe({name: 'submodule pipe'})
+      class SubModulePipe {
+      }
+
+      @NgModule({exports: [SubModuleComponent, SubModulePipe, SubModuleDirective]})
+      class SubModule {
+      }
+
+      class MainComponent {}
+
+      const ans = depsTracker.getStandaloneComponentScope(MainComponent as ComponentType<any>, [
+        forwardRef(() => Component1), forwardRef(() => Directive1), forwardRef(() => Pipe1),
+        forwardRef(() => SubModule)
+      ]);
+
+      expect(ans.compilation).toEqual({
+        pipes: new Set([Pipe1, SubModulePipe]),
+        directives: new Set(
+            [MainComponent, Component1, Directive1, SubModuleComponent, SubModuleDirective]),
+      });
+    });
+
+    it('should cache the computed scopes', () => {
+      @Component({standalone: true})
+      class Component1 {
+      }
+
+      @Directive({standalone: true})
+      class Directive1 {
+      }
+
+      @Pipe({name: 'pipe1', standalone: true})
+      class Pipe1 {
+      }
+
+      class MainComponent {}
+
+      let ans = depsTracker.getStandaloneComponentScope(
+          MainComponent as ComponentType<any>, [Component1, Directive1, Pipe1]);
+
+      expect(ans.compilation).toEqual({
+        pipes: new Set([Pipe1]),
+        directives: new Set([MainComponent, Component1, Directive1]),
+      });
+
+      ans = depsTracker.getStandaloneComponentScope(MainComponent as ComponentType<any>, []);
+
+      expect(ans.compilation).toEqual({
+        pipes: new Set([Pipe1]),
+        directives: new Set([MainComponent, Component1, Directive1]),
+      });
     });
   });
 });

--- a/packages/core/test/render3/deps_tracker_spec.ts
+++ b/packages/core/test/render3/deps_tracker_spec.ts
@@ -1,0 +1,671 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, Directive, forwardRef, NgModule, Pipe, Type} from '@angular/core';
+import {NgModuleDef} from '@angular/core/src/r3_symbols';
+import {NgModuleType} from '@angular/core/src/render3';
+
+import {TEST_ONLY} from '../../src/render3/deps_tracker/deps_tracker';
+
+const {DepsTracker} = TEST_ONLY;
+
+describe('runtime dependency tracker', () => {
+  let depsTracker = new DepsTracker();
+
+  beforeEach(() => {
+    depsTracker = new DepsTracker();
+  });
+
+  describe('getNgModuleScope method', () => {
+    it('should include empty scope for a module without any import/declarations/exports', () => {
+      @NgModule({})
+      class MainModule {
+      }
+
+      const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+      expect(ans.compilation).toEqual({
+        directives: new Set(),
+        pipes: new Set(),
+      });
+      expect(ans.exported).toEqual({
+        directives: new Set(),
+        pipes: new Set(),
+      });
+    });
+
+    it('should throw if applied to a non NgModule type', () => {
+      class RandomClass {}
+
+      expect(() => depsTracker.getNgModuleScope(RandomClass as NgModuleType)).toThrow();
+    });
+
+    describe('exports specs', () => {
+      it('should include the exported components/directives/pipes in exported scope', () => {
+        @Directive({})
+        class Directive1 {
+        }
+
+        @Pipe({name: 'pipe1'})
+        class Pipe1 {
+        }
+
+        @Component({})
+        class Component1 {
+        }
+
+        // No ɵcmp added yet.
+        class AsyncComponent {}
+
+        @NgModule({
+          exports: [Directive1, Pipe1, Component1, AsyncComponent],
+        })
+        class MainModule {
+        }
+
+        const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+        expect(ans.exported).toEqual({
+          pipes: new Set([Pipe1]),
+          directives: new Set([Directive1, Component1, AsyncComponent]),
+        });
+      });
+
+      it('should include the exported scope of an exported module in the exported scope', () => {
+        @Directive({})
+        class Directive1 {
+        }
+
+        @Pipe({name: 'pipe1'})
+        class Pipe1 {
+        }
+
+        @Component({})
+        class Component1 {
+        }
+
+        @NgModule({
+          exports: [Directive1, Pipe1, Component1],
+        })
+        class SubModule {
+        }
+
+        @NgModule({
+          exports: [SubModule],
+        })
+        class MainModule {
+        }
+
+        const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+        expect(ans.exported).toEqual({
+          pipes: new Set([Pipe1]),
+          directives: new Set([Directive1, Component1]),
+        });
+
+        expect(ans.compilation).toEqual({
+          pipes: new Set(),
+          directives: new Set(),
+        });
+      });
+
+      it('should combine the directly exported elements with the exported scope of exported module',
+         () => {
+           @Directive({})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1'})
+           class Pipe1 {
+           }
+
+           @Component({})
+           class Component1 {
+           }
+
+           @NgModule({
+             exports: [Directive1, Pipe1, Component1],
+           })
+           class SubModule {
+           }
+
+           @Component({})
+           class MainComponent {
+           }
+
+           @NgModule({
+             exports: [SubModule, MainComponent, Directive1, Pipe1, Component1],
+           })
+           class MainModule {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.exported).toEqual({
+             pipes: new Set([Pipe1]),
+             directives: new Set([Directive1, Component1, MainComponent]),
+           });
+
+           expect(ans.compilation).toEqual({
+             pipes: new Set(),
+             directives: new Set(),
+           });
+         });
+    });
+
+    describe('import specs', () => {
+      it('should contain the exported scope of an imported module in compilation scope', () => {
+        @Directive({})
+        class Directive1 {
+        }
+
+        @Pipe({name: 'pipe1'})
+        class Pipe1 {
+        }
+
+        @Component({})
+        class Component1 {
+        }
+
+        @Component({})
+        class PrivateComponent {
+        }
+
+        @NgModule({
+          exports: [Directive1, Component1, Pipe1],
+          declarations: [PrivateComponent],
+        })
+        class SubModule {
+        }
+
+        @NgModule({
+          imports: [SubModule],
+        })
+        class MainModule {
+        }
+
+        const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+        expect(ans.compilation).toEqual({
+          directives: new Set([Directive1, Component1]),
+          pipes: new Set([Pipe1]),
+        });
+      });
+
+      it('should contain imported standalone components/directive/pipes in compilation scope',
+         () => {
+           @Directive({standalone: true})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1', standalone: true})
+           class Pipe1 {
+           }
+
+           @Component({standalone: true})
+           class Component1 {
+           }
+
+           @NgModule({
+             imports: [Directive1, Pipe1, Component1],
+           })
+           class MainModule {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation).toEqual({
+             directives: new Set([Directive1, Component1]),
+             pipes: new Set([Pipe1]),
+           });
+         });
+
+      it('should contain the exported scope of a depth-2 transitively imported module in compilation scope',
+         () => {
+           @Directive({})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1'})
+           class Pipe1 {
+           }
+
+           @Component({})
+           class Component1 {
+           }
+
+           @Component({})
+           class PrivateComponent {
+           }
+
+           @NgModule({
+             exports: [Directive1, Component1, Pipe1],
+             declarations: [PrivateComponent],
+           })
+           class SubSubModule {
+           }
+
+           @NgModule({exports: [SubSubModule]})
+           class SubModule {
+           }
+
+           @NgModule({
+             imports: [SubModule],
+           })
+           class MainModule {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation).toEqual({
+             directives: new Set([Directive1, Component1]),
+             pipes: new Set([Pipe1]),
+           });
+         });
+
+      it('should poison compilation scope if an import is neither a NgModule nor a standalone component',
+         () => {
+           class RandomClass {}
+
+           @NgModule({
+             imports: [RandomClass],
+           })
+           class MainModule {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation.isPoisoned).toBeTrue();
+         });
+    });
+
+    describe('declarations specs', () => {
+      it('should include declared components/directives/pipes as part of compilation scope', () => {
+        @Directive({})
+        class Directive1 {
+        }
+
+        @Pipe({name: 'pipe1'})
+        class Pipe1 {
+        }
+
+        @Component({})
+        class Component1 {
+        }
+
+        // No ɵcmp added yet.
+        class AsyncComponent {}
+
+        @NgModule({
+          declarations: [Directive1, Pipe1, Component1, AsyncComponent],
+        })
+        class MainModule {
+        }
+
+        const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+        expect(ans.compilation).toEqual({
+          pipes: new Set([Pipe1]),
+          directives: new Set([Directive1, Component1, AsyncComponent]),
+        });
+        expect(ans.exported).toEqual({
+          pipes: new Set(),
+          directives: new Set(),
+        });
+      });
+
+      it('should poison the compilation scope if a standalone component is declared', () => {
+        @Component({standalone: true})
+        class Component1 {
+        }
+
+        @NgModule({
+          declarations: [Component1],
+        })
+        class MainModule {
+        }
+
+        const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+        expect(ans.compilation.isPoisoned).toBeTrue();
+      });
+
+      it('should poison compilation scope if declare a module', () => {
+        @NgModule({})
+        class SubModule {
+        }
+
+        @NgModule({
+          declarations: [SubModule],
+        })
+        class MainModule {
+        }
+
+        const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+        expect(ans.compilation.isPoisoned).toBeTrue();
+      });
+    });
+
+    describe('cache specs', () => {
+      it('should use cache for re-calculation', () => {
+        @Component({})
+        class Component1 {
+        }
+
+        @NgModule({
+          declarations: [Component1],
+        })
+        class MainModule {
+        }
+
+        let ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+        expect(ans.compilation).toEqual({
+          pipes: new Set(),
+          directives: new Set([Component1]),
+        });
+
+        // Modify the the module
+        (MainModule as NgModuleType).ɵmod.declarations = [];
+
+        ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+        expect(ans.compilation).toEqual({
+          pipes: new Set(),
+          directives: new Set([Component1]),
+        });
+      });
+    });
+
+    describe('forward ref specs', () => {
+      it('should include the exported scope of a forward ref imported module in the compilation scope when compiling in JIT mode',
+         () => {
+           @NgModule({imports: [forwardRef(() => SubModule)]})
+           class MainModule {
+           }
+
+           @Component({})
+           class Component1 {
+           }
+
+           @Directive({})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1'})
+           class Pipe1 {
+           }
+
+           @NgModule({exports: [Component1, Directive1, Pipe1]})
+           class SubModule {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation).toEqual({
+             pipes: new Set([Pipe1]),
+             directives: new Set([Component1, Directive1]),
+           });
+         });
+
+      it('should include the exported scope of a forward ref imported module in the compilation scope when compiling in AOT mode',
+         () => {
+           class MainModule {}
+           (MainModule as NgModuleType).ɵmod = createNgModuleDef({imports: () => ([SubModule])});
+
+           @Component({})
+           class Component1 {
+           }
+
+           @Directive({})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1'})
+           class Pipe1 {
+           }
+
+           @NgModule({exports: [Component1, Directive1, Pipe1]})
+           class SubModule {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation).toEqual({
+             pipes: new Set([Pipe1]),
+             directives: new Set([Component1, Directive1]),
+           });
+         });
+
+      it('should include forward ref imported standalone component in the compilation scope when compiling in JIT mode',
+         () => {
+           @NgModule({imports: [forwardRef(() => Component1)]})
+           class MainModule {
+           }
+
+           @Component({standalone: true})
+           class Component1 {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation).toEqual({
+             pipes: new Set([]),
+             directives: new Set([Component1]),
+           });
+         });
+
+      it('should include forward ref imported standalone component in the compilation scope when compiling in AOT mode',
+         () => {
+           class MainModule {}
+           (MainModule as NgModuleType).ɵmod = createNgModuleDef({imports: () => ([Component1])});
+
+           @Component({standalone: true})
+           class Component1 {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation).toEqual({
+             pipes: new Set([]),
+             directives: new Set([Component1]),
+           });
+         });
+
+      it('should include the forward ref declarations in the compilation scope when compiling in JIT mode',
+         () => {
+           @NgModule({
+             declarations: [
+               forwardRef(() => Component1), forwardRef(() => Directive1), forwardRef(() => Pipe1)
+             ],
+           })
+           class MainModule {
+           }
+
+           @Component({})
+           class Component1 {
+           }
+
+           @Directive({})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1'})
+           class Pipe1 {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation).toEqual({
+             pipes: new Set([Pipe1]),
+             directives: new Set([Component1, Directive1]),
+           });
+         });
+
+      it('should include the forward ref declarations in the compilation scope when compiling in AOT mode',
+         () => {
+           class MainModule {}
+           (MainModule as NgModuleType).ɵmod =
+               createNgModuleDef({declarations: () => ([Component1, Directive1, Pipe1])});
+
+           @Component({})
+           class Component1 {
+           }
+
+           @Directive({})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1'})
+           class Pipe1 {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation).toEqual({
+             pipes: new Set([Pipe1]),
+             directives: new Set([Component1, Directive1]),
+           });
+         });
+
+      it('should include the exported forward ref components/directives/pipes in exported scope when compiling in JIT mode',
+         () => {
+           @NgModule({
+             exports: [
+               forwardRef(() => Component1), forwardRef(() => Directive1), forwardRef(() => Pipe1)
+             ],
+           })
+           class MainModule {
+           }
+
+           @Component({})
+           class Component1 {
+           }
+
+           @Directive({})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1'})
+           class Pipe1 {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.exported).toEqual({
+             pipes: new Set([Pipe1]),
+             directives: new Set([Component1, Directive1]),
+           });
+         });
+
+      it('should include the exported forward ref components/directives/pipes in exported scope when compiling in AOT mode',
+         () => {
+           class MainModule {}
+           (MainModule as NgModuleType).ɵmod =
+               createNgModuleDef({exports: () => ([Component1, Directive1, Pipe1])});
+
+           @Component({})
+           class Component1 {
+           }
+
+           @Directive({})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1'})
+           class Pipe1 {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.exported).toEqual({
+             pipes: new Set([Pipe1]),
+             directives: new Set([Component1, Directive1]),
+           });
+         });
+
+      it('should include the exported scope of an exported forward ref module in the exported scope when compiling in JIT mode',
+         () => {
+           @NgModule({exports: [forwardRef(() => SubModule)]})
+           class MainModule {
+           }
+
+           @Component({})
+           class Component1 {
+           }
+
+           @Directive({})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1'})
+           class Pipe1 {
+           }
+
+           @NgModule({exports: [Component1, Directive1, Pipe1]})
+           class SubModule {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation).toEqual({
+             pipes: new Set(),
+             directives: new Set(),
+           });
+           expect(ans.exported).toEqual({
+             pipes: new Set([Pipe1]),
+             directives: new Set([Component1, Directive1]),
+           });
+         });
+
+      it('should include the exported scope of an exported forward ref module in the exported scope when compiling in AOT mode',
+         () => {
+           class MainModule {}
+           (MainModule as NgModuleType).ɵmod = createNgModuleDef({exports: () => ([SubModule])});
+
+           @Component({})
+           class Component1 {
+           }
+
+           @Directive({})
+           class Directive1 {
+           }
+
+           @Pipe({name: 'pipe1'})
+           class Pipe1 {
+           }
+
+           @NgModule({exports: [Component1, Directive1, Pipe1]})
+           class SubModule {
+           }
+
+           const ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
+
+           expect(ans.compilation).toEqual({
+             pipes: new Set(),
+             directives: new Set(),
+           });
+           expect(ans.exported).toEqual({
+             pipes: new Set([Pipe1]),
+             directives: new Set([Component1, Directive1]),
+           });
+         });
+    });
+  });
+});
+
+function createNgModuleDef(data: Partial<NgModuleDef<any>>): NgModuleDef<any> {
+  return {
+    bootstrap: [],
+    declarations: [],
+    exports: [],
+    imports: [],
+    ...data,
+  } as NgModuleDef<any>;
+}


### PR DESCRIPTION
An initial implementation which captures what we need for both JIT and local compilations. This PR only changes deps tracker files which are NOT being used anywhere yet. So this change does not affect anything. In a follow up PR I'll migrate JIT compilation to use this deps tracker (instead of transitiveScopesFor tools and monkey patching) and hopefully it will break lots of tests cross g3 and worldwide which makes it look like I have done something ...

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
