### PR TITLE
fix(core): toObservable() watcher keeps active upon observable completion

### DIFF
--- a/packages/core/rxjs-interop/src/to_observable.ts
+++ b/packages/core/rxjs-interop/src/to_observable.ts
@@ -9,6 +9,8 @@
 import {assertInInjectionContext, DestroyRef, effect, EffectRef, inject, Injector, Signal, untracked} from '@angular/core';
 import {Observable, ReplaySubject} from 'rxjs';
 
+import { finalize } from 'rxjs/operators';
+
 /**
  * Options for `toObservable`.
  *
@@ -57,5 +59,5 @@ export function toObservable<T>(
     subject.complete();
   });
 
-  return subject.asObservable();
+  return subject.asObservable().pipe(finalize(watcher.destroy));
 }


### PR DESCRIPTION

When the observable is completed or finished, but the injector keeps active (Like when calling toObservable() in guards), the effect watcher remains unnecessarily active. Currently, the code is set up to destroy the watcher only when the injector context is destroyed, but that already is the default behavior of signals and effects. Watcher should be destroyed when the observable is marked as complete instead of, because after that there is no reason to keep watching the orginal signal.

#51280 

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

