### PR TITLE
refactor(compiler): drop regular imports when symbols can be defer-loaded

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/factory.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/factory.ts
@@ -14,10 +14,22 @@ export type CompileFactoryFn = (metadata: R3FactoryMetadata) => CompileResult;
 
 export function compileNgFactoryDefField(metadata: R3FactoryMetadata): CompileResult {
   const res = compileFactoryFunction(metadata);
-  return {name: 'ɵfac', initializer: res.expression, statements: res.statements, type: res.type};
+  return {
+    name: 'ɵfac',
+    initializer: res.expression,
+    statements: res.statements,
+    type: res.type,
+    deferrableImports: null
+  };
 }
 
 export function compileDeclareFactory(metadata: R3FactoryMetadata): CompileResult {
   const res = compileDeclareFactoryFunction(metadata);
-  return {name: 'ɵfac', initializer: res.expression, statements: res.statements, type: res.type};
+  return {
+    name: 'ɵfac',
+    initializer: res.expression,
+    statements: res.statements,
+    type: res.type,
+    deferrableImports: null
+  };
 }

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/input_transforms.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/input_transforms.ts
@@ -22,7 +22,8 @@ export function compileInputTransformFields(inputs: ClassPropertyMapping<InputMa
         name: `ngAcceptInputType_${input.classPropertyName}`,
         type: outputAst.transplantedType(input.transform.type),
         statements: [],
-        initializer: null
+        initializer: null,
+        deferrableImports: null
       });
     }
   }

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/util.ts
@@ -332,7 +332,7 @@ export function createSourceSpan(node: ts.Node): ParseSourceSpan {
 export function compileResults(
     fac: CompileResult, def: R3CompiledExpression, metadataStmt: Statement|null, propName: string,
     additionalFields: CompileResult[]|null,
-    deferrableImports?: Set<ts.ImportDeclaration>): CompileResult[] {
+    deferrableImports: Set<ts.ImportDeclaration>|null): CompileResult[] {
   const statements = def.statements;
   if (metadataStmt !== null) {
     statements.push(metadataStmt);

--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/util.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/util.ts
@@ -331,7 +331,8 @@ export function createSourceSpan(node: ts.Node): ParseSourceSpan {
  */
 export function compileResults(
     fac: CompileResult, def: R3CompiledExpression, metadataStmt: Statement|null, propName: string,
-    additionalFields: CompileResult[]|null): CompileResult[] {
+    additionalFields: CompileResult[]|null,
+    deferrableImports?: Set<ts.ImportDeclaration>): CompileResult[] {
   const statements = def.statements;
   if (metadataStmt !== null) {
     statements.push(metadataStmt);
@@ -344,6 +345,7 @@ export function compileResults(
       initializer: def.expression,
       statements: def.statements,
       type: def.type,
+      deferrableImports,
     },
   ];
 

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1032,7 +1032,8 @@ export class ComponentDecoratorHandler implements
     const classMetadata = analysis.classMetadata !== null ?
         compileDeclareClassMetadata(analysis.classMetadata).toStmt() :
         null;
-    return compileResults(fac, def, classMetadata, 'ɵcmp', inputTransformFields);
+    return compileResults(
+        fac, def, classMetadata, 'ɵcmp', inputTransformFields, null /* deferrableImports */);
   }
 
   compileLocal(
@@ -1055,7 +1056,8 @@ export class ComponentDecoratorHandler implements
     const classMetadata = analysis.classMetadata !== null ?
         compileClassMetadata(analysis.classMetadata).toStmt() :
         null;
-    return compileResults(fac, def, classMetadata, 'ɵcmp', inputTransformFields);
+    return compileResults(
+        fac, def, classMetadata, 'ɵcmp', inputTransformFields, null /* deferrableImports */);
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1006,7 +1006,8 @@ export class ComponentDecoratorHandler implements
     const classMetadata = analysis.classMetadata !== null ?
         compileClassMetadata(analysis.classMetadata).toStmt() :
         null;
-    return compileResults(fac, def, classMetadata, 'ɵcmp', inputTransformFields);
+    const deferrableImports = this.deferredSymbolTracker.getDeferrableImportDecls();
+    return compileResults(fac, def, classMetadata, 'ɵcmp', inputTransformFields, deferrableImports);
   }
 
   compilePartial(

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/handler.ts
@@ -214,7 +214,8 @@ export class DirectiveDecoratorHandler implements
     const classMetadata = analysis.classMetadata !== null ?
         compileClassMetadata(analysis.classMetadata).toStmt() :
         null;
-    return compileResults(fac, def, classMetadata, 'ɵdir', inputTransformFields);
+    return compileResults(
+        fac, def, classMetadata, 'ɵdir', inputTransformFields, null /* deferrableImports */);
   }
 
   compilePartial(
@@ -227,7 +228,8 @@ export class DirectiveDecoratorHandler implements
         compileDeclareClassMetadata(analysis.classMetadata).toStmt() :
         null;
 
-    return compileResults(fac, def, classMetadata, 'ɵdir', inputTransformFields);
+    return compileResults(
+        fac, def, classMetadata, 'ɵdir', inputTransformFields, null /* deferrableImports */);
   }
 
   compileLocal(
@@ -239,7 +241,8 @@ export class DirectiveDecoratorHandler implements
     const classMetadata = analysis.classMetadata !== null ?
         compileClassMetadata(analysis.classMetadata).toStmt() :
         null;
-    return compileResults(fac, def, classMetadata, 'ɵdir', inputTransformFields);
+    return compileResults(
+        fac, def, classMetadata, 'ɵdir', inputTransformFields, null /* deferrableImports */);
   }
 
   /**

--- a/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/ng_module/src/handler.ts
@@ -779,12 +779,14 @@ export class NgModuleDecoratorHandler implements
         initializer: ngModuleDef.expression,
         statements: ngModuleDef.statements,
         type: ngModuleDef.type,
+        deferrableImports: null,
       },
       {
         name: 'ɵinj',
         initializer: injectorDef.expression,
         statements: injectorDef.statements,
         type: injectorDef.type,
+        deferrableImports: null,
       },
     ];
     return res;

--- a/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/injectable.ts
@@ -156,8 +156,13 @@ export class InjectableDecoratorHandler implements
     if (ɵprov === undefined) {
       // Only add a new ɵprov if there is not one already
       const res = compileInjectableFn(analysis.meta);
-      results.push(
-          {name: 'ɵprov', initializer: res.expression, statements: res.statements, type: res.type});
+      results.push({
+        name: 'ɵprov',
+        initializer: res.expression,
+        statements: res.statements,
+        type: res.type,
+        deferrableImports: null
+      });
     }
 
     return results;

--- a/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/src/pipe.ts
@@ -185,7 +185,7 @@ export class PipeDecoratorHandler implements
     const classMetadata = analysis.classMetadata !== null ?
         compileClassMetadata(analysis.classMetadata).toStmt() :
         null;
-    return compileResults(fac, def, classMetadata, 'ɵpipe', null);
+    return compileResults(fac, def, classMetadata, 'ɵpipe', null, null /* deferrableImports */);
   }
 
   compilePartial(node: ClassDeclaration, analysis: Readonly<PipeHandlerData>): CompileResult[] {
@@ -194,7 +194,7 @@ export class PipeDecoratorHandler implements
     const classMetadata = analysis.classMetadata !== null ?
         compileDeclareClassMetadata(analysis.classMetadata).toStmt() :
         null;
-    return compileResults(fac, def, classMetadata, 'ɵpipe', null);
+    return compileResults(fac, def, classMetadata, 'ɵpipe', null, null /* deferrableImports */);
   }
 
   compileLocal(node: ClassDeclaration, analysis: Readonly<PipeHandlerData>): CompileResult[] {
@@ -203,6 +203,6 @@ export class PipeDecoratorHandler implements
     const classMetadata = analysis.classMetadata !== null ?
         compileClassMetadata(analysis.classMetadata).toStmt() :
         null;
-    return compileResults(fac, def, classMetadata, 'ɵpipe', null);
+    return compileResults(fac, def, classMetadata, 'ɵpipe', null, null /* deferrableImports */);
   }
 }

--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -248,7 +248,7 @@ export interface CompileResult {
   initializer: Expression|null;
   statements: Statement[];
   type: Type;
-  deferrableImports?: Set<ts.ImportDeclaration>;
+  deferrableImports: Set<ts.ImportDeclaration>|null;
 }
 
 export interface ResolveResult<R> {

--- a/packages/compiler-cli/src/ngtsc/transform/src/api.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/api.ts
@@ -248,6 +248,7 @@ export interface CompileResult {
   initializer: Expression|null;
   statements: Statement[];
   type: Type;
+  deferrableImports?: Set<ts.ImportDeclaration>;
 }
 
 export interface ResolveResult<R> {

--- a/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
@@ -74,7 +74,7 @@ class IvyCompilationVisitor extends Visitor {
       // so that we can pass it to the transform visitor that will drop
       // corresponding regular import declarations.
       for (const classResult of result) {
-        if (classResult.deferrableImports && classResult.deferrableImports.size > 0) {
+        if (classResult.deferrableImports !== null && classResult.deferrableImports.size > 0) {
           classResult.deferrableImports.forEach(
               importDecl => this.deferrableImports.add(importDecl));
         }

--- a/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/src/transform.ts
@@ -56,6 +56,7 @@ export function ivyTransformFactory(
  */
 class IvyCompilationVisitor extends Visitor {
   public classCompilationMap = new Map<ts.ClassDeclaration, CompileResult[]>();
+  public deferrableImports = new Set<ts.ImportDeclaration>();
 
   constructor(private compilation: TraitCompiler, private constantPool: ConstantPool) {
     super();
@@ -68,6 +69,16 @@ class IvyCompilationVisitor extends Visitor {
     const result = this.compilation.compile(node, this.constantPool);
     if (result !== null) {
       this.classCompilationMap.set(node, result);
+
+      // Collect all deferrable imports declarations into a single set,
+      // so that we can pass it to the transform visitor that will drop
+      // corresponding regular import declarations.
+      for (const classResult of result) {
+        if (classResult.deferrableImports && classResult.deferrableImports.size > 0) {
+          classResult.deferrableImports.forEach(
+              importDecl => this.deferrableImports.add(importDecl));
+        }
+      }
     }
     return {node};
   }
@@ -83,7 +94,8 @@ class IvyTransformationVisitor extends Visitor {
       private classCompilationMap: Map<ts.ClassDeclaration, CompileResult[]>,
       private reflector: ReflectionHost, private importManager: ImportManager,
       private recordWrappedNodeExpr: RecordWrappedNodeFn<ts.Expression>,
-      private isClosureCompilerEnabled: boolean, private isCore: boolean) {
+      private isClosureCompilerEnabled: boolean, private isCore: boolean,
+      private deferrableImports: Set<ts.ImportDeclaration>) {
     super();
   }
 
@@ -151,6 +163,16 @@ class IvyTransformationVisitor extends Visitor {
         // Map over the class members and remove any Angular decorators from them.
         members.map(member => this._stripAngularDecorators(member)));
     return {node, after: statements};
+  }
+
+  override visitOtherNode<T extends ts.Node>(node: T): T {
+    if (ts.isImportDeclaration(node) && this.deferrableImports.has(node)) {
+      // Return `null` as an indication that this node should not be present
+      // in the final AST. Symbols from this import would be imported via
+      // dynamic imports.
+      return null!;
+    }
+    return node;
   }
 
   /**
@@ -281,7 +303,7 @@ function transformIvySourceFile(
   // results obtained at Step 1.
   const transformationVisitor = new IvyTransformationVisitor(
       compilation, compilationVisitor.classCompilationMap, reflector, importManager,
-      recordWrappedNode, isClosureCompilerEnabled, isCore);
+      recordWrappedNode, isClosureCompilerEnabled, isCore, compilationVisitor.deferrableImports);
   let sf = visit(file, transformationVisitor, context);
 
   // Generate the constant statements first, as they may involve adding additional imports

--- a/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/transform/test/compilation_spec.ts
@@ -102,7 +102,8 @@ runInEachFileSystem(() => {
             name: 'compileFull',
             initializer: o.literal(true),
             statements: [],
-            type: o.BOOL_TYPE
+            type: o.BOOL_TYPE,
+            deferrableImports: null,
           };
         }
 
@@ -111,7 +112,8 @@ runInEachFileSystem(() => {
             name: 'compileLocal',
             initializer: o.literal(true),
             statements: [],
-            type: o.BOOL_TYPE
+            type: o.BOOL_TYPE,
+            deferrableImports: null,
           };
         }
       }
@@ -140,7 +142,8 @@ runInEachFileSystem(() => {
             name: 'compileFull',
             initializer: o.literal(true),
             statements: [],
-            type: o.BOOL_TYPE
+            type: o.BOOL_TYPE,
+            deferrableImports: null,
           };
         }
 
@@ -149,7 +152,8 @@ runInEachFileSystem(() => {
             name: 'compilePartial',
             initializer: o.literal(true),
             statements: [],
-            type: o.BOOL_TYPE
+            type: o.BOOL_TYPE,
+            deferrableImports: null,
           };
         }
 
@@ -158,7 +162,8 @@ runInEachFileSystem(() => {
             name: 'compileLocal',
             initializer: o.literal(true),
             statements: [],
-            type: o.BOOL_TYPE
+            type: o.BOOL_TYPE,
+            deferrableImports: null,
           };
         }
       }
@@ -187,7 +192,8 @@ runInEachFileSystem(() => {
             name: 'compileFull',
             initializer: o.literal(true),
             statements: [],
-            type: o.BOOL_TYPE
+            type: o.BOOL_TYPE,
+            deferrableImports: null,
           };
         }
 
@@ -196,7 +202,8 @@ runInEachFileSystem(() => {
             name: 'compileLocal',
             initializer: o.literal(true),
             statements: [],
-            type: o.BOOL_TYPE
+            type: o.BOOL_TYPE,
+            deferrableImports: null,
           };
         }
       }
@@ -317,7 +324,8 @@ runInEachFileSystem(() => {
             name: 'compileFull',
             initializer: o.literal(true),
             statements: [],
-            type: o.BOOL_TYPE
+            type: o.BOOL_TYPE,
+            deferrableImports: null,
           };
         }
 
@@ -326,7 +334,8 @@ runInEachFileSystem(() => {
             name: 'compileLocal',
             initializer: o.literal(true),
             statements: [],
-            type: o.BOOL_TYPE
+            type: o.BOOL_TYPE,
+            deferrableImports: null,
           };
         }
       }

--- a/packages/compiler-cli/src/ngtsc/util/src/visitor.ts
+++ b/packages/compiler-cli/src/ngtsc/util/src/visitor.ts
@@ -78,7 +78,7 @@ export abstract class Visitor {
     // is completed.
     let visitedNode: T|null = null;
 
-    node = ts.visitEachChild(node, child => this._visit(child, context), context) as T;
+    node = ts.visitEachChild(node, child => child && this._visit(child, context), context) as T;
 
     if (ts.isClassDeclaration(node)) {
       visitedNode =
@@ -90,7 +90,7 @@ export abstract class Visitor {
 
     // If the visited node has a `statements` array then process them, maybe replacing the visited
     // node and adding additional statements.
-    if (ts.isBlock(visitedNode) || ts.isSourceFile(visitedNode)) {
+    if (visitedNode && (ts.isBlock(visitedNode) || ts.isSourceFile(visitedNode))) {
       visitedNode = this._maybeProcessStatements(visitedNode);
     }
 


### PR DESCRIPTION
This commit updates the logic to drop regular imports when all symbols that it brings can be defer-loaded.
The change ensures that there is no mix of regular and dynamic imports present in a source file.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No