### PR TITLE
fix(core): don't run input transforms with the component instance as context

### DIFF
--- a/packages/core/src/render3/instructions/shared.ts
+++ b/packages/core/src/render3/instructions/shared.ts
@@ -1313,7 +1313,7 @@ function writeToDirectiveInput<T>(
   try {
     const inputTransforms = def.inputTransforms;
     if (inputTransforms !== null && inputTransforms.hasOwnProperty(privateName)) {
-      value = inputTransforms[privateName].call(instance, value);
+      value = inputTransforms[privateName](value);
     }
     if (def.setInput !== null) {
       def.setInput(instance, value, publicName, privateName);


### PR DESCRIPTION
Input transform functions should be pure functions that process the incoming value of the input in order to apply coercion, clamping, or other transformations. It should not have access to the component state.