### PR TITLE
refactor(core): rename query "selector" to "locator"

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -294,13 +294,13 @@ export const ContentChild: ContentChildDecorator;
 
 // @public
 export interface ContentChildDecorator {
-    (selector: ProviderToken<unknown> | Function | string, opts?: {
+    (locator: ProviderToken<unknown> | Function | string, opts?: {
         descendants?: boolean;
         read?: any;
         static?: boolean;
     }): any;
     // (undocumented)
-    new (selector: ProviderToken<unknown> | Function | string, opts?: {
+    new (locator: ProviderToken<unknown> | Function | string, opts?: {
         descendants?: boolean;
         read?: any;
         static?: boolean;
@@ -315,13 +315,13 @@ export const ContentChildren: ContentChildrenDecorator;
 
 // @public
 export interface ContentChildrenDecorator {
-    (selector: ProviderToken<unknown> | Function | string, opts?: {
+    (locator: ProviderToken<unknown> | Function | string, opts?: {
         descendants?: boolean;
         emitDistinctChangesOnly?: boolean;
         read?: any;
     }): any;
     // (undocumented)
-    new (selector: ProviderToken<unknown> | Function | string, opts?: {
+    new (locator: ProviderToken<unknown> | Function | string, opts?: {
         descendants?: boolean;
         emitDistinctChangesOnly?: boolean;
         read?: any;
@@ -1185,9 +1185,9 @@ export interface Query {
     // (undocumented)
     isViewQuery: boolean;
     // (undocumented)
-    read: any;
+    locator: any;
     // (undocumented)
-    selector: any;
+    read: any;
     // (undocumented)
     static?: boolean;
 }
@@ -1523,12 +1523,12 @@ export const ViewChild: ViewChildDecorator;
 
 // @public
 export interface ViewChildDecorator {
-    (selector: ProviderToken<unknown> | Function | string, opts?: {
+    (locator: ProviderToken<unknown> | Function | string, opts?: {
         read?: any;
         static?: boolean;
     }): any;
     // (undocumented)
-    new (selector: ProviderToken<unknown> | Function | string, opts?: {
+    new (locator: ProviderToken<unknown> | Function | string, opts?: {
         read?: any;
         static?: boolean;
     }): ViewChild;
@@ -1542,12 +1542,12 @@ export const ViewChildren: ViewChildrenDecorator;
 
 // @public
 export interface ViewChildrenDecorator {
-    (selector: ProviderToken<unknown> | Function | string, opts?: {
+    (locator: ProviderToken<unknown> | Function | string, opts?: {
         read?: any;
         emitDistinctChangesOnly?: boolean;
     }): any;
     // (undocumented)
-    new (selector: ProviderToken<unknown> | Function | string, opts?: {
+    new (locator: ProviderToken<unknown> | Function | string, opts?: {
         read?: any;
         emitDistinctChangesOnly?: boolean;
     }): ViewChildren;

--- a/packages/core/src/metadata/di.ts
+++ b/packages/core/src/metadata/di.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {InjectionToken} from '../di/injection_token';
 import {ProviderToken} from '../di/provider_token';
 import {makePropDecorator} from '../util/decorators';
 
@@ -63,7 +62,7 @@ export interface Query {
   first: boolean;
   read: any;
   isViewQuery: boolean;
-  selector: any;
+  locator: any;
   static?: boolean;
 }
 
@@ -106,7 +105,7 @@ export interface ContentChildrenDecorator {
    *
    * **Metadata Properties**:
    *
-   * * **selector** - The directive type or the name used for querying.
+   * * **locator** - The directive type or the name used for querying.
    * * **descendants** - If `true` include all descendants of the element. If `false` then only
    * query direct children of the element.
    * * **emitDistinctChangesOnly** - The ` QueryList#changes` observable will emit new values only
@@ -116,7 +115,7 @@ export interface ContentChildrenDecorator {
    *   removed in future versions of Angular.
    * * **read** - Used to read a different token from the queried elements.
    *
-   * The following selectors are supported.
+   * The following locators are supported.
    *   * Any class with the `@Component` or `@Directive` decorator
    *   * A template reference variable as a string (e.g. query `<my-component #cmp></my-component>`
    * with `@ContentChildren('cmp')`)
@@ -127,12 +126,12 @@ export interface ContentChildrenDecorator {
    *   * A `TemplateRef` (e.g. query `<ng-template></ng-template>` with
    * `@ContentChildren(TemplateRef) template;`)
    *
-   * In addition, multiple string selectors can be separated with a comma (e.g.
+   * In addition, multiple string locators can be separated with a comma (e.g.
    * `@ContentChildren('cmp1,cmp2')`)
    *
    * The following values are supported by `read`:
    *   * Any class with the `@Component` or `@Directive` decorator
-   *   * Any provider defined on the injector of the component that is matched by the `selector` of
+   *   * Any provider defined on the injector of the component that is matched by the `locator` of
    * this query
    *   * Any provider defined through a string token (e.g. `{provide: 'token', useValue: 'val'}`)
    *   * `TemplateRef`, `ElementRef`, and `ViewContainerRef`
@@ -152,12 +151,12 @@ export interface ContentChildrenDecorator {
    *
    * @Annotation
    */
-  (selector: ProviderToken<unknown>|Function|string, opts?: {
+  (locator: ProviderToken<unknown>|Function|string, opts?: {
     descendants?: boolean,
     emitDistinctChangesOnly?: boolean,
     read?: any,
   }): any;
-  new(selector: ProviderToken<unknown>|Function|string,
+  new(locator: ProviderToken<unknown>|Function|string,
       opts?: {descendants?: boolean, emitDistinctChangesOnly?: boolean, read?: any}): Query;
 }
 
@@ -178,8 +177,8 @@ export type ContentChildren = Query;
  * @publicApi
  */
 export const ContentChildren: ContentChildrenDecorator = makePropDecorator(
-    'ContentChildren', (selector?: any, data: any = {}) => ({
-                         selector,
+    'ContentChildren', (locator?: any, data: any = {}) => ({
+                         locator,
                          first: false,
                          isViewQuery: false,
                          descendants: false,
@@ -198,8 +197,8 @@ export interface ContentChildDecorator {
    * @description
    * Property decorator that configures a content query.
    *
-   * Use to get the first element or the directive matching the selector from the content DOM.
-   * If the content DOM changes, and a new child matches the selector,
+   * Use to get the first element or the directive matching the locator from the content DOM.
+   * If the content DOM changes, and a new child matches the locator,
    * the property will be updated.
    *
    * Content queries are set before the `ngAfterContentInit` callback is called.
@@ -209,14 +208,14 @@ export interface ContentChildDecorator {
    *
    * **Metadata Properties**:
    *
-   * * **selector** - The directive type or the name used for querying.
+   * * **locator** - The directive type or the name used for querying.
    * * **descendants** - If `true` (default) include all descendants of the element. If `false` then
    * only query direct children of the element.
    * * **read** - Used to read a different token from the queried element.
    * * **static** - True to resolve query results before change detection runs,
    * false to resolve after change detection. Defaults to false.
    *
-   * The following selectors are supported.
+   * The following locators are supported.
    *   * Any class with the `@Component` or `@Directive` decorator
    *   * A template reference variable as a string (e.g. query `<my-component #cmp></my-component>`
    * with `@ContentChild('cmp')`)
@@ -229,7 +228,7 @@ export interface ContentChildDecorator {
    *
    * The following values are supported by `read`:
    *   * Any class with the `@Component` or `@Directive` decorator
-   *   * Any provider defined on the injector of the component that is matched by the `selector` of
+   *   * Any provider defined on the injector of the component that is matched by the `locator` of
    * this query
    *   * Any provider defined through a string token (e.g. `{provide: 'token', useValue: 'val'}`)
    *   * `TemplateRef`, `ElementRef`, and `ViewContainerRef`
@@ -244,9 +243,9 @@ export interface ContentChildDecorator {
    *
    * @Annotation
    */
-  (selector: ProviderToken<unknown>|Function|string,
+  (locator: ProviderToken<unknown>|Function|string,
    opts?: {descendants?: boolean, read?: any, static?: boolean}): any;
-  new(selector: ProviderToken<unknown>|Function|string,
+  new(locator: ProviderToken<unknown>|Function|string,
       opts?: {descendants?: boolean, read?: any, static?: boolean}): ContentChild;
 }
 
@@ -267,8 +266,8 @@ export type ContentChild = Query;
  */
 export const ContentChild: ContentChildDecorator = makePropDecorator(
     'ContentChild',
-    (selector?: any, data: any = {}) =>
-        ({selector, first: true, isViewQuery: false, descendants: true, ...data}),
+    (locator?: any, data: any = {}) =>
+        ({locator, first: true, isViewQuery: false, descendants: true, ...data}),
     Query);
 
 /**
@@ -291,7 +290,7 @@ export interface ViewChildrenDecorator {
    *
    * **Metadata Properties**:
    *
-   * * **selector** - The directive type or the name used for querying.
+   * * **locator** - The directive type or the name used for querying.
    * * **read** - Used to read a different token from the queried elements.
    * * **emitDistinctChangesOnly** - The ` QueryList#changes` observable will emit new values only
    *   if the QueryList result has changed. When `false` the `changes` observable might emit even
@@ -299,7 +298,7 @@ export interface ViewChildrenDecorator {
    *   ** Note: *** This config option is **deprecated**, it will be permanently set to `true` and
    * removed in future versions of Angular.
    *
-   * The following selectors are supported.
+   * The following locators are supported.
    *   * Any class with the `@Component` or `@Directive` decorator
    *   * A template reference variable as a string (e.g. query `<my-component #cmp></my-component>`
    * with `@ViewChildren('cmp')`)
@@ -310,12 +309,12 @@ export interface ViewChildrenDecorator {
    *   * A `TemplateRef` (e.g. query `<ng-template></ng-template>` with `@ViewChildren(TemplateRef)
    * template;`)
    *
-   * In addition, multiple string selectors can be separated with a comma (e.g.
+   * In addition, multiple string locators can be separated with a comma (e.g.
    * `@ViewChildren('cmp1,cmp2')`)
    *
    * The following values are supported by `read`:
    *   * Any class with the `@Component` or `@Directive` decorator
-   *   * Any provider defined on the injector of the component that is matched by the `selector` of
+   *   * Any provider defined on the injector of the component that is matched by the `locator` of
    * this query
    *   * Any provider defined through a string token (e.g. `{provide: 'token', useValue: 'val'}`)
    *   * `TemplateRef`, `ElementRef`, and `ViewContainerRef`
@@ -330,9 +329,9 @@ export interface ViewChildrenDecorator {
    *
    * @Annotation
    */
-  (selector: ProviderToken<unknown>|Function|string,
+  (locator: ProviderToken<unknown>|Function|string,
    opts?: {read?: any, emitDistinctChangesOnly?: boolean}): any;
-  new(selector: ProviderToken<unknown>|Function|string,
+  new(locator: ProviderToken<unknown>|Function|string,
       opts?: {read?: any, emitDistinctChangesOnly?: boolean}): ViewChildren;
 }
 
@@ -350,8 +349,8 @@ export type ViewChildren = Query;
  * @publicApi
  */
 export const ViewChildren: ViewChildrenDecorator = makePropDecorator(
-    'ViewChildren', (selector?: any, data: any = {}) => ({
-                      selector,
+    'ViewChildren', (locator?: any, data: any = {}) => ({
+                      locator,
                       first: false,
                       isViewQuery: true,
                       descendants: true,
@@ -370,21 +369,21 @@ export interface ViewChildDecorator {
   /**
    * @description
    * Property decorator that configures a view query.
-   * The change detector looks for the first element or the directive matching the selector
-   * in the view DOM. If the view DOM changes, and a new child matches the selector,
+   * The change detector looks for the first element or the directive matching the locator
+   * in the view DOM. If the view DOM changes, and a new child matches the locator,
    * the property is updated.
    *
    * View queries are set before the `ngAfterViewInit` callback is called.
    *
    * **Metadata Properties**:
    *
-   * * **selector** - The directive type or the name used for querying.
+   * * **locator** - The directive type or the name used for querying.
    * * **read** - Used to read a different token from the queried elements.
    * * **static** - True to resolve query results before change detection runs,
    * false to resolve after change detection. Defaults to false.
    *
    *
-   * The following selectors are supported.
+   * The following locators are supported.
    *   * Any class with the `@Component` or `@Directive` decorator
    *   * A template reference variable as a string (e.g. query `<my-component #cmp></my-component>`
    * with `@ViewChild('cmp')`)
@@ -397,7 +396,7 @@ export interface ViewChildDecorator {
    *
    * The following values are supported by `read`:
    *   * Any class with the `@Component` or `@Directive` decorator
-   *   * Any provider defined on the injector of the component that is matched by the `selector` of
+   *   * Any provider defined on the injector of the component that is matched by the `locator` of
    * this query
    *   * Any provider defined through a string token (e.g. `{provide: 'token', useValue: 'val'}`)
    *   * `TemplateRef`, `ElementRef`, and `ViewContainerRef`
@@ -412,8 +411,8 @@ export interface ViewChildDecorator {
    *
    * @Annotation
    */
-  (selector: ProviderToken<unknown>|Function|string, opts?: {read?: any, static?: boolean}): any;
-  new(selector: ProviderToken<unknown>|Function|string,
+  (locator: ProviderToken<unknown>|Function|string, opts?: {read?: any, static?: boolean}): any;
+  new(locator: ProviderToken<unknown>|Function|string,
       opts?: {read?: any, static?: boolean}): ViewChild;
 }
 
@@ -432,6 +431,6 @@ export type ViewChild = Query;
  */
 export const ViewChild: ViewChildDecorator = makePropDecorator(
     'ViewChild',
-    (selector: any, data: any) =>
-        ({selector, first: true, isViewQuery: true, descendants: true, ...data}),
+    (locator: any, data: any) =>
+        ({locator, first: true, isViewQuery: true, descendants: true, ...data}),
     Query);

--- a/packages/core/src/render3/jit/directive.ts
+++ b/packages/core/src/render3/jit/directive.ts
@@ -441,14 +441,14 @@ function addDirectiveDefToUndecoratedParents(type: Type<any>) {
   }
 }
 
-function convertToR3QueryPredicate(selector: any): any|string[] {
-  return typeof selector === 'string' ? splitByComma(selector) : resolveForwardRef(selector);
+function convertToR3QueryPredicate(locator: any): any|string[] {
+  return typeof locator === 'string' ? splitByComma(locator) : resolveForwardRef(locator);
 }
 
 export function convertToR3QueryMetadata(propertyName: string, ann: Query): R3QueryMetadataFacade {
   return {
     propertyName: propertyName,
-    predicate: convertToR3QueryPredicate(ann.selector),
+    predicate: convertToR3QueryPredicate(ann.locator),
     descendants: ann.descendants,
     first: ann.first,
     read: ann.read ? ann.read : null,
@@ -465,10 +465,10 @@ function extractQueriesMetadata(
       const annotations = propMetadata[field];
       annotations.forEach(ann => {
         if (isQueryAnn(ann)) {
-          if (!ann.selector) {
+          if (!ann.locator) {
             throw new Error(
                 `Can't construct a query for the property "${field}" of ` +
-                `"${stringifyForError(type)}" since the query selector wasn't defined.`);
+                `"${stringifyForError(type)}" since the query locator wasn't defined.`);
           }
           if (annotations.some(isInputAnnotation)) {
             throw new Error(`Cannot combine @Input decorators with query decorators`);

--- a/packages/core/src/render3/query.ts
+++ b/packages/core/src/render3/query.ts
@@ -226,7 +226,7 @@ class TQuery_ implements TQuery {
     if (Array.isArray(predicate)) {
       for (let i = 0; i < predicate.length; i++) {
         const name = predicate[i];
-        this.matchTNodeWithReadOption(tView, tNode, getIdxOfMatchingSelector(tNode, name));
+        this.matchTNodeWithReadOption(tView, tNode, getIdxOfMatchingLocator(tNode, name));
         // Also try matching the name to a provider since strings can be used as DI tokens too.
         this.matchTNodeWithReadOption(
             tView, tNode, locateDirectiveOrProvider(tNode, tView, name, false, false));
@@ -277,14 +277,14 @@ class TQuery_ implements TQuery {
  * (or -1 if a local name points to an element).
  *
  * @param tNode static data of a node to check
- * @param selector selector to match
- * @returns directive index, -1 or null if a selector didn't match any of the local names
+ * @param locator locator to match
+ * @returns directive index, -1 or null if a locator didn't match any of the local names
  */
-function getIdxOfMatchingSelector(tNode: TNode, selector: string): number|null {
+function getIdxOfMatchingLocator(tNode: TNode, locator: string): number|null {
   const localNames = tNode.localNames;
   if (localNames !== null) {
     for (let i = 0; i < localNames.length; i += 2) {
-      if (localNames[i] === selector) {
+      if (localNames[i] === locator) {
         return localNames[i + 1] as number;
       }
     }

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -1266,7 +1266,7 @@
     "name": "getFirstNativeNode"
   },
   {
-    "name": "getIdxOfMatchingSelector"
+    "name": "getIdxOfMatchingLocator"
   },
   {
     "name": "getInjectableDef"

--- a/packages/core/test/linker/query_integration_spec.ts
+++ b/packages/core/test/linker/query_integration_spec.ts
@@ -221,13 +221,13 @@ describe('Query API', () => {
       expect(asNativeElements(view.debugElement.children)).toHaveText('3d|2d|');
     });
 
-    it('should throw with descriptive error when query selectors are not present', () => {
+    it('should throw with descriptive error when query locators are not present', () => {
       TestBed.configureTestingModule({declarations: [MyCompBroken0, HasNullQueryCondition]});
       const template = '<has-null-query-condition></has-null-query-condition>';
       TestBed.overrideComponent(MyCompBroken0, {set: {template}});
       expect(() => TestBed.createComponent(MyCompBroken0))
           .toThrowError(`Can't construct a query for the property "errorTrigger" of "${
-              stringify(HasNullQueryCondition)}" since the query selector wasn't defined.`);
+              stringify(HasNullQueryCondition)}" since the query locator wasn't defined.`);
     });
   });
 

--- a/packages/core/test/render3/jit/directive_spec.ts
+++ b/packages/core/test/render3/jit/directive_spec.ts
@@ -45,7 +45,7 @@ describe('jit directive helper functions', () => {
   describe('convertToR3QueryMetadata', () => {
     it('should convert decorator with a single string selector', () => {
       expect(convertToR3QueryMetadata('propName', {
-        selector: 'localRef',
+        locator: 'localRef',
         descendants: false,
         first: false,
         isViewQuery: false,
@@ -65,7 +65,7 @@ describe('jit directive helper functions', () => {
 
     it('should convert decorator with multiple string selectors', () => {
       expect(convertToR3QueryMetadata('propName', {
-        selector: 'foo, bar,baz',
+        locator: 'foo, bar,baz',
         descendants: true,
         first: true,
         isViewQuery: true,
@@ -87,7 +87,7 @@ describe('jit directive helper functions', () => {
       class Directive {}
 
       const converted = convertToR3QueryMetadata('propName', {
-        selector: Directive,
+        locator: Directive,
         descendants: true,
         first: true,
         isViewQuery: true,


### PR DESCRIPTION
The first param for Angular queries (`@ViewChild` etc.) is currently named "selector". This is confusingly overloaded with CSS selectors, especially given that we _use_ CSS selectors in other parts of the framework. The term "locator" here is both accurate and easier to explain.