### PR TITLE
refactor(compiler): initial changes to compute defer block dependencies

### DIFF
--- a/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
+++ b/packages/compiler-cli/linker/src/file_linker/partial_linkers/partial_component_linker_1.ts
@@ -169,6 +169,11 @@ export class PartialComponentLinkerVersion1<TStatement, TExpression> implements
       declarationListEmitMode,
       styles: metaObj.has('styles') ? metaObj.getArray('styles').map(entry => entry.getString()) :
                                       [],
+
+      // Defer blocks are not yet supported in partial compilation.
+      deferBlocks: new Map(),
+      deferrableDeclToImportDecl: new Map(),
+
       encapsulation: metaObj.has('encapsulation') ?
           parseEncapsulation(metaObj.getValue('encapsulation')) :
           ViewEncapsulation.Emulated,

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -13,6 +13,7 @@ import {Cycle, CycleAnalyzer, CycleHandlingStrategy} from '../../../cycles';
 import {ErrorCode, FatalDiagnosticError, makeDiagnostic, makeRelatedInformation} from '../../../diagnostics';
 import {absoluteFrom, relative} from '../../../file_system';
 import {assertSuccessfulReferenceEmit, ImportedFile, ModuleResolver, Reference, ReferenceEmitter} from '../../../imports';
+import {DeferredSymbolTracker} from '../../../imports/src/deferred_symbol_tracker';
 import {DependencyTracker} from '../../../incremental/api';
 import {extractSemanticTypeParameters, SemanticDepGraphUpdater} from '../../../incremental/semantic_graph';
 import {IndexingContext} from '../../../indexer';
@@ -62,7 +63,8 @@ export class ComponentDecoratorHandler implements
       private semanticDepGraphUpdater: SemanticDepGraphUpdater|null,
       private annotateForClosureCompiler: boolean, private perf: PerfRecorder,
       private hostDirectivesResolver: HostDirectivesResolver, private includeClassMetadata: boolean,
