### PR TITLE
refactor(language-service): support showing tags info in the completion

### DIFF
--- a/packages/language-service/src/completions.ts
+++ b/packages/language-service/src/completions.ts
@@ -400,7 +400,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
         return undefined;
       }
 
-      const {kind, displayParts, documentation} =
+      const {kind, displayParts, documentation, tags} =
           getSymbolDisplayInfo(this.tsLS, this.typeChecker, symbol);
       return {
         kind: unsafeCastDisplayInfoKindToScriptElementKind(kind),
@@ -408,6 +408,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
         kindModifiers: ts.ScriptElementKindModifier.none,
         displayParts,
         documentation,
+        tags,
       };
     } else {
       return this.tsLS.getCompletionEntryDetails(
@@ -509,12 +510,14 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     const directive = tagMap.get(entryName)!;
     let displayParts: ts.SymbolDisplayPart[];
     let documentation: ts.SymbolDisplayPart[]|undefined = undefined;
+    let tags: ts.JSDocTagInfo[]|undefined = undefined;
     if (directive === null) {
       displayParts = [];
     } else {
       const displayInfo = getDirectiveDisplayInfo(this.tsLS, directive);
       displayParts = displayInfo.displayParts;
       documentation = displayInfo.documentation;
+      tags = displayInfo.tags;
     }
 
     return {
@@ -523,6 +526,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
       kindModifiers: ts.ScriptElementKindModifier.none,
       displayParts,
       documentation,
+      tags,
     };
   }
 
@@ -760,6 +764,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
     const completion = attrTable.get(name)!;
     let displayParts: ts.SymbolDisplayPart[];
     let documentation: ts.SymbolDisplayPart[]|undefined = undefined;
+    let tags: ts.JSDocTagInfo[]|undefined = undefined;
     let info: DisplayInfo|null;
     switch (completion.kind) {
       case AttributeCompletionKind.DomEvent:
@@ -774,6 +779,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
         info = getDirectiveDisplayInfo(this.tsLS, completion.directive);
         displayParts = info.displayParts;
         documentation = info.documentation;
+        tags = info.tags;
         break;
       case AttributeCompletionKind.StructuralDirectiveAttribute:
       case AttributeCompletionKind.DirectiveInput:
@@ -799,6 +805,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
         }
         displayParts = info.displayParts;
         documentation = info.documentation;
+        tags = info.tags;
     }
 
     return {
@@ -807,6 +814,7 @@ export class CompletionBuilder<N extends TmplAstNode|AST> {
       kindModifiers: ts.ScriptElementKindModifier.none,
       displayParts,
       documentation,
+      tags,
     };
   }
 


### PR DESCRIPTION
The Angular VSCode extension will support showing the tags info in this

[PR][1], so the language service can return the tags info now.

[1]: https://github.com/angular/vscode-ng-language-service/pull/1904

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
