### PR TITLE
docs(docs-infra): fix margin on contribute page heading

### DIFF
--- a/aio/src/styles/2-modules/contribute/_contribute.scss
+++ b/aio/src/styles/2-modules/contribute/_contribute.scss
@@ -1,8 +1,4 @@
 .contribute-container {
-  h2 {
-    margin: 0;
-  }
-
   .card-section {
     justify-content: space-between;
 


### PR DESCRIPTION
fix margin on h2 tag of contribute page being overwritten

closes #51391

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
![image](https://github.com/angular/angular/assets/54370141/0e403056-360f-4dad-888d-b4f2b3b0be21)


Issue Number: #51391


## What is the new behavior?
![image](https://github.com/angular/angular/assets/54370141/43ba585f-ec54-48de-9d4b-922ea4f5af28)



## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
