### PR TITLE
docs: add space before self closing tag

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/security_sensitive_constant_attributes.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_compiler_compliance/elements/security_sensitive_constant_attributes.ts
@@ -12,7 +12,7 @@ import {Component, NgModule} from '@angular/core';
     <embed src="https://angular.io/" />
 
     <!-- Another element with a src attribute that is not security sensitive -->
-    <img src="https://angular.io/"  alt="not-security-sensitive"/>
+    <img src="https://angular.io/"  alt="not-security-sensitive" />
   `
 })
 export class MyComponent {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/self_closing.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/nested_nodes/self_closing.ts
@@ -3,9 +3,9 @@ import {Component, NgModule} from '@angular/core';
 @Component({
   selector: 'my-component',
   template: `
-  <img src="logo.png" i18n  alt="self_closing_logo"/>
-  <img src="logo.png" i18n *ngIf="visible"  alt="visible"/>
-  <img src="logo.png" i18n *ngIf="visible" i18n-title title="App logo #{{ id }}"  alt="appLogo"/>
+  <img src="logo.png" i18n  alt="self_closing_logo" />
+  <img src="logo.png" i18n *ngIf="visible"  alt="visible" />
+  <img src="logo.png" i18n *ngIf="visible" i18n-title title="App logo #{{ id }}"  alt="appLogo" />
   `,
 })
 export class MyComponent {

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/ng-container_ng-template/self_closing_tags.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_i18n/ng-container_ng-template/self_closing_tags.ts
@@ -4,10 +4,10 @@ import {Component, NgModule} from '@angular/core';
   selector: 'my-component',
   template: `
   <ng-container i18n>
-    <img src="logo.png" title="Logo"  alt="i18_logo_1"/> is my logo #1
+    <img src="logo.png" title="Logo"  alt="i18_logo_1" /> is my logo #1
   </ng-container>
   <ng-template i18n>
-    <img src="logo.png" title="Logo" alt="i18_logo_2"/> is my logo #2
+    <img src="logo.png" title="Logo" alt="i18_logo_2" /> is my logo #2
   </ng-template>
 `,
 })


### PR DESCRIPTION
This fixes a parsing issue in tests where a missing space before a self closing slash fails to pass tests.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

