### PR TITLE
docs(docs-infra): fix wrong links in  first-app-lesson-14.md

### DIFF
--- a/aio/content/tutorial/first-app/first-app-lesson-14.md
+++ b/aio/content/tutorial/first-app/first-app-lesson-14.md
@@ -6,9 +6,9 @@ Up until this point your app has read data from a static array in an Angular ser
 
 **Estimated time**: ~15 minutes
 
-**Starting code:** <live-example name="first-app-lesson-06"></live-example>
+**Starting code:** <live-example name="first-app-lesson-13"></live-example>
 
-**Completed code:** <live-example name="first-app-lesson-07"></live-example>
+**Completed code:** <live-example name="first-app-lesson-14"></live-example>
 
 ## What you'll learn
 


### PR DESCRIPTION
docs(docs-infra): fix wrong links in first-app-lesson-14.md

in first-app-lesson-14.md, the links to starting code point to the wrong lesson 06 instead of lesson 13 and the links to completed code point to lesson 07 instead of lesson 14

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
At the beginn of every lesson, a link to the starting code points to the code of the previous lesson and a link to the completed code points to the code of the current lesson. In first-app-lesson-14.md those links point to lesson 6 and 7.

Issue Number: N/A


## What is the new behavior?
The link to the previous lesson is now 13.
The link to the current lesson is now 14.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
