### PR TITLE
docs: Add precisions about static/dynamic queries.

### DIFF
--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -202,8 +202,6 @@ export interface ContentChildDecorator {
    * If the content DOM changes, and a new child matches the selector,
    * the property will be updated.
    *
-   * Content queries are set before the `ngAfterContentInit` callback is called.
-   *
    * Does not retrieve elements or directives that are in other components' templates,
    * since a component's template is always a black box to its ancestors.
    *
@@ -233,6 +231,17 @@ export interface ContentChildDecorator {
    * this query
    *   * Any provider defined through a string token (e.g. `{provide: 'token', useValue: 'val'}`)
    *   * `TemplateRef`, `ElementRef`, and `ViewContainerRef`
+   *
+   * Difference between dynamic and static queries:
+   *
+   * | Queries                             | Details |
+   * |:---                                 |:---     |
+   * | Dynamic queries \(`static: false`\) | The query resolves before the `ngAfterContentInit()`
+   * callback is called. The result will be updated for changes to your view, such as changes to
+   * `ngIf` and `ngFor` blocks. | | Static queries \(`static: true`\)   | The query resolves once
+   * the view has been created, but before change detection runs (before the `ngOnInit()` callback
+   * is called). The result, though, will never be updated to reflect changes to your view, such as
+   * changes to `ngIf` and `ngFor` blocks.  |
    *
    * @usageNotes
    *
@@ -374,14 +383,12 @@ export interface ViewChildDecorator {
    * in the view DOM. If the view DOM changes, and a new child matches the selector,
    * the property is updated.
    *
-   * View queries are set before the `ngAfterViewInit` callback is called.
-   *
    * **Metadata Properties**:
    *
    * * **selector** - The directive type or the name used for querying.
    * * **read** - Used to read a different token from the queried elements.
-   * * **static** - True to resolve query results before change detection runs,
-   * false to resolve after change detection. Defaults to false.
+   * * **static** - `true` to resolve query results before change detection runs,
+   * `false` to resolve after change detection. Defaults to `false`.
    *
    *
    * The following selectors are supported.
@@ -401,6 +408,17 @@ export interface ViewChildDecorator {
    * this query
    *   * Any provider defined through a string token (e.g. `{provide: 'token', useValue: 'val'}`)
    *   * `TemplateRef`, `ElementRef`, and `ViewContainerRef`
+   *
+   * Difference between dynamic and static queries**:
+   *
+   * | Queries                             | Details |
+   * |:---                                 |:---     |
+   * | Dynamic queries \(`static: false`\) | The query resolves before the `ngAfterViewInit()`
+   * callback is called. The result will be updated for changes to your view, such as changes to
+   * `ngIf` and `ngFor` blocks. | | Static queries \(`static: true`\)   | The query resolves once
+   * the view has been created, but before change detection runs (before the `ngOnInit()` callback
+   * is called). The result, though, will never be updated to reflect changes to your view, such as
+   * changes to `ngIf` and `ngFor` blocks. |
    *
    * @usageNotes
    *


### PR DESCRIPTION
The table is mostly copied from guide/migration-dynamic-flag.

Fixes #51142