### PR TITLE
refactor(compiler): add compiler flag to enable deferred blocks for testing

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -54,9 +54,10 @@ export class ComponentDecoratorHandler implements
       private rootDirs: ReadonlyArray<string>, private defaultPreserveWhitespaces: boolean,
       private i18nUseExternalIds: boolean, private enableI18nLegacyMessageIdFormat: boolean,
       private usePoisonedData: boolean, private i18nNormalizeLineEndingsInICUs: boolean,
-      private moduleResolver: ModuleResolver, private cycleAnalyzer: CycleAnalyzer,
-      private cycleHandlingStrategy: CycleHandlingStrategy, private refEmitter: ReferenceEmitter,
-      private referencesRegistry: ReferencesRegistry, private depTracker: DependencyTracker|null,
+      private enabledBlockTypes: Set<string>, private moduleResolver: ModuleResolver,
+      private cycleAnalyzer: CycleAnalyzer, private cycleHandlingStrategy: CycleHandlingStrategy,
+      private refEmitter: ReferenceEmitter, private referencesRegistry: ReferencesRegistry,
+      private depTracker: DependencyTracker|null,
       private injectableRegistry: InjectableClassRegistry,
       private semanticDepGraphUpdater: SemanticDepGraphUpdater|null,
       private annotateForClosureCompiler: boolean, private perf: PerfRecorder,
@@ -66,6 +67,7 @@ export class ComponentDecoratorHandler implements
       enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
       i18nNormalizeLineEndingsInICUs: this.i18nNormalizeLineEndingsInICUs,
       usePoisonedData: this.usePoisonedData,
+      enabledBlockTypes: this.enabledBlockTypes,
     };
   }
 
@@ -81,8 +83,10 @@ export class ComponentDecoratorHandler implements
   private preanalyzeStylesCache = new Map<DeclarationNode, string[]|null>();
 
   private extractTemplateOptions: {
-    enableI18nLegacyMessageIdFormat: boolean; i18nNormalizeLineEndingsInICUs: boolean;
-    usePoisonedData: boolean;
+    enableI18nLegacyMessageIdFormat: boolean,
+    i18nNormalizeLineEndingsInICUs: boolean,
+    usePoisonedData: boolean,
+    enabledBlockTypes: Set<string>,
   };
 
   readonly precedence = HandlerPrecedence.PRIMARY;
@@ -329,6 +333,7 @@ export class ComponentDecoratorHandler implements
             enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
             i18nNormalizeLineEndingsInICUs: this.i18nNormalizeLineEndingsInICUs,
             usePoisonedData: this.usePoisonedData,
