### PR TITLE
refactor(core): deprecate `ANIMATION_MODULE_TYPE`  export from core

### DIFF
--- a/goldens/public-api/core/index.md
+++ b/goldens/public-api/core/index.md
@@ -50,7 +50,7 @@ export interface AfterViewInit {
     ngAfterViewInit(): void;
 }
 
-// @public
+// @public @deprecated
 export const ANIMATION_MODULE_TYPE: InjectionToken<"NoopAnimations" | "BrowserAnimations">;
 
 // @public

--- a/goldens/public-api/platform-browser/animations/index.md
+++ b/goldens/public-api/platform-browser/animations/index.md
@@ -4,13 +4,14 @@
 
 ```ts
 
-import { ANIMATION_MODULE_TYPE } from '@angular/core';
 import * as i0 from '@angular/core';
 import * as i1 from '@angular/platform-browser';
+import { InjectionToken } from '@angular/core';
 import { ModuleWithProviders } from '@angular/core';
 import { Provider } from '@angular/core';
 
-export { ANIMATION_MODULE_TYPE }
+// @public (undocumented)
+export const ANIMATION_MODULE_TYPE: InjectionToken<"NoopAnimations" | "BrowserAnimations">;
 
 // @public
 export class BrowserAnimationsModule {

--- a/packages/core/src/application_tokens.ts
+++ b/packages/core/src/application_tokens.ts
@@ -79,6 +79,7 @@ export const PACKAGE_ROOT_URL = new InjectionToken<string>('Application Packages
  * A [DI token](guide/glossary#di-token "DI token definition") that indicates which animations
  * module has been loaded.
  * @publicApi
+ * @deprecated Use the export from `@angular/platform-browser/animations`
  */
 export const ANIMATION_MODULE_TYPE =
     new InjectionToken<'NoopAnimations'|'BrowserAnimations'>('AnimationModuleType');

--- a/packages/platform-browser/animations/src/animations.ts
+++ b/packages/platform-browser/animations/src/animations.ts
@@ -11,7 +11,16 @@
  * @description
  * Entry point for all animation APIs of the animation browser package.
  */
-export {ANIMATION_MODULE_TYPE} from '@angular/core';
+
+/**
+ * Doing this to discard the @deprecated annotation from core
+ * TODO: Move the definition of ANIMATION_MODULE_TYPE inside the package
+ * once the definition has been removed from core
+ */
+import {ANIMATION_MODULE_TYPE} from '@angular/core';
+const _ANIMATION_MODULE_TYPE = ANIMATION_MODULE_TYPE;
+
+export {_ANIMATION_MODULE_TYPE as ANIMATION_MODULE_TYPE};
 export {BrowserAnimationsModule, BrowserAnimationsModuleConfig, NoopAnimationsModule, provideAnimations, provideNoopAnimations} from './module';
 
 export * from './private_export';

--- a/packages/platform-browser/animations/src/providers.ts
+++ b/packages/platform-browser/animations/src/providers.ts
@@ -15,6 +15,9 @@ import {ɵDomRendererFactory2 as DomRendererFactory2} from '@angular/platform-br
 import {BrowserAnimationBuilder} from './animation_builder';
 import {AnimationRendererFactory} from './animation_renderer';
 
+// NOTE: ANIMATION_MODULE_TYPE cannot be imported from ./animations because of a circularity
+// Once ANIMATION_MODULE_TYPE has been removed from core, it can be moved here
+
 @Injectable()
 export class InjectableAnimationEngine extends AnimationEngine implements OnDestroy {
   // The `ApplicationRef` is injected here explicitly to force the dependency ordering.

--- a/packages/platform-browser/test/browser/bootstrap_spec.ts
+++ b/packages/platform-browser/test/browser/bootstrap_spec.ts
@@ -8,7 +8,7 @@
 
 import {animate, style, transition, trigger} from '@angular/animations';
 import {DOCUMENT, isPlatformBrowser, ɵgetDOM as getDOM} from '@angular/common';
-import {ANIMATION_MODULE_TYPE, APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, importProvidersFrom, Inject, inject as _inject, InjectionToken, Injector, LOCALE_ID, NgModule, NgModuleRef, NgZone, OnDestroy, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Testability, TestabilityRegistry, TransferState, Type, VERSION} from '@angular/core';
+import {APP_INITIALIZER, Compiler, Component, createPlatformFactory, CUSTOM_ELEMENTS_SCHEMA, Directive, ErrorHandler, importProvidersFrom, Inject, inject as _inject, InjectionToken, Injector, LOCALE_ID, NgModule, NgModuleRef, NgZone, OnDestroy, PLATFORM_ID, PLATFORM_INITIALIZER, Provider, Sanitizer, StaticProvider, Testability, TestabilityRegistry, TransferState, Type, VERSION} from '@angular/core';
 import {ApplicationRef, destroyPlatform, provideZoneChangeDetection} from '@angular/core/src/application_ref';
 import {Console} from '@angular/core/src/console';
 import {ComponentRef} from '@angular/core/src/linker/component_factory';
@@ -16,7 +16,7 @@ import {inject, TestBed} from '@angular/core/testing';
 import {Log} from '@angular/core/testing/src/testing_internal';
 import {BrowserModule} from '@angular/platform-browser';
 import {platformBrowserDynamic} from '@angular/platform-browser-dynamic';
-import {provideAnimations, provideNoopAnimations} from '@angular/platform-browser/animations';
+import {ANIMATION_MODULE_TYPE, provideAnimations, provideNoopAnimations} from '@angular/platform-browser/animations';
 import {expect} from '@angular/platform-browser/testing/src/matchers';
 
 import {bootstrapApplication} from '../../src/browser';


### PR DESCRIPTION
DEPRECATED: ANIMATION_MODULE_TYPE

`ANIMATION_MODULE_TYPE` was exported by both `core` and `platform-browser/animations`. With this commit we deprecate the export from core and keep the other.