### PR TITLE
docs: remove the links to docs.angular.lat

### DIFF
--- a/aio/content/guide/localized-documentation.md
+++ b/aio/content/guide/localized-documentation.md
@@ -2,7 +2,6 @@
 
 This topic lists localized versions of the Angular documentation.
 
-*   [Espa&ntilde;ol](https://docs.angular.lat) <!-- Español -->
 *   [简体中文版](https://angular.cn) <!-- 简体中文版 -->
 *   [正體中文版](https://angular.tw) <!-- 正體中文版 -->
 *   [日本語版](https://angular.jp) <!-- 日本語版 -->

--- a/aio/content/navigation.json
+++ b/aio/content/navigation.json
@@ -1573,10 +1573,6 @@
       "title": "Languages",
       "children": [
         {
-          "title": "Español",
-          "url": "http://docs.angular.lat/"
-        },
-        {
           "title": "简体中文版",
           "url": "https://angular.cn/"
         },


### PR DESCRIPTION
docs.angular.lat hasn't been updated in a while and is stuck at v10. Let's remove the links to it.

The links are removed from the footer and from [this page](https://ng-dev-previews-fw--pr-angular-angular-51117-wd24aqhx.web.app/guide/localized-documentation).

Fixes #47644