### PR TITLE
fix(animations): remove `finish` listener once player is destroyed

### DIFF
--- a/packages/animations/browser/src/render/web_animations/web_animations_player.ts
+++ b/packages/animations/browser/src/render/web_animations/web_animations_player.ts
@@ -65,7 +65,14 @@ export class WebAnimationsPlayer implements AnimationPlayer {
     // @ts-expect-error overwriting a readonly property
     this.domPlayer = this._triggerWebAnimation(this.element, keyframes, this.options);
     this._finalKeyframe = keyframes.length ? keyframes[keyframes.length - 1] : new Map();
-    this.domPlayer.addEventListener('finish', () => this._onFinish());
+    const onFinish = () => this._onFinish();
+    this.domPlayer.addEventListener('finish', onFinish);
+    this.onDestroy(() => {
+      // We must remove the `finish` event listener once an animation has completed all its
+      // iterations. This action is necessary to prevent a memory leak since the listener captures
+      // `this`, creating a closure that prevents `this` from being garbage collected.
+      this.domPlayer.removeEventListener('finish', onFinish);
+    });
   }
 
   private _preparePlayerBeforeStart() {


### PR DESCRIPTION
This commit removes the `finish` listener from the Animation object once the animation is finished, effectively resolving a memory leak. Previously, the `finish` listener captured `this`, which prevented `this` from being garbage collected.

See the image below:

![Screenshot from 2023-07-22 00-13-37](https://github.com/angular/angular/assets/7337691/2a800642-95bf-4f39-a8b7-3de06b10444b)
