### PR TITLE
build: fix aio-preview job

### DIFF
--- a/.github/workflows/aio-preview-build.yml
+++ b/.github/workflows/aio-preview-build.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: ./.github/actions/yarn-install
 
-      - uses: angular/dev-infra/github-actions/setup-bazel-remote-exec@0109d498b0f6aae418ed4924a5e5c65695f0ac61
+      - uses: angular/dev-infra/github-actions/bazel/configure-remote@0109d498b0f6aae418ed4924a5e5c65695f0ac61
         with:
           bazelrc: ./.bazelrc.user
 


### PR DESCRIPTION
With this fix the aio-preview job on gh-actions should work fine again.


## PR Type
What kind of change does this PR introduce?


- [x] Build related changes

