### PR TITLE
fix(core): fixed function overloading with createSignalFromFunction that didn't have a matching implementation

### DIFF
--- a/packages/core/src/signals/src/api.ts
+++ b/packages/core/src/signals/src/api.ts
@@ -54,14 +54,14 @@ export function createSignalFromFunction<T>(node: ReactiveNode, fn: () => T): Si
  *     desired interface for the `Signal`.
  */
 export function createSignalFromFunction<T, U extends Record<string, unknown>>(
-    node: ReactiveNode, fn: () => T, extraApi: U): Signal<T>&U;
+  node: ReactiveNode, fn: () => T, extraApi: U): Signal<T>&U;
 
 /**
  * Converts `fn` into a marked signal function (where `isSignal(fn)` will be `true`), and
  * potentially add some set of extra properties (passed as an object record `extraApi`).
  */
 export function createSignalFromFunction<T, U extends Record<string, unknown> = {}>(
-    node: ReactiveNode, fn: () => T, extraApi: U = ({} as U)): Signal<T>&U {
+  node: ReactiveNode, fn: () => T, extraApi?: U): Signal<T>&U {
   (fn as any)[SIGNAL] = node;
   // Copy properties from `extraApi` to `fn` to complete the desired API of the `Signal`.
   return Object.assign(fn, extraApi) as (Signal<T>& U);


### PR DESCRIPTION
In the original code, extraApi wasn't optional in the function implementation, contradicting the overload signatures. By making extraApi optional, the function now aligns with its overload signatures and works correctly with either two or three arguments.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [X] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No
