### PR TITLE
docs: release notes for the v16.1.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<a name="16.1.9"></a>
+# 16.1.9 (2023-08-09)
+
+<!-- CHANGELOG SPLIT MARKER -->
+
 <a name="16.2.0-rc.0"></a>
 # 16.2.0-rc.0 (2023-08-02)
 ### compiler


### PR DESCRIPTION
Cherry-picks the changelog from the "16.1.x" branch to the next branch (main).