### PR TITLE
perf(platform-browser): use `WeakRef` to perform renderer cleanup

### DIFF
--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -28,7 +28,7 @@ export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/r
 export {allowSanitizationBypassAndThrow as ɵallowSanitizationBypassAndThrow, BypassType as ɵBypassType, getSanitizationBypassType as ɵgetSanitizationBypassType, SafeHtml as ɵSafeHtml, SafeResourceUrl as ɵSafeResourceUrl, SafeScript as ɵSafeScript, SafeStyle as ɵSafeStyle, SafeUrl as ɵSafeUrl, SafeValue as ɵSafeValue, unwrapSafeValue as ɵunwrapSafeValue} from './sanitization/bypass';
 export {_sanitizeHtml as ɵ_sanitizeHtml} from './sanitization/html_sanitizer';
 export {_sanitizeUrl as ɵ_sanitizeUrl} from './sanitization/url_sanitizer';
-export {setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl} from './signals';
+export {newWeakRef as ɵnewWeakRef, setAlternateWeakRefImpl as ɵsetAlternateWeakRefImpl, WeakRef as ɵWeakRef} from './signals';
 export {TESTABILITY as ɵTESTABILITY, TESTABILITY_GETTER as ɵTESTABILITY_GETTER} from './testability/testability';
 export {booleanAttribute, numberAttribute} from './util/coercion';
 export {devModeEqual as ɵdevModeEqual} from './util/comparison';

--- a/packages/core/src/signals/index.ts
+++ b/packages/core/src/signals/index.ts
@@ -13,4 +13,4 @@ export {ReactiveNode, setActiveConsumer} from './src/graph';
 export {CreateSignalOptions, setPostSignalSetFn, signal, WritableSignal} from './src/signal';
 export {untracked} from './src/untracked';
 export {Watch, WatchCleanupFn} from './src/watch';
-export {setAlternateWeakRefImpl} from './src/weak_ref';
+export {newWeakRef, setAlternateWeakRefImpl, WeakRef} from './src/weak_ref';

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -1236,6 +1236,9 @@
     "name": "nativeInsertBefore"
   },
   {
+    "name": "newWeakRef"
+  },
+  {
     "name": "nextNgElementId"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -1302,6 +1302,9 @@
     "name": "nativeInsertBefore"
   },
   {
+    "name": "newWeakRef"
+  },
+  {
     "name": "nextNgElementId"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -1041,6 +1041,9 @@
     "name": "nativeInsertBefore"
   },
   {
+    "name": "newWeakRef"
+  },
+  {
     "name": "nextNgElementId"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -1443,6 +1443,9 @@
     "name": "nativeParentNode"
   },
   {
+    "name": "newWeakRef"
+  },
+  {
     "name": "nextNgElementId"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -1404,6 +1404,9 @@
     "name": "nativeParentNode"
   },
   {
+    "name": "newWeakRef"
+  },
+  {
     "name": "nextBindingIndex"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -1113,6 +1113,9 @@
     "name": "nativeRemoveNode"
   },
   {
+    "name": "newWeakRef"
+  },
+  {
     "name": "nextNgElementId"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1692,6 +1692,9 @@
     "name": "navigationCancelingError"
   },
   {
+    "name": "newWeakRef"
+  },
+  {
     "name": "nextBindingIndex"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -918,6 +918,9 @@
     "name": "nativeInsertBefore"
   },
   {
+    "name": "newWeakRef"
+  },
+  {
     "name": "nextNgElementId"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -1242,6 +1242,9 @@
     "name": "nativeParentNode"
   },
   {
+    "name": "newWeakRef"
+  },
+  {
     "name": "nextBindingIndex"
   },
   {


### PR DESCRIPTION
Prior to this change, we removed the renders from the cache once there were more usages. This in some cases caused an increase in scripting example when removing a component and immediately re-creating it. This uses `WeakRef` to avoid this.

Related to: http://b/290666638