### PR TITLE
refactor: add readonly to public InjectionToken types

### DIFF
--- a/goldens/public-api/common/http/index.md
+++ b/goldens/public-api/common/http/index.md
@@ -24,7 +24,7 @@ export class FetchBackend implements HttpBackend {
 }
 
 // @public
-export const HTTP_INTERCEPTORS: InjectionToken<HttpInterceptor[]>;
+export const HTTP_INTERCEPTORS: InjectionToken<readonly HttpInterceptor[]>;
 
 // @public
 export abstract class HttpBackend implements HttpHandler {

--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -561,7 +561,7 @@ export abstract class EmbeddedViewRef<C> extends ViewRef {
 export function enableProdMode(): void;
 
 // @public
-export const ENVIRONMENT_INITIALIZER: InjectionToken<() => void>;
+export const ENVIRONMENT_INITIALIZER: InjectionToken<readonly (() => void)[]>;
 
 // @public
 export abstract class EnvironmentInjector implements Injector {

--- a/packages/common/http/src/interceptor.ts
+++ b/packages/common/http/src/interceptor.ts
@@ -175,19 +175,19 @@ function chainedInterceptorFn(
  * @publicApi
  */
 export const HTTP_INTERCEPTORS =
-    new InjectionToken<HttpInterceptor[]>(ngDevMode ? 'HTTP_INTERCEPTORS' : '');
+    new InjectionToken<readonly HttpInterceptor[]>(ngDevMode ? 'HTTP_INTERCEPTORS' : '');
 
 /**
  * A multi-provided token of `HttpInterceptorFn`s.
  */
 export const HTTP_INTERCEPTOR_FNS =
-    new InjectionToken<HttpInterceptorFn[]>(ngDevMode ? 'HTTP_INTERCEPTOR_FNS' : '');
+    new InjectionToken<readonly HttpInterceptorFn[]>(ngDevMode ? 'HTTP_INTERCEPTOR_FNS' : '');
 
 /**
  * A multi-provided token of `HttpInterceptorFn`s that are only set in root.
  */
 export const HTTP_ROOT_INTERCEPTOR_FNS =
-    new InjectionToken<HttpInterceptorFn[]>(ngDevMode ? 'HTTP_ROOT_INTERCEPTOR_FNS' : '');
+    new InjectionToken<readonly HttpInterceptorFn[]>(ngDevMode ? 'HTTP_ROOT_INTERCEPTOR_FNS' : '');
 
 /**
  * Creates an `HttpInterceptorFn` which lazily initializes an interceptor chain from the legacy

--- a/packages/core/src/di/initializer_token.ts
+++ b/packages/core/src/di/initializer_token.ts
@@ -14,4 +14,5 @@ import {InjectionToken} from './injection_token';
  *
  * @publicApi
  */
-export const ENVIRONMENT_INITIALIZER = new InjectionToken<() => void>('ENVIRONMENT_INITIALIZER');
+export const ENVIRONMENT_INITIALIZER =
+    new InjectionToken<ReadonlyArray<() => void>>('ENVIRONMENT_INITIALIZER');

--- a/packages/core/src/di/internal_tokens.ts
+++ b/packages/core/src/di/internal_tokens.ts
@@ -10,4 +10,5 @@ import {Type} from '../interface/type';
 
 import {InjectionToken} from './injection_token';
 
-export const INJECTOR_DEF_TYPES = new InjectionToken<Type<unknown>>('INJECTOR_DEF_TYPES');
+export const INJECTOR_DEF_TYPES =
+    new InjectionToken<ReadonlyArray<Type<unknown>>>('INJECTOR_DEF_TYPES');

--- a/packages/core/src/di/r3_injector.ts
+++ b/packages/core/src/di/r3_injector.ts
@@ -180,8 +180,7 @@ export class R3Injector extends EnvironmentInjector {
       this.scopes.add(record.value as InjectorScope);
     }
 
-    this.injectorDefTypes =
-        new Set(this.get(INJECTOR_DEF_TYPES.multi, EMPTY_ARRAY, InjectFlags.Self));
+    this.injectorDefTypes = new Set(this.get(INJECTOR_DEF_TYPES, EMPTY_ARRAY, InjectFlags.Self));
   }
 
   /**
@@ -324,7 +323,7 @@ export class R3Injector extends EnvironmentInjector {
     }
 
     try {
-      const initializers = this.get(ENVIRONMENT_INITIALIZER.multi, EMPTY_ARRAY, InjectFlags.Self);
+      const initializers = this.get(ENVIRONMENT_INITIALIZER, EMPTY_ARRAY, InjectFlags.Self);
       if (ngDevMode && !Array.isArray(initializers)) {
         throw new RuntimeError(
             RuntimeErrorCode.INVALID_MULTI_PROVIDER,


### PR DESCRIPTION
We enabled a lint rule internally to require that multi-provided `InjectionToken`s have a `readonly` array type, the tokens in this PR do not follow this rule and are causing lint violations.

Fixes #51124

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Some InjectionTokens have Array types and not ReadonlyArray types

Issue Number: 51124


## What is the new behavior?

InjectionTokens have the ReadonlyArray type

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

TGP passes internally: https://fusion2.corp.google.com/presubmit/557584282/OCL:557584282:BASE:557580613:1692245296757:4bb18ab5;groups=AlreadyFailing/targets