### PR TITLE
docs: Update first-app-lesson-11.md

### DIFF
--- a/aio/content/examples/first-app-lesson-10/src/app/housing-location/housing-location.component.ts
+++ b/aio/content/examples/first-app-lesson-10/src/app/housing-location/housing-location.component.ts
@@ -1,15 +1,19 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HousingLocation } from '../housinglocation';
+// #docregion import-router-module
 import { RouterModule } from '@angular/router';
+// #enddocregion
 
 @Component({
   selector: 'app-housing-location',
   standalone: true,
+  // #docregion import-router-module-deco
   imports: [
     CommonModule,
     RouterModule
   ],
+  // #enddocregion
   template: `
     <section class="listing">
       <img class="listing-photo" [src]="housingLocation.photo" alt="Exterior photo of {{housingLocation.name}}">

--- a/aio/content/tutorial/first-app/first-app-lesson-11.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-11.md
@@ -25,6 +25,16 @@ In lesson 10, you added a second route to `src/app/routes.ts`, this route includ
 
 In this case, `:id` is dynamic and will change based on how the route is requested by the code.
 
+1.  In `src/app/housing-location/housing-location.component.ts`, update the component to use routing:
+    1.  Add a file level import for `RoutingModule`:
+
+        <code-example header="Import RouterModule in src/app/housing-location/housing-location.component.ts" path="first-app-lesson-10/src/app/housing-location/housing-location.component.ts" region="import-router-module"></code-example>
+    
+    1.  Add `RouterModule` to the `@Component` metadata imports
+
+        <code-example header="Import RouterModule in src/app/housing-location/housing-location.component.ts" path="first-app-lesson-10/src/app/housing-location/housing-location.component.ts" region="import-router-module-deco"></code-example>
+    
+
 1.  In `src/app/housing-location/housing-location.component.ts`, add an anchor tag to the `section` element and include the `routerLink` directive:
 
     <code-example header="Add anchor with a routerLink directive to housing-location.component.ts" path="first-app-lesson-11/src/app/housing-location/housing-location.component.ts" region="add-router-link"></code-example>


### PR DESCRIPTION
docs: fix missing import in first-app lesson 11

The lesson doesn't import RouterModule, so the anchor tag is not actually working. This adds the necessaery steps to include RouterModule.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
