### PR TITLE
Roll forward "PR #51309"

### DIFF
--- a/packages/core/src/render3/definition.ts
+++ b/packages/core/src/render3/definition.ts
@@ -18,7 +18,7 @@ import {initNgDevMode} from '../util/ng_dev_mode';
 import {stringify} from '../util/stringify';
 
 import {NG_COMP_DEF, NG_DIR_DEF, NG_MOD_DEF, NG_PIPE_DEF} from './fields';
-import {ComponentDef, ComponentDefFeature, ComponentTemplate, ComponentType, ContentQueriesFunction, DependencyTypeList, DirectiveDef, DirectiveDefFeature, DirectiveDefListOrFactory, HostBindingsFunction, InputTransformFunction, NgModuleScopeInfoFromDecorator, PipeDef, PipeDefListOrFactory, TypeOrFactory, ViewQueriesFunction} from './interfaces/definition';
+import {ComponentDef, ComponentDefFeature, ComponentTemplate, ContentQueriesFunction, DependencyTypeList, DirectiveDef, DirectiveDefFeature, DirectiveDefListOrFactory, HostBindingsFunction, InputTransformFunction, PipeDef, PipeDefListOrFactory, TypeOrFactory, ViewQueriesFunction} from './interfaces/definition';
 import {TAttributes, TConstantsOrFactory} from './interfaces/node';
 import {CssSelectorList} from './interfaces/projection';
 import {stringifyCSSSelectorList} from './node_selector_matcher';
@@ -342,23 +342,6 @@ export function ɵɵdefineComponent<T>(componentDefinition: ComponentDefinition<
   });
 }
 
-/**
- * Generated next to NgModules to monkey-patch directive and pipe references onto a component's
- * definition, when generating a direct reference in the component file would otherwise create an
- * import cycle.
- *
- * See [this explanation](https://hackmd.io/Odw80D0pR6yfsOjg_7XCJg?view) for more details.
- *
- * @codeGenApi
- */
-export function ɵɵsetComponentScope(
-    type: ComponentType<any>, directives: Type<any>[]|(() => Type<any>[]),
-    pipes: Type<any>[]|(() => Type<any>[])): void {
-  const def = type.ɵcmp as ComponentDef<any>;
-  def.directiveDefs = extractDefListOrFactory(directives, /* pipeDef */ false);
-  def.pipeDefs = extractDefListOrFactory(pipes, /* pipeDef */ true);
-}
-
 export function extractDirectiveDef(type: Type<any>): DirectiveDef<any>|ComponentDef<any>|null {
   return getComponentDef(type) || getDirectiveDef(type);
 }
@@ -407,25 +390,6 @@ export function ɵɵdefineNgModule<T>(def: {
       id: def.id || null,
     };
     return res;
-  });
-}
-
-/**
- * Adds the module metadata that is necessary to compute the module's transitive scope to an
- * existing module definition.
- *
- * Scope metadata of modules is not used in production builds, so calls to this function can be
- * marked pure to tree-shake it from the bundle, allowing for all referenced declarations
- * to become eligible for tree-shaking as well.
- *
- * @codeGenApi
- */
-export function ɵɵsetNgModuleScope(type: any, scope: NgModuleScopeInfoFromDecorator): unknown {
-  return noSideEffects(() => {
-    const ngModuleDef = getNgModuleDef(type, true);
-    ngModuleDef.declarations = scope.declarations || EMPTY_ARRAY;
-    ngModuleDef.imports = scope.imports || EMPTY_ARRAY;
-    ngModuleDef.exports = scope.exports || EMPTY_ARRAY;
   });
 }
 
@@ -648,13 +612,13 @@ function initFeatures(definition:|Mutable<DirectiveDef<unknown>, keyof Directive
   definition.features?.forEach((fn) => fn(definition));
 }
 
