### PR TITLE
docs(core): clarify InjectionToken usage with non-reified types

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -338,7 +338,8 @@ groups:
           'aio/content/images/guide/view-encapsulation/**/{*,.*}',
           'aio/content/special-elements/**/{*,.*}',
           'aio/content/guide/hydration.md',
-          'aio/content/guide/signals.md'
+          'aio/content/guide/signals.md',
+          'aio/content/examples/injection-token/**/{*,.*}',
           ])
     reviewers:
       users:

--- a/aio/content/examples/examples.bzl
+++ b/aio/content/examples/examples.bzl
@@ -67,6 +67,7 @@ EXAMPLES = {
     "http": {"stackblitz": True, "zip": True},
     "i18n": {"stackblitz": True, "zip": True},
     "inputs-outputs": {"stackblitz": True, "zip": True},
+    "injection-token": {"stackblitz": False, "zip": False},
     "interpolation": {"stackblitz": True, "zip": True},
     "lazy-loading-ngmodules": {"stackblitz": True, "zip": True},
     "lifecycle-hooks": {"stackblitz": True, "zip": True},

--- a/aio/content/examples/injection-token/BUILD.bazel
+++ b/aio/content/examples/injection-token/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//aio/content/examples:examples.bzl", "docs_example")
+
+package(default_visibility = ["//visibility:public"])
+
+docs_example(
+    name = "injection-token",
+)

--- a/aio/content/examples/injection-token/e2e/src/app.e2e-spec.ts
+++ b/aio/content/examples/injection-token/e2e/src/app.e2e-spec.ts
@@ -1,0 +1,9 @@
+/*
+ * This example project is special in that it is not a cli app. To run tests appropriate for this
+ * project, the test command is overwritten in `aio/content/examples/injection-token/example-config.json`.
+ *
+ * This is an empty placeholder file to ensure that `aio/tools/examples/run-example-e2e.mjs` runs
+ * tests for this project.
+ *
+ * TODO: Fix our infrastructure/tooling, so that this hack is not necessary.
+ */

--- a/aio/content/examples/injection-token/example-config.json
+++ b/aio/content/examples/injection-token/example-config.json
@@ -1,0 +1,8 @@
+{
+  "tests": [
+    {
+      "cmd": "yarn",
+      "args": [ "tsc", "--project", "./tsconfig.app.json" ]
+    }
+  ]
+}

--- a/aio/content/examples/injection-token/src/main.ts
+++ b/aio/content/examples/injection-token/src/main.ts
@@ -1,0 +1,26 @@
+// TODO: Add unit tests for this file.
+/* eslint-disable @angular-eslint/no-output-native */
+// #docregion
+import {Injector, InjectionToken} from '@angular/core';
+
+interface MyInterface {
+  someProperty: string;
+}
+
+// #docregion InjectionToken
+
+const TOKEN = new InjectionToken<MyInterface>('SomeToken');
+
+// Setting up the provider using the same token instance
+const providers = [
+  {provide: TOKEN, useValue: {someProperty: 'exampleValue'}}, // Mock value for MyInterface
+];
+
+// Creating the injector with the provider
+const injector = Injector.create({providers});
+
+// Retrieving the value using the same token instance
+const myInterface = injector.get(TOKEN);
+// myInterface is inferred to be MyInterface.
+
+// #enddocregion InjectionToken

--- a/packages/core/src/di/injection_token.ts
+++ b/packages/core/src/di/injection_token.ts
@@ -21,11 +21,17 @@ import {ɵɵdefineInjectable} from './interface/defs';
  * `InjectionToken` is parameterized on `T` which is the type of object which will be returned by
  * the `Injector`. This provides an additional level of type safety.
  *
- * ```
- * interface MyInterface {...}
- * const myInterface = injector.get(new InjectionToken<MyInterface>('SomeToken'));
- * // myInterface is inferred to be MyInterface.
- * ```
+ * <div class="alert is-helpful">
+ *
+ * **Important Note**: Ensure that you use the same instance of the `InjectionToken` in both the
+ * provider and the injection call. Creating a new instance of `InjectionToken` in different places,
+ * even with the same description, will be treated as different tokens by Angular's DI system,
+ * leading to a `NullInjectorError`.
+ *
+ * </div>
+ *
+ * <code-example format="typescript" language="typescript" path="injection-token/src/main.ts"
+ * region="InjectionToken"></code-example>
  *
  * When creating an `InjectionToken`, you can optionally specify a factory function which returns
  * (possibly by creating) a default value of the parameterized type `T`. This sets up the
@@ -51,7 +57,6 @@ import {ɵɵdefineInjectable} from './interface/defs';
  * ### Tree-shakable InjectionToken
  *
  * {@example core/di/ts/injector_spec.ts region='ShakableInjectionToken'}
- *
  *
  * @publicApi
  */


### PR DESCRIPTION
- Emphasized the importance of using the same InjectionToken instance for both provider and injection call.
- Added examples to illustrate correct and incorrect usages to prevent NullInjectorError.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The current documentation for InjectionToken provides an example where a new instance of InjectionToken is passed to injector.get(). This can be misleading, especially when dealing with types that do not have a runtime representation, like interfaces. The documentation does not explicitly mention the potential issue of receiving a NullInjectorError if different instances of InjectionToken are used in the provider and the injection call.

Issue Number: #51270 


## What is the new behavior?

Documentation updated adding an example on proper usage and explanation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
