### PR TITLE
refactor(core): make deps tracker globally available

### DIFF
--- a/packages/core/src/render3/deps_tracker/deps_tracker.ts
+++ b/packages/core/src/render3/deps_tracker/deps_tracker.ts
@@ -10,6 +10,7 @@ import {resolveForwardRef} from '../../di';
 import {RuntimeError, RuntimeErrorCode} from '../../errors';
 import {Type} from '../../interface/type';
 import {NgModuleType} from '../../metadata/ng_module_def';
+import {global} from '../../util/global';
 import {getComponentDef, getNgModuleDef, isStandalone} from '../definition';
 import {ComponentType, NgModuleScopeInfoFromDecorator, RawScopeInfoFromDecorator} from '../interfaces/definition';
 import {isComponent, isDirective, isNgModule, isPipe, verifyStandaloneImport} from '../jit/util';
@@ -283,7 +284,15 @@ function addSet<T>(sourceSet: Set<T>, targetSet: Set<T>): void {
   }
 }
 
+/** Provides a singleton instance of deps tracker cross the whole app. */
+function getGlobalDepsTracker() {
+  const globalNg: {ɵdepsTracker?: DepsTracker} = global.ng || (global.ng = {});
+  globalNg.ɵdepsTracker = globalNg.ɵdepsTracker || new DepsTracker();
+
+  return globalNg.ɵdepsTracker;
+}
+
 /** The deps tracker to be used in the current Angular app in dev mode. */
-export const depsTracker = new DepsTracker();
+export const depsTracker = getGlobalDepsTracker();
 
 export const TEST_ONLY = {DepsTracker};


### PR DESCRIPTION
In some cases (e.g., aio tests) the file `dept_tracker.ts` might be loaded into browser multiple times (possibly due to presence in different chunks) and this leads to multiple copies of the deps tracker. But the dept tracker should be singleton. So we use `global` to achieve this.

This will effectively fix the local aio breakage in https://github.com/angular/angular/pull/51415

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
