### PR TITLE
feat(core): add `setFakeBaseSystemTime()` to public API

### DIFF
--- a/packages/core/test/fake_async_spec.ts
+++ b/packages/core/test/fake_async_spec.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, inject, tick} from '@angular/core/testing';
+import {discardPeriodicTasks, fakeAsync, flush, flushMicrotasks, inject, setFakeBaseSystemTime, tick,} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 import {EventManager} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
@@ -364,6 +364,19 @@ const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'
 
            discardPeriodicTasks();
          }));
+
+      it('should use fake base system time', fakeAsync(() => {
+           const fakeBaseTime = 1234500000;
+           const tickTime = 500;
+
+           setFakeBaseSystemTime(fakeBaseTime);
+
+           expect(Date.now().valueOf()).toBe(fakeBaseTime);
+
+           tick(tickTime);
+
+           expect(Date.now().valueOf()).toBe(fakeBaseTime + tickTime);
+         }));
     });
 
     describe('outside of the fakeAsync zone', () => {
@@ -388,6 +401,12 @@ const ProxyZoneSpec: {assertPresent: () => void} = (Zone as any)['ProxyZoneSpec'
       it('calling discardPeriodicTasks should throw', () => {
         expect(() => {
           discardPeriodicTasks();
+        }).toThrowError('The code should be running in the fakeAsync zone to call this function');
+      });
+
+      it('calling setFakeBaseSystemTime should throw', () => {
+        expect(() => {
+          setFakeBaseSystemTime(0);
         }).toThrowError('The code should be running in the fakeAsync zone to call this function');
       });
     });

--- a/packages/core/testing/src/fake_async.ts
+++ b/packages/core/testing/src/fake_async.ts
@@ -56,6 +56,25 @@ export function fakeAsync(fn: Function): (...args: any[]) => any {
 }
 
 /**
+ * Sets the fake base system time used for fakeAsync tests.
+ *
+ * When using `fakeAsync()`, APIs that use the native system time, such as `Date.now()`, are
+ * patched to use the given fake time value. The fake time advances when explicitly calling
+ * `tick()`: After calling `tick(5000)`, `Date.now()` will return a value 5 seconds after the given
+ * base time. Calling this method again after calling `tick()` will not reset the time.
+ *
+ * @param baseTimeInMillis The base time to use in milliseconds.
+ *
+ * @publicApi
+ */
+export function setFakeBaseSystemTime(baseTimeInMillis: number): void {
+  if (fakeAsyncTestModule) {
+    return fakeAsyncTestModule.setFakeBaseSystemTime(baseTimeInMillis);
+  }
+  throw new Error(fakeAsyncTestModuleNotLoadedErrorMessage);
+}
+
+/**
  * Simulates the asynchronous passage of time for the timers in the `fakeAsync` zone.
  *
  * The microtasks queue is drained at the very start of this function and after any timer callback

--- a/packages/zone.js/lib/zone-spec/fake-async-test.ts
+++ b/packages/zone.js/lib/zone-spec/fake-async-test.ts
@@ -813,6 +813,22 @@ Zone.__load_patch('fakeasync', (global: any, Zone: ZoneType, api: _ZonePrivate) 
   }
 
   /**
+   * Sets the fake base system time used for fakeAsync tests.
+   *
+   * When using `fakeAsync()`, APIs that use the native system time, such as `Date.now()`, are
+   * patched to use the given fake time value. The fake time advances when explicitly calling
+   * `tick()`: After calling `tick(5000)`, `Date.now()` will return a value 5 seconds after the
+   * given base time. Calling this method again after calling `tick()` will not reset the time.
+   *
+   * @param baseTimeInMillis The base time to use in milliseconds.
+   *
+   * @experimental
+   */
+  function setFakeBaseSystemTime(baseTimeInMillis: number): void {
+    _getFakeAsyncZoneSpec().setFakeBaseSystemTime(baseTimeInMillis);
+  }
+
+  /**
    * Simulates the asynchronous passage of time for the timers in the fakeAsync zone.
    *
    * The microtasks queue is drained at the very start of this function and after any timer callback
@@ -861,6 +877,13 @@ Zone.__load_patch('fakeasync', (global: any, Zone: ZoneType, api: _ZonePrivate) 
   function flushMicrotasks(): void {
     _getFakeAsyncZoneSpec().flushMicrotasks();
   }
-  (Zone as any)[api.symbol('fakeAsyncTest')] =
-      {resetFakeAsyncZone, flushMicrotasks, discardPeriodicTasks, tick, flush, fakeAsync};
+  (Zone as any)[api.symbol('fakeAsyncTest')] = {
+    resetFakeAsyncZone,
+    flushMicrotasks,
+    discardPeriodicTasks,
+    tick,
+    flush,
+    fakeAsync,
+    setFakeBaseSystemTime
+  };
 }, true);


### PR DESCRIPTION
Allows to specify a fake time in fakeAsync tests. Similar to using Jasmines "Clock" with a mockDate, which cannot be used in fakeAsync tests.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If you want to specify a fake "now" time in your tests, you need to use [Jasmines "Clock" feature](https://jasmine.github.io/api/5.1/Clock) with a mockDate. This does not work in fakeAsync tests. You need to remove fakeAsync from your test and use `jasmine.clock().tick()` instead of the usual `tick()`.

In our project we use page objects to interact with our components. They rely on being used in fakeAsync tests, because their methods call the `tick()` function. That means, currently we cannot use them in combination with a fake time.

Issue Number: N/A


## What is the new behavior?

In a fakeAsync test, you can specify a fake "now" time by calling `setFakeBaseSystemTime()`.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
