### PR TITLE
docs(router): Clarify how to clear secondary routes

### DIFF
--- a/aio/content/examples/router/src/app/compose-message/compose-message.component.ts
+++ b/aio/content/examples/router/src/app/compose-message/compose-message.component.ts
@@ -1,6 +1,6 @@
 // #docregion
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'app-compose-message',
@@ -12,7 +12,7 @@ export class ComposeMessageComponent {
   message = '';
   sending = false;
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private route: ActivatedRoute) {}
 
   send() {
     this.sending = true;
@@ -32,7 +32,7 @@ export class ComposeMessageComponent {
   closePopup() {
     // Providing a `null` value to the named outlet
     // clears the contents of the named outlet
-    this.router.navigate([{ outlets: { popup: null }}]);
+    this.router.navigate([{outlets: {popup: null}}], {relativeTo: this.route.parent});
   }
   // #enddocregion closePopup
 }

--- a/aio/content/guide/router-tutorial-toh.md
+++ b/aio/content/guide/router-tutorial-toh.md
@@ -1623,6 +1623,29 @@ This time, the value of `'popup'` is `null`.
 That's not a route, but it is a legitimate value.
 Setting the popup `RouterOutlet` to `null` clears the outlet and removes the secondary popup route from the current URL.
 
+<div class="alert is-critical">
+
+**Note:** All commands in the array passed to `Router.navigate()` target a _specific segment_ in the `UrlTree`. 
+We specify the parent of the `ActivatedRoute` as the `relativeTo` option because we want to remove `'popup'` from the segment which holds its reference.
+It's important to always be aware of which segments the commands will be applied to.
+
+</div>
+
+<div class="alert is-helpful">
+
+When `relativeTo` is not provided to the `Router.navigate()` method, the commands are processed starting at the root.
+We could omit the `relativeTo` option in this particular example because the `'popup'` outlet appears at the root level of the configuration.
+  
+</div>
+
+<div class="alert is-helpful">
+
+If you want to close an outlet which appears at any segment depth, you could accomplish
+this by creating a `UrlTree` from the current URL, recursively clearing segment `children` matching the outlet name, and finally 
+calling `Router.navigateByUrl()` with the `root` segment of the current `UrlTree`.
+
+</div>
+
 <a id="guards"></a>
 <a id="milestone-5-route-guards"></a>
 


### PR DESCRIPTION
The example for clearing secondary outlets currently only works because the named outlet appears at the root of the application's route config. If developers follow this example with an outlet that is not at the root level, they will not be able to close the outlet. This commit updates the example to provide a more robust way of clearing the outlet from the activated outlet component as well as providing a warning about how the commands are applied.

Lastly, there is a small bit of guidance provided for developers who might want to explore the ability to close an outlet from any location in the app, without needing to be aware of the activated route. An example of this can be found here:
https://stackblitz.com/edit/close-outlet-from-anywhere

resolves #51373
resolves #13523
