### PR TITLE
docs(docs-infra): fix `docs-watch` script

### DIFF
--- a/aio/scripts/fast-serve-and-watch.mjs
+++ b/aio/scripts/fast-serve-and-watch.mjs
@@ -3,8 +3,11 @@
     and runs a fast dgeni build on any changed files.
 */
 
+import {createRequire} from 'node:module';
 import spawn from 'cross-spawn';
-import watchr from '../tools/transforms/authors-package/watchr.js';
+import {watch} from '../tools/transforms/authors-package/watchr.js';
+
+const require = createRequire(import.meta.url);
 const architectCli = require.resolve('@angular-devkit/architect-cli/bin/architect');
 
 const serve = spawn(
@@ -30,4 +33,4 @@ serve.on('close', (code) => {
   process.exit(1);
 });
 
-watchr.watch(true);
+watch(true);

--- a/aio/tools/transforms/authors-package/watchr.mjs
+++ b/aio/tools/transforms/authors-package/watchr.mjs
@@ -20,7 +20,7 @@ function next(error) {
   }
 }
 
-function watch() {
+export function watch() {
   console.log('============================================================================');
   console.log('Started watching files in:');
   console.log(' - ', config.CONTENTS_PATH);
@@ -32,4 +32,3 @@ function watch() {
   watchr.open(config.API_SOURCE_PATH, listener, next);
 }
 
-exports.watch = watch;


### PR DESCRIPTION
With this commit we can use `yarn docs-watch` again
Fixes #51308

## PR Type
What kind of change does this PR introduce?

- [x] angular.io application / infrastructure changes