-function extractDefListOrFactory(
+export function extractDefListOrFactory(
     dependencies: TypeOrFactory<DependencyTypeList>|undefined,
     pipeDef: false): DirectiveDefListOrFactory|null;
-function extractDefListOrFactory(
+export function extractDefListOrFactory(
     dependencies: TypeOrFactory<DependencyTypeList>|undefined, pipeDef: true): PipeDefListOrFactory|
     null;
-function extractDefListOrFactory(
+export function extractDefListOrFactory(
     dependencies: TypeOrFactory<DependencyTypeList>|undefined, pipeDef: boolean): unknown {
   if (!dependencies) {
     return null;

--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -71,11 +71,6 @@ class DepsTracker implements DepsTrackerApi {
     }
 
     if (def.standalone) {
-      if (!rawImports) {
-        throw new Error(
-            'Standalone component should pass its raw import in order to compute its dependencies');
-      }
-
       const scope = this.getStandaloneComponentScope(type, rawImports);
 
       if (scope.compilation.isPoisoned) {
@@ -223,7 +218,7 @@ class DepsTracker implements DepsTrackerApi {
   /** @override */
   getStandaloneComponentScope(
       type: ComponentType<any>,
-      rawImports: (Type<any>|(() => Type<any>))[]): StandaloneComponentScope {
+      rawImports?: (Type<any>|(() => Type<any>))[]): StandaloneComponentScope {
     if (this.standaloneComponentsScopeCache.has(type)) {
       return this.standaloneComponentsScopeCache.get(type)!;
     }
@@ -236,7 +231,7 @@ class DepsTracker implements DepsTrackerApi {
 
   private computeStandaloneComponentScope(
       type: ComponentType<any>,
-      rawImports: (Type<any>|(() => Type<any>))[]): StandaloneComponentScope {
+      rawImports?: (Type<any>|(() => Type<any>))[]): StandaloneComponentScope {
     const ans: StandaloneComponentScope = {
       compilation: {
         // Standalone components are always able to self-reference.
@@ -245,7 +240,7 @@ class DepsTracker implements DepsTrackerApi {
       },
     };
 
-    for (const rawImport of rawImports) {
+    for (const rawImport of rawImports ?? []) {
       const imported = resolveForwardRef(rawImport) as Type<any>;
 
       try {

--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -11,7 +11,7 @@ import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {Type} from '../../interface/type';
 import {NgModuleType} from '../../metadata/ng_module_def';
 import {getComponentDef, getNgModuleDef, isStandalone} from '../definition';
-import {ComponentType, NgModuleScopeInfoFromDecorator} from '../interfaces/definition';
+import {ComponentType, NgModuleScopeInfoFromDecorator, RawScopeInfoFromDecorator} from '../interfaces/definition';
 import {isComponent, isDirective, isNgModule, isPipe, verifyStandaloneImport} from '../jit/util';
 import {maybeUnwrapFn} from '../util/misc_utils';
 
@@ -60,7 +60,7 @@ class DepsTracker implements DepsTrackerApi {
   }
 
   /** @override */
-  getComponentDependencies(type: ComponentType<any>, rawImports?: (Type<any>|(() => Type<any>))[]):
+  getComponentDependencies(type: ComponentType<any>, rawImports?: RawScopeInfoFromDecorator[]):
       ComponentDependencies {
     this.resolveNgModulesDecls();
 
@@ -216,9 +216,8 @@ class DepsTracker implements DepsTrackerApi {
   }
 
   /** @override */
-  getStandaloneComponentScope(
-      type: ComponentType<any>,
-      rawImports?: (Type<any>|(() => Type<any>))[]): StandaloneComponentScope {
+  getStandaloneComponentScope(type: ComponentType<any>, rawImports?: RawScopeInfoFromDecorator[]):
+      StandaloneComponentScope {
     if (this.standaloneComponentsScopeCache.has(type)) {
       return this.standaloneComponentsScopeCache.get(type)!;
     }
@@ -231,7 +230,7 @@ class DepsTracker implements DepsTrackerApi {
 
   private computeStandaloneComponentScope(
       type: ComponentType<any>,
-      rawImports?: (Type<any>|(() => Type<any>))[]): StandaloneComponentScope {
+      rawImports?: RawScopeInfoFromDecorator[]): StandaloneComponentScope {
     const ans: StandaloneComponentScope = {
       compilation: {
         // Standalone components are always able to self-reference.

--- a/packages/core/src/render3/index.ts
+++ b/packages/core/src/render3/index.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {LifecycleHooksFeature} from './component_ref';
-import {ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdefineNgModule, ɵɵdefinePipe, ɵɵsetComponentScope, ɵɵsetNgModuleScope} from './definition';
+import {ɵɵdefineComponent, ɵɵdefineDirective, ɵɵdefineNgModule, ɵɵdefinePipe} from './definition';
 import {ɵɵCopyDefinitionFeature} from './features/copy_definition_feature';
 import {ɵɵHostDirectivesFeature} from './features/host_directives_feature';
 import {ɵɵInheritDefinitionFeature} from './features/inherit_definition_feature';
@@ -16,6 +16,7 @@ import {ɵɵProvidersFeature} from './features/providers_feature';
 import {ɵɵStandaloneFeature} from './features/standalone_feature';
 import {ComponentDef, ComponentTemplate, ComponentType, DirectiveDef, DirectiveType, PipeDef} from './interfaces/definition';
 import {ɵɵComponentDeclaration, ɵɵDirectiveDeclaration, ɵɵFactoryDeclaration, ɵɵInjectorDeclaration, ɵɵNgModuleDeclaration, ɵɵPipeDeclaration} from './interfaces/public_definitions';
+import {ɵɵsetComponentScope, ɵɵsetNgModuleScope} from './scope';
 import {ComponentDebugMetadata, DirectiveDebugMetadata, getComponent, getDirectiveMetadata, getDirectives, getHostElement, getRenderedText} from './util/discovery_utils';
 
 export {NgModuleType} from '../metadata/ng_module_def';

--- a/packages/core/src/render3/interfaces/definition.ts
+++ b/packages/core/src/render3/interfaces/definition.ts
@@ -517,21 +517,34 @@ export type PipeTypeList =
 export const unusedValueExportToPlacateAjd = 1;
 
 /**
- * NgModule scope info as provided by NgModule decorator.
+ * NgModule scope info as provided by AoT compiler
+ *
+ * In full compilation Ivy resolved all the "module with providers" and forward refs the whole array
+ * if at least one element is forward refed. So we end up with type `Type<any>[]|(() =>
+ * Type<any>[])`.
+ *
+ * In local mode the compiler passes the raw info as they are to the runtime functions as it is not
+ * possible to resolve them any further due to limited info at compile time. So we end up with type
+ * `RawScopeInfoFromDecorator[]`.
  */
 export interface NgModuleScopeInfoFromDecorator {
   /** List of components, directives, and pipes declared by this module. */
-  declarations?: Type<any>[]|(() => Type<any>[]);
+  declarations?: Type<any>[]|(() => Type<any>[])|RawScopeInfoFromDecorator[];
 
-  /** List of modules or `ModuleWithProviders` imported by this module. */
-  imports?: Type<any>[]|(() => Type<any>[]);
+  /** List of modules or `ModuleWithProviders` or standalone components imported by this module. */
+  imports?: Type<any>[]|(() => Type<any>[])|RawScopeInfoFromDecorator[];
 
   /**
    * List of modules, `ModuleWithProviders`, components, directives, or pipes exported by this
    * module.
    */
-  exports?: Type<any>[]|(() => Type<any>[]);
+  exports?: Type<any>[]|(() => Type<any>[])|RawScopeInfoFromDecorator[];
 }
 
+/**
+ * The array element type passed to:
+ *  - NgModule's annotation imports/exports/declarations fields
+ *  - standalone component annotation imports field
+ */
 export type RawScopeInfoFromDecorator =
     Type<any>|ModuleWithProviders<any>|(() => Type<any>)|(() => ModuleWithProviders<any>);

--- a/packages/core/src/render3/local_compilation.ts
+++ b/packages/core/src/render3/local_compilation.ts
@@ -6,12 +6,12 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Type} from '../interface/type';
-
-import {DependencyTypeList, RawScopeInfoFromDecorator} from './interfaces/definition';
+import {depsTracker} from './deps_tracker/deps_tracker';
+import {ComponentType, DependencyTypeList, RawScopeInfoFromDecorator} from './interfaces/definition';
 
 export function ɵɵgetComponentDepsFactory(
-    type: Type<any>, rawImports?: RawScopeInfoFromDecorator): () => DependencyTypeList {
-  // TODO(pmvald): Implement this runtime using deps tracker.
-  return () => [];
+    type: ComponentType<any>, rawImports?: RawScopeInfoFromDecorator[]): () => DependencyTypeList {
+  return () => {
+    return depsTracker.getComponentDependencies(type, rawImports).dependencies;
+  };
 }

--- a/packages/core/src/render3/scope.ts
+++ b/packages/core/src/render3/scope.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Type} from '../interface/type';
+import {noSideEffects} from '../util/closure';
+import {EMPTY_ARRAY} from '../util/empty';
+
+import {extractDefListOrFactory, getNgModuleDef} from './definition';
+import {ComponentDef, ComponentType, NgModuleScopeInfoFromDecorator} from './interfaces/definition';
+
+/**
+ * Generated next to NgModules to monkey-patch directive and pipe references onto a component's
+ * definition, when generating a direct reference in the component file would otherwise create an
+ * import cycle.
+ *
+ * See [this explanation](https://hackmd.io/Odw80D0pR6yfsOjg_7XCJg?view) for more details.
+ *
+ * @codeGenApi
+ */
+export function ɵɵsetComponentScope(
+    type: ComponentType<any>, directives: Type<any>[]|(() => Type<any>[]),
+    pipes: Type<any>[]|(() => Type<any>[])): void {
+  const def = type.ɵcmp as ComponentDef<any>;
+  def.directiveDefs = extractDefListOrFactory(directives, /* pipeDef */ false);
+  def.pipeDefs = extractDefListOrFactory(pipes, /* pipeDef */ true);
+}
+
+/**
+ * Adds the module metadata that is necessary to compute the module's transitive scope to an
+ * existing module definition.
+ *
+ * Scope metadata of modules is not used in production builds, so calls to this function can be
+ * marked pure to tree-shake it from the bundle, allowing for all referenced declarations
+ * to become eligible for tree-shaking as well.
+ *
+ * @codeGenApi
+ */
+export function ɵɵsetNgModuleScope(type: any, scope: NgModuleScopeInfoFromDecorator): unknown {
+  return noSideEffects(() => {
+    const ngModuleDef = getNgModuleDef(type, true);
+    ngModuleDef.declarations = scope.declarations || EMPTY_ARRAY;
+    ngModuleDef.imports = scope.imports || EMPTY_ARRAY;
+    ngModuleDef.exports = scope.exports || EMPTY_ARRAY;
+  });
+}

--- a/packages/core/test/acceptance/local_compilation_spec.ts
+++ b/packages/core/test/acceptance/local_compilation_spec.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {Component, forwardRef, ɵɵdefineNgModule, ɵɵgetComponentDepsFactory, ɵɵsetNgModuleScope} from '@angular/core';
+import {ComponentType} from '@angular/core/src/render3';
+
+describe('component dependencies in local compilation', () => {
+  it('should compute correct set of dependencies when importing ng-modules directly', () => {
+    @Component({selector: 'sub'})
+    class SubComponent {
+    }
+
+    class SubModule {
+      static ɵmod = ɵɵdefineNgModule({type: SubModule});
+    }
+    ɵɵsetNgModuleScope(SubModule, {exports: [SubComponent]});
+
+    @Component({})
+    class MainComponent {
+    }
+
+    class MainModule {
+      static ɵmod = ɵɵdefineNgModule({type: MainModule});
+    }
+    ɵɵsetNgModuleScope(MainModule, {imports: [SubModule], declarations: [MainComponent]});
+
+    const deps = ɵɵgetComponentDepsFactory(MainComponent as ComponentType<any>)();
+
+    expect(deps).toEqual(jasmine.arrayWithExactContents([SubComponent, MainComponent]));
+  });
+
+  it('should compute correct set of dependencies when importing ng-modules with providers', () => {
+    @Component({selector: 'sub'})
+    class SubComponent {
+    }
+
+    class SubModule {
+      static ɵmod = ɵɵdefineNgModule({type: SubModule});
+    }
+    ɵɵsetNgModuleScope(SubModule, {exports: [SubComponent]});
+
+    @Component({})
+    class MainComponent {
+    }
+
+    class MainModule {
+      static ɵmod = ɵɵdefineNgModule({type: MainModule});
+    }
+    ɵɵsetNgModuleScope(
+        MainModule,
+        {imports: [{ngModule: SubModule, providers: []}], declarations: [MainComponent]});
+
+    const deps = ɵɵgetComponentDepsFactory(MainComponent as ComponentType<any>)();
+
+    expect(deps).toEqual(jasmine.arrayWithExactContents([SubComponent, MainComponent]));
+  });
+
+  it('should compute correct set of dependencies when importing ng-modules using forward ref',
+     () => {
+       @Component({selector: 'sub'})
+       class SubComponent {
+       }
+
+       class SubModule {
+         static ɵmod = ɵɵdefineNgModule({type: SubModule});
+       }
+       ɵɵsetNgModuleScope(SubModule, {exports: [forwardRef(() => SubComponent)]});
+
+       @Component({})
+       class MainComponent {
+       }
+
+       class MainModule {
+         static ɵmod = ɵɵdefineNgModule({type: MainModule});
+       }
+       ɵɵsetNgModuleScope(MainModule, {
+         imports: [forwardRef(() => SubModule)],
+         declarations: [forwardRef(() => MainComponent)]
+       });
+
+       const deps = ɵɵgetComponentDepsFactory(MainComponent as ComponentType<any>)();
+
+       expect(deps).toEqual(jasmine.arrayWithExactContents([SubComponent, MainComponent]));
+     });
+
+  it('should compute correct set of dependencies when importing ng-modules with providers using forward ref',
+     () => {
+       @Component({selector: 'sub'})
+       class SubComponent {
+       }
+
+       class SubModule {
+         static ɵmod = ɵɵdefineNgModule({type: SubModule});
+       }
+       ɵɵsetNgModuleScope(SubModule, {exports: [SubComponent]});
+
+       @Component({})
+       class MainComponent {
+       }
+
+       class MainModule {
+         static ɵmod = ɵɵdefineNgModule({type: MainModule});
+       }
+       ɵɵsetNgModuleScope(MainModule, {
+         imports: [forwardRef(() => ({ngModule: SubModule, providers: []}))],
+         declarations: [MainComponent]
+       });
+
+       const deps = ɵɵgetComponentDepsFactory(MainComponent as ComponentType<any>)();
+
+       expect(deps).toEqual(jasmine.arrayWithExactContents([SubComponent, MainComponent]));
+     });
+});

--- a/packages/core/test/render3/deps_tracker_spec.ts
+++ b/packages/core/test/render3/deps_tracker_spec.ts
@@ -986,18 +986,9 @@ describe('runtime dependency tracker', () => {
         class MainComponent {
         }
 
-        const ans = depsTracker.getComponentDependencies(MainComponent as ComponentType<any>, []);
+        const ans = depsTracker.getComponentDependencies(MainComponent as ComponentType<any>);
 
         expect(ans.dependencies).toEqual([MainComponent]);
-      });
-
-      it('should throw if no import is provided', () => {
-        @Component({standalone: true})
-        class MainComponent {
-        }
-
-        expect(() => depsTracker.getComponentDependencies(MainComponent as ComponentType<any>))
-            .toThrow();
       });
 
       it('should include imported standalone component/directive/pipe', () => {


### PR DESCRIPTION
Rolling forward of https://github.com/angular/angular/pull/51309

The PR does not seem to break AIO tests. The test `//aio:e2e` is flaky even at head and this PR does not seem to permanently break it.  

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
