### PR TITLE
fix(common): allow to specify only some properties of `DatePipeConfig`

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -141,9 +141,9 @@ export class DatePipe implements PipeTransform {
 // @public
 export interface DatePipeConfig {
     // (undocumented)
-    dateFormat: string;
+    dateFormat?: string;
     // (undocumented)
-    timezone: string;
+    timezone?: string;
 }
 
 // @public

--- a/packages/common/src/pipes/date_pipe_config.ts
+++ b/packages/common/src/pipes/date_pipe_config.ts
@@ -15,8 +15,8 @@
  * @publicApi
  */
 export interface DatePipeConfig {
-  dateFormat: string;
-  timezone: string;
+  dateFormat?: string;
+  timezone?: string;
 }
 
 /**


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?

The code already supports `DatePipeConfig` to have only some properties set, and not all. But the typing disallows it. This aligns the typing with the code.

Issue Number: N/A


## What is the new behavior?

Can specify only some properties of `DatePipeConfig`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
