### PR TITLE
Fix cross imports and avoid code duplication/singleton dependency tracking bugs

### DIFF
--- a/packages/animations/browser/src/private_export.ts
+++ b/packages/animations/browser/src/private_export.ts
@@ -10,7 +10,7 @@ export {AnimationStyleNormalizer as ɵAnimationStyleNormalizer, NoopAnimationSty
 export {WebAnimationsStyleNormalizer as ɵWebAnimationsStyleNormalizer} from './dsl/style_normalization/web_animations_style_normalizer';
 export {NoopAnimationDriver as ɵNoopAnimationDriver} from './render/animation_driver';
 export {AnimationEngine as ɵAnimationEngine} from './render/animation_engine_next';
-export {containsElement as ɵcontainsElement, getParentElement as ɵgetParentElement, invokeQuery as ɵinvokeQuery, validateStyleProperty as ɵvalidateStyleProperty} from './render/shared';
+export {containsElement as ɵcontainsElement, getParentElement as ɵgetParentElement, invokeQuery as ɵinvokeQuery, validateStyleProperty as ɵvalidateStyleProperty, validateWebAnimatableStyleProperty as ɵvalidateWebAnimatableStyleProperty} from './render/shared';
 export {WebAnimationsDriver as ɵWebAnimationsDriver} from './render/web_animations/web_animations_driver';
 export {WebAnimationsPlayer as ɵWebAnimationsPlayer} from './render/web_animations/web_animations_player';
-export {allowPreviousPlayerStylesMerge as ɵallowPreviousPlayerStylesMerge, normalizeKeyframes as ɵnormalizeKeyframes} from './util';
+export {allowPreviousPlayerStylesMerge as ɵallowPreviousPlayerStylesMerge, camelCaseToDashCase as ɵcamelCaseToDashCase, normalizeKeyframes as ɵnormalizeKeyframes} from './util';

--- a/packages/animations/browser/testing/src/mock_animation_driver.ts
+++ b/packages/animations/browser/testing/src/mock_animation_driver.ts
@@ -6,10 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {AnimationPlayer, AUTO_STYLE, NoopAnimationPlayer, ɵStyleDataMap} from '@angular/animations';
-import {AnimationDriver, ɵallowPreviousPlayerStylesMerge as allowPreviousPlayerStylesMerge, ɵcontainsElement as containsElement, ɵgetParentElement as getParentElement, ɵinvokeQuery as invokeQuery, ɵnormalizeKeyframes as normalizeKeyframes, ɵvalidateStyleProperty as validateStyleProperty,} from '@angular/animations/browser';
-
-import {validateWebAnimatableStyleProperty} from '../../src/render/shared';
-import {camelCaseToDashCase} from '../../src/util';
+import {AnimationDriver, ɵallowPreviousPlayerStylesMerge as allowPreviousPlayerStylesMerge, ɵcamelCaseToDashCase, ɵcontainsElement as containsElement, ɵgetParentElement as getParentElement, ɵinvokeQuery as invokeQuery, ɵnormalizeKeyframes as normalizeKeyframes, ɵvalidateStyleProperty as validateStyleProperty, ɵvalidateWebAnimatableStyleProperty} from '@angular/animations/browser';
 
 /**
  * @publicApi
@@ -22,8 +19,8 @@ export class MockAnimationDriver implements AnimationDriver {
   }
 
   validateAnimatableStyleProperty(prop: string): boolean {
-    const cssProp = camelCaseToDashCase(prop);
-    return validateWebAnimatableStyleProperty(cssProp);
+    const cssProp = ɵcamelCaseToDashCase(prop);
+    return ɵvalidateWebAnimatableStyleProperty(cssProp);
   }
 
   matchesElement(_element: any, _selector: string): boolean {

--- a/packages/bazel/src/ng_package/BUILD.bazel
+++ b/packages/bazel/src/ng_package/BUILD.bazel
@@ -14,15 +14,16 @@ ts_library(
     tsconfig = ":tsconfig.json",
     deps = [
         "@npm//@types/node",
+        "@npm//typescript",
     ],
 )
 
 filegroup(
     name = "package_assets",
     srcs = glob(["*.bzl"]) + [
-        "//packages/bazel/src/ng_package/rollup:package_assets",
         "BUILD.bazel",
         "rollup.config.js",
+        "//packages/bazel/src/ng_package/rollup:package_assets",
     ],
 )
 

--- a/packages/bazel/src/ng_package/api.ts
+++ b/packages/bazel/src/ng_package/api.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Interface describing a file captured in the Bazel action.
+ * https://docs.bazel.build/versions/main/skylark/lib/File.html.
+ */
+export interface BazelFileInfo {
+  /** Execroot-relative path pointing to the file. */
+  path: string;
+  /** The path of this file relative to its root. e.g. omitting `bazel-out/<..>/bin`. */
+  shortPath: string;
+}
+
+/** Interface describing an entry-point. */
+export interface EntryPointInfo {
+  /** ES2022 index file for the APF entry-point. */
+  index: BazelFileInfo;
+  /** Flat ES2022 ES module bundle file. */
+  fesm2022Bundle: BazelFileInfo;
+  /** Index type definition file for the APF entry-point. */
+  typings: BazelFileInfo;
+  /**
+   * Whether the index or typing paths have been guessed. For entry-points built
+   * through `ts_library`, there is no explicit setting that declares the entry-point
+   * so the index file is guessed.
+   */
+  guessedPaths: boolean;
+}
+
+/** Interface capturing relevant metadata for packaging. */
+export interface PackageMetadata {
+  /** NPM package name of the output. */
+  npmPackageName: string;
+  /** Record of entry-points (including the primary one) and their info. */
+  entryPoints: Record<string, EntryPointInfo>;
+}

--- a/packages/bazel/src/ng_package/cross_entry_points_imports.ts
+++ b/packages/bazel/src/ng_package/cross_entry_points_imports.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import ts from 'typescript';
+
+/** Interface describing an entry-point Bazel package. */
+interface EntryPointPackage {
+  /** Module name of the entry-point. */
+  name: string;
+  /** Execroot-relative path to the entry-point package. */
+  path: string;
+  /** Extracted info for the entry-point. */
+  info: EntryPointInfo;
+}
+
+import {BazelFileInfo, EntryPointInfo, PackageMetadata} from './api';
+
+/** Comment that can be used to skip a single import from being flagged. */
+const skipComment = '// @ng_package: ignore-cross-repo-import';
+
+/**
+ * Analyzes the given JavaScript source file and checks whether there are
+ * any relative imports that point to different entry-points or packages.
+ *
+ * Such imports are flagged and will be returned in the failure list. Cross
+ * entry-point or package imports result in duplicate code and therefore are
+ * forbidden (unless explicitly opted out via comment - {@link skipComment}).
+ */
+export function analyzeFileAndEnsureNoCrossImports(
+    file: BazelFileInfo, pkg: PackageMetadata): string[] {
+  const content = fs.readFileSync(file.path, 'utf8');
+  const sf = ts.createSourceFile(file.path, content, ts.ScriptTarget.Latest, true);
+  const fileDirPath = path.posix.dirname(file.path);
+  const fileDebugName = file.shortPath.replace(/\.[cm]js$/, '.ts');
+  const failures: string[] = [];
+
+  const owningPkg = determineOwningEntryPoint(file, pkg);
+  if (owningPkg === null) {
+    throw new Error(`Could not determine owning entry-point package of: ${file.shortPath}`);
+  }
+
+  // TODO: Consider handling deep dynamic import expressions.
+  for (const st of sf.statements) {
+    if (!ts.isImportDeclaration(st) || !ts.isStringLiteralLike(st.moduleSpecifier)) {
+      continue;
+    }
+    // Skip module imports.
+    if (!st.moduleSpecifier.text.startsWith('.')) {
+      continue;
+    }
+    // Skip this import if there is an explicit skip comment.
+    const leadingComments = ts.getLeadingCommentRanges(sf.text, st.getFullStart());
+    if (leadingComments !== undefined &&
+        leadingComments.some(c => sf.text.substring(c.pos, c.end) === skipComment)) {
+      continue;
+    }
+
+    const destinationPath = path.posix.join(fileDirPath, st.moduleSpecifier.text);
+    const targetPackage = determineOwningEntryPoint({path: destinationPath}, pkg);
+    if (targetPackage === null) {
+      failures.push(
+          `Could not determine owning entry-point package of: ${destinationPath}. Imported from: ${
+              fileDebugName}. Is this a relative import to another full package?.\n` +
+          `You can skip this import by adding a comment: ${skipComment}`);
+      continue;
+    }
+
+    if (targetPackage.path !== owningPkg.path) {
+      failures.push(
+          `Found relative cross entry-point import in: ${fileDebugName}. Import to: ${
+              st.moduleSpecifier.text}\n` +
+          `You can skip this import by adding a comment: ${skipComment}`);
+    }
+  }
+
+  return failures;
+}
+
+/** Determines the owning entry-point for the given JavaScript file. */
+function determineOwningEntryPoint(
+    file: Pick<BazelFileInfo, 'path'>, pkg: PackageMetadata): EntryPointPackage|null {
+  let owningEntryPoint: EntryPointPackage|null = null;
+
+  for (const [name, info] of Object.entries(pkg.entryPoints)) {
+    // Entry point directory is assumed because technically the entry-point
+    // could be deeper inside the entry-point source file package. This is
+    // unlikely though and we still catch most cases, especially in the standard
+    // folder layout where the APF entry-point index file resides at the top of
+    // the entry-point.
+    const assumedEntryPointDir = path.posix.dirname(info.index.path);
+
+    if (file.path.startsWith(assumedEntryPointDir) &&
+        (owningEntryPoint === null || owningEntryPoint.path.length < assumedEntryPointDir.length)) {
+      owningEntryPoint = {name, info, path: assumedEntryPointDir};
+    }
+  }
+
+  return owningEntryPoint;
+}

--- a/packages/bazel/src/ng_package/cross_entry_points_imports.ts
+++ b/packages/bazel/src/ng_package/cross_entry_points_imports.ts
@@ -10,6 +10,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import ts from 'typescript';
 
+import {BazelFileInfo, EntryPointInfo, PackageMetadata} from './api';
+
 /** Interface describing an entry-point Bazel package. */
 interface EntryPointPackage {
   /** Module name of the entry-point. */
@@ -19,8 +21,6 @@ interface EntryPointPackage {
   /** Extracted info for the entry-point. */
   info: EntryPointInfo;
 }
-
-import {BazelFileInfo, EntryPointInfo, PackageMetadata} from './api';
 
 /** Comment that can be used to skip a single import from being flagged. */
 const skipComment = '// @ng_package: ignore-cross-repo-import';

--- a/packages/bazel/src/ng_package/ng_package.bzl
+++ b/packages/bazel/src/ng_package/ng_package.bzl
@@ -323,13 +323,7 @@ def _ng_package_impl(ctx):
         # necessary to allow for entry-points to rely on sub-targets (as a perf improvement).
         unscoped_esm2022_depset = dep[JSEcmaScriptModuleInfo].sources
         unscoped_types_depset = dep[DeclarationInfo].transitive_declarations
-
-        # Note: Using `to_list()` is expensive but we cannot get around this here as
-        # we need to filter out generated files and need to be able to iterate through
-        # JavaScript files in order to capture the `esm2022/` in the APF, and to be able
-        # to detect entry-point index files when no flat module metadata is available.
-        unscoped_esm2022 = unscoped_esm2022_depset.to_list()
-        unscoped_all_entry_point_esm2022.extend(unscoped_esm2022)
+        unscoped_all_entry_point_esm2022.append(unscoped_esm2022_depset)
 
         # Extract the "module_name" from either "ts_library" or "ng_module". Both
         # set the "module_name" in the provider struct.
@@ -367,10 +361,15 @@ def _ng_package_impl(ctx):
             # typing files in order to determine the entry-point type file.
             unscoped_types = unscoped_types_depset.to_list()
 
+            # Note: Using `to_list()` is expensive but we cannot get around this here as
+            # we need to filter out generated files to be able to detect entry-point index
+            # files when no flat module metadata is available.
+            unscoped_esm2022_list = unscoped_esm2022_depset.to_list()
+
             # In case the dependency is built through the "ts_library" rule, or the "ng_module"
             # rule does not generate a flat module bundle, we determine the index file and
             # typings entry-point through the most reasonable defaults (i.e. "package/index").
-            es2022_entry_point = _find_matching_file(unscoped_esm2022, "%s/index.mjs" % entry_point_package)
+            es2022_entry_point = _find_matching_file(unscoped_esm2022_list, "%s/index.mjs" % entry_point_package)
             typings_entry_point = _find_matching_file(unscoped_types, "%s/index.d.ts" % entry_point_package)
             guessed_paths = True
 
@@ -428,9 +427,14 @@ def _ng_package_impl(ctx):
             ),
         )
 
