### PR TITLE
docs(docs-infra): typo in first-app-lesson-04.md

### DIFF
--- a/aio/content/tutorial/first-app/first-app-lesson-04.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-04.md
@@ -92,7 +92,7 @@ There are a few more lessons to complete before that happens.
 
     <code-example header="src/app/home/home.component.ts" path="first-app-lesson-04/src/app/home/home.component.ts"></code-example>
 
-    By adding the `housingLocation` property of type `HousingLocation` to the `HomeComponent` class, we're able to confirm that the data matches the description of the interface. If the data didn't satisfy the description of the if the IDE has enough information to give us helpful errors.
+    By adding the `housingLocation` property of type `HousingLocation` to the `HomeComponent` class, we're able to confirm that the data matches the description of the interface. If the data didn't satisfy the description of the interface, the IDE has enough information to give us helpful errors.
 
 1.  Save your changes and confirm the app does not have any errors. Open the browser and confirm that your application still displays the message "housing-location works!"
 


### PR DESCRIPTION
docs(docs-infra): Typo in first-app-lesson-04.md

fix an error in the description of Step 3 paragraph 5: 
instead of
"If the data didn't satisfy the description of the *IF* the IDE has enough information to give us helpful errors."
the correct text is now
"If the data didn't satisfy the description of the *INTERFACE,* the IDE has enough information to give us helpful errors."

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?


- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Wrong sentence in docs:
 If the data didn't satisfy the description of the if the IDE has enough information to give us helpful errors.

Issue Number: N/A


## What is the new behavior?
Correct sentence in docs:
 If the data didn't satisfy the description of the interface, the IDE has enough information to give us helpful errors.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No




## Other information
