### PR TITLE
Introduce conditional instructions

### DIFF
--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -1,0 +1,230 @@
+/****************************************************************************************************
+ * PARTIAL FILE: basic_switch.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+    }
+    value() {
+        return 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#switch value()}
+        {:case 0} case 0
+        {:case 1} case 1
+        {:case 2} case 2
+        {:default} default
+      {/switch}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#switch value()}
+        {:case 0} case 0
+        {:case 1} case 1
+        {:case 2} case 2
+        {:default} default
+      {/switch}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: basic_switch.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    value(): number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: switch_without_default.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.value = () => 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#switch value()}
+        {:case 0} case 0
+        {:case 1} case 1
+        {:case 2} case 2
+      {/switch}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#switch value()}
+        {:case 0} case 0
+        {:case 1} case 1
+        {:case 2} case 2
+      {/switch}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: switch_without_default.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    value: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: nested_switch.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.value = () => 1;
+        this.nestedValue = () => 2;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#switch value()}
+        {:case 0} case 0
+        {:case 1}
+          {#switch nestedValue()}
+            {:case 0} nested case 0
+            {:case 1} nested case 1
+            {:case 2} nested case 2
+          {/switch}
+        {:case 2} case 2
+      {/switch}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#switch value()}
+        {:case 0} case 0
+        {:case 1}
+          {#switch nestedValue()}
+            {:case 0} nested case 0
+            {:case 1} nested case 1
+            {:case 2} nested case 2
+          {/switch}
+        {:case 2} case 2
+      {/switch}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: nested_switch.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    value: () => number;
+    nestedValue: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: switch_with_pipe.js
+ ****************************************************************************************************/
+import { Component, Pipe } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestPipe {
+    tranform(value) {
+        return value;
+    }
+}
+TestPipe.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
+TestPipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, isStandalone: true, name: "test" });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, decorators: [{
+            type: Pipe,
+            args: [{ standalone: true, name: 'test' }]
+        }] });
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.value = () => 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, isStandalone: true, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#switch value() | test}
+        {:case 0} case 0
+        {:case 1} case 1
+        {:default} default
+      {/switch}
+    </div>
+  `, isInline: true, dependencies: [{ kind: "pipe", type: TestPipe, name: "test" }] });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#switch value() | test}
+        {:case 0} case 0
+        {:case 1} case 1
+        {:default} default
+      {/switch}
+    </div>
+  `,
+                    standalone: true,
+                    imports: [TestPipe]
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: switch_with_pipe.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestPipe {
+    tranform(value: unknown): unknown;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestPipe, never>;
+    static ɵpipe: i0.ɵɵPipeDeclaration<TestPipe, "test", true>;
+}
+export declare class MyApp {
+    message: string;
+    value: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/GOLDEN_PARTIAL.js
@@ -228,3 +228,413 @@ export declare class MyApp {
     static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, true, never>;
 }
 
+/****************************************************************************************************
+ * PARTIAL FILE: basic_if.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.value = () => 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#if value()}hello{/if}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#if value()}hello{/if}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: basic_if.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    value: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: basic_if_else.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.value = () => 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#if value()}hello{:else}goodbye{/if}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#if value()}hello{:else}goodbye{/if}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: basic_if_else.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    value: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: basic_if_else_if.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.value = () => 1;
+        this.otherValue = () => 2;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#if value() === 1}
+        one
+        {:else if otherValue() === 2} two
+        {:else if message} three
+        {:else} four
+      {/if}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#if value() === 1}
+        one
+        {:else if otherValue() === 2} two
+        {:else if message} three
+        {:else} four
+      {/if}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: basic_if_else_if.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    value: () => number;
+    otherValue: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: nested_if.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.val = 1;
+        this.innerVal = 2;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#if val === 0}
+        zero
+        {:else if val === 1} one
+        {:else if val === 2}
+          {#if innerVal === 0}
+            inner zero
+            {:else if innerVal === 1} inner one
+            {:else if innerVal === 2} inner two
+            {:else} inner three
+          {/if}
+        {:else} inner three
+      {/if}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#if val === 0}
+        zero
+        {:else if val === 1} one
+        {:else if val === 2}
+          {#if innerVal === 0}
+            inner zero
+            {:else if innerVal === 1} inner one
+            {:else if innerVal === 2} inner two
+            {:else} inner three
+          {/if}
+        {:else} inner three
+      {/if}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: nested_if.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    val: number;
+    innerVal: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: if_with_pipe.js
+ ****************************************************************************************************/
+import { Component, Pipe } from '@angular/core';
+import * as i0 from "@angular/core";
+export class TestPipe {
+    tranform(value) {
+        return value;
+    }
+}
+TestPipe.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, deps: [], target: i0.ɵɵFactoryTarget.Pipe });
+TestPipe.ɵpipe = i0.ɵɵngDeclarePipe({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, isStandalone: true, name: "test" });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: TestPipe, decorators: [{
+            type: Pipe,
+            args: [{ standalone: true, name: 'test' }]
+        }] });
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.val = 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#if (val | test) === 1}
+        one
+        {:else if (val | test) === 2} two
+        {:else} three
+      {/if}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#if (val | test) === 1}
+        one
+        {:else if (val | test) === 2} two
+        {:else} three
+      {/if}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: if_with_pipe.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class TestPipe {
+    tranform(value: unknown): unknown;
+    static ɵfac: i0.ɵɵFactoryDeclaration<TestPipe, never>;
+    static ɵpipe: i0.ɵɵPipeDeclaration<TestPipe, "test", true>;
+}
+export declare class MyApp {
+    message: string;
+    val: number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: if_with_alias.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.message = 'hello';
+        this.value = () => 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    <div>
+      {{message}}
+      {#if value(); as alias}{{value()}} as {{alias}}{/if}
+    </div>
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    <div>
+      {{message}}
+      {#if value(); as alias}{{value()}} as {{alias}}{/if}
+    </div>
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: if_with_alias.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    message: string;
+    value: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: if_nested_alias.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.value = () => 1;
+    }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    {#if value(); as root}
+      Root: {{value()}}/{{root}}
+      {#if value(); as inner}
+        Inner: {{value()}}/{{root}}/{{inner}}
+        {#if value(); as innermost}
+          Innermost: {{value()}}/{{root}}/{{inner}}/{{innermost}}
+        {/if}
+      {/if}
+    {/if}
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {#if value(); as root}
+      Root: {{value()}}/{{root}}
+      {#if value(); as inner}
+        Inner: {{value()}}/{{root}}/{{inner}}
+        {#if value(); as innermost}
+          Innermost: {{value()}}/{{root}}/{{inner}}/{{innermost}}
+        {/if}
+      {/if}
+    {/if}
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: if_nested_alias.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    value: () => number;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+
+/****************************************************************************************************
+ * PARTIAL FILE: if_nested_alias_listeners.js
+ ****************************************************************************************************/
+import { Component } from '@angular/core';
+import * as i0 from "@angular/core";
+export class MyApp {
+    constructor() {
+        this.value = () => 1;
+    }
+    log(_) { }
+}
+MyApp.ɵfac = i0.ɵɵngDeclareFactory({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, deps: [], target: i0.ɵɵFactoryTarget.Component });
+MyApp.ɵcmp = i0.ɵɵngDeclareComponent({ minVersion: "14.0.0", version: "0.0.0-PLACEHOLDER", type: MyApp, selector: "ng-component", ngImport: i0, template: `
+    {#if value(); as root}
+      <button (click)="log(value(), root)"></button>
+
+      {#if value(); as inner}
+        <button (click)="log(value(), root, inner)"></button>
+
+        {#if value(); as innermost}
+          <button (click)="log(value(), root, inner, innermost)"></button>
+        {/if}
+      {/if}
+    {/if}
+  `, isInline: true });
+i0.ɵɵngDeclareClassMetadata({ minVersion: "12.0.0", version: "0.0.0-PLACEHOLDER", ngImport: i0, type: MyApp, decorators: [{
+            type: Component,
+            args: [{
+                    template: `
+    {#if value(); as root}
+      <button (click)="log(value(), root)"></button>
+
+      {#if value(); as inner}
+        <button (click)="log(value(), root, inner)"></button>
+
+        {#if value(); as innermost}
+          <button (click)="log(value(), root, inner, innermost)"></button>
+        {/if}
+      {/if}
+    {/if}
+  `,
+                }]
+        }] });
+
+/****************************************************************************************************
+ * PARTIAL FILE: if_nested_alias_listeners.d.ts
+ ****************************************************************************************************/
+import * as i0 from "@angular/core";
+export declare class MyApp {
+    value: () => number;
+    log(_: any): void;
+    static ɵfac: i0.ɵɵFactoryDeclaration<MyApp, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<MyApp, "ng-component", never, {}, {}, never, never, false, never>;
+}
+

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "../test_case_schema.json",
+  "cases": [
+    {
+      "description": "should generate a basic switch block",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["switch"]
+      },
+      "inputFiles": [
+        "basic_switch.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "basic_switch_template.js",
+              "generated": "basic_switch.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate a switch block without a default block",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["switch"]
+      },
+      "inputFiles": [
+        "switch_without_default.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "switch_without_default_template.js",
+              "generated": "switch_without_default.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate nested switch blocks",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["switch"]
+      },
+      "inputFiles": [
+        "nested_switch.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "nested_switch_template.js",
+              "generated": "nested_switch.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate switch block with a pipe in its expression",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["switch"]
+      },
+      "inputFiles": [
+        "switch_with_pipe.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "switch_with_pipe_template.js",
+              "generated": "switch_with_pipe.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    }
+  ]
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/TEST_CASES.json
@@ -84,6 +84,174 @@
         }
       ],
       "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate a basic if block",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["if"]
+      },
+      "inputFiles": [
+        "basic_if.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "basic_if_template.js",
+              "generated": "basic_if.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate a basic if/else block",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["if"]
+      },
+      "inputFiles": [
+        "basic_if_else.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "basic_if_else_template.js",
+              "generated": "basic_if_else.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate a basic if/else if block",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["if"]
+      },
+      "inputFiles": [
+        "basic_if_else_if.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "basic_if_else_if_template.js",
+              "generated": "basic_if_else_if.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate a nested if block",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["if"]
+      },
+      "inputFiles": [
+        "nested_if.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "nested_if_template.js",
+              "generated": "nested_if.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate an if block using pipes in its conditions",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["if"]
+      },
+      "inputFiles": [
+        "if_with_pipe.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "if_with_pipe_template.js",
+              "generated": "if_with_pipe.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should generate an if block with an aliased expression",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["if"]
+      },
+      "inputFiles": [
+        "if_with_alias.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "if_with_alias_template.js",
+              "generated": "if_with_alias.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should expose the alias to nested conditional blocks",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["if"]
+      },
+      "inputFiles": [
+        "if_nested_alias.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "if_nested_alias_template.js",
+              "generated": "if_nested_alias.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
+    },
+    {
+      "description": "should expose the alias to nested event listeners",
+      "angularCompilerOptions": {
+        "_enabledBlockTypes": ["if"]
+      },
+      "inputFiles": [
+        "if_nested_alias_listeners.ts"
+      ],
+      "expectations": [
+        {
+          "files": [
+            {
+              "expected": "if_nested_alias_listeners_template.js",
+              "generated": "if_nested_alias_listeners.js"
+            }
+          ],
+          "failureMessage": "Incorrect template"
+        }
+      ],
+      "skipForTemplatePipeline": true
     }
   ]
 }

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      {#if value()}hello{/if}
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  value = () => 1;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      {#if value()}hello{:else}goodbye{/if}
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  value = () => 1;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_if.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_if.ts
@@ -1,0 +1,20 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      {#if value() === 1}
+        one
+        {:else if otherValue() === 2} two
+        {:else if message} three
+        {:else} four
+      {/if}
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  value = () => 1;
+  otherValue = () => 2;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_if_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_if_template.js
@@ -1,0 +1,41 @@
+function MyApp_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " one ");
+  }
+}
+
+function MyApp_Conditional_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " two ");
+  }
+}
+
+function MyApp_Conditional_4_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " three ");
+  }
+}
+
+function MyApp_Conditional_5_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " four ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0);
+    $r3$.ɵɵtemplate(3, MyApp_Conditional_3_Template, 1, 0);
+    $r3$.ɵɵtemplate(4, MyApp_Conditional_4_Template, 1, 0);
+    $r3$.ɵɵtemplate(5, MyApp_Conditional_5_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(2, ctx.value() === 1 ? 2 : ctx.otherValue() === 2 ? 3 : ctx.message ? 4 : 5);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_else_template.js
@@ -1,0 +1,27 @@
+function MyApp_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, "hello");
+  }
+}
+
+function MyApp_Conditional_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, "goodbye");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0);
+    $r3$.ɵɵtemplate(3, MyApp_Conditional_3_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(2, ctx.value() ? 2 : 3);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_if_template.js
@@ -1,0 +1,20 @@
+function MyApp_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, "hello");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(2, ctx.value() ? 2 : -1);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch.ts
@@ -1,0 +1,22 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      {#switch value()}
+        {:case 0} case 0
+        {:case 1} case 1
+        {:case 2} case 2
+        {:default} default
+      {/switch}
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+
+  value() {
+    return 1;
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/basic_switch_template.js
@@ -1,0 +1,42 @@
+function MyApp_Case_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 0 ");
+  }
+}
+
+function MyApp_Case_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 1 ");
+  }
+}
+
+function MyApp_Case_4_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 2 ");
+  }
+}
+
+function MyApp_Case_5_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " default ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0);
+    $r3$.ɵɵtemplate(3, MyApp_Case_3_Template, 1, 0);
+    $r3$.ɵɵtemplate(4, MyApp_Case_4_Template, 1, 0);
+    $r3$.ɵɵtemplate(5, MyApp_Case_5_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    let MyApp_contFlowTmp;
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(2, (MyApp_contFlowTmp = ctx.value()) === 0 ? 2 : MyApp_contFlowTmp === 1 ? 3 : MyApp_contFlowTmp === 2 ? 4 : 5);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias.ts
@@ -1,0 +1,18 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    {#if value(); as root}
+      Root: {{value()}}/{{root}}
+      {#if value(); as inner}
+        Inner: {{value()}}/{{root}}/{{inner}}
+        {#if value(); as innermost}
+          Innermost: {{value()}}/{{root}}/{{inner}}/{{innermost}}
+        {/if}
+      {/if}
+    {/if}
+  `,
+})
+export class MyApp {
+  value = () => 1;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_listeners.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_listeners.ts
@@ -1,0 +1,21 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    {#if value(); as root}
+      <button (click)="log(value(), root)"></button>
+
+      {#if value(); as inner}
+        <button (click)="log(value(), root, inner)"></button>
+
+        {#if value(); as innermost}
+          <button (click)="log(value(), root, inner, innermost)"></button>
+        {/if}
+      {/if}
+    {/if}
+  `,
+})
+export class MyApp {
+  value = () => 1;
+  log(_: any) {}
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_listeners_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_listeners_template.js
@@ -1,0 +1,68 @@
+function MyApp_Conditional_0_Conditional_1_Conditional_1_Template(rf, ctx) {
+  if (rf & 1) {
+    const $_r7$ = $r3$.ɵɵgetCurrentView();
+    $r3$.ɵɵelementStart(0, "button", 0);
+    $r3$.ɵɵlistener("click", function MyApp_Conditional_0_Conditional_1_Conditional_1_Template_button_click_0_listener() {
+      const $restoredCtx$ = $r3$.ɵɵrestoreView($_r7$);
+      const $innermost_r5$ = $restoredCtx$;
+      const $inner_r3$ = $r3$.ɵɵnextContext();
+      const $root_r1$ = $r3$.ɵɵnextContext();
+      const $ctx_r6$ = $r3$.ɵɵnextContext();
+      return $r3$.ɵɵresetView($ctx_r6$.log($ctx_r6$.value(), $root_r1$, $inner_r3$, $innermost_r5$));
+    });
+    $r3$.ɵɵelementEnd();
+  }
+}
+
+function MyApp_Conditional_0_Conditional_1_Template(rf, ctx) {
+  if (rf & 1) {
+    const $_r11$ = $r3$.ɵɵgetCurrentView();
+    $r3$.ɵɵelementStart(0, "button", 0);
+    $r3$.ɵɵlistener("click", function MyApp_Conditional_0_Conditional_1_Template_button_click_0_listener() {
+      const $restoredCtx$ = $r3$.ɵɵrestoreView($_r11$);
+      const $inner_r3$ = $restoredCtx$;
+      const $root_r1$ = $r3$.ɵɵnextContext();
+      const $ctx_r10$ = $r3$.ɵɵnextContext();
+      return $r3$.ɵɵresetView($ctx_r10$.log($ctx_r10$.value(), $root_r1$, $inner_r3$));
+    });
+    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵtemplate(1, MyApp_Conditional_0_Conditional_1_Conditional_1_Template, 1, 0);
+  }
+  if (rf & 2) {
+    const $ctx_r2$ = $r3$.ɵɵnextContext(2);
+    let MyApp_Conditional_0_Conditional_1_contFlowTmp;
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(1, (MyApp_Conditional_0_Conditional_1_contFlowTmp = $ctx_r2$.value()) ? 1 : -1, MyApp_Conditional_0_Conditional_1_contFlowTmp);
+  }
+}
+
+function MyApp_Conditional_0_Template(rf, ctx) {
+  if (rf & 1) {
+    const $_r14$ = $r3$.ɵɵgetCurrentView();
+    $r3$.ɵɵelementStart(0, "button", 0);
+    $r3$.ɵɵlistener("click", function MyApp_Conditional_0_Template_button_click_0_listener() {
+      const $restoredCtx$ = $r3$.ɵɵrestoreView($_r14$);
+      const $root_r1$ = $restoredCtx$;
+      const $ctx_r13$ = $r3$.ɵɵnextContext();
+      return $r3$.ɵɵresetView($ctx_r13$.log($ctx_r13$.value(), $root_r1$));
+    });
+    $r3$.ɵɵelementEnd();
+    $r3$.ɵɵtemplate(1, MyApp_Conditional_0_Conditional_1_Template, 2, 1);
+  }
+  if (rf & 2) {
+    const ctx_r0 = $r3$.ɵɵnextContext();
+    let MyApp_Conditional_0_contFlowTmp;
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(1, (MyApp_Conditional_0_contFlowTmp = ctx_r0.value()) ? 1 : -1, MyApp_Conditional_0_contFlowTmp);
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtemplate(0, MyApp_Conditional_0_Template, 2, 1);
+  }
+  if (rf & 2) {
+    let MyApp_contFlowTmp;
+    $r3$.ɵɵconditional(0, (MyApp_contFlowTmp = ctx.value()) ? 0 : -1, MyApp_contFlowTmp);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_nested_alias_template.js
@@ -1,0 +1,50 @@
+function MyApp_Conditional_0_Conditional_1_Conditional_1_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const $inner_r3$ = $r3$.ɵɵnextContext();
+    const $root_r1$ = $r3$.ɵɵnextContext();
+    const $ctx_r4$ = $r3$.ɵɵnextContext();
+    $r3$.ɵɵtextInterpolate4(" Innermost: ", $ctx_r4$.value(), "/", $root_r1$, "/", $inner_r3$, "/", ctx, " ");
+  }
+}
+
+function MyApp_Conditional_0_Conditional_1_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+    $r3$.ɵɵtemplate(1, MyApp_Conditional_0_Conditional_1_Conditional_1_Template, 1, 4);
+  }
+  if (rf & 2) {
+    const $root_r1$ = $r3$.ɵɵnextContext();
+    const $ctx_r2$ = $r3$.ɵɵnextContext();
+    let MyApp_Conditional_0_Conditional_1_contFlowTmp;
+    $r3$.ɵɵtextInterpolate3(" Inner: ", $ctx_r2$.value(), "/", $root_r1$, "/", ctx, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(1, (MyApp_Conditional_0_Conditional_1_contFlowTmp = $ctx_r2$.value()) ? 1 : -1, MyApp_Conditional_0_Conditional_1_contFlowTmp);
+  }
+}
+
+function MyApp_Conditional_0_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+    $r3$.ɵɵtemplate(1, MyApp_Conditional_0_Conditional_1_Template, 2, 4);
+  }
+  if (rf & 2) {
+    const $ctx_r0$ = $r3$.ɵɵnextContext();
+    let MyApp_Conditional_0_contFlowTmp;
+    $r3$.ɵɵtextInterpolate2(" Root: ", $ctx_r0$.value(), "/", ctx, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(1, (MyApp_Conditional_0_contFlowTmp = $ctx_r0$.value()) ? 1 : -1, MyApp_Conditional_0_contFlowTmp);
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtemplate(0, MyApp_Conditional_0_Template, 2, 3);
+  }
+  if (rf & 2) {
+    let MyApp_contFlowTmp;
+    $r3$.ɵɵconditional(0, (MyApp_contFlowTmp = ctx.value()) ? 0 : -1, MyApp_contFlowTmp);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias.ts
@@ -1,0 +1,14 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      {#if value(); as alias}{{value()}} as {{alias}}{/if}
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  value = () => 1;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_alias_template.js
@@ -1,0 +1,25 @@
+function MyApp_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0);
+  }
+  if (rf & 2) {
+    const $ctx0$ = $r3$.ɵɵnextContext();
+    $r3$.ɵɵtextInterpolate2("", $ctx0$.value(), " as ", ctx, "");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 2);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    let MyApp_contFlowTmp;
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(2, (MyApp_contFlowTmp = ctx.value()) ? 2 : -1, MyApp_contFlowTmp);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe.ts
@@ -1,0 +1,25 @@
+import {Component, Pipe} from '@angular/core';
+
+@Pipe({standalone: true, name: 'test'})
+export class TestPipe {
+  tranform(value: unknown) {
+    return value;
+  }
+}
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      {#if (val | test) === 1}
+        one
+        {:else if (val | test) === 2} two
+        {:else} three
+      {/if}
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  val = 1;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/if_with_pipe_template.js
@@ -1,0 +1,36 @@
+function MyApp_Conditional_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " one ");
+  }
+}
+
+function MyApp_Conditional_5_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " two ");
+  }
+}
+
+function MyApp_Conditional_6_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " three ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵpipe(2, "test");
+    $r3$.ɵɵtemplate(3, MyApp_Conditional_3_Template, 1, 0);
+    $r3$.ɵɵpipe(4, "test");
+    $r3$.ɵɵtemplate(5, MyApp_Conditional_5_Template, 1, 0);
+    $r3$.ɵɵtemplate(6, MyApp_Conditional_6_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(2);
+    $r3$.ɵɵconditional(3, $r3$.ɵɵpipeBind1(2, 3, ctx.val) === 1 ? 3 : $r3$.ɵɵpipeBind1(4, 5, ctx.val) === 2 ? 5 : 6);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if.ts
@@ -1,0 +1,26 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      {#if val === 0}
+        zero
+        {:else if val === 1} one
+        {:else if val === 2}
+          {#if innerVal === 0}
+            inner zero
+            {:else if innerVal === 1} inner one
+            {:else if innerVal === 2} inner two
+            {:else} inner three
+          {/if}
+        {:else} inner three
+      {/if}
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  val = 1;
+  innerVal = 2;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_if_template.js
@@ -1,0 +1,72 @@
+function MyApp_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " zero ");
+  }
+}
+
+function MyApp_Conditional_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " one ");
+  }
+}
+
+function MyApp_Conditional_4_Conditional_0_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " inner zero ");
+  }
+}
+
+function MyApp_Conditional_4_Conditional_1_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " inner one ");
+  }
+}
+
+function MyApp_Conditional_4_Conditional_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " inner two ");
+  }
+}
+
+function MyApp_Conditional_4_Conditional_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " inner three ");
+  }
+}
+
+function MyApp_Conditional_4_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtemplate(0, MyApp_Conditional_4_Conditional_0_Template, 1, 0);
+    $r3$.ɵɵtemplate(1, MyApp_Conditional_4_Conditional_1_Template, 1, 0);
+    $r3$.ɵɵtemplate(2, MyApp_Conditional_4_Conditional_2_Template, 1, 0);
+    $r3$.ɵɵtemplate(3, MyApp_Conditional_4_Conditional_3_Template, 1, 0);
+  }
+  if (rf & 2) {
+    const ctx_r2 = $r3$.ɵɵnextContext();
+    $r3$.ɵɵconditional(0, ctx_r2.innerVal === 0 ? 0 : ctx_r2.innerVal === 1 ? 1 : ctx_r2.innerVal === 2 ? 2 : 3);
+  }
+}
+
+function MyApp_Conditional_5_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " inner three ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵtemplate(2, MyApp_Conditional_2_Template, 1, 0);
+    $r3$.ɵɵtemplate(3, MyApp_Conditional_3_Template, 1, 0);
+    $r3$.ɵɵtemplate(4, MyApp_Conditional_4_Template, 4, 3);
+    $r3$.ɵɵtemplate(5, MyApp_Conditional_5_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(2, ctx.val === 0 ? 2 : ctx.val === 1 ? 3 : ctx.val === 2 ? 4 : 5);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_switch.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_switch.ts
@@ -1,0 +1,24 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      {#switch value()}
+        {:case 0} case 0
+        {:case 1}
+          {#switch nestedValue()}
+            {:case 0} nested case 0
+            {:case 1} nested case 1
+            {:case 2} nested case 2
+          {/switch}
+        {:case 2} case 2
+      {/switch}
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  value = () => 1;
+  nestedValue = () => 2;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_switch_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/nested_switch_template.js
@@ -1,0 +1,60 @@
+function MyApp_Case_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 0 ");
+  }
+}
+
+function MyApp_Case_3_Case_0_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " nested case 0 ");
+  }
+}
+
+function MyApp_Case_3_Case_1_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " nested case 1 ");
+  }
+}
+
+function MyApp_Case_3_Case_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " nested case 2 ");
+  }
+}
+
+function MyApp_Case_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtemplate(0, MyApp_Case_3_Case_0_Template, 1, 0);
+    $r3$.ɵɵtemplate(1, MyApp_Case_3_Case_1_Template, 1, 0);
+    $r3$.ɵɵtemplate(2, MyApp_Case_3_Case_2_Template, 1, 0);
+  }
+  if (rf & 2) {
+    const ctx_r1 = $r3$.ɵɵnextContext();
+    let MyApp_Case_3_contFlowTmp;
+    $r3$.ɵɵconditional(0, (MyApp_Case_3_contFlowTmp = ctx_r1.nestedValue()) === 0 ? 0 : MyApp_Case_3_contFlowTmp === 1 ? 1 : MyApp_Case_3_contFlowTmp === 2 ? 2 : -1);
+  }
+}
+
+function MyApp_Case_4_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 2 ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0);
+    $r3$.ɵɵtemplate(3, MyApp_Case_3_Template, 3, 4);
+    $r3$.ɵɵtemplate(4, MyApp_Case_4_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    let MyApp_contFlowTmp;
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(2, (MyApp_contFlowTmp = ctx.value()) === 0 ? 2 : MyApp_contFlowTmp === 1 ? 3 : MyApp_contFlowTmp === 2 ? 4 : -1);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe.ts
@@ -1,0 +1,27 @@
+import {Component, Pipe} from '@angular/core';
+
+@Pipe({standalone: true, name: 'test'})
+export class TestPipe {
+  tranform(value: unknown) {
+    return value;
+  }
+}
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      {#switch value() | test}
+        {:case 0} case 0
+        {:case 1} case 1
+        {:default} default
+      {/switch}
+    </div>
+  `,
+  standalone: true,
+  imports: [TestPipe]
+})
+export class MyApp {
+  message = 'hello';
+  value = () => 1;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_with_pipe_template.js
@@ -1,0 +1,18 @@
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵpipe(2, "test");
+    $r3$.ɵɵtemplate(3, MyApp_Case_3_Template, 1, 0);
+    $r3$.ɵɵtemplate(4, MyApp_Case_4_Template, 1, 0);
+    $r3$.ɵɵtemplate(5, MyApp_Case_5_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    let MyApp_contFlowTmp;
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(2);
+    $r3$.ɵɵconditional(3, (MyApp_contFlowTmp = $r3$.ɵɵpipeBind1(2, 4, ctx.value())) === 0 ? 3 : MyApp_contFlowTmp === 1 ? 4 : 5);
+  }
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_without_default.ts
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_without_default.ts
@@ -1,0 +1,18 @@
+import {Component} from '@angular/core';
+
+@Component({
+  template: `
+    <div>
+      {{message}}
+      {#switch value()}
+        {:case 0} case 0
+        {:case 1} case 1
+        {:case 2} case 2
+      {/switch}
+    </div>
+  `,
+})
+export class MyApp {
+  message = 'hello';
+  value = () => 1;
+}

--- a/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_without_default_template.js
+++ b/packages/compiler-cli/test/compliance/test_cases/r3_view_compiler_control_flow/switch_without_default_template.js
@@ -1,0 +1,35 @@
+function MyApp_Case_2_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 0 ");
+  }
+}
+
+function MyApp_Case_3_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 1 ");
+  }
+}
+
+function MyApp_Case_4_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵtext(0, " case 2 ");
+  }
+}
+…
+function MyApp_Template(rf, ctx) {
+  if (rf & 1) {
+    $r3$.ɵɵelementStart(0, "div");
+    $r3$.ɵɵtext(1);
+    $r3$.ɵɵtemplate(2, MyApp_Case_2_Template, 1, 0);
+    $r3$.ɵɵtemplate(3, MyApp_Case_3_Template, 1, 0);
+    $r3$.ɵɵtemplate(4, MyApp_Case_4_Template, 1, 0);
+    $r3$.ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    let MyApp_contFlowTmp;
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵtextInterpolate1(" ", ctx.message, " ");
+    $r3$.ɵɵadvance(1);
+    $r3$.ɵɵconditional(2, (MyApp_contFlowTmp = ctx.value()) === 0 ? 2 : MyApp_contFlowTmp === 1 ? 3 : MyApp_contFlowTmp === 2 ? 4 : -1);
+  }
+}

--- a/packages/compiler/src/render3/r3_identifiers.ts
+++ b/packages/compiler/src/render3/r3_identifiers.ts
@@ -161,6 +161,8 @@ export class Identifiers {
   static deferPrefetchOnViewport:
       o.ExternalReference = {name: 'ɵɵdeferPrefetchOnViewport', moduleName: CORE};
 
+  static conditional: o.ExternalReference = {name: 'ɵɵconditional', moduleName: CORE};
+
   static text: o.ExternalReference = {name: 'ɵɵtext', moduleName: CORE};
 
   static enableBindings: o.ExternalReference = {name: 'ɵɵenableBindings', moduleName: CORE};

--- a/packages/compiler/src/render3/view/util.ts
+++ b/packages/compiler/src/render3/view/util.ts
@@ -21,7 +21,7 @@ import {isI18nAttribute} from './i18n/util';
 /**
  * Checks whether an object key contains potentially unsafe chars, thus the key should be wrapped in
  * quotes. Note: we do not wrap all keys into quotes, as it may have impact on minification and may
- * bot work in some cases when object keys are mangled by minifier.
+ * not work in some cases when object keys are mangled by a minifier.
  *
  * TODO(FW-1136): this is a temporary solution, we need to come up with a better way of working with
  * inputs that contain potentially unsafe chars.
@@ -48,6 +48,9 @@ export const NON_BINDABLE_ATTR = 'ngNonBindable';
 
 /** Name for the variable keeping track of the context returned by `ɵɵrestoreView`. */
 export const RESTORED_VIEW_CONTEXT_NAME = 'restoredCtx';
+
+/** Special value representing a direct access to a template's context. */
+export const DIRECT_CONTEXT_REFERENCE = '#context';
 
 /**
  * Maximum length of a single instruction chain. Because our output AST uses recursion, we're

--- a/packages/core/src/render3/jit/environment.ts
+++ b/packages/core/src/render3/jit/environment.ts
@@ -138,6 +138,7 @@ export const angularCoreEnv: {[name: string]: Function} =
        'ɵɵclassProp': r3.ɵɵclassProp,
        'ɵɵadvance': r3.ɵɵadvance,
        'ɵɵtemplate': r3.ɵɵtemplate,
+       'ɵɵconditional': r3.ɵɵconditional,
        'ɵɵdefer': r3.ɵɵdefer,
        'ɵɵdeferWhen': r3.ɵɵdeferWhen,
        'ɵɵdeferOnIdle': r3.ɵɵdeferOnIdle,

--- a/packages/core/test/acceptance/control_flow_exploration_spec.ts
+++ b/packages/core/test/acceptance/control_flow_exploration_spec.ts
@@ -7,45 +7,27 @@
  */
 
 
-import {ɵɵconditional, ɵɵdefineComponent, ɵɵtemplate, ɵɵtext, ɵɵtextInterpolate} from '@angular/core';
+import {ɵsetEnabledBlockTypes as setEnabledBlockTypes} from '@angular/compiler/src/jit_compiler_facade';
+import {Component, Pipe, PipeTransform} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
 
 describe('control flow', () => {
   describe('if', () => {
-    function App_ng_template_0_Template(rf: number, ctx: unknown) {
-      if (rf & 1) {
-        ɵɵtext(0, 'Something');
-      }
-    }
-    function App_ng_template_1_Template(rf: number, ctx: unknown) {
-      if (rf & 1) {
-        ɵɵtext(0, 'Nothing');
+    beforeEach(() => setEnabledBlockTypes(['if']));
+    afterEach(() => setEnabledBlockTypes([]));
+
+    // Basic shared pipe used during testing.
+    @Pipe({name: 'multiply', pure: true, standalone: true})
+    class MultiplyPipe implements PipeTransform {
+      transform(value: number, amount: number) {
+        return value * amount;
       }
     }
 
     it('should add and remove views based on conditions change', () => {
+      @Component({standalone: true, template: '{#if show}Something{:else}Nothing{/if}'})
       class TestComponent {
         show = true;
-        static ɵcmp = ɵɵdefineComponent({
-          type: TestComponent,
-          selectors: [['some-cmp']],
-          decls: 2,
-          vars: 1,
-          template:
-              function TestComponent_Template(rf: number, ctx: any) {
-                if (rf & 1) {
-                  ɵɵtemplate(0, App_ng_template_0_Template, 1, 0);
-                  ɵɵtemplate(1, App_ng_template_1_Template, 1, 0);
-                }
-                if (rf & 2) {
-                  ɵɵconditional(0, ctx.show ? 0 : 1);
-                }
-              },
-          encapsulation: 2
-        });
-        static ɵfac = function TestComponent_Factory(t: any) {
-          return new (t || TestComponent)();
-        };
       }
 
       const fixture = TestBed.createComponent(TestComponent);
@@ -59,73 +41,160 @@ describe('control flow', () => {
     });
 
     it('should expose expression value in context', () => {
-      function App_ng_template_0_Template(rf: number, ctx: any) {
-        if (rf & 1) {
-          ɵɵtext(0, 'Something');
-        }
-        if (rf & 2) {
-          ɵɵtextInterpolate(ctx);
-        }
-      }
-
+      @Component({
+        standalone: true,
+        template: '{#if show; as alias}{{show}} aliased to {{alias}}{/if}',
+      })
       class TestComponent {
         show: any = true;
-        static ɵcmp = ɵɵdefineComponent({
-          type: TestComponent,
-          selectors: [['some-cmp']],
-          decls: 2,
-          vars: 1,
-          template:
-              function TestComponent_Template(rf: number, ctx: any) {
-                if (rf & 1) {
-                  ɵɵtemplate(0, App_ng_template_0_Template, 1, 1);
-                }
-                if (rf & 2) {
-                  let temp: any;
-                  ɵɵconditional(0, (temp = ctx.show) ? 0 : -1, temp);
-                }
-              },
-          encapsulation: 2
-        });
-        static ɵfac = function TestComponent_Factory(t: any) {
-          return new (t || TestComponent)();
-        };
       }
 
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toBe('true');
+      expect(fixture.nativeElement.textContent).toBe('true aliased to true');
 
       fixture.componentInstance.show = 1;
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toBe('1');
+      expect(fixture.nativeElement.textContent).toBe('1 aliased to 1');
     });
 
+    it('should not expose the aliased expression to `if` and `else if` blocks', () => {
+      @Component({
+        standalone: true,
+        template: `
+          {#if value === 1; as alias}
+            If: {{value}} as {{alias || 'unavailable'}}
+            {:else if value === 2} ElseIf: {{value}} as {{alias || 'unavailable'}}
+            {:else} Else: {{value}} as {{alias || 'unavailable'}}
+          {/if}
+        `,
+      })
+      class TestComponent {
+        value = 1;
+      }
+
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent.trim()).toBe('If: 1 as true');
+
+      fixture.componentInstance.value = 2;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent.trim()).toBe('ElseIf: 2 as unavailable');
+
+      fixture.componentInstance.value = 3;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent.trim()).toBe('Else: 3 as unavailable');
+    });
+
+    it('should expose the context to nested conditional blocks', () => {
+      @Component({
+        standalone: true,
+        imports: [MultiplyPipe],
+        template: `
+          {#if value | multiply:2; as root}
+            Root: {{value}}/{{root}}
+            {#if value | multiply:3; as inner}
+              Inner: {{value}}/{{root}}/{{inner}}
+              {#if value | multiply:4; as innermost}
+                Innermost: {{value}}/{{root}}/{{inner}}/{{innermost}}
+              {/if}
+            {/if}
+          {/if}
+        `,
+      })
+      class TestComponent {
+        value = 1;
+      }
+
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      let content = fixture.nativeElement.textContent;
+      expect(content).toContain('Root: 1/2');
+      expect(content).toContain('Inner: 1/2/3');
+      expect(content).toContain('Innermost: 1/2/3/4');
+
+      fixture.componentInstance.value = 2;
+      fixture.detectChanges();
+      content = fixture.nativeElement.textContent;
+      expect(content).toContain('Root: 2/4');
+      expect(content).toContain('Inner: 2/4/6');
+      expect(content).toContain('Innermost: 2/4/6/8');
+    });
+
+    it('should expose the context to listeners inside nested conditional blocks', () => {
+      let logs: any[] = [];
+
+      @Component({
+        standalone: true,
+        imports: [MultiplyPipe],
+        template: `
+          {#if value | multiply:2; as root}
+            <button (click)="log(['Root', value, root])"></button>
+
+            {#if value | multiply:3; as inner}
+              <button (click)="log(['Inner', value, root, inner])"></button>
+
+              {#if value | multiply:4; as innermost}
+                <button (click)="log(['Innermost', value, root, inner, innermost])"></button>
+              {/if}
+            {/if}
+          {/if}
+        `,
+      })
+      class TestComponent {
+        value = 1;
+
+        log(value: any) {
+          logs.push(value);
+        }
+      }
+
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      const buttons =
+          Array.from<HTMLButtonElement>(fixture.nativeElement.querySelectorAll('button'));
+      buttons.forEach(button => button.click());
+      fixture.detectChanges();
+
+      expect(logs).toEqual([['Root', 1, 2], ['Inner', 1, 2, 3], ['Innermost', 1, 2, 3, 4]]);
+
+      logs = [];
+      fixture.componentInstance.value = 2;
+      fixture.detectChanges();
+
+      buttons.forEach(button => button.click());
+      fixture.detectChanges();
+      expect(logs).toEqual([['Root', 2, 4], ['Inner', 2, 4, 6], ['Innermost', 2, 4, 6, 8]]);
+    });
+
+    it('should expose expression value passed through a pipe in context', () => {
+      @Component({
+        standalone: true,
+        template: '{#if value | multiply:2; as alias}{{value}} aliased to {{alias}}{/if}',
+        imports: [MultiplyPipe],
+      })
+      class TestComponent {
+        value = 1;
+      }
+
+      const fixture = TestBed.createComponent(TestComponent);
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('1 aliased to 2');
+
+      fixture.componentInstance.value = 4;
+      fixture.detectChanges();
+      expect(fixture.nativeElement.textContent).toBe('4 aliased to 8');
+    });
+
+    // QUESTION: fundamental mismatch between the "template" and "container" concepts
+    // those 2 calls to the ɵɵtemplate instruction will generate comment nodes and LContainer
     it('should destroy all views if there is nothing to display', () => {
+      @Component({
+        standalone: true,
+        template: '{#if show}Something{/if}',
+      })
       class TestComponent {
         show = true;
-        static ɵcmp = ɵɵdefineComponent({
-          type: TestComponent,
-          selectors: [['some-cmp']],
-          decls: 1,
-          vars: 1,
-          template:
-              function TestComponent_Template(rf: number, ctx: any) {
-                if (rf & 1) {
-                  // QUESTION: fundamental mismatch between the "template" and "container" concepts
-                  // those 2 calls to the ɵɵtemplate instruction will generate comment nodes and
-                  // LContainer
-                  ɵɵtemplate(0, App_ng_template_0_Template, 1, 0);
-                }
-                if (rf & 2) {
-                  ɵɵconditional(0, ctx.show ? 0 : -1);
-                }
-              },
-          encapsulation: 2
-        });
-        static ɵfac = function TestComponent_Factory(t: any) {
-          return new (t || TestComponent)();
-        };
       }
 
       const fixture = TestBed.createComponent(TestComponent);
@@ -139,66 +208,39 @@ describe('control flow', () => {
   });
 
   describe('switch', () => {
-    function App_ng_template_0_Template(rf: number, ctx: unknown) {
-      if (rf & 1) {
-        ɵɵtext(0, 'case 0');
-      }
-    }
+    beforeEach(() => setEnabledBlockTypes(['switch']));
+    afterEach(() => setEnabledBlockTypes([]));
 
-    function App_ng_template_1_Template(rf: number, ctx: unknown) {
-      if (rf & 1) {
-        ɵɵtext(0, 'case 1');
-      }
-    }
-
-    function App_ng_template_default_Template(rf: number, ctx: unknown) {
-      if (rf & 1) {
-        ɵɵtext(0, 'default');
-      }
-    }
-
+    // Open question: == vs. === for comparison
+    // == is the current Angular implementation
+    // === is used by JavaScript semantics
     it('should show a template based on a matching case', () => {
+      @Component({
+        standalone: true,
+        template: `
+          {#switch case}
+            {:case 0}case 0
+            {:case 1}case 1
+            {:default}default
+          {/switch}
+        `
+      })
       class TestComponent {
         case = 0;
-        static ɵcmp = ɵɵdefineComponent({
-          type: TestComponent,
-          selectors: [['some-cmp']],
-          decls: 3,
-          vars: 1,
-          template:
-              function TestComponent_Template(rf: number, ctx: any) {
-                if (rf & 1) {
-                  ɵɵtemplate(0, App_ng_template_0_Template, 1, 0);
-                  ɵɵtemplate(1, App_ng_template_1_Template, 1, 0);
-                  ɵɵtemplate(2, App_ng_template_default_Template, 1, 0);
-                }
-                if (rf & 2) {
-                  const expValue = ctx.case;
-                  // Open question: == vs. === for comparison
-                  // == is the current Angular implementation
-                  // === is used by JavaScript semantics
-                  ɵɵconditional(0, expValue === 0 ? 0 : expValue === 1 ? 1 : 2);
-                }
-              },
-          encapsulation: 2
-        });
-        static ɵfac = function TestComponent_Factory(t: any) {
-          return new (t || TestComponent)();
-        };
       }
 
       const fixture = TestBed.createComponent(TestComponent);
       fixture.detectChanges();
 
-      expect(fixture.nativeElement.textContent).toBe('case 0');
+      expect(fixture.nativeElement.textContent).toBe('case 0 ');
 
       fixture.componentInstance.case = 1;
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toBe('case 1');
+      expect(fixture.nativeElement.textContent).toBe('case 1 ');
 
       fixture.componentInstance.case = 5;
       fixture.detectChanges();
-      expect(fixture.nativeElement.textContent).toBe('default');
+      expect(fixture.nativeElement.textContent).toBe('default ');
     });
   });
 });


### PR DESCRIPTION
Adds the logic to generate instructions for `if` and `switch` blocks. Split up into the following commits to make it easier to review:

### refactor(compiler): generate switch block instructions
Adds the logic to generate the instructions for `switch` instructions. For the following block:

```html
{#switch value()}
  {:case 0} case 0
  {:case 1} case 1
  {:case 2} case 2
  {:default} default
{/switch}
```

The compiler will produce the following output:

```ts
function App_Template(rf, ctx) {
  if (rf & 1) {
    ɵɵtemplate(0, App_Case_0_Template, 1, 0);
    ɵɵtemplate(1, App_Case_1_Template, 1, 0);
    ɵɵtemplate(2, App_Case_2_Template, 1, 0);
    ɵɵtemplate(3, App_Case_3_Template, 1, 0);
  }
  if (rf & 2) {
    let App_contFlowTmp;
    ɵɵconditional(0, (App_contFlowTmp = ctx.value()) === 0 ? 0 : App_contFlowTmp === 1 ? 1 : App_contFlowTmp === 2 ? 2 : 3);
  }
}
```

### refactor(compiler): generate if block instructions
Adds the logic to generate the instructions for `if` blocks. There are two primary use cases we need to account for:

A conditional that doesn't use the `as` parameter of the `if` block. To support it we generate a nested ternary expression that evaluates to the index of the template whose condition is truthy. If the block doesn't have an `else` branch, we pass in a special `-1` value which means that no view will be rendered.

Example with an `else`:
```ts
// {#if expr}
//   ...
//   {:else if otherExpr} ...
//   {:else} ...
// {/if}

if (rf & 1) {
  ɵɵtemplate(0, App_Conditional_0_Template, 0, 0);
  ɵɵtemplate(1, App_Conditional_1_Template, 0, 0);
  ɵɵtemplate(2, App_Conditional_2_Template, 0, 0);
}
if (rf & 2) {
  ɵɵconditional(0, ctx.expr ? 0 : ctx.otherExpr ? 1 : 2);
}
```

Example without an `else`:
```ts
// {#if expr}
//   ...
//   {:else if otherExpr} ...
// {/if}

if (rf & 1) {
  ɵɵtemplate(0, App_Conditional_0_Template, 0, 0);
  ɵɵtemplate(1, App_Conditional_1_Template, 0, 0);
}
if (rf & 2) {
  ɵɵconditional(0, ctx.expr ? 0 : ctx.otherExpr ? 1 : -1);
}
```

If a conditional captures it's value in an alias (e.g. `{#if expr; as foo}`) we need to assign the value to a temporary variable before passing it along to `conditional`.

```ts
// {#if expr; as alias}...{/if}
if (rf & 1) {
  ɵɵtemplate(0, App_Conditional_0_Template, 1, 0);
}
if (rf & 2) {
  let App_contFlowTmp;
  ɵɵconditional(0, (App_contFlowTmp = ctx.expr) ? 0 : -1, App_contFlowTmp);
}
```

### test(core): remove manually-written control flow instructions
Updates the control flow tests to use the compiler instead of manually-written instructions. Also adds a couple of tests that I was using along the way to verify that things work as expected.