+    # Note: Using `to_list()` is expensive but we cannot get around this here as
+    # we need to filter out generated files and need to be able to iterate through
+    # JavaScript files in order to capture the relevant package-owned `esm2022/` in the APF.
+    unscoped_all_entry_point_esm2022_list = depset(transitive = unscoped_all_entry_point_esm2022).to_list()
+
     # Filter ESM2022 JavaScript inputs to files which are part of the owning package. The
     # packager should not copy external files into the package.
-    esm2022 = _filter_esm_files_to_include(unscoped_all_entry_point_esm2022, owning_package)
+    esm2022 = _filter_esm_files_to_include(unscoped_all_entry_point_esm2022_list, owning_package)
 
     packager_inputs = (
         static_files +

--- a/packages/bazel/src/ng_package/packager.ts
+++ b/packages/bazel/src/ng_package/packager.ts
@@ -9,40 +9,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-/**
- * Interface describing a file captured in the Bazel action.
- * https://docs.bazel.build/versions/main/skylark/lib/File.html.
- */
-interface BazelFileInfo {
-  /** Execroot-relative path pointing to the file. */
-  path: string;
-  /** The path of this file relative to its root. e.g. omitting `bazel-out/<..>/bin`. */
-  shortPath: string;
-}
-
-/** Interface describing an entry-point. */
-interface EntryPointInfo {
-  /** ES2022 index file for the APF entry-point. */
-  index: BazelFileInfo;
-  /** Flat ES2022 ES module bundle file. */
-  fesm2022Bundle: BazelFileInfo;
-  /** Index type definition file for the APF entry-point. */
-  typings: BazelFileInfo;
-  /**
-   * Whether the index or typing paths have been guessed. For entry-points built
-   * through `ts_library`, there is no explicit setting that declares the entry-point
-   * so the index file is guessed.
-   */
-  guessedPaths: boolean;
-}
-
-/** Interface capturing relevant metadata for packaging. */
-interface PackageMetadata {
-  /** NPM package name of the output. */
-  npmPackageName: string;
-  /** Record of entry-points (including the primary one) and their info. */
-  entryPoints: Record<string, EntryPointInfo>;
-}
+import {BazelFileInfo, PackageMetadata} from './api';
+import {analyzeFileAndEnsureNoCrossImports} from './cross_entry_points_imports';
 
 /**
  * List of known `package.json` fields which provide information about
@@ -222,7 +190,17 @@ function main(args: string[]): void {
     return getEntryPointSubpath(moduleName) !== '';
   }
 
-  esm2022.forEach(file => writeEsm2022File(file));
+  const crossEntryPointFailures: string[] = [];
+
+  esm2022.forEach(file => {
+    crossEntryPointFailures.push(...analyzeFileAndEnsureNoCrossImports(file, metadata));
+    writeEsm2022File(file);
+  });
+
+  if (crossEntryPointFailures.length) {
+    console.error(crossEntryPointFailures);
+    process.exit(1);
+  }
 
   // Copy all FESM files into the package output.
   fesm2022.forEach(f => copyFile(f.path, getFlatEsmOutputRelativePath(f)));
@@ -408,8 +386,8 @@ function main(args: string[]): void {
   function hasExplicitFormatProperties(parsedPackage: Readonly<PackageJson>): boolean {
     return Object.keys(parsedPackage)
         .some(
-            (fieldName: KnownPackageJsonFormatFields) =>
-                knownFormatPackageJsonFormatFields.includes(fieldName));
+            (fieldName: string) => knownFormatPackageJsonFormatFields.includes(
+                fieldName as KnownPackageJsonFormatFields));
   }
 
   /**

--- a/packages/bazel/src/ng_package/tsconfig.json
+++ b/packages/bazel/src/ng_package/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
     "noImplicitAny": true,
     "lib": ["es2015"],
     "types": ["node"]

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -28,3 +28,4 @@ export {VERSION} from './version';
 export {ViewportScroller, NullViewportScroller as ɵNullViewportScroller} from './viewport_scroller';
 export {XhrFactory} from './xhr';
 export {IMAGE_CONFIG, ImageConfig, IMAGE_LOADER, ImageLoader, ImageLoaderConfig, NgOptimizedImage, PRECONNECT_CHECK_BLOCKLIST, provideCloudflareLoader, provideCloudinaryLoader, provideImageKitLoader, provideImgixLoader} from './directives/ng_optimized_image';
+export {normalizeQueryParams as ɵnormalizeQueryParams} from './location/util';

--- a/packages/common/testing/src/location_mock.ts
+++ b/packages/common/testing/src/location_mock.ts
@@ -6,11 +6,9 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {Location, LocationStrategy} from '@angular/common';
+import {Location, LocationStrategy, ɵnormalizeQueryParams as normalizeQueryParams} from '@angular/common';
 import {EventEmitter, Injectable} from '@angular/core';
 import {SubscriptionLike} from 'rxjs';
-
-import {normalizeQueryParams} from '../../src/location/util';
 
 /**
  * A spy for {@link Location} that allows tests to fire simulated location events.

--- a/packages/core/rxjs-interop/src/to_signal.ts
+++ b/packages/core/rxjs-interop/src/to_signal.ts
@@ -6,11 +6,8 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import {assertInInjectionContext, computed, DestroyRef, inject, Injector, signal, Signal, WritableSignal} from '@angular/core';
+import {assertInInjectionContext, computed, DestroyRef, inject, Injector, signal, Signal, untracked, WritableSignal, ɵRuntimeError, ɵRuntimeErrorCode} from '@angular/core';
 import {Observable, Subscribable} from 'rxjs';
-
-import {RuntimeError, RuntimeErrorCode} from '../../src/errors';
-import {untracked} from '../../src/signals';
 
 /**
  * Options for `toSignal`.
@@ -186,8 +183,8 @@ export function toSignal<T, U = undefined>(
   });
 
   if (ngDevMode && options?.requireSync && untracked(state).kind === StateKind.NoValue) {
-    throw new RuntimeError(
-        RuntimeErrorCode.REQUIRE_SYNC_WITHOUT_SYNC_EMIT,
+    throw new ɵRuntimeError(
+        ɵRuntimeErrorCode.REQUIRE_SYNC_WITHOUT_SYNC_EMIT,
         '`toSignal()` called with `requireSync` but `Observable` did not emit synchronously.');
   }
 
@@ -206,8 +203,8 @@ export function toSignal<T, U = undefined>(
       case StateKind.NoValue:
         // This shouldn't really happen because the error is thrown on creation.
         // TODO(alxhub): use a RuntimeError when we finalize the error semantics
-        throw new RuntimeError(
-            RuntimeErrorCode.REQUIRE_SYNC_WITHOUT_SYNC_EMIT,
+        throw new ɵRuntimeError(
+            ɵRuntimeErrorCode.REQUIRE_SYNC_WITHOUT_SYNC_EMIT,
             '`toSignal()` called with `requireSync` but `Observable` did not emit synchronously.');
     }
   });

--- a/packages/core/src/core_private_export.ts
+++ b/packages/core/src/core_private_export.ts
@@ -15,7 +15,7 @@ export {getInjectableDef as ɵgetInjectableDef, ɵɵInjectableDeclaration, ɵɵI
 export {InternalEnvironmentProviders as ɵInternalEnvironmentProviders, isEnvironmentProviders as ɵisEnvironmentProviders} from './di/interface/provider';
 export {INJECTOR_SCOPE as ɵINJECTOR_SCOPE} from './di/scope';
 export {XSS_SECURITY_URL as ɵXSS_SECURITY_URL} from './error_details_base_url';
-export {formatRuntimeError as ɵformatRuntimeError, RuntimeError as ɵRuntimeError} from './errors';
+export {formatRuntimeError as ɵformatRuntimeError, RuntimeError as ɵRuntimeError, RuntimeErrorCode as ɵRuntimeErrorCode} from './errors';
 export {annotateForHydration as ɵannotateForHydration} from './hydration/annotate';
 export {withDomHydration as ɵwithDomHydration} from './hydration/api';
 export {IS_HYDRATION_DOM_REUSE_ENABLED as ɵIS_HYDRATION_DOM_REUSE_ENABLED} from './hydration/tokens';
@@ -24,7 +24,7 @@ export {CurrencyIndex as ɵCurrencyIndex, ExtraLocaleDataIndex as ɵExtraLocaleD
 export {DEFAULT_LOCALE_ID as ɵDEFAULT_LOCALE_ID} from './i18n/localization';
 export {InitialRenderPendingTasks as ɵInitialRenderPendingTasks} from './initial_render_pending_tasks';
 export {ComponentFactory as ɵComponentFactory} from './linker/component_factory';
-export {clearResolutionOfComponentResourcesQueue as ɵclearResolutionOfComponentResourcesQueue, resolveComponentResources as ɵresolveComponentResources} from './metadata/resource_loading';
+export {clearResolutionOfComponentResourcesQueue as ɵclearResolutionOfComponentResourcesQueue, isComponentDefPendingResolution as ɵisComponentDefPendingResolution, resolveComponentResources as ɵresolveComponentResources, restoreComponentResolutionQueue as ɵrestoreComponentResolutionQueue} from './metadata/resource_loading';
 export {ReflectionCapabilities as ɵReflectionCapabilities} from './reflection/reflection_capabilities';
 export {InjectorProfilerContext as ɵInjectorProfilerContext, setInjectorProfilerContext as ɵsetInjectorProfilerContext} from './render3/debug/injector_profiler';
 export {allowSanitizationBypassAndThrow as ɵallowSanitizationBypassAndThrow, BypassType as ɵBypassType, getSanitizationBypassType as ɵgetSanitizationBypassType, SafeHtml as ɵSafeHtml, SafeResourceUrl as ɵSafeResourceUrl, SafeScript as ɵSafeScript, SafeStyle as ɵSafeStyle, SafeUrl as ɵSafeUrl, SafeValue as ɵSafeValue, unwrapSafeValue as ɵunwrapSafeValue} from './sanitization/bypass';

--- a/packages/core/src/core_render3_private_export.ts
+++ b/packages/core/src/core_render3_private_export.ts
@@ -300,5 +300,8 @@ export {
   noSideEffects as ɵnoSideEffects,
 } from './util/closure';
 export { AfterRenderEventManager as ɵAfterRenderEventManager } from './render3/after_render_hooks';
+export {depsTracker as ɵdepsTracker, USE_RUNTIME_DEPS_TRACKER_FOR_JIT as ɵUSE_RUNTIME_DEPS_TRACKER_FOR_JIT} from './render3/deps_tracker/deps_tracker';
+export {generateStandaloneInDeclarationsError as ɵgenerateStandaloneInDeclarationsError} from './render3/jit/module';
+export {getAsyncClassMetadata as ɵgetAsyncClassMetadata} from './render3/metadata';
 
 // clang-format on

--- a/packages/core/testing/src/test_bed.ts
+++ b/packages/core/testing/src/test_bed.ts
@@ -27,6 +27,7 @@ import {
   Type,
   ɵconvertToBitFlags as convertToBitFlags,
   ɵflushModuleScopingQueueAsMuchAsPossible as flushModuleScopingQueueAsMuchAsPossible,
+  ɵgetAsyncClassMetadata as getAsyncClassMetadata,
   ɵgetUnknownElementStrictMode as getUnknownElementStrictMode,
   ɵgetUnknownPropertyStrictMode as getUnknownPropertyStrictMode,
   ɵRender3ComponentFactory as ComponentFactory,
@@ -35,12 +36,11 @@ import {
   ɵsetAllowDuplicateNgModuleIdsForTest as setAllowDuplicateNgModuleIdsForTest,
   ɵsetUnknownElementStrictMode as setUnknownElementStrictMode,
   ɵsetUnknownPropertyStrictMode as setUnknownPropertyStrictMode,
-  ɵstringify as stringify
-} from '@angular/core';
-
-import { getAsyncClassMetadata } from '../../src/render3/metadata';
+  ɵstringify as stringify} from '@angular/core';
 
 /* clang-format on */
+
+
 
 import {ComponentFixture} from './component_fixture';
 import {MetadataOverride} from './metadata_override';

--- a/packages/core/testing/src/test_bed_compiler.ts
+++ b/packages/core/testing/src/test_bed_compiler.ts
@@ -7,13 +7,9 @@
  */
 
 import {ResourceLoader} from '@angular/compiler';
-import {ApplicationInitStatus, Compiler, COMPILER_OPTIONS, Component, Directive, Injector, InjectorType, LOCALE_ID, ModuleWithComponentFactories, ModuleWithProviders, NgModule, NgModuleFactory, NgZone, Pipe, PlatformRef, Provider, provideZoneChangeDetection, resolveForwardRef, StaticProvider, Type, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵDirectiveDef as DirectiveDef, ɵgetInjectableDef as getInjectableDef, ɵInternalEnvironmentProviders as InternalEnvironmentProviders, ɵisEnvironmentProviders as isEnvironmentProviders, ɵNG_COMP_DEF as NG_COMP_DEF, ɵNG_DIR_DEF as NG_DIR_DEF, ɵNG_INJ_DEF as NG_INJ_DEF, ɵNG_MOD_DEF as NG_MOD_DEF, ɵNG_PIPE_DEF as NG_PIPE_DEF, ɵNgModuleFactory as R3NgModuleFactory, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵNgModuleType as NgModuleType, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵsetLocaleId as setLocaleId, ɵtransitiveScopesFor as transitiveScopesFor, ɵɵInjectableDeclaration as InjectableDeclaration} from '@angular/core';
+import {ApplicationInitStatus, Compiler, COMPILER_OPTIONS, Component, Directive, Injector, InjectorType, LOCALE_ID, ModuleWithComponentFactories, ModuleWithProviders, NgModule, NgModuleFactory, NgZone, Pipe, PlatformRef, Provider, provideZoneChangeDetection, resolveForwardRef, StaticProvider, Type, ɵclearResolutionOfComponentResourcesQueue, ɵcompileComponent as compileComponent, ɵcompileDirective as compileDirective, ɵcompileNgModuleDefs as compileNgModuleDefs, ɵcompilePipe as compilePipe, ɵDEFAULT_LOCALE_ID as DEFAULT_LOCALE_ID, ɵdepsTracker as depsTracker, ɵDirectiveDef as DirectiveDef, ɵgenerateStandaloneInDeclarationsError, ɵgetAsyncClassMetadata as getAsyncClassMetadata, ɵgetInjectableDef as getInjectableDef, ɵInternalEnvironmentProviders as InternalEnvironmentProviders, ɵisComponentDefPendingResolution, ɵisEnvironmentProviders as isEnvironmentProviders, ɵNG_COMP_DEF as NG_COMP_DEF, ɵNG_DIR_DEF as NG_DIR_DEF, ɵNG_INJ_DEF as NG_INJ_DEF, ɵNG_MOD_DEF as NG_MOD_DEF, ɵNG_PIPE_DEF as NG_PIPE_DEF, ɵNgModuleFactory as R3NgModuleFactory, ɵNgModuleTransitiveScopes as NgModuleTransitiveScopes, ɵNgModuleType as NgModuleType, ɵpatchComponentDefWithScope as patchComponentDefWithScope, ɵRender3ComponentFactory as ComponentFactory, ɵRender3NgModuleRef as NgModuleRef, ɵresolveComponentResources, ɵrestoreComponentResolutionQueue, ɵsetLocaleId as setLocaleId, ɵtransitiveScopesFor as transitiveScopesFor, ɵUSE_RUNTIME_DEPS_TRACKER_FOR_JIT as USE_RUNTIME_DEPS_TRACKER_FOR_JIT, ɵɵInjectableDeclaration as InjectableDeclaration} from '@angular/core';
 
-import {clearResolutionOfComponentResourcesQueue, isComponentDefPendingResolution, resolveComponentResources, restoreComponentResolutionQueue} from '../../src/metadata/resource_loading';
 import {ComponentDef, ComponentType} from '../../src/render3';
-import {depsTracker, USE_RUNTIME_DEPS_TRACKER_FOR_JIT} from '../../src/render3/deps_tracker/deps_tracker';
-import {generateStandaloneInDeclarationsError} from '../../src/render3/jit/module';
-import {getAsyncClassMetadata} from '../../src/render3/metadata';
 
 import {MetadataOverride} from './metadata_override';
 import {ComponentResolver, DirectiveResolver, NgModuleResolver, PipeResolver, Resolver} from './resolvers';
@@ -35,7 +31,7 @@ function assertNoStandaloneComponents(
     if (!getAsyncClassMetadata(type)) {
       const component = resolver.resolve(type);
       if (component && component.standalone) {
-        throw new Error(generateStandaloneInDeclarationsError(type, location));
+        throw new Error(ɵgenerateStandaloneInDeclarationsError(type, location));
       }
     }
   });
