### PR TITLE
docs: Add links to the injection context guide

### DIFF
--- a/aio/content/guide/lifecycle-hooks.md
+++ b/aio/content/guide/lifecycle-hooks.md
@@ -136,7 +136,7 @@ When using RxJS Observables in components or directives, you may want to complet
 data$ = http.get('...').pipe(takeUntilDestroyed());
 ```
 
-By default, `takeUntilDestroyed` must be called in an injection context so that it can access `DestroyRef`. If an injection context isn't available, you can explicitly provide a `DestroyRef`.
+By default, `takeUntilDestroyed` must be called in an [injection context](/guide/dependency-injection-context) so that it can access `DestroyRef`. If an injection context isn't available, you can explicitly provide a `DestroyRef`.
 
 ## General examples
 

--- a/aio/content/guide/rxjs-interop.md
+++ b/aio/content/guide/rxjs-interop.md
@@ -83,7 +83,7 @@ As the `query` signal changes, the `query$` Observable emits the latest query an
 
 ### Injection context
 
-`toObservable` by default needs to run in an injection context, such as during construction of a component or service. If an injection context is not available, an `Injector` can instead be explicitly specified.
+`toObservable` by default needs to run in an [injection context](/guide/dependency-injection-context), such as during construction of a component or service. If an injection context is not available, an `Injector` can instead be explicitly specified.
 
 ### Timing of `toObservable`
 

--- a/aio/content/guide/signals.md
+++ b/aio/content/guide/signals.md
@@ -140,7 +140,7 @@ Because of these risks, setting signals is disallowed by default in effects, but
 
 ### Injection context
 
-By default, registering a new effect with the `effect()` function requires an "injection context" (access to the `inject` function). The easiest way to provide this is to call `effect` within a component, directive, or service `constructor`:
+By default, registering a new effect with the `effect()` function requires an [injection context](/guide/dependency-injection-context) (access to the `inject` function). The easiest way to provide this is to call `effect` within a component, directive, or service `constructor`:
 
 ```ts
 @Component({...})

--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -38,8 +38,8 @@ export interface ToSignalOptions<T> {
   /**
    * `Injector` which will provide the `DestroyRef` used to clean up the Observable subscription.
    *
-   * If this is not provided, a `DestroyRef` will be retrieved from the current injection context,
-   * unless manual cleanup is requested.
+   * If this is not provided, a `DestroyRef` will be retrieved from the current [injection
+   * context](/guide/dependency-injection-context), unless manual cleanup is requested.
    */
   injector?: Injector;
 
@@ -67,8 +67,8 @@ export interface ToSignalOptions<T> {
  * By default, the subscription will be automatically cleaned up when the current [injection
  * context](guide/dependency-injection-context) is destroyed. For example, when `toObservable` is
  * called during the construction of a component, the subscription will be cleaned up when the
- * component is destroyed. If an injection context is not available, an explicit `Injector` can be
- * passed instead.
+ * component is destroyed. If an [injection context](/guide/dependency-injection-context) is not
+ * available, an explicit `Injector` can be passed instead.
  *
  * If the subscription should persist until the `Observable` itself completes, the `manualCleanup`
  * option can be specified instead, which disables the automatic subscription teardown. No injection
@@ -88,10 +88,11 @@ export function toSignal<T>(source: Observable<T>|Subscribable<T>): Signal<T|und
  * `initialValue`, or `undefined` if no `initialValue` is provided. If the `Observable` is
  * guaranteed to emit synchronously, then the `requireSync` option can be passed instead.
  *
- * By default, the subscription will be automatically cleaned up when the current injection context
- * is destroyed. For example, when `toObservable` is called during the construction of a component,
- * the subscription will be cleaned up when the component is destroyed. If an injection context is
- * not available, an explicit `Injector` can be passed instead.
+ * By default, the subscription will be automatically cleaned up when the current [injection
+ * context](/guide/dependency-injection-context) is destroyed. For example, when `toObservable` is
+ * called during the construction of a component, the subscription will be cleaned up when the
+ * component is destroyed. If an injection context is not available, an explicit `Injector` can be
+ * passed instead.
  *
  * If the subscription should persist until the `Observable` itself completes, the `manualCleanup`
  * option can be specified instead, which disables the automatic subscription teardown. No injection
@@ -119,8 +120,8 @@ export function toSignal<T>(
  * By default, the subscription will be automatically cleaned up when the current [injection
  * context](guide/dependency-injection-context) is destroyed. For example, when `toObservable` is
  * called during the construction of a component, the subscription will be cleaned up when the
- * component is destroyed. If an injection context is not available, an explicit `Injector` can be
- * passed instead.
+ * component is destroyed. If an [injection context](/guide/dependency-injection-context) is not
+ * available, an explicit `Injector` can be passed instead.
  *
  * If the subscription should persist until the `Observable` itself completes, the `manualCleanup`
  * option can be specified instead, which disables the automatic subscription teardown. No injection
@@ -144,10 +145,11 @@ export function toSignal<T, U extends T|null|undefined>(
  * immediately upon subscription. No `initialValue` is needed in this case, and the returned signal
  * does not include an `undefined` type.
  *
- * By default, the subscription will be automatically cleaned up when the current injection context
- * is destroyed. For example, when `toObservable` is called during the construction of a component,
- * the subscription will be cleaned up when the component is destroyed. If an injection context is
- * not available, an explicit `Injector` can be passed instead.
+ * By default, the subscription will be automatically cleaned up when the current [injection
+ * context](/guide/dependency-injection-context) is destroyed. For example, when `toObservable` is
+ * called during the construction of a component, the subscription will be cleaned up when the
+ * component is destroyed. If an injection context is not available, an explicit `Injector` can be
+ * passed instead.
  *
  * If the subscription should persist until the `Observable` itself completes, the `manualCleanup`
  * option can be specified instead, which disables the automatic subscription teardown. No injection


### PR DESCRIPTION
Adding some missing links to this new page. 