### PR TITLE
refactor(compiler-cli): add internal compiler option to control NgModule selector scope emit

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -178,7 +178,8 @@ export class NgModuleDecoratorHandler implements
       private refEmitter: ReferenceEmitter, private annotateForClosureCompiler: boolean,
       private onlyPublishPublicTypings: boolean,
       private injectableRegistry: InjectableClassRegistry, private perf: PerfRecorder,
-      private includeClassMetadata: boolean, private readonly compilationMode: CompilationMode) {}
+      private includeClassMetadata: boolean, private includeSelectorScope: boolean,
+      private readonly compilationMode: CompilationMode) {}
 
   readonly precedence = HandlerPrecedence.PRIMARY;
   readonly name = 'NgModuleDecoratorHandler';
@@ -381,7 +382,8 @@ export class NgModuleDecoratorHandler implements
         id,
         // Use `ɵɵsetNgModuleScope` to patch selector scopes onto the generated definition in a
         // tree-shakeable way.
-        selectorScopeMode: R3SelectorScopeMode.SideEffect,
+        selectorScopeMode: this.includeSelectorScope ? R3SelectorScopeMode.SideEffect :
+                                                       R3SelectorScopeMode.Omit,
         // TODO: to be implemented as a part of FW-1004.
         schemas: [],
       };

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/test/ng_module_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/test/ng_module_spec.ts
@@ -42,7 +42,7 @@ function setup(program: ts.Program, compilationMode = CompilationMode.FULL) {
       exportedProviderStatusResolver, /* semanticDepGraphUpdater */ null,
       /* isCore */ false, refEmitter,
       /* annotateForClosureCompiler */ false,
-      /* onlyPublishPublicTypings */ false, injectableRegistry, NOOP_PERF_RECORDER, true,
+      /* onlyPublishPublicTypings */ false, injectableRegistry, NOOP_PERF_RECORDER, true, true,
       compilationMode);
 
   return {handler, reflectionHost};
