### PR TITLE
ci: correctly check aio job results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
 
   aio-deploy:
     needs: [aio]
-    if: needs.aio.result == success() && github.event_name == 'push'
+    if: needs.aio.result == 'success' && github.event_name == 'push'
     runs-on:
       labels: ubuntu-latest
     steps:


### PR DESCRIPTION
Correctly check the aio job result to determine if we should deploy.
