### PR TITLE
build: include bazel build file in aio playground code

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -6,7 +6,6 @@
 node_modules
 dist
 aio/node_modules
-aio/content/example-playground
 aio/tools/examples/shared/node_modules
 aio/tools/examples/shared/example-scaffold
 

--- a/aio/content/examples/examples.bzl
+++ b/aio/content/examples/examples.bzl
@@ -131,7 +131,6 @@ def docs_example(name, test = True, test_tags = [], test_exec_properties = {}, f
     native.filegroup(
         name = "files",
         srcs = native.glob(["**"], exclude = [
-            "BUILD.bazel",
             "**/node_modules/**",  # Node modules may exist from the legacy setup.
         ]),
     )


### PR DESCRIPTION
Include the bazel build file in the aio playground code so it contains the same bazel targets as the regular examples.
