### PR TITLE
fix(compiler): handle ambient types in input transform function

### DIFF
--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -13,7 +13,7 @@ import {ErrorCode, FatalDiagnosticError, makeRelatedInformation} from '../../../
 import {assertSuccessfulReferenceEmit, ImportFlags, Reference, ReferenceEmitter} from '../../../imports';
 import {ClassPropertyMapping, HostDirectiveMeta, InputMapping, InputTransform} from '../../../metadata';
 import {DynamicValue, EnumValue, PartialEvaluator, ResolvedValue, traceDynamicValue} from '../../../partial_evaluator';
-import {ClassDeclaration, ClassMember, ClassMemberKind, Decorator, filterToMembersWithDecorator, isNamedClassDeclaration, ReflectionHost, reflectObjectLiteral} from '../../../reflection';
+import {AmbientImport, ClassDeclaration, ClassMember, ClassMemberKind, Decorator, filterToMembersWithDecorator, isNamedClassDeclaration, ReflectionHost, reflectObjectLiteral} from '../../../reflection';
 import {CompilationMode} from '../../../transform';
 import {createSourceSpan, createValueHasWrongTypeError, forwardRefResolver, getConstructorDependencies, ReferencesRegistry, toR3Reference, tryUnwrapForwardRef, unwrapConstructorDependencies, unwrapExpression, validateConstructorDependencies, wrapFunctionExpressionsInParens, wrapTypeReference,} from '../../common';
 
