### PR TITLE
refactor(core): switch signals to a refcounting algorithm

### DIFF
--- a/goldens/size-tracking/integration-payloads.json
+++ b/goldens/size-tracking/integration-payloads.json
@@ -16,7 +16,7 @@
   "cli-hello-world-lazy": {
     "uncompressed": {
       "runtime": 2734,
-      "main": 232018,
+      "main": 238106,
       "polyfills": 33810,
       "src_app_lazy_lazy_routes_ts": 487
     }
@@ -38,7 +38,7 @@
   "platform-server/standalone/browser": {
     "uncompressed": {
       "runtime": 2694,
-      "main": 232544,
+      "main": 238273,
       "polyfills": 33782
     }
   },

--- a/packages/core/src/render3/node_manipulation.ts
+++ b/packages/core/src/render3/node_manipulation.ts
@@ -9,6 +9,7 @@
 import {hasInSkipHydrationBlockFlag} from '../hydration/skip_hydration';
 import {ViewEncapsulation} from '../metadata/view';
 import {RendererStyleFlags2} from '../render/api_flags';
+import {consumerDestroy} from '../signals';
 import {addToArray, removeFromArray} from '../util/array_utils';
 import {assertDefined, assertEqual, assertFunction, assertNumber, assertString} from '../util/assert';
 import {escapeCommentText} from '../util/dom';
@@ -376,8 +377,8 @@ export function destroyLView(tView: TView, lView: LView) {
   if (!(lView[FLAGS] & LViewFlags.Destroyed)) {
     const renderer = lView[RENDERER];
 
-    lView[REACTIVE_TEMPLATE_CONSUMER]?.destroy();
-    lView[REACTIVE_HOST_BINDING_CONSUMER]?.destroy();
+    lView[REACTIVE_TEMPLATE_CONSUMER] && consumerDestroy(lView[REACTIVE_TEMPLATE_CONSUMER]);
+    lView[REACTIVE_HOST_BINDING_CONSUMER] && consumerDestroy(lView[REACTIVE_HOST_BINDING_CONSUMER]);
 
     if (renderer.destroyNode) {
       applyView(tView, lView, renderer, WalkTNodeTreeAction.Destroy, null, null);

--- a/packages/core/src/render3/reactivity/effect.ts
+++ b/packages/core/src/render3/reactivity/effect.ts
@@ -11,7 +11,7 @@ import {Injector} from '../../di/injector';
 import {inject} from '../../di/injector_compatibility';
 import {ɵɵdefineInjectable} from '../../di/interface/defs';
 import {DestroyRef} from '../../linker/destroy_ref';
-import {Watch} from '../../signals';
+import {Watch, watch} from '../../signals';
 
 /**
  * An effect can, optionally, register a cleanup function. If registered, the cleanup is executed
@@ -38,7 +38,7 @@ export class EffectManager {
       effectFn: (onCleanup: (cleanupFn: EffectCleanupFn) => void) => void,
       destroyRef: DestroyRef|null, allowSignalWrites: boolean): EffectRef {
     const zone = (typeof Zone === 'undefined') ? null : Zone.current;
-    const watch = new Watch(effectFn, (watch) => {
+    const w = watch(effectFn, (watch) => {
       if (!this.all.has(watch)) {
         return;
       }
@@ -46,18 +46,18 @@ export class EffectManager {
       this.queue.set(watch, zone);
     }, allowSignalWrites);
 
-    this.all.add(watch);
+    this.all.add(w);
 
     // Effects start dirty.
-    watch.notify();
+    w.notify();
 
     let unregisterOnDestroy: (() => void)|undefined;
 
     const destroy = () => {
-      watch.cleanup();
+      w.cleanup();
       unregisterOnDestroy?.();
-      this.all.delete(watch);
-      this.queue.delete(watch);
+      this.all.delete(w);
+      this.queue.delete(w);
     };
 
     unregisterOnDestroy = destroyRef?.onDestroy(destroy);

--- a/packages/core/src/signals/index.ts
+++ b/packages/core/src/signals/index.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {createSignalFromFunction, defaultEquals, isSignal, Signal, ValueEqualityFn} from './src/api';
+export {defaultEquals, isSignal, Signal, SIGNAL, ValueEqualityFn} from './src/api';
 export {computed, CreateComputedOptions} from './src/computed';
 export {setThrowInvalidWriteToSignalError} from './src/errors';
-export {ReactiveNode, setActiveConsumer} from './src/graph';
+export {consumerAfterComputation, consumerBeforeComputation, consumerDestroy, producerAccessed, producerNotifyConsumers, producerUpdatesAllowed, producerUpdateValueVersion, REACTIVE_NODE, ReactiveNode, setActiveConsumer} from './src/graph';
 export {CreateSignalOptions, setPostSignalSetFn, signal, WritableSignal} from './src/signal';
 export {untracked} from './src/untracked';
-export {Watch, WatchCleanupFn} from './src/watch';
+export {Watch, watch, WatchCleanupFn} from './src/watch';
 export {setAlternateWeakRefImpl} from './src/weak_ref';

--- a/packages/core/src/signals/src/api.ts
+++ b/packages/core/src/signals/src/api.ts
@@ -13,7 +13,7 @@ import {ReactiveNode} from './graph';
  *
  * This can be used to auto-unwrap signals in various cases, or to auto-wrap non-signal values.
  */
-const SIGNAL = Symbol('SIGNAL');
+export const SIGNAL = Symbol('SIGNAL');
 
 /**
  * A reactive value which notifies consumers of any changes.
@@ -36,35 +36,6 @@ export type Signal<T> = (() => T)&{
  */
 export function isSignal(value: unknown): value is Signal<unknown> {
   return typeof value === 'function' && (value as Signal<unknown>)[SIGNAL] !== undefined;
-}
-
-/**
- * Converts `fn` into a marked signal function (where `isSignal(fn)` will be `true`).
- *
- * @param fn A zero-argument function which will be converted into a `Signal`.
- */
-export function createSignalFromFunction<T>(node: ReactiveNode, fn: () => T): Signal<T>;
-
-/**
- * Converts `fn` into a marked signal function (where `isSignal(fn)` will be `true`), and
- * potentially add some set of extra properties (passed as an object record `extraApi`).
- *
- * @param fn A zero-argument function which will be converted into a `Signal`.
- * @param extraApi An object whose properties will be copied onto `fn` in order to create a specific
- *     desired interface for the `Signal`.
- */
-export function createSignalFromFunction<T, U extends Record<string, unknown>>(
-    node: ReactiveNode, fn: () => T, extraApi: U): Signal<T>&U;
-
-/**
- * Converts `fn` into a marked signal function (where `isSignal(fn)` will be `true`), and
- * potentially add some set of extra properties (passed as an object record `extraApi`).
- */
-export function createSignalFromFunction<T, U extends Record<string, unknown> = {}>(
-    node: ReactiveNode, fn: () => T, extraApi: U = ({} as U)): Signal<T>&U {
-  (fn as any)[SIGNAL] = node;
-  // Copy properties from `extraApi` to `fn` to complete the desired API of the `Signal`.
-  return Object.assign(fn, extraApi) as (Signal<T>& U);
 }
 
 /**

--- a/packages/core/src/signals/src/weak_ref.ts
+++ b/packages/core/src/signals/src/weak_ref.ts
@@ -6,45 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-// Required as the signals library is in a separate package, so we need to explicitly ensure the
-// global `ngDevMode` type is defined.
-import '../../util/ng_dev_mode';
-
-import {global} from '../../util/global';
-
-/**
- * A `WeakRef`-compatible reference that fakes the API with a strong reference
- * internally.
- */
-class LeakyRef<T>/* implements WeakRef<T> */ {
-  constructor(private readonly ref: T) {}
-
-  deref(): T|undefined {
-    return this.ref;
-  }
-}
-
-// `WeakRef` is not always defined in every TS environment where Angular is compiled. Instead,
-// read it off of the global context if available.
-// tslint:disable-next-line: no-toplevel-property-access
-let WeakRefImpl: WeakRefCtor|undefined = global['WeakRef'] ?? LeakyRef;
-
-export interface WeakRef<T extends object> {
-  deref(): T|undefined;
-}
-
-export function newWeakRef<T extends object>(value: T): WeakRef<T> {
-  if (typeof ngDevMode !== 'undefined' && ngDevMode && WeakRefImpl === undefined) {
-    throw new Error(`Angular requires a browser which supports the 'WeakRef' API`);
-  }
-  return new WeakRefImpl!(value);
-}
-
-export interface WeakRefCtor {
-  new<T extends object>(value: T): WeakRef<T>;
-}
-
-export function setAlternateWeakRefImpl(impl: WeakRefCtor) {
-  // no-op since the alternate impl is included by default by the framework. Remove once internal
-  // migration is complete.
+export function setAlternateWeakRefImpl(impl: unknown) {
+  // TODO: remove this function
 }

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -420,13 +420,13 @@
     "name": "R3Injector"
   },
   {
+    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
+  },
+  {
+    "name": "REACTIVE_NODE"
+  },
+  {
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "ReactiveLViewConsumer"
-  },
-  {
-    "name": "ReactiveNode"
   },
   {
     "name": "RefCountOperator"
@@ -546,10 +546,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "Watch"
-  },
-  {
-    "name": "WeakRefImpl"
+    "name": "WATCH_NODE"
   },
   {
     "name": "WebAnimationsPlayer"
@@ -609,9 +606,6 @@
     "name": "_locateOrCreateElementNode"
   },
   {
-    "name": "_nextReactiveId"
-  },
-  {
     "name": "_platformInjector"
   },
   {
@@ -664,6 +658,9 @@
   },
   {
     "name": "applyView"
+  },
+  {
+    "name": "assertConsumerNode"
   },
   {
     "name": "attachPatchData"
@@ -741,6 +738,24 @@
     "name": "connectableObservableDescriptor"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
+    "name": "consumerBeforeComputation"
+  },
+  {
+    "name": "consumerDestroy"
+  },
+  {
+    "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
+  },
+  {
+    "name": "consumerPollProducersForChange"
+  },
+  {
     "name": "containsElement"
   },
   {
@@ -772,6 +787,9 @@
   },
   {
     "name": "createLView"
+  },
+  {
+    "name": "createLViewConsumer"
   },
   {
     "name": "createNodeInjector"
@@ -1291,6 +1309,12 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -459,13 +459,13 @@
     "name": "R3Injector"
   },
   {
+    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
+  },
+  {
+    "name": "REACTIVE_NODE"
+  },
+  {
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "ReactiveLViewConsumer"
-  },
-  {
-    "name": "ReactiveNode"
   },
   {
     "name": "RefCountOperator"
@@ -600,10 +600,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "Watch"
-  },
-  {
-    "name": "WeakRefImpl"
+    "name": "WATCH_NODE"
   },
   {
     "name": "WebAnimationsPlayer"
@@ -663,9 +660,6 @@
     "name": "_locateOrCreateElementNode"
   },
   {
-    "name": "_nextReactiveId"
-  },
-  {
     "name": "_platformInjector"
   },
   {
@@ -721,6 +715,9 @@
   },
   {
     "name": "applyView"
+  },
+  {
+    "name": "assertConsumerNode"
   },
   {
     "name": "attachPatchData"
@@ -798,6 +795,24 @@
     "name": "connectableObservableDescriptor"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
+    "name": "consumerBeforeComputation"
+  },
+  {
+    "name": "consumerDestroy"
+  },
+  {
+    "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
+  },
+  {
+    "name": "consumerPollProducersForChange"
+  },
+  {
     "name": "containsElement"
   },
   {
@@ -832,6 +847,9 @@
   },
   {
     "name": "createLView"
+  },
+  {
+    "name": "createLViewConsumer"
   },
   {
     "name": "createNodeInjector"
@@ -1366,6 +1384,12 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -345,13 +345,13 @@
     "name": "R3Injector"
   },
   {
+    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
+  },
+  {
+    "name": "REACTIVE_NODE"
+  },
+  {
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "ReactiveLViewConsumer"
-  },
-  {
-    "name": "ReactiveNode"
   },
   {
     "name": "RefCountOperator"
@@ -459,10 +459,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "Watch"
-  },
-  {
-    "name": "WeakRefImpl"
+    "name": "WATCH_NODE"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"
@@ -502,9 +499,6 @@
   },
   {
     "name": "_locateOrCreateElementNode"
-  },
-  {
-    "name": "_nextReactiveId"
   },
   {
     "name": "_platformInjector"
@@ -553,6 +547,9 @@
   },
   {
     "name": "applyView"
+  },
+  {
+    "name": "assertConsumerNode"
   },
   {
     "name": "attachPatchData"
@@ -609,6 +606,24 @@
     "name": "connectableObservableDescriptor"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
+    "name": "consumerBeforeComputation"
+  },
+  {
+    "name": "consumerDestroy"
+  },
+  {
+    "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
+  },
+  {
+    "name": "consumerPollProducersForChange"
+  },
+  {
     "name": "convertToBitFlags"
   },
   {
@@ -628,6 +643,9 @@
   },
   {
     "name": "createLView"
+  },
+  {
+    "name": "createLViewConsumer"
   },
   {
     "name": "createNodeInjector"
@@ -1087,6 +1105,12 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -462,6 +462,12 @@
     "name": "R3ViewContainerRef"
   },
   {
+    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
+  },
+  {
+    "name": "REACTIVE_NODE"
+  },
+  {
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
@@ -475,12 +481,6 @@
   },
   {
     "name": "ReactiveFormsModule"
-  },
-  {
-    "name": "ReactiveLViewConsumer"
-  },
-  {
-    "name": "ReactiveNode"
   },
   {
     "name": "RefCountOperator"
@@ -612,10 +612,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "Watch"
-  },
-  {
-    "name": "WeakRefImpl"
+    "name": "WATCH_NODE"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"
@@ -670,9 +667,6 @@
   },
   {
     "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_nextReactiveId"
   },
   {
     "name": "_platformInjector"
@@ -736,6 +730,9 @@
   },
   {
     "name": "assertAllValuesPresent"
+  },
+  {
+    "name": "assertConsumerNode"
   },
   {
     "name": "assertControlPresent"
@@ -825,6 +822,24 @@
     "name": "connectableObservableDescriptor"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
+    "name": "consumerBeforeComputation"
+  },
+  {
+    "name": "consumerDestroy"
+  },
+  {
+    "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
+  },
+  {
+    "name": "consumerPollProducersForChange"
+  },
+  {
     "name": "controlNameBinding"
   },
   {
@@ -856,6 +871,9 @@
   },
   {
     "name": "createLView"
+  },
+  {
+    "name": "createLViewConsumer"
   },
   {
     "name": "createNodeInjector"
@@ -1504,6 +1522,12 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -453,6 +453,12 @@
     "name": "R3ViewContainerRef"
   },
   {
+    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
+  },
+  {
+    "name": "REACTIVE_NODE"
+  },
+  {
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
@@ -460,12 +466,6 @@
   },
   {
     "name": "RadioControlRegistryModule"
-  },
-  {
-    "name": "ReactiveLViewConsumer"
-  },
-  {
-    "name": "ReactiveNode"
   },
   {
     "name": "RefCountOperator"
@@ -603,10 +603,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "Watch"
-  },
-  {
-    "name": "WeakRefImpl"
+    "name": "WATCH_NODE"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"
@@ -658,9 +655,6 @@
   },
   {
     "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_nextReactiveId"
   },
   {
     "name": "_platformInjector"
@@ -721,6 +715,9 @@
   },
   {
     "name": "applyViewChange"
+  },
+  {
+    "name": "assertConsumerNode"
   },
   {
     "name": "attachInjectFlag"
@@ -798,6 +795,24 @@
     "name": "connectableObservableDescriptor"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
+    "name": "consumerBeforeComputation"
+  },
+  {
+    "name": "consumerDestroy"
+  },
+  {
+    "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
+  },
+  {
+    "name": "consumerPollProducersForChange"
+  },
+  {
     "name": "controlPath"
   },
   {
@@ -826,6 +841,9 @@
   },
   {
     "name": "createLView"
+  },
+  {
+    "name": "createLViewConsumer"
   },
   {
     "name": "createNodeInjector"
@@ -1468,6 +1486,12 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -264,10 +264,10 @@
     "name": "R3Injector"
   },
   {
-    "name": "ReactiveLViewConsumer"
+    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
   },
   {
-    "name": "ReactiveNode"
+    "name": "REACTIVE_NODE"
   },
   {
     "name": "RefCountOperator"
@@ -351,10 +351,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "Watch"
-  },
-  {
-    "name": "WeakRefImpl"
+    "name": "WATCH_NODE"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"
@@ -385,9 +382,6 @@
   },
   {
     "name": "_injectImplementation"
-  },
-  {
-    "name": "_nextReactiveId"
   },
   {
     "name": "_platformInjector"
@@ -421,6 +415,9 @@
   },
   {
     "name": "applyView"
+  },
+  {
+    "name": "assertConsumerNode"
   },
   {
     "name": "attachPatchData"
@@ -471,6 +468,24 @@
     "name": "connectableObservableDescriptor"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
+    "name": "consumerBeforeComputation"
+  },
+  {
+    "name": "consumerDestroy"
+  },
+  {
+    "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
+  },
+  {
+    "name": "consumerPollProducersForChange"
+  },
+  {
     "name": "convertToBitFlags"
   },
   {
@@ -487,6 +502,9 @@
   },
   {
     "name": "createLView"
+  },
+  {
+    "name": "createLViewConsumer"
   },
   {
     "name": "createNodeInjector"
@@ -859,6 +877,12 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -381,6 +381,12 @@
     "name": "R3Injector"
   },
   {
+    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
+  },
+  {
+    "name": "REACTIVE_NODE"
+  },
+  {
     "name": "REFERENCE_NODE_BODY"
   },
   {
@@ -391,12 +397,6 @@
   },
   {
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "ReactiveLViewConsumer"
-  },
-  {
-    "name": "ReactiveNode"
   },
   {
     "name": "RefCountOperator"
@@ -513,10 +513,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "Watch"
-  },
-  {
-    "name": "WeakRefImpl"
+    "name": "WATCH_NODE"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"
@@ -556,9 +553,6 @@
   },
   {
     "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_nextReactiveId"
   },
   {
     "name": "_platformInjector"
@@ -604,6 +598,9 @@
   },
   {
     "name": "applyView"
+  },
+  {
+    "name": "assertConsumerNode"
   },
   {
     "name": "attachPatchData"
@@ -666,6 +663,24 @@
     "name": "connectableObservableDescriptor"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
+    "name": "consumerBeforeComputation"
+  },
+  {
+    "name": "consumerDestroy"
+  },
+  {
+    "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
+  },
+  {
+    "name": "consumerPollProducersForChange"
+  },
+  {
     "name": "convertToBitFlags"
   },
   {
@@ -682,6 +697,9 @@
   },
   {
     "name": "createLView"
+  },
+  {
+    "name": "createLViewConsumer"
   },
   {
     "name": "createNodeInjector"
@@ -1153,6 +1171,12 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -531,6 +531,12 @@
     "name": "R3ViewContainerRef"
   },
   {
+    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
+  },
+  {
+    "name": "REACTIVE_NODE"
+  },
+  {
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
   },
   {
@@ -544,12 +550,6 @@
   },
   {
     "name": "ROUTES"
-  },
-  {
-    "name": "ReactiveLViewConsumer"
-  },
-  {
-    "name": "ReactiveNode"
   },
   {
     "name": "RedirectRequest"
@@ -777,10 +777,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "Watch"
-  },
-  {
-    "name": "WeakRefImpl"
+    "name": "WATCH_NODE"
   },
   {
     "name": "XSS_SECURITY_URL"
@@ -829,9 +826,6 @@
   },
   {
     "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_nextReactiveId"
   },
   {
     "name": "_platformInjector"
@@ -898,6 +892,9 @@
   },
   {
     "name": "applyView"
+  },
+  {
+    "name": "assertConsumerNode"
   },
   {
     "name": "attachPatchData"
@@ -978,6 +975,24 @@
     "name": "connectableObservableDescriptor"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
+    "name": "consumerBeforeComputation"
+  },
+  {
+    "name": "consumerDestroy"
+  },
+  {
+    "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
+  },
+  {
+    "name": "consumerPollProducersForChange"
+  },
+  {
     "name": "containsSegmentGroup"
   },
   {
@@ -1021,6 +1036,9 @@
   },
   {
     "name": "createLView"
+  },
+  {
+    "name": "createLViewConsumer"
   },
   {
     "name": "createNewSegmentChildren"
@@ -1780,6 +1798,12 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -309,13 +309,13 @@
     "name": "R3Injector"
   },
   {
+    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
+  },
+  {
+    "name": "REACTIVE_NODE"
+  },
+  {
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "ReactiveLViewConsumer"
-  },
-  {
-    "name": "ReactiveNode"
   },
   {
     "name": "RefCountOperator"
@@ -411,10 +411,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "Watch"
-  },
-  {
-    "name": "WeakRefImpl"
+    "name": "WATCH_NODE"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"
@@ -454,9 +451,6 @@
   },
   {
     "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_nextReactiveId"
   },
   {
     "name": "_platformInjector"
@@ -499,6 +493,9 @@
   },
   {
     "name": "applyView"
+  },
+  {
+    "name": "assertConsumerNode"
   },
   {
     "name": "attachPatchData"
@@ -549,6 +546,24 @@
     "name": "connectableObservableDescriptor"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
+    "name": "consumerBeforeComputation"
+  },
+  {
+    "name": "consumerDestroy"
+  },
+  {
+    "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
+  },
+  {
+    "name": "consumerPollProducersForChange"
+  },
+  {
     "name": "convertToBitFlags"
   },
   {
@@ -562,6 +577,9 @@
   },
   {
     "name": "createLView"
+  },
+  {
+    "name": "createLViewConsumer"
   },
   {
     "name": "createNodeInjector"
@@ -952,6 +970,12 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -369,13 +369,13 @@
     "name": "R3ViewContainerRef"
   },
   {
+    "name": "REACTIVE_LVIEW_CONSUMER_NODE"
+  },
+  {
+    "name": "REACTIVE_NODE"
+  },
+  {
     "name": "REMOVE_STYLES_ON_COMPONENT_DESTROY"
-  },
-  {
-    "name": "ReactiveLViewConsumer"
-  },
-  {
-    "name": "ReactiveNode"
   },
   {
     "name": "RefCountOperator"
@@ -528,10 +528,7 @@
     "name": "ViewRef"
   },
   {
-    "name": "Watch"
-  },
-  {
-    "name": "WeakRefImpl"
+    "name": "WATCH_NODE"
   },
   {
     "name": "ZONE_IS_STABLE_OBSERVABLE"
@@ -583,9 +580,6 @@
   },
   {
     "name": "_locateOrCreateTextNode"
-  },
-  {
-    "name": "_nextReactiveId"
   },
   {
     "name": "_platformInjector"
@@ -643,6 +637,9 @@
   },
   {
     "name": "applyViewChange"
+  },
+  {
+    "name": "assertConsumerNode"
   },
   {
     "name": "assertTemplate"
@@ -714,6 +711,24 @@
     "name": "connectableObservableDescriptor"
   },
   {
+    "name": "consumerAfterComputation"
+  },
+  {
+    "name": "consumerBeforeComputation"
+  },
+  {
+    "name": "consumerDestroy"
+  },
+  {
+    "name": "consumerIsLive"
+  },
+  {
+    "name": "consumerMarkDirty"
+  },
+  {
+    "name": "consumerPollProducersForChange"
+  },
+  {
     "name": "convertToBitFlags"
   },
   {
@@ -739,6 +754,9 @@
   },
   {
     "name": "createLView"
+  },
+  {
+    "name": "createLViewConsumer"
   },
   {
     "name": "createNodeInjector"
@@ -1294,6 +1312,12 @@
   },
   {
     "name": "processInjectorTypesWithProviders"
+  },
+  {
+    "name": "producerRemoveLiveConsumerAtIndex"
+  },
+  {
+    "name": "producerUpdateValueVersion"
   },
   {
     "name": "profiler"

--- a/packages/core/test/signals/computed_spec.ts
+++ b/packages/core/test/signals/computed_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {computed, signal, Watch} from '@angular/core/src/signals';
+import {computed, signal, watch} from '@angular/core/src/signals';
 
 describe('computed', () => {
   it('should create computed', () => {
@@ -136,7 +136,7 @@ describe('computed', () => {
     const derived = computed(() => source().toUpperCase());
 
     let watchCount = 0;
-    const watch = new Watch(
+    const w = watch(
         () => {
           derived();
         },
@@ -145,7 +145,7 @@ describe('computed', () => {
         },
         false);
 
-    watch.run();
+    w.run();
     expect(watchCount).toEqual(0);
 
     // change signal, mark downstream dependencies dirty
@@ -157,7 +157,7 @@ describe('computed', () => {
     expect(watchCount).toEqual(1);
 
     // resetting dependencies back to clean
-    watch.run();
+    w.run();
     expect(watchCount).toEqual(1);
 
     // expecting another notification at this point

--- a/packages/core/test/signals/effect_util.ts
+++ b/packages/core/test/signals/effect_util.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Watch, WatchCleanupFn} from '@angular/core/src/signals';
+import {watch, Watch, WatchCleanupFn} from '@angular/core/src/signals';
 
 let queue = new Set<Watch>();
 
@@ -15,10 +15,10 @@ let queue = new Set<Watch>();
  */
 export function testingEffect(effectFn: (onCleanup: (cleanupFn: WatchCleanupFn) => void) => void):
     void {
-  const watch = new Watch(effectFn, queue.add.bind(queue), true);
+  const w = watch(effectFn, queue.add.bind(queue), true);
 
   // Effects start dirty.
-  watch.notify();
+  w.notify();
 }
 
 export function flushEffects(): void {

--- a/packages/core/test/signals/watch_spec.ts
+++ b/packages/core/test/signals/watch_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {computed, signal, Watch} from '@angular/core/src/signals';
+import {computed, signal, watch} from '@angular/core/src/signals';
 
 import {flushEffects, resetEffects, testingEffect} from './effect_util';
 
@@ -46,7 +46,6 @@ describe('watchers', () => {
     const countA = signal(0);
     const countB = signal(100);
     const useCountA = signal(true);
-
 
     const runLog: number[] = [];
     testingEffect(() => {
@@ -162,7 +161,7 @@ describe('watchers', () => {
   it('should throw an error when reading a signal during the notification phase', () => {
     const source = signal(0);
     let ranScheduler = false;
-    const watch = new Watch(
+    const w = watch(
         () => {
           source();
         },
@@ -173,7 +172,7 @@ describe('watchers', () => {
         false);
 
     // Run the effect manually to initiate dependency tracking.
-    watch.run();
+    w.run();
 
     // Changing the signal will attempt to schedule the effect.
     source.set(1);


### PR DESCRIPTION
This commit switches the signals library from a bidirectional symmetric
dependency graph using weak references, to a bidirectional _asymmetric_
graph which uses strong references. This is made possible with a reference
counting algorithm which only tracks producer -> consumer references for
effect-like "live" consumers, preventing memory leaks.

The new algorithm should be simpler and faster than the previous
implementation as weak references are fairly slow to create and traverse.
A tradeoff is that non-live consumers must now poll their producers when
read, as they cannot rely on dirty notifications.
