### PR TITLE
docs: remove duplicate words.

### DIFF
--- a/aio/content/examples/structural-directives/src/app/unless.directive.ts
+++ b/aio/content/examples/structural-directives/src/app/unless.directive.ts
@@ -9,7 +9,7 @@ import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
 // #enddocregion no-docs
  *
  * If the expression assigned to `appUnless` evaluates to a truthy value
- * then the templated elements are removed removed from the DOM,
+ * then the templated elements are removed from the DOM,
  * the templated elements are (re)inserted into the DOM.
  *
  * <div *appUnless="errorCount" class="success">

--- a/aio/content/guide/lifecycle-hooks.md
+++ b/aio/content/guide/lifecycle-hooks.md
@@ -101,7 +101,7 @@ The `ngOnDestroy()` method is also the time to notify another part of the applic
 
 ### DestroyRef
 
-In addition to to `ngOnDestroy()`, you can inject Angular's `DestroyRef` and register callback functions to be called when the enclosing context is destroyed. This can be useful for building reusable utilities that require cleanup.
+In addition to `ngOnDestroy()`, you can inject Angular's `DestroyRef` and register callback functions to be called when the enclosing context is destroyed. This can be useful for building reusable utilities that require cleanup.
 
 Register a callback with the `DestroyRef`:
 

