### PR TITLE
Deferred followup refactors

### DIFF
--- a/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
+++ b/packages/compiler-cli/src/ngtsc/indexer/src/template.ts
@@ -238,10 +238,7 @@ class TemplateVisitor extends TmplAstRecursiveVisitor {
   }
 
   override visitDeferredBlock(deferred: TmplAstDeferredBlock) {
-    this.visitAll(deferred.children);
-    deferred.placeholder?.visit(this);
-    deferred.loading?.visit(this);
-    deferred.error?.visit(this);
+    deferred.visitAll(this);
   }
 
   override visitDeferredBlockPlaceholder(block: TmplAstDeferredBlockPlaceholder) {

--- a/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/extended/api/api.ts
@@ -161,12 +161,7 @@ class TemplateVisitor<Code extends ErrorCode> extends RecursiveAstVisitor implem
 
 
   visitDeferredBlock(deferred: TmplAstDeferredBlock): void {
-    this.visitAllNodes(deferred.children);
-    this.visitAllNodes(deferred.triggers);
-    this.visitAllNodes(deferred.prefetchTriggers);
-    deferred.placeholder && this.visit(deferred.placeholder);
-    deferred.loading && this.visit(deferred.loading);
-    deferred.error && this.visit(deferred.error);
+    deferred.visitAll(this);
   }
 
   visitDeferredTrigger(trigger: TmplAstDeferredTrigger): void {

--- a/packages/compiler/src/render3/r3_deferred_blocks.ts
+++ b/packages/compiler/src/render3/r3_deferred_blocks.ts
@@ -177,22 +177,20 @@ function parseErrorBlock(ast: html.Block, visitor: html.Visitor): t.DeferredBloc
 
 function parsePrimaryTriggers(
     params: html.BlockParameter[], bindingParser: BindingParser, errors: ParseError[]) {
-  const triggers: t.DeferredTrigger[] = [];
-  const prefetchTriggers: t.DeferredTrigger[] = [];
+  const triggers: t.DeferredBlockTriggers = {};
+  const prefetchTriggers: t.DeferredBlockTriggers = {};
 
   for (const param of params) {
     // The lexer ignores the leading spaces so we can assume
     // that the expression starts with a keyword.
     if (WHEN_PARAMETER_PATTERN.test(param.expression)) {
-      const result = parseWhenTrigger(param, bindingParser, errors);
-      result !== null && triggers.push(result);
+      parseWhenTrigger(param, bindingParser, triggers, errors);
     } else if (ON_PARAMETER_PATTERN.test(param.expression)) {
-      triggers.push(...parseOnTrigger(param, errors));
+      parseOnTrigger(param, triggers, errors);
     } else if (PREFETCH_WHEN_PATTERN.test(param.expression)) {
-      const result = parseWhenTrigger(param, bindingParser, errors);
-      result !== null && prefetchTriggers.push(result);
+      parseWhenTrigger(param, bindingParser, prefetchTriggers, errors);
     } else if (PREFETCH_ON_PATTERN.test(param.expression)) {
-      prefetchTriggers.push(...parseOnTrigger(param, errors));
+      parseOnTrigger(param, prefetchTriggers, errors);
     } else {
       errors.push(new ParseError(param.sourceSpan, 'Unrecognized trigger'));
     }

--- a/packages/compiler/src/render3/r3_deferred_blocks.ts
+++ b/packages/compiler/src/render3/r3_deferred_blocks.ts
@@ -112,6 +112,10 @@ function parsePlaceholderBlock(ast: html.Block, visitor: html.Visitor): t.Deferr
 
   for (const param of ast.parameters) {
     if (MINIMUM_PARAMETER_PATTERN.test(param.expression)) {
+      if (minimumTime != null) {
+        throw new Error(`Placeholder block can only have one "minimum" parameter`);
+      }
+
       const parsedTime =
           parseDeferredTime(param.expression.slice(getTriggerParametersStart(param.expression)));
 
@@ -137,6 +141,10 @@ function parseLoadingBlock(ast: html.Block, visitor: html.Visitor): t.DeferredBl
 
   for (const param of ast.parameters) {
     if (AFTER_PARAMETER_PATTERN.test(param.expression)) {
+      if (afterTime != null) {
+        throw new Error(`Loading block can only have one "after" parameter`);
+      }
+
       const parsedTime =
           parseDeferredTime(param.expression.slice(getTriggerParametersStart(param.expression)));
 
@@ -146,6 +154,10 @@ function parseLoadingBlock(ast: html.Block, visitor: html.Visitor): t.DeferredBl
 
       afterTime = parsedTime;
     } else if (MINIMUM_PARAMETER_PATTERN.test(param.expression)) {
+      if (minimumTime != null) {
+        throw new Error(`Loading block can only have one "minimum" parameter`);
+      }
+
       const parsedTime =
           parseDeferredTime(param.expression.slice(getTriggerParametersStart(param.expression)));
 

--- a/packages/compiler/src/render3/r3_deferred_triggers.ts
+++ b/packages/compiler/src/render3/r3_deferred_triggers.ts
@@ -40,51 +40,50 @@ enum OnTriggerType {
 /** Parses a `when` deferred trigger. */
 export function parseWhenTrigger(
     {expression, sourceSpan}: html.BlockParameter, bindingParser: BindingParser,
-    errors: ParseError[]): t.BoundDeferredTrigger|null {
+    triggers: t.DeferredBlockTriggers, errors: ParseError[]): void {
   const whenIndex = expression.indexOf('when');
 
   // This is here just to be safe, we shouldn't enter this function
   // in the first place if a block doesn't have the "when" keyword.
   if (whenIndex === -1) {
     errors.push(new ParseError(sourceSpan, `Could not find "when" keyword in expression`));
-    return null;
+  } else {
+    const start = getTriggerParametersStart(expression, whenIndex + 1);
+    const parsed = bindingParser.parseBinding(
+        expression.slice(start), false, sourceSpan, sourceSpan.start.offset + start);
+    trackTrigger('when', triggers, new t.BoundDeferredTrigger(parsed, sourceSpan));
   }
-
-  const start = getTriggerParametersStart(expression, whenIndex + 1);
-  const parsed = bindingParser.parseBinding(
-      expression.slice(start), false, sourceSpan, sourceSpan.start.offset + start);
-
-  return new t.BoundDeferredTrigger(parsed, sourceSpan);
 }
 
 /** Parses an `on` trigger */
 export function parseOnTrigger(
-    {expression, sourceSpan}: html.BlockParameter, errors: ParseError[]): t.DeferredTrigger[] {
+    {expression, sourceSpan}: html.BlockParameter, triggers: t.DeferredBlockTriggers,
+    errors: ParseError[]): void {
   const onIndex = expression.indexOf('on');
 
   // This is here just to be safe, we shouldn't enter this function
   // in the first place if a block doesn't have the "on" keyword.
   if (onIndex === -1) {
     errors.push(new ParseError(sourceSpan, `Could not find "on" keyword in expression`));
-    return [];
+  } else {
+    const start = getTriggerParametersStart(expression, onIndex + 1);
+    const parser = new OnTriggerParser(expression, start, sourceSpan, triggers, errors);
+    parser.parse();
   }
-
-  const start = getTriggerParametersStart(expression, onIndex + 1);
-  return new OnTriggerParser(expression, start, sourceSpan, errors).parse();
 }
+
 
 class OnTriggerParser {
   private index = 0;
   private tokens: Token[];
-  private triggers: t.DeferredTrigger[] = [];
 
   constructor(
       private expression: string, private start: number, private span: ParseSourceSpan,
-      private errors: ParseError[]) {
+      private triggers: t.DeferredBlockTriggers, private errors: ParseError[]) {
     this.tokens = new Lexer().tokenize(expression.slice(start));
   }
 
-  parse(): t.DeferredTrigger[] {
+  parse(): void {
     while (this.tokens.length > 0 && this.index < this.tokens.length) {
       const token = this.token();
 
@@ -113,8 +112,6 @@ class OnTriggerParser {
 
       this.advance();
     }
-
-    return this.triggers;
   }
 
   private advance() {
@@ -141,27 +138,27 @@ class OnTriggerParser {
     try {
       switch (identifier.toString()) {
         case OnTriggerType.IDLE:
-          this.triggers.push(createIdleTrigger(parameters, sourceSpan));
+          this.trackTrigger('idle', createIdleTrigger(parameters, sourceSpan));
           break;
 
         case OnTriggerType.TIMER:
-          this.triggers.push(createTimerTrigger(parameters, sourceSpan));
+          this.trackTrigger('timer', createTimerTrigger(parameters, sourceSpan));
           break;
 
         case OnTriggerType.INTERACTION:
-          this.triggers.push(createInteractionTrigger(parameters, sourceSpan));
+          this.trackTrigger('interaction', createInteractionTrigger(parameters, sourceSpan));
           break;
 
         case OnTriggerType.IMMEDIATE:
-          this.triggers.push(createImmediateTrigger(parameters, sourceSpan));
+          this.trackTrigger('immediate', createImmediateTrigger(parameters, sourceSpan));
           break;
 
         case OnTriggerType.HOVER:
-          this.triggers.push(createHoverTrigger(parameters, sourceSpan));
+          this.trackTrigger('hover', createHoverTrigger(parameters, sourceSpan));
           break;
 
         case OnTriggerType.VIEWPORT:
-          this.triggers.push(createViewportTrigger(parameters, sourceSpan));
+          this.trackTrigger('viewport', createViewportTrigger(parameters, sourceSpan));
           break;
 
         default:
@@ -245,6 +242,10 @@ class OnTriggerParser {
     return this.expression.slice(this.start + this.token().index, this.start + this.token().end);
   }
 
+  private trackTrigger(name: keyof t.DeferredBlockTriggers, trigger: t.DeferredTrigger): void {
+    trackTrigger(name, this.triggers, trigger);
+  }
+
   private error(token: Token, message: string): void {
     const newStart = this.span.start.moveBy(this.start + token.index);
     const newEnd = newStart.moveBy(token.end - token.index);
@@ -254,6 +255,13 @@ class OnTriggerParser {
   private unexpectedToken(token: Token) {
     this.error(token, `Unexpected token "${token}"`);
   }
+}
+
+/** Adds a trigger to a map of triggers. */
+function trackTrigger(
+    name: keyof t.DeferredBlockTriggers, allTriggers: t.DeferredBlockTriggers,
+    trigger: t.DeferredTrigger) {
+  allTriggers[name] = trigger as any;
 }
 
 function createIdleTrigger(

--- a/packages/compiler/src/render3/r3_deferred_triggers.ts
+++ b/packages/compiler/src/render3/r3_deferred_triggers.ts
@@ -51,7 +51,7 @@ export function parseWhenTrigger(
     const start = getTriggerParametersStart(expression, whenIndex + 1);
     const parsed = bindingParser.parseBinding(
         expression.slice(start), false, sourceSpan, sourceSpan.start.offset + start);
-    trackTrigger('when', triggers, new t.BoundDeferredTrigger(parsed, sourceSpan));
+    trackTrigger('when', triggers, errors, new t.BoundDeferredTrigger(parsed, sourceSpan));
   }
 }
 
@@ -243,7 +243,7 @@ class OnTriggerParser {
   }
 
   private trackTrigger(name: keyof t.DeferredBlockTriggers, trigger: t.DeferredTrigger): void {
-    trackTrigger(name, this.triggers, trigger);
+    trackTrigger(name, this.triggers, this.errors, trigger);
   }
 
   private error(token: Token, message: string): void {
@@ -259,9 +259,13 @@ class OnTriggerParser {
 
 /** Adds a trigger to a map of triggers. */
 function trackTrigger(
-    name: keyof t.DeferredBlockTriggers, allTriggers: t.DeferredBlockTriggers,
+    name: keyof t.DeferredBlockTriggers, allTriggers: t.DeferredBlockTriggers, errors: ParseError[],
     trigger: t.DeferredTrigger) {
-  allTriggers[name] = trigger as any;
+  if (allTriggers[name]) {
+    errors.push(new ParseError(trigger.sourceSpan, `Duplicate "${name}" trigger is not allowed`));
+  } else {
+    allTriggers[name] = trigger as any;
+  }
 }
 
 function createIdleTrigger(

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -337,9 +337,10 @@ class DirectiveBinder<DirectiveT extends DirectiveMeta> implements Visitor {
   }
 
   visitDeferredBlock(deferred: DeferredBlock): void {
+    const wasInDeferBlock = this.isInDeferBlock;
     this.isInDeferBlock = true;
     deferred.children.forEach(child => child.visit(this));
-    this.isInDeferBlock = false;
+    this.isInDeferBlock = wasInDeferBlock;
 
     deferred.placeholder?.visit(this);
     deferred.loading?.visit(this);
@@ -520,9 +521,10 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
   visitDeferredBlock(deferred: DeferredBlock) {
     this.deferBlocks.add(deferred);
 
+    const wasInDeferBlock = this.isInDeferBlock;
     this.isInDeferBlock = true;
     deferred.children.forEach(this.visitNode);
-    this.isInDeferBlock = false;
+    this.isInDeferBlock = wasInDeferBlock;
 
     deferred.placeholder && this.visitNode(deferred.placeholder);
     deferred.loading && this.visitNode(deferred.loading);

--- a/packages/compiler/src/render3/view/t2_binder.ts
+++ b/packages/compiler/src/render3/view/t2_binder.ts
@@ -524,8 +524,6 @@ class TemplateBinder extends RecursiveAstVisitor implements Visitor {
     deferred.children.forEach(this.visitNode);
     this.isInDeferBlock = false;
 
-    deferred.triggers.forEach(this.visitNode);
-    deferred.prefetchTriggers.forEach(this.visitNode);
     deferred.placeholder && this.visitNode(deferred.placeholder);
     deferred.loading && this.visitNode(deferred.loading);
     deferred.error && this.visitNode(deferred.error);

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -106,20 +106,11 @@ class R3AstSourceSpans implements t.Visitor<void> {
   }
 
   visitDeferredBlock(deferred: t.DeferredBlock): void {
-    const blocks: t.Node[] = [];
-    deferred.placeholder && blocks.push(deferred.placeholder);
-    deferred.loading && blocks.push(deferred.loading);
-    deferred.error && blocks.push(deferred.error);
     this.result.push([
       'DeferredBlock', humanizeSpan(deferred.sourceSpan), humanizeSpan(deferred.startSourceSpan),
       humanizeSpan(deferred.endSourceSpan)
     ]);
-    this.visitAll([
-      deferred.triggers,
-      deferred.prefetchTriggers,
-      deferred.children,
-      blocks,
-    ]);
+    deferred.visitAll(this);
   }
 
   visitDeferredTrigger(trigger: t.DeferredTrigger): void {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1096,6 +1096,44 @@ describe('R3 template transform', () => {
         expectDeferredError('{#defer on viewport(a, b)}hello{/defer}')
             .toThrowError(/"viewport" trigger can only have zero or one parameters/);
       });
+
+      it('should report duplicate when triggers', () => {
+        expectDeferredError('{#defer when isVisible(); when somethingElse()}hello{/defer}')
+            .toThrowError(/Duplicate "when" trigger is not allowed/);
+      });
+
+      it('should report duplicate on triggers', () => {
+        expectDeferredError('{#defer on idle; when isVisible(); on timer(10), idle}hello{/defer}')
+            .toThrowError(/Duplicate "idle" trigger is not allowed/);
+      });
+
+      it('should report duplicate prefetch when triggers', () => {
+        expectDeferredError(
+            '{#defer prefetch when isVisible(); prefetch when somethingElse()}hello{/defer}')
+            .toThrowError(/Duplicate "when" trigger is not allowed/);
+      });
+
+      it('should report duplicate prefetch on triggers', () => {
+        expectDeferredError(
+            '{#defer prefetch on idle; prefetch when isVisible(); prefetch on timer(10), idle}hello{/defer}')
+            .toThrowError(/Duplicate "idle" trigger is not allowed/);
+      });
+
+      it('should report multiple minimum parameters on a placeholder block', () => {
+        expectDeferredError(
+            '{#defer}hello{:placeholder minimum 1s; minimum 500ms}placeholder{/defer}')
+            .toThrowError(/Placeholder block can only have one "minimum" parameter/);
+      });
+
+      it('should report multiple minimum parameters on a loading block', () => {
+        expectDeferredError('{#defer}hello{:loading minimum 1s; minimum 500ms}loading{/defer}')
+            .toThrowError(/Loading block can only have one "minimum" parameter/);
+      });
+
+      it('should report multiple after parameters on a loading block', () => {
+        expectDeferredError('{#defer}hello{:loading after 1s; after 500ms}loading{/defer}')
+            .toThrowError(/Loading block can only have one "after" parameter/);
+      });
     });
   });
 });

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -89,17 +89,8 @@ class R3AstHumanizer implements t.Visitor<void> {
   }
 
   visitDeferredBlock(deferred: t.DeferredBlock): void {
-    const blocks: t.Node[] = [];
-    deferred.placeholder && blocks.push(deferred.placeholder);
-    deferred.loading && blocks.push(deferred.loading);
-    deferred.error && blocks.push(deferred.error);
     this.result.push(['DeferredBlock']);
-    this.visitAll([
-      deferred.triggers,
-      deferred.prefetchTriggers,
-      deferred.children,
-      blocks,
-    ]);
+    deferred.visitAll(this);
   }
 
   visitDeferredTrigger(trigger: t.DeferredTrigger): void {

--- a/packages/compiler/test/render3/util/expression.ts
+++ b/packages/compiler/test/render3/util/expression.ts
@@ -148,12 +148,7 @@ class ExpressionSourceHumanizer extends e.RecursiveAstVisitor implements t.Visit
   }
 
   visitDeferredBlock(deferred: t.DeferredBlock) {
-    t.visitAll(this, deferred.triggers);
-    t.visitAll(this, deferred.prefetchTriggers);
-    t.visitAll(this, deferred.children);
-    deferred.placeholder && this.visit(deferred.placeholder);
-    deferred.loading && this.visit(deferred.loading);
-    deferred.error && this.visit(deferred.error);
+    deferred.visitAll(this);
   }
 
   visitDeferredTrigger(trigger: t.DeferredTrigger): void {

--- a/packages/language-service/src/template_target.ts
+++ b/packages/language-service/src/template_target.ts
@@ -478,10 +478,7 @@ class TemplateTargetVisitor implements t.Visitor {
   }
 
   visitDeferredBlock(deferred: t.DeferredBlock) {
-    this.visitAll(deferred.children);
-    deferred.placeholder && this.visit(deferred.placeholder);
-    deferred.loading && this.visit(deferred.loading);
-    deferred.error && this.visit(deferred.error);
+    deferred.visitAll(this);
   }
 
   visitDeferredBlockPlaceholder(block: t.DeferredBlockPlaceholder) {


### PR DESCRIPTION
A couple of refactors around `defer` that we had discussed before plus one bug fix I found along the way. Includes the following changes:

### refactor(compiler): store deferred triggers as a map
Stores the `deferred` block triggers as a map instead of an array, because triggers can't be duplicated and because having to search through an array will be inconvenient later on.

I've also added a `DeferredBlock.visitAll` method to deduplicate the logic from the various visitor implementations.

### refactor(compiler): add more deferred validations
Adds validations for the following invalid deferred block structures:
* Duplicated triggers.
* Multiple `minimum` parameters on `placeholder` and `loading` blocks.
* Multiple `after` parameters on `loading` blocks.

### refactor(compiler): correctly identify lazy directives and pipes used after a nested defer block
Fixes that if a directive/pipe is used after a nested `defer` block, we weren't tracking it as lazy anymore. This was due to the fact that we were resetting the `isInDeferBlock` to false every time instead of the previous value.