### PR TITLE
docs(docs-infra): Hide decorator option row if empty.

### DIFF
--- a/aio/tools/transforms/templates/api/decorator.template.html
+++ b/aio/tools/transforms/templates/api/decorator.template.html
@@ -42,6 +42,7 @@
           </code-example>
         </td>
       </tr>
+      {%- if option.description or option.usageNotes %}
       <tr>
         <td>
           {%- if option.description %}
@@ -53,6 +54,7 @@
           {% endif %}
         </td>
       </tr>
+      {% endif %}
     </tbody>
   </table>
   {% endfor %}


### PR DESCRIPTION
In cases where the decorator option has no description nor usageNotes, we can hide that row.

Before : https://angular.io/api/core/Inject
After : https://ng-dev-previews-fw--pr-angular-angular-51327-xjxixrw8.web.app/api/core/Inject