### PR TITLE
feat(core): changing runtime error NG0300 to built-time error

### DIFF
--- a/packages/core/src/render3/errors.ts
+++ b/packages/core/src/render3/errors.ts
@@ -46,14 +46,16 @@ export function assertComponentDef(type: Type<unknown>) {
   }
 }
 
-/** Called when there are multiple component selectors that match a given node */
+/**
+ * Called when there are multiple component selectors that match a given node
+ * changed from RuntimeError(RuntimeErrorCode.MULTIPLE_COMPONENTS_MATCH) to error at built-time
+ * */
 export function throwMultipleComponentError(
     tNode: TNode, first: Type<unknown>, second: Type<unknown>): never {
-  throw new RuntimeError(
-      RuntimeErrorCode.MULTIPLE_COMPONENTS_MATCH,
+  throw new Error(
       `Multiple components match node with tagname ${tNode.value}: ` +
-          `${stringifyForError(first)} and ` +
-          `${stringifyForError(second)}`);
+      `${stringifyForError(first)} and ` +
+      `${stringifyForError(second)}`);
 }
 
 /** Throws an ExpressionChangedAfterChecked error if checkNoChanges mode is on. */

--- a/packages/core/test/acceptance/component_spec.ts
+++ b/packages/core/test/acceptance/component_spec.ts
@@ -397,8 +397,7 @@ describe('component', () => {
 
       TestBed.configureTestingModule({declarations: [App, CompA, CompB]});
       expect(() => TestBed.createComponent(App))
-          .toThrowError(
-              /NG0300: Multiple components match node with tagname comp: CompA and CompB/);
+          .toThrowError(/Multiple components match node with tagname comp: CompA and CompB/);
     });
 
     it('should not throw if a standalone component imports itself', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
Currently, [NG0300](https://angular.io/errors/NG0300) is thrown at runtime

Issue Number: [#48377](https://github.com/angular/angular/issues/48377)

## What is the new behavior?
Introduce to same behavior at built-time

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
