### PR TITLE
refactor(compiler): handle braces in block parameters

### DIFF
--- a/packages/compiler/src/ml_parser/lexer.ts
+++ b/packages/compiler/src/ml_parser/lexer.ts
@@ -263,11 +263,11 @@ class _Tokenizer {
       this._beginToken(TokenType.BLOCK_PARAMETER);
       const start = this._cursor.clone();
       let inQuote: number|null = null;
+      let openBraces = 0;
 
       // Consume the parameter until the next semicolon or brace.
       // Note that we skip over semicolons/braces inside of strings.
-      while ((this._cursor.peek() !== chars.$SEMICOLON && this._cursor.peek() !== chars.$RBRACE &&
-              this._cursor.peek() !== chars.$EOF) ||
+      while ((this._cursor.peek() !== chars.$SEMICOLON && this._cursor.peek() !== chars.$EOF) ||
              inQuote !== null) {
         const char = this._cursor.peek();
 
@@ -278,6 +278,14 @@ class _Tokenizer {
           inQuote = null;
         } else if (inQuote === null && chars.isQuote(char)) {
           inQuote = char;
+        } else if (char === chars.$LBRACE && inQuote === null) {
+          openBraces++;
+        } else if (char === chars.$RBRACE && inQuote === null) {
+          if (openBraces === 0) {
+            break;
+          } else if (openBraces > 0) {
+            openBraces--;
+          }
         }
 
         this._cursor.advance();


### PR DESCRIPTION
Fixes that using braces in the block parameters would result in incorrect tokens being produced. Currently we don't have any blocks that allow object literal parameters, but it may come up in the future.