### PR TITLE
fix(core): handle `deref` returning `null` on `RefactiveNode`.

### DIFF
--- a/packages/core/src/signals/src/graph.ts
+++ b/packages/core/src/signals/src/graph.ts
@@ -149,7 +149,9 @@ export abstract class ReactiveNode {
     for (const [producerId, edge] of this.producers) {
       const producer = edge.producerNode.deref();
 
-      if (producer === undefined || edge.atTrackingVersion !== this.trackingVersion) {
+      // On Safari < 16.1 deref can return null, we need to check for null also.
+      // See https://github.com/WebKit/WebKit/commit/44c15ba58912faab38b534fef909dd9e13e095e0
+      if (producer == null || edge.atTrackingVersion !== this.trackingVersion) {
         // This dependency edge is stale, so remove it.
         this.producers.delete(producerId);
         producer?.consumers.delete(this.id);
@@ -177,7 +179,10 @@ export abstract class ReactiveNode {
     try {
       for (const [consumerId, edge] of this.consumers) {
         const consumer = edge.consumerNode.deref();
-        if (consumer === undefined || consumer.trackingVersion !== edge.atTrackingVersion) {
+
+        // On Safari < 16.1 deref can return null, we need to check for null also.
+        // See https://github.com/WebKit/WebKit/commit/44c15ba58912faab38b534fef909dd9e13e095e0
+        if (consumer == null || consumer.trackingVersion !== edge.atTrackingVersion) {
           this.consumers.delete(consumerId);
           consumer?.producers.delete(this.id);
           continue;


### PR DESCRIPTION
On Safari <16.1 there is a bug where `deref` can return `null`.

Fixes #50989

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] No