### PR TITLE
refactor(core): Better use of Object.keys()

### DIFF
--- a/packages/core/test/render3/is_shape_of.ts
+++ b/packages/core/test/render3/is_shape_of.ts
@@ -61,8 +61,7 @@ export type ShapeOf<T> = {
  */
 export function isShapeOf<T>(obj: any, shapeOf: ShapeOf<T>): obj is T {
   if (typeof obj === 'object' && obj) {
-    return Object.keys(shapeOf).reduce(
-        (prev, key) => prev && obj.hasOwnProperty(key), true as boolean);
+    return Object.keys(shapeOf).every((key) => obj.hasOwnProperty(key));
   }
   return false;
 }

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -56,8 +56,7 @@ describe('r3 jit environment', () => {
   it('should support all r3 symbols', () => {
     Object
         // Map over the static properties of Identifiers.
-        .keys(Identifiers)
-        .map(key => (Identifiers as any as {[key: string]: string | ExternalReference})[key])
+        .values(Identifiers)
         // A few such properties are string constants. Ignore them, and focus on ExternalReferences.
         .filter(isExternalReference)
         // Some references are to interface types. Only take properties which have runtime values.

--- a/packages/core/test/render3/matchers.ts
+++ b/packages/core/test/render3/matchers.ts
@@ -180,7 +180,7 @@ export function matchDomElement(
     let actualStr = isDOMElement(_actual) ? `<${_actual.tagName}${toString(_actual.attributes)}>` :
                                             JSON.stringify(_actual);
     let expectedStr = `<${expectedTagName || '*'}${
-        Object.keys(expectedAttrs).map(key => ` ${key}=${JSON.stringify(expectedAttrs[key])}`)}>`;
+        Object.entries(expectedAttrs).map(([key, value]) => ` ${key}=${JSON.stringify(value)}`)}>`;
     return `[${actualStr} != ${expectedStr}]`;
   };
 

--- a/packages/core/test/sanitization/sanitization_spec.ts
+++ b/packages/core/test/sanitization/sanitization_spec.ts
@@ -91,8 +91,7 @@ describe('sanitization', () => {
     const sanitizerNameByContext: Map<number, Function> = new Map([
       [SecurityContext.URL, ɵɵsanitizeUrl], [SecurityContext.RESOURCE_URL, ɵɵsanitizeResourceUrl]
     ]);
-    Object.keys(schema).forEach(key => {
-      const context = schema[key];
+    Object.entries(schema).forEach(([key, context]) => {
       if (context === SecurityContext.URL || SecurityContext.RESOURCE_URL) {
         const [tag, prop] = key.split('|');
         const contexts = contextsByProp.get(prop) || new Set<number>();


### PR DESCRIPTION
Code cleaning arround the `Object.keys()` in the core tests.