### PR TITLE
fix(common): Allow safeUrl for ngSrc in NgOptimizedImage

### DIFF
--- a/goldens/public-api/common/index.md
+++ b/goldens/public-api/common/index.md
@@ -617,6 +617,8 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
     // (undocumented)
     static ngAcceptInputType_height: unknown;
     // (undocumented)
+    static ngAcceptInputType_ngSrc: string | i1_2.SafeValue;
+    // (undocumented)
     static ngAcceptInputType_priority: unknown;
     // (undocumented)
     static ngAcceptInputType_width: unknown;

--- a/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
+++ b/packages/common/src/directives/ng_optimized_image/ng_optimized_image.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {booleanAttribute, Directive, ElementRef, inject, InjectionToken, Injector, Input, NgZone, numberAttribute, OnChanges, OnDestroy, OnInit, PLATFORM_ID, Renderer2, SimpleChanges, ɵformatRuntimeError as formatRuntimeError, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {booleanAttribute, Directive, ElementRef, inject, InjectionToken, Injector, Input, NgZone, numberAttribute, OnChanges, OnDestroy, OnInit, PLATFORM_ID, Renderer2, SimpleChanges, ɵformatRuntimeError as formatRuntimeError, ɵRuntimeError as RuntimeError, ɵSafeValue as SafeValue, ɵunwrapSafeValue as unwrapSafeValue} from '@angular/core';
 
 import {RuntimeErrorCode} from '../../errors';
 import {isPlatformServer} from '../../platform_id';
@@ -245,7 +245,7 @@ export class NgOptimizedImage implements OnInit, OnChanges, OnDestroy {
    * Image name will be processed by the image loader and the final URL will be applied as the `src`
    * property of the image.
    */
-  @Input({required: true}) ngSrc!: string;
+  @Input({required: true, transform: unwrapSafeUrl}) ngSrc!: string;
 
   /**
    * A comma separated list of width or density descriptors.
@@ -992,4 +992,13 @@ function assertNoLoaderParamsWithoutLoader(dir: NgOptimizedImage, imageLoader: I
 
 function round(input: number): number|string {
   return Number.isInteger(input) ? input : input.toFixed(2);
+}
+
+// Transform function to handle SafeValue input for ngSrc. This doesn't do any sanitization,
+// as that is not needed for img.src and img.srcset. This transform is purely for compatibility.
+function unwrapSafeUrl(value: string|SafeValue): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  return unwrapSafeValue(value);
 }


### PR DESCRIPTION
This PR makes a small change to NgOptimizedImage to properly allow inputs of the safeUrl type for ngSrc in NgOptimizedImage. This is purely for compatibility/migration concerns, as NgOptimizedImage does not enforce sanitization on the `src` url, as that is not an xss vector in modern browsers.

The change is made using a transform which automatically unwraps provided safeUrl values, so the rest of the NgOptimizedImage still treats the ngSrc as always being a string.

CC: @AndrewKushnir @kara 