### PR TITLE
feat(forms): Add a method to enable/disable a control from a boolean value

### DIFF
--- a/goldens/public-api/forms/index.md
+++ b/goldens/public-api/forms/index.md
@@ -79,6 +79,19 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
         emitEvent?: boolean;
     }): void;
     setParent(parent: FormGroup | FormArray | null): void;
+    setState(state: {
+        enabled: boolean;
+    }, opts?: {
+        onlySelf?: boolean;
+        emitEvent?: boolean;
+    }): void;
+    // (undocumented)
+    setState(state: {
+        disabled: boolean;
+    }, opts?: {
+        onlySelf?: boolean;
+        emitEvent?: boolean;
+    }): void;
     setValidators(validators: ValidatorFn | ValidatorFn[] | null): void;
     abstract setValue(value: TRawValue, options?: Object): void;
     readonly status: FormControlStatus;

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -15,7 +15,6 @@ import {RuntimeErrorCode} from '../errors';
 import {FormArray, FormGroup} from '../forms';
 import {addValidators, composeAsyncValidators, composeValidators, hasValidator, removeValidators, toObservable} from '../validators';
 
-
 /**
  * Reports that a control is valid, meaning that no errors exist in the input value.
  *
@@ -989,6 +988,37 @@ export abstract class AbstractControl<TValue = any, TRawValue extends TValue = T
 
     this._updateAncestors({...opts, skipPristineCheck});
     this._onDisabledChange.forEach((changeFn) => changeFn(false));
+  }
+
+  /**
+   * Enables or disables the control depending on the first argument.
+   * This means the control is included in validation checks and
+   * the aggregate value of its parent. Its status recalculates based on its value and
+   * its validators.
+   *
+   * By default, if the control has children, all children are enabled.
+   *
+   * @see {@link AbstractControl.status}
+   *
+   * @param opts Configure options that control how the control propagates changes and
+   * emits events when marked as untouched
+   * * `onlySelf`: When true, mark only this control. When false or not supplied,
+   * marks all direct ancestors. Default is false.
+   * * `emitEvent`: When true or not supplied (the default), both the `statusChanges` and
+   * `valueChanges`
+   * observables emit events with the latest status and value when the control is enabled.
+   * When false, no events are emitted.
+   */
+  setState(state: {enabled: boolean}, opts?: {onlySelf?: boolean, emitEvent?: boolean}): void;
+  setState(state: {disabled: boolean}, opts?: {onlySelf?: boolean, emitEvent?: boolean}): void;
+  setState(state: {disabled: boolean}|{enabled: boolean}, opts: {
+    onlySelf?: boolean,
+    emitEvent?: boolean
+  } = {}): void {
+    (((state as {enabled: boolean}).enabled) ||
+     ((state as {disabled: boolean}).disabled === false)) ?
+        this.enable(opts) :
+        this.disable(opts);
   }
 
   private _updateAncestors(

--- a/packages/forms/test/form_control_spec.ts
+++ b/packages/forms/test/form_control_spec.ts
@@ -1220,6 +1220,28 @@ describe('FormControl', () => {
       expect(c.valid).toBe(true);
     });
 
+    it('should mark the control as disabled with setState', () => {
+      const c = new FormControl(null);
+      expect(c.disabled).toBe(false);
+      expect(c.valid).toBe(true);
+
+      c.setState({enabled: false});
+      expect(c.disabled).toBe(true);
+      expect(c.valid).toBe(false);
+
+      c.setState({enabled: true});
+      expect(c.disabled).toBe(false);
+      expect(c.valid).toBe(true);
+
+      c.setState({disabled: true});
+      expect(c.disabled).toBe(true);
+      expect(c.valid).toBe(false);
+
+      c.setState({disabled: false});
+      expect(c.disabled).toBe(false);
+      expect(c.valid).toBe(true);
+    });
+
     it('should set the control status as disabled', () => {
       const c = new FormControl(null);
       expect(c.status).toEqual('VALID');


### PR DESCRIPTION
A single method to keep the API surface minimal.
Nothing is written in stone, I'm open to amend the method name if I get better suggestions ! 

Fixes #47916