### PR TITLE
docs: missing steps in first-app-lesson-11.md

### DIFF
--- a/aio/content/examples/first-app-lesson-11/src/app/housing-location/housing-location.component.ts
+++ b/aio/content/examples/first-app-lesson-11/src/app/housing-location/housing-location.component.ts
@@ -1,15 +1,19 @@
 import { Component, Input } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HousingLocation } from '../housinglocation';
+// #docregion import-router-module
 import { RouterModule } from '@angular/router';
+// #enddocregion
 
 @Component({
   selector: 'app-housing-location',
   standalone: true,
+  // #docregion import-router-module-deco
   imports: [
     CommonModule,
     RouterModule
   ],
+  // #enddocregion
   // #docregion add-router-link
   template: `
     <section class="listing">

--- a/aio/content/tutorial/first-app/first-app-lesson-11.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-11.md
@@ -25,13 +25,22 @@ In lesson 10, you added a second route to `src/app/routes.ts` which includes a s
 
 In this case, `:id` is dynamic and will change based on how the route is requested by the code.
 
-1.  In `src/app/housing-location/housing-location.component.ts`, add an anchor tag to the `section` element and include the `routerLink` directive:
+1.  In `src/app/housing-location/housing-location.component.ts`, update the component to use routing:
+    1.  Add a file level import for `RoutingModule`:
 
-    <code-example header="Add anchor with a routerLink directive to housing-location.component.ts" path="first-app-lesson-11/src/app/housing-location/housing-location.component.ts" region="add-router-link"></code-example>
+        <code-example header="Import RouterModule in src/app/housing-location/housing-location.component.ts" path="first-app-lesson-11/src/app/housing-location/housing-location.component.ts" region="import-router-module"></code-example>
+    
+    1.  Add `RouterModule` to the `@Component` metadata imports
 
-    The `routerLink` directive enables Angular's router to create dynamic links in the application. The value assigned to the `routerLink` is an array with two entries: the static portion of the path and the dynamic data.
-
-    For the `routerLink` to work in the template, add a file level import of `RouterLink` and `RouterOutlet` from '@angular/router', then update the component `imports` array to include both `RouterLink` and `RouterOutlet`.
+        <code-example header="Import RouterModule in src/app/housing-location/housing-location.component.ts" path="first-app-lesson-11/src/app/housing-location/housing-location.component.ts" region="import-router-module-deco"></code-example>
+    
+    1. In the `template` property, add an anchor tag to the `section` element and include the `routerLink` directive:
+    
+        <code-example header="Add anchor with a routerLink directive to housing-location.component.ts" path="first-app-lesson-11/src/app/housing-location/housing-location.component.ts" region="add-router-link"></code-example>
+    
+        The `routerLink` directive enables Angular's router to create dynamic links in the application. The value assigned to the `routerLink` is an array with two entries: the static portion of the path and the dynamic data.
+    
+        For the `routerLink` to work in the template, add a file level import of `RouterLink` and `RouterOutlet` from '@angular/router', then update the component `imports` array to include both `RouterLink` and `RouterOutlet`.
 1. At this point you can confirm that the routing is working in your app. In the browser, refresh the home page and click the "Learn More" button for a housing location.
 
     <section class="lightbox">


### PR DESCRIPTION
docs(docs-infra): missing steps in first-app-lesson-11.md

add 2 missing steps in Step 1 - Create a new service for your app 
Before adding the anchor tag to the template, an import statement needs to be added and the imports of the component need to be expanded. The app will not work, if you skip this. Since this is a beginners-tutorial, I think those two steps need to be mentioned.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
In https://angular.io/tutorial/first-app/first-app-lesson-11, an anchor tag is added to the template of src/app/housing-location/housing-location.component.ts. Currently, there is no import statemend added and the imports are not expanded. The app crashes in that state.

Issue Number: N/A


## What is the new behavior?
With the two added steps, the import-statement is present and the imports contain  RouterModule, and the app runs as desired.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
