### PR TITLE
fix(router): handle unhandled promise rejections with ErrorHandler

### DIFF
--- a/packages/router/src/navigation_transition.ts
+++ b/packages/router/src/navigation_transition.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {EnvironmentInjector, inject, Injectable, Type} from '@angular/core';
+import {EnvironmentInjector, ErrorHandler as ErrorHandlerClass, inject, Injectable, Type} from '@angular/core';
 import {BehaviorSubject, combineLatest, EMPTY, Observable, of, Subject} from 'rxjs';
 import {catchError, defaultIfEmpty, filter, finalize, map, switchMap, take, tap} from 'rxjs/operators';
 
@@ -293,6 +293,8 @@ export class NavigationTransitions {
   private readonly urlSerializer = inject(UrlSerializer);
   private readonly rootContexts = inject(ChildrenOutletContexts);
   private readonly inputBindingEnabled = inject(INPUT_BINDER, {optional: true}) !== null;
+
+  private readonly errorHandler = inject(ErrorHandlerClass);
   navigationId = 0;
   get hasRequestedNavigation() {
     return this.navigationId !== 0;
@@ -727,11 +729,15 @@ export class NavigationTransitions {
                                      isBrowserTriggeredNavigation(overallTransitionState.source)
                                };
 
-                               router.scheduleNavigation(
-                                   mergedTree, IMPERATIVE_NAVIGATION, null, extras, {
-                                     resolve: overallTransitionState.resolve,
-                                     reject: overallTransitionState.reject,
-                                     promise: overallTransitionState.promise
+                               router
+                                   .scheduleNavigation(
+                                       mergedTree, IMPERATIVE_NAVIGATION, null, extras, {
+                                         resolve: overallTransitionState.resolve,
+                                         reject: overallTransitionState.reject,
+                                         promise: overallTransitionState.promise
+                                       })
+                                   .catch(e => {
+                                     this.errorHandler.handleError(e);
                                    });
                              }
 

--- a/packages/router/test/computed_state_restoration.spec.ts
+++ b/packages/router/test/computed_state_restoration.spec.ts
@@ -431,10 +431,9 @@ describe('`restoredState#ɵrouterPageId`', () => {
 
          TestBed.inject(ThrowingCanActivateGuard).throw = true;
 
-         expect(() => {
-           location.back();
-           advance(fixture);
-         }).toThrow();
+         location.back();
+         advance(fixture);
+
          expect(location.path()).toEqual('/second');
          expect(location.getState()).toEqual(jasmine.objectContaining({ɵrouterPageId: 2}));
 


### PR DESCRIPTION
Pass errors from calls that returned promises to ErrorHandler. These calls returned promises that could fail but were neither caught nor propagated. This caused "Unhandled (in promise)" errors on the console.

**I'll be happy to add some unit test but I want to validate the approach first. Is it OK to inject ErrorHandlers in these two places?**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
If a resolver rejects, "Unhandled (in promise)" errors are shown in the console (aside from the standard Angular navigation error handling). This is because there are calls to methods that return promises, but the results of these promises are never checked.

Issue Number: N/A


## What is the new behavior?
Promise rejections are caught and sent to ErrorHandler.handleError.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
