### PR TITLE
docs: mention DomSanitizer in ElementRef documentation

### DIFF
--- a/packages/core/src/linker/element_ref.ts
+++ b/packages/core/src/linker/element_ref.ts
@@ -53,8 +53,8 @@ export class ElementRef<T = any> {
    *   <header>Use with caution</header>
    *   <p>
    *    Use this API as the last resort when direct access to DOM is needed. Use templating and
-   *    data-binding provided by Angular instead. Alternatively you can take a look at {@link
-   * Renderer2} which provides an API that can be safely used.
+   *    data-binding provided by Angular instead. If used, it is
+   * recommended in combination with {@link DomSanitizer} for maxiumum security;
    *   </p>
    * </div>
    */

--- a/packages/core/src/render/api.ts
+++ b/packages/core/src/render/api.ts
@@ -56,6 +56,11 @@ export abstract class RendererFactory2 {
  * not statically known, use the `setProperty()` or
  * `setAttribute()` method.
  *
+ * <div class="callout is-important">
+ *  Please be aware that usage of `Renderer2`, in context of accessing DOM elements, provides no
+ * extra security which makes it equivalent to {@link ElementRef}.
+ * </div>
+ *
  * @publicApi
  */
 export abstract class Renderer2 {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Related to: https://github.com/angular/angular/issues/46904

In the current state, the documentation suggests that usage of `Renderer2` provides a safe way to access DOM elements. It only provides a wrapper method around it thus we are not using DOM API directly when coding, which is fine, but doesn't provide any additional security so it might be confusing. (to me it was until I checked the source code and saw that I also need to use `.sanitize()` for security benefits)

Sorry if I misunderstood something.

Issue Number: N/A


## What is the new behavior?
I mentioned the `DomSanitizer` so that it is a bit more clear that using `Renderer2` isn't enough by itself but for maximum security but that it should be used in combination with the `DomSanitizer`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
