### PR TITLE
docs(docs-infra): fix rendering of `Exported from` section on Firefox.

### DIFF
--- a/aio/tools/transforms/templates/api/lib/ngmodule.html
+++ b/aio/tools/transforms/templates/api/lib/ngmodule.html
@@ -6,10 +6,10 @@
   <li>
     {%- if ngModule.path %}
     <a href="{$ ngModule.path $}">
-      <code-example language="ts" hideCopy="true" class="no-box">{$ ngModule.name | escape $}</code-example>
+      <code>{$ ngModule.name | escape $}</code>
     </a>
     {%- else %}
-    <code-example language="ts" hideCopy="true" class="no-box">'{$ ngModule | escape $}'</code-example>
+    <code>'{$ ngModule | escape $}'</code>
     {%- endif %}
   </li>
   {%- endfor %}


### PR DESCRIPTION
On Firefox when an `a` element contains a block-level element, the `a` element is not aligned with the `li` marker.

Fixes #51112

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] angular.io application / infrastructure changes:

The modified macro is only use in 3 templates : class, directive and pipe. 
You can compare the 3 following on Firefox to confirm the fix : 

| Before  | After |
| ------------- | ------------- |
| [NgModel](https://angular.io/api/forms/NgModel)  | [NgModel](https://ng-dev-previews-fw--pr-angular-angular-51116-kf62gp5a.web.app/api/forms/NgModel) |
| [AsyncPipe](https://angular.io/api/common/AsyncPipe) | [AsyncPipe](https://ng-dev-previews-fw--pr-angular-angular-51116-kf62gp5a.web.app/api/common/AsyncPipe) |
| [FormGroupDirective](https://angular.io/api/forms/FormGroupDirective) | [FormGroupDirective](https://ng-dev-previews-fw--pr-angular-angular-51116-kf62gp5a.web.app/api/forms/FormGroupDirective)
