### PR TITLE
fix(forms): handle controls with inherited property names

### DIFF
--- a/packages/forms/src/model/form_group.ts
+++ b/packages/forms/src/model/form_group.ts
@@ -206,7 +206,7 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
       control: AbstractControl<any>): AbstractControl<any>;
 
   registerControl<K extends string&keyof TControl>(name: K, control: TControl[K]): TControl[K] {
-    if (this.controls[name]) return (this.controls as any)[name];
+    if (this.controls.hasOwnProperty(name)) return (this.controls as any)[name];
     this.controls[name] = control;
     control.setParent(this as FormGroup);
     control._registerOnCollectionChange(this._onCollectionChange);
@@ -265,7 +265,7 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
    * removed. When false, no events are emitted.
    */
   removeControl(name: string, options: {emitEvent?: boolean;} = {}): void {
-    if ((this.controls as any)[name])
+    if ((this.controls as any).hasOwnProperty(name))
       (this.controls as any)[name]._registerOnCollectionChange(() => {});
     delete ((this.controls as any)[name]);
     this.updateValueAndValidity({emitEvent: options.emitEvent});
@@ -296,7 +296,8 @@ export class FormGroup<TControl extends {[K in keyof TControl]: AbstractControl<
   setControl<K extends string&keyof TControl>(name: K, control: TControl[K], options: {
     emitEvent?: boolean
   } = {}): void {
-    if (this.controls[name]) this.controls[name]._registerOnCollectionChange(() => {});
+    if (this.controls.hasOwnProperty(name))
+      this.controls[name]._registerOnCollectionChange(() => {});
     delete (this.controls[name]);
     if (control) this.registerControl(name, control);
     this.updateValueAndValidity({emitEvent: options.emitEvent});

--- a/packages/forms/test/form_group_spec.ts
+++ b/packages/forms/test/form_group_spec.ts
@@ -202,6 +202,22 @@ describe('FormGroup', () => {
          expect(g.valid).toBe(false);
          expect(logger).toEqual([]);
        });
+
+    it('should add control with inherited property name', () => {
+      const g: FormGroup = new FormGroup({});
+
+      g.addControl('valueOf', new FormControl('1'));
+
+      expect(g.value).toEqual({'valueOf': '1'});
+    });
+
+    it('should remove control with inherited property name', () => {
+      const g: FormGroup = new FormGroup({valueOf: new FormControl('1')});
+
+      g.removeControl('valueOf');
+
+      expect(g.value).toEqual({});
+    });
   });
 
   describe('dirty', () => {
@@ -1929,6 +1945,18 @@ describe('FormGroup', () => {
       g.statusChanges.subscribe(() => logger.push('status change'));
       g.setControl('one', c2, {emitEvent: false});
       expect(logger).toEqual([]);
+    });
+
+    it('should replace existing control with inherited property name with new control', () => {
+      const c1 = new FormControl('old', Validators.minLength(10));
+      const c2 = new FormControl('new!', Validators.minLength(10));
+      g = new FormGroup({valueOf: c1});
+
+      g.setControl('valueOf', c2);
+
+      expect(g.controls['valueOf']).toEqual(c2);
+      expect(g.value).toEqual({valueOf: 'new!'});
+      expect(g.valid).toBe(false);
     });
   });
 


### PR DESCRIPTION
FormGroups now properly handle controls with names that are inherited from the 'controls' object prototype like 'constructor' and 'valueOf'.

Fixes #51029

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## What is the current behavior?
Adding, removing, or setting a form control would sometimes error or return an inherited value for property names that are inherited from Object.prototype like `valueOf` and `constructor`.

Issue Number: #51029 


## What is the new behavior?
Controls with names that match inherited properties are now treated the same as any other control, with no errors or surprising behavior.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
