### PR TITLE
fix(devtools): stop trying to detect angular after 10 tries

### DIFF
--- a/devtools/projects/shell-browser/src/app/detect-angular-for-extension-icon.ts
+++ b/devtools/projects/shell-browser/src/app/detect-angular-for-extension-icon.ts
@@ -19,6 +19,8 @@ export interface AngularDetection {
   isSupportedAngularVersion: boolean;
 }
 
+let numberOfAngularDetectionTries = 5;
+
 function detectAngular(win: Window): void {
   const isDebugMode = Boolean((win as any).ng);
   const ngVersionElement = document.querySelector('[ng-version]');
@@ -44,8 +46,8 @@ function detectAngular(win: Window): void {
         isAngularDevTools: true,
       } as AngularDetection,
       '*');
-
-  if (!isAngular) {
+  numberOfAngularDetectionTries--;
+  if (!isAngular && numberOfAngularDetectionTries > 0) {
     setTimeout(() => detectAngular(win), 1000);
   }
 }


### PR DESCRIPTION
Just because this extension exists, all the
opened tabs continuously try to detect angular
without an end. I think that is very irresponsible.

Also, I have just randomly added `10` as the number of tries

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
As of now, the extension tries to detect angular without an end to it. This is an odd behaviour and will make each and every
tab of the browser run the script forever.

Issue Number: N/A


## What is the new behavior?

We try to detect angular for a maximum of 10 times and stop it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
