### PR TITLE
refactor(platform-browser): remove unused `ɵgetDOM` re-export

### DIFF
--- a/packages/platform-browser/src/private_export.ts
+++ b/packages/platform-browser/src/private_export.ts
@@ -6,7 +6,6 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-export {ɵgetDOM} from '@angular/common';
 export {initDomAdapter as ɵinitDomAdapter, INTERNAL_BROWSER_PLATFORM_PROVIDERS as ɵINTERNAL_BROWSER_PLATFORM_PROVIDERS} from './browser';
 export {BrowserDomAdapter as ɵBrowserDomAdapter} from './browser/browser_adapter';
 export {BrowserGetTestability as ɵBrowserGetTestability} from './browser/testability';


### PR DESCRIPTION
That re-export `ɵgetDOM` does not serve any purpose anymore.


## Does this PR introduce a breaking change?

- [x] No