### PR TITLE
ci: fix escaping for determing current stable version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - '[0-9]+.[0-9]+.x'
+      - 'correct-escaping'
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -168,7 +169,7 @@ jobs:
       - name: Set the stable branch environment variable
         id: latest_version
         run: |
-          echo "CI_STABLE_BRANCH=$(npm info @angular/core dist-tags.latest | sed -r 's/^\\s*([0-9]+\\.[0-9]+)\\.[0-9]+.*$/\\1.x/')" >> $GITHUB_OUTPUT
+          echo "CI_STABLE_BRANCH=$(npm info @angular/core dist-tags.latest | sed -r 's/^\s*([0-9]+\.[0-9]+)\.[0-9]+.*$/\1.x/')" >> $GITHUB_OUTPUT
           echo "CI_BRANCH=$(echo ${{ github.event.ref }} | cut -d '/' -f 3)" >> $GITHUB_OUTPUT
       - name: Deploy aio to production
         env:


### PR DESCRIPTION
Fix the escaping for the sed command determining the stable version