--- a/aio/src/app/shared/location.service.ts
+++ b/aio/src/app/shared/location.service.ts
@@ -146,7 +146,7 @@ export class LocationService {
 
     const { pathname, search, hash } = anchor;
     // Fix in-page anchors that are supposed to point to fragments inside the page, but are resolved
-    // relative the the root path (`/`), due to the base URL being set to `/`.
+    // relative the root path (`/`), due to the base URL being set to `/`.
     // (See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base#in-page_anchors.)
     const isInPageAnchor = anchor.getAttribute('href')?.startsWith('#') ?? false;
     const correctPathname = isInPageAnchor ? this.location.path() : pathname;

--- a/packages/core/src/linker/view_container_ref.ts
+++ b/packages/core/src/linker/view_container_ref.ts
@@ -349,7 +349,7 @@ const R3ViewContainerRef = class ViewContainerRef extends VE_ViewContainerRef {
 
     // This function supports 2 signatures and we need to handle options correctly for both:
     //   1. When first argument is a Component type. This signature also requires extra
-    //      options to be provided as as object (more ergonomic option).
+    //      options to be provided as object (more ergonomic option).
     //   2. First argument is a Component factory. In this case extra options are represented as
     //      positional arguments. This signature is less ergonomic and will be deprecated.
     if (isComponentFactory) {

--- a/packages/core/src/render3/hooks.ts
+++ b/packages/core/src/render3/hooks.ts
@@ -124,14 +124,14 @@ export function registerPostOrderHooks(tView: TView, tNode: TNode): void {
  * This is done by storing and maintaining flags in the view: the {@link InitPhaseState},
  * and the index within that phase. They can be seen as a cursor in the following structure:
  * [[onInit1, onInit2], [afterContentInit1], [afterViewInit1, afterViewInit2, afterViewInit3]]
- * They are are stored as flags in LView[FLAGS].
+ * They are stored as flags in LView[FLAGS].
  *
  * 2. Pre-order hooks can be executed in batches, because of the select instruction.
  * To be able to pause and resume their execution, we also need some state about the hook's array
  * that is being processed:
  * - the index of the next hook to be executed
  * - the number of init hooks already found in the processed part of the  array
- * They are are stored as flags in LView[PREORDER_HOOK_FLAGS].
+ * They are stored as flags in LView[PREORDER_HOOK_FLAGS].
  */
 
 

--- a/packages/core/test/linker/ng_module_integration_spec.ts
+++ b/packages/core/test/linker/ng_module_integration_spec.ts
@@ -770,7 +770,7 @@ describe('NgModule', () => {
         class MyService1 {
           public innerService: MyService2;
           constructor(injector: Injector) {
-            // Create MyService2 before it it's initialized by TestModule.
+            // Create MyService2 before it's initialized by TestModule.
             this.innerService = injector.get(MyService2);
           }
         }

--- a/packages/core/test/render3/deps_tracker_spec.ts
+++ b/packages/core/test/render3/deps_tracker_spec.ts
@@ -371,7 +371,7 @@ describe('runtime dependency tracker', () => {
           directives: new Set([Component1]),
         });
 
-        // Modify the the module
+        // Modify the module
         (MainModule as NgModuleType).ɵmod.declarations = [];
 
         ans = depsTracker.getNgModuleScope(MainModule as NgModuleType);
@@ -400,7 +400,7 @@ describe('runtime dependency tracker', () => {
           directives: new Set([Component1]),
         });
 
-        // Modify the the module
+        // Modify the module
         (MainModule as NgModuleType).ɵmod.declarations = [];
         depsTracker.clearScopeCacheFor(MainModule as NgModuleType);
 

--- a/packages/forms/src/directives/abstract_control_directive.ts
+++ b/packages/forms/src/directives/abstract_control_directive.ts
@@ -60,7 +60,7 @@ export abstract class AbstractControlDirective {
 
   /**
    * @description
-   * Reports whether a control is pending, meaning that that async validation is occurring and
+   * Reports whether a control is pending, meaning that async validation is occurring and
    * errors are not yet available for the input value. If the control is not present, null is
    * returned.
    */

--- a/packages/forms/src/directives/radio_control_value_accessor.ts
+++ b/packages/forms/src/directives/radio_control_value_accessor.ts
@@ -207,7 +207,7 @@ export class RadioControlValueAccessor extends BuiltInControlValueAccessor imple
      * when an *enabled* control was attached. This bug was fixed in v15 in #47576.
      *
      * This had a side effect: previously, it was possible to instantiate a reactive form control
-     * with `[attr.disabled]=true`, even though the the corresponding control was enabled in the
+     * with `[attr.disabled]=true`, even though the corresponding control was enabled in the
      * model. This resulted in a mismatch between the model and the DOM. Now, because
      * `setDisabledState` is always called, the value in the DOM will be immediately overwritten
      * with the "correct" enabled value.

--- a/packages/forms/src/model/abstract_model.ts
+++ b/packages/forms/src/model/abstract_model.ts
@@ -31,7 +31,7 @@ export const VALID = 'VALID';
 export const INVALID = 'INVALID';
 
 /**
- * Reports that a control is pending, meaning that that async validation is occurring and
+ * Reports that a control is pending, meaning that async validation is occurring and
  * errors are not yet available for the input value.
  *
  * @see {@link markAsPending}
@@ -56,7 +56,7 @@ export const DISABLED = 'DISABLED';
  * value.
  * * **INVALID**: Reports that a control is invalid, meaning that an error exists in the input
  * value.
- * * **PENDING**: Reports that a control is pending, meaning that that async validation is
+ * * **PENDING**: Reports that a control is pending, meaning that async validation is
  * occurring and errors are not yet available for the input value.
  * * **DISABLED**: Reports that a control is
  * disabled, meaning that the control is exempt from ancestor calculations of validity or value.
@@ -321,7 +321,7 @@ export type ɵWriteable<T> = {
 export type ɵGetProperty<T, K> =
     // K is a string
     K extends string ? ɵGetProperty<T, ɵCoerceStrArrToNumArr<ɵTokenize<K, '.'>>> :
-    // Is is an array
+    // Is it an array
     ɵWriteable<K> extends Array<string|number> ? ɵNavigate<T, ɵWriteable<K>> :
     // Fall through permissively if we can't calculate the type of K.
     any;

--- a/packages/forms/test/reactive_integration_spec.ts
+++ b/packages/forms/test/reactive_integration_spec.ts
@@ -4187,7 +4187,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         // - FormControlDirective was destroyed and connection to a value accessor and view
         //   validators should also be destroyed.
         // - Since there is a second instance of the FormControlDirective directive present in the
-        //   template, we expect to see see calls to value accessor B (since it's applied to
+        //   template, we expect to see calls to value accessor B (since it's applied to
         //   that directive instance) and validators applied on a control instance itself (not a
         //   part of a view setup).
         expect(valueAccessorBSpy).toHaveBeenCalledWith('Updated Value');
@@ -4262,7 +4262,7 @@ const ValueAccessorB = createControlValueAccessor('[cva-b]');
         // - `FormControlName` was destroyed and connection to the value accessor A and
         //   validators should also be destroyed.
         // - Since there is a second instance of `FormControlName` directive present in the
-        //   template, we expect to see see calls to the value accessor B (since it's applied to
+        //   template, we expect to see calls to the value accessor B (since it's applied to
         //   that directive instance) and validators applied on a control instance itself (not a
         //   part of a view setup).
         expect(valueAccessorBSpy).toHaveBeenCalledWith('Updated value');

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -520,7 +520,7 @@ class ExpressionVisitor extends e.RecursiveAstVisitor {
     if (node instanceof e.ASTWithSource) {
       // In order to reduce noise, do not include `ASTWithSource` in the path.
       // For the purpose of source spans, there is no difference between
-      // `ASTWithSource` and and underlying node that it wraps.
+      // `ASTWithSource` and underlying node that it wraps.
       node = node.ast;
     }
     // The third condition is to account for the implicit receiver, which should

--- a/packages/router/src/router.ts
+++ b/packages/router/src/router.ts
@@ -312,7 +312,7 @@ export class Router {
   private readonly location = inject(Location);
 
   /**
-   * Indicates whether the the application has opted in to binding Router data to component inputs.
+   * Indicates whether the application has opted in to binding Router data to component inputs.
    *
    * This option is enabled by the `withComponentInputBinding` feature of `provideRouter` or
    * `bindToComponentInputs` in the `ExtraOptions` of `RouterModule.forRoot`.


### PR DESCRIPTION
Using the `\b(\w+)\s+\1\b` we can find duplicate words. Let's remove them so we don't get more PRs with this simple changes. 

