### PR TITLE
refactor: add `readonly` to public `InjectionToken` types

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -38,7 +38,7 @@ export interface AfterViewInit {
 export const ANIMATION_MODULE_TYPE: InjectionToken<"NoopAnimations" | "BrowserAnimations">;
 
 // @public
-export const APP_BOOTSTRAP_LISTENER: InjectionToken<((compRef: ComponentRef<any>) => void)[]>;
+export const APP_BOOTSTRAP_LISTENER: InjectionToken<readonly ((compRef: ComponentRef<any>) => void)[]>;
 
 // @public
 export const APP_ID: InjectionToken<string>;
@@ -1139,7 +1139,7 @@ export interface PipeTransform {
 export const PLATFORM_ID: InjectionToken<Object>;
 
 // @public
-export const PLATFORM_INITIALIZER: InjectionToken<(() => void)[]>;
+export const PLATFORM_INITIALIZER: InjectionToken<readonly (() => void)[]>;
 
 // @public
 export const platformCore: (extraProviders?: StaticProvider[] | undefined) => PlatformRef;

--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -611,10 +611,10 @@ export class MinValidator extends AbstractValidatorDirective {
 }
 
 // @public
-export const NG_ASYNC_VALIDATORS: InjectionToken<(Function | Validator)[]>;
+export const NG_ASYNC_VALIDATORS: InjectionToken<readonly (Function | Validator)[]>;
 
 // @public
-export const NG_VALIDATORS: InjectionToken<(Function | Validator)[]>;
+export const NG_VALIDATORS: InjectionToken<readonly (Function | Validator)[]>;
 
 // @public
 export const NG_VALUE_ACCESSOR: InjectionToken<readonly ControlValueAccessor[]>;

--- a/goldens/public-api/platform-server/index.md
+++ b/goldens/public-api/platform-server/index.md
@@ -18,7 +18,7 @@ import { Type } from '@angular/core';
 import { Version } from '@angular/core';
 
 // @public
-export const BEFORE_APP_SERIALIZED: InjectionToken<(() => void | Promise<void>)[]>;
+export const BEFORE_APP_SERIALIZED: InjectionToken<readonly (() => void | Promise<void>)[]>;
 
 // @public
 export const INITIAL_CONFIG: InjectionToken<PlatformConfig>;

--- a/goldens/public-api/router/upgrade/index.md
+++ b/goldens/public-api/router/upgrade/index.md
@@ -10,7 +10,7 @@ import { UpgradeModule } from '@angular/upgrade/static';
 
 // @public
 export const RouterUpgradeInitializer: {
-    provide: InjectionToken<((compRef: ComponentRef<any>) => void)[]>;
+    provide: InjectionToken<readonly ((compRef: ComponentRef<any>) => void)[]>;
     multi: boolean;
     useFactory: (ngUpgrade: UpgradeModule) => () => void;
     deps: (typeof UpgradeModule)[];

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -76,7 +76,7 @@ const PLATFORM_DESTROY_LISTENERS =
  * @publicApi
  */
 export const APP_BOOTSTRAP_LISTENER =
-    new InjectionToken<Array<(compRef: ComponentRef<any>) => void>>('appBootstrapListener');
+    new InjectionToken<ReadonlyArray<(compRef: ComponentRef<any>) => void>>('appBootstrapListener');
 
 export function compileNgModuleFactory<M>(
     injector: Injector, options: CompilerOptions,
@@ -1100,8 +1100,7 @@ export class ApplicationRef {
               'Please check that the `APP_BOOTSTRAP_LISTENER` token is configured as a ' +
               '`multi: true` provider.');
     }
-    listeners.push(...this._bootstrapListeners);
-    listeners.forEach((listener) => listener(componentRef));
+    [...this._bootstrapListeners, ...listeners].forEach((listener) => listener(componentRef));
   }
 
   /** @internal */

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -51,7 +51,8 @@ const DEFAULT_APP_ID = 'ng';
  * A function that is executed when a platform is initialized.
  * @publicApi
  */
-export const PLATFORM_INITIALIZER = new InjectionToken<Array<() => void>>('Platform Initializer');
+export const PLATFORM_INITIALIZER =
+    new InjectionToken<ReadonlyArray<() => void>>('Platform Initializer');
 
 /**
  * A token that indicates an opaque platform ID.

--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -58,7 +58,7 @@ function hasValidLength(value: any): boolean {
  *
  * @publicApi
  */
-export const NG_VALIDATORS = new InjectionToken<Array<Validator|Function>>('NgValidators');
+export const NG_VALIDATORS = new InjectionToken<ReadonlyArray<Validator|Function>>('NgValidators');
 
 /**
  * @description
@@ -90,7 +90,7 @@ export const NG_VALIDATORS = new InjectionToken<Array<Validator|Function>>('NgVa
  * @publicApi
  */
 export const NG_ASYNC_VALIDATORS =
-    new InjectionToken<Array<Validator|Function>>('NgAsyncValidators');
+    new InjectionToken<ReadonlyArray<Validator|Function>>('NgAsyncValidators');
 
 /**
  * A regular expression that matches valid e-mail addresses.

--- a/packages/platform-server/src/tokens.ts
+++ b/packages/platform-server/src/tokens.ts
@@ -64,4 +64,4 @@ export const INITIAL_CONFIG = new InjectionToken<PlatformConfig>('Server.INITIAL
  * @publicApi
  */
 export const BEFORE_APP_SERIALIZED =
-    new InjectionToken<Array<() => void | Promise<void>>>('Server.RENDER_MODULE_HOOK');
+    new InjectionToken<ReadonlyArray<() => void | Promise<void>>>('Server.RENDER_MODULE_HOOK');


### PR DESCRIPTION
We enabled a lint rule internally to require that multi-provided `InjectionToken`s have a `readonly` array type, the tokens in this PR do not follow this rule and are causing lint violations.

Fixes #51124

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Some InjectionTokens have Array types and not ReadonlyArray types

Issue Number: 51124


## What is the new behavior?

InjectionTokens have the ReadonlyArray type

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