-      private readonly compilationMode: CompilationMode) {
+      private readonly compilationMode: CompilationMode,
+      private readonly deferredSymbolsTracker: DeferredSymbolTracker) {
     this.extractTemplateOptions = {
       enableI18nLegacyMessageIdFormat: this.enableI18nLegacyMessageIdFormat,
       i18nNormalizeLineEndingsInICUs: this.i18nNormalizeLineEndingsInICUs,

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/metadata.ts
@@ -23,7 +23,8 @@ import {ParsedTemplateWithSource, StyleUrlMeta} from './resources';
  * be included here.
  */
 export type ComponentMetadataResolvedFields = SubsetOfKeys<
-    R3ComponentMetadata<R3TemplateDependencyMetadata>, 'declarations'|'declarationListEmitMode'>;
+    R3ComponentMetadata<R3TemplateDependencyMetadata>,
+    'declarations'|'declarationListEmitMode'|'deferBlocks'|'deferrableDeclToImportDecl'>;
 
 export interface ComponentAnalysisData {
   /**

--- a/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/test/component_spec.ts
@@ -13,7 +13,7 @@ import {CycleAnalyzer, CycleHandlingStrategy, ImportGraph} from '../../../cycles
 import {ErrorCode, FatalDiagnosticError, ngErrorCode} from '../../../diagnostics';
 import {absoluteFrom} from '../../../file_system';
 import {runInEachFileSystem} from '../../../file_system/testing';
-import {ModuleResolver, Reference, ReferenceEmitter} from '../../../imports';
+import {DeferredSymbolTracker, ModuleResolver, Reference, ReferenceEmitter} from '../../../imports';
 import {CompoundMetadataReader, DtsMetadataReader, HostDirectivesResolver, LocalMetadataRegistry, ResourceRegistry} from '../../../metadata';
 import {PartialEvaluator} from '../../../partial_evaluator';
 import {NOOP_PERF_RECORDER} from '../../../perf';
@@ -102,6 +102,7 @@ function setup(
       hostDirectivesResolver,
       true,
       compilationMode,
+      new DeferredSymbolTracker(checker),
   );
   return {reflectionHost, handler, resourceLoader, metaRegistry};
 }

--- a/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
+++ b/packages/compiler-cli/src/ngtsc/core/src/compiler.ts
@@ -14,7 +14,7 @@ import {CycleAnalyzer, CycleHandlingStrategy, ImportGraph} from '../../cycles';
 import {COMPILER_ERRORS_WITH_GUIDES, ERROR_DETAILS_PAGE_BASE_URL, ErrorCode, FatalDiagnosticError, ngErrorCode} from '../../diagnostics';
 import {checkForPrivateExports, ReferenceGraph} from '../../entry_point';
 import {absoluteFromSourceFile, AbsoluteFsPath, LogicalFileSystem, resolve} from '../../file_system';
-import {AbsoluteModuleStrategy, AliasingHost, AliasStrategy, DefaultImportTracker, ImportRewriter, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, NoopImportRewriter, PrivateExportAliasingHost, R3SymbolsImportRewriter, Reference, ReferenceEmitStrategy, ReferenceEmitter, RelativePathStrategy, UnifiedModulesAliasingHost, UnifiedModulesStrategy} from '../../imports';
+import {AbsoluteModuleStrategy, AliasingHost, AliasStrategy, DefaultImportTracker, DeferredSymbolTracker, ImportRewriter, LocalIdentifierStrategy, LogicalProjectStrategy, ModuleResolver, NoopImportRewriter, PrivateExportAliasingHost, R3SymbolsImportRewriter, Reference, ReferenceEmitStrategy, ReferenceEmitter, RelativePathStrategy, UnifiedModulesAliasingHost, UnifiedModulesStrategy} from '../../imports';
 import {IncrementalBuildStrategy, IncrementalCompilation, IncrementalState} from '../../incremental';
 import {SemanticSymbol} from '../../incremental/semantic_graph';
 import {generateAnalysis, IndexedComponent, IndexingContext} from '../../indexer';
@@ -1017,6 +1017,8 @@ export class NgCompiler {
 
     const resourceRegistry = new ResourceRegistry();
 
+    const deferredSymbolsTracker = new DeferredSymbolTracker(this.inputProgram.getTypeChecker());
+
     // Note: If this compilation builds `@angular/core`, we always build in full compilation
     // mode. Code inside the core package is always compatible with itself, so it does not
     // make sense to go through the indirection of partial compilation
@@ -1070,7 +1072,7 @@ export class NgCompiler {
           this.moduleResolver, this.cycleAnalyzer, cycleHandlingStrategy, refEmitter,
           referencesRegistry, this.incrementalCompilation.depGraph, injectableRegistry,
           semanticDepGraphUpdater, this.closureCompilerEnabled, this.delegatingPerfRecorder,
-          hostDirectivesResolver, supportTestBed, compilationMode),
+          hostDirectivesResolver, supportTestBed, compilationMode, deferredSymbolsTracker),
 
       // TODO(alxhub): understand why the cast here is necessary (something to do with `null`
       // not being assignable to `unknown` when wrapped in `Readonly`).

--- a/packages/compiler-cli/src/ngtsc/imports/index.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/index.ts
@@ -9,6 +9,7 @@
 export {AliasingHost, AliasStrategy, PrivateExportAliasingHost, UnifiedModulesAliasingHost} from './src/alias';
 export {ImportRewriter, NoopImportRewriter, R3SymbolsImportRewriter, validateAndRewriteCoreSymbol} from './src/core';
 export {DefaultImportTracker} from './src/default';
+export {DeferredSymbolTracker} from './src/deferred_symbol_tracker';
 export {AbsoluteModuleStrategy, assertSuccessfulReferenceEmit, EmittedReference, FailedEmitResult, ImportedFile, ImportFlags, LocalIdentifierStrategy, LogicalProjectStrategy, ReferenceEmitKind, ReferenceEmitResult, ReferenceEmitStrategy, ReferenceEmitter, RelativePathStrategy, UnifiedModulesStrategy} from './src/emitter';
 export {isAliasImportDeclaration, loadIsReferencedAliasDeclarationPatch} from './src/patch_alias_reference_resolution';
 export {Reexport} from './src/reexport';

--- a/packages/compiler-cli/src/ngtsc/imports/src/deferred_symbol_tracker.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/deferred_symbol_tracker.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import ts from 'typescript';
+
+import {getContainingImportDeclaration} from '../../reflection/src/typescript';
+
+const AssumeEager = 'AssumeEager';
+type AssumeEager = typeof AssumeEager;
+
+/**
+ * Allows to register a symbol as deferrable and keep track of its usage.
+ *
+ * This information is later used to determine whether it's safe to drop
+ * a regular import of this symbol (actually the entire import declaration)
+ * in favor of using a dynamic import for cases when `{#defer}` blocks are used.
+ */
+export class DeferredSymbolTracker {
+  private readonly imports =
+      new Map<ts.ImportDeclaration, Map<string, Set<ts.Identifier>|AssumeEager>>();
+
+  constructor(private readonly typeChecker: ts.TypeChecker) {}
+
+  /**
+   * Given an import declaration node, extract the names of all imported symbols
+   * and return them as a map where each symbol is a key and `AssumeEager` is a value.
+   *
+   * The logic recognizes the following import shapes:
+   *
+   * Case 1: `import {a, b as B} from 'a'`
+   * Case 2: `import X from 'a'`
+   * Case 3: `import * as x from 'a'`
+   */
+  private extractImportedSymbols(importDecl: ts.ImportDeclaration): Map<string, AssumeEager> {
+    const symbolMap = new Map<string, AssumeEager>();
+
+    // Unsupported case: `import 'a'`
+    if (importDecl.importClause === undefined) {
+      throw new Error(`Provided import declaration doesn't have any symbols.`);
+    }
+
+    if (importDecl.importClause.namedBindings !== undefined) {
+      const bindings = importDecl.importClause.namedBindings;
+      if (ts.isNamedImports(bindings)) {
+        // Case 1: `import {a, b as B} from 'a'`
+        for (const element of bindings.elements) {
+          symbolMap.set(element.name.text, AssumeEager);
+        }
+      } else {
+        // Case 2: `import X from 'a'`
+        symbolMap.set(bindings.name.text, AssumeEager);
+      }
+    } else if (importDecl.importClause.name !== undefined) {
+      // Case 2: `import * as x from 'a'`
+      symbolMap.set(importDecl.importClause.name.text, AssumeEager);
+    } else {
+      throw new Error('Unrecognized import structure.');
+    }
+    return symbolMap;
+  }
+
+  /**
+   * Marks a given identifier and an associated import declaration as a candidate
+   * for defer loading.
+   */
+  markAsDeferrableCandidate(identifier: ts.Identifier, importDecl: ts.ImportDeclaration): void {
+    // Do we come across this import for the first time?
+    if (!this.imports.has(importDecl)) {
+      const symbolMap = this.extractImportedSymbols(importDecl);
+      this.imports.set(importDecl, symbolMap);
+    }
+
+    const symbolMap = this.imports.get(importDecl)!;
+
+    if (!symbolMap.has(identifier.text)) {
+      throw new Error(
+          `The '${identifier.text}' identifier doesn't belong ` +
+          `to the provided import declaration.`);
+    }
+
+    if (symbolMap.get(identifier.text) === AssumeEager) {
+      // We process this symbol for the first time, populate references.
+      symbolMap.set(
+          identifier.text, this.lookupIdentifiersInSourceFile(identifier.text, importDecl));
+    }
+
+    const identifiers = symbolMap.get(identifier.text) as Set<ts.Identifier>;
+
+    // Drop the current identifier, since we are trying to make it deferrable
+    // (it's used as a dependency in one of the `{#defer}` blocks).
+    identifiers.delete(identifier);
+  }
+
+  /**
+   * Whether all symbols from a given import declaration have no references
+   * in a source file, thus it's safe to use dynamic imports.
+   */
+  canDefer(importDecl: ts.ImportDeclaration): boolean {
+    if (!this.imports.has(importDecl)) {
+      return false;
+    }
+
+    const symbolsMap = this.imports.get(importDecl)!;
+    for (const [symbol, refs] of symbolsMap) {
+      if (refs === AssumeEager || refs.size > 0) {
+        // There may be still eager references to this symbol.
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Returns a set of import declarations that is safe to remove
+   * from the current source file and generate dynamic imports instead.
+   */
+  getDeferrableImportDecls(): Set<ts.ImportDeclaration> {
+    const deferrableDecls = new Set<ts.ImportDeclaration>();
+    for (const [importDecl] of this.imports) {
+      if (this.canDefer(importDecl)) {
+        deferrableDecls.add(importDecl);
+      }
+    }
+    return deferrableDecls;
+  }
+
+  private lookupIdentifiersInSourceFile(name: string, importDecl: ts.ImportDeclaration):
+      Set<ts.Identifier> {
+    const results = new Set<ts.Identifier>();
+    const visit = (node: ts.Node): void => {
+      if (node === importDecl) {
+        // Don't record references from the declaration itself.
+        return;
+      }
+
+      if (ts.isIdentifier(node) && node.text === name) {
+        // Is `node` actually a reference to this symbol?
+        const sym = this.typeChecker.getSymbolAtLocation(node);
+        if (sym === undefined) {
+          return;
+        }
+
+        if (sym.declarations === undefined || sym.declarations.length === 0) {
+          return;
+        }
+        const importClause = sym.declarations[0];
+        // Is declaration from this import statement?
+        const decl = getContainingImportDeclaration(importClause);
+        if (decl !== importDecl) {
+          return;
+        }
+
+        // `node` *is* a reference to the same import.
+        results.add(node);
+      }
+      ts.forEachChild(node, visit);
+    };
+
+    visit(importDecl.getSourceFile());
+    return results;
+  }
+}

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -466,6 +466,11 @@ export interface Import {
    * This could either be an absolute module name (@angular/core for example) or a relative path.
    */
   from: string;
+
+  /**
+   * TypeScript node that represents this import.
+   */
+  node: ts.ImportDeclaration;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -255,7 +255,11 @@ export class TypeScriptReflectionHost implements ReflectionHost {
       return null;
     }
 
-    return {from: importDecl.moduleSpecifier.text, name: getExportedName(decl, id)};
+    return {
+      from: importDecl.moduleSpecifier.text,
+      name: getExportedName(decl, id),
+      node: importDecl,
+    };
   }
 
   /**
@@ -304,6 +308,7 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return {
       from: importDeclaration.moduleSpecifier.text,
       name: id.text,
+      node: namespaceDeclaration.parent.parent,
     };
   }
 

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -659,7 +659,7 @@ function getFarLeftIdentifier(propertyAccess: ts.PropertyAccessExpression): ts.I
  * Return the ImportDeclaration for the given `node` if it is either an `ImportSpecifier` or a
  * `NamespaceImport`. If not return `null`.
  */
-function getContainingImportDeclaration(node: ts.Node): ts.ImportDeclaration|null {
+export function getContainingImportDeclaration(node: ts.Node): ts.ImportDeclaration|null {
   return ts.isImportSpecifier(node) ? node.parent!.parent!.parent! :
       ts.isNamespaceImport(node)    ? node.parent.parent :
                                       null;

--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -196,6 +196,12 @@ export class CompilerFacadeImpl implements CompilerFacade {
       template,
       declarations: facade.declarations.map(convertDeclarationFacadeToMetadata),
       declarationListEmitMode: DeclarationListEmitMode.Direct,
+
+      // TODO: leaving empty in JIT mode for now,
+      // to be implemented as one of the next steps.
+      deferBlocks: new Map(),
+      deferrableDeclToImportDecl: new Map(),
+
       styles: [...facade.styles, ...template.styles],
       encapsulation: facade.encapsulation,
       interpolation,
@@ -470,6 +476,12 @@ function convertDeclareComponentFacadeToMetadata(
     viewProviders: decl.viewProviders !== undefined ? new WrappedNodeExpr(decl.viewProviders) :
                                                       null,
     animations: decl.animations !== undefined ? new WrappedNodeExpr(decl.animations) : null,
+
+    // TODO: leaving empty in JIT mode for now,
+    // to be implemented as one of the next steps.
+    deferBlocks: new Map(),
+    deferrableDeclToImportDecl: new Map(),
+
     changeDetection: decl.changeDetection ?? ChangeDetectionStrategy.Default,
     encapsulation: decl.encapsulation ?? ViewEncapsulation.Emulated,
     interpolation,

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -139,6 +139,8 @@ export class Identifiers {
 
   static templateCreate: o.ExternalReference = {name: 'ɵɵtemplate', moduleName: CORE};
 
+  static defer: o.ExternalReference = {name: 'ɵɵdefer', moduleName: CORE};
+
   static text: o.ExternalReference = {name: 'ɵɵtext', moduleName: CORE};
 
   static enableBindings: o.ExternalReference = {name: 'ɵɵenableBindings', moduleName: CORE};

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -218,11 +218,11 @@ export interface R3ComponentMetadata<DeclarationT extends R3TemplateDependency> 
   declarations: DeclarationT[];
 
   /**
-   * Map of all types that can be defer loaded -> corresponding module specifier
-   * strings (that can later be used as a value in dynamic imports).
+   * Map of all types that can be defer loaded (ts.ClassDeclaration) ->
+   * corresponding import declaration (ts.ImportDeclaration) within
+   * the current source file.
    */
-  // TODO: fix types! (ClassDeclaration -> ImportDeclaration)
-  deferrableDeclToImportDecl: Map<any, any>;
+  deferrableDeclToImportDecl: Map<o.Expression, o.Expression>;
 
   /**
    * Map of {#defer} blocks -> their corresponding dependencies.

--- a/packages/compiler/src/render3/view/api.ts
+++ b/packages/compiler/src/render3/view/api.ts
@@ -170,6 +170,31 @@ export const enum DeclarationListEmitMode {
 }
 
 /**
+ * Describes a dependency used within a `{#defer}` block.
+ */
+export interface DeferBlockTemplateDependency {
+  /**
+   * Reference to a dependency.
+   */
+  type: o.WrappedNodeExpr<unknown>;
+
+  /**
+   * Dependency class name.
+   */
+  symbolName: string;
+
+  /**
+   * Whether this dependency can be defer-loaded.
+   */
+  isDeferrable: boolean;
+
+  /**
+   * Import path where this dependency is located.
+   */
+  importPath: string|null;
+}
+
+/**
  * Information needed to compile a component for the render3 runtime.
  */
 export interface R3ComponentMetadata<DeclarationT extends R3TemplateDependency> extends
@@ -191,6 +216,18 @@ export interface R3ComponentMetadata<DeclarationT extends R3TemplateDependency> 
   };
 
   declarations: DeclarationT[];
+
+  /**
+   * Map of all types that can be defer loaded -> corresponding module specifier
+   * strings (that can later be used as a value in dynamic imports).
+   */
+  // TODO: fix types! (ClassDeclaration -> ImportDeclaration)
+  deferrableDeclToImportDecl: Map<any, any>;
+
+  /**
+   * Map of {#defer} blocks -> their corresponding dependencies.
+   */
+  deferBlocks: Map<t.DeferredBlock, Array<DeferBlockTemplateDependency>>;
 
   /**
    * Specifies how the 'directives' and/or `pipes` array, if generated, need to be emitted.

--- a/packages/compiler/src/render3/view/compiler.ts
+++ b/packages/compiler/src/render3/view/compiler.ts
@@ -194,7 +194,7 @@ export function compileComponentFromMetadata(
     const template = meta.template;
     const templateBuilder = new TemplateDefinitionBuilder(
         constantPool, BindingScope.createRootScope(), 0, templateTypeName, null, null, templateName,
-        R3.namespaceHTML, meta.relativeContextFilePath, meta.i18nUseExternalIds);
+        R3.namespaceHTML, meta.relativeContextFilePath, meta.i18nUseExternalIds, meta.deferBlocks);
 
     const templateFunctionExpression = templateBuilder.buildTemplateFunction(template.nodes, []);
 

--- a/packages/compiler/src/render3/view/t2_api.ts
+++ b/packages/compiler/src/render3/view/t2_api.ts
@@ -7,7 +7,7 @@
  */
 
 import {AST} from '../../expression_parser/ast';
-import {BoundAttribute, BoundEvent, Element, Node, Reference, Template, TextAttribute, Variable} from '../r3_ast';
+import {BoundAttribute, BoundEvent, DeferredBlock, Element, Node, Reference, Template, TextAttribute, Variable} from '../r3_ast';
 
 
 /*
@@ -173,12 +173,31 @@ export interface BoundTarget<DirectiveT extends DirectiveMeta> {
   getEntitiesInTemplateScope(template: Template|null): ReadonlySet<Reference|Variable>;
 
   /**
-   * Get a list of all the directives used by the target.
+   * Get a list of all the directives used by the target,
+   * including directives from `{#defer}` blocks.
    */
   getUsedDirectives(): DirectiveT[];
 
   /**
-   * Get a list of all the pipes used by the target.
+   * Get a list of eagerly used directives from the target.
+   * Note: this list *excludes* directives from `{#defer}` blocks.
+   */
+  getEagerlyUsedDirectives(): DirectiveT[];
+
+  /**
+   * Get a list of all the pipes used by the target,
+   * including pipes from `{#defer}` blocks.
    */
   getUsedPipes(): string[];
+
+  /**
+   * Get a list of eagerly used pipes from the target.
+   * Note: this list *excludes* pipes from `{#defer}` blocks.
+   */
+  getEagerlyUsedPipes(): string[];
+
+  /**
+   * Get a list of all {#defer} blocks used by the target.
+   */
+  getDeferBlocks(): DeferredBlock[];
 }

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -46,15 +46,15 @@ export class R3TargetBinder<DirectiveT extends DirectiveMeta> implements TargetB
     //   - bindings: Map of inputs, outputs, and attributes to the directive/element that claims
     //     them. TODO(alxhub): handle multiple directives claiming an input/output/etc.
     //   - references: Map of #references to their targets.
-    const {directives, bindings, references} =
+    const {directives, eagerDirectives, bindings, references} =
         DirectiveBinder.apply(target.template, this.directiveMatcher);
     // Finally, run the TemplateBinder to bind references, variables, and other entities within the
     // template. This extracts all the metadata that doesn't depend on directive matching.
-    const {expressions, symbols, nestingLevel, usedPipes} =
+    const {expressions, symbols, nestingLevel, usedPipes, eagerPipes, deferBlocks} =
         TemplateBinder.applyWithScope(target.template, scope);
     return new R3BoundTarget(
-        target, directives, bindings, references, expressions, symbols, nestingLevel,
-        templateEntities, usedPipes);
+        target, directives, eagerDirectives, bindings, references, expressions, symbols,
+        nestingLevel, templateEntities, usedPipes, eagerPipes, deferBlocks);
   }
 }
 
@@ -211,9 +211,13 @@ class Scope implements Visitor {
  * Usually used via the static `apply()` method.
  */
 class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
+  // Indicates whether we are visiting elements within a {#defer} block
+  private isInDeferBlock = false;
+
   constructor(
       private matcher: SelectorMatcher<DirectiveT[]>,
       private directives: Map<Element|Template, DirectiveT[]>,
+      private eagerDirectives: DirectiveT[],
       private bindings: Map<BoundAttribute|BoundEvent|TextAttribute, DirectiveT|Element|Template>,
       private references:
           Map<Reference, {directive: DirectiveT, node: Element|Template}|Element|Template>) {}
@@ -233,6 +237,7 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
   static apply<DirectiveT extends DirectiveMeta>(
       template: Node[], selectorMatcher: SelectorMatcher<DirectiveT[]>): {
     directives: Map<Element|Template, DirectiveT[]>,
+    eagerDirectives: DirectiveT[],
     bindings: Map<BoundAttribute|BoundEvent|TextAttribute, DirectiveT|Element|Template>,
     references: Map<Reference, {directive: DirectiveT, node: Element|Template}|Element|Template>,
   } {
@@ -241,9 +246,11 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
         new Map<BoundAttribute|BoundEvent|TextAttribute, DirectiveT|Element|Template>();
     const references =
         new Map<Reference, {directive: DirectiveT, node: Element | Template}|Element|Template>();
-    const matcher = new DirectiveBinder(selectorMatcher, directives, bindings, references);
+    const eagerDirectives: DirectiveT[] = [];
+    const matcher =
+        new DirectiveBinder(selectorMatcher, directives, eagerDirectives, bindings, references);
     matcher.ingest(template);
-    return {directives, bindings, references};
+    return {directives, eagerDirectives, bindings, references};
   }
 
   private ingest(template: Node[]): void {
@@ -268,6 +275,9 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
     this.matcher.match(cssSelector, (_selector, results) => directives.push(...results));
     if (directives.length > 0) {
       this.directives.set(node, directives);
+      if (!this.isInDeferBlock) {
+        this.eagerDirectives.push(...directives);
+      }
     }
 
     // Resolve any references that are created on this node.
@@ -327,7 +337,10 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
   }
 
   visitDeferredBlock(deferred: DeferredBlock): void {
+    this.isInDeferBlock = true;
     deferred.children.forEach(child => child.visit(this));
+    this.isInDeferBlock = false;
+
     deferred.placeholder?.visit(this);
     deferred.loading?.visit(this);
     deferred.error?.visit(this);
@@ -371,9 +384,13 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
 class TemplateBinder extends RecursiveAstVisitor implements Visitor {
   private visitNode: (node: Node) => void;
 
+  // Indicates whether we are visiting elements within a {#defer} block
+  private isInDeferBlock = false;
+
   private constructor(
       private bindings: Map<AST, Reference|Variable>,
       private symbols: Map<Reference|Variable, Template>, private usedPipes: Set<string>,
+      private eagerPipes: Set<string>, private deferBlocks: Set<DeferredBlock>,
       private nestingLevel: Map<Template, number>, private scope: Scope,
       private template: Template|null, private level: number) {
     super();
@@ -410,17 +427,21 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     symbols: Map<Variable|Reference, Template>,
     nestingLevel: Map<Template, number>,
     usedPipes: Set<string>,
+    eagerPipes: Set<string>,
+    deferBlocks: Set<DeferredBlock>,
   } {
     const expressions = new Map<AST, Reference|Variable>();
     const symbols = new Map<Variable|Reference, Template>();
     const nestingLevel = new Map<Template, number>();
     const usedPipes = new Set<string>();
+    const eagerPipes = new Set<string>();
     const template = nodes instanceof Template ? nodes : null;
+    const deferBlocks = new Set<DeferredBlock>();
     // The top-level template has nesting level 0.
-    const binder =
-        new TemplateBinder(expressions, symbols, usedPipes, nestingLevel, scope, template, 0);
+    const binder = new TemplateBinder(
+        expressions, symbols, usedPipes, eagerPipes, deferBlocks, nestingLevel, scope, template, 0);
     binder.ingest(nodes);
-    return {expressions, symbols, nestingLevel, usedPipes};
+    return {expressions, symbols, nestingLevel, usedPipes, eagerPipes, deferBlocks};
   }
 
   private ingest(template: Template|Node[]): void {
@@ -457,8 +478,8 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     // Next, recurse into the template using its scope, and bumping the nesting level up by one.
     const childScope = this.scope.getChildScope(template);
     const binder = new TemplateBinder(
-        this.bindings, this.symbols, this.usedPipes, this.nestingLevel, childScope, template,
-        this.level + 1);
+        this.bindings, this.symbols, this.usedPipes, this.eagerPipes, this.deferBlocks,
+        this.nestingLevel, childScope, template, this.level + 1);
     binder.ingest(template);
   }
 
@@ -497,9 +518,14 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
   }
 
   visitDeferredBlock(deferred: DeferredBlock) {
+    this.deferBlocks.add(deferred);
+
+    this.isInDeferBlock = true;
+    deferred.children.forEach(this.visitNode);
+    this.isInDeferBlock = false;
+
     deferred.triggers.forEach(this.visitNode);
     deferred.prefetchTriggers.forEach(this.visitNode);
-    deferred.children.forEach(this.visitNode);
     deferred.placeholder && this.visitNode(deferred.placeholder);
     deferred.loading && this.visitNode(deferred.loading);
     deferred.error && this.visitNode(deferred.error);
@@ -528,6 +554,9 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
   }
   override visitPipe(ast: BindingPipe, context: any): any {
     this.usedPipes.add(ast.name);
+    if (!this.isInDeferBlock) {
+      this.eagerPipes.add(ast.name);
+    }
     return super.visitPipe(ast, context);
   }
 
@@ -574,6 +603,7 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
 export class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTarget<DirectiveT> {
   constructor(
       readonly target: Target, private directives: Map<Element|Template, DirectiveT[]>,
+      private eagerDirectives: DirectiveT[],
       private bindings: Map<BoundAttribute|BoundEvent|TextAttribute, DirectiveT|Element|Template>,
       private references:
           Map<BoundAttribute|BoundEvent|Reference|TextAttribute,
@@ -582,7 +612,8 @@ export class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTar
       private symbols: Map<Reference|Variable, Template>,
       private nestingLevel: Map<Template, number>,
       private templateEntities: Map<Template|null, ReadonlySet<Reference|Variable>>,
-      private usedPipes: Set<string>) {}
+      private usedPipes: Set<string>, private eagerPipes: Set<string>,
+      private deferredBlocks: Set<DeferredBlock>) {}
 
   getEntitiesInTemplateScope(template: Template|null): ReadonlySet<Reference|Variable> {
     return this.templateEntities.get(template) ?? new Set();
@@ -620,8 +651,21 @@ export class R3BoundTarget<DirectiveT extends DirectiveMeta> implements BoundTar
     return Array.from(set.values());
   }
 
+  getEagerlyUsedDirectives(): DirectiveT[] {
+    const set = new Set<DirectiveT>(this.eagerDirectives);
+    return Array.from(set.values());
+  }
+
   getUsedPipes(): string[] {
     return Array.from(this.usedPipes);
+  }
+
+  getEagerlyUsedPipes(): string[] {
+    return Array.from(this.eagerPipes);
+  }
+
+  getDeferBlocks(): DeferredBlock[] {
+    return Array.from(this.deferredBlocks);
   }
 }
 

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -197,6 +197,7 @@ export {
   ɵɵsyntheticHostProperty,
   ɵɵtemplate,
   ɵɵtemplateRefExtractor,
+  ɵɵdefer,
   ɵɵtext,
   ɵɵtextInterpolate,
   ɵɵtextInterpolate1,

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -118,6 +118,8 @@ export {
 
   ɵɵtemplate,
 
+  ɵɵdefer,
+
   ɵɵtext,
   ɵɵtextInterpolate,
   ɵɵtextInterpolate1,

--- a/packages/core/src/render3/instructions/all.ts
+++ b/packages/core/src/render3/instructions/all.ts
@@ -50,4 +50,5 @@ export * from './style_map_interpolation';
 export * from './style_prop_interpolation';
 export * from './host_property';
 export * from './i18n';
+export * from './defer';
 export {ɵgetUnknownElementStrictMode, ɵsetUnknownElementStrictMode, ɵgetUnknownPropertyStrictMode, ɵsetUnknownPropertyStrictMode} from './element_validation';

--- a/packages/core/src/render3/instructions/defer.ts
+++ b/packages/core/src/render3/instructions/defer.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Type} from '../../interface/type';
+
+export type DeferredDepsFn = () => Array<Promise<Type<unknown>>|Type<unknown>>;
+
+/**
+ * Creates runtime data structures for `{#defer}` blocks.
+ *
+ * @param index The index of the defer block in the data array
+ * @param deferredDepsFn Function that contains dependencies for this defer block
+ *
+ * @codeGenApi
+ */
+export function ɵɵdefer(index: number, deferredDepsFn: DeferredDepsFn|null) {
+  // TODO: implement runtime logic.
+}

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -138,6 +138,7 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵclassProp': r3.ɵɵclassProp,
        'ɵɵadvance': r3.ɵɵadvance,
        'ɵɵtemplate': r3.ɵɵtemplate,
+       'ɵɵdefer': r3.ɵɵdefer,
        'ɵɵtext': r3.ɵɵtext,
        'ɵɵtextInterpolate': r3.ɵɵtextInterpolate,
        'ɵɵtextInterpolate1': r3.ɵɵtextInterpolate1,


### PR DESCRIPTION
⚠️ **Disclaimer** ⚠️ **this PR implements syntax that is still in an open RFC. It will be adjusted once the RFC is closed.**

This PR contains several commits (see each commit for additional info) that add initial version of the logic to compute dependencies of defer blocks used in a template. The code contains a few TODOs that will be resolved in followup PRs.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No