### PR TITLE
Control flow AST followup fixes

### DIFF
--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -257,9 +257,19 @@ export class SwitchBlockCase implements Node {
   }
 }
 
+export interface ForLoopBlockContext {
+  $index?: string;
+  $first?: string;
+  $last?: string;
+  $even?: string;
+  $odd?: string;
+  $count?: string;
+}
+
 export class ForLoopBlock implements Node {
   constructor(
-      public itemName: string, public expression: AST, public trackBy: AST, public children: Node[],
+      public itemName: string, public expression: AST, public trackBy: AST,
+      public contextVariables: ForLoopBlockContext|null, public children: Node[],
       public empty: ForLoopBlockEmpty|null, public sourceSpan: ParseSourceSpan,
       public startSourceSpan: ParseSourceSpan, public endSourceSpan: ParseSourceSpan|null) {}
 

--- a/packages/compiler/src/render3/r3_ast.ts
+++ b/packages/compiler/src/render3/r3_ast.ts
@@ -259,11 +259,9 @@ export class SwitchBlockCase implements Node {
 
 export class ForLoopBlock implements Node {
   constructor(
-      public itemName: string, public expression: AST,
-      // TODO(crisbeto): figure out if trackBy should be an AST
-      public trackBy: string, public children: Node[], public empty: ForLoopBlockEmpty|null,
-      public sourceSpan: ParseSourceSpan, public startSourceSpan: ParseSourceSpan,
-      public endSourceSpan: ParseSourceSpan|null) {}
+      public itemName: string, public expression: AST, public trackBy: AST, public children: Node[],
+      public empty: ForLoopBlockEmpty|null, public sourceSpan: ParseSourceSpan,
+      public startSourceSpan: ParseSourceSpan, public endSourceSpan: ParseSourceSpan|null) {}
 
   visit<Result>(visitor: Visitor<Result>): Result {
     return visitor.visitForLoopBlock(this);

--- a/packages/compiler/test/render3/r3_ast_spans_spec.ts
+++ b/packages/compiler/test/render3/r3_ast_spans_spec.ts
@@ -718,7 +718,7 @@ describe('R3 AST source spans', () => {
     it('is correct for if blocks', () => {
       const html = `{#if cond.expr; as foo}` +
           `Main case was true!` +
-          `{:else if other.expr; as bar}` +
+          `{:else if other.expr}` +
           `Extra case was true!` +
           `{:else}` +
           `False case!` +
@@ -727,15 +727,12 @@ describe('R3 AST source spans', () => {
       expectFromHtml(html, ['if']).toEqual([
         [
           'IfBlock',
-          '{#if cond.expr; as foo}Main case was true!{:else if other.expr; as bar}Extra case was true!{:else}False case!{/if}',
+          '{#if cond.expr; as foo}Main case was true!{:else if other.expr}Extra case was true!{:else}False case!{/if}',
           '{#if cond.expr; as foo}', '{/if}'
         ],
         ['IfBlockBranch', '{#if cond.expr; as foo}Main case was true!', '{#if cond.expr; as foo}'],
         ['Text', 'Main case was true!'],
-        [
-          'IfBlockBranch', '{:else if other.expr; as bar}Extra case was true!',
-          '{:else if other.expr; as bar}'
-        ],
+        ['IfBlockBranch', '{:else if other.expr}Extra case was true!', '{:else if other.expr}'],
         ['Text', 'Extra case was true!'],
         ['IfBlockBranch', '{:else}False case!', '{:else}'],
         ['Text', 'False case!'],

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -1521,7 +1521,7 @@ describe('R3 template transform', () => {
       expectIf(`
         {#if cond.expr; as foo}
           Main case was true!
-        {:else if other.expr; as bar}
+        {:else if other.expr}
           Extra case was true!
         {:else}
           False case!
@@ -1530,7 +1530,7 @@ describe('R3 template transform', () => {
         ['IfBlock'],
         ['IfBlockBranch', 'cond.expr', 'foo'],
         ['Text', ' Main case was true! '],
-        ['IfBlockBranch', 'other.expr', 'bar'],
+        ['IfBlockBranch', 'other.expr'],
         ['Text', ' Extra case was true! '],
         ['IfBlockBranch', null],
         ['Text', ' False case! '],
@@ -1622,10 +1622,10 @@ describe('R3 template transform', () => {
         `).toThrowError(/Conditional can only have one "as" expression/);
       });
 
-      it('should report an else if block that has multiple `as` expressions', () => {
+      it('should report an else if block that has an `as` expression', () => {
         expectIfError(`
-          {#if foo}hello{:else if bar; as one; as two}goodbye{/if}
-        `).toThrowError(/Conditional can only have one "as" expression/);
+          {#if foo}hello{:else if bar; as alias}goodbye{/if}
+        `).toThrowError(/"as" expression is only allowed on the primary "if" block/);
       });
 
       it('should report an unknown block inside an if block', () => {

--- a/packages/compiler/test/render3/r3_template_transform_spec.ts
+++ b/packages/compiler/test/render3/r3_template_transform_spec.ts
@@ -105,7 +105,7 @@ class R3AstHumanizer implements t.Visitor<void> {
   }
 
   visitForLoopBlock(block: t.ForLoopBlock): void {
-    this.result.push(['ForLoopBlock', unparse(block.expression), block.trackBy]);
+    this.result.push(['ForLoopBlock', unparse(block.expression), unparse(block.trackBy)]);
     this.visitAll([block.children]);
     block.empty?.visit(this);
   }


### PR DESCRIPTION
Includes the following fixes to control flow AST:

### refactor(compiler): don't allow as expressions in else if blocks
Based on some discussions, these changes remove the ability to have an `as` expression on an `else if` block.

### refactor(compiler): parse for loop track as an expression
Adds some logic to store the `track` parameter of a `for` loop block as an expression AST instead of a string.

### refactor(compiler): parse let parameters in for loop
Adds the logic to parse `let` parameters of a `for` loop block which was missed in #51299.