### PR TITLE
refactor(compiler): add utility to enable deferred blocks for testing

### DIFF
--- a/packages/compiler/src/jit_compiler_facade.ts
+++ b/packages/compiler/src/jit_compiler_facade.ts
@@ -27,6 +27,13 @@ import {makeBindingParser, parseTemplate} from './render3/view/template';
 import {ResourceLoader} from './resource_loader';
 import {DomElementSchemaRegistry} from './schema/dom_element_schema_registry';
 
+let enabledBlockTypes: Set<string>|undefined;
+
+/** Temporary utility that enables specific block types in JIT compilations. */
+export function ɵsetEnabledBlockTypes(types: string[]) {
+  enabledBlockTypes = types.length > 0 ? new Set(types) : undefined;
+}
+
 export class CompilerFacadeImpl implements CompilerFacade {
   FactoryTarget = FactoryTarget;
   ResourceLoader = ResourceLoader;
@@ -524,11 +531,8 @@ function parseJitTemplate(
   const interpolationConfig =
       interpolation ? InterpolationConfig.fromArray(interpolation) : DEFAULT_INTERPOLATION_CONFIG;
   // Parse the template and check for errors.
-  const parsed = parseTemplate(template, sourceMapUrl, {
-    preserveWhitespaces,
-    interpolationConfig,
-    enabledBlockTypes: new Set(),  // TODO: enable deferred blocks when testing in JIT mode.
-  });
+  const parsed = parseTemplate(
+      template, sourceMapUrl, {preserveWhitespaces, interpolationConfig, enabledBlockTypes});
   if (parsed.errors !== null) {
     const errors = parsed.errors.map(err => err.toString()).join(', ');
     throw new Error(`Errors during JIT compilation of template for ${typeName}: ${errors}`);


### PR DESCRIPTION
Adds the `ɵsetEnabledBlockTypes` utility that can be used when writing JIT tests using `defer` blocks. Intended usage:

```ts
import {ɵsetEnabledBlockTypes as setEnabledBlockTypes} from '@angular/compiler/src/jit_compiler_facade';

describe('deferred tests', () => {
  beforeEach(() => setEnabledBlockTypes(['defer']));
  afterEach(() => setEnabledBlockTypes([]));

  it('should work', () => {
    // test goes here
  });
});
```