### PR TITLE
refactor(core): remove unnecessary imports of ng_dev_mode

### DIFF
--- a/packages/core/src/di/injector_compatibility.ts
+++ b/packages/core/src/di/injector_compatibility.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import '../util/ng_dev_mode';
-
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {Type} from '../interface/type';
 import {stringify} from '../util/stringify';

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import '../util/ng_dev_mode';
-
 import {RuntimeError, RuntimeErrorCode} from '../errors';
 import {OnDestroy} from '../interface/lifecycle_hooks';
 import {Type} from '../interface/type';

--- a/packages/core/src/render3/context_discovery.ts
+++ b/packages/core/src/render3/context_discovery.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import '../util/ng_dev_mode';
 
 import {assertDefined, assertDomNode} from '../util/assert';
 import {EMPTY_ARRAY} from '../util/empty';

--- a/packages/core/src/render3/i18n/i18n_parse.ts
+++ b/packages/core/src/render3/i18n/i18n_parse.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import '../../util/ng_dev_mode';
 import '../../util/ng_i18n_closure_mode';
 
 import {XSS_SECURITY_URL} from '../../error_details_base_url';

--- a/packages/core/src/render3/instructions/i18n.ts
+++ b/packages/core/src/render3/instructions/i18n.ts
@@ -5,7 +5,6 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import '../../util/ng_dev_mode';
 import '../../util/ng_i18n_closure_mode';
 
 import {assertDefined} from '../../util/assert';

--- a/packages/core/src/render3/node_selector_matcher.ts
+++ b/packages/core/src/render3/node_selector_matcher.ts
@@ -6,8 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import '../util/ng_dev_mode';
-
 import {assertDefined, assertEqual, assertNotEqual} from '../util/assert';
 
 import {AttributeMarker, TAttributes, TNode, TNodeType} from './interfaces/node';

--- a/packages/core/src/signals/src/graph.ts
+++ b/packages/core/src/signals/src/graph.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Required as the signals library is in a separate package, so we need to explicitly ensure the
-// global `ngDevMode` type is defined.
-import '../../util/ng_dev_mode';
 
 import {newWeakRef, WeakRef} from './weak_ref';
 

--- a/packages/core/src/signals/src/weak_ref.ts
+++ b/packages/core/src/signals/src/weak_ref.ts
@@ -6,9 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Required as the signals library is in a separate package, so we need to explicitly ensure the
-// global `ngDevMode` type is defined.
-import '../../util/ng_dev_mode';
 
 import {global} from '../../util/global';
 


### PR DESCRIPTION
The definition of `ngDevMode` is fine without the import.

## PR Type
What kind of change does this PR introduce?


- [x] Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
