### PR TITLE
docs: release notes for the v16.1.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+<a name="16.1.6"></a>
+# 16.1.6 (2023-07-19)
+### http
+| Commit | Type | Description |
+| -- | -- | -- |
+| [dea8dc0378](https://github.com/angular/angular/commit/dea8dc0378c5b777b1879f22189fe32cbe61b36b) | fix | Run fetch request out the angular zone ([#50981](https://github.com/angular/angular/pull/50981)) |
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.2.0-next.2"></a>
 # 16.2.0-next.2 (2023-07-13)
 ### animations


### PR DESCRIPTION
Cherry-picks the changelog from the "16.1.x" branch to the next branch (main).