### PR TITLE
DESCENDANT_VIEWS_TO_REFRESH counter refactors

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -36,7 +36,7 @@ import {Renderer} from '../interfaces/renderer';
 import {RComment, RElement, RNode, RText} from '../interfaces/renderer_dom';
 import {SanitizerFn} from '../interfaces/sanitization';
 import {isComponentDef, isComponentHost, isContentQueryHost} from '../interfaces/type_checks';
-import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, EMBEDDED_VIEW_INJECTOR, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, HostBindingOpCodes, HYDRATION, ID, INJECTOR, LView, LViewEnvironment, LViewFlags, NEXT, PARENT, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER, RENDERER, T_HOST, TData, TVIEW, TView, TViewType} from '../interfaces/view';
+import {CHILD_HEAD, CHILD_TAIL, CLEANUP, CONTEXT, DECLARATION_COMPONENT_VIEW, DECLARATION_VIEW, DESCENDANT_VIEWS_TO_REFRESH, EMBEDDED_VIEW_INJECTOR, ENVIRONMENT, FLAGS, HEADER_OFFSET, HOST, HostBindingOpCodes, HYDRATION, ID, INJECTOR, LView, LViewEnvironment, LViewFlags, NEXT, PARENT, REACTIVE_HOST_BINDING_CONSUMER, REACTIVE_TEMPLATE_CONSUMER, RENDERER, T_HOST, TData, TVIEW, TView, TViewType} from '../interfaces/view';
 import {assertPureTNodeType, assertTNodeType} from '../node_assert';
 import {clearElementContents, updateTextNode} from '../node_manipulation';
 import {isInlineTemplate, isNodeMatchingSelectorList} from '../node_selector_matcher';
@@ -105,6 +105,7 @@ export function createLView<T>(
   resetPreOrderHookFlags(lView);
   ngDevMode && tView.declTNode && parentLView && assertTNodeForLView(tView.declTNode, parentLView);
   lView[PARENT] = lView[DECLARATION_VIEW] = parentLView;
+  lView[DESCENDANT_VIEWS_TO_REFRESH] = 0;
   lView[CONTEXT] = context;
   lView[ENVIRONMENT] = (environment || parentLView && parentLView[ENVIRONMENT])!;
   ngDevMode && assertDefined(lView[ENVIRONMENT], 'LViewEnvironment is required');

--- a/packages/core/src/render3/util/view_utils.ts
+++ b/packages/core/src/render3/util/view_utils.ts
@@ -199,14 +199,21 @@ function updateViewsToRefresh(lView: LView, amount: 1|- 1) {
     return;
   }
   parent[DESCENDANT_VIEWS_TO_REFRESH] += amount;
+
   let viewOrContainer: LView|LContainer = parent;
-  parent = parent[PARENT];
-  while (parent !== null &&
-         ((amount === 1 && viewOrContainer[DESCENDANT_VIEWS_TO_REFRESH] === 1) ||
-          (amount === -1 && viewOrContainer[DESCENDANT_VIEWS_TO_REFRESH] === 0))) {
+  parent = viewOrContainer[PARENT];
+  function affectsParentCounter() {
+    const shouldIncrementParentCount =
+        amount === 1 && viewOrContainer[DESCENDANT_VIEWS_TO_REFRESH] === 1;
+    const shouldDecrementParentCount =
+        amount === -1 && viewOrContainer[DESCENDANT_VIEWS_TO_REFRESH] === 0;
+    return shouldDecrementParentCount || shouldIncrementParentCount;
+  }
+
+  while (parent !== null && affectsParentCounter()) {
     parent[DESCENDANT_VIEWS_TO_REFRESH] += amount;
     viewOrContainer = parent;
-    parent = parent[PARENT];
+    parent = viewOrContainer[PARENT];
   }
 }
 


### PR DESCRIPTION
### commit 1

This commit updates the `createLView` function to initialize the
`DESCENDANT_VIEWS_TO_REFRESH` slot.


### commit 2

This commit updates the conditional in the `updateViewsToRefresh`
function to be done inside a helper function. At the moment, the logic
is simple enough to be included in the `while` line directly, but the
logic isn't actually fully correct. Future commits will add to these
conditions and it will be easier to read as a helper function.