### PR TITLE
docs: remove MessageService information from HeroService section

### DIFF
--- a/aio/content/tutorial/tour-of-heroes/toh-pt4.md
+++ b/aio/content/tutorial/tour-of-heroes/toh-pt4.md
@@ -20,10 +20,7 @@ This tutorial creates a `HeroService` that all application classes can use to ge
 Instead of creating that service with the [`new` keyword](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Operators/new), use the [*dependency injection*](guide/dependency-injection) that Angular supports to inject it into the `HeroesComponent` constructor.
 
 Services are a great way to share information among classes that *don't know each other*.
-Create a `MessageService` next and inject it in these two places.
-
-*   Inject in `HeroService`, which uses the service to send a message
-*   Inject in `MessagesComponent`, which displays that message, and also displays the ID when the user clicks a hero
+Create a `HeroService` next and inject it in the `HeroesComponent`, to provide hero data.
 
 ## Create the `HeroService`
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Tour of Heroes pt. 4 wanted to explain services by introduce into the `HeroService`, but immediately named the later upcomming `MessageService`. That was confusing, since the next section doesn't introduce the `MessageService`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
