### PR TITLE
deprecate `PACKAGE_ROOT_URL` token

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -124,6 +124,13 @@ v16 - v19
 | `@angular/platform-browser`         | [`BrowserModule.withServerTransition`](api/platform-browser/BrowserModule#withservertransition)            | v16           | v18         |
 | `@angular/platform-browser`         | [`makeStateKey`, `StateKey` and `TransferState`](#platform-browser), symbols were moved to `@angular/core`                                        | v16           | v18         |
 
+
+### Deprecated features that can be removed in v19 or later
+
+| Area                                | API or Feature                                                                                             | Deprecated in | May be removed in |
+|:---                                 |:---                                                                                                        |:---           |:---               |
+| `@angular/core` | `PACKAGE_ROOT_URL` | v17 | v19 |
+
 ### Deprecated features with no planned removal version
 
 | Area                                | API or Feature                                                                                             | Deprecated in | May be removed in |

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1110,7 +1110,7 @@ export interface OutputDecorator {
     new (alias?: string): any;
 }
 
-// @public
+// @public @deprecated
 export const PACKAGE_ROOT_URL: InjectionToken<string>;
 
 // @public

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -66,6 +66,7 @@ export const PLATFORM_ID = new InjectionToken<Object>('Platform ID', {
  * A [DI token](guide/glossary#di-token "DI token definition") that indicates the root directory of
  * the application
  * @publicApi
+ * @deprecated
  */
 export const PACKAGE_ROOT_URL = new InjectionToken<string>('Application Packages Root URL');
 

--- a/packages/platform-browser-dynamic/src/compiler_factory.ts
+++ b/packages/platform-browser-dynamic/src/compiler_factory.ts
@@ -7,17 +7,7 @@
  */
 
 import {CompilerConfig} from '@angular/compiler';
-import {Compiler, CompilerFactory, CompilerOptions, InjectionToken, Injector, MissingTranslationStrategy, PACKAGE_ROOT_URL, StaticProvider, ViewEncapsulation} from '@angular/core';
-
-export const ERROR_COLLECTOR_TOKEN = new InjectionToken('ErrorCollector');
-
-/**
- * A default provider for {@link PACKAGE_ROOT_URL} that maps to '/'.
- */
-export const DEFAULT_PACKAGE_URL_PROVIDER = {
-  provide: PACKAGE_ROOT_URL,
-  useValue: '/'
-};
+import {Compiler, CompilerFactory, CompilerOptions, Injector, MissingTranslationStrategy, StaticProvider, ViewEncapsulation} from '@angular/core';
 
 export const COMPILER_PROVIDERS =
     <StaticProvider[]>[{provide: Compiler, useFactory: () => new Compiler()}];


### PR DESCRIPTION
2 commits here: 

* Deprecation of the public `PACKAGE_ROOT_URL` token. (Was used in VE, removed in #43884)
* Removal of it's only usage within the project (which was dead code already) 

The depreciation should be just a technicality as the token has no purpose anymore. 

## Does this PR introduce a breaking change?

- [x] No