+            enabledBlockTypes: this.enabledBlockTypes,
           });
     }
     const templateResource =

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/resources.ts
@@ -118,6 +118,7 @@ export interface ExtractTemplateOptions {
   usePoisonedData: boolean;
   enableI18nLegacyMessageIdFormat: boolean;
   i18nNormalizeLineEndingsInICUs: boolean;
+  enabledBlockTypes: Set<string>;
 }
 
 export function extractTemplate(
@@ -215,6 +216,7 @@ function parseExtractedTemplate(
     enableI18nLegacyMessageIdFormat: options.enableI18nLegacyMessageIdFormat,
     i18nNormalizeLineEndingsInICUs,
     alwaysAttemptHtmlToR3AstConversion: options.usePoisonedData,
+    enabledBlockTypes: options.enabledBlockTypes,
   });
 
   // Unfortunately, the primary parse of the template above may not contain accurate source map

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -88,6 +88,7 @@ function setup(
       /* enableI18nLegacyMessageIdFormat */ false,
       !!usePoisonedData,
       /* i18nNormalizeLineEndingsInICUs */ false,
+      /* enabledBlockTypes */ new Set(),
       moduleResolver,
       cycleAnalyzer,
       CycleHandlingStrategy.UseRemoteScoping,
@@ -556,7 +557,7 @@ runInEachFileSystem(() => {
                 contents: `
             import {Component} from '@angular/core';
             import {SomeModule} from './some_where';
-            
+
             @Component({
               standalone: true,
               selector: 'main',
@@ -593,7 +594,7 @@ runInEachFileSystem(() => {
                 contents: `
             import {Component} from '@angular/core';
             import {SomeModule} from './some_where';
-            
+
             @Component({
               selector: 'main',
               template: '<span>Hi!</span>',
@@ -632,7 +633,7 @@ runInEachFileSystem(() => {
                 contents: `
             import {Component, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
             import {SomeModule} from './some_where';
-            
+
             @Component({
               standalone: true,
               selector: 'main',
@@ -670,7 +671,7 @@ runInEachFileSystem(() => {
                 contents: `
             import {Component, CUSTOM_ELEMENTS_SCHEMA} from '@angular/core';
             import {SomeModule} from './some_where';
-            
+
             @Component({
               selector: 'main',
               template: '<span>Hi!</span>',

--- a/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
+++ b/packages/compiler-cli/src/ngtsc/core/api/src/options.ts
@@ -31,6 +31,14 @@ export interface TestOnlyOptions {
   _enableTemplateTypeChecker?: boolean;
 
   /**
+   * Names of the blocks that should be enabled. E.g. `_enabledBlockTypes: ['defer']`
+   * would allow usages of `{#defer}{/defer}` in templates.
+   *
+   * @internal
+   */
+  _enabledBlockTypes?: string[];
+
+  /**
    * An option to enable ngtsc's internal performance tracing.
    *
    * This should be a path to a JSON file where trace information will be written. This is sensitive

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -254,6 +254,7 @@ export class NgCompiler {
   private moduleResolver: ModuleResolver;
   private resourceManager: AdapterResourceLoader;
   private cycleAnalyzer: CycleAnalyzer;
+  private enabledBlockTypes: Set<string>;
   readonly ignoreForDiagnostics: Set<ts.SourceFile>;
   readonly ignoreForEmit: Set<ts.SourceFile>;
   readonly enableTemplateTypeChecker: boolean;
@@ -321,6 +322,7 @@ export class NgCompiler {
   ) {
     this.enableTemplateTypeChecker =
         enableTemplateTypeChecker || (options._enableTemplateTypeChecker ?? false);
+    this.enabledBlockTypes = new Set(options._enabledBlockTypes ?? []);
     this.constructionDiagnostics.push(
         ...this.adapter.constructionDiagnostics, ...verifyCompatibleTypeCheckOptions(this.options));
 
@@ -1064,11 +1066,11 @@ export class NgCompiler {
           this.resourceManager, this.adapter.rootDirs, this.options.preserveWhitespaces || false,
           this.options.i18nUseExternalIds !== false,
           this.options.enableI18nLegacyMessageIdFormat !== false, this.usePoisonedData,
-          this.options.i18nNormalizeLineEndingsInICUs === true, this.moduleResolver,
-          this.cycleAnalyzer, cycleHandlingStrategy, refEmitter, referencesRegistry,
-          this.incrementalCompilation.depGraph, injectableRegistry, semanticDepGraphUpdater,
-          this.closureCompilerEnabled, this.delegatingPerfRecorder, hostDirectivesResolver,
-          supportTestBed, compilationMode),
+          this.options.i18nNormalizeLineEndingsInICUs === true, this.enabledBlockTypes,
+          this.moduleResolver, this.cycleAnalyzer, cycleHandlingStrategy, refEmitter,
+          referencesRegistry, this.incrementalCompilation.depGraph, injectableRegistry,
+          semanticDepGraphUpdater, this.closureCompilerEnabled, this.delegatingPerfRecorder,
+          hostDirectivesResolver, supportTestBed, compilationMode),
 
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null`
       // not being assignable to `unknown` when wrapped in `Readonly`).

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -8871,6 +8871,26 @@ function allTests(os: string) {
         expect(dtsContents).toContain('static ngAcceptInputType_value: boolean | string;');
       });
     });
+
+    // TODO: replace with tests for `defer`.
+    // TODO: maybe put deferred tests in a separate file?
+    describe('deferred blocks', () => {
+      it('should not error for deferred blocks', () => {
+        env.tsconfig({_enabledBlockTypes: ['defer']});
+        env.write('/test.ts', `
+          import {Component} from '@angular/core';
+
+          @Component({
+            selector: 'test-cmp',
+            template: '{#defer}hello{/defer}',
+          })
+          export class TestCmp {}
+      `);
+
+        const diags = env.driveDiagnostics();
+        expect(diags.length).toBe(0);
+      });
+    });
   });
 
   function expectTokenAtPosition<T extends ts.Node>(

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -524,7 +524,11 @@ function parseJitTemplate(
   const interpolationConfig =
       interpolation ? InterpolationConfig.fromArray(interpolation) : DEFAULT_INTERPOLATION_CONFIG;
   // Parse the template and check for errors.
-  const parsed = parseTemplate(template, sourceMapUrl, {preserveWhitespaces, interpolationConfig});
+  const parsed = parseTemplate(template, sourceMapUrl, {
+    preserveWhitespaces,
+    interpolationConfig,
+    enabledBlockTypes: new Set(),  // TODO: enable deferred blocks when testing in JIT mode.
+  });
   if (parsed.errors !== null) {
     const errors = parsed.errors.map(err => err.toString()).join(', ');
     throw new Error(`Errors during JIT compilation of template for ${typeName}: ${errors}`);

--- a/packages/compiler/src/render3/r3_template_transform.ts
+++ b/packages/compiler/src/render3/r3_template_transform.ts
@@ -59,6 +59,7 @@ export interface Render3ParseResult {
 
 interface Render3ParseOptions {
   collectCommentNodes: boolean;
+  enabledBlockTypes: Set<string>;
 }
 
 export function htmlAstToRender3Ast(
@@ -324,15 +325,14 @@ class HtmlAstToIvyAst implements html.Visitor {
       return null;
     }
 
-    switch (primaryBlock.name) {
-      case 'defer':
-        const {node, errors} = createDeferredBlock(group, this, this.bindingParser);
-        this.errors.push(...errors);
-        return node;
-      default:
-        this.reportError(`Unrecognized block "${primaryBlock.name}".`, primaryBlock.sourceSpan);
-        return null;
+    if (primaryBlock.name === 'defer' && this.options.enabledBlockTypes.has(primaryBlock.name)) {
+      const {node, errors} = createDeferredBlock(group, this, this.bindingParser);
+      this.errors.push(...errors);
+      return node;
     }
+
+    this.reportError(`Unrecognized block "${primaryBlock.name}".`, primaryBlock.sourceSpan);
+    return null;
   }
 
   visitBlock(block: html.Block, context: any) {}

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -182,8 +182,8 @@ function humanizeSpan(span: ParseSourceSpan|null|undefined): string {
   return span.toString();
 }
 
-function expectFromHtml(html: string, tokenizeBlocks = false) {
-  const res = parse(html, {tokenizeBlocks});
+function expectFromHtml(html: string, enabledBlockTypes?: string[]) {
+  const res = parse(html, {enabledBlockTypes});
   return expectFromR3Nodes(res.nodes);
 }
 
@@ -587,7 +587,7 @@ describe('R3 AST source spans', () => {
           'Loading failed :(' +
           '{/defer}';
 
-      expectFromHtml(html, true).toEqual([
+      expectFromHtml(html, ['defer']).toEqual([
         [
           'DeferredBlock',
           '{#defer when isVisible() && foo; on hover, timer(10s), idle, immediate, ' +

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -147,8 +147,8 @@ class R3AstHumanizer implements t.Visitor<void> {
   }
 }
 
-function expectFromHtml(html: string, ignoreError = false, tokenizeBlocks = false) {
-  const res = parse(html, {ignoreError, tokenizeBlocks});
+function expectFromHtml(html: string, ignoreError = false, enabledBlockTypes?: string[]) {
+  const res = parse(html, {ignoreError, enabledBlockTypes});
   return expectFromR3Nodes(res.nodes);
 }
 
@@ -708,11 +708,11 @@ describe('R3 template transform', () => {
   describe('deferred blocks', () => {
     // TODO(crisbeto): temporary utility while blocks are disabled by default.
     function expectDeferred(html: string) {
-      return expectFromR3Nodes(parse(html, {tokenizeBlocks: true}).nodes);
+      return expectFromR3Nodes(parse(html, {enabledBlockTypes: ['defer']}).nodes);
     }
 
     function expectDeferredError(html: string) {
-      return expect(() => parse(html, {tokenizeBlocks: true}));
+      return expect(() => parse(html, {enabledBlockTypes: ['defer']}));
     }
 
     it('should parse a simple deferred block', () => {

--- a/packages/compiler/test/render3/view/util.ts
+++ b/packages/compiler/test/render3/view/util.ts
@@ -145,14 +145,14 @@ export function parseR3(input: string, options: {
   preserveWhitespaces?: boolean,
   leadingTriviaChars?: string[],
   ignoreError?: boolean,
-  tokenizeBlocks?: boolean
+  enabledBlockTypes?: string[],
 } = {}): Render3ParseResult {
   const htmlParser = new HtmlParser();
-
+  const enabledBlockTypes = new Set(options.enabledBlockTypes ?? []);
   const parseResult = htmlParser.parse(input, 'path:://to/template', {
     tokenizeExpansionForms: true,
     leadingTriviaChars: options.leadingTriviaChars ?? LEADING_TRIVIA_CHARS,
-    tokenizeBlocks: options.tokenizeBlocks ?? false,
+    tokenizeBlocks: enabledBlockTypes.size > 0,
   });
 
   if (parseResult.errors.length > 0 && !options.ignoreError) {
@@ -172,7 +172,8 @@ export function parseR3(input: string, options: {
       ['onEvent'], ['onEvent']);
   const bindingParser =
       new BindingParser(expressionParser, DEFAULT_INTERPOLATION_CONFIG, schemaRegistry, []);
-  const r3Result = htmlAstToRender3Ast(htmlNodes, bindingParser, {collectCommentNodes: false});
+  const r3Result = htmlAstToRender3Ast(
+      htmlNodes, bindingParser, {collectCommentNodes: false, enabledBlockTypes});
 
   if (r3Result.errors.length > 0 && !options.ignoreError) {
     const msg = r3Result.errors.map(e => e.toString()).join('\n');


### PR DESCRIPTION
Adds a new compiler option that will allow `defer` (and other) blocks to be enabled when writing unit tests.