### PR TITLE
docs: add privacy policy link at the bottom of the page

### DIFF
--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -1531,6 +1531,11 @@
           "url": "https://github.com/angular/code-of-conduct/blob/main/CODE_OF_CONDUCT.md",
           "title": "Code of Conduct",
           "tooltip": "Treating each other with respect."
+        },
+        {
+          "url": "https://policies.google.com/privacy",
+          "title": "Privacy Policy",
+          "tooltip": "Learn about Google's privacy policy."
         }
       ]
     },


### PR DESCRIPTION
We currently show a link to the privacy policy in the cookie pop-up and based on recommendation we are also adding it to the bottom of the page.
