### PR TITLE
docs: remove trailing periods after `@see`

### DIFF
--- a/packages/common/src/i18n/locale_data_api.ts
+++ b/packages/common/src/i18n/locale_data_api.ts
@@ -13,7 +13,7 @@ import {CURRENCIES_EN, CurrenciesSymbols} from './currencies';
 
 /**
  * Format styles that can be used to represent numbers.
- * @see {@link getLocaleNumberFormat}.
+ * @see {@link getLocaleNumberFormat}
  * @see [Internationalization (i18n) Guide](/guide/i18n-overview)
  *
  * @publicApi

--- a/packages/core/src/di/interface/provider.ts
+++ b/packages/core/src/di/interface/provider.ts
@@ -250,7 +250,7 @@ export interface FactoryProvider extends FactorySansProvider {
  * Describes how an `Injector` should be configured as static (that is, without reflection).
  * A static provider provides tokens to an injector for various types of dependencies.
  *
- * @see {@link Injector.create()}.
+ * @see {@link Injector.create()}
  * @see ["Dependency Injection Guide"](guide/dependency-injection-providers).
  *
  * @publicApi

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -75,10 +75,10 @@ export const emitDistinctChangesOnlyDefaultValue = true;
 /**
  * Base class for query metadata.
  *
- * @see {@link ContentChildren}.
- * @see {@link ContentChild}.
- * @see {@link ViewChildren}.
- * @see {@link ViewChild}.
+ * @see {@link ContentChildren}
+ * @see {@link ContentChild}
+ * @see {@link ViewChildren}
+ * @see {@link ViewChild}
  *
  * @publicApi
  */
@@ -87,7 +87,7 @@ export abstract class Query {}
 /**
  * Type of the ContentChildren decorator / constructor function.
  *
- * @see {@link ContentChildren}.
+ * @see {@link ContentChildren}
  * @publicApi
  */
 export interface ContentChildrenDecorator {
@@ -274,7 +274,7 @@ export const ContentChild: ContentChildDecorator = makePropDecorator(
 /**
  * Type of the ViewChildren decorator / constructor function.
  *
- * @see {@link ViewChildren}.
+ * @see {@link ViewChildren}
  *
  * @publicApi
  */
@@ -363,7 +363,7 @@ export const ViewChildren: ViewChildrenDecorator = makePropDecorator(
 /**
  * Type of the ViewChild decorator / constructor function.
  *
- * @see {@link ViewChild}.
+ * @see {@link ViewChild}
  * @publicApi
  */
 export interface ViewChildDecorator {

--- a/packages/router/src/events.ts
+++ b/packages/router/src/events.ts
@@ -432,7 +432,7 @@ export class ResolveStart extends RouterEvent {
 
 /**
  * An event triggered at the end of the Resolve phase of routing.
- * @see {@link ResolveStart}.
+ * @see {@link ResolveStart}
  *
  * @publicApi
  */

--- a/packages/router/src/models.ts
+++ b/packages/router/src/models.ts
@@ -124,7 +124,7 @@ export type Data = {
  *
  * Represents the resolved data associated with a particular route.
  *
- * @see {@link Route#resolve}.
+ * @see {@link Route#resolve}
  *
  * @publicApi
  */

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -65,7 +65,7 @@ export const subsetMatchOptions: IsActiveMatchOptions = {
  *
  * A service that provides navigation among views and URL manipulation capabilities.
  *
- * @see {@link Route}.
+ * @see {@link Route}
  * @see [Routing and Navigation Guide](guide/router).
  *
  * @ngModule RouterModule


### PR DESCRIPTION
This fixes a rendering issue where the periods would be bellow the text block.

A good example of that issue can be seen in : https://angular.io/api/core/Query

![Screenshot 2023-07-23 at 09 37 02](https://github.com/angular/angular/assets/1300985/9008202a-351e-4c89-8fc9-1a48bdbde8d6)
