### PR TITLE
refactor(compiler): apply component metadata asynchronously when defer blocks are present

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/common/src/metadata.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/common/src/metadata.ts
@@ -164,10 +164,13 @@ function isAngularDecorator(decorator: Decorator, isCore: boolean): boolean {
  * of an AST node, thus removing any references to them. Useful if a particular node has to be
  * taken from one place any emitted to another one exactly as it has been written.
  */
-function removeIdentifierReferences<T extends ts.Node>(node: T, name: string): T {
+export function removeIdentifierReferences<T extends ts.Node>(
+    node: T, names: string|Set<string>): T {
   const result =
       ts.transform(node, [context => root => ts.visitNode(root, function walk(current: ts.Node): T {
-                     return (ts.isIdentifier(current) && current.text === name ?
+                     return (ts.isIdentifier(current) &&
+                                     (typeof names === 'string' ? current.text === names :
+                                                                  names.has(current.text)) ?
                                  ts.factory.createIdentifier(current.text) :
                                  ts.visitEachChild(current, walk, context)) as T;
                    }) as T]);

--- a/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/component/src/handler.ts
@@ -1013,7 +1013,7 @@ export class ComponentDecoratorHandler implements
 
     if (analysis.classMetadata) {
       // Drop references to existing imports for deferrable symbols that should be present
-      // in the `setClassMetadataAsync` call. Otherwise, the import declaration gets retained.
+      // in the `setClassMetadataAsync` call. Otherwise, an import declaration gets retained.
       const deferrableSymbols = new Set(deferrableTypes.keys());
       const rewrittenDecoratorsNode = removeIdentifierReferences(
           (analysis.classMetadata.decorators as WrappedNodeExpr<ts.Node>).node, deferrableSymbols);

--- a/packages/compiler-cli/src/ngtsc/imports/src/core.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/core.ts
@@ -61,6 +61,7 @@ const CORE_SUPPORTED_SYMBOLS = new Map<string, string>([
   ['ɵɵinject', 'ɵɵinject'],
   ['ɵɵFactoryDeclaration', 'ɵɵFactoryDeclaration'],
   ['ɵsetClassMetadata', 'setClassMetadata'],
+  ['ɵsetClassMetadataAsync', 'setClassMetadataAsync'],
   ['ɵɵInjectableDeclaration', 'ɵɵInjectableDeclaration'],
   ['ɵɵInjectorDeclaration', 'ɵɵInjectorDeclaration'],
   ['ɵɵNgModuleDeclaration', 'ɵɵNgModuleDeclaration'],

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -9130,7 +9130,7 @@ function allTests(os: string) {
 
           const jsContents = env.getContents('test.js');
 
-          expect(jsContents).toContain('ɵɵdefer(0, TestCmp_Defer_0_DepsFn)');
+          expect(jsContents).toContain('ɵɵdefer(1, 0, TestCmp_Defer_1_DepsFn)');
           expect(jsContents)
               .toContain(
                   // ngDevMode check is present
@@ -9185,7 +9185,7 @@ function allTests(os: string) {
              const jsContents = env.getContents('test.js');
 
              // Dependency function eagerly references `CmpA`.
-             expect(jsContents).toContain('function TestCmp_Defer_0_DepsFn() { return [CmpA]; }');
+             expect(jsContents).toContain('function TestCmp_Defer_1_DepsFn() { return [CmpA]; }');
 
              // The `setClassMetadataAsync` wasn't generated, since there are no deferrable
              // symbols.

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -67,7 +67,7 @@ export {BoundAttribute as TmplAstBoundAttribute, BoundEvent as TmplAstBoundEvent
 export * from './render3/view/t2_api';
 export * from './render3/view/t2_binder';
 export {Identifiers as R3Identifiers} from './render3/r3_identifiers';
-export {R3ClassMetadata, CompileClassMetadataFn, compileClassMetadata} from './render3/r3_class_metadata_compiler';
+export {R3ClassMetadata, CompileClassMetadataFn, compileClassMetadata, compileComponentClassMetadata} from './render3/r3_class_metadata_compiler';
 export {compileFactoryFunction, R3DependencyMetadata, R3FactoryMetadata, FactoryTarget} from './render3/r3_factory';
 export {compileNgModule, R3NgModuleMetadata, R3SelectorScopeMode, R3NgModuleMetadataKind, R3NgModuleMetadataGlobal} from './render3/r3_module_compiler';
 export {compileInjector, R3InjectorMetadata} from './render3/r3_injector_compiler';

--- a/packages/compiler/src/render3/r3_class_metadata_compiler.ts
+++ b/packages/compiler/src/render3/r3_class_metadata_compiler.ts
@@ -53,3 +53,69 @@ export function compileClassMetadata(metadata: R3ClassMetadata): o.Expression {
   const iife = o.fn([], [devOnlyGuardedExpression(fnCall).toStmt()]);
   return iife.callFn([]);
 }
+
+/**
+ * Wraps the `setClassMetadata` function with extra logic that dynamically
+ * loads dependencies from `{#defer}` blocks.
+ *
+ * Generates a call like this:
+ * ```
+ * setClassMetadataAsync(type, () => {
+ *   return [
+ *     import('./cmp-a').then(m => m.CmpA);
+ *     import('./cmp-b').then(m => m.CmpB);
+ *   ];
+ * }, (CmpA, CmpB) => {
+ *   setClassMetadata(type, decorators, ctorParameters, propParameters);
+ * });
+ * ```
+ *
+ * Similarly to the `setClassMetadata` call, it's wrapped into the `ngDevMode`
+ * check to tree-shake away this code in production mode.
+ */
+export function compileComponentClassMetadata(
+    metadata: R3ClassMetadata, deferrableTypes: Map<string, string>): o.Expression {
+  if (!deferrableTypes || deferrableTypes.size === 0) {
+    // If there are no deferrable symbols - just generate the `setClassMetadata` call.
+    return compileClassMetadata(metadata);
+  }
+
+  const dynamicImports: o.Expression[] = [];
+  const importedSymbols: o.FnParam[] = [];
+  for (const [symbolName, importPath] of deferrableTypes) {
+    // e.g. `function(m) { return m.CmpA; }`
+    const innerFn = o.fn(
+        [new o.FnParam('m', o.DYNAMIC_TYPE)],
+        [new o.ReturnStatement(o.variable('m').prop(symbolName))]);
+
+    // e.g. `import('./cmp-a').then(...)`
+    const importExpr = (new o.DynamicImportExpr(importPath)).prop('then').callFn([innerFn]);
+
+    dynamicImports.push(importExpr);
+    importedSymbols.push(new o.FnParam(symbolName, o.DYNAMIC_TYPE));
+  }
+
+  // e.g. `function() { return [ ... ]; }`
+  const dependencyLoadingFn = o.fn([], [new o.ReturnStatement(o.literalArr(dynamicImports))]);
+
+  // e.g. `setClassMetadata(...)`
+  const setClassMetadataCall = o.importExpr(R3.setClassMetadata).callFn([
+    metadata.type,
+    metadata.decorators,
+    metadata.ctorParameters ?? o.literal(null),
+    metadata.propDecorators ?? o.literal(null),
+  ]);
+
+  // e.g. `function(CmpA) { setClassMetadata(...); }`
+  const setClassMetaWrapper = o.fn(importedSymbols, [setClassMetadataCall.toStmt()]);
+
+  // Final `setClassMetadataAsync()` call with all arguments
+  const setClassMetaAsync = o.importExpr(R3.setClassMetadataAsync).callFn([
+    metadata.type, dependencyLoadingFn, setClassMetaWrapper
+  ]);
+
+  // Generate an ngDevMode guarded call to `setClassMetadataAsync` with
+  // the class identifier and its metadata, so that this call can be tree-shaken.
+  const iife = o.fn([], [devOnlyGuardedExpression(setClassMetaAsync).toStmt()]);
+  return iife.callFn([]);
+}

--- a/packages/compiler/src/render3/r3_class_metadata_compiler.ts
+++ b/packages/compiler/src/render3/r3_class_metadata_compiler.ts
@@ -70,13 +70,13 @@ export function compileClassMetadata(metadata: R3ClassMetadata): o.Expression {
  * });
  * ```
  *
- * Similarly to the `setClassMetadata` call, it's wrapped into the `ngDevMode`
+ * Similar to the `setClassMetadata` call, it's wrapped into the `ngDevMode`
  * check to tree-shake away this code in production mode.
  */
 export function compileComponentClassMetadata(
     metadata: R3ClassMetadata, deferrableTypes: Map<string, string>): o.Expression {
   if (!deferrableTypes || deferrableTypes.size === 0) {
-    // If there are no deferrable symbols - just generate the `setClassMetadata` call.
+    // If there are no deferrable symbols - just generate a regular `setClassMetadata` call.
     return compileClassMetadata(metadata);
   }
 

--- a/packages/compiler/src/render3/r3_class_metadata_compiler.ts
+++ b/packages/compiler/src/render3/r3_class_metadata_compiler.ts
@@ -75,7 +75,7 @@ export function compileClassMetadata(metadata: R3ClassMetadata): o.Expression {
  */
 export function compileComponentClassMetadata(
     metadata: R3ClassMetadata, deferrableTypes: Map<string, string>): o.Expression {
-  if (!deferrableTypes || deferrableTypes.size === 0) {
+  if (deferrableTypes.size === 0) {
     // If there are no deferrable symbols - just generate a regular `setClassMetadata` call.
     return compileClassMetadata(metadata);
   }

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -331,6 +331,8 @@ export class Identifiers {
   static declareClassMetadata:
       o.ExternalReference = {name: 'ɵɵngDeclareClassMetadata', moduleName: CORE};
   static setClassMetadata: o.ExternalReference = {name: 'ɵsetClassMetadata', moduleName: CORE};
+  static setClassMetadataAsync:
+      o.ExternalReference = {name: 'ɵsetClassMetadataAsync', moduleName: CORE};
 
   static queryRefresh: o.ExternalReference = {name: 'ɵɵqueryRefresh', moduleName: CORE};
   static viewQuery: o.ExternalReference = {name: 'ɵɵviewQuery', moduleName: CORE};

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -65,6 +65,7 @@ export {
   PipeDef as ɵPipeDef,
   RenderFlags as ɵRenderFlags,
   setClassMetadata as ɵsetClassMetadata,
+  setClassMetadataAsync as ɵsetClassMetadataAsync,
   setLocaleId as ɵsetLocaleId,
   store as ɵstore,
   ɵɵadvance,

--- a/packages/core/src/r3_symbols.ts
+++ b/packages/core/src/r3_symbols.ts
@@ -26,7 +26,7 @@ export {ɵɵdefineInjectable, ɵɵdefineInjector, ɵɵInjectableDeclaration} fro
 export {NgModuleDef} from './metadata/ng_module_def';
 export {ɵɵdefineNgModule} from './render3/definition';
 export {ɵɵFactoryDeclaration, ɵɵInjectorDeclaration, ɵɵNgModuleDeclaration} from './render3/interfaces/public_definitions';
-export {setClassMetadata} from './render3/metadata';
+export {setClassMetadata, setClassMetadataAsync} from './render3/metadata';
 export {NgModuleFactory} from './render3/ng_module_ref';
 export {noSideEffects as ɵnoSideEffects} from './util/closure';
 

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -158,6 +158,7 @@ export {
 export {CssSelectorList, ProjectionSlots} from './interfaces/projection';
 export {
   setClassMetadata,
+  setClassMetadataAsync,
 } from './metadata';
 export {NgModuleFactory, NgModuleRef, createEnvironmentInjector} from './ng_module_ref';
 export {

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -22,7 +22,6 @@ import {getComponentDef, getDirectiveDef, getNgModuleDef, getPipeDef} from '../d
 import {depsTracker, USE_RUNTIME_DEPS_TRACKER_FOR_JIT} from '../deps_tracker/deps_tracker';
 import {NG_COMP_DEF, NG_DIR_DEF, NG_FACTORY_DEF} from '../fields';
 import {ComponentDef, ComponentType, DirectiveDefList, PipeDefList} from '../interfaces/definition';
-import {getAsyncClassMetadata} from '../metadata';
 import {stringifyForError} from '../util/stringify_utils';
 
 import {angularCoreEnv} from './environment';
@@ -60,12 +59,6 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
   (typeof ngDevMode === 'undefined' || ngDevMode) && initNgDevMode();
 
   let ngComponentDef: ComponentDef<unknown>|null = null;
-
-  if (getAsyncClassMetadata(type)) {
-    throw new Error(
-        `Component '${type.name}' has unresolved metadata. ` +
-        `Please call \`await TestBed.compileComponents()\` before running this test.`);
-  }
 
   // Metadata may have resources which need to be resolved.
   maybeQueueResolutionOfComponentResources(type, metadata);

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -22,6 +22,7 @@ import {getComponentDef, getDirectiveDef, getNgModuleDef, getPipeDef} from '../d
 import {depsTracker, USE_RUNTIME_DEPS_TRACKER_FOR_JIT} from '../deps_tracker/deps_tracker';
 import {NG_COMP_DEF, NG_DIR_DEF, NG_FACTORY_DEF} from '../fields';
 import {ComponentDef, ComponentType, DirectiveDefList, PipeDefList} from '../interfaces/definition';
+import {getAsyncClassMetadata} from '../metadata';
 import {stringifyForError} from '../util/stringify_utils';
 
 import {angularCoreEnv} from './environment';
@@ -59,6 +60,12 @@ export function compileComponent(type: Type<any>, metadata: Component): void {
   (typeof ngDevMode === 'undefined' || ngDevMode) && initNgDevMode();
 
   let ngComponentDef: ComponentDef<unknown>|null = null;
+
+  if (getAsyncClassMetadata(type)) {
+    throw new Error(
+        `Component '${type.name}' has unresolved metadata. ` +
+        `Please call \`await TestBed.compileComponents()\` before running this test.`);
+  }
 
   // Metadata may have resources which need to be resolved.
   maybeQueueResolutionOfComponentResources(type, metadata);

--- a/packages/core/test/render3/jit/directive_spec.ts
+++ b/packages/core/test/render3/jit/directive_spec.ts
@@ -7,9 +7,9 @@
  */
 
 import {Directive, HostListener, Input} from '@angular/core';
-import {setClassMetadata} from '@angular/core/src/render3/metadata';
 
 import {convertToR3QueryMetadata, directiveMetadata, extendsDirectlyFromObject} from '../../../src/render3/jit/directive';
+import {setClassMetadata} from '../../../src/render3/metadata';
 
 describe('jit directive helper functions', () => {
   describe('extendsDirectlyFromObject', () => {

--- a/packages/core/test/render3/jit_environment_spec.ts
+++ b/packages/core/test/render3/jit_environment_spec.ts
@@ -29,6 +29,7 @@ const INTERFACE_EXCEPTIONS = new Set<string>([
  */
 const AOT_ONLY = new Set<string>([
   'ɵsetClassMetadata',
+  'ɵsetClassMetadataAsync',
 ]);
 
 /**

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -38,6 +38,8 @@ import {
   ɵstringify as stringify
 } from '@angular/core';
 
+import { getAsyncClassMetadata } from '../../src/render3/metadata';
+
 /* clang-format on */
 
 import {ComponentFixture} from './component_fixture';
@@ -591,6 +593,12 @@ export class TestBedImpl implements TestBed {
     const testComponentRenderer = this.inject(TestComponentRenderer);
     const rootElId = `root${_nextRootElementId++}`;
     testComponentRenderer.insertRootElement(rootElId);
+
+    if (getAsyncClassMetadata(type)) {
+      throw new Error(
+          `Component '${type.name}' has unresolved metadata. ` +
+          `Please call \`await TestBed.compileComponents()\` before running this test.`);
+    }
 
     const componentDef = (type as any).ɵcmp;
 

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -386,11 +386,19 @@ export class TestBedCompiler {
     // Compile all queued components, directives, pipes.
     let needsAsyncResources = false;
     this.pendingComponents.forEach(declaration => {
+      if (getAsyncClassMetadata(declaration)) {
+        throw new Error(
+            `Component '${declaration.name}' has unresolved metadata. ` +
+            `Please call \`await TestBed.compileComponents()\` before running this test.`);
+      }
+
       needsAsyncResources = needsAsyncResources || isComponentDefPendingResolution(declaration);
+
       const metadata = this.resolvers.component.resolve(declaration);
       if (metadata === null) {
         throw invalidTypeError(declaration.name, 'Component');
       }
+
       this.maybeStoreNgDef(NG_COMP_DEF, declaration);
       compileComponent(declaration, metadata);
     });


### PR DESCRIPTION
This commit updates compiler logic to generate the `setClassMetadataAsync` calls for components that used defer blocks. The `setClassMetadataAsync` function loads deferrable dependencies and invokes the `setClassMetadata` synchronously once everything is loaded. This change is needed to avoid eager references to deferrable symbols in component metadata in generated code.

## PR Type
What kind of change does this PR introduce?

- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No