### PR TITLE
Enable using the runtime dependency tracker in JIT compiler

### DIFF
--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -124,11 +124,8 @@ class DepsTracker implements DepsTrackerApi {
 
   /** @override */
   clearScopeCacheFor(type: Type<any>): void {
-    if (isNgModule(type)) {
-      this.ngModulesScopeCache.delete(type);
-    } else if (isComponent(type)) {
-      this.standaloneComponentsScopeCache.delete(type);
-    }
+    this.ngModulesScopeCache.delete(type as NgModuleType);
+    this.standaloneComponentsScopeCache.delete(type as ComponentType<any>);
   }
 
   /** @override */

--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -24,7 +24,7 @@ import {ComponentDependencies, DepsTrackerApi, NgModuleScope, StandaloneComponen
  *
  * @deprecated For migration purposes only, to be removed soon.
  */
-export const USE_RUNTIME_DEPS_TRACKER_FOR_JIT = false;
+export const USE_RUNTIME_DEPS_TRACKER_FOR_JIT = true;
 
 /**
  * An implementation of DepsTrackerApi which will be used for JIT and local compilation.

--- a/packages/core/test/test_bed_spec.ts
+++ b/packages/core/test/test_bed_spec.ts
@@ -11,6 +11,8 @@ import {TestBed, TestBedImpl} from '@angular/core/testing/src/test_bed';
 import {By} from '@angular/platform-browser';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
+import {NgModuleType} from '../src/render3';
+import {depsTracker} from '../src/render3/deps_tracker/deps_tracker';
 import {TEARDOWN_TESTING_MODULE_ON_DESTROY_DEFAULT, THROW_ON_UNKNOWN_ELEMENTS_DEFAULT, THROW_ON_UNKNOWN_PROPERTIES_DEFAULT} from '../testing/src/test_bed_common';
 
 const NAME = new InjectionToken<string>('name');
@@ -1628,10 +1630,9 @@ describe('TestBed', () => {
       expect(cmpDefBeforeReset.pipeDefs().length).toEqual(1);
       expect(cmpDefBeforeReset.directiveDefs().length).toEqual(2);  // directive + component
 
-      const modDefBeforeReset = (SomeModule as any).ɵmod;
-      const transitiveScope = modDefBeforeReset.transitiveCompileScopes.compilation;
-      expect(transitiveScope.pipes.size).toEqual(1);
-      expect(transitiveScope.directives.size).toEqual(2);
+      const scopeBeforeReset = depsTracker.getNgModuleScope(SomeModule as NgModuleType);
+      expect(scopeBeforeReset.compilation.pipes.size).toEqual(1);
+      expect(scopeBeforeReset.compilation.directives.size).toEqual(2);
 
       TestBed.resetTestingModule();
 
@@ -1639,8 +1640,18 @@ describe('TestBed', () => {
       expect(cmpDefAfterReset.pipeDefs).toBe(null);
       expect(cmpDefAfterReset.directiveDefs).toBe(null);
 
-      const modDefAfterReset = (SomeModule as any).ɵmod;
-      expect(modDefAfterReset.transitiveCompileScopes).toBe(null);
+      const scopeAfterReset = depsTracker.getNgModuleScope(SomeModule as NgModuleType);
+
+      expect(scopeAfterReset).toEqual({
+        compilation: {
+          pipes: new Set(),
+          directives: new Set([SomeComponent]),
+        },
+        exported: {
+          pipes: new Set(),
+          directives: new Set(),
+        }
+      });
     });
 
     it('should cleanup ng defs for classes with no ng annotations (in case of inheritance)', () => {


### PR DESCRIPTION
This change simply flips the flag `USE_RUNTIME_DEPS_TRACKER_FOR_JIT` guarding usage of runtime dependency tracker in the JIT compiler. As a result, the JIT compiler will use the runtime dependency tracker for calculating scopes instead of patching them into the types. 

This change particularly affects all the Angular tests in g3. Multiple TGPs were run, including [this most recent one](https://fusion2.corp.google.com/presubmit/554610152/OCL:554610152:BASE:554552090:1691471462261:98ccfc2f;groups=NewlyFailing,PossiblyAlreadyFailing/targets) and all were green. 

In the event of any further failure, we can simply revert this PR (or alternatively just set the flag `USE_RUNTIME_DEPS_TRACKER_FOR_JIT` to false) to resolve the issue.

Once this change was confirm not to break anything, the flag `USE_RUNTIME_DEPS_TRACKER_FOR_JIT` will be deleted in a separate PR.

Also, some internal tests had to be updated as we adopt to use the runtime dependency tracker.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
