### PR TITLE
refactor(core): implement flag to ignore ngZone in message event listener

### DIFF
--- a/devtools/projects/shell-browser/src/app/chrome-message-bus.ts
+++ b/devtools/projects/shell-browser/src/app/chrome-message-bus.ts
@@ -73,6 +73,7 @@ export class ChromeMessageBus extends MessageBus<Events> {
     this._port.postMessage({
       topic,
       args,
+      __ignore_ng_zone__: true,
     });
     return true;
   }

--- a/devtools/projects/shell-browser/src/app/same-page-message-bus.ts
+++ b/devtools/projects/shell-browser/src/app/same-page-message-bus.ts
@@ -68,6 +68,7 @@ export class SamePageMessageBus extends MessageBus<Events> {
           source: this._source,
           topic,
           args,
+          __ignore_ng_zone__: true,
         },
         '*');
     return true;

--- a/devtools/src/iframe-message-bus.ts
+++ b/devtools/src/iframe-message-bus.ts
@@ -69,6 +69,12 @@ export class IFrameMessageBus extends MessageBus<Events> {
           source: this._source,
           topic,
           args,
+          // Since both the devtools app and the demo app use IframeMessageBus,
+          // we want to only ignore the ngZone for the demo app. This will let us
+          // prevent infinite change detection loops triggered by message
+          // event listeners but also not prevent the NgZone in the devtools app
+          // from updating its UI.
+          __ignore_ng_zone__: this._source === 'angular-devtools',
         },
         '*');
     return true;


### PR DESCRIPTION
This flag allows message event listeners to prevent callbacks from executing within the NgZone if they contain a special `__ignore_ng_zone__` flag.

This flag is built with Angular DevTools in mind, where it prevents an infinite change detection loop in inspected applications that have message event listeners

Cycle we want to avoid by using this flag:
CD -> Inspected app emits componentTreeDirty event to DevTools -> DevTools emits event to get new component Tree from Inspected app -> Inspected app message event listener fires -> CD


closes #45572