@@ -127,9 +127,9 @@ runInEachFileSystem(() => {
                 contents: `
                   import {NgModule} from '@angular/core';
                   import {SomeModule} from './some_where';
-                  
+
                   @NgModule({
-                    imports: [SomeModule],              
+                    imports: [SomeModule],
                   }) class TestModule {}
               `
               }
@@ -157,9 +157,9 @@ runInEachFileSystem(() => {
                 contents: `
                   import {NgModule} from '@angular/core';
                   import {SomeModule} from './some_where';
-                  
+
                   @NgModule({
-                    exports: [SomeModule],              
+                    exports: [SomeModule],
                   }) class TestModule {}
               `
               }
@@ -187,9 +187,9 @@ runInEachFileSystem(() => {
                 contents: `
                   import {NgModule} from '@angular/core';
                   import {SomeComponent} from './some_where';
-                  
+
                   @NgModule({
-                    declarations: [SomeComponent],              
+                    declarations: [SomeComponent],
                   }) class TestModule {}
               `
               }
@@ -217,9 +217,9 @@ runInEachFileSystem(() => {
                 contents: `
                   import {NgModule} from '@angular/core';
                   import {SomeComponent} from './some_where';
-                  
+
                   @NgModule({
-                    bootstrap: [SomeComponent],              
+                    bootstrap: [SomeComponent],
                   }) class TestModule {}
               `
               }
@@ -247,9 +247,9 @@ runInEachFileSystem(() => {
                 contents: `
                   import {NgModule, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
                   import {SomeComponent} from './some_where';
-                  
+
                   @NgModule({
-                    schemas: [CUSTOM_ELEMENTS_SCHEMA],         
+                    schemas: [CUSTOM_ELEMENTS_SCHEMA],
                   }) class TestModule {}
               `
               }

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -55,6 +55,17 @@ export interface InternalOptions {
    * @internal
    */
   supportTestBed?: boolean;
+
+  /**
+   * Enables the usage of the JIT compiler in combination with AOT compiled code by emitting
+   * selector scope information for NgModules.
+   *
+   * This is only intended to be used by the Angular CLI.
+   * Defaults to true if not specified.
+   *
+   * @internal
+   */
+  supportJitMode?: boolean;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -1041,6 +1041,7 @@ export class NgCompiler {
         CycleHandlingStrategy.Error;
 
     const strictCtorDeps = this.options.strictInjectionParameters || false;
+    const supportJitMode = this.options.supportJitMode ?? true;
     const supportTestBed = this.options.supportTestBed ?? true;
 
     // Libraries compiled in partial mode could potentially be used with TestBed within an
@@ -1049,6 +1050,10 @@ export class NgCompiler {
     if (supportTestBed === false && compilationMode === CompilationMode.PARTIAL) {
       throw new Error(
           'TestBed support ("supportTestBed" option) cannot be disabled in partial compilation mode.');
+    }
+    if (supportJitMode === false && compilationMode === CompilationMode.PARTIAL) {
+      throw new Error(
+          'JIT mode support ("supportJitMode" option) cannot be disabled in partial compilation mode.');
     }
 
     // Set up the IvyCompilation, which manages state for the Ivy transformer.
@@ -1088,7 +1093,8 @@ export class NgCompiler {
           reflector, evaluator, metaReader, metaRegistry, ngModuleScopeRegistry, referencesRegistry,
           exportedProviderStatusResolver, semanticDepGraphUpdater, isCore, refEmitter,
           this.closureCompilerEnabled, this.options.onlyPublishPublicTypingsForNgModules ?? false,
-          injectableRegistry, this.delegatingPerfRecorder, supportTestBed, compilationMode),
+          injectableRegistry, this.delegatingPerfRecorder, supportTestBed, supportJitMode,
+          compilationMode),
     ];
 
     const traitCompiler = new TraitCompiler(

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -4909,6 +4909,60 @@ function allTests(os: string) {
               trim('MyModule.ɵmod = /*@__PURE__*/ i0.ɵɵdefineNgModule({ type: MyModule });'));
     });
 
+    it('should emit setNgModuleScope calls for NgModules by default', () => {
+      env.write('test.ts', `
+      import {Component, Directive, Injectable, NgModule, Pipe} from '@angular/core';
+
+      @Component({selector: 'cmp', template: 'I am a component!'}) class TestComponent {}
+      @Directive({selector: 'dir'}) class TestDirective {}
+      @Injectable() class TestInjectable {}
+      @NgModule({declarations: [TestComponent, TestDirective]}) class TestNgModule {}
+      @Pipe({name: 'pipe'}) class TestPipe {}
+    `);
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).toContain('\u0275setNgModuleScope(TestNgModule, ');
+    });
+
+    it('should emit setNgModuleScope calls for NgModules when supportJitMode is true', () => {
+      env.tsconfig({
+        'supportJitMode': true,
+      });
+      env.write('test.ts', `
+      import {Component, Directive, Injectable, NgModule, Pipe} from '@angular/core';
+
+      @Component({selector: 'cmp', template: 'I am a component!'}) class TestComponent {}
+      @Directive({selector: 'dir'}) class TestDirective {}
+      @Injectable() class TestInjectable {}
+      @NgModule({declarations: [TestComponent, TestDirective]}) class TestNgModule {}
+      @Pipe({name: 'pipe'}) class TestPipe {}
+    `);
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).toContain('\u0275setNgModuleScope(TestNgModule, ');
+    });
+
+    it('should not emit setNgModuleScope calls for NgModules when supportJitMode is false', () => {
+      env.tsconfig({
+        'supportJitMode': false,
+      });
+      env.write('test.ts', `
+      import {Component, Directive, Injectable, NgModule, Pipe} from '@angular/core';
+
+      @Component({selector: 'cmp', template: 'I am a component!'}) class TestComponent {}
+      @Directive({selector: 'dir'}) class TestDirective {}
+      @Injectable() class TestInjectable {}
+      @NgModule({declarations: [TestComponent, TestDirective]}) class TestNgModule {}
+      @Pipe({name: 'pipe'}) class TestPipe {}
+    `);
+
+      env.driveMain();
+      const jsContents = env.getContents('test.js');
+      expect(jsContents).not.toContain('\u0275setNgModuleScope(');
+    });
+
     it('should emit setClassMetadata calls for all types by default', () => {
       env.write('test.ts', `
       import {Component, Directive, Injectable, NgModule, Pipe} from '@angular/core';


### PR DESCRIPTION
An internal compiler option named `supportJitMode` is now available for use by the Angular CLI. This option currently controls the emit of NgModule selector scope information. This emitted information is only needed in AOT mode when an application also uses JIT. However, AOT mode combined with JIT mode is not currently supported nor will work in the Angular CLI. With the Angular CLI, JIT mode is only supported if the entire application is built in JIT mode. Without this option, the CLI needs to manually perform a code transform to remove the information and also replicate TypeScript's import eliding. This is can be a complicated operation and must be continually kept up to date with any changes to both the Angular compiler and TypeScript. The introduction of this new option alleviates these concerns while also removing several build time actions that would otherwise need to be performed on every application build.
