### PR TITLE
docs-infra: set meta description per page

### DIFF
--- a/aio/content/marketing/index.html
+++ b/aio/content/marketing/index.html
@@ -17,9 +17,9 @@
       </h1>
 
       <div class="cta-button-container">
-        <p class="cta-link">
+        <div class="cta-link">
           <a class="button hero-cta no-print" href="quick-start">Try Angular</a>
-        </p>
+        </div>
       </div>
 
     </div>

--- a/aio/src/testing/doc-viewer-utils.ts
+++ b/aio/src/testing/doc-viewer-utils.ts
@@ -21,7 +21,7 @@ export class TestDocViewerComponent extends DocViewerComponent {
   override nextViewContainer: HTMLElement;
 
   // Only used for type-casting; the actual implementation is irrelevant.
-  override prepareTitleAndToc(_targetElem: HTMLElement, _docId: string): () => void {
+  override prepareMetadataAndToc(_targetElem: HTMLElement, _docId: string): () => void {
     return null as any;
   }
 


### PR DESCRIPTION
aio currently uses the same `<meta name="Description">` content for every page. It seems like this might be causing a problem with search engine indexing such that different pages are being marked as duplicates of each other. It's unfortunately impossible to know whether this will actually fix the issue without it going live.