@@ -819,7 +819,8 @@ function assertEmittableInputType(
         // exported, otherwise TS won't emit it to the .d.ts.
         if (declaration.node.getSourceFile() !== contextFile) {
           const emittedType = refEmitter.emit(
-              new Reference(declaration.node, null, declaration.isAmbient), contextFile,
+              new Reference(declaration.node, null, declaration.viaModule === AmbientImport),
+              contextFile,
               ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
                   ImportFlags.AllowRelativeDtsImports | ImportFlags.AllowAmbientReferences);
 

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -819,9 +819,9 @@ function assertEmittableInputType(
         // exported, otherwise TS won't emit it to the .d.ts.
         if (declaration.node.getSourceFile() !== contextFile) {
           const emittedType = refEmitter.emit(
-              new Reference(declaration.node), contextFile,
+              new Reference(declaration.node, null, declaration.isAmbient), contextFile,
               ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
-                  ImportFlags.AllowRelativeDtsImports);
+                  ImportFlags.AllowRelativeDtsImports | ImportFlags.AllowAmbientReferences);
 
           assertSuccessfulReferenceEmit(emittedType, node, 'type');
         } else if (!reflector.isStaticallyExported(declaration.node)) {

--- a/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
+++ b/packages/compiler-cli/src/ngtsc/annotations/directive/src/shared.ts
@@ -819,7 +819,8 @@ function assertEmittableInputType(
         // exported, otherwise TS won't emit it to the .d.ts.
         if (declaration.node.getSourceFile() !== contextFile) {
           const emittedType = refEmitter.emit(
-              new Reference(declaration.node, null, declaration.viaModule === AmbientImport),
+              new Reference(
+                  declaration.node, declaration.viaModule === AmbientImport ? AmbientImport : null),
               contextFile,
               ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
                   ImportFlags.AllowRelativeDtsImports | ImportFlags.AllowAmbientReferences);

--- a/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/emitter.ts
@@ -236,11 +236,16 @@ export class LocalIdentifierStrategy implements ReferenceEmitStrategy {
 
     // If the reference is to an ambient type, it can be referenced directly.
     if (ref.isAmbient && importFlags & ImportFlags.AllowAmbientReferences) {
-      return {
-        kind: ReferenceEmitKind.Success,
-        expression: new WrappedNodeExpr(identifierOfNode(ref.node)),
-        importedFile: null,
-      };
+      const identifier = identifierOfNode(ref.node);
+      if (identifier !== null) {
+        return {
+          kind: ReferenceEmitKind.Success,
+          expression: new WrappedNodeExpr(identifier),
+          importedFile: null,
+        };
+      } else {
+        return null;
+      }
     }
 
     // A Reference can have multiple identities in different files, so it may already have an

--- a/packages/compiler-cli/src/ngtsc/imports/src/references.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/references.ts
@@ -54,7 +54,9 @@ export class Reference<T extends ts.Node = ts.Node> {
 
   private _alias: Expression|null = null;
 
-  constructor(readonly node: T, bestGuessOwningModule: OwningModule|null = null) {
+  constructor(
+      readonly node: T, bestGuessOwningModule: OwningModule|null = null,
+      readonly isAmbient = false) {
     this.bestGuessOwningModule = bestGuessOwningModule;
 
     const id = identifierOfNode(node);
@@ -160,14 +162,14 @@ export class Reference<T extends ts.Node = ts.Node> {
   }
 
   cloneWithAlias(alias: Expression): Reference<T> {
-    const ref = new Reference(this.node, this.bestGuessOwningModule);
+    const ref = new Reference(this.node, this.bestGuessOwningModule, this.isAmbient);
     ref.identifiers = [...this.identifiers];
     ref._alias = alias;
     return ref;
   }
 
   cloneWithNoIdentifiers(): Reference<T> {
-    const ref = new Reference(this.node, this.bestGuessOwningModule);
+    const ref = new Reference(this.node, this.bestGuessOwningModule, this.isAmbient);
     ref._alias = this._alias;
     ref.identifiers = [];
     return ref;

--- a/packages/compiler-cli/src/ngtsc/imports/src/references.ts
+++ b/packages/compiler-cli/src/ngtsc/imports/src/references.ts
@@ -9,6 +9,7 @@
 import {Expression} from '@angular/compiler';
 import ts from 'typescript';
 
+import {AmbientImport} from '../../reflection';
 import {identifierOfNode} from '../../util/src/typescript';
 
 export interface OwningModule {
@@ -54,10 +55,16 @@ export class Reference<T extends ts.Node = ts.Node> {
 
   private _alias: Expression|null = null;
 
-  constructor(
-      readonly node: T, bestGuessOwningModule: OwningModule|null = null,
-      readonly isAmbient = false) {
-    this.bestGuessOwningModule = bestGuessOwningModule;
+  readonly isAmbient: boolean;
+
+  constructor(readonly node: T, bestGuessOwningModule: OwningModule|AmbientImport|null = null) {
+    if (bestGuessOwningModule === AmbientImport) {
+      this.isAmbient = true;
+      this.bestGuessOwningModule = null;
+    } else {
+      this.isAmbient = false;
+      this.bestGuessOwningModule = bestGuessOwningModule as OwningModule | null;
+    }
 
     const id = identifierOfNode(node);
     if (id !== null) {
@@ -162,14 +169,16 @@ export class Reference<T extends ts.Node = ts.Node> {
   }
 
   cloneWithAlias(alias: Expression): Reference<T> {
-    const ref = new Reference(this.node, this.bestGuessOwningModule, this.isAmbient);
+    const ref =
+        new Reference(this.node, this.isAmbient ? AmbientImport : this.bestGuessOwningModule);
     ref.identifiers = [...this.identifiers];
     ref._alias = alias;
     return ref;
   }
 
   cloneWithNoIdentifiers(): Reference<T> {
-    const ref = new Reference(this.node, this.bestGuessOwningModule, this.isAmbient);
+    const ref =
+        new Reference(this.node, this.isAmbient ? AmbientImport : this.bestGuessOwningModule);
     ref._alias = this._alias;
     ref.identifiers = [];
     return ref;

--- a/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
+++ b/packages/compiler-cli/src/ngtsc/partial_evaluator/src/interpreter.ts
@@ -739,7 +739,7 @@ function joinModuleContext(existing: Context, node: ts.Node, decl: Declaration):
   absoluteModuleName?: string,
   resolutionContext?: string,
 } {
-  if (decl.viaModule !== null && decl.viaModule !== existing.absoluteModuleName) {
+  if (typeof decl.viaModule === 'string' && decl.viaModule !== existing.absoluteModuleName) {
     return {
       absoluteModuleName: decl.viaModule,
       resolutionContext: node.getSourceFile().fileName,

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -495,6 +495,11 @@ export interface Declaration<T extends ts.Declaration = ts.Declaration> {
    * TypeScript reference to the declaration itself, if one exists.
    */
   node: T;
+
+  /**
+   * Whether the node is a reference to an ambient type.
+   */
+  isAmbient: boolean;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/host.ts
@@ -479,6 +479,13 @@ export interface Import {
  */
 export type DeclarationNode = ts.Declaration;
 
+export type AmbientImport = {
+  __brand: 'AmbientImport'
+};
+
+/** Indicates that a declaration is referenced through an ambient type. */
+export const AmbientImport = {} as AmbientImport;
+
 /**
  * The declaration of a symbol, along with information about how it was imported into the
  * application.
@@ -489,17 +496,12 @@ export interface Declaration<T extends ts.Declaration = ts.Declaration> {
    * was imported via an absolute module (even through a chain of re-exports). If the symbol is part
    * of the application and was not imported from an absolute path, this will be `null`.
    */
-  viaModule: string|null;
+  viaModule: string|AmbientImport|null;
 
   /**
    * TypeScript reference to the declaration itself, if one exists.
    */
   node: T;
-
-  /**
-   * Whether the node is a reference to an ambient type.
-   */
-  isAmbient: boolean;
 }
 
 /**

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -8,7 +8,7 @@
 
 import ts from 'typescript';
 
-import {ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, DeclarationNode, Decorator, FunctionDefinition, Import, isDecoratorIdentifier, ReflectionHost} from './host';
+import {AmbientImport, ClassDeclaration, ClassMember, ClassMemberKind, CtorParameter, Declaration, DeclarationNode, Decorator, FunctionDefinition, Import, isDecoratorIdentifier, ReflectionHost} from './host';
 import {typeToValue} from './type_to_value';
 import {isNamedClassDeclaration} from './util';
 
@@ -339,10 +339,6 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     }
 
     const importInfo = originalId && this.getImportOfIdentifier(originalId);
-    const viaModule =
-        importInfo !== null && importInfo.from !== null && !importInfo.from.startsWith('.') ?
-        importInfo.from :
-        null;
 
     // Now, resolve the Symbol to its declaration by following any and all aliases.
     while (symbol.flags & ts.SymbolFlags.Alias) {
@@ -354,14 +350,12 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     if (symbol.valueDeclaration !== undefined) {
       return {
         node: symbol.valueDeclaration,
-        viaModule,
-        isAmbient: this._isAmbient(symbol.valueDeclaration, originalId, importInfo)
+        viaModule: this._viaModule(symbol.valueDeclaration, originalId, importInfo),
       };
     } else if (symbol.declarations !== undefined && symbol.declarations.length > 0) {
       return {
         node: symbol.declarations[0],
-        viaModule,
-        isAmbient: this._isAmbient(symbol.declarations[0], originalId, importInfo)
+        viaModule: this._viaModule(symbol.declarations[0], originalId, importInfo),
       };
     } else {
       return null;
@@ -500,11 +494,17 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     return exportSet;
   }
 
-  private _isAmbient(
-      declaration: ts.Declaration, originalId: ts.Identifier|null,
-      importInfo: Import|null): boolean {
-    return importInfo === null && originalId !== null &&
-        declaration.getSourceFile() !== originalId.getSourceFile();
+  private _viaModule(
+      declaration: ts.Declaration, originalId: ts.Identifier|null, importInfo: Import|null): string
+      |AmbientImport|null {
+    if (importInfo === null && originalId !== null &&
+        declaration.getSourceFile() !== originalId.getSourceFile()) {
+      return AmbientImport;
+    }
+
+    return importInfo !== null && importInfo.from !== null && !importInfo.from.startsWith('.') ?
+        importInfo.from :
+        null;
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/src/typescript.ts
@@ -355,11 +355,13 @@ export class TypeScriptReflectionHost implements ReflectionHost {
       return {
         node: symbol.valueDeclaration,
         viaModule,
+        isAmbient: this._isAmbient(symbol.valueDeclaration, originalId, importInfo)
       };
     } else if (symbol.declarations !== undefined && symbol.declarations.length > 0) {
       return {
         node: symbol.declarations[0],
         viaModule,
+        isAmbient: this._isAmbient(symbol.declarations[0], originalId, importInfo)
       };
     } else {
       return null;
@@ -496,6 +498,13 @@ export class TypeScriptReflectionHost implements ReflectionHost {
     }
 
     return exportSet;
+  }
+
+  private _isAmbient(
+      declaration: ts.Declaration, originalId: ts.Identifier|null,
+      importInfo: Import|null): boolean {
+    return importInfo === null && originalId !== null &&
+        declaration.getSourceFile() !== originalId.getSourceFile();
   }
 }
 

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -407,7 +407,6 @@ runInEachFileSystem(() => {
         expect(decl).toEqual({
           node: targetDecl,
           viaModule: 'absolute',
-          isAmbient: false,
         });
       });
 
@@ -437,7 +436,6 @@ runInEachFileSystem(() => {
         expect(decl).toEqual({
           node: targetDecl,
           viaModule: 'absolute',
-          isAmbient: false,
         });
       });
     });

--- a/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
+++ b/packages/compiler-cli/src/ngtsc/reflection/test/ts_host_spec.ts
@@ -407,6 +407,7 @@ runInEachFileSystem(() => {
         expect(decl).toEqual({
           node: targetDecl,
           viaModule: 'absolute',
+          isAmbient: false,
         });
       });
 
@@ -436,6 +437,7 @@ runInEachFileSystem(() => {
         expect(decl).toEqual({
           node: targetDecl,
           viaModule: 'absolute',
+          isAmbient: false,
         });
       });
     });

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -278,8 +278,8 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
       };
     }
 
-    const reference =
-        new Reference(declaration.node, owningModule, declaration.viaModule === AmbientImport);
+    const reference = new Reference(
+        declaration.node, declaration.viaModule === AmbientImport ? AmbientImport : owningModule);
     const emittedType = this.refEmitter.emit(
         reference, this.contextFile,
         ImportFlags.NoAliasing | ImportFlags.AllowTypeImports | ImportFlags.AllowAmbientReferences);

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -278,9 +278,10 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
       };
     }
 
-    const reference = new Reference(declaration.node, owningModule);
+    const reference = new Reference(declaration.node, owningModule, declaration.isAmbient);
     const emittedType = this.refEmitter.emit(
-        reference, this.contextFile, ImportFlags.NoAliasing | ImportFlags.AllowTypeImports);
+        reference, this.contextFile,
+        ImportFlags.NoAliasing | ImportFlags.AllowTypeImports | ImportFlags.AllowAmbientReferences);
 
     assertSuccessfulReferenceEmit(emittedType, target, 'type');
 

--- a/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
+++ b/packages/compiler-cli/src/ngtsc/translator/src/type_translator.ts
@@ -10,7 +10,7 @@ import * as o from '@angular/compiler';
 import ts from 'typescript';
 
 import {assertSuccessfulReferenceEmit, ImportFlags, OwningModule, Reference, ReferenceEmitter} from '../../imports';
-import {ReflectionHost} from '../../reflection';
+import {AmbientImport, ReflectionHost} from '../../reflection';
 
 import {Context} from './context';
 import {ImportManager} from './import_manager';
@@ -271,14 +271,15 @@ class TypeTranslatorVisitor implements o.ExpressionVisitor, o.TypeVisitor {
     }
 
     let owningModule = viaModule;
-    if (declaration.viaModule !== null) {
+    if (typeof declaration.viaModule === 'string') {
       owningModule = {
         specifier: declaration.viaModule,
         resolutionContext: type.getSourceFile().fileName,
       };
     }
 
-    const reference = new Reference(declaration.node, owningModule, declaration.isAmbient);
+    const reference =
+        new Reference(declaration.node, owningModule, declaration.viaModule === AmbientImport);
     const emittedType = this.refEmitter.emit(
         reference, this.contextFile,
         ImportFlags.NoAliasing | ImportFlags.AllowTypeImports | ImportFlags.AllowAmbientReferences);

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/environment.ts
@@ -126,11 +126,11 @@ export class Environment implements ReferenceEmitEnvironment {
     return translateExpression(ngExpr.expression, this.importManager);
   }
 
-  canReferenceType(ref: Reference): boolean {
-    const result = this.refEmitter.emit(
-        ref, this.contextFile,
-        ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
-            ImportFlags.AllowRelativeDtsImports);
+  canReferenceType(
+      ref: Reference,
+      flags: ImportFlags = ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
+          ImportFlags.AllowRelativeDtsImports): boolean {
+    const result = this.refEmitter.emit(ref, this.contextFile, flags);
     return result.kind === ReferenceEmitKind.Success;
   }
 
@@ -139,11 +139,11 @@ export class Environment implements ReferenceEmitEnvironment {
    *
    * This may involve importing the node into the file if it's not declared there already.
    */
-  referenceType(ref: Reference): ts.TypeNode {
-    const ngExpr = this.refEmitter.emit(
-        ref, this.contextFile,
-        ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
-            ImportFlags.AllowRelativeDtsImports);
+  referenceType(
+      ref: Reference,
+      flags: ImportFlags = ImportFlags.NoAliasing | ImportFlags.AllowTypeImports |
+          ImportFlags.AllowRelativeDtsImports): ts.TypeNode {
+    const ngExpr = this.refEmitter.emit(ref, this.contextFile, flags);
     assertSuccessfulReferenceEmit(ngExpr, this.contextFile, 'symbol');
 
     // Create an `ExpressionType` from the `Expression` and translate it via `translateType`.

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
@@ -8,7 +8,7 @@
 import ts from 'typescript';
 
 import {OwningModule, Reference} from '../../imports';
-import {DeclarationNode, ReflectionHost} from '../../reflection';
+import {AmbientImport, DeclarationNode, ReflectionHost} from '../../reflection';
 import {canEmitType, TypeEmitter} from '../../translator';
 
 /**
@@ -93,14 +93,14 @@ export class TypeParameterEmitter {
     }
 
     let owningModule: OwningModule|null = null;
-    if (declaration.viaModule !== null) {
+    if (typeof declaration.viaModule === 'string') {
       owningModule = {
         specifier: declaration.viaModule,
         resolutionContext: type.getSourceFile().fileName,
       };
     }
 
-    return new Reference(declaration.node, owningModule, declaration.isAmbient);
+    return new Reference(declaration.node, owningModule, declaration.viaModule === AmbientImport);
   }
 
   private translateTypeReference(

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
@@ -100,7 +100,8 @@ export class TypeParameterEmitter {
       };
     }
 
-    return new Reference(declaration.node, owningModule, declaration.viaModule === AmbientImport);
+    return new Reference(
+        declaration.node, declaration.viaModule === AmbientImport ? AmbientImport : owningModule);
   }
 
   private translateTypeReference(

--- a/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
+++ b/packages/compiler-cli/src/ngtsc/typecheck/src/type_parameter_emitter.ts
@@ -100,7 +100,7 @@ export class TypeParameterEmitter {
       };
     }
 
-    return new Reference(declaration.node, owningModule);
+    return new Reference(declaration.node, owningModule, declaration.isAmbient);
   }
 
   private translateTypeReference(

--- a/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
+++ b/packages/compiler-cli/test/ngtsc/ngtsc_spec.ts
@@ -8863,6 +8863,35 @@ function allTests(os: string) {
             .toContain('features: [i0.ɵɵInputTransformsFeature, i0.ɵɵInheritDefinitionFeature]');
         expect(dtsContents).toContain('static ngAcceptInputType_value: boolean | string;');
       });
+
+      it('should compile an input with using an ambient type in the transform function', () => {
+        env.write('node_modules/external/index.d.ts', `
+          import {ElementRef} from '@angular/core';
+
+          export declare function coerceElement(value: HTMLElement | ElementRef<HTMLElement>): HTMLElement;
+        `);
+
+        env.write('/test.ts', `
+          import {Directive, Input, Component} from '@angular/core';
+          import {coerceElement} from 'external';
+
+          @Directive({standalone: true})
+          export class Dir {
+            @Input({transform: coerceElement}) element!: HTMLElement;
+          }
+        `);
+
+        env.driveMain();
+
+        const jsContents = env.getContents('test.js');
+        const dtsContents = env.getContents('test.d.ts');
+
+        expect(jsContents).toContain('inputs: { element: ["element", "element", coerceElement] }');
+        expect(jsContents).toContain('features: [i0.ɵɵInputTransformsFeature]');
+        expect(dtsContents)
+            .toContain(
+                'static ngAcceptInputType_element: HTMLElement | i0.ElementRef<HTMLElement>;');
+      });
     });
 
     describe('deferred blocks', () => {


### PR DESCRIPTION
Fixes that the compiler was throwing an error if an ambient type is used inside of an input `transform` function. The problem was that the reference emitter was trying to write a reference to the ambient type's source file which isn't necessary.

Fixes #51424.