@@ -236,7 +232,7 @@ export class TestBedCompiler {
       const metadata = this.resolvers.component.resolve(type)! as Component;
       return !!metadata.styleUrls && metadata.styleUrls.length > 0;
     };
-    const overrideStyleUrls = !!def && !isComponentDefPendingResolution(type) && hasStyleUrls();
+    const overrideStyleUrls = !!def && !ɵisComponentDefPendingResolution(type) && hasStyleUrls();
 
     // In Ivy, compiling a component does not require knowing the module providing the
     // component's scope, so overrideTemplateUsingTestingModule can be implemented purely via
@@ -298,7 +294,7 @@ export class TestBedCompiler {
         }
         return Promise.resolve(resourceLoader.get(url));
       };
-      await resolveComponentResources(resolver);
+      await ɵresolveComponentResources(resolver);
     }
   }
 
@@ -387,7 +383,7 @@ export class TestBedCompiler {
             `Please call \`await TestBed.compileComponents()\` before running this test.`);
       }
 
-      needsAsyncResources = needsAsyncResources || isComponentDefPendingResolution(declaration);
+      needsAsyncResources = needsAsyncResources || ɵisComponentDefPendingResolution(declaration);
 
       const metadata = this.resolvers.component.resolve(declaration);
       if (metadata === null) {
@@ -580,7 +576,7 @@ export class TestBedCompiler {
       // Check whether a give Type has respective NG def (ɵcmp) and compile if def is
       // missing. That might happen in case a class without any Angular decorators extends another
       // class where Component/Directive/Pipe decorator is defined.
-      if (isComponentDefPendingResolution(type) || !type.hasOwnProperty(NG_COMP_DEF)) {
+      if (ɵisComponentDefPendingResolution(type) || !type.hasOwnProperty(NG_COMP_DEF)) {
         this.pendingComponents.add(type);
       }
       this.seenComponents.add(type);
@@ -748,7 +744,7 @@ export class TestBedCompiler {
     if (this.originalComponentResolutionQueue === null) {
       this.originalComponentResolutionQueue = new Map();
     }
-    clearResolutionOfComponentResourcesQueue().forEach(
+    ɵclearResolutionOfComponentResourcesQueue().forEach(
         (value, key) => this.originalComponentResolutionQueue!.set(key, value));
   }
 
@@ -759,7 +755,7 @@ export class TestBedCompiler {
    */
   private restoreComponentResolutionQueue() {
     if (this.originalComponentResolutionQueue !== null) {
-      restoreComponentResolutionQueue(this.originalComponentResolutionQueue);
+      ɵrestoreComponentResolutionQueue(this.originalComponentResolutionQueue);
       this.originalComponentResolutionQueue = null;
     }
   }

--- a/packages/localize/src/utils/src/messages.ts
+++ b/packages/localize/src/utils/src/messages.ts
@@ -7,6 +7,7 @@
  */
 // This module specifier is intentionally a relative path to allow bundling the code directly
 // into the package.
+// @ng_package: ignore-cross-repo-import
 import {computeMsgId} from '../../../../compiler/src/i18n/digest';
 
 import {BLOCK_MARKER, ID_SEPARATOR, LEGACY_ID_INDICATOR, MEANING_SEPARATOR} from './constants';

--- a/packages/upgrade/static/BUILD.bazel
+++ b/packages/upgrade/static/BUILD.bazel
@@ -15,7 +15,7 @@ ng_module(
     deps = [
         "//packages/core",
         "//packages/platform-browser",
-        "//packages/upgrade/src/common",
+        "//packages/upgrade",
     ],
 )
 

--- a/packages/upgrade/static/common.ts
+++ b/packages/upgrade/static/common.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+/**
+ * Note: We intentionally use cross entry-point relative paths here. This
+ * is because the primary entry-point is deprecated and we also don't have
+ * it available in G3.
+ */
+
+// @ng_package: ignore-cross-repo-import
+import * as ɵangular1 from '../src/common/src/angular1';
+// @ng_package: ignore-cross-repo-import
+import * as ɵconstants from '../src/common/src/constants';
+// @ng_package: ignore-cross-repo-import
+import * as ɵupgradeHelper from '../src/common/src/upgrade_helper';
+// @ng_package: ignore-cross-repo-import
+import * as ɵutil from '../src/common/src/util';
+
+export {ɵangular1, ɵconstants, ɵupgradeHelper, ɵutil};

--- a/packages/upgrade/static/public_api.ts
+++ b/packages/upgrade/static/public_api.ts
@@ -13,6 +13,7 @@ export {VERSION} from '../src/common/src/version';
 export {downgradeModule} from './src/downgrade_module';
 export {UpgradeComponent} from './src/upgrade_component';
 export {UpgradeModule} from './src/upgrade_module';
+export * from './common';
 
 
 // This file only re-exports items to appear in the public api. Keep it that way.

--- a/packages/upgrade/static/src/upgrade_component.ts
+++ b/packages/upgrade/static/src/upgrade_component.ts
@@ -8,10 +8,7 @@
 
 import {Directive, DoCheck, ElementRef, EventEmitter, Injector, OnChanges, OnDestroy, OnInit, SimpleChanges} from '@angular/core';
 
-import {IAttributes, IAugmentedJQuery, IDirective, IInjectorService, ILinkFn, IScope, ITranscludeFunction} from '../../src/common/src/angular1';
-import {$SCOPE} from '../../src/common/src/constants';
-import {IBindingDestination, IControllerInstance, UpgradeHelper} from '../../src/common/src/upgrade_helper';
-import {isFunction} from '../../src/common/src/util';
+import {ɵangular1, ɵconstants, ɵupgradeHelper, ɵutil} from '../common';
 
 const NOT_SUPPORTED: any = 'NOT_SUPPORTED';
 const INITIAL_VALUE = {
@@ -69,16 +66,16 @@ class Bindings {
  */
 @Directive()
 export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
-  private helper: UpgradeHelper;
+  private helper: ɵupgradeHelper.UpgradeHelper;
 
-  private $element: IAugmentedJQuery;
-  private $componentScope: IScope;
+  private $element: ɵangular1.IAugmentedJQuery;
+  private $componentScope: ɵangular1.IScope;
 
-  private directive: IDirective;
+  private directive: ɵangular1.IDirective;
   private bindings: Bindings;
 
-  private controllerInstance?: IControllerInstance;
-  private bindingDestination?: IBindingDestination;
+  private controllerInstance?: ɵupgradeHelper.IControllerInstance;
+  private bindingDestination?: ɵupgradeHelper.IBindingDestination;
 
   // We will be instantiating the controller in the `ngOnInit` hook, when the
   // first `ngOnChanges` will have been already triggered. We store the
@@ -99,7 +96,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
    *   injection into the base class constructor.
    */
   constructor(name: string, elementRef: ElementRef, injector: Injector) {
-    this.helper = new UpgradeHelper(injector, name, elementRef);
+    this.helper = new ɵupgradeHelper.UpgradeHelper(injector, name, elementRef);
 
     this.$element = this.helper.$element;
 
@@ -108,7 +105,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
 
     // We ask for the AngularJS scope from the Angular injector, since
     // we will put the new component scope onto the new injector for each component
-    const $parentScope = injector.get($SCOPE);
+    const $parentScope = injector.get(ɵconstants.$SCOPE);
     // QUESTION 1: Should we create an isolated scope if the scope is only true?
     // QUESTION 2: Should we make the scope accessible through `$element.scope()/isolateScope()`?
     this.$componentScope = $parentScope.$new(!!this.directive.scope);
@@ -119,7 +116,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
   /** @nodoc */
   ngOnInit() {
     // Collect contents, insert and compile template
-    const attachChildNodes: ILinkFn|undefined = this.helper.prepareTransclusion();
+    const attachChildNodes: ɵangular1.ILinkFn|undefined = this.helper.prepareTransclusion();
     const linkFn = this.helper.compileTemplate();
 
     // Instantiate controller
@@ -128,7 +125,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     let controllerInstance = controllerType ?
         this.helper.buildController(controllerType, this.$componentScope) :
         undefined;
-    let bindingDestination: IBindingDestination;
+    let bindingDestination: ɵupgradeHelper.IBindingDestination;
 
     if (!bindToController) {
       bindingDestination = this.$componentScope;
@@ -154,12 +151,12 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     }
 
     // Hook: $onInit
-    if (this.controllerInstance && isFunction(this.controllerInstance.$onInit)) {
+    if (this.controllerInstance && ɵutil.isFunction(this.controllerInstance.$onInit)) {
       this.controllerInstance.$onInit();
     }
 
     // Hook: $doCheck
-    if (controllerInstance && isFunction(controllerInstance.$doCheck)) {
+    if (controllerInstance && ɵutil.isFunction(controllerInstance.$doCheck)) {
       const callDoCheck = () => controllerInstance?.$doCheck?.();
 
       this.unregisterDoCheckWatcher = this.$componentScope.$parent.$watch(callDoCheck);
@@ -170,8 +167,8 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     const link = this.directive.link;
     const preLink = typeof link == 'object' && link.pre;
     const postLink = typeof link == 'object' ? link.post : link;
-    const attrs: IAttributes = NOT_SUPPORTED;
-    const transcludeFn: ITranscludeFunction = NOT_SUPPORTED;
+    const attrs: ɵangular1.IAttributes = NOT_SUPPORTED;
+    const transcludeFn: ɵangular1.ITranscludeFunction = NOT_SUPPORTED;
     if (preLink) {
       preLink(this.$componentScope, this.$element, attrs, requiredControllers, transcludeFn);
     }
@@ -183,7 +180,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     }
 
     // Hook: $postLink
-    if (this.controllerInstance && isFunction(this.controllerInstance.$postLink)) {
+    if (this.controllerInstance && ɵutil.isFunction(this.controllerInstance.$postLink)) {
       this.controllerInstance.$postLink();
     }
   }
@@ -219,13 +216,13 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
 
   /** @nodoc */
   ngOnDestroy() {
-    if (isFunction(this.unregisterDoCheckWatcher)) {
+    if (ɵutil.isFunction(this.unregisterDoCheckWatcher)) {
       this.unregisterDoCheckWatcher();
     }
     this.helper.onDestroy(this.$componentScope, this.controllerInstance);
   }
 
-  private initializeBindings(directive: IDirective, name: string) {
+  private initializeBindings(directive: ɵangular1.IDirective, name: string) {
     const btcIsObject = typeof directive.bindToController === 'object';
     if (btcIsObject && Object.keys(directive.scope!).length) {
       throw new Error(
@@ -278,7 +275,7 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
         });
   }
 
-  private bindOutputs(bindingDestination: IBindingDestination) {
+  private bindOutputs(bindingDestination: ɵupgradeHelper.IBindingDestination) {
     // Bind `&` bindings to the corresponding outputs
     this.bindings.expressionBoundProperties.forEach(propName => {
       const outputName = this.bindings.propertyToOutputMap[propName];
@@ -288,12 +285,13 @@ export class UpgradeComponent implements OnInit, OnChanges, DoCheck, OnDestroy {
     });
   }
 
-  private forwardChanges(changes: SimpleChanges, bindingDestination: IBindingDestination) {
+  private forwardChanges(
+      changes: SimpleChanges, bindingDestination: ɵupgradeHelper.IBindingDestination) {
     // Forward input changes to `bindingDestination`
     Object.keys(changes).forEach(
         propName => bindingDestination[propName] = changes[propName].currentValue);
 
-    if (isFunction(bindingDestination.$onChanges)) {
+    if (ɵutil.isFunction(bindingDestination.$onChanges)) {
       bindingDestination.$onChanges(changes);
     }
   }

--- a/packages/upgrade/static/src/upgrade_module.ts
+++ b/packages/upgrade/static/src/upgrade_module.ts
@@ -8,9 +8,7 @@
 
 import {Injector, NgModule, NgZone, PlatformRef, Testability} from '@angular/core';
 
-import {bootstrap, element as angularElement, IInjectorService, IIntervalService, IProvideService, ITestabilityService, module_ as angularModule} from '../../src/common/src/angular1';
-import {$$TESTABILITY, $DELEGATE, $INJECTOR, $INTERVAL, $PROVIDE, INJECTOR_KEY, LAZY_MODULE_REF, UPGRADE_APP_TYPE_KEY, UPGRADE_MODULE_NAME} from '../../src/common/src/constants';
-import {controllerKey, destroyApp, LazyModuleRef, UpgradeAppType} from '../../src/common/src/util';
+import {ɵangular1, ɵconstants, ɵutil} from '../common';
 
 import {angular1Providers, setTempInjectorRef} from './angular1_providers';
 import {NgAdapterInjector} from './util';
@@ -176,25 +174,27 @@ export class UpgradeModule {
   bootstrap(
       element: Element, modules: string[] = [], config?: any /*angular.IAngularBootstrapConfig*/):
       any /*ReturnType<typeof angular.bootstrap>*/ {
-    const INIT_MODULE_NAME = UPGRADE_MODULE_NAME + '.init';
+    const INIT_MODULE_NAME = ɵconstants.UPGRADE_MODULE_NAME + '.init';
 
     // Create an ng1 module to bootstrap
-    angularModule(INIT_MODULE_NAME, [])
+    ɵangular1
+        .module_(INIT_MODULE_NAME, [])
 
-        .constant(UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
+        .constant(ɵconstants.UPGRADE_APP_TYPE_KEY, ɵutil.UpgradeAppType.Static)
 
-        .value(INJECTOR_KEY, this.injector)
+        .value(ɵconstants.INJECTOR_KEY, this.injector)
 
         .factory(
-            LAZY_MODULE_REF, [INJECTOR_KEY, (injector: Injector) => ({injector} as LazyModuleRef)])
+            ɵconstants.LAZY_MODULE_REF,
+            [ɵconstants.INJECTOR_KEY, (injector: Injector) => ({injector} as ɵutil.LazyModuleRef)])
 
         .config([
-          $PROVIDE, $INJECTOR,
-          ($provide: IProvideService, $injector: IInjectorService) => {
-            if ($injector.has($$TESTABILITY)) {
-              $provide.decorator($$TESTABILITY, [
-                $DELEGATE,
-                (testabilityDelegate: ITestabilityService) => {
+          ɵconstants.$PROVIDE, ɵconstants.$INJECTOR,
+          ($provide: ɵangular1.IProvideService, $injector: ɵangular1.IInjectorService) => {
+            if ($injector.has(ɵconstants.$$TESTABILITY)) {
+              $provide.decorator(ɵconstants.$$TESTABILITY, [
+                ɵconstants.$DELEGATE,
+                (testabilityDelegate: ɵangular1.ITestabilityService) => {
                   const originalWhenStable: Function = testabilityDelegate.whenStable;
                   const injector = this.injector;
                   // Cannot use arrow function below because we need the context
@@ -216,10 +216,10 @@ export class UpgradeModule {
               ]);
             }
 
-            if ($injector.has($INTERVAL)) {
-              $provide.decorator($INTERVAL, [
-                $DELEGATE,
-                (intervalDelegate: IIntervalService) => {
+            if ($injector.has(ɵconstants.$INTERVAL)) {
+              $provide.decorator(ɵconstants.$INTERVAL, [
+                ɵconstants.$DELEGATE,
+                (intervalDelegate: ɵangular1.IIntervalService) => {
                   // Wrap the $interval service so that setInterval is called outside NgZone,
                   // but the callback is still invoked within it. This is so that $interval
                   // won't block stability, which preserves the behavior from AngularJS.
@@ -239,7 +239,7 @@ export class UpgradeModule {
                         });
                       };
 
-                  (Object.keys(intervalDelegate) as (keyof IIntervalService)[])
+                  (Object.keys(intervalDelegate) as (keyof ɵangular1.IIntervalService)[])
                       .forEach(prop => (wrappedInterval as any)[prop] = intervalDelegate[prop]);
 
                   // the `flush` method will be present when ngMocks is used
@@ -258,24 +258,25 @@ export class UpgradeModule {
         ])
 
         .run([
-          $INJECTOR,
-          ($injector: IInjectorService) => {
+          ɵconstants.$INJECTOR,
+          ($injector: ɵangular1.IInjectorService) => {
             this.$injector = $injector;
             const $rootScope = $injector.get('$rootScope');
 
             // Initialize the ng1 $injector provider
             setTempInjectorRef($injector);
-            this.injector.get($INJECTOR);
+            this.injector.get(ɵconstants.$INJECTOR);
 
             // Put the injector on the DOM, so that it can be "required"
-            angularElement(element).data!(controllerKey(INJECTOR_KEY), this.injector);
+            ɵangular1.element(element).data!
+                (ɵutil.controllerKey(ɵconstants.INJECTOR_KEY), this.injector);
 
             // Destroy the AngularJS app once the Angular `PlatformRef` is destroyed.
             // This does not happen in a typical SPA scenario, but it might be useful for
             // other use-cases where disposing of an Angular/AngularJS app is necessary
             // (such as Hot Module Replacement (HMR)).
             // See https://github.com/angular/angular/issues/39935.
-            this.platformRef.onDestroy(() => destroyApp($injector));
+            this.platformRef.onDestroy(() => ɵutil.destroyApp($injector));
 
             // Wire up the ng1 rootScope to run a digest cycle whenever the zone settles
             // We need to do this in the next tick so that we don't prevent the bootup stabilizing
@@ -299,14 +300,16 @@ export class UpgradeModule {
           }
         ]);
 
-    const upgradeModule = angularModule(UPGRADE_MODULE_NAME, [INIT_MODULE_NAME].concat(modules));
+    const upgradeModule =
+        ɵangular1.module_(ɵconstants.UPGRADE_MODULE_NAME, [INIT_MODULE_NAME].concat(modules));
 
     // Make sure resumeBootstrap() only exists if the current bootstrap is deferred
     const windowAngular = (window as any)['angular'];
     windowAngular.resumeBootstrap = undefined;
 
     // Bootstrap the AngularJS application inside our zone
-    const returnValue = this.ngZone.run(() => bootstrap(element, [upgradeModule.name], config));
+    const returnValue =
+        this.ngZone.run(() => ɵangular1.bootstrap(element, [upgradeModule.name], config));
 
     // Patch resumeBootstrap() to run inside the ngZone
     if (windowAngular.resumeBootstrap) {

--- a/packages/upgrade/static/testing/BUILD.bazel
+++ b/packages/upgrade/static/testing/BUILD.bazel
@@ -14,7 +14,7 @@ ng_module(
     ),
     deps = [
         "//packages/core/testing",
-        "//packages/upgrade/src/common",
+        "//packages/upgrade/static",
     ],
 )
 

--- a/packages/upgrade/static/testing/src/create_angular_testing_module.ts
+++ b/packages/upgrade/static/testing/src/create_angular_testing_module.ts
@@ -7,9 +7,8 @@
  */
 
 import {Injector, NgModule, Type} from '@angular/core';
+import {ɵangular1 as angular, ɵconstants} from '@angular/upgrade/static';
 
-import * as angular from '../../../src/common/src/angular1';
-import {$INJECTOR, INJECTOR_KEY, UPGRADE_APP_TYPE_KEY} from '../../../src/common/src/constants';
 import {UpgradeAppType} from '../../../src/common/src/util';
 
 let $injector: angular.IInjectorService|null = null;
@@ -19,7 +18,7 @@ export function $injectorFactory() {
   return $injector;
 }
 
-@NgModule({providers: [{provide: $INJECTOR, useFactory: $injectorFactory}]})
+@NgModule({providers: [{provide: ɵconstants.$INJECTOR, useFactory: $injectorFactory}]})
 export class AngularTestingModule {
   constructor(i: Injector) {
     injector = i;
@@ -94,8 +93,8 @@ export class AngularTestingModule {
 export function createAngularTestingModule(
     angularJSModules: string[], strictDi?: boolean): Type<any> {
   angular.module_('$$angularJSTestingModule', angularJSModules)
-      .constant(UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
-      .factory(INJECTOR_KEY, () => injector);
+      .constant(ɵconstants.UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
+      .factory(ɵconstants.INJECTOR_KEY, () => injector);
   $injector = angular.injector(['ng', '$$angularJSTestingModule'], strictDi);
   return AngularTestingModule;
 }

--- a/packages/upgrade/static/testing/src/create_angularjs_testing_module.ts
+++ b/packages/upgrade/static/testing/src/create_angularjs_testing_module.ts
@@ -8,9 +8,8 @@
 
 import {Injector} from '@angular/core';
 import {TestBed} from '@angular/core/testing';
+import {ɵangular1 as ng, ɵconstants} from '@angular/upgrade/static';
 
-import * as ng from '../../../src/common/src/angular1';
-import {$INJECTOR, INJECTOR_KEY, UPGRADE_APP_TYPE_KEY} from '../../../src/common/src/constants';
 import {UpgradeAppType} from '../../../src/common/src/util';
 
 
@@ -83,15 +82,15 @@ import {UpgradeAppType} from '../../../src/common/src/util';
  */
 export function createAngularJSTestingModule(angularModules: any[]): string {
   return ng.module_('$$angularJSTestingModule', [])
-      .constant(UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
+      .constant(ɵconstants.UPGRADE_APP_TYPE_KEY, UpgradeAppType.Static)
       .factory(
-          INJECTOR_KEY,
+          ɵconstants.INJECTOR_KEY,
           [
-            $INJECTOR,
+            ɵconstants.$INJECTOR,
             ($injector: ng.IInjectorService) => {
               TestBed.configureTestingModule({
                 imports: angularModules,
-                providers: [{provide: $INJECTOR, useValue: $injector}]
+                providers: [{provide: ɵconstants.$INJECTOR, useValue: $injector}]
               });
               return TestBed.inject(Injector);
             }


### PR DESCRIPTION
See individual commits. This will allow us to remove the unreliable lint rule in the components repo as well.
https://github.com/angular/components/blob/5d65f1dc4a719fd673b4d77f2f5bdba61d7ac523/tools/tslint-rules/noCrossEntryPointRelativeImportsRule.ts

Also see: https://github.com/angular/angular/pull/51495