### PR TITLE
ci: remove GHA lint job from required statuses

### DIFF
--- a/.github/angular-robot.yml
+++ b/.github/angular-robot.yml
@@ -69,7 +69,6 @@ merge:
     # list of PR statuses that need to be successful
     requiredStatuses:
       - 'ci/circleci: build'
-      - 'CI / lint (pull_request)'
       - 'google-internal-tests'
       - 'pullapprove'
 


### PR DESCRIPTION
Remove the GHA lint job from required statuses as it is a Github Check and Angular Robot doesn't find it
