### PR TITLE
fix(core): disallow reactive node creation in consumer context

### DIFF
--- a/packages/core/src/render3/reactive_lview_consumer.ts
+++ b/packages/core/src/render3/reactive_lview_consumer.ts
@@ -14,7 +14,8 @@ import {ComponentTemplate, HostBindingsFunction, RenderFlags} from './interfaces
 import {LView, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER} from './interfaces/view';
 
 export class ReactiveLViewConsumer extends ReactiveNode {
-  protected override consumerAllowSignalWrites = false;
+  protected override readonly consumerAllowReactiveNodeCreation = false;
+  protected override readonly consumerAllowSignalWrites = false;
   private _lView: LView|null = null;
 
   set lView(lView: LView) {

--- a/packages/core/src/signals/src/computed.ts
+++ b/packages/core/src/signals/src/computed.ts
@@ -63,6 +63,10 @@ const ERRORED: any = Symbol('ERRORED');
 class ComputedImpl<T> extends ReactiveNode {
   constructor(private computation: () => T, private equal: (oldValue: T, newValue: T) => boolean) {
     super();
+    if (!this.producerReactiveNodesCreationAllowed) {
+      throw new Error(
+          'A new computed signal creation is disallowed in the current reactive context.');
+    }
   }
   /**
    * Current value of the computation.
@@ -87,6 +91,8 @@ class ComputedImpl<T> extends ReactiveNode {
   private stale = true;
 
   protected override readonly consumerAllowSignalWrites = false;
+
+  protected override readonly consumerAllowReactiveNodeCreation = false;
 
   protected override onConsumerDependencyMayHaveChanged(): void {
     if (this.stale) {

--- a/packages/core/src/signals/src/graph.ts
+++ b/packages/core/src/signals/src/graph.ts
@@ -127,6 +127,12 @@ export abstract class ReactiveNode {
   protected abstract readonly consumerAllowSignalWrites: boolean;
 
   /**
+   * Whether new reactive node creation should be allowed when this `ReactiveNode` is the current
+   * consumer.
+   */
+  protected abstract readonly consumerAllowReactiveNodeCreation: boolean;
+
+  /**
    * Called for consumers whenever one of their dependencies notifies that it might have a new
    * value.
    */
@@ -240,6 +246,14 @@ export abstract class ReactiveNode {
    */
   protected get producerUpdatesAllowed(): boolean {
     return activeConsumer?.consumerAllowSignalWrites !== false;
+  }
+
+  /**
+   * Whether this `ReactiveNode` in its producer capacity is currently allowed to create new nodes
+   * in a reactive graph.
+   */
+  protected get producerReactiveNodesCreationAllowed(): boolean {
+    return activeConsumer?.consumerAllowReactiveNodeCreation !== false;
   }
 
   /**

--- a/packages/core/src/signals/src/signal.ts
+++ b/packages/core/src/signals/src/signal.ts
@@ -54,6 +54,8 @@ class WritableSignalImpl<T> extends ReactiveNode {
 
   protected override readonly consumerAllowSignalWrites = false;
 
+  protected override readonly consumerAllowReactiveNodeCreation = false;
+
   constructor(private value: T, private equal: ValueEqualityFn<T>) {
     super();
   }

--- a/packages/core/src/signals/src/watch.ts
+++ b/packages/core/src/signals/src/watch.ts
@@ -29,6 +29,7 @@ const NOOP_CLEANUP_FN: WatchCleanupFn = () => {};
  * provided scheduling operation to coordinate calling `Watch.run()`.
  */
 export class Watch extends ReactiveNode {
+  protected override readonly consumerAllowReactiveNodeCreation = false;
   protected override readonly consumerAllowSignalWrites: boolean;
   private dirty = false;
   private cleanupFn = NOOP_CLEANUP_FN;

--- a/packages/core/test/signals/computed_spec.ts
+++ b/packages/core/test/signals/computed_spec.ts
@@ -174,4 +174,15 @@ describe('computed', () => {
 
     expect(illegal).toThrow();
   });
+
+  it('should disallow creation of reactive nodes in computed', () => {
+    const source = signal(0);
+    const outer = computed(() => {
+      const illegal = computed(() => source());
+      return illegal();
+    });
+
+    expect(outer).toThrowError(
+        'A new computed signal creation is disallowed in the current reactive context.');
+  });
 });


### PR DESCRIPTION
This change introduces a check around reactive node creation. On the high level it disallows creation of the new reactive nodes while executing consumer functions (computed, effects, template dirty-checking).

It might turn out that this check is too restrictive and there are legitimate use-cases for which we would want to allow reactive node creation while executing computed, effect etc. This is why this PR has infrastructure to enable those checks on the per reactive node type.

We do start with the most restrictive version of checks and might gradually releax those checks as we learn more.

Closes #51055
