### PR TITLE
docs: add mention of paramsInheritanceStrategy in the router doc

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -135,7 +135,9 @@ To get information from a route:
 
     **NOTE:** <br>
     You can bind all route data with key, value pairs to component inputs: static or resolved route data, path parameters, matrix parameters, and query parameters.
-
+    <br>
+    If you want to use the parent components route info you will need to set the router {@link paramsInheritanceStrategy} option:
+    `withRouterConfig({paramsInheritanceStrategy: 'always'})`
     </div>
 
 <a id="wildcard-route-how-to"></a>


### PR DESCRIPTION
`paramsInheritanceStrategy` might be usefull in combination of `withComponentInputBinding`. Let's add a mention in the note !

Thx to @elgreco247 for the suggestion 👍🏻 

## PR Type
What kind of change does this PR introduce?

- [x] Documentation content changes