### PR TITLE
refactor(compiler): handle deferred when trigger with a pipe

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/GOLDEN_PARTIAL.js
@@ -450,3 +450,62 @@ export declare class MyApp {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_when_with_pipe.js
+ ****************************************************************************************************/
+import { Component, Pipe } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestPipe {
+    tranform() {
+        return true;
+    }
+}
+TestPipe.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
+TestPipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, isStandalone: true, name: "testPipe" });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, decorators: [{
+            type: Pipe,
+            args: [{ standalone: true, name: 'testPipe' }]
+        }] });
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.isReady = true;
+    }
+    isVisible() {
+        return false;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    {{message}}
+    {#defer when isVisible() && (isReady | testPipe)}Hello{/defer}
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {{message}}
+    {#defer when isVisible() && (isReady | testPipe)}Hello{/defer}
+  `,
+                    standalone: true,
+                    imports: [TestPipe],
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: deferred_when_with_pipe.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestPipe {
+    tranform(): boolean;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestPipe, never>;
+    static ɵpipe: i0.ɵɵPipeDeclaration<TestPipe, "testPipe", true>;
+}
+export declare class MyApp {
+    message: string;
+    isReady: boolean;
+    isVisible(): boolean;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/TEST_CASES.json
@@ -171,6 +171,27 @@
         }
       ],
       "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate a deferred block with a `when` trigger that has a pipe",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["defer"]
+      },
+      "inputFiles": [
+        "deferred_when_with_pipe.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "deferred_when_with_pipe_template.js",
+              "generated": "deferred_when_with_pipe.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_when_with_pipe.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_when_with_pipe.ts
@@ -1,0 +1,25 @@
+import {Component, Pipe} from '@angular/core';
+
+@Pipe({standalone: true, name: 'testPipe'})
+export class TestPipe {
+  tranform() {
+    return true;
+  }
+}
+
+@Component({
+  template: `
+    {{message}}
+    {#defer when isVisible() && (isReady | testPipe)}Hello{/defer}
+  `,
+  standalone: true,
+  imports: [TestPipe],
+})
+export class MyApp {
+  message = 'hello';
+  isReady = true;
+
+  isVisible() {
+    return false;
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_when_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_deferred/deferred_when_with_pipe_template.js
@@ -1,0 +1,13 @@
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+    $r3$.ɵɵtemplate(1, MyApp_Defer_1_Template, 1, 0);
+    $r3$.ɵɵdefer(2, 1);
+    $r3$.ɵɵpipe(3, "testPipe");
+  }
+  if (rf & 2) {
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(2);
+    $r3$.ɵɵdeferWhen(ctx.isVisible() && $r3$.ɵɵpipeBind1(3, 2, ctx.isReady));
+  }
+}

--- a/packages/compiler/src/render3/view/template.ts
+++ b/packages/compiler/src/render3/view/template.ts
@@ -1175,10 +1175,11 @@ export class TemplateDefinitionBuilder implements t.Visitor<void>, LocalResolver
 
     // `deferWhen(ctx.someValue)`
     if (when) {
-      this.allocateBindingSlots(null);
+      const value = when.value.visit(this._valueConverter);
+      this.allocateBindingSlots(value);
       this.updateInstructionWithAdvance(
           deferredIndex, when.sourceSpan, prefetch ? R3.deferPrefetchWhen : R3.deferWhen,
-          () => this.convertPropertyBinding(when.value));
+          () => this.convertPropertyBinding(value));
     }
 
     // Note that we generate an implicit `on idle` if the `deferred` block has no triggers.


### PR DESCRIPTION
Fixes that we weren't processing `when` conditions correctly which led to a compilation error when a pipe is used inside the expression.