### PR TITLE
refactor(core): migrate JIT to use deps tracker behind a flag

### DIFF
--- a/packages/core/src/render3/deps_tracker/api.ts
+++ b/packages/core/src/render3/deps_tracker/api.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type} from '../../core';
+import {Type} from '../../interface/type';
 import {NgModuleType} from '../../metadata/ng_module_def';
 import {ComponentType, DependencyTypeList, DirectiveType, NgModuleScopeInfoFromDecorator, PipeType} from '../interfaces/definition';
 
@@ -84,7 +84,7 @@ export interface DepsTrackerApi {
    * The main application of this method is for test beds where we want to clear the cache to
    * enforce scope update after overriding.
    */
-  clearScopeCacheFor(type: ComponentType<any>|NgModuleType): void;
+  clearScopeCacheFor(type: Type<any>): void;
 
   /**
    * Returns the scope of NgModule. Mainly to be used by JIT and test bed.

--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -12,11 +12,19 @@ import {Type} from '../../interface/type';
 import {NgModuleType} from '../../metadata/ng_module_def';
 import {getComponentDef, getNgModuleDef, isStandalone} from '../definition';
 import {ComponentType, NgModuleScopeInfoFromDecorator} from '../interfaces/definition';
-import {verifyStandaloneImport} from '../jit/directive';
-import {isComponent, isDirective, isModuleWithProviders, isNgModule, isPipe} from '../jit/util';
+import {isComponent, isDirective, isNgModule, isPipe, verifyStandaloneImport} from '../jit/util';
 import {maybeUnwrapFn} from '../util/misc_utils';
 
 import {ComponentDependencies, DepsTrackerApi, NgModuleScope, StandaloneComponentScope} from './api';
+
+/**
+ * Indicates whether to use the runtime dependency tracker for scope calculation in JIT compilation.
+ * The value "false" means the old code path based on patching scope info into the types will be
+ * used.
+ *
+ * @deprecated For migration purposes only, to be removed soon.
+ */
+export const USE_RUNTIME_DEPS_TRACKER_FOR_JIT = false;
 
 /**
  * An implementation of DepsTrackerApi which will be used for JIT and local compilation.
@@ -115,7 +123,7 @@ class DepsTracker implements DepsTrackerApi {
   }
 
   /** @override */
-  clearScopeCacheFor(type: ComponentType<any>|NgModuleType): void {
+  clearScopeCacheFor(type: Type<any>): void {
     if (isNgModule(type)) {
       this.ngModulesScopeCache.delete(type);
     } else if (isComponent(type)) {

--- a/packages/core/src/render3/jit/module.ts
+++ b/packages/core/src/render3/jit/module.ts
@@ -20,6 +20,7 @@ import {deepForEach, flatten} from '../../util/array_utils';
 import {assertDefined} from '../../util/assert';
 import {EMPTY_ARRAY} from '../../util/empty';
 import {GENERATED_COMP_IDS, getComponentDef, getDirectiveDef, getNgModuleDef, getPipeDef, isStandalone} from '../definition';
+import {depsTracker, USE_RUNTIME_DEPS_TRACKER_FOR_JIT} from '../deps_tracker/deps_tracker';
 import {NG_COMP_DEF, NG_DIR_DEF, NG_FACTORY_DEF, NG_MOD_DEF, NG_PIPE_DEF} from '../fields';
 import {ComponentDef} from '../interfaces/definition';
 import {maybeUnwrapFn} from '../util/misc_utils';
@@ -489,7 +490,16 @@ export function patchComponentDefWithScope<C>(
  */
 export function transitiveScopesFor<T>(type: Type<T>): NgModuleTransitiveScopes {
   if (isNgModule(type)) {
-    return transitiveScopesForNgModule(type);
+    if (USE_RUNTIME_DEPS_TRACKER_FOR_JIT) {
+      const scope = depsTracker.getNgModuleScope(type);
+      const def = getNgModuleDef(type, true);
+      return {
+        schemas: def.schemas || null,
+        ...scope,
+      };
+    } else {
+      return transitiveScopesForNgModule(type);
+    }
   } else if (isStandalone(type)) {
     const directiveDef = getComponentDef(type) || getDirectiveDef(type);
     if (directiveDef !== null) {

--- a/packages/core/src/render3/jit/util.ts
+++ b/packages/core/src/render3/jit/util.ts
@@ -6,11 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
+import {isForwardRef, resolveForwardRef} from '../../di/forward_ref';
 import {ModuleWithProviders} from '../../di/interface/provider';
 import {Type} from '../../interface/type';
 import {NgModuleDef} from '../../metadata/ng_module_def';
 import {getComponentDef, getDirectiveDef, getNgModuleDef, getPipeDef} from '../definition';
 import {ComponentType, DirectiveType, PipeType} from '../interfaces/definition';
+import {stringifyForError} from '../util/stringify_utils';
 
 export function isModuleWithProviders(value: any): value is ModuleWithProviders<{}> {
   return (value as {ngModule?: any}).ngModule !== undefined;
@@ -30,4 +32,46 @@ export function isDirective<T>(value: Type<T>): value is DirectiveType<T> {
 
 export function isComponent<T>(value: Type<T>): value is ComponentType<T> {
   return !!getComponentDef(value);
+}
+
+function getDependencyTypeForError(type: Type<any>) {
+  if (getComponentDef(type)) return 'component';
+  if (getDirectiveDef(type)) return 'directive';
+  if (getPipeDef(type)) return 'pipe';
+  return 'type';
+}
+
+export function verifyStandaloneImport(depType: Type<unknown>, importingType: Type<unknown>) {
+  if (isForwardRef(depType)) {
+    depType = resolveForwardRef(depType);
+    if (!depType) {
+      throw new Error(`Expected forwardRef function, imported from "${
+          stringifyForError(importingType)}", to return a standalone entity or NgModule but got "${
+          stringifyForError(depType) || depType}".`);
+    }
+  }
+
+  if (getNgModuleDef(depType) == null) {
+    const def = getComponentDef(depType) || getDirectiveDef(depType) || getPipeDef(depType);
+    if (def != null) {
+      // if a component, directive or pipe is imported make sure that it is standalone
+      if (!def.standalone) {
+        throw new Error(`The "${stringifyForError(depType)}" ${
+            getDependencyTypeForError(depType)}, imported from "${
+            stringifyForError(
+                importingType)}", is not standalone. Did you forget to add the standalone: true flag?`);
+      }
+    } else {
+      // it can be either a module with provider or an unknown (not annotated) type
+      if (isModuleWithProviders(depType)) {
+        throw new Error(`A module with providers was imported from "${
+            stringifyForError(
+                importingType)}". Modules with providers are not supported in standalone components imports.`);
+      } else {
+        throw new Error(`The "${stringifyForError(depType)}" type, imported from "${
+            stringifyForError(
+                importingType)}", must be a standalone component / directive / pipe or an NgModule. Did you forget to add the required @Component / @Directive / @Pipe or @NgModule annotation?`);
+      }
+    }
+  }
 }


### PR DESCRIPTION
This PR does not make any change to the current logic as it is guarded by a flag. The actual migration happens when the flag is set to True. In [this  draft](https://github.com/angular/angular/pull/51123) you can see the next step where this flag is set to true. I ran some TGPs for this PR and it is green. So the changes here work in the wild.

Also had to tweak the imports to avoid circular deps (left comments).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
