### PR TITLE
ci: migrate framework tests to GHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,7 @@ jobs:
             - ./ng
             - ./bazel_repository_cache
 
+  # TODO: Remove test job after confirmation that the GHA version is stable.
   test:
     executor:
       name: test-browser-executor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,19 @@ jobs:
         run: yarn install --frozen-lockfile --network-timeout 100000
       - name: Test all windows CI targets
         run: bazel test --test_tag_filters="-browser:chromium-local" //packages/compiler-cli/...
+
+  test:
+    runs-on: ubuntu-latest-4core
+    steps:
+      - name: Initialize environment
+        uses: angular/dev-infra/github-actions/npm/checkout-and-setup-node@45de46d9ba0e0689b7a846fd31ec9e241807ca71
+        with:
+          cache-node-modules: true
+      - name: Setup Bazel
+        uses: angular/dev-infra/github-actions/bazel/setup@45de46d9ba0e0689b7a846fd31ec9e241807ca71
+      - name: Setup Bazel Remote Caching
+        uses: angular/dev-infra/github-actions/bazel/configure-remote@45de46d9ba0e0689b7a846fd31ec9e241807ca71
+      - name: Install node modules
+        run: yarn install --frozen-lockfile --network-timeout 100000
+      - name: Run CI tests for framework
+        run: yarn test:ci


### PR DESCRIPTION
Migrate framework presubmit test job to use Github Actions
