### PR TITLE
refactor(core): deprecate `NgProbeToken`

### DIFF
--- a/aio/content/guide/deprecations.md
+++ b/aio/content/guide/deprecations.md
@@ -130,6 +130,7 @@ v16 - v19
 | Area                                | API or Feature                                                                                             | Deprecated in | May be removed in |
 |:---                                 |:---                                                                                                        |:---           |:---               |
 | `@angular/core` | `PACKAGE_ROOT_URL` | v17 | v19 |
+| `@angular/core` | `NgProbeToken` | v17 | v19 |
 
 ### Deprecated features with no planned removal version
 
@@ -187,6 +188,7 @@ In the [API reference section](api) of this site, deprecated APIs are indicated 
 | [`providedIn: 'any'`](api/core/Injectable#providedIn) | none | v15 | This option has confusing semantics and nearly zero usage. |
 | [`EnvironmentInjector.runInContext`](api/core/EnvironmentInjector#runInContext) | `runInInjectionContext`  | v16 | `runInInjectionContext` is a more flexible operation which supports element injectors as well |
 | [`@Component.moduleId`](api/core/Component#moduleId) | none | v16 |
+| [`NgProbeToken`](api/core/NgProbeToken) | none | v16 | `ng.prob` was replaced by `ng.getComponent` since Ivy
 
 
 <a id="testing"></a>

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -1036,7 +1036,7 @@ export abstract class NgModuleRef<T> {
     abstract onDestroy(callback: () => void): void;
 }
 
-// @public
+// @public @deprecated
 export class NgProbeToken {
     constructor(name: string, token: any);
     // (undocumented)

--- a/packages/core/src/application_ref.ts
+++ b/packages/core/src/application_ref.ts
@@ -151,6 +151,7 @@ export function isBoundToModule<C>(cf: ComponentFactory<C>): boolean {
 /**
  * A token for third-party components that can register themselves with NgProbe.
  *
+ * @deprecated
  * @publicApi
  */
 export class NgProbeToken {

--- a/packages/router/src/router_module.ts
+++ b/packages/router/src/router_module.ts
@@ -7,7 +7,7 @@
  */
 
 import {HashLocationStrategy, Location, LocationStrategy, PathLocationStrategy, ViewportScroller} from '@angular/common';
-import {APP_BOOTSTRAP_LISTENER, ComponentRef, inject, Inject, InjectionToken, ModuleWithProviders, NgModule, NgProbeToken, NgZone, Optional, Provider, SkipSelf, ɵRuntimeError as RuntimeError} from '@angular/core';
+import {APP_BOOTSTRAP_LISTENER, ComponentRef, inject, Inject, InjectionToken, ModuleWithProviders, NgModule, NgZone, Optional, Provider, SkipSelf, ɵRuntimeError as RuntimeError} from '@angular/core';
 
 import {EmptyOutletComponent} from './components/empty_outlet';
 import {RouterLink} from './directives/router_link';
@@ -54,10 +54,6 @@ export const ROUTER_PROVIDERS: Provider[] = [
   (typeof ngDevMode === 'undefined' || ngDevMode) ? {provide: ROUTER_IS_PROVIDED, useValue: true} :
                                                     [],
 ];
-
-export function routerNgProbeToken() {
-  return new NgProbeToken('Router', Router);
-}
 
 /**
  * @description
@@ -123,7 +119,6 @@ export class RouterModule {
         config?.useHash ? provideHashLocationStrategy() : providePathLocationStrategy(),
         provideRouterScroller(),
         config?.preloadingStrategy ? withPreloading(config.preloadingStrategy).ɵproviders : [],
-        {provide: NgProbeToken, multi: true, useFactory: routerNgProbeToken},
         config?.initialNavigation ? provideInitialNavigation(config) : [],
         config?.bindToComponentInputs ? withComponentInputBinding().ɵproviders : [],
         provideRouterInitializer(),


### PR DESCRIPTION
This token serves no purpose on Ivy.