### PR TITLE
fix(core): handle hydration of view containers that use component hosts as anchors

### DIFF
--- a/packages/core/src/render3/collect_native_nodes.ts
+++ b/packages/core/src/render3/collect_native_nodes.ts
@@ -8,16 +8,15 @@
 
 import {assertParentView} from './assert';
 import {icuContainerIterate} from './i18n/i18n_tree_shaking';
-import {CONTAINER_HEADER_OFFSET, NATIVE} from './interfaces/container';
+import {CONTAINER_HEADER_OFFSET, LContainer, NATIVE} from './interfaces/container';
 import {TIcuContainerNode, TNode, TNodeType} from './interfaces/node';
 import {RNode} from './interfaces/renderer_dom';
 import {isLContainer} from './interfaces/type_checks';
-import {DECLARATION_COMPONENT_VIEW, HOST, LView, T_HOST, TVIEW, TView} from './interfaces/view';
+import {DECLARATION_COMPONENT_VIEW, HOST, LView, TVIEW, TView} from './interfaces/view';
 import {assertTNodeType} from './node_assert';
 import {getProjectionNodes} from './node_manipulation';
 import {getLViewParent} from './util/view_traversal_utils';
 import {unwrapRNode} from './util/view_utils';
-
 
 
 export function collectNativeNodes(
@@ -38,30 +37,7 @@ export function collectNativeNodes(
     // ViewContainerRef). When we find a LContainer we need to descend into it to collect root nodes
     // from the views in this container.
     if (isLContainer(lNode)) {
-      for (let i = CONTAINER_HEADER_OFFSET; i < lNode.length; i++) {
-        const lViewInAContainer = lNode[i];
-        const lViewFirstChildTNode = lViewInAContainer[TVIEW].firstChild;
-        if (lViewFirstChildTNode !== null) {
-          collectNativeNodes(
-              lViewInAContainer[TVIEW], lViewInAContainer, lViewFirstChildTNode, result);
-        }
-      }
-
-      // When an LContainer is created, the anchor (comment) node is:
-      // - (1) either reused in case of an ElementContainer (<ng-container>)
-      // - (2) or a new comment node is created
-      // In the first case, the anchor comment node would be added to the final
-      // list by the code above (`result.push(unwrapRNode(lNode))`), but the second
-      // case requires extra handling: the anchor node needs to be added to the
-      // final list manually. See additional information in the `createAnchorNode`
-      // function in the `view_container_ref.ts`.
-      //
-      // In the first case, the same reference would be stored in the `NATIVE`
-      // and `HOST` slots in an LContainer. Otherwise, this is the second case and
-      // we should add an element to the final list.
-      if (lNode[NATIVE] !== lNode[HOST]) {
-        result.push(lNode[NATIVE]);
-      }
+      collectNativeNodesInLContainer(lNode, result);
     }
 
     const tNodeType = tNode.type;
@@ -87,4 +63,34 @@ export function collectNativeNodes(
   }
 
   return result;
+}
+
+/**
+ * Collects all root nodes in all views in a given LContainer.
+ */
+export function collectNativeNodesInLContainer(lContainer: LContainer, result: any[]) {
+  for (let i = CONTAINER_HEADER_OFFSET; i < lContainer.length; i++) {
+    const lViewInAContainer = lContainer[i];
+    const lViewFirstChildTNode = lViewInAContainer[TVIEW].firstChild;
+    if (lViewFirstChildTNode !== null) {
+      collectNativeNodes(lViewInAContainer[TVIEW], lViewInAContainer, lViewFirstChildTNode, result);
+    }
+  }
+
+  // When an LContainer is created, the anchor (comment) node is:
+  // - (1) either reused in case of an ElementContainer (<ng-container>)
+  // - (2) or a new comment node is created
+  // In the first case, the anchor comment node would be added to the final
+  // list by the code in the `collectNativeNodes` function
+  // (see the `result.push(unwrapRNode(lNode))` line), but the second
+  // case requires extra handling: the anchor node needs to be added to the
+  // final list manually. See additional information in the `createAnchorNode`
+  // function in the `view_container_ref.ts`.
+  //
+  // In the first case, the same reference would be stored in the `NATIVE`
+  // and `HOST` slots in an LContainer. Otherwise, this is the second case and
+  // we should add an element to the final list.
+  if (lContainer[NATIVE] !== lContainer[HOST]) {
+    result.push(lContainer[NATIVE]);
+  }
 }

--- a/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations-standalone/bundle.golden_symbols.json
@@ -717,6 +717,9 @@
     "name": "collectNativeNodes"
   },
   {
+    "name": "collectNativeNodesInLContainer"
+  },
+  {
     "name": "commitLViewConsumerIfHasProducers"
   },
   {

--- a/packages/core/test/bundling/animations/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/animations/bundle.golden_symbols.json
@@ -774,6 +774,9 @@
     "name": "collectNativeNodes"
   },
   {
+    "name": "collectNativeNodesInLContainer"
+  },
+  {
     "name": "commitLViewConsumerIfHasProducers"
   },
   {

--- a/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/cyclic_import/bundle.golden_symbols.json
@@ -588,6 +588,9 @@
     "name": "collectNativeNodes"
   },
   {
+    "name": "collectNativeNodesInLContainer"
+  },
+  {
     "name": "commitLViewConsumerIfHasProducers"
   },
   {

--- a/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_reactive/bundle.golden_symbols.json
@@ -786,6 +786,9 @@
     "name": "collectNativeNodes"
   },
   {
+    "name": "collectNativeNodesInLContainer"
+  },
+  {
     "name": "collectStylingFromDirectives"
   },
   {

--- a/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/forms_template_driven/bundle.golden_symbols.json
@@ -765,6 +765,9 @@
     "name": "collectNativeNodes"
   },
   {
+    "name": "collectNativeNodesInLContainer"
+  },
+  {
     "name": "collectStylingFromDirectives"
   },
   {

--- a/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hello_world/bundle.golden_symbols.json
@@ -453,6 +453,9 @@
     "name": "collectNativeNodes"
   },
   {
+    "name": "collectNativeNodesInLContainer"
+  },
+  {
     "name": "commitLViewConsumerIfHasProducers"
   },
   {

--- a/packages/core/test/bundling/hydration/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/hydration/bundle.golden_symbols.json
@@ -648,6 +648,9 @@
     "name": "collectNativeNodes"
   },
   {
+    "name": "collectNativeNodesInLContainer"
+  },
+  {
     "name": "commitLViewConsumerIfHasProducers"
   },
   {

--- a/packages/core/test/bundling/router/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/router/bundle.golden_symbols.json
@@ -942,6 +942,9 @@
     "name": "collectNativeNodes"
   },
   {
+    "name": "collectNativeNodesInLContainer"
+  },
+  {
     "name": "collectQueryResults"
   },
   {

--- a/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/standalone_bootstrap/bundle.golden_symbols.json
@@ -531,6 +531,9 @@
     "name": "collectNativeNodes"
   },
   {
+    "name": "collectNativeNodesInLContainer"
+  },
+  {
     "name": "commitLViewConsumerIfHasProducers"
   },
   {

--- a/packages/core/test/bundling/todo/bundle.golden_symbols.json
+++ b/packages/core/test/bundling/todo/bundle.golden_symbols.json
@@ -687,6 +687,9 @@
     "name": "collectNativeNodes"
   },
   {
+    "name": "collectNativeNodesInLContainer"
+  },
+  {
     "name": "collectStylingFromDirectives"
   },
   {


### PR DESCRIPTION
This commit fixes an issue where serialization of a view container fails in case it uses a component host as an anchor. This fix is similar to the fix from #51247, but for cases when we insert a component (that acts as a host for a view container) deeper in a hierarchy.

Resolves #51318.


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No