### PR TITLE
refactor(core): deprecate `ANIMATION_MODULE_TYPE`  export from core

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -50,7 +50,7 @@ export interface AfterViewInit {
     ngAfterViewInit(): void;
 }
 
-// @public
+// @public @deprecated
 export const ANIMATION_MODULE_TYPE: InjectionToken<"NoopAnimations" | "BrowserAnimations">;
 
 // @public

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -79,6 +79,7 @@ export const PACKAGE_ROOT_URL = new InjectionToken<string>('Application Packages
  * A [DI token](guide/glossary#di-token "DI token definition") that indicates which animations
  * module has been loaded.
  * @publicApi
+ * @deprecated Use the export from `@angular/platform-browser/animations`
  */
 export const ANIMATION_MODULE_TYPE =
     new InjectionToken<'NoopAnimations'|'BrowserAnimations'>('AnimationModuleType');

--- a/packages/core/src/linker/destroy_ref.ts
+++ b/packages/core/src/linker/destroy_ref.ts
@@ -70,3 +70,17 @@ class NodeInjectorDestroyRef extends DestroyRef {
 function injectDestroyRef(): DestroyRef {
   return new NodeInjectorDestroyRef(getLView());
 }
+
+/**
+ * Destroy implementation where the destroy callback will be called explicitly by calling destroyFn.
+ */
+export class CallableDestroyRef extends DestroyRef {
+  destroyFn: (() => unknown)|undefined;
+
+  override onDestroy(callback: () => void): () => void {
+    this.destroyFn = callback;
+    return () => {
+      this.destroyFn = undefined;
+    };
+  }
+}

--- a/packages/platform-browser/animations/src/animations.ts
+++ b/packages/platform-browser/animations/src/animations.ts
@@ -11,7 +11,14 @@
  * @description
  * Entry point for all animation APIs of the animation browser package.
  */
-export {ANIMATION_MODULE_TYPE} from '@angular/core';
+
+/**
+ * Doing this no mark the re-export as deprecated
+ */
+import {ANIMATION_MODULE_TYPE } from '@angular/core';
+const _ANIMATION_MODULE_TYPE = ANIMATION_MODULE_TYPE;
+
+export {_ANIMATION_MODULE_TYPE as ANIMATION_MODULE_TYPE};
 export {BrowserAnimationsModule, BrowserAnimationsModuleConfig, NoopAnimationsModule, provideAnimations, provideNoopAnimations} from './module';
 
 export * from './private_export';

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -9,11 +9,12 @@
 import {AnimationBuilder} from '@angular/animations';
 import {AnimationDriver, ɵAnimationEngine as AnimationEngine, ɵAnimationStyleNormalizer as AnimationStyleNormalizer, ɵNoopAnimationDriver as NoopAnimationDriver, ɵWebAnimationsDriver as WebAnimationsDriver, ɵWebAnimationsStyleNormalizer as WebAnimationsStyleNormalizer} from '@angular/animations/browser';
 import {DOCUMENT} from '@angular/common';
-import {ANIMATION_MODULE_TYPE, ApplicationRef, Inject, Injectable, NgZone, OnDestroy, Provider, RendererFactory2} from '@angular/core';
+import {ApplicationRef, Inject, Injectable, NgZone, OnDestroy, Provider, RendererFactory2} from '@angular/core';
 import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-browser';
 
 import {BrowserAnimationBuilder} from './animation_builder';
 import {AnimationRendererFactory} from './animation_renderer';
+import {ANIMATION_MODULE_TYPE} from './animations';
 
 @Injectable()
 export class InjectableAnimationEngine extends AnimationEngine implements OnDestroy {

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -8,7 +8,7 @@
 
 import {animate, style, transition, trigger} from '@angular/animations';
 import {DOCUMENT, isPlatformBrowser, ɵgetDOM as getDOM} from '@angular/common';
-import {ANIMATION_MODULE_TYPE, APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, importProvidersFrom, Inject, inject as _inject, InjectionToken, Injector, LOCALE_ID, NgModule, NgModuleRef, NgZone, OnDestroy, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Testability, TestabilityRegistry, TransferState, Type, VERSION} from '@angular/core';
+import {APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, importProvidersFrom, Inject, inject as _inject, InjectionToken, Injector, LOCALE_ID, NgModule, NgModuleRef, NgZone, OnDestroy, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Testability, TestabilityRegistry, TransferState, Type, VERSION} from '@angular/core';
 import {ApplicationRef, destroyPlatform, provideZoneChangeDetection} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
@@ -16,7 +16,7 @@ import {inject, TestBed} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
-import {provideAnimations, provideNoopAnimations} from '@angular/platform-browser/animations';
+import {provideAnimations, provideNoopAnimations, ANIMATION_MODULE_TYPE} from '@angular/platform-browser/animations';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {bootstrapApplication} from '../../src/browser';


### PR DESCRIPTION
DEPRECATED: ANIMATION_MODULE_TYPE

`ANIMATION_MODULE_TYPE` was both exported by core and platform-browser/animations. With this commit with deprecate the export from core and keep the other. 